### PR TITLE
kinship: add Son-In-Law/Daughter-In-Law variant for Nigeria 2023-24

### DIFF
--- a/lsms_library/categorical_mapping/kinship.yml
+++ b/lsms_library/categorical_mapping/kinship.yml
@@ -108,6 +108,7 @@ Parent Of Head Or Spouse:    [1, 0, consanguineal]
 Sister/Brother Of Head Or Spouse: [0, 1, consanguineal]
 Brother/Sister:              [0, 1, consanguineal]
 Son/Daughter-In-Law:         [-1, 0, affinal]
+Son-In-Law/Daughter-In-Law:  [-1, 0, affinal]   # Nigeria 2023-24 GHS-Panel s1q3
 Father/Mother-In-Law:        [1, 0, affinal]
 Brother/Sister-In-Law:       [0, 1, affinal]
 Head Of Household:           [0, 0, consanguineal]


### PR DESCRIPTION
## Summary

One-line addition to `lsms_library/categorical_mapping/kinship.yml`. The Nigeria GHS-Panel Wave 5 `s1q3` (relationship to head of household) Stata categorical includes the value `Son-In-Law/Daughter-In-Law` — suffix repeated on each side of the slash, distinct from the already-mapped `Son/Daughter-In-Law` (single shared suffix).

Without this entry, `_expand_kinship` emits

```
UserWarning: Unknown relationship labels (add to kinship.yml):
             ['Son-In-Law/Daughter-In-Law']
```

every time a household roster including Wave-5 rows is built (surfaced by PR #203).

Maps to `[-1, 0, affinal]` — same `Generation` / `Distance` / `Affinity` tuple as the existing `Son/Daughter-In-Law` entry.

## Test plan

- [x] Smoke test: `_load_kinship_map()` includes the new key; `_expand_kinship` runs on the new variant with `warnings.simplefilter('error')` enabled and produces the expected `(-1, 0, affinal)` columns.

## Related

- #203 — Nigeria age_handler + 2023-24 wave wiring (where this warning surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)