### PR TITLE
Ethiopia household_roster: years-or-months Age fallback (#178)

### DIFF
--- a/lsms_library/countries/Ethiopia/2011-12/_/2011-12.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/2011-12.py
@@ -1,0 +1,25 @@
+"""Wave-level formatting helpers for Ethiopia 2011-12.
+
+Falls back to ``age_in_months // 12`` when ``hh_s1q04_a`` (years) is
+missing.  All cleanup logic lives in ``../../_/_age_helpers.py``;
+see there for why this isn't a wrapper around ``age_handler``.
+
+GH #178.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_HELPERS = Path(__file__).resolve().parent.parent.parent / "_" / "_age_helpers.py"
+_spec = importlib.util.spec_from_file_location("_ethiopia_age_helpers", _HELPERS)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def Age(value):
+    return _mod.age_components(value)
+
+
+def household_roster(df):
+    return _mod.run_household_roster(df)

--- a/lsms_library/countries/Ethiopia/2011-12/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2011-12/_/data_info.yml
@@ -47,7 +47,12 @@ household_roster:
         pid: individual_id
     myvars:
         Sex: hh_s1q03
-        Age: hh_s1q04_a
+        # Age list = [age_in_years, age_in_months].  ../_/2011-12.py
+        # falls back to floor(months/12) when years is missing.
+        # Empirical rescue: 2777 of 2998 missing rows (GH #178).
+        Age:
+            - hh_s1q04_a
+            - hh_s1q04_b
         Relationship: hh_s1q02
         MonthsAway: hh_s1q05
 

--- a/lsms_library/countries/Ethiopia/2013-14/_/2013-14.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/2013-14.py
@@ -1,0 +1,24 @@
+"""Wave-level formatting helpers for Ethiopia 2013-14.
+
+Falls back to ``age_in_months // 12`` when ``hh_s1q04_a`` (years) is
+missing.  All cleanup logic lives in ``../../_/_age_helpers.py``.
+
+GH #178.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_HELPERS = Path(__file__).resolve().parent.parent.parent / "_" / "_age_helpers.py"
+_spec = importlib.util.spec_from_file_location("_ethiopia_age_helpers", _HELPERS)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def Age(value):
+    return _mod.age_components(value)
+
+
+def household_roster(df):
+    return _mod.run_household_roster(df)

--- a/lsms_library/countries/Ethiopia/2013-14/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2013-14/_/data_info.yml
@@ -56,7 +56,13 @@ household_roster:
         pid: individual_id2
     myvars:
         Sex: hh_s1q03
-        Age: hh_s1q04_a
+        # Age list = [age_in_years, age_in_months].  ../_/2013-14.py
+        # falls back to floor(months/12) when years is missing.
+        # The DOB triplet (hh_s1q04g_*) exists but is only filled
+        # when years is also filled, so adds no rescue (GH #178).
+        Age:
+            - hh_s1q04_a
+            - hh_s1q04_b
         Relationship: hh_s1q02
         MonthsAway: hh_s1q05
 

--- a/lsms_library/countries/Ethiopia/2015-16/_/2015-16.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/2015-16.py
@@ -1,0 +1,24 @@
+"""Wave-level formatting helpers for Ethiopia 2015-16.
+
+Falls back to ``age_in_months // 12`` when ``hh_s1q04a`` (years) is
+missing.  All cleanup logic lives in ``../../_/_age_helpers.py``.
+
+GH #178.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_HELPERS = Path(__file__).resolve().parent.parent.parent / "_" / "_age_helpers.py"
+_spec = importlib.util.spec_from_file_location("_ethiopia_age_helpers", _HELPERS)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def Age(value):
+    return _mod.age_components(value)
+
+
+def household_roster(df):
+    return _mod.run_household_roster(df)

--- a/lsms_library/countries/Ethiopia/2015-16/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2015-16/_/data_info.yml
@@ -59,7 +59,13 @@ household_roster:
         pid: individual_id2
     myvars:
         Sex: hh_s1q03
-        Age: hh_s1q04a
+        # Age list = [age_in_years, age_in_months].  ../_/2015-16.py
+        # falls back to floor(months/12) when years is missing.
+        # The DOB triplet (hh_s1q04g_*) exists but is only filled
+        # when years is also filled, so adds no rescue (GH #178).
+        Age:
+            - hh_s1q04a
+            - hh_s1q04b
         Relationship: hh_s1q02
         MonthsAway: hh_s1q05
 

--- a/lsms_library/countries/Ethiopia/_/_age_helpers.py
+++ b/lsms_library/countries/Ethiopia/_/_age_helpers.py
@@ -1,0 +1,80 @@
+"""Shared Age-rescue helpers for Ethiopia waves.
+
+Why this file isn't a wrapper around ``age_handler``
+====================================================
+
+GH #178 asked us to "adopt ``age_handler()``" along the lines of the
+Niger / Togo / Uganda adoption pattern.  An empirical audit of the five
+Ethiopia ESS GSEC2-equivalent files showed that fix doesn't apply
+verbatim:
+
+  * **2018-19, 2021-22** have no Age gap at all (``s1q03a`` is 100 %
+    non-null in both waves).
+  * **2011-12, 2013-14, 2015-16** do have gaps, but the only DOB
+    triplet is ``hh_s1q04g_*`` — asked of a tiny ~3 % subset of rows
+    and *only* when ``hh_s1q04_a`` is already filled, so it provides
+    zero rescue.  (And the year column is in the **Ethiopian
+    calendar** with month names like 'Yekatit' / 'Hamle' in 2013-14
+    and Gregorian month names in 2015-16, so a real DOB rescue would
+    require Ethiopian-Gregorian conversion plus dual month-name
+    handling.)
+
+What *does* close the gap is the parallel **Age in months** column
+(``hh_s1q04_b`` / ``hh_s1q04b`` / ``s1q03b``), which the surveyor
+fills out for under-5 children.  When ``age_years`` is missing and
+``age_months`` is present, ``Age = months // 12`` is correct (years of
+age is the floor of total months / 12).  Empirical rescue:
+
+    2011-12: 2998 missing -> 2777 rescued (92.6 %)
+    2013-14:  748 missing ->   26 rescued ( 3.5 %)
+    2015-16: 4023 missing ->   11 rescued ( 0.3 %)
+
+so 2814 of 7769 cross-wave Ethiopia gap rows recover.
+
+The function below is what each adopting wave's
+``<wave>.py::household_roster`` calls.  Filename starts with an
+underscore so the country-level formatting-function loader (which
+checks ``ethiopia.py`` and ``mapping.py``) ignores it.
+
+GH #178.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def _coerce_int(x, lo, hi):
+    """Return int(x) clamped to ``[lo, hi]``, or None on bad input."""
+    if pd.isna(x):
+        return None
+    try:
+        v = int(float(x))
+    except (TypeError, ValueError):
+        return None
+    return v if lo <= v <= hi else None
+
+
+def age_components(value):
+    """Pre-process the YAML-list ``Age`` value for a single row.
+
+    ``value`` is a 2-element pandas Series ``[years_col, months_col]``.
+    Returns ``[years_or_None, months_or_None]`` with sentinels and out-
+    of-range values mapped to ``None``.
+    """
+    years = _coerce_int(value.iloc[0], 0, 130)
+    months = _coerce_int(value.iloc[1], 0, 1500)  # 1500 mo = 125 y
+    return [years, months]
+
+
+def run_household_roster(df):
+    """Reduce list-valued ``Age`` to an int via years-or-months fallback."""
+    def _age_from_row(row):
+        years, months = row['Age']
+        if years is not None:
+            return years
+        if months is not None:
+            return months // 12
+        return None
+
+    df['Age'] = df.apply(_age_from_row, axis=1)
+    return df


