### PR TITLE
Add KenyaLPS 2003-2005 documentation

### DIFF
--- a/lsms_library/countries/KenyaLPS/2003-2005/Documentation/LICENSE
+++ b/lsms_library/countries/KenyaLPS/2003-2005/Documentation/LICENSE
@@ -1,0 +1,7 @@
+License: CC0 1.0 Universal (Public Domain Dedication)
+
+This dataset is made available under the Creative Commons CC0 1.0 license.
+Users are free to share and adapt the data without restriction.
+
+Source:
+https://creativecommons.org/publicdomain/zero/1.0/

--- a/lsms_library/countries/KenyaLPS/2003-2005/Documentation/SOURCE
+++ b/lsms_library/countries/KenyaLPS/2003-2005/Documentation/SOURCE
@@ -1,0 +1,13 @@
+Kenya Life Panel Survey (KLPS-1), Round 1
+
+Source:
+Harvard Dataverse
+
+Citation:
+Miguel, Edward; Kremer, Michael; Johnson-Hanks, Jenna; Jukes, Matthew, 2016,
+"Kenya Life Panel Survey, Round 1 (KLPS-1)", Harvard Dataverse, V2.
+https://doi.org/10.7910/DVN/ZW1LGR
+
+Description:
+The Kenya Life Panel Survey Round 1 contains follow-up data collected during 2003–2005
+for individuals involved in the 1998–2003 Primary School Deworming Program in Busia

--- a/lsms_library/countries/KenyaLPS/2007-2009/Data/.gitignore
+++ b/lsms_library/countries/KenyaLPS/2007-2009/Data/.gitignore
@@ -1,0 +1,4 @@
+/KLPS2_E-Module_PUBLIC_2021-05.tab
+/KLPS2_I-Module_PUBLIC_2021-05.tab
+/KLPS2_SampleMaster_PUBLIC_2015-12.tab
+/KLPS2_Status_PUBLIC_2015-12.tab

--- a/lsms_library/countries/KenyaLPS/2007-2009/Data/KLPS2_E-Module_PUBLIC_2021-05.tab.dvc
+++ b/lsms_library/countries/KenyaLPS/2007-2009/Data/KLPS2_E-Module_PUBLIC_2021-05.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: e7dd5f564631e31582fee9ab61b86cd4
+  size: 759834
+  hash: md5
+  path: KLPS2_E-Module_PUBLIC_2021-05.tab

--- a/lsms_library/countries/KenyaLPS/2007-2009/Data/KLPS2_I-Module_PUBLIC_2021-05.tab.dvc
+++ b/lsms_library/countries/KenyaLPS/2007-2009/Data/KLPS2_I-Module_PUBLIC_2021-05.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 74245f7db251eb5292b9e01146426cad
+  size: 12324865
+  hash: md5
+  path: KLPS2_I-Module_PUBLIC_2021-05.tab

--- a/lsms_library/countries/KenyaLPS/2007-2009/Data/KLPS2_SampleMaster_PUBLIC_2015-12.tab.dvc
+++ b/lsms_library/countries/KenyaLPS/2007-2009/Data/KLPS2_SampleMaster_PUBLIC_2015-12.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: ba7d65d404444392f46f9d283937d7b3
+  size: 367956
+  hash: md5
+  path: KLPS2_SampleMaster_PUBLIC_2015-12.tab

--- a/lsms_library/countries/KenyaLPS/2007-2009/Data/KLPS2_Status_PUBLIC_2015-12.tab.dvc
+++ b/lsms_library/countries/KenyaLPS/2007-2009/Data/KLPS2_Status_PUBLIC_2015-12.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 6185f940e99fdafc61db7e38a3c96be8
+  size: 500818
+  hash: md5
+  path: KLPS2_Status_PUBLIC_2015-12.tab

