### PR TITLE
GhanaLSS wave-specific yml + .py 

### DIFF
--- a/GhanaLSS/1987-88/_/1987-88.py
+++ b/GhanaLSS/1987-88/_/1987-88.py
@@ -1,0 +1,50 @@
+# Formatting  Functions for Ghana 1987-88
+import pandas as pd
+import numpy as np
+import lsms_library.local_tools as tools
+from collections import defaultdict
+
+region_dict = tools.get_categorical_mapping(tablename = 'region', dirs=['../../_/', '../_/', './_/'])
+
+def i(value):
+    '''
+    Formatting household id
+    '''
+    return tools.format_id(value)
+
+def Sex(value):
+    '''
+    Formatting sex veriable
+    '''
+    return (lambda s: 'MF'[s-1])(value)
+
+def Age(value):
+    '''
+    Formatting age variable
+    '''
+    return int(value) if value.isdigit() else pd.NA
+
+def Birthplace(value):
+    '''
+    Formatting birthplace variable
+    '''
+    #needs mapping
+    return region_dict.get(str(value), np.nan)
+
+def Relation(value):
+    '''
+    Formatting relationship variable
+    '''
+    #needs mapping
+    relationship_dict = tools.get_categorical_mapping(tablename = 'relationship', dirs=['../../_/', '../_/', './_/', '.'])
+
+    return relationship_dict.get(value, np.nan)
+
+def Region(value):
+    '''
+    Formatting region variable
+    '''
+
+    return region_dict.get(str(value), np.nan)
+
+Visits = range(1,7)

--- a/GhanaLSS/1987-88/_/data_info.yml
+++ b/GhanaLSS/1987-88/_/data_info.yml
@@ -1,0 +1,27 @@
+Country: GhanaLSS
+Wave: 1987-88
+
+cluster_features:
+    file: Y01A.DAT
+    idxvars:
+        w: CLUST
+        v: CLUST
+    myvars:
+        Region: REGION
+
+household_roster:
+    file: Y01A.DAT
+    idxvars:
+        w: CLUST
+        v: CLUST
+        i: HID
+        pid: PID
+    myvars:
+        Sex: SEX
+        Age: AGEY
+        Birthplace: REGION
+        Relation: REL
+
+
+
+

--- a/GhanaLSS/1988-89/_/1988-89.py
+++ b/GhanaLSS/1988-89/_/1988-89.py
@@ -1,0 +1,49 @@
+# Formatting  Functions for Ghana 1988-89
+import pandas as pd
+import numpy as np
+import lsms_library.local_tools as tools
+from collections import defaultdict
+from pathlib import Path
+
+region_dict = tools.get_categorical_mapping(tablename = 'region', dirs=['../../_/', '../_/', './_/', '.'])
+
+def i(value):
+    '''
+    Formatting household id
+    '''
+    return tools.format_id(value)
+
+def Sex(value):
+    '''
+    Formatting sex veriable
+    '''
+    return (lambda s: 'MF'[s-1])(value)
+
+def Age(value):
+    '''
+    Formatting age variable
+    '''
+    return int(value)
+
+def Birthplace(value):
+    '''
+    Formatting birthplace variable
+    '''
+    return region_dict.get(str(value), np.nan)
+
+def Relation(value):
+    '''
+    Formatting relationship variable
+    '''
+    relationship_dict = tools.get_categorical_mapping(tablename = 'relationship', dirs=['../../_/', '../_/', './_/', '.'])
+
+    return relationship_dict.get(value, np.nan)
+
+def Region(value):
+    '''
+    Formatting region variable
+    '''
+
+    return region_dict.get(str(value), np.nan)
+
+Visits = range(1,7)

