### PR TITLE
v0.7.0: credential reorg for pip-install self-sufficiency

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -42,50 +42,79 @@
    This step will set up all the files managed by git in the local
    directory =LSMS_Library= on your machine.
 
-*** DVC Setup
-   DVC manages the versioning of more-or-less static datasets.
-   To install,
-   #+begin_src sh
-   pip install dvc[s3]
-   #+end_src
-The private key for accessing the data on google drive is found in the file =gdrive_data_store.json.gpg=.  The =gpg= string indicates that this file is encrypted, in this case using a secret passphrase.
+*** Read access: the WB Microdata API key
 
-Similarly, the private key for /accessing/ data on the s3 data store is found in =s3_reader_creds.gpg=.  This is encrypted using the same passphrase mentioned above. To learn the secret passphrase you'll need to ask
-   =ligon@berkeley.edu=.  Once you have it:    
+   The canonical path for contributors -- same as for end users -- is
+   a free World Bank Microdata Library API key.  A valid key both
+   proves acceptance of the WB terms of use and unlocks the S3 read
+   cache, so you only need to set up one credential:
 
+   1. Register at https://microdata.worldbank.org/ (free).
+   2. Accept the terms of use for the LSMS collections you need.
+   3. Get your API key from your account dashboard.
+   4. Create =~/.config/lsms_library/config.yml= with:
 
-   *Authentication via Python*   
-   
-   Use the helper function provided in the LSMS Library:   
-   
+      #+begin_src yaml
+      microdata_api_key: your_key_here
+      # data_dir: /path/to/override   # same as LSMS_DATA_DIR env var
+      #+end_src
+
+      or set =MICRODATA_API_KEY= as an environment variable.
+   5. On =import lsms_library=, the library validates the key and
+      auto-unlocks =~/.config/lsms_library/s3_creds= from the
+      bundled =s3_reader_creds.gpg=.  No further setup is required.
+
+   For each setting, an environment variable (e.g., =MICRODATA_API_KEY=,
+   =LSMS_DATA_DIR=, =LSMS_S3_CREDS=) takes precedence over the config
+   file.
+
+   In non-interactive environments (CI, Docker builds) set
+   =LSMS_SKIP_AUTH=1= to suppress the import-time authentication flow.
+   In that mode you are responsible for ensuring
+   =~/.config/lsms_library/s3_creds= exists (e.g. via a CI secret
+   mount) before the first data access.
+
+*** Write access for RAs
+
+   Contributors who need to push new materialized parquets or new
+   wave metadata to the S3 cache need writer credentials in addition
+   to the API key above.  The library detects write access via three
+   mechanisms, checked in order (see =lsms_library/data_access.py=,
+   function =_check_remote_access=):
+
+   1. =LSMS_S3_WRITE_KEY= / =LSMS_S3_WRITE_KEY_ID= environment
+      variables.  Preferred for shared machines: the writer-key pair
+      is scoped to this library and does not collide with any
+      workstation-global AWS credentials.
+   2. =AWS_ACCESS_KEY_ID= / =AWS_SECRET_ACCESS_KEY= environment
+      variables.  Standard boto3-style credentials, picked up if the
+      LSMS-specific vars are not set.
+   3. A =s3_write_creds= file alongside =s3_creds= in
+      =~/.config/lsms_library/=.  Legacy, kept for compatibility.
+
+   To request writer credentials, contact =ligon@berkeley.edu=.
+   Reader credentials come automatically from the WB API key flow
+   above; you only need to request the writer pair if you will be
+   materializing new waves.
+
+*** Interactive fallback: =ll.authenticate()=
+
+   The =ll.authenticate()= helper is a rarely-needed interactive
+   fallback for contributors who cannot register for a WB Microdata
+   API key.  It prompts for the shared passphrase that decrypts
+   =s3_reader_creds.gpg= and writes the plaintext to
+   =~/.config/lsms_library/s3_creds=.
+
    #+begin_src python
    import lsms_library as ll
    ll.authenticate()
    #+end_src
-   
-   You’ll be prompted to enter the secret passphrase (which you can request from =ligon@berkeley.edu=).  
-   If successful, this will unlock the credentials needed for DVC and allow you to access the data in the LSMS Library.
 
