### PR TITLE
Remove deprecated pandas patterns for pandas 3.0 compatibility

### DIFF
--- a/lsms_library/countries/CotedIvoire/2018-19/_/food_expenditures.py
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/food_expenditures.py
@@ -29,7 +29,7 @@ def food_expenditures(fn='',purchased=None,away=None,produced=None,given=None,it
 
     expenditures.columns.name = 'i'
     expenditures.index.name = 'j'
-    expenditures.replace(0, np.nan, inplace=True)
+    expenditures = expenditures.replace(0, np.nan)
     
     return expenditures
 

--- a/lsms_library/countries/CotedIvoire/2018-19/_/household_characteristics.py
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/household_characteristics.py
@@ -78,7 +78,7 @@ df['t'] = df['vague'].apply(lambda r: ['2018','2019'][r==2])
 df['m'] = "Cote d'Ivoire"
 
 df['Rural'] = df['s00q04'] - 1
-df.set_index(['j','t','m'],inplace=True)
+df = df.set_index(['j','t','m'])
 
 z = z.join(df['Rural'])
 

--- a/lsms_library/countries/CotedIvoire/2018-19/_/nonfood_expenditures.py
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/nonfood_expenditures.py
@@ -29,7 +29,7 @@ def nonfood_expenditures(fn='',purchased=None,away=None,produced=None,given=None
 
     expenditures.columns.name = 'i'
     expenditures.index.name = 'j'
-    expenditures.replace(0, np.nan, inplace=True)
+    expenditures = expenditures.replace(0, np.nan)
     
     return expenditures
 

--- a/lsms_library/countries/CotedIvoire/_/cotedivoire.py
+++ b/lsms_library/countries/CotedIvoire/_/cotedivoire.py
@@ -9,7 +9,7 @@ def harmonized_food_labels(fn='../../_/food_items.org'):
     food_items = pd.read_csv(fn,delimiter='|',skipinitialspace=True,converters={1:int,2:lambda s: s.strip()})
     food_items.columns = [s.strip() for s in food_items.columns]
     food_items = food_items[['Code','Preferred Label']].dropna()
-    food_items.set_index('Code',inplace=True)    
+    food_items = food_items.set_index('Code')
 
     return food_items.to_dict()['Preferred Label']
     
@@ -50,8 +50,8 @@ def food_expenditures(fn='',purchased=None,away=None,produced=None,given=None,it
 
     expenditures.columns.name = 'i'
     expenditures.index.name = 'j'
-    expenditures.replace(0, np.nan, inplace=True)
-    
+    expenditures = expenditures.replace(0, np.nan)
+
     return expenditures
 
 def food_quantities(fn='',item='item',HHID='HHID',
@@ -64,7 +64,7 @@ def food_quantities(fn='',item='item',HHID='HHID',
                                                     itmcd=item,HHID=HHID,units=units,itemlabels=food_items,fn_type='csv')
     quantities.columns.name = 'i'
     quantities.index.name = 'j'
-    quantities.replace(0, np.nan, inplace=True)
+    quantities = quantities.replace(0, np.nan)
 
     return quantities
 

--- a/lsms_library/countries/Ethiopia/2011-12/_/shocks.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/shocks.py
@@ -40,6 +40,6 @@ shocks = shocks.astype({'Shock': 'category',
                         }) 
 
 shocks.insert(1, 't', '2011-12')
-shocks.set_index(['j','t','Shock'], inplace = True)
+shocks = shocks.set_index(['j','t','Shock'])
 
 to_parquet(shocks,'shocks.parquet')

--- a/lsms_library/countries/Ethiopia/2013-14/_/shocks.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/shocks.py
@@ -40,6 +40,6 @@ shocks = shocks.astype({'Shock': 'category',
                         }) 
 
 shocks.insert(1, 't', '2013-14')
-shocks.set_index(['j','t','Shock'], inplace = True)
+shocks = shocks.set_index(['j','t','Shock'])
 
 to_parquet(shocks,'shocks.parquet')

--- a/lsms_library/countries/Ethiopia/2015-16/_/shocks.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/shocks.py
@@ -40,6 +40,6 @@ shocks = shocks.astype({'Shock': 'category',
                         }) 
 
 shocks.insert(1, 't', '2015-16')
-shocks.set_index(['j','t','Shock'], inplace = True)
+shocks = shocks.set_index(['j','t','Shock'])
 
 to_parquet(shocks,'shocks.parquet')

--- a/lsms_library/countries/Ethiopia/2018-19/_/shocks.py
+++ b/lsms_library/countries/Ethiopia/2018-19/_/shocks.py
@@ -38,6 +38,6 @@ shocks = shocks.astype({'Shock': 'category',
                         }) 
 
 shocks.insert(1, 't', '2018-19')
-shocks.set_index(['j','t','Shock'], inplace = True)
+shocks = shocks.set_index(['j','t','Shock'])
 
 to_parquet(shocks,'shocks.parquet')

--- a/lsms_library/countries/Ethiopia/_/ethiopia.py
+++ b/lsms_library/countries/Ethiopia/_/ethiopia.py
@@ -20,7 +20,7 @@ def harmonized_unit_labels(fn='../../_/unitlabels.csv',key='Code',value='Preferr
     unitlabels = pd.read_csv(fn)
     unitlabels.columns = [s.strip() for s in unitlabels.columns]
     unitlabels = unitlabels[[key,value]].dropna()
-    unitlabels.set_index(key,inplace=True)
+    unitlabels = unitlabels.set_index(key)
 
     return unitlabels.squeeze().str.strip().to_dict()
 
@@ -44,7 +44,7 @@ def harmonized_food_labels(fn='../../_/food_items.org',key=list(Waves.keys()),va
     else:
         food_items = food_items[[key] + [value]].replace('---', np.nan).dropna(how = 'all')
         
-    food_items.set_index(key,inplace=True)
+    food_items = food_items.set_index(key)
 
     return food_items.squeeze().str.strip().to_dict()
 

--- a/lsms_library/countries/Ethiopia/_/fct_tools.py
+++ b/lsms_library/countries/Ethiopia/_/fct_tools.py
@@ -45,7 +45,7 @@ def harmonize_nutrient(df, nutrient_labels_df):
     #fill NaNs in the "Energy" row with values in "Energy (Atwater General Factors)"
     e1 = "Energy"
     e2 = "Energy (Atwater General Factors)"
-    df.loc[[e1, e2]] = df.loc[[e1, e2]].fillna(method="bfill")
+    df.loc[[e1, e2]] = df.loc[[e1, e2]].bfill()
     
     #rename
     n_labels_fct = dict(zip(nutrient_labels_df['FDC Label'], nutrient_labels_df['Preferred Label'], ))

--- a/lsms_library/countries/GhanaLSS/_/ghanalss.py
+++ b/lsms_library/countries/GhanaLSS/_/ghanalss.py
@@ -135,7 +135,7 @@ def harmonized_food_labels2(fn='../../_/food_items.org'):
     food_items = pd.read_csv(fn,delimiter='|',skipinitialspace=True,converters={1:int,2:lambda s: s.strip()})
     food_items.columns = [s.strip() for s in food_items.columns]
     food_items = food_items[['Code','Preferred Label']].dropna()
-    food_items.set_index('Code',inplace=True)    
+    food_items = food_items.set_index('Code')
 
     return food_items.to_dict()['Preferred Label']
 
@@ -158,7 +158,7 @@ def harmonized_food_labels(fn='../../_/food_items.org',key=list(Waves.keys()),va
     else:
         food_items = food_items[[key] + [value]].replace('---', np.nan).dropna(how = 'all')
         
-    food_items.set_index(key,inplace=True)
+    food_items = food_items.set_index(key)
 
     return food_items.squeeze().str.strip().to_dict()
 

--- a/lsms_library/countries/GhanaSPS/_/ghanasps.py
+++ b/lsms_library/countries/GhanaSPS/_/ghanasps.py
@@ -16,7 +16,7 @@ def harmonized_food_labels2(fn='../../_/food_items.org'):
     food_items = pd.read_csv(fn,delimiter='|',skipinitialspace=True,converters={1:int,2:lambda s: s.strip()})
     food_items.columns = [s.strip() for s in food_items.columns]
     food_items = food_items[['Code','Preferred Label']].dropna()
-    food_items.set_index('Code',inplace=True)    
+    food_items = food_items.set_index('Code')
 
     return food_items.to_dict()['Preferred Label']
 
@@ -39,7 +39,7 @@ def harmonized_food_labels(fn='../../_/food_items.org',key=list(Waves.keys()),va
     else:
         food_items = food_items[[key] + [value]].replace('---', np.nan).dropna(how = 'all')
         
-    food_items.set_index(key,inplace=True)
+    food_items = food_items.set_index(key)
 
     return food_items.squeeze().str.strip().to_dict()
 

--- a/lsms_library/countries/Guatemala/_/guatemala.py
+++ b/lsms_library/countries/Guatemala/_/guatemala.py
@@ -32,6 +32,6 @@ def harmonized_food_labels(fn='../../_/food_items.csv',key='Code',value='Preferr
                 break
 
     food_items = food_items[[key,value]].dropna()
-    food_items.set_index(key,inplace=True)
+    food_items = food_items.set_index(key)
 
     return food_items.squeeze().str.strip().to_dict()

--- a/lsms_library/countries/Niger/2018-19/_/household_characteristics.py
+++ b/lsms_library/countries/Niger/2018-19/_/household_characteristics.py
@@ -22,7 +22,7 @@ with dvc.api.open('../Data/s01_me_ner2018.dta', mode='rb') as dta:
 df['j'] = (df['grappe'].astype(str) + df['menage'].astype(str)).astype(str)
 joined = pd.merge(df, df_general, how = 'left', on ='j')
 
-joined.replace(9999, np.nan, inplace=True)
+joined = joined.replace(9999, np.nan)
 
 joined = age_handler(joined, interview_date = 's00q23a', age = 's01q04a',  m = 's01q03b', d= 's01q03a', y= 's01q03c', interview_year= '2018')
 

--- a/lsms_library/countries/Nigeria/2010-11/_/nonfood_expenditures.py
+++ b/lsms_library/countries/Nigeria/2010-11/_/nonfood_expenditures.py
@@ -70,7 +70,7 @@ x = x.drop_duplicates()
 
 x['j'] = x['j'].astype(int).astype(str)
 
-x.set_index(['j','t','m','i'],inplace=True)
+x = x.set_index(['j','t','m','i'])
 
 x = x['value'].unstack('i')
 

--- a/lsms_library/countries/Nigeria/2012-13/_/individual_unit_values.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/individual_unit_values.py
@@ -29,7 +29,7 @@ def rectify(food,units=unitcodes,conv=conv):
     food['gift unit'] = food['gift unit'].replace(units)
     food['gift unit'] = food['gift unit'].fillna('None')
 
-    food.set_index(['j','t','m','i','u'],inplace=True)
+    food = food.set_index(['j','t','m','i','u'])
 
     # Get prices implied by purchases
 
@@ -38,7 +38,7 @@ def rectify(food,units=unitcodes,conv=conv):
     purchases['unit value'] = purchases['purchased value']/purchases['purchased quantity']
 
     unit_values = purchases[['purchased unit','unit value']].dropna()
-    unit_values.rename(columns={'purchased unit':'u'},inplace=True)
+    unit_values = unit_values.rename(columns={'purchased unit':'u'})
     unit_values = unit_values.reset_index().set_index(['j','t','m','i','u']).squeeze()
 
 

--- a/lsms_library/countries/Nigeria/2012-13/_/nonfood_expenditures.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/nonfood_expenditures.py
@@ -70,7 +70,7 @@ x = x.drop_duplicates()
 
 x['j'] = x['j'].astype(int).astype(str)
 
-x.set_index(['j','t','m','i'],inplace=True)
+x = x.set_index(['j','t','m','i'])
 
 x = x['value'].unstack('i')
 

--- a/lsms_library/countries/Nigeria/2012-13/_/units.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/units.py
@@ -41,13 +41,13 @@ with dvc.api.open('../Data/food_conv_w2pp.csv') as csv:
 conv_pp = conv_pp.replace({'s7bq2b':unitcodes,
                      'item_cd':{int(k):v for k,v in foodlabels['2013Q1'].items()}})
 
-conv_ph.rename(columns={'item_cd':'i',
+conv_ph = conv_ph.rename(columns={'item_cd':'i',
                         'nsu_cd':'u',
-                        'conv':'Mapping'},inplace=True)
+                        'conv':'Mapping'})
 
-conv_pp.rename(columns={'item_cd':'i',
+conv_pp = conv_pp.rename(columns={'item_cd':'i',
                         's7bq2b':'u',
-                        'conv':'Mapping'},inplace=True)
+                        'conv':'Mapping'})
 
 conv_ph = conv_ph.set_index(['i','u'])
 conv_pp = conv_pp.set_index(['i','u'])

--- a/lsms_library/countries/Nigeria/2015-16/_/individual_unit_values.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/individual_unit_values.py
@@ -29,7 +29,7 @@ def rectify(food,units=unitcodes,conv=conv):
     food['gift unit'] = food['gift unit'].replace(units)
     food['gift unit'] = food['gift unit'].fillna('None')
 
-    food.set_index(['j','t','m','i','u'],inplace=True)
+    food = food.set_index(['j','t','m','i','u'])
 
     # Get prices implied by purchases
 
@@ -38,7 +38,7 @@ def rectify(food,units=unitcodes,conv=conv):
     purchases['unit value'] = purchases['purchased value']/purchases['purchased quantity']
 
     unit_values = purchases[['purchased unit','unit value']].dropna()
-    unit_values.rename(columns={'purchased unit':'u'},inplace=True)
+    unit_values = unit_values.rename(columns={'purchased unit':'u'})
     unit_values = unit_values.reset_index().set_index(['j','t','m','i','u']).squeeze()
 
 

--- a/lsms_library/countries/Nigeria/2015-16/_/nonfood_expenditures.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/nonfood_expenditures.py
@@ -68,7 +68,7 @@ x = x.drop_duplicates()
 
 x['j'] = x['j'].astype(int).astype(str)
 
-x.set_index(['j','t','m','i'],inplace=True)
+x = x.set_index(['j','t','m','i'])
 
 x = x['value'].unstack('i')
 

--- a/lsms_library/countries/Nigeria/2015-16/_/units.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/units.py
@@ -68,15 +68,14 @@ conv = conv0.replace({'unit_cd':unitcodes,
 conv = conv.drop(['item_name','unit_name','conv_national','note','unit_other'],axis=1)
 
 
-conv.rename(columns={'item_cd':'i',
+conv = conv.rename(columns={'item_cd':'i',
                      'unit_cd':'u',
                      'conv_NC_1':'North central',
                      'conv_NE_2':'North east',
                      'conv_NW_3':'North west',
                      'conv_SE_4':'South east',
                      'conv_SS_5':'South south',
-                     'conv_SW_6':'South west'},
-            inplace=True)
+                     'conv_SW_6':'South west'})
 
 conv = conv.set_index(['i','u'])
 conv.columns.name = 'm'

--- a/lsms_library/countries/Nigeria/2018-19/_/individual_unit_values.py
+++ b/lsms_library/countries/Nigeria/2018-19/_/individual_unit_values.py
@@ -25,7 +25,7 @@ def rectify(food,units=unitcodes):
     food['purchased unit'] = food['purchased unit'].fillna('None')
  
 
-    food.set_index(['j','t','m','i','u'],inplace=True)
+    food = food.set_index(['j','t','m','i','u'])
 
     # Get prices implied by purchases
 
@@ -34,7 +34,7 @@ def rectify(food,units=unitcodes):
     purchases['unit value'] = purchases['purchased value']/purchases['purchased quantity']
 
     unit_values = purchases[['purchased unit','unit value']].dropna()
-    unit_values.rename(columns={'purchased unit':'u'},inplace=True)
+    unit_values = unit_values.rename(columns={'purchased unit':'u'})
     unit_values = unit_values.reset_index().set_index(['j','t','m','i','u']).squeeze()
 
 

--- a/lsms_library/countries/Nigeria/2018-19/_/nonfood_expenditures.py
+++ b/lsms_library/countries/Nigeria/2018-19/_/nonfood_expenditures.py
@@ -67,7 +67,7 @@ x = x.drop_duplicates()
 
 x['j'] = x['j'].astype(int).astype(str)
 
-x.set_index(['j','t','m','i'],inplace=True)
+x = x.set_index(['j','t','m','i'])
 
 x = x['value'].unstack('i')
 

--- a/lsms_library/countries/Nigeria/2018-19/_/units.py
+++ b/lsms_library/countries/Nigeria/2018-19/_/units.py
@@ -68,15 +68,14 @@ conv = conv0.replace({'unit_cd':unitcodes,
 conv = conv.drop(['item_name','unit_name','conv_national','note','unit_other'],axis=1)
 
 
-conv.rename(columns={'item_cd':'i',
+conv = conv.rename(columns={'item_cd':'i',
                      'unit_cd':'u',
                      'conv_NC_1':'North central',
                      'conv_NE_2':'North east',
                      'conv_NW_3':'North west',
                      'conv_SE_4':'South east',
                      'conv_SS_5':'South south',
-                     'conv_SW_6':'South west'},
-            inplace=True)
+                     'conv_SW_6':'South west'})
 
 conv = conv.set_index(['i','u'])
 conv.columns.name = 'm'

--- a/lsms_library/countries/Panama/2008/_/food_acquired.py
+++ b/lsms_library/countries/Panama/2008/_/food_acquired.py
@@ -24,7 +24,7 @@ df = df.rename({'hogar': 'j', 'producto':'i', 's11a6a':'quantity bought', 's11a6
 
 cat_columns = df.iloc[:, 2:].select_dtypes(['category']).columns
 df[cat_columns] = df[cat_columns].apply(lambda x: x.cat.codes)
-df.replace({-1: np.nan}, inplace=True)
+df = df.replace({-1: np.nan})
 val = df._get_numeric_data()
 val[val >= 99999] = np.nan
 val[val == 0] = np.nan

--- a/lsms_library/countries/Tanzania/2008-15/_/household_roster.py
+++ b/lsms_library/countries/Tanzania/2008-15/_/household_roster.py
@@ -23,7 +23,7 @@ roster = pd.DataFrame({
     'Relationship': df.hb_05.values.tolist(),
 })
 
-roster.replace({'t': round_match}, inplace=True)
+roster = roster.replace({'t': round_match})
 
 # Convert household ID and pid to string
 roster['i'] = roster['i'].astype(str)

--- a/lsms_library/countries/Tanzania/2008-15/_/shocks.py
+++ b/lsms_library/countries/Tanzania/2008-15/_/shocks.py
@@ -59,7 +59,7 @@ shocks = pd.DataFrame({
     'HowCoped2': df.hr_06_3.values.tolist(),
 })
 
-shocks.replace({'t': round_match}, inplace=True)
+shocks = shocks.replace({'t': round_match})
 
 # Convert household ID to string
 shocks['i'] = shocks['i'].astype(int).astype(str)

--- a/lsms_library/countries/Tanzania/2019-20/_/household_characteristics.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/household_characteristics.py
@@ -25,7 +25,7 @@ df = df.loc[np.isfinite(df.min(axis=1)),:]
 #reformat
 df = df.reset_index()
 df.insert(1, 't', '2019-20')
-df.set_index(['j','t'], inplace = True)
+df = df.set_index(['j','t'])
 
 assert df.index.is_unique, "Non-unique index!  Fix me!"
 

--- a/lsms_library/countries/Tanzania/2020-21/_/household_characteristics.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/household_characteristics.py
@@ -24,7 +24,7 @@ df = df.loc[np.isfinite(df.min(axis=1)),:]
 #reformat
 df = df.reset_index()
 df.insert(1, 't', '2020-21')
-df.set_index(['j','t'], inplace = True)
+df = df.set_index(['j','t'])
 
 assert df.index.is_unique, "Non-unique index!  Fix me!"
 

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -26,7 +26,7 @@ def map_08_15(df, col):
     map_round = {1: '2008-09', 2: '2010-11', 3: '2012-13', 4: '2014-15'}
     hhid_sorted['round'] = hhid_sorted['round'].map(map_round)
     hhid_sorted = hhid_sorted.dropna(how='any')
-    hhid_sorted.rename(columns={'r_hhid': 'i', 'round': 't'}, inplace=True)
+    hhid_sorted = hhid_sorted.rename(columns={'r_hhid': 'i', 'round': 't'})
     hhid_sorted = hhid_sorted.set_index(['t', 'i'])[['previous_i']]
     hhid_sorted = hhid_sorted.loc[~hhid_sorted.index.duplicated(keep='first')]
     return hhid_sorted
@@ -97,7 +97,7 @@ def harmonized_food_labels(fn='../../_/food_items.org'):
     food_items = pd.read_csv(fn,delimiter='|',skipinitialspace=True,converters={1:int,2:lambda s: s.strip()})
     food_items.columns = [s.strip() for s in food_items.columns]
     food_items = food_items[['Code','Preferred Label']].dropna()
-    food_items.set_index('Code',inplace=True)    
+    food_items = food_items.set_index('Code')
 
     return food_items.to_dict()['Preferred Label']
     
@@ -175,7 +175,7 @@ def harmonized_unit_labels(fn='../../_/unitlabels.csv',key='Label',value='Prefer
     unitlabels = pd.read_csv(fn)
     unitlabels.columns = [s.strip() for s in unitlabels.columns]
     unitlabels = unitlabels[[key,value]].dropna()
-    unitlabels.set_index(key,inplace=True)
+    unitlabels = unitlabels.set_index(key)
     return unitlabels.squeeze().str.strip().to_dict()
 
     
@@ -187,7 +187,7 @@ def food_acquired(fn,myvars):
     if 'year' in myvars:
         #map round code to actual years
         dict = {1:'2008-09', 2:'2010-11', 3:'2012-13', 4:'2014-15'}
-        df.replace({"year": dict},inplace=True)
+        df = df.replace({"year": dict})
         df = df.set_index(['HHID','item','year']).dropna(how='all')
         df.index.names = ['j','i','t']
         try:
@@ -216,10 +216,10 @@ def food_acquired(fn,myvars):
     #df = df.rename(index=harmonized_food_labels(),level='i')
     unitlabels = {0: float("nan"), 'KILOGRAMS':'Kg', 'GRAMS':'Gram', 'LITRE':'Litre', 'MILLILITRE':'Millilitre', 'PIECES':'Piece'}
     unitcolumn = {'unit_ttl_consume': unitlabels, 'unit_purchase': unitlabels, 'unit_own': unitlabels, 'unit_inkind': unitlabels}
-    df.replace(unitcolumn,inplace=True)
+    df = df.replace(unitcolumn)
 
     #fix quantities that are read as categorical vars
-    df.replace(['none', 'NONE', 'hakuna'], 0, inplace = True)
+    df = df.replace(['none', 'NONE', 'hakuna'], 0)
     df = df.astype({"quant_purchase": 'float64',
                     "quant_own" : 'float64',
                     "quant_inkind" : 'float64'})
@@ -276,7 +276,7 @@ def id_match(df, wave, waves_dict):
             uphi = uphi[['UPHI', 'y4_hhid']].dropna()
             m = m.merge(uphi, how= 'left', on = 'y4_hhid')
 
-            m['UPHI'].replace('', np.nan, inplace=True)
+            m['UPHI'] = m['UPHI'].replace('', np.nan)
             m['UPHI'] = m['UPHI'].fillna(m.pop(waves_dict[wave][2]))
             m.j = m.UPHI
             m = m.drop(columns=['UPHI', 'y4_hhid'])
@@ -292,7 +292,7 @@ def id_match(df, wave, waves_dict):
             h = h[[waves_dict[wave][1], waves_dict[wave][2], waves_dict[wave][3]]]
             h[waves_dict[wave][1]] = h[waves_dict[wave][1]].astype(int).astype(str)
             dict = {1:'2008-09', 2:'2010-11', 3:'2012-13', 4:'2014-15'}
-            h.replace({"round": dict},inplace=True)
+            h = h.replace({"round": dict})
             m = df.merge(h.drop_duplicates(), how = 'left', left_on =['j','t'], right_on =[waves_dict[wave][2], waves_dict[wave][3]])
             m['UPHI'] = m['UPHI'].fillna(m.pop('j'))
             m = m.rename(columns={'UPHI': 'j'})
@@ -310,7 +310,7 @@ def new_harmonize_units(df, unit_conversion):
     pattern = r"[p+]"
     for i in range(4):
         df[pair['quant'][i]] = df[pair['quant'][i]].astype(np.int64) * df[pair['unit'][i]]
-        df[pair['quant'][i]].replace('', 0, inplace=True)
+        df[pair['quant'][i]] = df[pair['quant'][i]].replace('', 0)
         if df[pair['quant'][i]].dtype != 'O':
             df[pair['unit'][i]] = 'kg'
         else: 
@@ -320,7 +320,7 @@ def new_harmonize_units(df, unit_conversion):
     df['agg_u'] = df[pair['unit']].apply(lambda x: max(x) if min(x) == max(x) else min(x) + '+' + max(x), axis = 1)
 
     df['unitvalue_purchase'] = df['value_purchase']/df['quant_purchase']
-    df.replace([np.inf, -np.inf, 0], np.nan, inplace=True)
+    df = df.replace([np.inf, -np.inf, 0], np.nan)
     return df
 
 

--- a/lsms_library/countries/Togo/_/togo.py
+++ b/lsms_library/countries/Togo/_/togo.py
@@ -8,7 +8,7 @@ def harmonized_food_labels(fn='../../_/food_items.org'):
     food_items = pd.read_csv(fn,delimiter='|',skipinitialspace=True,converters={1:int,2:lambda s: s.strip()})
     food_items.columns = [s.strip() for s in food_items.columns]
     food_items = food_items[['Code','Preferred Label']].dropna()
-    food_items.set_index('Code',inplace=True)    
+    food_items = food_items.set_index('Code')
 
     return food_items.to_dict()['Preferred Label']
     

--- a/lsms_library/countries/Uganda/2005-06/_/housing.py
+++ b/lsms_library/countries/Uganda/2005-06/_/housing.py
@@ -23,7 +23,7 @@ for k,v in d.items():
         housing[k] = housing[k].apply(v[1])
     except IndexError:
         pass
-housing.set_index('hhid', inplace=True)
+housing = housing.set_index('hhid')
 housing.index.name = 'j'
 
 to_parquet(housing, 'housing.parquet')

--- a/lsms_library/countries/Uganda/2005-06/_/shocks.py
+++ b/lsms_library/countries/Uganda/2005-06/_/shocks.py
@@ -81,6 +81,6 @@ shocks = pd.DataFrame({"i": df.HHID.values.tolist(),
                     "HowCoped1":df.h16q7b.values.tolist(),
                     "HowCoped2":df.h16q7c.values.tolist()})
 shocks.insert(1, 't', '2005-06')
-shocks.set_index(['i','t','Shock'], inplace = True)
+shocks = shocks.set_index(['i','t','Shock'])
 
 to_parquet(shocks, 'shocks.parquet')

--- a/lsms_library/countries/Uganda/2009-10/_/housing.py
+++ b/lsms_library/countries/Uganda/2009-10/_/housing.py
@@ -25,7 +25,7 @@ for k,v in d.items():
     except IndexError:
         pass
 
-housing.set_index('hhid', inplace=True)
+housing = housing.set_index('hhid')
 housing.index.name = 'j'
 
 to_parquet(housing, 'housing.parquet')

--- a/lsms_library/countries/Uganda/2009-10/_/shocks.py
+++ b/lsms_library/countries/Uganda/2009-10/_/shocks.py
@@ -89,6 +89,6 @@ shocks = shocks.astype({'Shock': 'category',
                         }) 
 
 shocks.insert(1, 't', '2009-10')
-shocks.set_index(['i','t','Shock'], inplace = True)
+shocks = shocks.set_index(['i','t','Shock'])
 
 to_parquet(shocks,'shocks.parquet')

--- a/lsms_library/countries/Uganda/2010-11/_/housing.py
+++ b/lsms_library/countries/Uganda/2010-11/_/housing.py
@@ -26,7 +26,7 @@ for k,v in d.items():
     except IndexError:
         pass
 
-housing.set_index('hhid', inplace=True)
+housing = housing.set_index('hhid')
 housing.index.name = 'j'
 
 to_parquet(housing, 'housing.parquet')

--- a/lsms_library/countries/Uganda/2010-11/_/shocks.py
+++ b/lsms_library/countries/Uganda/2010-11/_/shocks.py
@@ -88,6 +88,6 @@ shocks = shocks.astype({'Shock': 'category',
                         }) 
 
 shocks.insert(1, 't', '2010-11')
-shocks.set_index(['i','t','Shock'], inplace = True)
+shocks = shocks.set_index(['i','t','Shock'])
 
 to_parquet(shocks, 'shocks.parquet')

--- a/lsms_library/countries/Uganda/2011-12/_/housing.py
+++ b/lsms_library/countries/Uganda/2011-12/_/housing.py
@@ -25,7 +25,7 @@ for k,v in d.items():
     except IndexError:
         pass
     
-housing.set_index('hhid', inplace=True)
+housing = housing.set_index('hhid')
 housing.index.name = 'j'
 
 to_parquet(housing, 'housing.parquet')

--- a/lsms_library/countries/Uganda/2011-12/_/shocks.py
+++ b/lsms_library/countries/Uganda/2011-12/_/shocks.py
@@ -87,6 +87,6 @@ shocks = shocks.astype({'Shock': 'category',
                         }) 
 
 shocks.insert(1, 't', '2011-12')
-shocks.set_index(['i','t','Shock'], inplace = True)
+shocks = shocks.set_index(['i','t','Shock'])
 
 to_parquet(shocks, 'shocks.parquet')

--- a/lsms_library/countries/Uganda/2013-14/_/housing.py
+++ b/lsms_library/countries/Uganda/2013-14/_/housing.py
@@ -25,7 +25,7 @@ for k,v in d.items():
     except IndexError:
         pass
 
-housing.set_index('hhid', inplace=True)
+housing = housing.set_index('hhid')
 housing.index.name = 'j'
 
 to_parquet(housing, 'housing.parquet')

--- a/lsms_library/countries/Uganda/2013-14/_/shocks.py
+++ b/lsms_library/countries/Uganda/2013-14/_/shocks.py
@@ -56,6 +56,6 @@ shocks = shocks.astype({'Shock': 'category',
                         }) 
 
 shocks.insert(1, 't', '2013-14')
-shocks.set_index(['i','t','Shock'], inplace = True)
+shocks = shocks.set_index(['i','t','Shock'])
 
 to_parquet(shocks, 'shocks.parquet')

--- a/lsms_library/countries/Uganda/2015-16/_/housing.py
+++ b/lsms_library/countries/Uganda/2015-16/_/housing.py
@@ -26,7 +26,7 @@ for k,v in d.items():
     except IndexError:
         pass
 
-housing.set_index('hhid', inplace=True)
+housing = housing.set_index('hhid')
 housing.index.name = 'j'
 
 

--- a/lsms_library/countries/Uganda/2015-16/_/shocks.py
+++ b/lsms_library/countries/Uganda/2015-16/_/shocks.py
@@ -58,6 +58,6 @@ shocks = shocks.astype({'Shock': 'category',
                         }) 
 
 shocks.insert(1, 't', '2015-16')
-shocks.set_index(['i','t','Shock'], inplace = True)
+shocks = shocks.set_index(['i','t','Shock'])
 
 to_parquet(shocks, 'shocks.parquet')

--- a/lsms_library/countries/Uganda/2018-19/_/housing.py
+++ b/lsms_library/countries/Uganda/2018-19/_/housing.py
@@ -26,7 +26,7 @@ for k,v in d.items():
     except IndexError:
         pass
 
-housing.set_index('hhid', inplace=True)
+housing = housing.set_index('hhid')
 housing.index.name = 'j'
 
 to_parquet(housing, 'housing.parquet')

--- a/lsms_library/countries/Uganda/2018-19/_/shocks.py
+++ b/lsms_library/countries/Uganda/2018-19/_/shocks.py
@@ -62,6 +62,6 @@ shocks = shocks.astype({'Shock': 'category',
                         }) 
 
 shocks.insert(1, 't', '2018-19')
-shocks.set_index(['i','t','Shock'], inplace = True)
+shocks = shocks.set_index(['i','t','Shock'])
 
 to_parquet(shocks, 'shocks.parquet')

--- a/lsms_library/countries/Uganda/2019-20/_/housing.py
+++ b/lsms_library/countries/Uganda/2019-20/_/housing.py
@@ -25,7 +25,7 @@ for k,v in d.items():
     except IndexError:
         pass
 
-housing.set_index('hhid', inplace=True)
+housing = housing.set_index('hhid')
 housing.index.name = 'j'
 
 to_parquet(housing, 'housing.parquet')

--- a/lsms_library/countries/Uganda/2019-20/_/shocks.py
+++ b/lsms_library/countries/Uganda/2019-20/_/shocks.py
@@ -57,7 +57,7 @@ shocks = shocks.astype({'Shock': 'category',
 
 shocks.insert(1, 't', '2019-20')
 
-shocks.set_index(['i','t','Shock'], inplace = True)
+shocks = shocks.set_index(['i','t','Shock'])
 
 
 

--- a/lsms_library/countries/Uganda/_/fct_addition.py
+++ b/lsms_library/countries/Uganda/_/fct_addition.py
@@ -45,7 +45,7 @@ def harmonize_nutrient(df):
     #fill NaNs in the "Energy" row with values in "Energy (Atwater General Factors)"
     e1 = "Energy"
     e2 = "Energy (Atwater General Factors)"
-    df.loc[[e1, e2]] = df.loc[[e1, e2]].fillna(method="bfill")
+    df.loc[[e1, e2]] = df.loc[[e1, e2]].bfill()
     
     #rename
     labels = {"Energy" : "Energy",

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -30,7 +30,7 @@ def harmonized_unit_labels(fn='../../_/unitlabels.csv',key='Code',value='Preferr
     unitlabels = pd.read_csv(fn)
     unitlabels.columns = [s.strip() for s in unitlabels.columns]
     unitlabels = unitlabels[[key,value]].dropna()
-    unitlabels.set_index(key,inplace=True)
+    unitlabels = unitlabels.set_index(key)
 
     unitlabels = unitlabels.squeeze().str.strip().to_dict()
 
@@ -41,7 +41,7 @@ def harmonized_food_labels(fn='../../_/food_items.org',key='Code',value='Preferr
     food_items = pd.read_csv(fn,delimiter='|',skipinitialspace=True,converters={1:int,2:lambda s: s.strip()})
     food_items.columns = [s.strip() for s in food_items.columns]
     food_items = food_items[[key,value]].dropna()
-    food_items.set_index(key,inplace=True)
+    food_items = food_items.set_index(key)
 
     return food_items.squeeze().str.strip().to_dict()
 

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -323,7 +323,7 @@ def harmonized_unit_labels(fn: str = '../../_/unitlabels.csv', key: str = 'Code'
     unitlabels = pd.read_csv(fn)
     unitlabels.columns = [s.strip() for s in unitlabels.columns]
     unitlabels = unitlabels[[key,value]].dropna()
-    unitlabels.set_index(key,inplace=True)
+    unitlabels = unitlabels.set_index(key)
 
     return unitlabels.squeeze().str.strip().to_dict()
 
@@ -333,7 +333,7 @@ def harmonized_food_labels(fn: str = '../../_/food_items.org', key: str = 'Code'
     food_items = pd.read_csv(fn,delimiter='|',skipinitialspace=True,converters={1:int,2:lambda s: s.strip()})
     food_items.columns = [s.strip() for s in food_items.columns]
     food_items = food_items[[key,value]].dropna()
-    food_items.set_index(key,inplace=True)
+    food_items = food_items.set_index(key)
 
     return food_items.squeeze().str.strip().to_dict()
 

--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -88,12 +88,12 @@ def conversion_to_kgs(df, price = ['Expenditure'], quantity = 'Quantity', index=
         'gramm': 1 / 1000
     }
     #convert the value type in index level 'u' to be string
-    v.reset_index(unit_col, inplace=True)
+    v = v.reset_index(unit_col)
     if unit_col != 'u':
-        v.rename(columns={unit_col: 'u'}, inplace=True)
+        v = v.rename(columns={unit_col: 'u'})
     v['u'] = v['u'].astype(str)
     v['Kgs'] = v.apply(lambda row: row[quantity] * unit_conversion.get(row['u'].lower(), np.nan), axis=1)
-    v.set_index('u', append=True, inplace=True)
+    v = v.set_index('u', append=True)
     pkg = v[price].divide(v['Kgs'], axis=0)
     pkg = pkg.groupby(index).median().median(axis=1)
     po = v[price].groupby(index + ['u']).median().median(axis=1)


### PR DESCRIPTION
## Summary

- Replace all `inplace=True` usage (68 occurrences across 51 files) with the reassignment pattern (e.g., `df = df.set_index(...)`) — `inplace` is removed in pandas 3.0
- Replace `fillna(method="bfill")` with `.bfill()` in Ethiopia `fct_tools.py` and Uganda `fct_addition.py` — the `method` parameter was removed in pandas 2.0
- Affected countries: CotedIvoire, Ethiopia, GhanaLSS, GhanaSPS, Guatemala, Niger, Nigeria, Panama, Tanzania, Togo, Uganda
- Core files updated: `local_tools.py`, `transformations.py`

## Test plan

- [x] Verified no remaining `inplace=True` in any `.py` file
- [x] Verified no remaining `fillna(method=...)` in any `.py` file
- [x] All runnable unit tests pass (70 passed, 57 skipped due to missing DVC/S3 credentials)
- [ ] Full integration test with DVC data access (requires credentials)

https://claude.ai/code/session_01Sa4pnUnrvuNWxDZrdo1Pxd