### PR TITLE
Upgrade pytest minimum version to ^8.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ version = "0.0.0"
 poetry-dynamic-versioning = { version = ">=1.0.0,<2.0.0", extras = ["plugin"] }
 
 [tool.poetry.group.test.dependencies]
-pytest = "^6.0.0"
+pytest = "^8.0.0"
 ipython = "^9.4.0"
 matplotlib = "^3.10.0"
 


### PR DESCRIPTION
## Summary

- Upgrade `pytest` from `^6.0.0` to `^8.0.0` in `pyproject.toml`
- pytest 6.x is incompatible with the `anyio` pytest plugin, which imports `_pytest.scope` (added in pytest 7), causing test collection to crash with `ModuleNotFoundError: No module named '_pytest.scope'`

## Test plan

- [x] Verified `poetry run pytest` no longer crashes on collection after upgrading
- [x] All runnable tests pass with pytest 8+

https://claude.ai/code/session_01Sa4pnUnrvuNWxDZrdo1Pxd