--- a/GhanaLSS/1988-89/_/data_info.yml
+++ b/GhanaLSS/1988-89/_/data_info.yml
@@ -1,0 +1,27 @@
+Country: GhanaLSS
+Wave: 1988-89
+
+cluster_features:
+    file: Y01A.DAT
+    idxvars:
+        w: CLUST
+        v: CLUST
+    myvars:
+        Region: REGION
+
+household_roster:
+    file: Y01A.DAT
+    idxvars:
+        w: CLUST
+        v: CLUST
+        i: HID
+        pid: PID
+    myvars:
+        Sex: SEX
+        Age: AGEY
+        Birthplace: REGION
+        Relation: REL
+
+
+
+

--- a/GhanaLSS/1991-92/_/1991-92.py
+++ b/GhanaLSS/1991-92/_/1991-92.py
@@ -1,0 +1,59 @@
+# Formatting  Functions for Ghana 1991-92
+import pandas as pd
+import numpy as np
+import lsms_library.local_tools as tools
+from collections import defaultdict
+
+region_dict = tools.get_categorical_mapping(tablename = 'region', dirs=['../../_/', '../_/', './_/', '.'])
+rural_dict = tools.get_categorical_mapping(tablename = 'rural', dirs=['1991-92/_/', '../../1991-92/_/', '../1991-92/_/', '.', './_/'])
+
+def i(value):
+    '''
+    Formatting household id
+    '''
+    return tools.format_id(value.iloc[0])+tools.format_id(value.iloc[1],zeropadding=2)
+
+def Sex(value):
+    '''
+    Formatting sex veriable
+    '''
+    return (lambda s: 'MF'[int(s)-1])(value)
+
+def Age(value):
+    '''
+    Formatting age variable
+    '''
+    return int(value)
+
+def Birthplace(value):
+    '''
+    Formatting birthplace variable
+    '''
+    if value > 1e99:
+        print('extremely large value warning?', value)
+        return np.nan
+    return (lambda x: region_dict[f"{x:3.0f}".strip()])(value)
+
+def Relation(value):
+    '''
+    Formatting relationship variable
+    '''
+    relationship_dict = tools.get_categorical_mapping(tablename = 'relationship', dirs=['../../_/', '../_/', './_/', '.'])
+    return relationship_dict.get(value, np.nan)
+
+def Region(value):
+    '''
+    Formatting region variable
+    '''
+
+    return (lambda x: region_dict[f"{x:3.0f}".strip()])(value)
+    
+
+def Rural(value):
+    '''
+    Formatting rural variable
+    '''
+
+    return rural_dict.get(value, np.nan)
+
+Visits = range(1,7)

--- a/GhanaLSS/1991-92/_/data_info.yml
+++ b/GhanaLSS/1991-92/_/data_info.yml
@@ -1,0 +1,27 @@
+Country: GhanaLSS
+Wave: 1991-92
+
+cluster_features:
+    file: POV_GH.DTA
+    idxvars:
+        w: clust
+        v: clust
+    myvars:
+        Region: region
+        Rural: loc2
+
+
+household_roster:
+    file: S1.DTA
+    idxvars:
+        w: clust
+        v: clust
+        i: 
+            - clust
+            - nh
+        pid: pid
+    myvars:
+        Sex: sex
+        Age: agey
+        Birthplace: s1q10
+        Relation: rel

