### PR TITLE
Fix food_prices derivation for Malawi (and similar countries)

### DIFF
--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -112,19 +112,39 @@ def conversion_to_kgs(df, price = ['Expenditure'], quantity = 'Quantity', index=
 # used by the transformation functions below.
 _COLUMN_ALIASES = {
     'value_purchase': 'Expenditure',
+    'expenditure': 'Expenditure',
     'quant_ttl_consume': 'Quantity',
+    'quantity_consumed': 'Quantity',
     'quant_purchase': 'Quantity',  # fallback if quant_ttl_consume absent
 }
 
+# Column names that should be promoted to the 'u' index level
+_UNIT_COLUMN_ALIASES = ['u', 'units', 'u_consumed', 'unit']
+
 
 def _normalize_columns(df):
-    """Rename legacy food_acquired columns to canonical names if needed."""
+    """Rename legacy food_acquired columns to canonical names if needed.
+
+    Also promotes a unit column to the 'u' index level when 'u' is not
+    already in the index.
+    """
     renames = {}
     for old, new in _COLUMN_ALIASES.items():
         if new not in df.columns and old in df.columns and new not in renames.values():
             renames[old] = new
     if renames:
         df = df.rename(columns=renames)
+
+    # Promote unit column to 'u' index level if not already present
+    if 'u' not in df.index.names:
+        for col in _UNIT_COLUMN_ALIASES:
+            if col in df.columns:
+                df = df.rename(columns={col: 'u'}).set_index('u', append=True)
+                break
+            elif col in df.index.names and col != 'u':
+                df.index = df.index.rename({col: 'u'})
+                break
+
     return df
 
 KNOWN_METRIC = {
@@ -229,7 +249,7 @@ def food_prices_from_acquired(df):
     v = v[['price_per_kg']].replace([0, np.inf, -np.inf], np.nan).dropna()
 
     idx_names = list(v.index.names)
-    group_by = [n for n in ['t', 'v', 'j'] if n in idx_names]
+    group_by = [n for n in ['t', 'v', 'm', 'i'] if n in idx_names]
 
     p = v.groupby(group_by).median()
     p = p.rename(columns={'price_per_kg': 'Price'})


### PR DESCRIPTION
## Summary

Fixes `KeyError: 'Level t not found'` when building Malawi food_prices (#95). Three changes to `transformations.py`:

1. **Add column aliases** for Malawi naming conventions (`expenditure` → `Expenditure`, `quantity_consumed` → `Quantity`)
2. **Auto-promote unit columns to index**: Malawi's wave-level food_acquired has units as a column (`u_consumed`) rather than an index level `u`. The normalization now detects columns like `u_consumed`, `units`, `unit` and promotes them to the `u` index level, enabling kg conversion.
3. **Fix `food_prices_from_acquired` groupby**: Was grouping by `['t', 'v', 'j']` (period × household) — should be `['t', 'v', 'm', 'i']` (period × market × food item) to compute median prices across households.

## Verified

```python
>>> c = ll.Country('Malawi', trust_cache=True)
>>> c.food_prices()
# Shape: (47855, 1), Index: ['i', 't', 'm']
>>> c.food_expenditures()
# Shape: (682025, 1), Index: ['i', 't', 'j']
```

## Test plan

- [x] 49 unit tests pass
- [x] `Country('Malawi').food_prices()` returns valid data (was crashing before)
- [x] `Country('Malawi').food_expenditures()` returns valid data
- [x] Prices correctly grouped by period × market × food item

Closes #95

https://claude.ai/code/session_01Sa4pnUnrvuNWxDZrdo1Pxd