### PR TITLE
Add Peru categorical mappings and fix 1994 data_info.yml

### DIFF
--- a/lsms_library/countries/Peru/1994/_/data_info.yml
+++ b/lsms_library/countries/Peru/1994/_/data_info.yml
@@ -6,66 +6,44 @@ cluster_features:
     idxvars:
         v: segmento
     myvars:
-        Region: a02
+        Region: a01
         Rural: a06
-
+    mappings:
+        Region: DPTO
+        Rural: AREA
 
 household_roster:
-    file: ehcvm_individu_mli2021.dta
-    idxvars:
-        v: grappe
-        i: 
-            - grappe
-            - menage
-        pid:
-            - grappe
-            - menage 
-            - numind
-    myvars:
-        Sex: sexe
-        Age: age
-        Relationship: lien
-
-food_acquired:
-    file: s07b_me_mli2021.dta
-    idxvars:
-        v: grappe
-        visit: vague
-        i: 
-            - grappe
-            - menage
-        j: s07bq01
-        u: s07bq03b
-    myvars:
-        Quantity: s07bq03a
-        Expenditure: s07bq08
-        Produced: s07bq04
-
-individual_education:
-    file: ehcvm_individu_mli2021.dta
-    idxvars:
-        v: grappe
-        i: 
-            - grappe
-            - menage
-        pid:
-            - grappe
-            - menage 
-            - numind
-    myvars:
-        Educational Attainment: 'educ_hi'
-
-interview_date:
-    file: s00_me_mli2021.dta
-    idxvars:
-        v: grappe
-        visit: vague
-        i: 
-            - grappe
-            - menage
-    myvars:
-        Int_t: s00q23a
-
-
-
-
+    dfs:
+        - df_roster
+        - df_cluster
+    df_roster:
+        file: REG02.DTA
+        idxvars:
+            i:
+                - segmento
+                - vivienda
+                - hogar
+            pid: b00
+        myvars:
+            Sex: b02
+            Age: b03
+            Relationship: b01
+    df_cluster:
+        file: REG01.DTA
+        idxvars:
+            i:
+                - segmento
+                - vivienda
+                - hogar
+        myvars:
+            v: segmento
+    merge_on:
+        - i
+    final_index:
+        - t
+        - v
+        - i
+        - pid
+    mappings:
+        Sex: Sex
+        Relationship: Relationship

--- a/lsms_library/countries/Peru/_/categorical_mapping.org
+++ b/lsms_library/countries/Peru/_/categorical_mapping.org
@@ -1,0 +1,101 @@
+Categorical mappings for Peru ENNIV surveys.
+
+Value labels sourced from the 1991 ENNIV "Diccionario de Variables"
+(DICCIONA.ASC), verified against 1994 frequency distributions.
+Codes are consistent across waves (1985, 1990, 1991, 1994).
+
+* Relationship
+
+#+name: Relationship
+| Code | Preferred Label        |
+|------+------------------------|
+|    0 | Persona no pariente    |
+|    1 | Jefe                   |
+|    2 | Conyuge                |
+|    3 | Hijo/a                 |
+|    4 | Yerno/Nuera            |
+|    5 | Nieto/a                |
+|    6 | Padre/Suegro           |
+|    7 | Otro pariente          |
+|    8 | Trabajador domestico   |
+|    9 | Pensionista            |
+
+* Sex
+
+#+name: Sex
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | M               |
+|    2 | F               |
+
+* Marital Status
+
+#+name: EST-CIVIL
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Conviviente     |
+|    2 | Casado/a        |
+|    3 | Viudo/a         |
+|    4 | Divorciado/a    |
+|    5 | Separado/a      |
+|    6 | Soltero/a       |
+
+* Language
+
+#+name: LENGUA
+| Code | Preferred Label    |
+|------+--------------------|
+|    1 | Castellano         |
+|    2 | Quechua            |
+|    3 | Aymara             |
+|    4 | Otra lengua nativa |
+|    5 | Ingles             |
+|    6 | Otro extranjero    |
+|    7 | No habla           |
+
+* Area
+
+#+name: AREA
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Urbano          |
+|    2 | Rural           |
+
+* Yes/No
+
+#+name: SI_NO
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Si              |
+|    2 | No              |
+
+* Department
+
+#+name: DPTO
+| Code | Preferred Label |
+|------+-----------------|
+|   01 | Amazonas        |
+|   02 | Ancash          |
+|   03 | Apurimac        |
+|   04 | Arequipa        |
+|   05 | Ayacucho        |
+|   06 | Cajamarca       |
+|   07 | Callao          |
+|   08 | Cusco           |
+|   09 | Huancavelica    |
+|   10 | Huanuco         |
+|   11 | Ica             |
+|   12 | Junin           |
+|   13 | La Libertad     |
+|   14 | Lambayeque      |
+|   15 | Lima            |
+|   16 | Loreto          |
+|   17 | Madre de Dios   |
+|   18 | Moquegua        |
+|   19 | Pasco           |
+|   20 | Piura           |
+|   21 | Puno            |
+|   22 | San Martin      |
+|   23 | Tacna           |
+|   24 | Tumbes          |
+|   25 | Ucayali         |


### PR DESCRIPTION
## Summary
- Created `categorical_mapping.org` for Peru with value labels for all coded variables (relationship, sex, marital status, language, urban/rural, department codes), sourced from the 1991 ENNIV codebook and validated against 1994 frequency distributions
- Fixed 1994 `data_info.yml` which incorrectly referenced Mali EHCVM files; now points to actual Peru data files (`REG01.DTA`, `REG02.DTA`) with correct column mappings
- Addresses #28: Peru .DTA files are old Stata 5 format that genuinely lack embedded value labels

## Test plan
- [ ] Verify `categorical_mapping.org` labels are correctly applied when loading Peru 1994 data
- [ ] Verify `cluster_features` reads Region/Rural from REG01.DTA with DPTO/AREA mappings
- [ ] Verify `household_roster` correctly joins `v` from REG01.DTA and maps Sex/Relationship labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)