### PR TITLE
Auto-commit DVC lockfile updates on master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,15 @@ jobs:
           LSMS_SKIP_AUTH: "1"
         run: poetry run pytest
 
-  # DVC lockfile freshness — runs on all branches but does not block PRs.
+  # DVC lockfile freshness — detect stale lockfiles and auto-commit fixes.
   # Core library changes (country.py, local_tools.py) dirty every country's
-  # lockfile even when outputs are unchanged; a full rebuild requires S3
-  # data access and 20+ minutes.  Keep this advisory so it doesn't block
-  # routine development.
+  # lockfile even when outputs are unchanged.  The refresh job uses
+  # `dvc commit` to update dep hashes without re-running pipelines.
   dvc-lock-check:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
+    outputs:
+      is_dirty: ${{ steps.check.outputs.is_dirty }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -41,9 +42,52 @@ jobs:
       - name: Install dependencies
         run: poetry install
       - name: Verify DVC lockfiles
+        id: check
         env:
           LSMS_SKIP_AUTH: "1"
-        run: poetry run python -m lsms_library.cli refresh-dvc-locks --all --check
+        run: |
+          if poetry run python -m lsms_library.cli refresh-dvc-locks --all --check; then
+            echo "is_dirty=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_dirty=true" >> "$GITHUB_OUTPUT"
+          fi
+        # Don't fail the job — the refresh job below will fix it
+        continue-on-error: true
+
+  # Auto-refresh stale DVC lockfiles by updating dep hashes (no pipeline re-run).
+  refresh-dvc-locks:
+    runs-on: ubuntu-latest
+    needs: dvc-lock-check
+    if: needs.dvc-lock-check.outputs.is_dirty == 'true'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need a token that can push back to the repo
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Install dependencies
+        run: poetry install
+      - name: Refresh lockfile hashes
+        env:
+          LSMS_SKIP_AUTH: "1"
+        run: poetry run python -m lsms_library.cli refresh-dvc-locks --all --commit-only
+      - name: Commit and push updated lockfiles
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add lsms_library/countries/*/dvc.lock
+          if git diff --cached --quiet; then
+            echo "No lockfile changes to commit."
+          else
+            git commit -m "ci: refresh DVC lockfiles (dep hashes only)"
+            git push
+          fi
 
   # Build and deploy documentation to GitHub Pages
   docs:

--- a/lsms_library/cli.py
+++ b/lsms_library/cli.py
@@ -450,6 +450,12 @@ def refresh_dvc_locks(
         "--check/--update",
         help="Only verify that lockfiles are up to date (no repro runs).",
     ),
+    commit_only: bool = typer.Option(
+        False,
+        "--commit-only",
+        help="Update lockfile hashes with `dvc commit` (no pipeline re-run). "
+        "Use when deps changed but outputs are still valid.",
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run/--execute",
@@ -505,6 +511,29 @@ def refresh_dvc_locks(
         if dirty:
             raise typer.Exit(1)
         typer.echo("All requested lockfiles are up to date.")
+        return
+
+    if commit_only:
+        for name, dvc_file in targets:
+            rel = dvc_file.relative_to(countries_dir).as_posix()
+            status = _collect_dvc_status(rel, countries_dir)
+            if not status:
+                typer.echo(f"[CLEAN] {name}")
+                continue
+            stage_ref = f"{rel}:materialize"
+            cmd = ["commit", "--force", stage_ref]
+            preview = " ".join(["dvc", *cmd])
+            typer.echo(f"[COMMIT] {name}: {preview}")
+            if dry_run:
+                continue
+            subprocess.run(
+                _dvc_cmd(*cmd),
+                cwd=countries_dir,
+                check=True,
+                stdout=sys.stderr,
+                stderr=sys.stderr,
+            )
+            typer.echo(f"[DONE] {name}")
         return
 
     for name, dvc_file in targets:


### PR DESCRIPTION
## Summary
This PR adds automated detection and fixing of stale DVC lockfiles on the master branch. When dependency hashes change but pipeline outputs remain valid, the CI now automatically updates lockfiles using `dvc commit` and pushes the changes back to the repository.

## Key Changes

- **Enhanced `dvc-lock-check` job**: Modified to detect stale lockfiles and output a flag (`is_dirty`) indicating whether updates are needed, without blocking the workflow
- **New `refresh-dvc-locks` job**: Added a conditional job that runs only when lockfiles are detected as stale. It:
  - Uses the new `--commit-only` flag to update dependency hashes without re-running pipelines
  - Automatically commits and pushes changes with a descriptive message
  - Runs only on the master branch with appropriate git credentials
- **New `--commit-only` CLI option**: Added to `refresh_dvc_locks` command to update lockfile hashes via `dvc commit` when dependencies change but outputs are still valid, avoiding expensive pipeline re-runs
- **Updated documentation**: Clarified in comments that core library changes dirty lockfiles even when outputs are unchanged, and that the refresh job efficiently handles this scenario

## Implementation Details

- The check step uses `continue-on-error: true` to allow the workflow to proceed even when lockfiles are stale
- The refresh job conditionally runs based on the `is_dirty` output from the check job
- Git commits are made by the `github-actions[bot]` user with appropriate configuration
- The implementation safely handles cases where no changes need to be committed

https://claude.ai/code/session_01EqvyzE6EX4oS1oBvjM8KQt