--- a/GhanaLSS/1998-99/_/1998-99.py
+++ b/GhanaLSS/1998-99/_/1998-99.py
@@ -1,0 +1,59 @@
+# Formatting  Functions for Ghana 1998-99
+import pandas as pd
+import numpy as np
+import lsms_library.local_tools as tools
+from collections import defaultdict
+
+region_dict = tools.get_categorical_mapping(tablename = 'region', dirs=['../../_/', '../_/', './_/', '.'])
+rural_dict = tools.get_categorical_mapping(tablename = 'rural', dirs=['1998-99/_/', '../../1998-99/_/', '../1998-99/_/', '.', './_/'])
+
+def i(value):
+    '''
+    Formatting household id
+    '''
+    return tools.format_id(value.iloc[0])+tools.format_id(value.iloc[1],zeropadding=2)
+
+def Sex(value):
+    '''
+    Formatting sex veriable
+    '''
+    return (lambda s: 'MF'[int(s)-1])(value)
+
+def Age(value):
+    '''
+    Formatting age variable
+    '''
+    return int(value)
+
+def Birthplace(value):
+    '''
+    Formatting birthplace variable
+    '''
+    if value > 1e99:
+        print('extremely large value warning?', value)
+        return np.nan
+    return (lambda x: region_dict[f"{x:3.0f}".strip()])(value)
+
+def Relation(value):
+    '''
+    Formatting relationship variable
+    '''
+    relationship_dict = tools.get_categorical_mapping(tablename = 'relationship', dirs=['../../_/', '../_/', './_/', '.'])
+    return relationship_dict.get(value, np.nan)
+
+def Region(value):
+    '''
+    Formatting region variable
+    '''
+
+    return region_dict.get(str(int(value)), np.nan)
+    
+
+def Rural(value):
+    '''
+    Formatting rural variable
+    '''
+
+    return rural_dict.get(value)
+
+Visits = range(1,7)

--- a/GhanaLSS/1998-99/_/data_info.yml
+++ b/GhanaLSS/1998-99/_/data_info.yml
@@ -1,0 +1,27 @@
+Country: GhanaLSS
+Wave: 1998-99
+
+cluster_features:
+    file: SEC0A.DTA
+    idxvars:
+        w: clust
+        v: clust
+    myvars:
+        Region: region
+        Rural: loc2
+
+
+household_roster:
+    file: SEC1.DTA
+    idxvars:
+        w: clust
+        v: clust
+        i: 
+            - clust
+            - nh
+        pid: pid
+    myvars:
+        Sex: sex
+        Age: agey
+        Birthplace: s1q10
+        Relation: rel

--- a/GhanaLSS/2005-06/_/2005-06.py
+++ b/GhanaLSS/2005-06/_/2005-06.py
@@ -1,0 +1,55 @@
+# Formatting  Functions for Ghana 2005-06
+import pandas as pd
+import numpy as np
+import lsms_library.local_tools as tools
+from collections import defaultdict
+
+def i(value):
+    '''
+    Formatting household id
+    '''
+    return tools.format_id(value)
+
+def Sex(value):
+    '''
+    Formatting sex veriable
+    '''
+    return value.upper()[0]
+
+def Age(value):
+    '''
+    Formatting age variable
+    '''
+    return int(value)
+
+def Birthplace(value):
+    '''
+    Formatting birthplace variable
+    '''
+    if isinstance(value, float) and np.isnan(value):
+        return np.nan
+    else:
+        return value.title()
+    
+def Relation(value):
+    '''
+    Formatting relationship variable
+    '''
+
+    return value.title()
+
+def Region(value):
+    '''
+    Formatting region variable
+    '''
+
+    return value.title()
+
+def Rural(value):
+    '''
+    Formatting rural variable
+    '''
+
+    return value.title()
+
+Visits = range(1,7)

--- a/GhanaLSS/2005-06/_/data_info.yml
+++ b/GhanaLSS/2005-06/_/data_info.yml
@@ -1,0 +1,25 @@
+Country: GhanaLSS
+Wave: 2005-06
+
+cluster_features:
+    file: aggregates/pov_gh5.dta
+    idxvars:
+        w: clust
+        v: clust
+    myvars:
+        Region: region
+        Rural: loc2
+
+
+household_roster:
+    file: parta/sec1.dta
+    idxvars:
+        w: clust
+        v: clust
+        i: hhid
+        pid: pid
+    myvars:
+        Sex: s1q2
+        Age: s1q5y
+        Birthplace: s1q11
+        Relation: s1q3


### PR DESCRIPTION
- .yml and .py files for 1987-88, 1988-89, 1991-92, 1998-99, 2005-06
- presently, with how .get_categorical_mapping() works, must be run within one of the folders within GhanaLSS, but should be somewhat flexible on what subfolder, can change as necessary
- also fixed previous prqs issue w/ extra files
