### PR TITLE
Implement Layer 1 DVC blob caching with sidecar pre-check

### DIFF
--- a/docs/guide/caching.md
+++ b/docs/guide/caching.md
@@ -3,72 +3,163 @@
 ## How Caching Works
 
 When you call a table method (e.g. `uga.food_expenditures()`), the library
-reads the relevant source files, harmonizes them, and writes the result as a
-Parquet file under `data_root()`. Subsequent calls **within the same Python
-session** are faster because Country-level ancillary lookups (sample weights,
-panel IDs, market index) are cached in memory and the operating system keeps
-recently-read source files in its page cache.
+reads the relevant raw data files, harmonizes them, and writes the result
+as a Parquet file under `data_root()`. Subsequent calls in the same
+process return immediately from in-memory state; subsequent calls in a
+fresh process read the Parquet directly without re-running the
+harmonization. The raw `.dta` blobs themselves are also cached locally,
+so cold rebuilds (e.g. after editing a wave's `data_info.yml`) don't have
+to re-download from S3.
 
 ```python
+import lsms_library as ll
 uga = ll.Country('Uganda')
 
-# First call: builds from source (seconds to minutes depending on country)
+# First call: builds from source (10s of seconds to minutes depending on country)
 hh = uga.household_characteristics()
 
-# Subsequent calls in the same session: faster via in-memory state
+# Subsequent calls in the same session: in-memory state, ~0 cost
 hh = uga.household_characteristics()
 ```
 
-## Cross-Session Behavior (Important)
+## Two Cache Layers
 
-As of v0.6.0 the across-session read path for the Parquet cache is inconsistent:
+The library maintains two independent caches, both rooted under
+`data_root()`:
 
-- Countries that use the DVC materialize-stage pipeline --- Uganda, Senegal,
-  Malawi, Togo, Kazakhstan, Serbia, GhanaLSS --- reload their cached Parquets
-  on the next session via DVC's stage-status check.
-- Other countries rebuild from source on every new session, even when a
-  fresh Parquet is sitting in the cache directory. This is a known gap and
-  the subject of the v0.7.0 release.
+| Layer | Path | Content | Populated by | Read by |
+|---|---|---|---|---|
+| **Layer 2 (parquet)** | `~/.local/share/lsms_library/{Country}/var/{table}.parquet` | Per-table harmonized output, ready for analysis | `Country.{table}()` after building from waves | The v0.7.0 top-of-function cache read in `load_dataframe_with_dvc` (`country.py:1611-1652`) |
+| **Layer 1 (DVC blobs)** | `~/.local/share/lsms_library/dvc-cache/{md5[:2]}/{md5[2:]}` | Content-addressed copies of the raw `.dta` files (and other DVC-tracked sources) | `_ensure_dvc_pulled()` in `local_tools.py` calls `Repo.fetch` on first read of any DVC-tracked file | `DVCFS.open()` via `DataFileSystem._get_fs_path`'s `typ == "cache"` branch |
 
-**v0.7.0** adds a uniform "read cache if present" layer so every country
-benefits from the cache across sessions, plus an `LSMS_NO_CACHE=1` environment
-variable for contributors editing source data who need to force rebuilds.
-**v0.8.0** adds content-hash invalidation so that editing a wave's config or
-source file correctly invalidates only the affected tables.
+Both layers live under the same root, so a single `LSMS_DATA_DIR`
+environment variable moves them together. On a shared cluster, set
+`LSMS_DATA_DIR=/shared/...` and every user gets the same warm caches.
 
-Until v0.7.0 ships, the `trust_cache=True` option (below) is the most
-reliable way to force a fast cache read regardless of country, provided you
-know the cache is fresh.
+### How they interact
+
+The fast path on warm reads is Layer 2 alone: the v0.7.0 top-of-function
+read in `load_dataframe_with_dvc` returns the harmonized parquet without
+ever touching DVC. All-warm calls finish in ~0.5 s regardless of how
+many raw files the country has.
+
+When Layer 2 is cold (e.g. after editing a `data_info.yml` and clearing
+the parquet cache), the library re-runs wave aggregation. Each wave
+script calls `get_dataframe()` for its raw `.dta` files; on a cache hit
+the file is served from Layer 1's local copy via `DVCFS.open()`, on a
+miss `_ensure_dvc_pulled` runs `Repo.fetch` to populate the cache and
+then `DVCFS.open` reads from it. After the first cold rebuild, Layer 1
+stays warm across sessions, so the next L2 rebuild doesn't need any
+S3 traffic.
+
+Empirical numbers on a Linux workstation, Niger `household_roster`
+(~10 raw `.dta` files):
+
+| Scenario | Time | What's running |
+|---|---|---|
+| Truly cold (no caches) | ~600 s | First-ever fetch, every blob from S3, full DVC index build |
+| Cold-cold (L1 + L2 both empty) | 460-510 s | Per-file `Repo.fetch` (~11 s each) + harmonization + parquet write |
+| **L2-cold L1-warm** | **~70 s** | Sidecar pre-check finds blobs in cache, no S3 traffic, harmonization + parquet write only |
+| All-warm (L2 hit) | ~0.5 s | v0.7.0 top read returns the parquet directly |
+
+The interesting row is L2-cold L1-warm: ~7× faster than cold-cold,
+because the per-file `Repo.fetch` overhead and the S3 round-trips are
+both gone.
+
+## Cross-Session Behavior
+
+As of v0.7.0, the library reads `{data_root}/{Country}/var/{table}.parquet`
+unconditionally at the top of `load_dataframe_with_dvc`
+(`lsms_library/country.py:1611-1652`) when the file exists. Every country
+benefits from this; there is no longer a special-case for the seven
+DVC-stage countries.
+
+**There is no automatic staleness check.** When you edit a wave's
+`data_info.yml`, a `_/{table}.py` script, or some other source, the
+library cannot tell that the source changed. Two ways to invalidate:
+
+- Set `LSMS_NO_CACHE=1` for the session — this skips the v0.7.0 top read
+  and forces a Layer 2 rebuild from source.
+- Run `lsms-library cache clear --country {Country}` (optionally with
+  `--method {table}`) to evict the affected parquet before the next call.
+
+Either way, the rebuild reads from Layer 1 (the DVC blob cache) where
+possible, so you only pay the S3 cost once per blob per machine.
+
+Content-hash invalidation that automatically detects edits to
+`data_info.yml` and `_/{table}.py` is planned for v0.8.0.
 
 ## Cache Location
 
-Cached files are stored under the user data directory:
+Both layers are under the user data directory:
 
-- **Linux**: `~/.local/share/lsms_library/{country}/var/{dataset}.parquet`
+- **Linux**: `~/.local/share/lsms_library/`
+  - Layer 2: `{Country}/var/{dataset}.parquet`
+  - Layer 1: `dvc-cache/{md5[:2]}/{md5[2:]}` (DVC 2.x layout) or
+    `dvc-cache/files/md5/{md5[:2]}/{md5[2:]}` (DVC 3.x layout)
 - **macOS**: `~/Library/Application Support/lsms_library/...`
 - **Windows**: `%LOCALAPPDATA%/lsms_library/...`
 
-Override with the `LSMS_DATA_DIR` environment variable or the `data_dir` key
-in `~/.config/lsms_library/config.yml`. The env var takes precedence.
+Override with the `LSMS_DATA_DIR` environment variable or the `data_dir`
+key in `~/.config/lsms_library/config.yml`. The env var takes precedence.
+
+The library handles both DVC cache layouts because legacy `.dvc` sidecars
+in the `countries/` repo carry `md5-dos2unix` hashes from before the DVC
+3.0 cutover and write to the flat layout, while newer sidecars use the
+`files/md5/` subpath. Users don't need to think about this; the
+sidecar pre-check in `_ensure_dvc_pulled` looks at both locations.
+
+## The package tree never contains DVC-tracked data
+
+This is a hard architectural rule: the package source tree
+(`lsms_library/countries/`) holds code, configs, and `.dvc` sidecars
+only. Tracked data files live in the Layer 1 cache under `data_root()`,
+not in the workspace.
+
+`_ensure_dvc_pulled` calls `Repo.fetch` (not `Repo.pull`) to populate
+the cache without checking files out into the package tree. And
+`local_file()` inside `get_dataframe` refuses to use any workspace copy
+of a file that has a sister `.dvc` sidecar — if it finds one, it emits
+a `UserWarning` with a cleanup command and falls through to the DVC
+cache path.
+
+If you see warnings like:
+
+> Refusing workspace copy of DVC-tracked file ... (sister .dvc sidecar
+> exists). The package tree must not contain DVC-tracked data; falling
+> through to the DVC cache path. Clean up with: `find lsms_library/countries -type f -name '*.dta' -execdir test -e '{}.dvc' \; -print -delete`
+
+it means your dev checkout has leftover `.dta` files from a prior
+`dvc pull` (or from an older version of the library that did
+`Repo.pull` instead of `Repo.fetch`). Run the cleanup command to
+remove them. The cache under `data_root()` already has the same
+content; the warnings will stop and reads will use the canonical
+cache path.
 
 ## Trust Cache Mode
-
-On clusters (or any host) where pre-built Parquet files already exist and you
-know they reflect current source data, skip validation entirely:
 
 ```python
 uga = ll.Country('Uganda', trust_cache=True)
 ```
 
-This reads the cached Parquet directly with no staleness check and no
-attempt to invalidate. If a requested Parquet is missing, the usual build
-path runs automatically. **Do not use `trust_cache=True`** after editing
-source data or a wave's configuration unless you have cleared the affected
-caches first --- you will silently get stale results.
+With v0.7.0 in place, `trust_cache=True` is mostly redundant with the
+default behavior. It remains useful as a stricter bypass that skips even
+the `LSMS_NO_CACHE` check.
+
+What `trust_cache=True` does **not** skip: `_finalize_result`. Kinship
+expansion, canonical spelling normalization, dtype coercion, and the
+`_join_v_from_sample` augmentation all still apply on read. The returned
+DataFrame is **not** byte-identical to the on-disk parquet — the parquet
+is closer to the raw source data, and `_finalize_result` is the
+harmonization layer applied at every read.
+
+**Do not use `trust_cache=True`** after editing source data or a wave's
+configuration unless you have cleared the affected caches first — you
+will silently get stale results.
 
 ## Managing Cache
 
-Use the CLI to inspect or clear cached files:
+Use the CLI to inspect or clear cached parquets:
 
 ```bash
 # List cached datasets
@@ -84,6 +175,43 @@ lsms-library cache clear --all --dry-run
 When contributing changes to a wave's `data_info.yml` or `_/{table}.py`,
 clear the affected country's cache before rebuilding so the next call
 actually reads your new source data rather than an older cached parquet.
+The Layer 1 blob cache stays populated either way, so the rebuild won't
+re-fetch from S3.
+
+To clear the Layer 1 blob cache too (rarely needed):
+
+```bash
+rm -rf ~/.local/share/lsms_library/dvc-cache/
+```
+
+## Adding new data files
+
+Two workflows for getting new survey data into the library, both of
+which write `.dta` (or other source) files into a `Data/` directory
+under the package tree as a transient step:
+
+1. **Manual** (per CONTRIBUTING.org). Download the source files,
+   place them in the appropriate `lsms_library/countries/{Country}/{wave}/Data/`
+   directory, and run `dvc add` to generate the `.dvc` sidecar. Then
+   `dvc push` to upload the blob to the S3 remote.
+2. **Automated via the World Bank Microdata API**. The
+   `data_access.get_data_file()` fallback in `local_tools.py` can
+   download missing files from the World Bank Microdata Library
+   (requires `MICRODATA_API_KEY`) and add them to DVC for you.
+
+In both cases the new file lives temporarily in the workspace. **Once
+the `.dvc` sidecar exists, remove the workspace copy** — the file is
+now in the Layer 1 cache and `local_file()` will refuse to read the
+workspace copy on subsequent calls (with the cleanup warning). Removing
+it keeps the package tree clean and consistent with the architectural
+rule above.
+
+```bash
+# After dvc add succeeds:
+rm lsms_library/countries/Niger/2024-25/Data/new_section.dta
+# The blob is in ~/.local/share/lsms_library/dvc-cache/...
+# and DVC.open will serve it from there.
+```
 
 ## Build Backends
 
@@ -92,14 +220,21 @@ country and environment:
 
 | Backend | When Used | Description |
 |---------|-----------|-------------|
-| DVC stage layer | Default, for the 7 countries with a populated `dvc.yaml` | DVC hashes stage deps (Python files + country config dir) and reads cache when clean |
-| Python aggregator | Default, for countries without `dvc.yaml` | Reads wave-level `data_info.yml` and builds in memory; cache is currently write-only for this path until v0.7.0 |
-| Make / script | `LSMS_BUILD_BACKEND=make`, or when `data_scheme.yml` marks a table `materialize: make` | Per-country/wave Makefiles and scripts; the only choice for tables that cannot be expressed purely in YAML |
+| Python aggregator | Default for all countries | Reads wave-level `data_info.yml` and builds in memory; Layer 2 parquet is written and read across sessions via the v0.7.0 top read |
+| DVC stage layer | The 7 countries with a populated `dvc.yaml` (Uganda, Senegal, Malawi, Togo, Kazakhstan, Serbia, GhanaLSS) | DVC hashes stage deps and reads cache when clean. Note: on hosts where `python3` resolves to Python < 3.9 (e.g. Savio login nodes with Python 3.6.8), `stage.reproduce()` fails with `ModuleNotFoundError` and the library silently falls back to the Python aggregator path |
+| Make / script | When `data_scheme.yml` marks a table `materialize: make` | Per-country/wave Makefiles and standalone Python scripts; the only choice for tables that cannot be expressed purely in YAML (post-planting/post-harvest dual rounds, multi-wave source files, etc.) |
 
 ```bash
-# Bypass the DVC stage layer for a country that has one
+# Force the Python aggregator path (bypasses the DVC stage layer for
+# the 7 stage-configured countries; mostly useful for debugging stage
+# resolution issues)
 export LSMS_BUILD_BACKEND=make
 ```
+
+Note that `LSMS_BUILD_BACKEND=make` dispatches `_aggregate_wave_data`
+directly to `load_from_waves` (`country.py:1830`), bypassing both the
+DVC stage layer and the Layer 2 Parquet cache. Use only when actively
+debugging.
 
 ## Build Parallelism
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ df = roster()      # Load all countries into one DataFrame
 - **Cross-Country Analysis** -- `Feature` class concatenates harmonized data
   across countries
 - **DVC Integration** -- stream data from remote storage
-- **Parquet Cache** -- materialize once, reuse within a session; cross-session read path and content-hash invalidation land in v0.7.0 and v0.8.0 (see the [Caching guide](guide/caching.md))
+- **Two-Layer Cache** -- DVC blob cache (Layer 1, populated lazily on first read of any tracked file) and harmonized parquet cache (Layer 2, the v0.7.0 fast path that serves warm reads in ~0.5 s). Both live under `data_root()` and are controlled together by `LSMS_DATA_DIR`. See the [Caching guide](guide/caching.md).
 - **Extensible** -- add new surveys via YAML configuration files
 
 ## Next Steps

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -78,9 +78,21 @@ def _ensure_dvc_pulled(fn) -> None:
     YAML parse -- no DVC Python API, no ``DVCFS.repo``, no index walk,
     no minutes-long lazy index build.
 
-    Only on a cache miss does this fall through to ``DVCFS.repo.pull``,
+    Only on a cache miss does this fall through to ``DVCFS.repo.fetch``,
     which is wrapped in ``_dvc_working_directory(_COUNTRIES_DIR)``
-    because ``Repo.pull`` resolves targets against ``os.getcwd()``.
+    because ``Repo.fetch`` resolves targets against ``os.getcwd()``.
+
+    **Why fetch and not pull**: ``Repo.pull = Repo.fetch + Repo.checkout``.
+    The ``checkout`` step materializes the file in the workspace at its
+    DVC-tracked path -- which is **inside the package tree**
+    (``_COUNTRIES_DIR``).  We do not want DVC-tracked data files
+    materializing in the package tree under any circumstances; the
+    package tree is for code and ``.dvc`` sidecars only, and data lives
+    under ``data_root()``.  ``Repo.fetch`` populates the local DVC cache
+    (which is under ``data_root()`` thanks to the ``cache.dir`` override
+    on ``DVCFS``) without touching the workspace at all.  After the
+    fetch, ``DVCFS.open`` serves reads from the cache via
+    ``DataFileSystem._get_fs_path``'s ``typ == "cache"`` branch.
 
     Every error is swallowed.  This function is best-effort warming
     glue; the caller's ``DVCFS.open`` streaming fallback handles any
@@ -131,13 +143,14 @@ def _ensure_dvc_pulled(fn) -> None:
         try:
             rel_path = abs_path.relative_to(_COUNTRIES_DIR)
         except ValueError:
-            return  # outside the countries dir, can't pull
+            return  # outside the countries dir, can't fetch
+
     except Exception:
         return  # bad sidecar shape, missing key, OS error: bail to streaming
 
     try:
         with _dvc_working_directory(_COUNTRIES_DIR):
-            DVCFS.repo.pull(targets=[str(rel_path)], jobs=1)
+            DVCFS.repo.fetch(targets=[str(rel_path)], jobs=1)
     except Exception:
         pass
 
@@ -361,9 +374,11 @@ def get_dataframe(fn: str | Path, convert_categoricals: bool = True, encoding: s
         # fallback).  This restores the Layer-1 caching that
         # ``slurm_logs/DESIGN_dvc_layer1_caching.md`` originally
         # diagnosed as dormant -- the working approach uses
-        # ``Repo.pull`` and a runtime ``cache.dir`` config override
-        # at ``DVCFS`` construction (see _DVC_CACHE_DIR above), not
-        # the ``cache_remote_stream`` kwarg the prior session tried.
+        # ``Repo.fetch`` (NOT ``Repo.pull``, which would also check
+        # the file out into the package tree) plus a runtime
+        # ``cache.dir`` config override at ``DVCFS`` construction
+        # (see _DVC_CACHE_DIR above), not the ``cache_remote_stream``
+        # kwarg the prior session tried.
         _ensure_dvc_pulled(fn)
         try:
             with DVCFS.open(fn,mode='rb') as f:

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -9,8 +9,10 @@ import numpy as np
 import pandas as pd
 import dvc.api
 from collections import defaultdict
+from contextlib import contextmanager
 from cfe.df_utils import use_indices
 import warnings
+import yaml
 import json
 import difflib
 import re
@@ -27,10 +29,117 @@ import inspect
 from typing import Any
 from .paths import data_root, var_path, wave_data_path, COUNTRIES_ROOT
 
-# Initialize DVC filesystem once and reuse it
+# Initialize DVC filesystem once and reuse it.
+#
+# The runtime ``config={"cache": {"dir": ...}}`` override pins the
+# DVC object cache to a user-writable location under ``data_root()``,
+# so the same ``LSMS_DATA_DIR`` controls both the parquet cache (Layer 2)
+# and the DVC blob cache (Layer 1).  Without this override, the cache
+# falls back to ``{_COUNTRIES_DIR}/.dvc/cache`` which is unwritable in
+# pip-installed layouts.
+#
+# The override also makes the DVCFileSystem cache-read fast path
+# (``DataFileSystem._get_fs_path`` iterating ``["cache", "remote", "data"]``)
+# resolve into a populated directory, so any blob present at
+# ``{_DVC_CACHE_DIR}/{md5[:2]}/{md5[2:]}`` is served from local disk
+# instead of streaming from S3.  See ``_ensure_dvc_pulled`` below for
+# the warming side of the round-trip.
 _PACKAGE_ROOT = Path(__file__).resolve().parent
 _COUNTRIES_DIR = _PACKAGE_ROOT / "countries"
-DVCFS = DVCFileSystem(os.fspath(_COUNTRIES_DIR))
+_DVC_CACHE_DIR = data_root() / "dvc-cache"
+_DVC_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+DVCFS = DVCFileSystem(
+    os.fspath(_COUNTRIES_DIR),
+    config={"cache": {"dir": os.fspath(_DVC_CACHE_DIR)}},
+)
+
+
+@contextmanager
+def _dvc_working_directory(path):
+    """Temporarily switch the process working directory.
+
+    ``Repo.pull(targets=[...])`` resolves targets against ``os.getcwd()``,
+    not against the repo root, so callers must change directory before
+    invoking it.  ``country.py`` has its own copy at module level; this
+    one is duplicated here to avoid a circular import.
+    """
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def _ensure_dvc_pulled(fn) -> None:
+    """Best-effort warm of the local DVC cache for a tracked path.
+
+    The hot path (cache hit) is two ``os.path.exists`` calls and a tiny
+    YAML parse -- no DVC Python API, no ``DVCFS.repo``, no index walk,
+    no minutes-long lazy index build.
+
+    Only on a cache miss does this fall through to ``DVCFS.repo.pull``,
+    which is wrapped in ``_dvc_working_directory(_COUNTRIES_DIR)``
+    because ``Repo.pull`` resolves targets against ``os.getcwd()``.
+
+    Every error is swallowed.  This function is best-effort warming
+    glue; the caller's ``DVCFS.open`` streaming fallback handles any
+    failure to populate the cache.
+
+    See ``slurm_logs/DESIGN_dvc_layer1_caching.md`` for the empirical
+    investigation that landed this design.
+    """
+    try:
+        # Try several interpretations of fn to find the .dvc sidecar.
+        # Wave scripts pass cwd-relative paths like '../Data/foo.dta'.
+        # Interactive callers may pass countries-relative paths like
+        # 'Niger/2018-19/Data/foo.dta'.  Both forms must work.
+        fn_path = Path(fn)
+        candidates = []
+        if fn_path.is_absolute():
+            candidates.append(fn_path)
+        else:
+            candidates.append((Path.cwd() / fn_path).resolve())
+            candidates.append((_COUNTRIES_DIR / fn_path).resolve())
+
+        abs_path = None
+        for c in candidates:
+            if (c.parent / f"{c.name}.dvc").exists():
+                abs_path = c
+                break
+        if abs_path is None:
+            return  # no sidecar found at any interpretation; not DVC-tracked
+
+        sidecar = abs_path.parent / f"{abs_path.name}.dvc"
+        with sidecar.open() as fh:
+            sidecar_data = yaml.safe_load(fh)
+        md5 = sidecar_data["outs"][0]["md5"]
+        # Check both DVC 2.x and DVC 3.0 cache layouts.  DVC 3.x is
+        # backward-compatible and reads from both.  Most blobs in the
+        # LSMS countries repo land in the legacy flat layout because
+        # the existing .dvc sidecars carry md5-dos2unix hashes from
+        # the original DVC 2.x dvc-adds; new sidecars (post-migration)
+        # would use the DVC-3.0 files/md5/ subpath layout.  See
+        # https://dvc.org/doc/user-guide/upgrade for the version
+        # history.
+        cache_layouts = (
+            _DVC_CACHE_DIR / md5[:2] / md5[2:],                  # DVC 2.x
+            _DVC_CACHE_DIR / "files" / "md5" / md5[:2] / md5[2:], # DVC 3.x
+        )
+        if any(p.exists() for p in cache_layouts):
+            return  # cache hit -- DVCFS.open() will serve from local
+        try:
+            rel_path = abs_path.relative_to(_COUNTRIES_DIR)
+        except ValueError:
+            return  # outside the countries dir, can't pull
+    except Exception:
+        return  # bad sidecar shape, missing key, OS error: bail to streaming
+
+    try:
+        with _dvc_working_directory(_COUNTRIES_DIR):
+            DVCFS.repo.pull(targets=[str(rel_path)], jobs=1)
+    except Exception:
+        pass
 
 def _to_numeric(x,coerce=False):
     try:
@@ -243,18 +352,19 @@ def get_dataframe(fn: str | Path, convert_categoricals: bool = True, encoding: s
         except (TypeError,ValueError): # Needs filename?
             df = read_file(fn,convert_categoricals=convert_categoricals,encoding=encoding)
     elif file_system_path(fn):
-        # NOTE: Layer-1 (raw .dta blob) caching is currently dormant.
-        # An earlier attempt passed cache_remote_stream=True per
-        # slurm_logs/DESIGN_dvc_layer1_caching.md, but empirical
-        # testing on DVC 3.67.0 (Niger Run A, 2026-04-11) showed the
-        # kwarg is silently dropped: 363s S3 stream, zero bytes
-        # written to /global/scratch/users/ligon/.dvc/cache.  Both
-        # `cache_remote_stream=True` and the actual 3.67.0 kwarg name
-        # `cache=True` were tried; neither populated the cache.
-        # The dormant Layer-1 path is reverted here pending a real
-        # fix (likely DVCFS.get_file() or Repo.pull, see follow-up
-        # in the design doc).  See country.py:1611-1812 for the
-        # working Layer-2 (parquet) cache that landed in v0.7.0.
+        # Layer-1 (raw .dta blob) caching: best-effort warm the local
+        # DVC object cache before streaming.  ``_ensure_dvc_pulled``
+        # is a no-op when the blob is already cached (cache hit ->
+        # ``DVCFS.open`` below serves it from local disk via
+        # ``_get_fs_path``'s ``typ == "cache"`` branch) and a no-op
+        # on any failure (streaming via ``DVCFS.open`` is the
+        # fallback).  This restores the Layer-1 caching that
+        # ``slurm_logs/DESIGN_dvc_layer1_caching.md`` originally
+        # diagnosed as dormant -- the working approach uses
+        # ``Repo.pull`` and a runtime ``cache.dir`` config override
+        # at ``DVCFS`` construction (see _DVC_CACHE_DIR above), not
+        # the ``cache_remote_stream`` kwarg the prior session tried.
+        _ensure_dvc_pulled(fn)
         try:
             with DVCFS.open(fn,mode='rb') as f:
                 df = read_file(f,convert_categoricals=convert_categoricals,encoding=encoding)

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -154,6 +154,35 @@ def _ensure_dvc_pulled(fn) -> None:
     except Exception:
         pass
 
+
+def _is_polluted_workspace_copy(fn) -> bool:
+    """True if *fn* exists on disk AND has a sister ``.dvc`` sidecar.
+
+    A workspace copy of a DVC-tracked file is pollution from a checkout
+    side effect (e.g., ``dvc pull`` from the package tree, or a third-
+    party tool that did the equivalent).  The DVC cache (under
+    ``data_root()``) is the canonical location for tracked data; the
+    package tree is for code and ``.dvc`` sidecars only.
+
+    This helper is used by ``local_file`` inside ``get_dataframe`` to
+    refuse the workspace copy and force the read through the DVC cache
+    path instead.
+
+    A file *without* a sister sidecar is **not** pollution -- it could
+    be freshly downloaded new data being prepped for ``dvc add``,
+    scratch data the user supplied directly, output from the
+    WB-fallback auto-add path in ``data_access.get_data_file``, or any
+    other legitimate non-tracked use.  Returns False in all of those
+    cases.
+    """
+    try:
+        p = Path(fn).resolve()
+        sidecar = p.parent / f"{p.name}.dvc"
+        return sidecar.exists()
+    except Exception:
+        return False
+
+
 def _to_numeric(x,coerce=False):
     try:
         if coerce:
@@ -261,9 +290,28 @@ def get_dataframe(fn: str | Path, convert_categoricals: bool = True, encoding: s
         try:
             with open(fn) as f:
                 pass
-            return True
         except FileNotFoundError:
             return False
+        # Hardening: a workspace copy of a DVC-tracked file is pollution
+        # from a checkout side effect (manual ``dvc pull``, third-party
+        # tool, etc.), not a legitimate fast path.  Refuse to use it so
+        # the read goes through the DVC cache (under ``data_root()``)
+        # via ``file_system_path`` -> ``_ensure_dvc_pulled`` ->
+        # ``DVCFS.open``.  Files without a sister sidecar are fine
+        # (new data being prepped for ``dvc add``, user scratch data,
+        # WB-fallback downloads).
+        if _is_polluted_workspace_copy(fn):
+            warnings.warn(
+                f"Refusing workspace copy of DVC-tracked file {fn} "
+                f"(sister .dvc sidecar exists). The package tree must "
+                f"not contain DVC-tracked data; falling through to the "
+                f"DVC cache path. Clean up with: "
+                f"find lsms_library/countries -type f -name '*.dta' "
+                f"-execdir test -e '{{}}.dvc' \\; -print -delete",
+                stacklevel=3,
+            )
+            return False
+        return True
     
     def file_system_path(fn):
     # is the file a relative path or it's the full path from our fs (DVCFileSystem)?

--- a/slurm_logs/DESIGN_dvc_layer1_caching.md
+++ b/slurm_logs/DESIGN_dvc_layer1_caching.md
@@ -829,3 +829,37 @@ old behavior.
   updated from `repo.pull` to `repo.fetch`.  Test docstrings updated.
 - `slurm_logs/DESIGN_dvc_layer1_caching.md` -- this follow-up #2
   appendix.
+
+## 2026-04-11 follow-up #3: path-normalization probe and `local_file` hardening
+
+Two changes were originally gated on the path-normalization probe:
+
+**Probe result (this session)**: from a wave-script-style cwd
+(`cd lsms_library/countries/Niger/2018-19/_/`), calling
+`DVCFS.open('../Data/grappe_gps_ner2018.dta', mode='rb').read()`
+returned `35366` bytes -- the correct file content.  fsspec /
+DVCFileSystem already handles cwd-relative paths in this form.
+**Change #2 (path canonicalizer in `_resolve_data_path`) is not
+needed.**
+
+**Change #3 landed in this commit**: `_is_polluted_workspace_copy`
+helper + `local_file()` hardening.  The new helper returns True iff a
+file exists on disk *and* has a sister `.dvc` sidecar; `local_file()`
+calls it after a successful `open()` and, if True, emits a
+`UserWarning` and returns False to force the read through the DVC
+cache path.  Files without sidecars are still legitimate fast paths
+(new data being prepped for `dvc add`, scratch data, WB-fallback
+downloads).  The warning includes the cleanup command so users can
+fix their workspace.
+
+The hardening is opt-out only via the cleanup itself: until users
+remove the polluted workspace files under `lsms_library/countries/`,
+they will see warnings on every read.  That's the intended UX --
+the warnings are the symptom that signals the cleanup is needed.
+
+Tests in `TestLayer1Caching`:
+- `test_is_polluted_workspace_copy_true_when_sidecar_exists`
+- `test_is_polluted_workspace_copy_false_when_no_sidecar` (covers
+  the new-data add cases the user pointed out)
+- `test_is_polluted_workspace_copy_false_on_bad_input`
+- `test_get_dataframe_warns_and_falls_through_on_polluted_workspace`

--- a/slurm_logs/DESIGN_dvc_layer1_caching.md
+++ b/slurm_logs/DESIGN_dvc_layer1_caching.md
@@ -863,3 +863,69 @@ Tests in `TestLayer1Caching`:
   the new-data add cases the user pointed out)
 - `test_is_polluted_workspace_copy_false_on_bad_input`
 - `test_get_dataframe_warns_and_falls_through_on_polluted_workspace`
+
+## 2026-04-11 follow-up #4: Probe 7 end-to-end validation + docs reconciliation
+
+End-to-end measurements on the user's Linux workstation, after Pieces
+1+2 + change #1 + change #3 had landed and the workspace was clean:
+
+| Scenario | Time | Notes |
+|---|---|---|
+| Truly cold (~10 min in user's first run) | ~600 s | First-ever fetch, no caches anywhere |
+| Cold-cold (empty L1 + L2, two runs) | 464 s, 504 s | ~10 sequential `Repo.fetch` calls × ~11 s each + harmonization. ~10% variance is bigger than the cost of any individual checkout step would have been -- confirms that change #1 (`Repo.pull` -> `Repo.fetch`) is a correctness fix, not a cold-case performance fix |
+| **L2-cold L1-warm** | **71.6 s** | The headline measurement. ~7× speedup vs cold-cold. Sidecar pre-check in `_ensure_dvc_pulled` finds blobs in `~/.local/share/lsms_library/dvc-cache/` and short-circuits before `Repo.fetch` -- evidenced by the absence of any `Collecting / Fetching` progress lines |
+| All-warm (v0.7.0 Layer 2 hit) | 0.5 s | Unchanged from baseline. No regression |
+
+Workspace pollution check after cold-cold:
+`find lsms_library/countries -type f -name '*.dta'` returns nothing.
+`Repo.fetch` does not check files out to the package tree.
+
+Cache directory after cold-cold:
+`~/.local/share/lsms_library/dvc-cache/` = 19 MB, with both layouts
+populated (top-level prefix dirs `1e/`, `59/`, ... for legacy
+`md5-dos2unix` blobs and a `files/` subdir for DVC 3.x raw-md5 blobs).
+The dual-layout pre-check correctly handles both.
+
+### Piece 3 — docs reconciliation (this commit)
+
+Probe 7's validation unblocked the docs rewrite that was originally
+deferred from the v0.7.0 plan.  Three files updated:
+
+- **`docs/guide/caching.md`** -- substantive rewrite. New "Two Cache
+  Layers" table at the top, accurate cross-session-behavior section
+  reflecting v0.7.0 (no "v0.6.0 inconsistent" framing), new "package
+  tree never contains DVC-tracked data" section explaining the
+  architectural rule and the cleanup warning, new "Adding new data
+  files" section covering both the manual and the WB-fallback
+  workflows, fixed Build Backends table (removed obsolete "write-only
+  until v0.7.0" claim, added the make backend's bypass-everything
+  caveat, added the Savio Python 3.6.8 footnote on the DVC stage
+  layer).
+- **`docs/index.md`** line 55 -- updated bullet from "Parquet Cache"
+  (single layer) to "Two-Layer Cache" (DVC blob + harmonized
+  parquet), with a note about the v0.7.0 0.5 s warm number.
+- **`slurm_logs/DESIGN_dvc_layer1_caching.md`** -- this follow-up #4
+  appendix recording the Probe 7 numbers and the docs commit.
+
+### Optional follow-ups (not in this branch)
+
+1. **Batched fetch at the Country level**: collapse the ~10 sequential
+   `Repo.fetch` calls in the cold case to one batched call. ~80 s
+   savings on cold runs. Worth doing if cold runs become a frequent
+   user complaint; the cold case is a one-time cost per
+   `(country, machine)` pair so it may not be worth the complexity.
+2. **Migrate `.dvc` sidecars to DVC 3.0 hashes**: `dvc cache migrate`
+   + regenerate every sidecar under `countries/` to use raw `md5`
+   instead of `md5-dos2unix`. Eliminates the legacy hash code path
+   entirely. Significant git churn, S3 cleanup via `dvc gc -c`,
+   coordinated with anyone working on the data side. Decoupled from
+   this branch by the dual-layout pre-check.
+3. **One-time operational cleanup** for hosts with prior workspace
+   pollution from old `Repo.pull`-based versions or manual
+   `dvc pull` invocations:
+
+       find lsms_library/countries -type f -name '*.dta' \
+           -execdir test -e '{}.dvc' \; -delete
+
+   The library will warn until the user runs this; the warnings are
+   the intended signal.

--- a/slurm_logs/DESIGN_dvc_layer1_caching.md
+++ b/slurm_logs/DESIGN_dvc_layer1_caching.md
@@ -634,3 +634,95 @@ cache.  Deferred to a future session.
 - The `~/.cache/dvc/` location referenced earlier in this doc is
   misleading on this host — the real cache lives at
   `/global/scratch/users/ligon/.dvc/cache/` per the global DVC config.
+
+## 2026-04-11 follow-up: Layer 1 caching restored via runtime config override + Repo.pull
+
+The "deferred to a future session" item above landed in the same
+afternoon.  The breakthrough was reframing the question: instead of
+asking "how do we make `DVCFileSystem.open()` populate the cache",
+ask "how do we make `DVCFileSystem.open()` *read* from a populated
+cache".  Reading from a populated cache is automatic in DVC 3.67.0
+via `DataFileSystem._get_fs_path` iterating
+`["cache", "remote", "data"]`; the only thing needed is to wire up
+`info.cache` correctly via a runtime `config={"cache": {"dir": X}}`
+override on the `DVCFileSystem` constructor.
+
+### Probes that landed it
+
+- **Probe 1 (storage_map inspection)**: confirmed the runtime config
+  override propagates from `DVCFileSystem(..., config=...)` through
+  `fs.repo` to every index entry's `storage_map[key].cache`.  The
+  `info.cache` is a real `LocalHashFileDB` rooted at the override
+  directory.
+- **Probe 2 (cwd footgun)**: first attempt at `Repo.pull(targets=[X])`
+  failed with `NoOutputOrStageError` because `Repo.pull` resolves
+  targets against `os.getcwd()`, not against the repo root.  Fix:
+  wrap the call in a chdir context manager (the same idiom
+  `country.py:1658` uses).
+- **Probe 2 (multi-MB end-to-end)**: cold S3 stream of a 7 MB Niger
+  file took **17.465 s**; warm cache read of the same file took
+  **0.010 s**.  ~1750× speedup, same order of magnitude as the
+  Layer 2 numbers reported above.
+- **Probe 2 (side-effect caching disproof)**: `DVCFileSystem.open()`
+  does **not** populate the cache as a side effect of streaming; the
+  empty cache stayed empty after the 17 s cold read.  This means
+  Layer 1 warming requires explicit `Repo.pull`, not a clever
+  `DVCFS.open` flag.
+
+### Critical correction to the layout discussion above
+
+The "two cache layouts coexist" interpretation in earlier versions of
+this doc was wrong.  The flat
+`{cache_dir}/{md5[:2]}/{md5[2:]}` layout we observed via `Repo.pull`
+is the **DVC 2.x cache layout**, used because the LSMS `countries/`
+sidecars carry `md5-dos2unix` hashes from the original DVC 2.x
+`dvc add`-s.  The DVC 3.0 cache layout is
+`{cache_dir}/files/md5/{md5[:2]}/{md5[2:]}`, used for sidecars with
+raw `md5` hashes.  DVC 3.x is backward-compatible and reads from
+both; `dvc cache migrate` is the explicit consolidation path.  See
+https://dvc.org/doc/user-guide/upgrade.
+
+`repo.cache.local.path` reports the DVC-3.x-native subpath
+(`{cache_dir}/files/md5`) regardless of which layout is in actual
+use; this is misleading diagnostic noise but not a bug.  The
+storage_map's `info.cache.odb.path` reports the legacy root, which
+is what `Repo.pull` actually writes to for legacy-hash sidecars.
+
+### What landed
+
+- `lsms_library/local_tools.py:33` — `DVCFS` now constructed with
+  `config={"cache": {"dir": data_root() / "dvc-cache"}}`.
+- `lsms_library/local_tools.py` — new `_ensure_dvc_pulled(fn)` helper
+  with sidecar pre-check (cache hit = two `os.path.exists` calls,
+  no DVC API), `_dvc_working_directory` cwd wrapper, dual-layout
+  blob lookup (DVC 2.x flat + DVC 3.0 `files/md5/`), full exception
+  swallowing.
+- `lsms_library/local_tools.py:get_dataframe` — calls
+  `_ensure_dvc_pulled(fn)` in the `file_system_path` branch before
+  the `DVCFS.open(fn)` stream.
+- `tests/test_dvc_caching.py` — new `TestLayer1Caching` class with
+  unit tests for: Piece 1 cache.dir override, sidecar pre-check
+  cache-hit short-circuit (both layouts), cache-miss falling
+  through to `Repo.pull`, error swallowing, cwd-independence
+  regression test, countries-relative path handling.
+
+### Follow-ups (separate workstreams)
+
+- **Migrate `.dvc` sidecars to DVC 3.0 hash algorithm**.  Run
+  `dvc cache migrate` and regenerate every sidecar under
+  `countries/`.  Eliminates the legacy hash code path entirely.
+  Significant git churn (every tracked `.dta`'s md5 changes), needs
+  `dvc gc -c` to clean orphaned legacy blobs from S3, needs CI
+  rebaseline if any tests hardcode hash values.  Decoupled from
+  this fix by the dual-layout pre-check.
+- **Probe 6 — `Repo.pull` cost characterization**.  Time cold and
+  warm `Repo.pull` calls for small/medium/large files; verify the
+  warm-pull cost is acceptable for the cache-miss fallback path.
+- **Probe 7 — End-to-end payoff measurement**.  Re-run the Niger
+  cold-rebuild benchmark with Pieces 1+2 in place; expected drop
+  from 363 s to ~10-30 s for the L2-cold / L1-warm case.
+- **Cache migration UX**.  When LSMS users on hosts with prior
+  `~/.cache/dvc/` populated by `dvc pull` CLI install this version,
+  they don't automatically benefit from those blobs because the
+  override pins the cache elsewhere.  Document the migration in
+  `docs/guide/caching.md` (Piece 3 of the plan).

--- a/slurm_logs/DESIGN_dvc_layer1_caching.md
+++ b/slurm_logs/DESIGN_dvc_layer1_caching.md
@@ -726,3 +726,106 @@ is what `Repo.pull` actually writes to for legacy-hash sidecars.
   they don't automatically benefit from those blobs because the
   override pins the cache elsewhere.  Document the migration in
   `docs/guide/caching.md` (Piece 3 of the plan).
+
+## 2026-04-11 follow-up #2: structural correction — `Repo.fetch` not `Repo.pull`
+
+After the initial fix landed (commit `8d333f8`), end-to-end smoke tests
+on the user's dev workstation revealed that the `_ensure_dvc_pulled`
+helper had a structural problem: it called `DVCFS.repo.pull(...)`,
+which is `Repo.fetch + Repo.checkout`.  The `checkout` step
+materializes the file in the workspace at its DVC-tracked path --
+**inside the package tree**.
+
+The user's hard architectural rule: *"we definitely don't want those
+dta files materializing in the package tree, regardless of who's
+responsible"*.  The package tree is for code and `.dvc` sidecars; data
+lives under `data_root()`.
+
+### Why this matters
+
+`Repo.pull`'s workspace-checkout side effect created a hidden coupling:
+
+1. First `get_dataframe` call on a fresh clone -> `Repo.pull` -> blob
+   in cache **and** file in workspace.
+2. Subsequent `get_dataframe` calls -> `local_file()` returns True
+   (workspace file exists) -> reads directly from disk -> the entire
+   DVC code path is short-circuited -> the cache (which we worked so
+   hard to populate correctly) is never read.
+
+The 1750x speedup from the multi-MB Probe 2 was measuring the right
+primitive in isolation but didn't reflect production behavior, because
+the production hot path never reached the `DVCFS.open` cache-read
+branch.  The user's "L2-cold L1-warm" timing of 43.1 s vs cold-cold
+of 41.4 s was the smoking gun: identical timings because both runs
+were going through the local-file path, with our Layer 1 helper
+silently bypassed.
+
+### The fix
+
+`Repo.pull` -> `Repo.fetch` in `_ensure_dvc_pulled`.  `Repo.fetch`
+populates the local cache without checking out to the workspace.
+After this change:
+
+1. First `get_dataframe` call on a fresh clone -> `Repo.fetch` -> blob
+   in cache, workspace untouched.
+2. Subsequent `get_dataframe` calls -> `local_file()` returns False
+   (no workspace file) -> falls into `file_system_path` ->
+   `_ensure_dvc_pulled` finds blob in cache (sidecar pre-check hit) ->
+   no fetch needed -> `DVCFS.open` reads from cache via the
+   `_get_fs_path[typ='cache']` branch.  The 1750x cache-read speedup
+   is now actually exercised in production.
+
+### Coordinated changes still needed (gated by probes)
+
+This commit lands change #1 (the fetch fix) only.  Two related
+changes are gated on a probe and a future commit:
+
+**Change #2: Path normalization at the `get_dataframe` boundary.**
+With workspace files no longer being materialized, `local_file()`
+returns False for DVC-tracked paths and we fall into
+`DVCFS.open('../Data/foo.dta')`.  But `DVCFS` is rooted at
+`_COUNTRIES_DIR` and its path normalization is fs-root-relative, so
+`'../Data/...'` may not resolve correctly.  **Probe needed**: from
+a wave-script-style cwd, call `DVCFS.open('../Data/foo.dta').read()`
+and see whether it works.  If yes, no change needed.  If no, add a
+canonicalizer in `_resolve_data_path` (or a sibling helper) to
+convert cwd-relative paths to fs-root-relative form before passing
+to DVCFS.
+
+**Change #3: Harden `local_file()` with a sister-sidecar check.**
+The right rule is "a file in the workspace is pollution iff it has
+a sister `.dvc` sidecar".  If yes, refuse to use it (force the DVC
+path so reads go through the cache).  If no, the file is either
+freshly downloaded new data being prepped for `dvc add`, or scratch
+data the user is supplying directly, or output from the
+WB-fallback auto-add path -- all legitimate uses.  Pure Python
+check at the call site, no filesystem permission tricks needed.
+The user considered (and rejected) a more aggressive read-only
+approach because the legitimate add-new-data workflows (manual
+per CONTRIBUTING.org, WB-fallback auto-add in
+`data_access.get_data_file`) need write access to those
+directories.
+
+**Cleanup task (separate one-time op)**: existing dev checkouts
+have `.dta` files under `lsms_library/countries/` from the prior
+`Repo.pull` behavior or from manual `dvc pull` invocations.
+Clean up with a safe filter that only deletes files where a sister
+`.dvc` sidecar exists:
+
+    find lsms_library/countries -type f -name '*.dta' \
+        -execdir test -e '{}.dvc' \; -print -delete
+
+Worth running on every dev workstation that's been used with the
+old behavior.
+
+### What landed in this commit
+
+- `lsms_library/local_tools.py:_ensure_dvc_pulled` -- one-line change:
+  `DVCFS.repo.pull(...)` -> `DVCFS.repo.fetch(...)`.  Plus updated
+  docstring explaining why fetch and not pull.
+- `lsms_library/local_tools.py:get_dataframe` -- comment update at
+  the call site to reflect the fetch rationale.
+- `tests/test_dvc_caching.py:TestLayer1Caching` -- 12 mock references
+  updated from `repo.pull` to `repo.fetch`.  Test docstrings updated.
+- `slurm_logs/DESIGN_dvc_layer1_caching.md` -- this follow-up #2
+  appendix.

--- a/tests/test_dvc_caching.py
+++ b/tests/test_dvc_caching.py
@@ -1047,7 +1047,9 @@ class TestLayer1Caching:
     automatically when ``info.cache`` is wired up correctly.  Pieces 1
     and 2 land both halves of the round-trip: Piece 1 pins ``cache.dir``
     via runtime config override, Piece 2 populates the cache via
-    explicit ``Repo.pull`` from inside ``get_dataframe``.
+    explicit ``Repo.fetch`` from inside ``get_dataframe`` (NOT ``Repo.pull``,
+    which would also check the file out into the package tree -- a
+    structural rule discovered in this same session).
 
     See ``slurm_logs/DESIGN_dvc_layer1_caching.md`` for the empirical
     investigation that led to this design.
@@ -1088,10 +1090,10 @@ class TestLayer1Caching:
         target.write_bytes(b"")
         with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
             local_tools._ensure_dvc_pulled(str(target))
-            mock_dvcfs.repo.pull.assert_not_called()
+            mock_dvcfs.repo.fetch.assert_not_called()
 
     def test_ensure_dvc_pulled_noop_when_blob_cached_legacy_layout(self, tmp_path, monkeypatch):
-        """Sidecar + blob in legacy DVC 2.x flat layout -> no ``Repo.pull``.
+        """Sidecar + blob in legacy DVC 2.x flat layout -> no ``Repo.fetch``.
 
         This is the dominant hit path for the LSMS repo today: the
         ``.dvc`` sidecars carry ``md5-dos2unix`` hashes from the
@@ -1118,10 +1120,10 @@ class TestLayer1Caching:
 
         with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
             local_tools._ensure_dvc_pulled(str(target))
-            mock_dvcfs.repo.pull.assert_not_called()
+            mock_dvcfs.repo.fetch.assert_not_called()
 
     def test_ensure_dvc_pulled_noop_when_blob_cached_dvc3_layout(self, tmp_path, monkeypatch):
-        """Sidecar + blob in DVC 3.0 ``files/md5/`` layout -> no ``Repo.pull``.
+        """Sidecar + blob in DVC 3.0 ``files/md5/`` layout -> no ``Repo.fetch``.
 
         Future-proofing for after the LSMS repo migrates to DVC 3.0
         hashes via ``dvc cache migrate`` (separate workstream).  Once
@@ -1149,12 +1151,12 @@ class TestLayer1Caching:
 
         with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
             local_tools._ensure_dvc_pulled(str(target))
-            mock_dvcfs.repo.pull.assert_not_called()
+            mock_dvcfs.repo.fetch.assert_not_called()
 
     def test_ensure_dvc_pulled_calls_pull_on_miss(self, tmp_path, monkeypatch):
-        """Sidecar present + blob NOT in cache -> ``Repo.pull`` is called.
+        """Sidecar present + blob NOT in cache -> ``Repo.fetch`` is called.
 
-        Verifies the target passed to ``Repo.pull`` is the
+        Verifies the target passed to ``Repo.fetch`` is the
         countries-relative path, not the absolute path or the
         script-relative path.
         """
@@ -1180,12 +1182,12 @@ class TestLayer1Caching:
 
         with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
             local_tools._ensure_dvc_pulled(str(target))
-            mock_dvcfs.repo.pull.assert_called_once()
-            call = mock_dvcfs.repo.pull.call_args
+            mock_dvcfs.repo.fetch.assert_called_once()
+            call = mock_dvcfs.repo.fetch.call_args
             assert call.kwargs.get("targets") == ["TestC/wave/Data/foo.dta"]
 
     def test_ensure_dvc_pulled_swallows_pull_errors(self, tmp_path, monkeypatch):
-        """If ``Repo.pull`` raises, ``_ensure_dvc_pulled`` returns silently.
+        """If ``Repo.fetch`` raises, ``_ensure_dvc_pulled`` returns silently.
 
         Layer-1 warming is best-effort; the streaming fallback in
         ``get_dataframe`` should still run.
@@ -1207,13 +1209,13 @@ class TestLayer1Caching:
         monkeypatch.setattr(local_tools, "_COUNTRIES_DIR", countries_dir)
 
         with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
-            mock_dvcfs.repo.pull.side_effect = RuntimeError("simulated S3 failure")
+            mock_dvcfs.repo.fetch.side_effect = RuntimeError("simulated S3 failure")
             # Should NOT raise
             local_tools._ensure_dvc_pulled(str(target))
-            mock_dvcfs.repo.pull.assert_called_once()
+            mock_dvcfs.repo.fetch.assert_called_once()
 
     def test_ensure_dvc_pulled_changes_cwd_to_countries(self, tmp_path, monkeypatch):
-        """``Repo.pull`` is invoked from inside ``_COUNTRIES_DIR``.
+        """``Repo.fetch`` is invoked from inside ``_COUNTRIES_DIR``.
 
         Cwd-independence regression test for the footgun discovered in
         Probe 2 of the 2026-04-11 session: ``Repo.pull(targets=[X])``
@@ -1251,7 +1253,7 @@ class TestLayer1Caching:
 
         try:
             with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
-                mock_dvcfs.repo.pull.side_effect = record_cwd
+                mock_dvcfs.repo.fetch.side_effect = record_cwd
                 local_tools._ensure_dvc_pulled(str(target))
         finally:
             os.chdir(original_cwd)
@@ -1282,7 +1284,7 @@ class TestLayer1Caching:
 
         with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
             local_tools._ensure_dvc_pulled(str(target))
-            mock_dvcfs.repo.pull.assert_not_called()
+            mock_dvcfs.repo.fetch.assert_not_called()
 
     def test_ensure_dvc_pulled_handles_malformed_sidecar(self, tmp_path, monkeypatch):
         """A sidecar with unexpected shape -> bail silently, no pull."""
@@ -1300,7 +1302,7 @@ class TestLayer1Caching:
 
         with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
             local_tools._ensure_dvc_pulled(str(target))
-            mock_dvcfs.repo.pull.assert_not_called()
+            mock_dvcfs.repo.fetch.assert_not_called()
 
     def test_ensure_dvc_pulled_handles_countries_relative_path(self, tmp_path, monkeypatch):
         """Interactive callers can pass countries-relative paths.
@@ -1337,8 +1339,8 @@ class TestLayer1Caching:
             with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
                 # Pass the countries-relative path, not an absolute path
                 local_tools._ensure_dvc_pulled("TestC/wave/Data/foo.dta")
-                mock_dvcfs.repo.pull.assert_called_once()
-                call = mock_dvcfs.repo.pull.call_args
+                mock_dvcfs.repo.fetch.assert_called_once()
+                call = mock_dvcfs.repo.fetch.call_args
                 assert call.kwargs.get("targets") == ["TestC/wave/Data/foo.dta"]
         finally:
             os.chdir(original_cwd)

--- a/tests/test_dvc_caching.py
+++ b/tests/test_dvc_caching.py
@@ -1033,3 +1033,312 @@ class TestCachePathGeneration:
         assert cache_path.suffix == ".json"
         assert cache_path.parent.name == "_"
         assert method_name in cache_path.name
+
+
+class TestLayer1Caching:
+    """Tests for the Layer-1 (DVC blob) caching restored in Pieces 1+2.
+
+    Background: an earlier session at 2026-04-11 concluded that Layer-1
+    caching was dormant in DVC 3.67.0 because the ``cache=True`` /
+    ``cache_remote_stream=True`` kwargs on ``DVCFileSystem.open()`` are
+    no-ops.  That conclusion was correct as far as it went but missed
+    the actual mechanism: ``DataFileSystem._get_fs_path`` iterates
+    ``["cache", "remote", "data"]`` and reads from a populated cache
+    automatically when ``info.cache`` is wired up correctly.  Pieces 1
+    and 2 land both halves of the round-trip: Piece 1 pins ``cache.dir``
+    via runtime config override, Piece 2 populates the cache via
+    explicit ``Repo.pull`` from inside ``get_dataframe``.
+
+    See ``slurm_logs/DESIGN_dvc_layer1_caching.md`` for the empirical
+    investigation that led to this design.
+    """
+
+    def test_module_dvcfs_uses_data_root(self):
+        """Piece 1: the module-level ``DVCFS`` picks up the
+        ``data_root() / "dvc-cache"`` override.
+
+        Note: the absolute path of ``_DVC_CACHE_DIR`` is captured at
+        module import time and may not match a freshly-evaluated
+        ``data_root()`` if a prior test in the same session mutated
+        ``LSMS_DATA_DIR``.  We therefore check the *shape* of the
+        path (suffix == "dvc-cache" + directory was created) and the
+        propagation through ``DVCFS.repo`` rather than identity with
+        a freshly evaluated ``data_root()``.
+        """
+        from lsms_library.local_tools import DVCFS, _DVC_CACHE_DIR
+
+        assert _DVC_CACHE_DIR.name == "dvc-cache"
+        assert _DVC_CACHE_DIR.exists()
+
+        # The cache.local.path may include a "files/md5" subpath in
+        # some DVC versions; the operative path the storage_map cache
+        # uses is the override root.  Either form is acceptable as
+        # long as it starts with the override root.
+        cache_path = Path(DVCFS.repo.cache.local.path)
+        assert str(cache_path).startswith(str(_DVC_CACHE_DIR)), (
+            f"DVCFS cache.dir override not propagating: "
+            f"expected prefix {_DVC_CACHE_DIR}, got {cache_path}"
+        )
+
+    def test_ensure_dvc_pulled_noop_when_no_sidecar(self, tmp_path):
+        """No ``.dvc`` sidecar -> ``_ensure_dvc_pulled`` is a no-op."""
+        from lsms_library import local_tools
+
+        target = tmp_path / "no_sidecar.dta"
+        target.write_bytes(b"")
+        with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
+            local_tools._ensure_dvc_pulled(str(target))
+            mock_dvcfs.repo.pull.assert_not_called()
+
+    def test_ensure_dvc_pulled_noop_when_blob_cached_legacy_layout(self, tmp_path, monkeypatch):
+        """Sidecar + blob in legacy DVC 2.x flat layout -> no ``Repo.pull``.
+
+        This is the dominant hit path for the LSMS repo today: the
+        ``.dvc`` sidecars carry ``md5-dos2unix`` hashes from the
+        original DVC 2.x ``dvc add``-s, so the blobs land in the flat
+        layout under the cache root.
+        """
+        from lsms_library import local_tools
+
+        target = tmp_path / "data" / "foo.dta"
+        target.parent.mkdir()
+        target.write_bytes(b"")
+        sidecar = target.parent / "foo.dta.dvc"
+        md5 = "abcdef0123456789abcdef0123456789"
+        sidecar.write_text(
+            f"outs:\n- md5: {md5}\n  size: 0\n  path: foo.dta\n"
+        )
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        # Legacy DVC 2.x layout: {cache_dir}/{md5[:2]}/{md5[2:]}
+        (cache_dir / md5[:2]).mkdir()
+        (cache_dir / md5[:2] / md5[2:]).write_bytes(b"")
+        monkeypatch.setattr(local_tools, "_DVC_CACHE_DIR", cache_dir)
+
+        with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
+            local_tools._ensure_dvc_pulled(str(target))
+            mock_dvcfs.repo.pull.assert_not_called()
+
+    def test_ensure_dvc_pulled_noop_when_blob_cached_dvc3_layout(self, tmp_path, monkeypatch):
+        """Sidecar + blob in DVC 3.0 ``files/md5/`` layout -> no ``Repo.pull``.
+
+        Future-proofing for after the LSMS repo migrates to DVC 3.0
+        hashes via ``dvc cache migrate`` (separate workstream).  Once
+        the sidecars are regenerated, blobs land at
+        ``{cache_dir}/files/md5/{md5[:2]}/{md5[2:]}``; the pre-check
+        must still recognize them.
+        """
+        from lsms_library import local_tools
+
+        target = tmp_path / "data" / "foo.dta"
+        target.parent.mkdir()
+        target.write_bytes(b"")
+        sidecar = target.parent / "foo.dta.dvc"
+        md5 = "fedcba9876543210fedcba9876543210"
+        sidecar.write_text(
+            f"outs:\n- md5: {md5}\n  size: 0\n  path: foo.dta\n"
+        )
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        # DVC 3.0 layout: {cache_dir}/files/md5/{md5[:2]}/{md5[2:]}
+        (cache_dir / "files" / "md5" / md5[:2]).mkdir(parents=True)
+        (cache_dir / "files" / "md5" / md5[:2] / md5[2:]).write_bytes(b"")
+        monkeypatch.setattr(local_tools, "_DVC_CACHE_DIR", cache_dir)
+
+        with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
+            local_tools._ensure_dvc_pulled(str(target))
+            mock_dvcfs.repo.pull.assert_not_called()
+
+    def test_ensure_dvc_pulled_calls_pull_on_miss(self, tmp_path, monkeypatch):
+        """Sidecar present + blob NOT in cache -> ``Repo.pull`` is called.
+
+        Verifies the target passed to ``Repo.pull`` is the
+        countries-relative path, not the absolute path or the
+        script-relative path.
+        """
+        from lsms_library import local_tools
+
+        countries_dir = tmp_path / "countries"
+        target_dir = countries_dir / "TestC" / "wave" / "Data"
+        target_dir.mkdir(parents=True)
+        # Note: the .dta file itself does NOT exist on disk; only the
+        # sidecar.  This matches the typical fresh-checkout state.
+        target = target_dir / "foo.dta"
+        sidecar = target.parent / "foo.dta.dvc"
+        md5 = "0123456789abcdef0123456789abcdef"
+        sidecar.write_text(
+            f"outs:\n- md5: {md5}\n  size: 0\n  path: foo.dta\n"
+        )
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        # Note: blob NOT placed in cache_dir
+        monkeypatch.setattr(local_tools, "_DVC_CACHE_DIR", cache_dir)
+        monkeypatch.setattr(local_tools, "_COUNTRIES_DIR", countries_dir)
+
+        with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
+            local_tools._ensure_dvc_pulled(str(target))
+            mock_dvcfs.repo.pull.assert_called_once()
+            call = mock_dvcfs.repo.pull.call_args
+            assert call.kwargs.get("targets") == ["TestC/wave/Data/foo.dta"]
+
+    def test_ensure_dvc_pulled_swallows_pull_errors(self, tmp_path, monkeypatch):
+        """If ``Repo.pull`` raises, ``_ensure_dvc_pulled`` returns silently.
+
+        Layer-1 warming is best-effort; the streaming fallback in
+        ``get_dataframe`` should still run.
+        """
+        from lsms_library import local_tools
+
+        countries_dir = tmp_path / "countries"
+        target_dir = countries_dir / "TestC" / "Data"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "foo.dta"
+        sidecar = target.parent / "foo.dta.dvc"
+        sidecar.write_text(
+            "outs:\n- md5: 0123456789abcdef0123456789abcdef\n"
+            "  size: 0\n  path: foo.dta\n"
+        )
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr(local_tools, "_DVC_CACHE_DIR", cache_dir)
+        monkeypatch.setattr(local_tools, "_COUNTRIES_DIR", countries_dir)
+
+        with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
+            mock_dvcfs.repo.pull.side_effect = RuntimeError("simulated S3 failure")
+            # Should NOT raise
+            local_tools._ensure_dvc_pulled(str(target))
+            mock_dvcfs.repo.pull.assert_called_once()
+
+    def test_ensure_dvc_pulled_changes_cwd_to_countries(self, tmp_path, monkeypatch):
+        """``Repo.pull`` is invoked from inside ``_COUNTRIES_DIR``.
+
+        Cwd-independence regression test for the footgun discovered in
+        Probe 2 of the 2026-04-11 session: ``Repo.pull(targets=[X])``
+        resolves ``X`` against ``os.getcwd()``, not against the repo
+        root, so without an explicit chdir the call fails with
+        ``NoOutputOrStageError`` from any cwd that isn't already
+        ``lsms_library/countries/``.
+        """
+        from lsms_library import local_tools
+
+        countries_dir = (tmp_path / "countries").resolve()
+        target_dir = countries_dir / "TestC" / "Data"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "foo.dta"
+        sidecar = target.parent / "foo.dta.dvc"
+        sidecar.write_text(
+            "outs:\n- md5: 0123456789abcdef0123456789abcdef\n"
+            "  size: 0\n  path: foo.dta\n"
+        )
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr(local_tools, "_DVC_CACHE_DIR", cache_dir)
+        monkeypatch.setattr(local_tools, "_COUNTRIES_DIR", countries_dir)
+
+        # Start from a cwd that is NOT countries_dir.
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        original_cwd = Path.cwd()
+        os.chdir(elsewhere)
+
+        observed = []
+
+        def record_cwd(*args, **kwargs):
+            observed.append(Path.cwd())
+
+        try:
+            with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
+                mock_dvcfs.repo.pull.side_effect = record_cwd
+                local_tools._ensure_dvc_pulled(str(target))
+        finally:
+            os.chdir(original_cwd)
+
+        assert len(observed) == 1
+        assert observed[0] == countries_dir
+        # And the original cwd is restored after the helper returns
+        assert Path.cwd() == original_cwd
+
+    def test_ensure_dvc_pulled_bails_on_path_outside_countries(self, tmp_path, monkeypatch):
+        """A sidecar at a path outside _COUNTRIES_DIR -> no pull (no error)."""
+        from lsms_library import local_tools
+
+        countries_dir = (tmp_path / "countries").resolve()
+        countries_dir.mkdir()
+        outside = tmp_path / "outside" / "Data"
+        outside.mkdir(parents=True)
+        target = outside / "foo.dta"
+        sidecar = outside / "foo.dta.dvc"
+        sidecar.write_text(
+            "outs:\n- md5: 0123456789abcdef0123456789abcdef\n"
+            "  size: 0\n  path: foo.dta\n"
+        )
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr(local_tools, "_DVC_CACHE_DIR", cache_dir)
+        monkeypatch.setattr(local_tools, "_COUNTRIES_DIR", countries_dir)
+
+        with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
+            local_tools._ensure_dvc_pulled(str(target))
+            mock_dvcfs.repo.pull.assert_not_called()
+
+    def test_ensure_dvc_pulled_handles_malformed_sidecar(self, tmp_path, monkeypatch):
+        """A sidecar with unexpected shape -> bail silently, no pull."""
+        from lsms_library import local_tools
+
+        target = tmp_path / "foo.dta"
+        target.write_bytes(b"")
+        sidecar = tmp_path / "foo.dta.dvc"
+        # Missing 'outs' key entirely
+        sidecar.write_text("not a real dvc sidecar\n")
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr(local_tools, "_DVC_CACHE_DIR", cache_dir)
+
+        with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
+            local_tools._ensure_dvc_pulled(str(target))
+            mock_dvcfs.repo.pull.assert_not_called()
+
+    def test_ensure_dvc_pulled_handles_countries_relative_path(self, tmp_path, monkeypatch):
+        """Interactive callers can pass countries-relative paths.
+
+        e.g. ``get_dataframe('Niger/2018-19/Data/foo.dta')`` from an
+        ipython session whose cwd is unrelated to ``countries/``.  The
+        helper must find the sidecar by trying ``_COUNTRIES_DIR / fn``
+        as one of the candidate interpretations.
+        """
+        from lsms_library import local_tools
+
+        countries_dir = (tmp_path / "countries").resolve()
+        target_dir = countries_dir / "TestC" / "wave" / "Data"
+        target_dir.mkdir(parents=True)
+        # Sidecar exists at the countries-relative location
+        sidecar = target_dir / "foo.dta.dvc"
+        md5 = "0123456789abcdef0123456789abcdef"
+        sidecar.write_text(
+            f"outs:\n- md5: {md5}\n  size: 0\n  path: foo.dta\n"
+        )
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr(local_tools, "_DVC_CACHE_DIR", cache_dir)
+        monkeypatch.setattr(local_tools, "_COUNTRIES_DIR", countries_dir)
+
+        # Start from a cwd unrelated to countries_dir
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        original_cwd = Path.cwd()
+        os.chdir(elsewhere)
+
+        try:
+            with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
+                # Pass the countries-relative path, not an absolute path
+                local_tools._ensure_dvc_pulled("TestC/wave/Data/foo.dta")
+                mock_dvcfs.repo.pull.assert_called_once()
+                call = mock_dvcfs.repo.pull.call_args
+                assert call.kwargs.get("targets") == ["TestC/wave/Data/foo.dta"]
+        finally:
+            os.chdir(original_cwd)

--- a/tests/test_dvc_caching.py
+++ b/tests/test_dvc_caching.py
@@ -1344,3 +1344,94 @@ class TestLayer1Caching:
                 assert call.kwargs.get("targets") == ["TestC/wave/Data/foo.dta"]
         finally:
             os.chdir(original_cwd)
+
+    # ----------- _is_polluted_workspace_copy / local_file hardening -----------
+
+    def test_is_polluted_workspace_copy_true_when_sidecar_exists(self, tmp_path):
+        """A workspace file with a sister .dvc sidecar is pollution."""
+        from lsms_library import local_tools
+
+        target = tmp_path / "foo.dta"
+        target.write_bytes(b"data")
+        sidecar = tmp_path / "foo.dta.dvc"
+        sidecar.write_text("outs:\n- md5: 0123\n  size: 4\n  path: foo.dta\n")
+
+        assert local_tools._is_polluted_workspace_copy(str(target)) is True
+
+    def test_is_polluted_workspace_copy_false_when_no_sidecar(self, tmp_path):
+        """A workspace file without a sister sidecar is legitimate.
+
+        Covers the new-data-being-added cases: manual ``cp + dvc add``,
+        WB-fallback auto-add, user scratch data.  ``local_file()`` should
+        happily use these.
+        """
+        from lsms_library import local_tools
+
+        target = tmp_path / "freshly_downloaded.dta"
+        target.write_bytes(b"data")
+        # No sidecar created
+
+        assert local_tools._is_polluted_workspace_copy(str(target)) is False
+
+    def test_is_polluted_workspace_copy_false_on_bad_input(self):
+        """Bad input -> False, no exception."""
+        from lsms_library import local_tools
+
+        # None, empty string, missing file -- all should return False quietly
+        assert local_tools._is_polluted_workspace_copy("/nonexistent/path/foo") is False
+
+    def test_get_dataframe_warns_and_falls_through_on_polluted_workspace(self, tmp_path, monkeypatch):
+        """When local_file finds a polluted workspace copy, it should warn
+        and fall through to the DVC code path instead of using the file.
+
+        We mock DVCFS.open and observe both the warning and the fall-through.
+        """
+        from lsms_library import local_tools
+        import warnings
+
+        # Create a fake .dta + sister sidecar
+        target = tmp_path / "polluted.dta"
+        target.write_bytes(b"workspace data")
+        sidecar = tmp_path / "polluted.dta.dvc"
+        sidecar.write_text(
+            "outs:\n- md5: deadbeefcafebabe0123456789abcdef\n"
+            "  size: 14\n  path: polluted.dta\n"
+        )
+
+        # Stub DVCFS.open to return a sentinel BytesIO so we can detect
+        # whether the fall-through path was taken
+        import io
+        dvcfs_mock = patch.object(
+            local_tools.DVCFS, "open",
+            return_value=io.BytesIO(b"from cache")
+        )
+        # Stub _ensure_dvc_pulled to a no-op so we don't try real DVC ops
+        ensure_mock = patch.object(local_tools, "_ensure_dvc_pulled", return_value=None)
+        # Stub read_file (via the inner closure) -- this is harder; instead
+        # we'll just make sure the warning fires and trust that the rest of
+        # get_dataframe will do its thing.  We test the warning here and
+        # the fall-through behavior is covered by the
+        # _is_polluted_workspace_copy unit tests above plus the
+        # local_file logic.
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with dvcfs_mock, ensure_mock:
+                try:
+                    local_tools.get_dataframe(str(target))
+                except Exception:
+                    # We don't care if read_file fails on the BytesIO --
+                    # what matters is whether the warning fired before
+                    # we got there.
+                    pass
+
+        polluted_warnings = [
+            w for w in caught
+            if "Refusing workspace copy" in str(w.message)
+        ]
+        assert len(polluted_warnings) == 1, (
+            f"Expected exactly one 'Refusing workspace copy' warning, "
+            f"got {[str(w.message) for w in caught]}"
+        )
+        assert "polluted.dta" in str(polluted_warnings[0].message)
+        assert ".dvc sidecar" in str(polluted_warnings[0].message)


### PR DESCRIPTION
## Summary

This PR implements Layer 1 (DVC blob) caching to dramatically speed up cold rebuilds by caching raw `.dta` files locally. The implementation uses a runtime DVC cache directory override and a sidecar pre-check to avoid expensive `Repo.fetch` calls on cache hits.

## Key Changes

**Core caching infrastructure** (`lsms_library/local_tools.py`):
- Pin DVC cache to `data_root() / "dvc-cache"` via runtime config override on `DVCFS` constructor, making the cache location user-writable and controllable via `LSMS_DATA_DIR`
- Add `_ensure_dvc_pulled()` helper that performs a fast sidecar pre-check (two `os.path.exists` calls + YAML parse) before falling back to `Repo.fetch` on cache miss
- Support both DVC 2.x flat cache layout (`{cache}/{md5[:2]}/{md5[2:]}`) and DVC 3.x layout (`{cache}/files/md5/{md5[:2]}/{md5[2:]}`) for backward compatibility
- Wrap `Repo.fetch` in `_dvc_working_directory` context manager to handle cwd-relative path resolution
- Add `_is_polluted_workspace_copy()` helper to detect and refuse workspace copies of DVC-tracked files (files with sister `.dvc` sidecars)
- Harden `local_file()` to emit a `UserWarning` and fall through to the DVC cache path when a workspace copy is detected

**Integration** (`lsms_library/local_tools.py`):
- Call `_ensure_dvc_pulled()` in `get_dataframe()` before `DVCFS.open()` to warm the cache on first access

**Documentation** (`docs/guide/caching.md`):
- Explain the two-layer cache architecture (Layer 2: parquet harmonized output; Layer 1: DVC blob cache)
- Document cache locations and how they interact
- Provide empirical performance numbers (~7× speedup for L2-cold L1-warm scenario)
- Clarify the architectural rule that DVC-tracked data never materializes in the package tree
- Update cache invalidation guidance for v0.7.0 behavior

**Design documentation** (`slurm_logs/DESIGN_dvc_layer1_caching.md`):
- Add follow-up sections documenting the empirical investigation, critical corrections to cache layout understanding, and structural fixes (fetch vs. pull, path normalization probe results, workspace pollution hardening)

**Comprehensive test coverage** (`tests/test_dvc_caching.py`):
- New `TestLayer1Caching` class with 15 unit tests covering:
  - Cache directory override propagation
  - Sidecar pre-check cache-hit short-circuit (both DVC 2.x and 3.x layouts)
  - Cache-miss fallback to `Repo.fetch`
  - Error swallowing for best-effort warming
  - Cwd-independence regression test
  - Countries-relative path handling
  - Workspace pollution detection and warning

## Notable Implementation Details

- **Cache hit fast path**: Two `os.path.exists` calls + YAML parse, no DVC API invocation
- **Fetch not pull**: Uses `Repo.fetch` instead of `Repo.pull` to populate cache without checking files out into the package tree (architectural requirement)
- **Dual layout support**: Pre-check looks at both legacy DVC 2.x and DVC 3.x cache layouts, enabling seamless migration
- **Best-effort design**: All errors in `_ensure_dvc_pulled` are swallowed; streaming fallback in `DVCFS.open` handles any cache warming failures
- **Workspace pollution detection**: `local_file()` now refuses workspace copies that have sister `.dvc` sidecars, forcing reads through the canonical DVC cache path

## Performance Impact

Empirical measurements on Linux workstation (Niger household_roster, ~10 raw files):
- **L2-cold L1-warm**: ~71.6 s (~7× faster than cold

https://claude.ai/code/session_012KdcC26GSZRTWX1GmDa8dd