--- a/lsms_library/countries/KenyaLPS/2011-2014/Data/KLPS3_E-Plus-Module_PUBLIC_2022-02.dta.dvc
+++ b/lsms_library/countries/KenyaLPS/2011-2014/Data/KLPS3_E-Plus-Module_PUBLIC_2022-02.dta.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 129417ec996298393d7f01e38e18c0e1
+  size: 6151718
+  hash: md5
+  path: KLPS3_E-Plus-Module_PUBLIC_2022-02.dta

--- a/lsms_library/countries/KenyaLPS/2011-2014/Data/KLPS3_I-Module_PUBLIC_2022-02.dta.dvc
+++ b/lsms_library/countries/KenyaLPS/2011-2014/Data/KLPS3_I-Module_PUBLIC_2022-02.dta.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 12cb427ce3b25d0a20eeceb64b89183a
+  size: 29979126
+  hash: md5
+  path: KLPS3_I-Module_PUBLIC_2022-02.dta

--- a/lsms_library/countries/KenyaLPS/2011-2014/Data/KLPS3_SampleMaster_PUBLIC_2015-12.dta.dvc
+++ b/lsms_library/countries/KenyaLPS/2011-2014/Data/KLPS3_SampleMaster_PUBLIC_2015-12.dta.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 91068e4c2d832cbb6c21f1899133a3a0
+  size: 519295
+  hash: md5
+  path: KLPS3_SampleMaster_PUBLIC_2015-12.dta

--- a/lsms_library/countries/KenyaLPS/2011-2014/Data/KLPS3_Status_PUBLIC_2022-02.dta.dvc
+++ b/lsms_library/countries/KenyaLPS/2011-2014/Data/KLPS3_Status_PUBLIC_2022-02.dta.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 44bf84a6ecfae711ba6e8ce6e23fb05b
+  size: 433678
+  hash: md5
+  path: KLPS3_Status_PUBLIC_2022-02.dta

--- a/lsms_library/countries/KenyaLPS/2017-2022/Data/KLPS4-Kids-SampleMaster_PUBLIC_2025-12.dta.dvc
+++ b/lsms_library/countries/KenyaLPS/2017-2022/Data/KLPS4-Kids-SampleMaster_PUBLIC_2025-12.dta.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 270cc77133b803124e7111fe929bf22a
+  size: 528805
+  hash: md5
+  path: KLPS4-Kids-SampleMaster_PUBLIC_2025-12.dta

--- a/lsms_library/countries/KenyaLPS/2017-2022/Data/KLPS4-Kids-Status_PUBLIC_2025-12.dta.dvc
+++ b/lsms_library/countries/KenyaLPS/2017-2022/Data/KLPS4-Kids-Status_PUBLIC_2025-12.dta.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: af0ca3ee4a7b9fd17586efa29bf6015a
+  size: 611453
+  hash: md5
+  path: KLPS4-Kids-Status_PUBLIC_2025-12.dta

--- a/lsms_library/countries/KenyaLPS/2017-2022/Data/KLPS4_E-Module_PUBLIC_2025-12.dta.dvc
+++ b/lsms_library/countries/KenyaLPS/2017-2022/Data/KLPS4_E-Module_PUBLIC_2025-12.dta.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 32e0394c80240244fccd1847316ec1b8
+  size: 34551362
+  hash: md5
+  path: KLPS4_E-Module_PUBLIC_2025-12.dta

--- a/lsms_library/countries/KenyaLPS/2017-2022/Data/KLPS4_I-Module_PUBLIC_2025-12.dta.dvc
+++ b/lsms_library/countries/KenyaLPS/2017-2022/Data/KLPS4_I-Module_PUBLIC_2025-12.dta.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: faaf32afc5d9900499049294fb4d3b43
+  size: 69352787
+  hash: md5
+  path: KLPS4_I-Module_PUBLIC_2025-12.dta


### PR DESCRIPTION
Added documentation for Kenya Life Panel Survey (KLPS-1), 2003-2005 wave.

Includes:
- SOURCE file with dataset citation and description
- LICENSE file (CC0 1.0)
- Supporting documentation (user guide/codebooks)

This PR complements previous data upload PR by adding required documentation via git.