### PR TITLE
feat(food): add labels= kwarg to derived food tables

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -1373,6 +1373,52 @@ class Country:
 
         return df
 
+    def _relabel_j(self, df: pd.DataFrame, labels: str | None, *, reaggregate: bool) -> pd.DataFrame:
+        """Rename the ``j`` index level using a column of the country's food label table.
+
+        ``labels='Preferred'`` (or ``None``) is a no-op.  For any other value
+        ``X``, look for a column named ``'X Label'`` (falling back to ``'X'``)
+        in ``food_items`` or ``harmonize_food`` under ``categorical_mapping``,
+        keyed on ``'Preferred Label'`` (the current ``j`` values).
+        """
+        if labels in (None, 'Preferred'):
+            return df
+        if not isinstance(df, pd.DataFrame) or 'j' not in (df.index.names or []):
+            raise KeyError(
+                f"Cannot apply labels={labels!r}: result has no 'j' index level"
+            )
+        cat_maps = self.categorical_mapping or {}
+        table = cat_maps.get('food_items')
+        if table is None:
+            table = cat_maps.get('harmonize_food')
+        if table is None:
+            raise KeyError(
+                f"No food label table ('food_items' or 'harmonize_food') "
+                f"on {self.name!r} for labels={labels!r}"
+            )
+        if 'Preferred Label' not in table.columns:
+            raise KeyError(
+                f"Food label table on {self.name!r} has no 'Preferred Label' column"
+            )
+        target = f"{labels} Label" if f"{labels} Label" in table.columns else labels
+        if target not in table.columns:
+            available = [c for c in table.columns if c != 'Preferred Label']
+            raise KeyError(
+                f"Column {target!r} not in food label table on {self.name!r}; "
+                f"available: {available}"
+            )
+        rdict = (table[['Preferred Label', target]]
+                 .dropna()
+                 .set_index('Preferred Label')[target]
+                 .to_dict())
+        result = df.rename(index=rdict, level='j')
+        if reaggregate:
+            numeric = result.select_dtypes(include='number')
+            if not numeric.empty:
+                result = numeric.groupby(list(result.index.names)).sum(min_count=1)
+        result.attrs = dict(df.attrs)
+        return result
+
     def _finalize_result(self, df: Any, scheme_entry: dict[str, Any], method_name: str) -> pd.DataFrame | dict[str, Any]:
         """
         Apply final harmonization steps (index augmentation, normalization, id walk)
@@ -2238,7 +2284,7 @@ class Country:
             return method
 
         if name in self.data_scheme or name in self._FOOD_DERIVED or name in self._ROSTER_DERIVED:
-            def method(waves=None, market=None):
+            def method(waves=None, market=None, labels='Preferred'):
                 # For derived food tables, try deriving from food_acquired first
                 # before falling back to wave-level scripts / make
                 if (name in self._FOOD_DERIVED
@@ -2251,17 +2297,24 @@ class Country:
                         'food_prices': food_prices_from_acquired,
                         'food_quantities': food_quantities_from_acquired,
                     }[name]
+                    derived = None
                     try:
                         fa = self._aggregate_wave_data(waves, 'food_acquired')
                         if isinstance(fa, pd.DataFrame) and not fa.empty:
-                            result = transform_fn(fa)
+                            derived = transform_fn(fa)
                             scheme_entry = self._materialization_entry(name)
-                            result = self._finalize_result(result, scheme_entry, name)
-                            if market is not None:
-                                result = self._add_market_index(result, column=market)
-                            return result
+                            derived = self._finalize_result(derived, scheme_entry, name)
                     except Exception:
-                        pass  # Fall through to normal aggregation
+                        derived = None  # Fall through to normal aggregation
+                    if derived is not None:
+                        # Relabel is outside the except so user-facing KeyErrors
+                        # (bad labels=) propagate instead of silently falling
+                        # through to the legacy aggregation path.
+                        reagg = name in {'food_expenditures', 'food_quantities'}
+                        derived = self._relabel_j(derived, labels, reaggregate=reagg)
+                        if market is not None:
+                            derived = self._add_market_index(derived, column=market)
+                        return derived
 
                 # Derive household_characteristics from household_roster
                 if (name in self._ROSTER_DERIVED
@@ -2295,6 +2348,15 @@ class Country:
                 "market : str, optional\n"
                 "    Column from cluster_features (e.g. 'Region') to add as\n"
                 "    an ``m`` index level for demand estimation.\n"
+                "labels : str, optional\n"
+                "    Label column to use for the ``j`` index on derived food\n"
+                "    tables (food_expenditures, food_quantities, food_prices).\n"
+                "    Defaults to ``'Preferred'`` (current behaviour).  Other\n"
+                "    values (e.g. ``'Aggregate'``) select a same-named column\n"
+                "    from the country's ``food_items`` / ``harmonize_food``\n"
+                "    table; ``food_expenditures`` and ``food_quantities`` are\n"
+                "    re-aggregated after renaming.  Raises ``KeyError`` if the\n"
+                "    column is absent.\n"
             )
             method.__name__ = name
             method.__qualname__ = f"Country.{name}"

--- a/tests/test_food_labels.py
+++ b/tests/test_food_labels.py
@@ -1,0 +1,192 @@
+"""Tests for the ``labels=`` kwarg on derived food tables.
+
+The first block unit-tests ``Country._relabel_j`` with a synthetic DataFrame
+and an inline fake ``categorical_mapping``; it runs without any data cache.
+
+The second block exercises ``Country('Uganda').food_expenditures(labels=...)``
+end-to-end and is skipped when the Uganda food cache is cold.
+"""
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from lsms_library import Country
+from lsms_library.country import Country as _CountryCls
+from lsms_library.paths import data_root
+
+
+# ---------------------------------------------------------------------------
+# Cache-independent unit tests for _relabel_j
+# ---------------------------------------------------------------------------
+
+
+def _fake_country(cat_maps):
+    """Minimal stand-in exposing the attributes ``_relabel_j`` reads."""
+    fake = SimpleNamespace(
+        name="TestLand",
+        categorical_mapping=cat_maps,
+    )
+    # Bind the real method; it only touches self.name / self.categorical_mapping.
+    fake._relabel_j = _CountryCls._relabel_j.__get__(fake)
+    return fake
+
+
+def _sample_expenditure_df():
+    idx = pd.MultiIndex.from_tuples(
+        [
+            ("T1", "V1", "H1", "Beans (fresh)"),
+            ("T1", "V1", "H1", "Beans (dry)"),
+            ("T1", "V1", "H1", "Matoke (bunch)"),
+            ("T1", "V1", "H2", "Matoke (cluster)"),
+        ],
+        names=["t", "v", "i", "j"],
+    )
+    return pd.DataFrame({"Expenditure": [10.0, 5.0, 2.0, 3.0]}, index=idx)
+
+
+def _food_items_table():
+    return pd.DataFrame(
+        {
+            "Code": [1, 2, 3, 4],
+            "Preferred Label": [
+                "Beans (fresh)",
+                "Beans (dry)",
+                "Matoke (bunch)",
+                "Matoke (cluster)",
+            ],
+            "Aggregate Label": ["Beans", "Beans", "Matoke", "Matoke"],
+        }
+    )
+
+
+def test_relabel_j_preferred_is_noop():
+    fake = _fake_country({"food_items": _food_items_table()})
+    df = _sample_expenditure_df()
+    out = fake._relabel_j(df, "Preferred", reaggregate=True)
+    assert out is df  # short-circuits before any work
+
+
+def test_relabel_j_none_is_noop():
+    fake = _fake_country({"food_items": _food_items_table()})
+    df = _sample_expenditure_df()
+    out = fake._relabel_j(df, None, reaggregate=True)
+    assert out is df
+
+
+def test_relabel_j_aggregate_collapses_and_sums():
+    fake = _fake_country({"food_items": _food_items_table()})
+    df = _sample_expenditure_df()
+    out = fake._relabel_j(df, "Aggregate", reaggregate=True)
+
+    j = set(out.index.get_level_values("j"))
+    assert j == {"Beans", "Matoke"}
+    # Beans (fresh) 10 + Beans (dry) 5 = 15 for (T1, V1, H1, Beans)
+    assert out.loc[("T1", "V1", "H1", "Beans"), "Expenditure"] == 15.0
+    # Totals conserved
+    assert out["Expenditure"].sum() == pytest.approx(df["Expenditure"].sum())
+
+
+def test_relabel_j_no_reaggregate_keeps_duplicates():
+    fake = _fake_country({"food_items": _food_items_table()})
+    df = _sample_expenditure_df()
+    out = fake._relabel_j(df, "Aggregate", reaggregate=False)
+    # Two "Beans" rows remain (not summed) — price-table semantics
+    assert out.index.duplicated().any()
+
+
+def test_relabel_j_missing_column_raises():
+    fake = _fake_country({"food_items": _food_items_table()})
+    df = _sample_expenditure_df()
+    with pytest.raises(KeyError, match="French"):
+        fake._relabel_j(df, "French", reaggregate=True)
+
+
+def test_relabel_j_missing_table_raises():
+    fake = _fake_country({})
+    df = _sample_expenditure_df()
+    with pytest.raises(KeyError, match="food label table"):
+        fake._relabel_j(df, "Aggregate", reaggregate=True)
+
+
+def test_relabel_j_uses_harmonize_food_fallback():
+    table = _food_items_table().rename(columns={"Aggregate Label": "Aggregate"})
+    fake = _fake_country({"harmonize_food": table})
+    df = _sample_expenditure_df()
+    # Column is named 'Aggregate' (no ' Label' suffix); the helper should find it.
+    out = fake._relabel_j(df, "Aggregate", reaggregate=True)
+    assert set(out.index.get_level_values("j")) == {"Beans", "Matoke"}
+
+
+# ---------------------------------------------------------------------------
+# Uganda end-to-end tests (require food_acquired cache)
+# ---------------------------------------------------------------------------
+
+
+def _uganda_food_cache_exists() -> bool:
+    root = data_root("Uganda")
+    return (root / "var" / "food_acquired.parquet").exists()
+
+
+_SKIP_NO_CACHE = pytest.mark.skipif(
+    not _uganda_food_cache_exists(),
+    reason="Uganda food_acquired parquet not cached; requires data build",
+)
+
+
+@pytest.fixture(scope="module")
+def uga():
+    return Country("Uganda")
+
+
+@_SKIP_NO_CACHE
+def test_default_labels_matches_preferred(uga):
+    """``labels='Preferred'`` is the explicit form of the default."""
+    pref = uga.food_expenditures()
+    explicit = uga.food_expenditures(labels="Preferred")
+    pd.testing.assert_frame_equal(
+        pref.sort_index(), explicit.sort_index(), check_like=True
+    )
+
+
+@_SKIP_NO_CACHE
+def test_aggregate_collapses_variants(uga):
+    """``labels='Aggregate'`` replaces Preferred labels with coarser Aggregate ones."""
+    pref = uga.food_expenditures()
+    agg = uga.food_expenditures(labels="Aggregate")
+
+    j_pref = set(pref.index.get_level_values("j"))
+    j_agg = set(agg.index.get_level_values("j"))
+
+    # Variants like "Matoke (bunch)" collapse to "Matoke"
+    assert any(lbl.startswith("Matoke (") for lbl in j_pref), (
+        f"Expected 'Matoke (...)' variants in Preferred labels; got sample "
+        f"{sorted(list(j_pref))[:10]}"
+    )
+    assert "Matoke" in j_agg
+    assert not any(lbl.startswith("Matoke (") for lbl in j_agg), (
+        f"Aggregate labels should not contain 'Matoke (...)' variants; got "
+        f"{[l for l in j_agg if l.startswith('Matoke')]}"
+    )
+
+    # Aggregate index must have fewer or equal distinct items
+    assert len(j_agg) <= len(j_pref)
+
+
+@_SKIP_NO_CACHE
+def test_aggregate_preserves_total_expenditure(uga):
+    """Summing collapses groups; the grand total must be preserved."""
+    pref = uga.food_expenditures()
+    agg = uga.food_expenditures(labels="Aggregate")
+    # NaN-tolerant comparison on the single Expenditure column
+    pref_total = pref["Expenditure"].sum(skipna=True)
+    agg_total = agg["Expenditure"].sum(skipna=True)
+    assert agg_total == pytest.approx(pref_total, rel=1e-9)
+
+
+@_SKIP_NO_CACHE
+def test_unknown_labels_raise_keyerror(uga):
+    """A non-existent label column raises ``KeyError`` listing what's available."""
+    with pytest.raises(KeyError, match=r"(?i)food label table|French|not in"):
+        uga.food_expenditures(labels="French")