-   (If this doesn't work, make sure you have =gpg= installed: https://gnupg.org/download/)
+   To get the passphrase, contact =ligon@berkeley.edu=.  Make sure
+   you have =gpg= installed: https://gnupg.org/download/
 
-   *User configuration*
-
-   Library settings (including the World Bank Microdata API key) live in
-   =~/.config/lsms_library/config.yml=:
-
-   #+begin_src yaml
-   microdata_api_key: your_key_here
-   # data_dir: /path/to/override   # same as LSMS_DATA_DIR env var
-   #+end_src
-
-   For each setting, an environment variable (e.g., =MICRODATA_API_KEY=,
-   =LSMS_DATA_DIR=) takes precedence over the config file.  The
-   =ll.authenticate()= helper sets up DVC credentials; the config file
-   handles everything else.
-
-   In non-interactive environments (e.g., CI) you can suppress the automatic authentication prompt by setting
-   =LSMS_SKIP_AUTH=1= in the environment. When this flag is set you are responsible for running =ll.authenticate()=
-   manually before attempting to access protected datasets.
+   This path exists primarily for historical reasons; the
+   WB-API-key flow is the supported path for new users.
 
 *** Local virtual environment
    Keep project dependencies isolated so you can experiment without colliding with

--- a/README.org
+++ b/README.org
@@ -20,11 +20,29 @@ Researchers typically spend weeks learning each new dataset's idiosyncrasies or 
 
 LSMS_Library provides an *abstraction layer* that gives you a consistent interface to work with any supported LSMS dataset. Instead of harmonizing the data itself (which loses information), we harmonize the /way you access/ the data.
 
-* Quick Start
+* Installation
+
+From PyPI (when available):
 
 #+begin_src bash
 pip install LSMS_Library
 #+end_src
+
+From github (current release):
+
+#+begin_src bash
+pip install git+https://github.com/ligon/LSMS_Library.git@v0.7.0
+#+end_src
+
+From a source checkout (for contributors):
+
+#+begin_src bash
+git clone https://github.com/ligon/LSMS_Library.git
+cd LSMS_Library
+poetry install
+#+end_src
+
+* Quick Start
 
 #+begin_src python
 import lsms_library as ll
@@ -41,11 +59,43 @@ roster.countries   # ['Burkina_Faso', 'Ethiopia', 'Mali', 'Uganda', ...]
 df = roster()      # Harmonized DataFrame across all countries
 #+end_src
 
-** Data Access
+* Data Access
 
-This library provides code for working with LSMS survey data.  The underlying microdata must be obtained directly from the [[https://microdata.worldbank.org/][World Bank Microdata Library]] under their terms of use.  Users are responsible for complying with the World Bank's data access agreements.
+This library abstracts over Living Standards Measurement Study (LSMS) survey data.  The underlying microdata belongs to the respective national statistics offices and the World Bank; users must accept the [[https://microdata.worldbank.org/][World Bank Microdata Library]]'s terms of use before accessing it.
 
-Contributors who wish to add new surveys should contact ligon@berkeley.edu to discuss the workflow.  You will need to establish [[https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key][GPG/PGP credentials]] for repository write access.
+** Authentication: the WB Microdata API key
+
+1. Register at https://microdata.worldbank.org/ (free).
+2. Accept the terms of use for the LSMS collections you want to access.
+3. Get your API key from your account dashboard.
+4. Create =~/.config/lsms_library/config.yml= with:
+
+   #+begin_src yaml
+   microdata_api_key: your_key_here
+   # data_dir: /path/to/override   # same as LSMS_DATA_DIR env var
+   #+end_src
+
+   or set =MICRODATA_API_KEY= as an environment variable.
+5. On =import lsms_library=, the library validates your key against the WB catalog and automatically unlocks access to the S3 read cache.  No further setup is required.
+
+** The S3 cache
+
+Once your WB API key is validated, the library unlocks a read-only S3 cache that mirrors the WB Microdata downloads.  This is a convenience -- the S3 cache is faster than the WB NADA API and reduces load on the WB service -- but it is not a separate access layer.  The WB terms of use are the authoritative gate; the S3 cache just provides the same data faster.
+
+Decrypted plaintext credentials are written to =~/.config/lsms_library/s3_creds= (or the path in the =LSMS_S3_CREDS= environment variable), not into the package tree -- so the library is safe to install from a wheel into a read-only site-packages directory.
+
+** Non-interactive environments
+
+In CI, Docker builds, or other non-interactive contexts, set =LSMS_SKIP_AUTH=1= to suppress the import-time authentication flow.  In that mode you are responsible for ensuring =~/.config/lsms_library/s3_creds= exists (e.g. via a CI secret mount) before the first data access.
+
+** Data cache location
+
+Parquet caches materialize under the platform-appropriate user data directory:
+
+- Linux: =~/.local/share/lsms_library/= by default
+- Override with =LSMS_DATA_DIR= env var or =data_dir= in =config.yml=
+
+See the [[https://ligon.github.io/LSMS_Library/guide/caching/][caching guide]] for details on =trust_cache=, the =Country= and =Feature= classes, and per-country build methods.
 
 * Documentation
 

--- a/lsms_library/__init__.py
+++ b/lsms_library/__init__.py
@@ -156,8 +156,8 @@ except Exception:
     # DVC optional; if missing, proceed without UI tweaks
     pass
 
-gpg_path = Path(__file__).resolve().parent / 'countries' / '.dvc'
-creds_file = gpg_path / 's3_creds'
+from .config import s3_creds_path as _s3_creds_path
+creds_file = _s3_creds_path()
 
 SKIP_AUTH = os.getenv("LSMS_SKIP_AUTH", "").lower() in {"1", "true", "yes"}
 

--- a/lsms_library/config.py
+++ b/lsms_library/config.py
@@ -98,3 +98,23 @@ def data_dir() -> str | None:
 def config_path() -> Path:
     """Return the path to the config file (may not exist yet)."""
     return _config_file()
+
+
+def s3_creds_path() -> Path:
+    """Return the user-writable path for decrypted S3 credentials.
+
+    Precedence: ``$LSMS_S3_CREDS`` env var → ``<config_dir>/s3_creds``.
+    Does NOT create the file or its parent directory.
+
+    This path is where :func:`lsms_library.data_access._auto_unlock_s3`
+    writes the plaintext S3 reader credentials after decrypting
+    ``s3_reader_creds.gpg`` with the obfuscated passphrase, and where
+    :func:`lsms_library.dvc_permissions.authenticate` writes them in
+    the interactive fallback.  Moving the write target out of the
+    package tree makes the library safe to install into a read-only
+    site-packages directory (e.g. a pip-installed wheel).
+    """
+    override = os.environ.get("LSMS_S3_CREDS", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return _config_dir() / "s3_creds"

--- a/lsms_library/data_access.py
+++ b/lsms_library/data_access.py
@@ -19,7 +19,11 @@ World Bank Microdata Library, and access levels are ``"read"`` or
 When a valid ``MICRODATA_API_KEY`` is detected, the module automatically
 decrypts the S3 read credentials (``s3_reader_creds.gpg``) so that DVC
 can stream data without the user having to run ``ll.authenticate()``
-interactively.
+interactively.  The decrypted plaintext is written to the user-writable
+path returned by :func:`lsms_library.config.s3_creds_path` (defaulting
+to ``~/.config/lsms_library/s3_creds``), not into the package tree —
+this is what makes the library safe to install into a read-only
+site-packages directory.
 
 Environment variables
 ---------------------
@@ -28,6 +32,9 @@ MICRODATA_API_KEY
     the WB terms of use.
 LSMS_S3_WRITE_KEY
     If set, grants write access to S3 remotes.
+LSMS_S3_CREDS
+    Override path for the decrypted S3 reader credentials.  Defaults
+    to ``<config_dir>/s3_creds`` (see :func:`lsms_library.config.s3_creds_path`).
 LSMS_SKIP_AUTH
     If ``"1"``/``"true"``/``"yes"``, skip the interactive GPG passphrase
     prompt on import.
@@ -148,7 +155,14 @@ def _check_remote_access(remote_name: str, remote_cfg: dict[str, str],
     if url.startswith("s3://"):
         cred_path = remote_cfg.get("credentialpath")
         has_read = False
-        if cred_path:
+
+        # Prefer the user-writable location (new in v0.7.0).
+        user_creds = config.s3_creds_path()
+        if user_creds.exists() and user_creds.stat().st_size > 0:
+            has_read = True
+        # Fall back to the legacy in-tree location for users who
+        # already have countries/.dvc/s3_creds from an editable install.
+        elif cred_path:
             cred_file = dvc_dir / cred_path
             has_read = cred_file.exists() and cred_file.stat().st_size > 0
 
@@ -264,7 +278,8 @@ def _auto_unlock_s3(dvc_dir: Path | None = None) -> bool:
     if dvc_dir is None:
         dvc_dir = _COUNTRIES_DIR / ".dvc"
 
-    creds_file = dvc_dir / "s3_creds"
+    creds_file = config.s3_creds_path()
+    creds_file.parent.mkdir(parents=True, exist_ok=True)
     if creds_file.exists() and creds_file.stat().st_size > 0:
         return True
 

--- a/lsms_library/dvc_permissions.py
+++ b/lsms_library/dvc_permissions.py
@@ -69,7 +69,12 @@ def authenticate(gpg_key_file='s3_reader_creds.gpg', max_attempts: int = 3,
 
     def _write_creds(decrypted_data, interactive: bool = True):
         """Write decrypted credentials to disk."""
-        creds_file = gpg_path / 's3_creds'
+        # Deferred import: dvc_permissions is imported very early by
+        # lsms_library/__init__.py, and we don't want a top-level
+        # `from . import config` edge during that bootstrap.
+        from lsms_library import config as _cfg
+        creds_file = _cfg.s3_creds_path()
+        creds_file.parent.mkdir(parents=True, exist_ok=True)
 
         if creds_file.exists() and interactive:
             user_input = input(f"The file {creds_file} already exists. Overwrite? (yes/no): ").strip().lower()
@@ -93,9 +98,15 @@ def authenticate(gpg_key_file='s3_reader_creds.gpg', max_attempts: int = 3,
 
     # Interactive path: prompt on TTY
     print(
-        "\n*** LSMS_Library DVC authentication ***\n"
-        "Contact ligon@berkeley.edu to request access credentials.\n"
-        "Enter your passphrase to unlock the survey data stream.\n"
+        "\n*** LSMS_Library DVC authentication (interactive fallback) ***\n"
+        "The preferred way to authenticate is to obtain a free World\n"
+        "Bank Microdata Library API key and set it in\n"
+        "  ~/.config/lsms_library/config.yml   (key: microdata_api_key)\n"
+        "or as the MICRODATA_API_KEY environment variable.  With a valid\n"
+        "WB API key, the library auto-unlocks S3 credentials on import.\n"
+        "\n"
+        "If you cannot use a WB API key, you can enter the shared\n"
+        "passphrase below.  See README.org for details.\n"
     )
 
     for attempt in range(1, max_attempts + 1):

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -79,6 +79,7 @@ import pyreadstat
 import inspect
 from typing import Any
 from .paths import data_root, var_path, wave_data_path, COUNTRIES_ROOT
+from .config import s3_creds_path as _s3_creds_path
 
 # Initialize DVC filesystem once and reuse it.
 #
@@ -95,13 +96,28 @@ from .paths import data_root, var_path, wave_data_path, COUNTRIES_ROOT
 # ``{_DVC_CACHE_DIR}/{md5[:2]}/{md5[2:]}`` is served from local disk
 # instead of streaming from S3.  See ``_ensure_dvc_pulled`` below for
 # the warming side of the round-trip.
+#
+# Similarly, the ``credentialpath`` override on the ``ligonresearch_s3``
+# remote redirects DVC's S3 credential lookup away from the packaged
+# (and in pip-installed layouts, read-only) ``.dvc/s3_creds`` path to
+# the user-writable ``s3_creds_path()``.  DVC is lazy about credential
+# validation: the file at this path does not need to exist at
+# ``DVCFileSystem`` construction time.  The auto-unlock pass later in
+# ``lsms_library/__init__.py`` populates it before the first S3 access.
 _PACKAGE_ROOT = Path(__file__).resolve().parent
 _COUNTRIES_DIR = _PACKAGE_ROOT / "countries"
 _DVC_CACHE_DIR = data_root() / "dvc-cache"
 _DVC_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 DVCFS = DVCFileSystem(
     os.fspath(_COUNTRIES_DIR),
-    config={"cache": {"dir": os.fspath(_DVC_CACHE_DIR)}},
+    config={
+        "remote": {
+            "ligonresearch_s3": {
+                "credentialpath": str(_s3_creds_path()),
+            },
+        },
+        "cache": {"dir": os.fspath(_DVC_CACHE_DIR)},
+    },
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,13 @@ lsms-library = "lsms_library.cli:main"
 repository = "https://github.com/ligon/LSMS_Library"
 
 [tool.poetry]
+include = [
+    "lsms_library/countries/.dvc/config",
+    "lsms_library/countries/.dvc/s3_config",
+    "lsms_library/countries/.dvc/.gitignore",
+    "lsms_library/countries/.dvc/plots/*.json",
+    "lsms_library/countries/.dvc/s3_reader_creds.gpg",
+]
 version = "0.0.0"
 
 [tool.poetry.requires-plugins]

--- a/tests/test_data_access.py
+++ b/tests/test_data_access.py
@@ -233,6 +233,14 @@ class TestValidateWbApiKey:
 # ---------------------------------------------------------------------------
 
 class TestAutoUnlockS3:
+    @pytest.fixture(autouse=True)
+    def _patch_creds_path(self, dvc_dir, monkeypatch):
+        """Redirect s3_creds_path() to the temp dvc_dir so tests stay
+        self-contained and don't touch ~/.config/lsms_library/."""
+        import lsms_library.config as _cfg
+        monkeypatch.setattr(_cfg, "s3_creds_path",
+                            lambda: dvc_dir / "s3_creds")
+
     def test_returns_true_when_creds_already_exist(self, dvc_dir):
         from lsms_library.data_access import _auto_unlock_s3
 


### PR DESCRIPTION
## Summary

- **Bundle `.dvc/` metadata in the wheel** via `[tool.poetry] include` so pip installs ship with DVC remote config and the encrypted GPG blob
- **Redirect all credential writes** from the read-only package tree (`countries/.dvc/s3_creds`) to `~/.config/lsms_library/s3_creds` via a new `config.s3_creds_path()` helper (overridable with `$LSMS_S3_CREDS`)
- **Override `credentialpath`** on the `ligonresearch_s3` remote at `DVCFileSystem` construction time so DVC looks for creds at the user-writable path
- **Backward-compat**: `_check_remote_access` checks the new location first, falls back to legacy in-tree `s3_creds` for existing editable installs
- **Docs reframe**: README gets a full Installation + Data Access walkthrough; CONTRIBUTING leads with the WB Microdata API key flow, adds a "Write access for RAs" section, repositions `ll.authenticate()` as an interactive fallback

Implements the 8-file plan from `slurm_logs/v0.7.0_handoff.org` (minus the `dvc_cache_dir()` helper — the Layer-1 caching work already pins `_DVC_CACHE_DIR = data_root() / "dvc-cache"`, keeping `LSMS_DATA_DIR` as the single cache-location env var).

## Verification done

- `poetry build && unzip -l dist/*.whl | grep '\.dvc/'` — all 8 metadata files present
- `LSMS_SKIP_AUTH=1 poetry run python -c "import lsms_library as ll; print(ll.Country('Uganda', trust_cache=False).waves)"` — prints 8 waves, `ll.creds_file` resolves to `~/.config/lsms_library/s3_creds`
- 219/219 tests pass in `test_dvc_caching.py test_wave_getattr.py test_schema_consistency.py test_feature.py`

## Test plan

- [ ] Merge and `poetry build` the wheel
- [ ] Fresh-venv `pip install` + `import lsms_library` with `MICRODATA_API_KEY` set — verify `~/.config/lsms_library/s3_creds` is auto-created
- [ ] Tag v0.7.0 and cut the release

https://claude.ai/code/session_01J59DdqdpjdzUikYrLXLAfk
