### PR TITLE
Fix Copy-on-Write patterns and add pandas 3.0 guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,3 +32,13 @@ New surveys are added via YAML config files under `lsms_library/countries/`, not
 
 ## Data Access
 Underlying microdata must be obtained from the [World Bank Microdata Library](https://microdata.worldbank.org/) under their terms of use. Contributors need GPG/PGP keys for repository write access.
+
+## Pandas Conventions (>=3.0)
+This codebase targets pandas 3.0+. Follow these rules in all new and modified code:
+
+- **No `inplace=True`**: Use `df = df.set_index(...)` instead of `df.set_index(..., inplace=True)`. The `inplace` parameter is removed in pandas 3.0.
+- **Use `pd.NA`, not `np.nan`, for missing values in string columns**: Pandas 3.0 defaults to `StringDtype` (PyArrow-backed) where `np.nan` is not a valid sentinel. Use `pd.NA` when replacing/filling missing values in string, ID, or categorical columns (e.g., `.replace('', pd.NA)`, `.replace('nan', pd.NA)`). `np.nan` is still fine for numeric (float) columns.
+- **Use `pd.isna()` / `pd.notna()`, not `np.isnan()`**: `np.isnan()` raises `TypeError` on `pd.NA`. The pandas functions handle both `np.nan` and `pd.NA`.
+- **Use `.bfill()` / `.ffill()`, not `.fillna(method=...)`**: The `method` parameter was removed in pandas 2.0.
+- **No chained indexing for writes**: Copy-on-Write (CoW) is default in pandas 3.0. `df[mask]['col'] = val` silently fails. Use `df.loc[mask, 'col'] = val` instead. For reads, prefer `df.loc[mask, 'col'].iloc[0]` over `df.loc[mask, :]['col'][0]`.
+- **No mutating views**: Do not modify DataFrames obtained from `_get_numeric_data()`, `select_dtypes()`, or `groupby()` and expect changes to propagate. Work on `df` directly or assign results back explicitly.

--- a/lsms_library/countries/Ethiopia/_/fct_tools.py
+++ b/lsms_library/countries/Ethiopia/_/fct_tools.py
@@ -14,7 +14,7 @@ def nutrient_df(df, apikey):
     count = 0
     for food in df["Preferred Label"].tolist():
         try:
-            FDC = df.loc[df["Preferred Label"] ==food,:]["FDC ID"][count]
+            FDC = df.loc[df["Preferred Label"] == food, "FDC ID"].iloc[0]
             count+=1
             D[food] = fdc.nutrients(apikey,FDC).Quantity
         except AttributeError:
@@ -23,14 +23,14 @@ def nutrient_df(df, apikey):
     D = pd.DataFrame(D,dtype=float)
 
     return D
-    
+
 #create a DataFrame of units of nutrients of food items
 def unit_df(df, apikey):
     D = {}
     count = 0
     for food in df["Preferred Label"].tolist():
         try:
-            FDC = df.loc[df["Preferred Label"] ==food,:]["FDC ID"][count]
+            FDC = df.loc[df["Preferred Label"] == food, "FDC ID"].iloc[0]
             count+=1
             D[food] = fdc.nutrients(apikey,FDC).Units
         except AttributeError:

--- a/lsms_library/countries/GhanaLSS/_/ghanalss.py
+++ b/lsms_library/countries/GhanaLSS/_/ghanalss.py
@@ -312,11 +312,12 @@ def change_id(x,fn=None,id0=None,id1=None,transform_id1=None):
 
 def concate_id(df, parta, partb, leading_zero = False, digit = None):
     df = df.replace('', pd.NA)
-    df.loc[df[parta].isna(), partb] = np.nan
-    df.loc[df[partb].isna(), parta] = np.nan
+    df.loc[df[parta].isna(), partb] = pd.NA
+    df.loc[df[partb].isna(), parta] = pd.NA
     if leading_zero and digit != None:
         df['newid'] = df[parta].astype('Int64').astype(str) + df[partb].astype('Int64').astype(str).str.zfill(digit)
     else:
         df['newid'] = df[parta].astype('Int64').astype(str) + df[partb].astype('Int64').astype(str)
-    df['newid'] = df['newid'].replace(df[df[parta].isna()]['newid'][0], pd.NA)
+    na_id = df.loc[df[parta].isna(), 'newid'].iloc[0]
+    df['newid'] = df['newid'].replace(na_id, pd.NA)
     return df['newid']

--- a/lsms_library/countries/Panama/2008/_/food_acquired.py
+++ b/lsms_library/countries/Panama/2008/_/food_acquired.py
@@ -25,9 +25,9 @@ df = df.rename({'hogar': 'j', 'producto':'i', 's11a6a':'quantity bought', 's11a6
 cat_columns = df.iloc[:, 2:].select_dtypes(['category']).columns
 df[cat_columns] = df[cat_columns].apply(lambda x: x.cat.codes)
 df = df.replace({-1: np.nan})
-val = df._get_numeric_data()
-val[val >= 99999] = np.nan
-val[val == 0] = np.nan
+num_cols = df.select_dtypes(include=[np.number]).columns
+df[num_cols] = df[num_cols].where(df[num_cols] < 99999)
+df[num_cols] = df[num_cols].where(df[num_cols] != 0)
 
 food_items = df_from_orgfile('../../_/food_items.org')
 food_items = food_items.loc[:, ['Preferred Label', t]]


### PR DESCRIPTION
## Summary

- Fix Copy-on-Write (CoW) incompatible patterns that silently fail or raise errors in pandas 3.0
- Add pandas 3.0 coding conventions to `CLAUDE.md` to prevent regressions

### CoW fixes:
- **Panama/2008 `food_acquired.py`**: Replaced `_get_numeric_data()` view mutation (`val[val >= 99999] = np.nan`) with `.where()` on column subset — view mutations silently fail under CoW
- **GhanaLSS `ghanalss.py`**: Replaced chained indexing `df[mask]['col'][0]` with `df.loc[mask, 'col'].iloc[0]`, and `np.nan` → `pd.NA` for string column assignments
- **Ethiopia `fct_tools.py`**: Replaced chained indexing `df.loc[mask, :]["col"][n]` with `df.loc[mask, "col"].iloc[0]`

### CLAUDE.md additions:
Six pandas 3.0 rules documented: no `inplace`, `pd.NA` for strings, `pd.isna()` not `np.isnan()`, `.bfill()`/`.ffill()`, no chained indexing writes, no view mutations.

## Test plan

- [x] All 49 runnable unit tests pass
- [ ] Full data pipeline test with DVC materialization

https://claude.ai/code/session_01Sa4pnUnrvuNWxDZrdo1Pxd