### PR TITLE
Fix CI: skip data-dependent test when LSMS_SKIP_AUTH is set

### DIFF
--- a/tests/test_wave_getattr.py
+++ b/tests/test_wave_getattr.py
@@ -13,6 +13,7 @@ Related issues:
 - Regression fix: commit 0cdde86e
 """
 from dataclasses import dataclass, field
+import os
 
 import pytest
 
@@ -154,6 +155,10 @@ def test_wave_recursion_flag_cleanup():
     assert '_in_getattr' not in wave.__dict__
 
 
+@pytest.mark.skipif(
+    os.getenv("LSMS_SKIP_AUTH", "").lower() in {"1", "true", "yes"},
+    reason="Requires DVC data access (LSMS_SKIP_AUTH is set)",
+)
 def test_fallback_path_uses_wave_data_scheme():
     """Test that the fallback path at country.py:987 works.
 


### PR DESCRIPTION
## Summary

- Skip `test_fallback_path_uses_wave_data_scheme` when `LSMS_SKIP_AUTH=1`
- This test triggers DVC data downloads that hang indefinitely without S3 credentials, causing the CI `unit-tests` job to time out after 3 minutes
- The `data-tests` job (which has credentials) still exercises this code path

## Test plan

- [x] Full suite: 140 passed, 137 skipped, 0 failed in ~5 seconds with `LSMS_SKIP_AUTH=1`
- [x] Test correctly skips in no-credentials environment

https://claude.ai/code/session_01Sa4pnUnrvuNWxDZrdo1Pxd