### PR TITLE
Fix file handle leaks by using context managers in YAML tests

### DIFF
--- a/SkunkWorks/test_list_based_tags.py
+++ b/SkunkWorks/test_list_based_tags.py
@@ -94,7 +94,8 @@ with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
     temp_path = f.name
 
 try:
-    result = yaml.safe_load(open(temp_path))
+    with open(temp_path) as f:
+        result = yaml.safe_load(f)
 
     print("\n" + "="*70)
     print("Loaded Structure:")

--- a/SkunkWorks/test_tag_as_name.py
+++ b/SkunkWorks/test_tag_as_name.py
@@ -101,7 +101,8 @@ with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
     temp_path = f.name
 
 try:
-    result = yaml.safe_load(open(temp_path))
+    with open(temp_path) as _f:
+        result = yaml.safe_load(_f)
     print("✓ Successfully loaded YAML\n")
 
     print("cluster_features.myvars:")
@@ -133,7 +134,8 @@ with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
     temp_path = f.name
 
 try:
-    result = yaml.safe_load(open(temp_path))
+    with open(temp_path) as _f:
+        result = yaml.safe_load(_f)
     print("✓ Loaded, but structure may be unexpected:")
     print(f"myvars content: {result['cluster_features']['myvars']}")
     print("\nNote: YAML doesn't support '!Tag value' as a mapping entry.")

--- a/SkunkWorks/test_tag_as_name_final.py
+++ b/SkunkWorks/test_tag_as_name_final.py
@@ -108,7 +108,8 @@ with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
     temp_path = f.name
 
 try:
-    result = yaml.safe_load(open(temp_path))
+    with open(temp_path) as f:
+        result = yaml.safe_load(f)
 
     print("="*70)
     print("✓ Successfully loaded YAML with tag-as-name syntax")

--- a/SkunkWorks/test_yaml_tags.py
+++ b/SkunkWorks/test_yaml_tags.py
@@ -103,7 +103,8 @@ with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
     temp_path = f.name
 
 try:
-    result = yaml.safe_load(open(temp_path))
+    with open(temp_path) as f:
+        result = yaml.safe_load(f)
     print("✓ Successfully loaded YAML with tags\n")
     print("cluster_features.myvars:")
     for k, v in result['cluster_features']['myvars'].items():


### PR DESCRIPTION
## Summary
Updated four test files to properly manage file handles by using `with` statements instead of leaving files open implicitly.

## Key Changes
- **test_tag_as_name.py**: Wrapped `yaml.safe_load(open(temp_path))` calls with context managers (2 occurrences)
- **test_list_based_tags.py**: Wrapped `yaml.safe_load(open(temp_path))` call with context manager
- **test_tag_as_name_final.py**: Wrapped `yaml.safe_load(open(temp_path))` call with context manager
- **test_yaml_tags.py**: Wrapped `yaml.safe_load(open(temp_path))` call with context manager

## Implementation Details
All changes follow the same pattern:
```python
# Before
result = yaml.safe_load(open(temp_path))

# After
with open(temp_path) as f:
    result = yaml.safe_load(f)
```

This ensures file handles are properly closed after use, preventing resource leaks and following Python best practices for file handling.

https://claude.ai/code/session_01SciLTR65UnCo58jw5qGepb