### PR DESCRIPTION
## Summary

- `Country('X').food_expenditures(labels='Aggregate')` (and same on `food_quantities` / `food_prices`) renames the `j` index level using a column from the country's `food_items` or `harmonize_food` table, keyed on `'Preferred Label'`.
- Default `labels='Preferred'` is a no-op, so existing callers are unaffected.
- `food_expenditures` and `food_quantities` re-aggregate numeric columns after renaming because Aggregate labels collapse multiple variants into one; `food_prices` keeps the raw per-observation grain.
- Errors from a bad `labels=` (missing column or missing table) now surface as `KeyError` instead of silently falling through to the legacy `!make` path.

## Design

- New `Country._relabel_j` helper lives next to `_apply_categorical_mappings` in `country.py`. Parallels the existing `harmonize_assets -> j` hook at `country.py:1444-1452`, but parameterized on the target column so richer tables (e.g. Aggregate, future language columns) work.
- Column resolution: tries `'{labels} Label'` first, falls back to `'{labels}'`.
- Table lookup: `food_items` (Uganda convention) first, then `harmonize_food` (EHCVM / GhanaLSS / Nigeria / Malawi convention).
- Lays groundwork for the SkunkWorks cross-country label harmonization design without committing to it.

## Usage

```python
import lsms_library as ll
uga = ll.Country('Uganda')
uga.food_expenditures()                       # j = Preferred Label (current)
uga.food_expenditures(labels='Aggregate')     # 'Matoke (bunch)', 'Matoke (cluster)' -> 'Matoke'
uga.food_expenditures(labels='French')        # KeyError: column not in table
```

