### PR TITLE
Uganda v0.7.1: fix v-encoding, cluster_features grain, silent HH drop (#196, #197, #161 partial)

### DIFF
--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -15,6 +15,24 @@ if __name__=='__main__':
 else:
     from lsms_library.local_tools import format_id
 
+def District(x):
+    """Canonical District form across all Uganda waves.
+
+    Pre-2018 waves source ``District`` from numeric Stata columns
+    (``h1aq1``, ``h1aq1a``) which df_data_grabber stringifies to
+    ``'101.0'``-style float-strings (CLAUDE.md: ``format_id`` is
+    auto-applied to ``idxvars`` but NOT to ``myvars``).  Post-2018
+    waves source from string columns (``district_name`` / ``district``)
+    which need no normalisation but ``format_id`` is a no-op on them.
+
+    Defining a country-level ``District`` formatter routes every
+    Uganda ``District`` myvar through the canonical normalizer so
+    cross-wave District values share an int-string encoding.
+    GH #161.
+    """
+    return format_id(x)
+
+
 def v(x):
     """Canonical cluster-id form for Uganda's ``v`` myvar across all tables.
 

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -15,6 +15,28 @@ if __name__=='__main__':
 else:
     from lsms_library.local_tools import format_id
 
+def v(x):
+    """Canonical cluster-id form for Uganda's ``v`` myvar across all tables.
+
+    Uganda declares ``v`` as a ``myvar`` in ``sample`` (and elsewhere)
+    rather than an ``idxvar``, so the auto-applied ``format_id`` does
+    not fire and numeric cluster codes like ``10120402`` get
+    float-stringified to ``'10120402.0'`` -- which silently fails to
+    join against ``cluster_features.v`` and ``household_characteristics.v``
+    where ``v`` is in ``idxvars`` and *does* go through ``format_id``.
+
+    Defining a country-level ``v`` formatter routes every Uganda
+    ``v`` myvar through ``format_id``, restoring the cross-table
+    invariant.  ``format_id`` is a no-op on already-canonical strings
+    (e.g., the ``parish_name`` strings in 2018-19, 2019-20) and maps
+    empty strings to ``None`` (cleaning up the 565-row ``v == ''``
+    leak in 2009-10's sample).
+
+    GH #196.
+    """
+    return format_id(x)
+
+
 # Data to link household ids across waves
 Waves = {'2005-06':(),
          '2009-10':(), # ID of parent household  in ('GSEC1.dta',"HHID",'HHID_parent'), but not clear how to use

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -766,6 +766,32 @@ class Wave:
     # This cluster_features method is explicitly defined because additional processing is required after calling grab_data.
     def cluster_features(self) -> pd.DataFrame:
         df = self.grab_data('cluster_features')
+        # Some countries declare ``i: <HHID>`` in cluster_features
+        # ``idxvars`` so the YAML can merge a household-level df_geo
+        # for GPS.  The result then has HH grain (one row per
+        # household) instead of the canonical ``(t, v)`` cluster
+        # grain documented in ``data_scheme.yml``.  Collapse with
+        # ``.first()`` for non-GPS columns (Region/Rural/District are
+        # invariant within a cluster by construction of the LSMS-ISA
+        # sampling design) and ``.mean()`` for Latitude/Longitude
+        # (HH-level GPS approximated as the cluster centroid).
+        # GH #161.
+        if 'i' in df.index.names:
+            keep_levels = [lvl for lvl in df.index.names if lvl != 'i']
+            if df.columns.size:
+                agg = {
+                    c: ('mean' if c in ('Latitude', 'Longitude') else 'first')
+                    for c in df.columns
+                }
+                df = df.groupby(level=keep_levels).agg(agg)
+            else:
+                df = df.groupby(level=keep_levels).first()
+        # ``i`` may also leak in as a *column* when df_geo's idxvars
+        # include it (the merge step turns the duplicate into a column).
+        # Drop it: cluster_features is keyed on ``(t, v)``, the
+        # household identifier has no place in the result.  GH #161.
+        if 'i' in df.columns:
+            df = df.drop(columns='i')
         # if cluster_feature data is from old other_features.parquet file, region is called 'm' so we need to rename it
         if 'm' in df.index.names:
             df = df.reset_index(level = 'm').rename(columns = {'m':'Region'})

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -637,8 +637,15 @@ def df_data_grabber(fn: str | Path, idxvars: dict[str, Any] | str, convert_categ
             else: # A list?
                 for k in kwargs:
                     out[k] = df[k]
-    else:
-        out = df
+    # When ``kwargs`` (myvars) is empty, ``out`` already holds just
+    # the renamed idxvars frame (built above from the ``idxvars`` dict)
+    # which is what ``set_index(list(idxvars.keys()))`` needs.  An
+    # earlier ``else: out = df`` branch overwrote ``out`` with the raw
+    # DataFrame, which still had source column names (``identif`` /
+    # ``id4`` etc.) so ``set_index(['i','v'])`` raised
+    # ``KeyError: "None of ['i','v'] are in the columns"``.  Two
+    # countries hit this: Azerbaijan 1995 and Timor-Leste 2001 sample
+    # df_cover (both declare a deliberately-empty ``myvars: {}``).
 
     out = out.set_index(list(idxvars.keys()))
 

--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -217,6 +217,39 @@ def roster_to_characteristics(df, age_cuts=(4, 9, 14, 19, 31, 51), drop='pid', f
     )
     roster_df = dummies(roster_df,['sex_age'])
     roster_df.index = roster_df.index.droplevel(drop)
+    # Pandas' ``groupby(...)`` default is ``dropna=True``, which silently
+    # excludes rows whose index has NaN in any of ``final_index``.  We
+    # keep that drop (the canonical (t, v, i) key assumes v is
+    # meaningful) but warn loudly with the per-wave count so the loss
+    # isn't invisible to the caller.  GH #197.
+    idx_df = roster_df.index.to_frame(index=False)
+    nan_mask = idx_df[final_index].isna().any(axis=1)
+    n_nan_rows = int(nan_mask.sum())
+    if n_nan_rows > 0:
+        import warnings as _warnings
+        nan_idx = idx_df.loc[nan_mask]
+        # Per-wave row count keyed off ``t`` (the typical user-visible
+        # axis); HH count is a row-count proxy since (t, i) uniquely
+        # identifies a household.
+        if 't' in nan_idx.columns:
+            per_wave = (
+                nan_idx.assign(_one=1)
+                .groupby('t', dropna=True)['_one']
+                .sum()
+                .sort_index()
+                .to_dict()
+            )
+        else:
+            per_wave = {'<no-t>': n_nan_rows}
+        _warnings.warn(
+            f"household_characteristics: dropped {n_nan_rows} roster rows "
+            f"with NaN in one of {final_index} (typically v) "
+            f"-- per-wave: {per_wave}.  These are usually movers / "
+            f"split-offs whose sample() row lacks a cluster code; see "
+            f"GH #197.",
+            UserWarning,
+            stacklevel=3,
+        )
     result = roster_df.groupby(level=final_index).sum()
     result['log HSize'] = np.log(result.sum(axis=1))
     result.columns = result.columns.get_level_values(0)

--- a/tests/test_uganda_v_grain_invariants.py
+++ b/tests/test_uganda_v_grain_invariants.py
@@ -1,0 +1,152 @@
+"""Regression tests for Uganda v-encoding and cluster_features grain.
+
+These codify the invariants restored by:
+
+* GH #196: ``Country('Uganda').sample()['v']`` and
+  ``cluster_features().v`` / ``household_characteristics().v`` use the
+  same canonical string encoding (no float-stringification mismatch).
+* GH #197: ``household_characteristics()`` warns loudly when roster
+  rows are dropped due to NaN ``v``; the warning names the per-wave
+  count.
+* GH #161: ``cluster_features()`` is at ``(t, v)`` grain with no
+  duplicate keys, no stray ``i`` column, and ``District`` values are
+  not float-stringified (no ``"101.0"`` -> the canonical ``"101"``).
+
+Tests skip if Uganda data isn't available (no DVC / no ``.dta``
+files on disk).
+"""
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import pandas as pd
+import pytest
+
+
+def _uganda_or_skip():
+    """Return ``Country('Uganda')`` or skip if data is unavailable."""
+    try:
+        import lsms_library as ll
+        return ll.Country('Uganda')
+    except Exception as exc:  # pragma: no cover - environment-dependent
+        pytest.skip(f"Uganda not available: {exc!r}")
+
+
+@pytest.fixture(scope='module')
+def uga():
+    return _uganda_or_skip()
+
+
+@pytest.fixture(scope='module')
+def uga_sample(uga):
+    try:
+        return uga.sample()
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"sample() failed: {exc!r}")
+
+
+@pytest.fixture(scope='module')
+def uga_cf(uga):
+    try:
+        return uga.cluster_features()
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"cluster_features() failed: {exc!r}")
+
+
+# ---------------------------------------------------------------------------
+# GH #196: cross-table v encoding
+# ---------------------------------------------------------------------------
+
+
+class TestVEncodingMatchesAcrossTables:
+    """``sample().v`` and ``cluster_features().v`` must use the same
+    canonical string form for every wave with cluster data."""
+
+    def test_no_float_stringified_v_in_sample(self, uga_sample):
+        """``'10120402.0'``-style float-stringification must not appear."""
+        v = uga_sample.reset_index()['v'].dropna().astype(str)
+        bad = [s for s in v.unique() if s.endswith('.0')]
+        assert not bad, f"sample().v has float-stringified entries: {bad[:5]}"
+
+    @pytest.mark.parametrize('wave', [
+        '2005-06', '2010-11', '2011-12', '2013-14', '2015-16',
+        '2018-19', '2019-20',
+    ])
+    def test_sample_v_matches_cluster_features_v(self, uga_sample, uga_cf, wave):
+        """Every cluster present in cluster_features should also be in
+        sample for the same wave (or be a documented synthetic ``@``
+        cluster from the 2009-10 mover/split-off fallback)."""
+        sw = set(uga_sample.reset_index().query('t == @wave')['v'].dropna())
+        cw = set(uga_cf.reset_index().query('t == @wave')['v'].dropna())
+        assert cw, f"cluster_features has no v entries for {wave}"
+        # cluster_features's v must all be in sample's v -- the
+        # sample is the authoritative cluster list.
+        missing = cw - sw
+        assert not missing, (
+            f"{wave}: {len(missing)} cluster_features v values missing "
+            f"from sample().v -- {sorted(missing)[:5]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GH #197: silent HH drop loud warning
+# ---------------------------------------------------------------------------
+
+
+class TestSilentHHDropWarns:
+    """``household_characteristics()`` must warn when groupby drops NaN-v
+    roster rows, naming the per-wave row count."""
+
+    def test_warning_emitted_with_per_wave_breakdown(self, uga):
+        # Some Uganda waves have NaN-v roster rows (panel-refresh movers,
+        # 2018-19 parish-name gaps).  The warning must fire and name the
+        # affected waves.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            _ = uga.household_characteristics()
+        relevant = [
+            w for w in caught
+            if 'household_characteristics' in str(w.message)
+            and 'dropped' in str(w.message)
+        ]
+        assert relevant, (
+            "Expected a UserWarning naming the dropped roster rows; "
+            f"got: {[str(w.message)[:80] for w in caught]}"
+        )
+        msg = str(relevant[0].message)
+        assert 'per-wave' in msg, f"Warning missing per-wave breakdown: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# GH #161: cluster_features grain + District format
+# ---------------------------------------------------------------------------
+
+
+class TestClusterFeaturesGrain:
+    """``cluster_features`` is per-cluster, not per-household."""
+
+    def test_index_is_t_v(self, uga_cf):
+        assert list(uga_cf.index.names) == ['t', 'v']
+
+    def test_no_duplicate_keys(self, uga_cf):
+        n_dup = int(uga_cf.index.duplicated().sum())
+        assert n_dup == 0, f"cluster_features has {n_dup} duplicate (t, v) keys"
+
+    def test_no_stray_i_column(self, uga_cf):
+        assert 'i' not in uga_cf.columns, (
+            f"cluster_features leaks the household ``i`` column: "
+            f"{list(uga_cf.columns)}"
+        )
+
+    def test_district_no_float_stringified(self, uga_cf):
+        """``District`` from numeric Stata columns must not stringify
+        to ``'101.0'``-style values."""
+        if 'District' not in uga_cf.columns:
+            pytest.skip("no District column")
+        dist = uga_cf['District'].dropna().astype(str)
+        bad = [s for s in dist.unique() if s.endswith('.0')]
+        assert not bad, (
+            f"District has float-stringified entries: {bad[:5]}.  "
+            f"format_id should strip the trailing .0"
+        )


### PR DESCRIPTION
## Summary

Three Uganda-related bugs blocking the AER replication and a small framework robustness fix surfaced along the way.  Targeted at the v0.7.1 release.

| Commit | Issue | What it does |
|---|---|---|
| 934d4823 | **#196**, **#197** | Country-level \`v\` formatter routes every Uganda \`v\` myvar through \`format_id\`. \`roster_to_characteristics\` warns loudly on the silent-drop pattern. |
| 3bb1bbd1 | **#161 partial** | Framework fix in \`Country.cluster_features()\`: collapse HH grain to \`(t, v)\` via groupby, drop the stray \`i\` column, plus a country-level \`District\` formatter for Uganda. Adds \`tests/test_uganda_v_grain_invariants.py\` (13 regression tests). |
| 48d89a9d | (latent bug) | \`df_data_grabber\` no longer crashes on \`myvars: {}\` (Timor-Leste 2001 \`sample\`, Azerbaijan 1995 \`sample\`). Closes the long-standing \`test_covers_all_waves[Timor-Leste]\` failure. |

## #196: Uganda \`v\` encoding mismatch

Pre-fix: \`sample().v\` returned \`'10120402.0'\` (float-stringified because \`v\` is a \`myvar\` not an \`idxvar\`) while \`cluster_features().v\` and \`household_characteristics().v\` returned \`'10120402'\` (int-stringified via auto-applied \`format_id\`).  In 2013-14 the two encodings produced **zero overlap** on a \`DataFrame.join\` — silently dropping every row of a user-side cross-table join.

Per-wave overlap after fix:

| Wave | Pre-fix | Post-fix |
|---|---|---|
| 2005-06 | 322/322 | 322/322 |
| 2009-10 | 317/317 | 317/317 (+339 synthetic \`@lat,lon\` clusters from mover/split-off fallback) |
| 2010-11 | 324/324 | 324/324 |
| 2011-12 | 321/321 | 321/321 |
| 2013-14 | **0/706** | **706/706** |
| 2015-16 | 875/875 | 875/875 |
| 2018-19 | 751/751 | 751/751 (parish_name strings; format_id is a no-op) |
| 2019-20 | 793/793 | 793/793 |

## #197: silent HH drop in \`household_characteristics\`

\`roster_to_characteristics\` collapses the person-level roster via \`groupby(level=['t','v','i']).sum()\`.  Pandas' \`groupby(..., dropna=True)\` default silently excluded any group whose index has NaN in one of those levels — typically NaN \`v\` from movers/split-offs without a real cluster code.  Fix #196 reduces the count substantially (Uganda 2009-10 went from 565 silent drops to 24), but the silent-drop pattern itself is fixed by adding a \`UserWarning\` immediately before the groupby that names the per-wave row count.  Empirical Uganda counts post-fix:

\`\`\`
UserWarning: household_characteristics: dropped 448 roster rows
with NaN in one of ['t','v','i'] (typically v) -- per-wave:
{'2009-10': 110, '2013-14': 7, '2018-19': 328, '2019-20': 3}
\`\`\`

## #161 (partial): \`cluster_features\` grain + District format

Three of #161's six sub-issues:

1. **Wrong grain.** \`cluster_features\` was at *household* grain because every Uganda wave declares \`i: <HHID>\` in idxvars to support a HH-level df_geo merge for GPS.  Framework fix in \`Country.cluster_features()\`: when \`i\` is in the index, collapse via groupby with \`.first()\` for non-GPS columns (Region/Rural/District are invariant within a cluster by sampling design) and \`.mean()\` for Latitude/Longitude (HH-level GPS approximated as the cluster centroid).
2. **Stray \`i\` column.**  Drop it explicitly after the merge step.
3. **Stringified-float \`District\`.**  Country-level \`District\` formatter routes through \`format_id\`.

Verified non-regression on **6 other countries** (Niger, Senegal, Ethiopia, Tanzania, Malawi, Nigeria) — each still returns \`(t, v)\`-indexed, 0 duplicates, no \`i\` column.

Out of #161's scope (deferred): GPS wiring for unwired waves (issue 4), 2019-20 optional Lat/Lon flag (issue 5), small asymmetric nulls (issue 7), cross-wave \`v\` semantics drift (issue 6).  Per AER paper plan: paper uses GPS from a different source.

## Latent bug: empty \`myvars\` crash

Surfaced while running the cross-country test sweep — \`test_covers_all_waves[Timor-Leste]\` was failing.  Root cause: \`df_data_grabber\` had:

\`\`\`python
if len(kwargs):
    for k, v in kwargs.items():
        out[k] = grabber(df, v)
else:
    out = df              # <-- bug: overwrites the renamed idxvars frame
out.set_index(list(idxvars.keys()))   # KeyError: 'i', 'v' not in columns
\`\`\`

Two countries hit this: Timor-Leste 2001 \`sample.df_cover\` and Azerbaijan 1995 \`sample.df_cover\`.  Both load post-fix.

Followup issue #207 tracks restoring Timor-Leste's interview_date wiring (separate, smaller task).

## Test plan

- [x] \`pytest tests/test_uganda_v_grain_invariants.py\`: 13 passed
- [x] \`pytest tests/test_age_handler.py\`: 33 passed
- [x] \`pytest tests/test_sample.py::TestSample::test_covers_all_waves[Timor-Leste,Azerbaijan]\`: 2 passed (was 1 failing pre-fix)
- [x] Full \`pytest tests/\` minus the baseline-snapshot test: 437 passed, 0 regressions
- [x] Cross-country \`Country(c).cluster_features()\` smoke test on 6 countries: all clean
- [x] \`Country('Uganda').household_characteristics()\` emits the GH #197 warning with per-wave counts
- [x] Existing \`tests/test_uganda_invariance.py\` still passes (the baseline doesn't include sample/cluster_features entries, so nothing to regenerate)

## Release notes (for v0.7.1)

These changes plus the previously-merged work since v0.7.0 (PR #200-#205, the kinship variant, and the merge-master commits) form v0.7.1.  The release should follow:

1. Merge this PR into \`development\`
2. Merge \`development\` into \`master\`
3. Tag \`v0.7.1\` from master
4. \`PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring poetry build && poetry publish\`
5. Pin the AER replication \`use_parquet\` branch to \`lsms_library==0.7.1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)