### PR TITLE
Replace np.isnan() with pd.isna()/pd.notna()

### DIFF
--- a/lsms_library/countries/GhanaLSS/2005-06/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/2005-06/_/mapping.py
@@ -26,8 +26,8 @@ def Birthplace(value):
     '''
     Formatting birthplace variable
     '''
-    if isinstance(value, float) and np.isnan(value):
-        return np.nan
+    if pd.isna(value):
+        return value
     else:
         return value.title()
     

--- a/lsms_library/countries/Senegal/2018-19/_/2018-19.py
+++ b/lsms_library/countries/Senegal/2018-19/_/2018-19.py
@@ -41,8 +41,8 @@ def Birthplace(value):
     '''
     Formatting birthplace variable
     '''
-    if isinstance(value, float) and np.isnan(value):
-        return np.nan
+    if pd.isna(value):
+        return value
     else:
         return value.title()
     

--- a/lsms_library/countries/Uganda/2005-06/_/plots.py
+++ b/lsms_library/countries/Uganda/2005-06/_/plots.py
@@ -5,7 +5,7 @@ sys.path.append('../../../_/')
 from lsms_library.local_tools import df_data_grabber, to_parquet
     
 def intercrop_area(row):
-    if not np.isnan(row['area_percentage']):
+    if pd.notna(row['area_percentage']):
         return row['acres'] * row['area_percentage']/100
     else:
         return row['acres']

--- a/lsms_library/countries/Uganda/2009-10/_/plots.py
+++ b/lsms_library/countries/Uganda/2009-10/_/plots.py
@@ -5,7 +5,7 @@ sys.path.append('../../../_/')
 from lsms_library.local_tools import df_data_grabber, to_parquet
     
 def intercrop_area(row):
-    if not np.isnan(row['area_percentage']):
+    if pd.notna(row['area_percentage']):
         return row['acres'] * row['area_percentage']/100
     else:
         return row['acres']

--- a/lsms_library/countries/Uganda/2010-11/_/plots.py
+++ b/lsms_library/countries/Uganda/2010-11/_/plots.py
@@ -5,7 +5,7 @@ sys.path.append('../../../_/')
 from lsms_library.local_tools import df_data_grabber, to_parquet
     
 def intercrop_area(row):
-    if not np.isnan(row['area_percentage']):
+    if pd.notna(row['area_percentage']):
         return row['acres'] * row['area_percentage']/100
     else:
         return row['acres']

--- a/lsms_library/countries/Uganda/2011-12/_/plots.py
+++ b/lsms_library/countries/Uganda/2011-12/_/plots.py
@@ -5,7 +5,7 @@ sys.path.append('../../../_/')
 from lsms_library.local_tools import df_data_grabber, to_parquet
     
 def intercrop_area(row):
-    if not np.isnan(row['area_percentage']):
+    if pd.notna(row['area_percentage']):
         return row['acres'] * row['area_percentage']/100
     else:
         return row['acres']

--- a/lsms_library/countries/Uganda/2013-14/_/plots.py
+++ b/lsms_library/countries/Uganda/2013-14/_/plots.py
@@ -5,7 +5,7 @@ sys.path.append('../../../_/')
 from lsms_library.local_tools import df_data_grabber, to_parquet
     
 def intercrop_area(row):
-    if not np.isnan(row['area_percentage']):
+    if pd.notna(row['area_percentage']):
         return row['acres'] * row['area_percentage']/100
     else:
         return row['acres']

--- a/lsms_library/countries/Uganda/2015-16/_/plots.py
+++ b/lsms_library/countries/Uganda/2015-16/_/plots.py
@@ -5,7 +5,7 @@ sys.path.append('../../../_/')
 from lsms_library.local_tools import df_data_grabber, to_parquet
     
 def intercrop_area(row):
-    if not np.isnan(row['area_percentage']):
+    if pd.notna(row['area_percentage']):
         return row['acres'] * row['area_percentage']/100
     else:
         return row['acres']

--- a/lsms_library/countries/Uganda/2018-19/_/plots.py
+++ b/lsms_library/countries/Uganda/2018-19/_/plots.py
@@ -5,7 +5,7 @@ sys.path.append('../../../_/')
 from lsms_library.local_tools import df_data_grabber, to_parquet
     
 def intercrop_area(row):
-    if not np.isnan(row['area_percentage']):
+    if pd.notna(row['area_percentage']):
         return row['acres'] * row['area_percentage']/100
     else:
         return row['acres']

--- a/lsms_library/countries/Uganda/2019-20/_/plots.py
+++ b/lsms_library/countries/Uganda/2019-20/_/plots.py
@@ -5,7 +5,7 @@ sys.path.append('../../../_/')
 from lsms_library.local_tools import df_data_grabber, to_parquet
     
 def intercrop_area(row):
-    if not np.isnan(row['area_percentage']):
+    if pd.notna(row['area_percentage']):
         return row['acres'] * row['area_percentage']/100
     else:
         return row['acres']


### PR DESCRIPTION
## Summary

- Replace `np.isnan()` with `pd.isna()` and `not np.isnan()` with `pd.notna()` across 10 files
- `np.isnan()` raises `TypeError` on `pd.NA` values (used by pandas 3.0 nullable/Arrow-backed dtypes)
- `pd.isna()`/`pd.notna()` handle both `np.nan` and `pd.NA` correctly
- Also fixes `isinstance(value, float) and np.isnan(value)` pattern in Senegal and GhanaLSS mapping files, which would miss `pd.NA` (not a float)

**Files changed:**
- 8 Uganda `plots.py` files (2005-2019)
- `Senegal/2018-19/_/2018-19.py`
- `GhanaLSS/2005-06/_/mapping.py`

## Test plan

- [x] Verified no remaining `np.isnan` in any `.py` file
- [ ] Integration tests with DVC data access

https://claude.ai/code/session_01Sa4pnUnrvuNWxDZrdo1Pxd