## Test plan

- [x] New cache-free unit tests in `tests/test_food_labels.py` (7 tests, all pass):
  - `labels='Preferred'` and `labels=None` are short-circuit no-ops
  - `labels='Aggregate'` collapses variants and sums (total conserved)
  - `reaggregate=False` path preserves duplicates (for `food_prices`)
  - Missing column raises `KeyError` listing what's available
  - Missing food label table raises `KeyError`
  - `harmonize_food` fallback works when `food_items` is absent
- [x] Four Uganda end-to-end tests (`labels='Aggregate'` round trip, total preservation, error path) skip cleanly when the `food_acquired` cache is cold; no CI infra change needed.
- [x] Regression: `pytest tests/test_food_prices_dtype.py tests/test_schema_consistency.py` - 162 passed, 4 skipped.
- [x] Live signature + docstring introspection: `inspect.signature(uga.food_expenditures)` shows `(waves=None, market=None, labels='Preferred')` on all three derived food methods.

## Out of scope (follow-ups)

- Populating `Aggregate Label` columns for non-Uganda countries (data entry).
- Cross-country `lsms_library/categorical_mapping/food_items.yml` per `SkunkWorks/cross_country_label_harmonization.org` - separate feature.
- Applying `labels=` to `food_acquired()` - straightforward extension once this lands.

https://claude.ai/code/session_01EvPtoxPn4isxNmkFgMYn8B