### PR TITLE
narrow broad except Exception across lsms_library (#176, #188-#192)

### DIFF
--- a/SkunkWorks/test_list_based_tags.py
+++ b/SkunkWorks/test_list_based_tags.py
@@ -94,7 +94,8 @@ with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
     temp_path = f.name
 
 try:
-    result = yaml.safe_load(open(temp_path))
+    with open(temp_path) as fh:
+        result = yaml.safe_load(fh)
 
     print("\n" + "="*70)
     print("Loaded Structure:")

--- a/SkunkWorks/test_tag_as_name.py
+++ b/SkunkWorks/test_tag_as_name.py
@@ -101,7 +101,8 @@ with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
     temp_path = f.name
 
 try:
-    result = yaml.safe_load(open(temp_path))
+    with open(temp_path) as fh:
+        result = yaml.safe_load(fh)
     print("✓ Successfully loaded YAML\n")
 
     print("cluster_features.myvars:")
@@ -133,7 +134,8 @@ with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
     temp_path = f.name
 
 try:
-    result = yaml.safe_load(open(temp_path))
+    with open(temp_path) as fh:
+        result = yaml.safe_load(fh)
     print("✓ Loaded, but structure may be unexpected:")
     print(f"myvars content: {result['cluster_features']['myvars']}")
     print("\nNote: YAML doesn't support '!Tag value' as a mapping entry.")

--- a/SkunkWorks/test_tag_as_name_final.py
+++ b/SkunkWorks/test_tag_as_name_final.py
@@ -108,7 +108,8 @@ with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
     temp_path = f.name
 
 try:
-    result = yaml.safe_load(open(temp_path))
+    with open(temp_path) as fh:
+        result = yaml.safe_load(fh)
 
     print("="*70)
     print("✓ Successfully loaded YAML with tag-as-name syntax")

--- a/SkunkWorks/test_yaml_tags.py
+++ b/SkunkWorks/test_yaml_tags.py
@@ -103,7 +103,8 @@ with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
     temp_path = f.name
 
 try:
-    result = yaml.safe_load(open(temp_path))
+    with open(temp_path) as fh:
+        result = yaml.safe_load(fh)
     print("✓ Successfully loaded YAML with tags\n")
     print("cluster_features.myvars:")
     for k, v in result['cluster_features']['myvars'].items():

--- a/lsms_library/__init__.py
+++ b/lsms_library/__init__.py
@@ -130,12 +130,15 @@ try:
     if hasattr(dvc_ui, "rich_console"):
         try:
             dvc_ui.rich_console.file = stderr
-        except Exception:
+        except (AttributeError, ImportError):
+            # Defensive against DVC rich-console API drift; programmer bugs
+            # (TypeError, NameError) propagate.
             pass
     if hasattr(dvc_ui, "error_console"):
         try:
             dvc_ui.error_console.file = stderr
-        except Exception:
+        except (AttributeError, ImportError):
+            # Defensive against DVC rich-console API drift.
             pass
     original_init = LoggerHandler.__init__
 
@@ -153,8 +156,9 @@ try:
         for handler in logger_obj.handlers:
             if isinstance(handler, LoggerHandler) and getattr(handler, "stream", None) is not stderr:
                 handler.stream = stderr
-except Exception:
-    # DVC optional; if missing, proceed without UI tweaks
+except (ImportError, AttributeError):
+    # DVC optional or its UI module changed shape; proceed without
+    # UI tweaks.  Programmer bugs surface unchanged.
     pass
 
 from .config import s3_creds_path as _s3_creds_path
@@ -175,10 +179,15 @@ if not SKIP_AUTH and not creds_file.exists():
             # Local GPG decryption failed or no .gpg file — fall back to
             # interactive passphrase prompt.
             raise RuntimeError("auto-unlock did not produce S3 credentials")
-    except Exception:
+    except (ImportError, RuntimeError, OSError):
+        # Auto-unlock skipped (missing dep), failed (no .gpg / bad
+        # passphrase / gpg binary missing).  Fall through to interactive
+        # authenticate(); programmer bugs propagate.
         try:
             authenticate()
-        except Exception as exc:
+        except (RuntimeError, OSError) as exc:
+            # Auth flow failure (network, subprocess, missing creds).
+            # Warn but don't crash import.
             warnings.warn(
                 f"Automatic DVC authentication failed: {exc}. "
                 "Set LSMS_SKIP_AUTH=1 to suppress, or set "

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -51,6 +51,7 @@ from sys import stderr
 import sys
 from dvc.repo import Repo
 from dvc.exceptions import DvcException, PathMissingError
+from pyarrow.lib import ArrowInvalid
 from datetime import datetime
 from typing import Any, Callable, Iterable
 from contextlib import contextmanager, redirect_stdout
@@ -751,7 +752,10 @@ class Wave:
             try:
                 cache_path.parent.mkdir(parents=True, exist_ok=True)
                 df = to_parquet(df, cache_path, absolute_path=True)
-            except Exception as exc:
+            except (OSError, ValueError, ArrowInvalid) as exc:
+                # Disk full / permission denied / parquet serialization
+                # failure -> warn and continue with the in-memory df.
+                # Programmer bugs propagate.
                 warnings.warn(
                     f'wave-level L2 cache write failed for '
                     f'{self.country.name}/{self.year}/{request}: {exc}'
@@ -1230,7 +1234,11 @@ class Country:
         if 'sample' in self.data_scheme:
             try:
                 s = self.sample()
-            except Exception as exc:
+            except (OSError, KeyError, ValueError, AttributeError,
+                    DvcException) as exc:
+                # Sample-table missing / mis-shaped / DVC-fetch failure ->
+                # fall back to wave-level region scan.  Programmer bugs
+                # (TypeError, NameError) surface unchanged.
                 logger.info(
                     "_add_market_index: could not load sample() for HH-level "
                     "lookup of column %r on %s: %s",
@@ -1653,7 +1661,11 @@ class Country:
                 elif current != reference_order:
                     try:
                         df = df.reorder_levels(reference_order)
-                    except Exception as e:
+                    except (ValueError, KeyError, TypeError) as e:
+                        # reorder_levels raises ValueError on level mismatch;
+                        # KeyError/TypeError on bad arg shapes.  Re-raise
+                        # with a richer message so the offending key is
+                        # surfaced.
                         raise ValueError(f"Cannot reorder index levels for '{key}': {e}")
                 aligned_dfs[key] = df
 
@@ -1969,10 +1981,16 @@ class Country:
                         f"v0.7.0 cache read: {method_name} from {cache_path}"
                     )
                     return cached_df
-                except Exception as cache_read_error:
-                    logger.debug(
+                except (OSError, ArrowInvalid) as cache_read_error:
+                    # Stale / corrupted cache parquet -> rebuild from source.
+                    # Surface to the user (not just debug log) so a silent
+                    # cache-miss isn't mistaken for a healthy build.
+                    # Programmer bugs (TypeError, AttributeError) propagate.
+                    warnings.warn(
                         f"v0.7.0 cache read failed for {method_name} "
-                        f"({cache_read_error!r}); rebuilding from source"
+                        f"({cache_read_error!r}); rebuilding from source",
+                        category=UserWarning,
+                        stacklevel=2,
                     )
 
             dvc_root = self.file_path.parent
@@ -2163,6 +2181,9 @@ class Country:
                     if df is None:
                         raise _rebuild_failure_error(self.name, method_name)
             except Exception as error:
+                # broad catch intentional: tee-into-log then re-raise so
+                # _log_issue() captures every materialization failure for
+                # the issues tracker before the exception propagates.
                 _log_issue(self.name, method_name, waves, error)
                 raise
         return self._finalize_result(df, scheme_entry, method_name)

--- a/lsms_library/data_access.py
+++ b/lsms_library/data_access.py
@@ -44,11 +44,13 @@ from __future__ import annotations
 
 import base64
 import configparser
+import json
 import logging
 import os
 import re
 import subprocess
 import tempfile
+import urllib.error
 import zipfile
 from pathlib import Path
 from urllib.parse import urlparse
@@ -221,7 +223,10 @@ def _validate_wb_api_key(api_key: str) -> bool:
         with urllib.request.urlopen(req, timeout=15) as resp:
             data = json.loads(resp.read())
         _wb_key_validated = data.get("result", {}).get("found", 0) > 0
-    except Exception:
+    except (urllib.error.URLError, OSError, TimeoutError,
+            json.JSONDecodeError):
+        # network / HTTP / decode failure — treat as un-validated; programmer
+        # bugs (TypeError, AttributeError) propagate.
         _wb_key_validated = False
 
     return _wb_key_validated
@@ -245,7 +250,9 @@ def _gpg_decrypt(gpg_file: Path, passphrase: str) -> str | None:
             return str(decrypted)
     except ImportError:
         pass
-    except Exception as exc:
+    except (OSError, RuntimeError, ValueError) as exc:
+        # python-gnupg wraps the gpg binary; runtime/IO/value errors are the
+        # plausible failure modes.  Programmer bugs surface unchanged.
         logger.debug("python-gnupg decryption failed: %s", exc)
 
     # Subprocess fallback (works when only the gpg binary is installed)
@@ -260,7 +267,9 @@ def _gpg_decrypt(gpg_file: Path, passphrase: str) -> str | None:
             )
             if result.returncode == 0:
                 return result.stdout.decode()
-        except Exception as exc:
+        except (OSError, subprocess.SubprocessError) as exc:
+            # subprocess failure (binary missing, timeout, etc.); other
+            # exceptions are programmer bugs and should propagate.
             logger.debug("gpg subprocess error: %s", exc)
 
     return None
@@ -389,7 +398,8 @@ def _read_source_url(country: str, wave: str) -> str | None:
         text = source.read_text()
         m = re.search(r'https?://[^\s\]\)]+', text)
         return m.group(0).rstrip("/") if m else None
-    except Exception:
+    except (OSError, UnicodeDecodeError):
+        # File missing or undecodable — treat as no-source-link.
         return None
 
 
@@ -409,7 +419,8 @@ def _get_catalog_idno(catalog_url: str) -> str | None:
             html = resp.read().decode("utf-8", errors="replace")
         m = re.search(r'data-idno="([^"]+)"', html)
         return m.group(1) if m else None
-    except Exception:
+    except (urllib.error.URLError, OSError, TimeoutError):
+        # network / HTTP / timeout — caller treats None as "scrape failed".
         return None
 
 
@@ -430,7 +441,9 @@ def _find_stata_zip_url(api_base: str, idno: str,
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             data = json.loads(resp.read())
-    except Exception as e:
+    except (urllib.error.URLError, OSError, TimeoutError,
+            json.JSONDecodeError) as e:
+        # network / HTTP / timeout / JSON decode — caller handles None.
         logger.debug("NADA resources API error for %s: %s", idno, e)
         return None
 
@@ -508,7 +521,9 @@ def _download_and_extract(download_url: str, zip_filename: str,
 
         logger.warning("File %s not found in %s", target_file, zip_filename)
         return False
-    except Exception as e:
+    except (urllib.error.URLError, OSError, TimeoutError,
+            zipfile.BadZipFile) as e:
+        # network / HTTP / disk / corrupt-zip; programmer bugs propagate.
         logger.error("Download/extract failed: %s", e)
         return False
     finally:
@@ -556,7 +571,9 @@ def _extract_all_from_zip(download_url: str, zip_filename: str,
                         extracted.append(dest)
                         logger.info("  Extracted %s", basename)
         return extracted
-    except Exception as e:
+    except (urllib.error.URLError, OSError, TimeoutError,
+            zipfile.BadZipFile) as e:
+        # network / HTTP / disk / corrupt-zip; programmer bugs propagate.
         logger.error("Full zip download/extract failed: %s", e)
         return extracted
     finally:
@@ -654,7 +671,9 @@ def push_to_cache(path: str | Path,
 
         logger.info("Pushed to cache: %s", path)
         return True
-    except Exception as exc:
+    except (OSError, subprocess.SubprocessError) as exc:
+        # subprocess invocation / timeout / dvc binary missing; programmer
+        # bugs (TypeError, etc.) propagate.
         logger.error("push_to_cache error: %s", exc)
         return False
 
@@ -741,7 +760,9 @@ def push_to_cache_batch(paths: list[str | Path],
         logger.info("dvc push: %d files done.", len(abs_paths))
 
         return abs_paths
-    except Exception as exc:
+    except (OSError, subprocess.SubprocessError) as exc:
+        # subprocess invocation / timeout / dvc binary missing; programmer
+        # bugs (TypeError, etc.) propagate.
         logger.error("push_to_cache_batch error: %s", exc)
         return []
 
@@ -827,7 +848,9 @@ def _wb_catalog_search(country_code: str,
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             data = json.loads(resp.read())
-    except Exception as exc:
+    except (urllib.error.URLError, OSError, TimeoutError,
+            json.JSONDecodeError) as exc:
+        # network / HTTP / decode failure; programmer bugs propagate.
         logger.error("WB catalog search failed: %s", exc)
         return []
 
@@ -1171,7 +1194,9 @@ def get_data_file(path: str | Path,
                 fs.get_file(dvc_path, str(abs_path))
                 logger.info("Fetched from DVC: %s", path)
                 return abs_path
-        except Exception as e:
+        except (OSError, ValueError, KeyError, ImportError) as e:
+            # DVC handle / network / config-key issues fall back to WB
+            # download.  Programmer bugs (TypeError, AttributeError) propagate.
             logger.debug("DVC fetch failed: %s", e)
 
     # 3. Try World Bank download

--- a/lsms_library/diagnostics.py
+++ b/lsms_library/diagnostics.py
@@ -26,6 +26,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import yaml as _yaml
+from pyarrow.lib import ArrowInvalid
 
 from .paths import data_root, COUNTRIES_ROOT
 from .yaml_utils import load_yaml
@@ -47,7 +48,9 @@ def _load_api_derived() -> dict[str, set[str]]:
         info_path = files("lsms_library") / "data_info.yml"
         with open(info_path, "r", encoding="utf-8") as f:
             info = _yaml.safe_load(f)
-    except Exception:
+    except (OSError, _yaml.YAMLError):
+        # Missing or malformed data_info.yml -> empty derived-columns map.
+        # Programmer bugs (TypeError, AttributeError) propagate.
         return {}
     result: dict[str, set[str]] = {}
     for table, cols in info.get("Columns", {}).items():
@@ -439,7 +442,8 @@ def _check_index_overlap_with_spine(df: pd.DataFrame, country: str) -> Check:
                      "other_features not cached (skipped)")
     try:
         spine = pd.read_parquet(spine_path, engine="pyarrow")
-    except Exception:
+    except (OSError, ArrowInvalid):
+        # Stale / corrupt spine parquet -> skip overlap check.
         return Check("index_overlap_with_spine", "pass", "Could not read spine (skipped)")
     if "i" not in spine.index.names:
         return Check("index_overlap_with_spine", "pass", "Spine has no 'i' index (skipped)")
@@ -721,7 +725,7 @@ def validate_feature(
         c = Country(country)
         method = getattr(c, feature)
         df = method()
-    except Exception as e:
+    except Exception as e:  # broad catch intentional: surfaced via Check report
         report.checks.append(Check("load_data", "fail", str(e)))
         return report
     report.checks.append(Check("load_data", "pass",
@@ -777,7 +781,7 @@ def validate_feature(
                 report.checks.append(
                     Check("cross_country", "pass",
                           f"{reference_country} doesn't have {feature} (skipped)"))
-        except Exception as e:
+        except Exception as e:  # broad catch intentional: surfaced via Check report
             report.checks.append(
                 Check("cross_country", "warn",
                       f"Could not load reference {reference_country}: {e}"))
@@ -867,7 +871,7 @@ def _check_has_panel_ids(country) -> Check:
         if not pi:
             return Check("has_panel_ids", "fail", "panel_ids is empty or None")
         return Check("has_panel_ids", "pass", f"{len(pi)} panel ID mappings")
-    except Exception as e:
+    except Exception as e:  # broad catch intentional: surfaced via Check report
         return Check("has_panel_ids", "fail", f"Could not load panel_ids: {e}")
 
 
@@ -880,7 +884,7 @@ def _check_has_updated_ids(country) -> Check:
         waves_with_mappings = {w for w, m in ui.items() if m}
         return Check("has_updated_ids", "pass",
                      f"{len(waves_with_mappings)} waves with ID mappings")
-    except Exception as e:
+    except Exception as e:  # broad catch intentional: surfaced via Check report
         return Check("has_updated_ids", "fail", f"Could not load updated_ids: {e}")
 
 
@@ -919,7 +923,7 @@ def _check_updated_ids_cover_waves(country) -> Check:
         return Check("updated_ids_cover_waves", "pass",
                      f"All {len(covered)} follow-up waves have mappings "
                      f"(baselines: {sorted(baselines)})")
-    except Exception as e:
+    except Exception as e:  # broad catch intentional: surfaced via Check report
         return Check("updated_ids_cover_waves", "fail", str(e))
 
 
@@ -978,7 +982,7 @@ def _check_ids_are_self_consistent(country) -> Check:
         if issues:
             return Check("ids_self_consistent", "warn", "; ".join(issues[:5]))
         return Check("ids_self_consistent", "pass")
-    except Exception as e:
+    except Exception as e:  # broad catch intentional: surfaced via Check report
         return Check("ids_self_consistent", "fail", str(e))
 
 
@@ -1014,7 +1018,9 @@ def _compute_panel_spine(country) -> tuple[pd.DataFrame | None, str]:
                     .set_index(["i", "t"])
                 )
                 return spine, "cached household_roster.parquet"
-        except Exception:
+        except (OSError, ArrowInvalid, KeyError):
+            # Cache miss / corrupt parquet / missing 'i'|'t' columns ->
+            # fall through to the API path.
             pass
 
     # Next try the API (applies the full finalize pipeline including
@@ -1030,7 +1036,11 @@ def _compute_panel_spine(country) -> tuple[pd.DataFrame | None, str]:
                 .set_index(["i", "t"])
             )
             return spine, "household_roster (API)"
-    except Exception:
+    except (OSError, ArrowInvalid, KeyError, ValueError, AttributeError,
+            RuntimeError):
+        # API build failure (missing wave / bad config / DVC fetch) ->
+        # fall through to the cluster_features fallback.  Programmer bugs
+        # (NameError, TypeError on bad caller args) propagate.
         pass
 
     # Last-resort: legacy cluster_features parquet.
@@ -1045,7 +1055,8 @@ def _compute_panel_spine(country) -> tuple[pd.DataFrame | None, str]:
                     .set_index(["i", "t"])
                 )
                 return spine, f"cached cluster_features.parquet"
-        except Exception:
+        except (OSError, ArrowInvalid, KeyError):
+            # Stale / corrupt cluster_features parquet -> caller gets None.
             pass
 
     return None, "no household_roster / cluster_features available"
@@ -1164,7 +1175,7 @@ def _check_panel_attrition_monotonic(country) -> Check:
         return Check("attrition_monotonic", "pass",
                      f"Attrition chains OK ({provenance}): "
                      + "; ".join(summaries[:6]))
-    except Exception as e:
+    except Exception as e:  # broad catch intentional: surfaced via Check report
         return Check("attrition_monotonic", "fail", str(e))
 
 
@@ -1223,7 +1234,7 @@ def _check_ids_applied_consistently(country) -> Check:
             return Check("ids_applied_consistently", "warn", "; ".join(issues[:5]))
         return Check("ids_applied_consistently", "pass",
                      f"Spine IDs look canonical ({provenance})")
-    except Exception as e:
+    except Exception as e:  # broad catch intentional: surfaced via Check report
         return Check("ids_applied_consistently", "fail", str(e))
 
 
@@ -1330,7 +1341,7 @@ def _check_panel_ids_targets_exist(country) -> Check:
             )
         return Check("panel_ids_targets_exist", "pass",
                      f"All {total} chain endpoints present in {provenance}")
-    except Exception as e:
+    except Exception as e:  # broad catch intentional: surfaced via Check report
         return Check("panel_ids_targets_exist", "fail", str(e))
 
 
@@ -1395,7 +1406,7 @@ def _check_id_walk_idempotent(country) -> Check:
         return Check("id_walk_idempotent", "pass",
                      f"id_walk is idempotent on {provenance} "
                      f"({before_rows} rows)")
-    except Exception as e:
+    except Exception as e:  # broad catch intentional: surfaced via Check report
         return Check("id_walk_idempotent", "fail", str(e))
 
 

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -214,13 +214,19 @@ def _ensure_dvc_pulled(fn) -> None:
         except ValueError:
             return  # outside the countries dir, can't fetch
 
-    except Exception:
-        return  # bad sidecar shape, missing key, OS error: bail to streaming
+    except (OSError, yaml.YAMLError, KeyError, IndexError, TypeError):
+        # Bad sidecar shape (None / wrong type), missing 'outs'/'md5' key,
+        # corrupt YAML, or filesystem error -> bail to streaming.  Programmer
+        # bugs (NameError, AttributeError) propagate.
+        return
 
     try:
         with _dvc_working_directory(_COUNTRIES_DIR):
             DVCFS.repo.fetch(targets=[str(rel_path)], jobs=1)
-    except Exception:
+    except (OSError, ValueError, KeyError, RuntimeError):
+        # Fetch is best-effort warming.  DVC raises RuntimeError on remote
+        # config / auth issues; OSError on network/disk; ValueError/KeyError
+        # on bad sidecar metadata.  Stream-fallback handles all of them.
         pass
 
 
@@ -248,7 +254,9 @@ def _is_polluted_workspace_copy(fn) -> bool:
         p = Path(fn).resolve()
         sidecar = p.parent / f"{p.name}.dvc"
         return sidecar.exists()
-    except Exception:
+    except (OSError, ValueError):
+        # Path-resolution failure (loop, permission denied) -> not pollution.
+        # TypeError / AttributeError signal a programmer bug and propagate.
         return False
 
 
@@ -329,7 +337,9 @@ def _try_get_data_file(fn: str | Path) -> Path | None:
     """
     try:
         from .data_access import get_data_file
-    except Exception:
+    except ImportError:
+        # data_access import-time failure (missing optional dep) -> caller
+        # falls back to other paths.
         return None
 
     p = Path(fn)

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -414,7 +414,10 @@ def get_dataframe(fn: str | Path, convert_categoricals: bool = True, encoding: s
             try:
                 df_pr, meta = pyreadstat.read_sav(f, apply_value_formats=convert_categoricals, encoding=encoding)
                 return df_pr
-            except Exception:
+            except (ValueError, pyreadstat.ReadstatError, OSError,
+                    NotImplementedError):
+                # Format-fallback: parser/IO errors mean "try next reader".
+                # Programmer bugs (TypeError, AttributeError) propagate.
                 pass
         elif Path(fn).suffix.lower() == '.sav':
             # SAV file accessed as a stream (e.g. via DVC); pyreadstat needs a path
@@ -422,7 +425,9 @@ def get_dataframe(fn: str | Path, convert_categoricals: bool = True, encoding: s
                 return _pyreadstat_via_tempfile(
                     pyreadstat.read_sav, f, '.sav',
                     apply_value_formats=convert_categoricals, encoding=encoding)
-            except Exception:
+            except (ValueError, pyreadstat.ReadstatError, OSError,
+                    NotImplementedError):
+                # Format-fallback: parser/IO errors mean "try next reader".
                 pass
 
         try:
@@ -445,7 +450,10 @@ def get_dataframe(fn: str | Path, convert_categoricals: bool = True, encoding: s
                 return _pyreadstat_via_tempfile(
                     pyreadstat.read_dta, f, Path(fn).suffix or '.dta',
                     apply_value_formats=convert_categoricals, encoding=encoding)
-        except Exception:
+        except (ValueError, pyreadstat.ReadstatError, OSError,
+                NotImplementedError):
+            # Format-fallback: parser/IO errors mean "try the next reader"
+            # (csv, excel, feather, fwf).  Programmer bugs propagate.
             pass
 
         try:
@@ -507,9 +515,10 @@ def get_dataframe(fn: str | Path, convert_categoricals: bool = True, encoding: s
         try:
             with dvc.api.open(fn,mode='rb') as f:
                 df = read_file(f,convert_categoricals=convert_categoricals,encoding=encoding)
-        except Exception:
-            # Last resort: try get_data_file() which can download from
-            # the World Bank Microdata Library (requires MICRODATA_API_KEY).
+        except (OSError, ValueError, KeyError, ImportError):
+            # DVC handle / config / network failure -> fall back to the WB
+            # Microdata download path.  Programmer bugs (TypeError,
+            # AttributeError) propagate so they aren't silently masked.
             local_path = _try_get_data_file(fn)
             if local_path is not None:
                 with open(local_path, mode='rb') as f:

--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -484,8 +484,11 @@ def _get_kg_factors(df):
                 for unit, factor in inferred.items():
                     if unit.lower() not in factors and np.isfinite(factor) and factor > 0:
                         factors[unit.lower()] = factor
-            except Exception:
-                pass  # If inference fails, proceed with known metric only
+            except (ValueError, ZeroDivisionError, KeyError):
+                # Inference is best-effort; numeric / lookup failure means
+                # we proceed with the known-metric factors only.  Programmer
+                # bugs (TypeError, AttributeError) propagate.
+                pass
 
     return factors
 


### PR DESCRIPTION
## Summary

Six related issues from `SkunkWorks/except_exception_audit.md` rolled into one branch — six separate commits, each scoped to one issue so the tree stays bisectable. Every broad `except Exception` (and `safe_load(open())`) the audit catalogued is either narrowed to per-site types, replaced with a `with`-block, or annotated as intentionally broad with an inline comment.

The common shape: programmer bugs (`TypeError`, `AttributeError`, `NameError`) now propagate where they used to be logged as "network failure" / "cache miss" / "DVC unavailable". Library, IO, network, and parser errors stay caught with comments explaining each set.

| Commit | Issue | What changed |
|---|---|---|
| b58bfa4c | #188 | `data_access.py` — 12 sites narrowed per protected call (urlopen+json, subprocess, gnupg, file regex, DVC fetch). `urllib.error`/`json` promoted to module imports. |
| 7cef2cc3 | #189 | `local_tools.py` format-fallback chain — pyreadstat readers + DVC-open fallback narrowed to parser/IO types. |
| d6d840c3 | #191 | `__init__.py` + `local_tools.py` startup guards — DVC UI tweaks (`AttributeError, ImportError`), auto-unlock (`ImportError, RuntimeError, OSError`), sidecar detection, `data_access` import guard. |
| 4e97a75f | #192 | `country.py` cache reads + `transformations.py:487`. v0.7.0 cache-read failure promoted from `logger.debug` to `warnings.warn(UserWarning)` so stale-cache fall-throughs are visible. The `_log_issue` tee-into-log site is documented as intentionally broad. |
| 13325bfa | #190 | `diagnostics.py` — 5 silent-skip sites narrowed to `(OSError, ArrowInvalid, ...)`; 10 `Check`-reporter sites annotated `# broad catch intentional: surfaced via Check report`. |
| bc12f314 | #176 | 5 SkunkWorks YAML-tag prototype scripts — `yaml.safe_load(open(temp_path))` → `with open(temp_path) as fh: yaml.safe_load(fh)`. Production sites in `country.py` were already fixed; this clears the audit grep. |

After this branch, `rg 'safe_load\(\s*open\(|load_yaml\(\s*open\('` returns zero, and every remaining `except Exception` in `lsms_library/` is either narrowed or carries a `# broad catch intentional:` comment.

## Test plan

- [x] `pytest tests/` (full suite, ~90 min) — exit 0, no regressions.
- [x] `import lsms_library` smoke test — clean.
- [x] `Country('Uganda').household_roster()` — returns (147612, 7) DataFrame.
- [x] `diagnostics.check_panel_consistency(Country('Uganda'))` — 8 checks run, all pass/warn (no failures from the narrowed clauses).
- [x] `rg 'safe_load\(\s*open\(|load_yaml\(\s*open\('` — zero hits.
- [x] `grep 'except Exception' lsms_library/*.py` — only sites with `# broad catch intentional` annotation remain.

Closes #176, closes #188, closes #189, closes #190, closes #191, closes #192.