### PR DESCRIPTION
## Summary

Closes #178. After an empirical audit of the five Ethiopia ESS GSEC2-equivalent files, the literal "adopt `age_handler()`" approach the issue suggested doesn't apply — Ethiopia has the parallel `age_months` column rather than a usable DOB triplet. This PR closes the Age gap with a years-or-months fallback instead.

## Why not `age_handler()`

| Wave | Age gap | DOB triplet present? | Notes |
|------|---|---|---|
| 2011-12 | 2998 (15.9%) | no | only `hh_s1q04_a` (years) + `hh_s1q04_b` (months) |
| 2013-14 | 748 (2.9%) | yes — `hh_s1q04g_*` | only filled where age_years is **also** filled (zero rescue); year is **Ethiopian calendar**; month is Amharic ('Yekatit') |
| 2015-16 | 4023 (14.4%) | yes — `hh_s1q04g_*` | same: zero rescue; month is Gregorian English here |
| 2018-19 | 0 | no | `s1q03a` 100% non-null (only 1 row with sentinel 99, ambiguous with real centenarians) |
| 2021-22 | 0 | no | `s1q03a` 100% non-null (4 rows == 99) |

The DOB triplet is a survey audit/confirmation question, not a fallback. A real DOB rescue would require Ethiopian-Gregorian calendar conversion plus dual month-name handling — high effort, zero return on the actual missing rows.

## What works: months fallback

For under-5 children, surveyors fill `age_months` (`hh_s1q04_b` / `hh_s1q04b` / `s1q03b`). When `age_years` is missing but `age_months` is present, `Age = months // 12` is correct.

## Changes

- New helper `Ethiopia/_/_age_helpers.py` with the years-or-months logic and a docstring explaining the audit.
- YAML list pattern in 3 waves: `Age: [age_years_col, age_months_col]`.
- 22-line `<wave>.py` shim in each adopting wave.
- 2018-19 / 2021-22 untouched — no gap, and a 99-sentinel rescue would risk dropping real centenarian data.

## Empirical impact

| Wave | Before | After | Rescued |
|------|---|---|---|
| 2011-12 | 15867 | 18644 | **+2777** (92.6% of missing) |
| 2013-14 | 25410 | 25436 | +26 (3.5%) |
| 2015-16 | 23967 | 23978 | +11 (0.3%) |
| 2018-19 | 29503 | 29503 | 0 |
| 2021-22 | 25374 | 25374 | 0 |

Total: **+2814 rows**. Cross-wave Age non-null rises from 120121 to 122935 (+2.3%).

## Test plan

- [x] `pytest tests/test_age_handler.py tests/test_age_dtype_consistency.py -k Ethiopia`: 2 passed.
- [x] `Country('Ethiopia').household_roster()` returns 127890×8; Age dtype Int64, range 0..100, no negative values, sample looks correct.
- [x] All 5 waves load without error under `LSMS_NO_CACHE=1`.

## Related

- #165 — parent `age_handler()` adoption plan.
- #177 — Uganda sibling (PR #201).
- #179 — Nigeria sibling (script-path, harder; not yet started).

🤖 Generated with [Claude Code](https://claude.com/claude-code)