### PR TITLE
fix(Malawi/2010-11): derive Region from case_id, not hh_a01

### DIFF
--- a/lsms_library/countries/Malawi/2010-11/_/food_acquired.py
+++ b/lsms_library/countries/Malawi/2010-11/_/food_acquired.py
@@ -14,14 +14,17 @@ df = get_dataframe('../Data/Full_Sample/Household/hh_mod_g1.dta', convert_catego
 conversions = pd.read_csv('ihs3_conversions.csv')
 
 # Read region directly from household module for conversion table merge
-# 2010-11 has no 'region' column; derive from district code hh_a01 (1xx=North, 2xx=Central, 3xx=Southern)
+# 2010-11 has no 'region' column.  hh_a01 is the district *name* (string,
+# e.g. "Chitipa"), not a numeric district code; derive Region from the
+# first character of case_id instead (1=North, 2=Central, 3=Southern).
 hh = get_dataframe('../Data/Full_Sample/Household/hh_mod_a_filt.dta')
-_region_map = {1: 'North', 2: 'Central', 3: 'Southern'}
-regions = hh[['case_id', 'hh_a01']].drop_duplicates().set_index('case_id')['hh_a01']
-regions = (pd.to_numeric(regions, errors='coerce') // 100).map(_region_map).dropna()
+_region_map = {'1': 'North', '2': 'Central', '3': 'Southern'}
+regions = (hh[['case_id']].drop_duplicates()
+           .assign(region=lambda d: d['case_id'].astype(str).str[0].map(_region_map))
+           .dropna(subset=['region'])
+           .set_index('case_id')['region'])
 regions.index.name = 'j'
 regions.name = 'm'
-regions = regions.astype(str)
 
 columns_dict = {'case_id': 'j', 'hh_g02' : 'i', 'hh_g03a': 'quantity_consumed', 'hh_g03b' : 'unitcode_consumed', 'hh_g03b_os': 'unitsdetail_consumed',
                 'hh_g05': 'expenditure', 'hh_g04a': 'quantity_bought', 'hh_g04b': 'unitcode_bought', 'hh_g04b_os': 'unitsdetail_bought',


### PR DESCRIPTION
Closes #214.

## What

Fixes the 2010-11 build of `Malawi/_/food_acquired.py` which was silently dropping the entire wave from `Country('Malawi').food_expenditures()` due to a numeric coercion that always produced NaN.

## Why

The script treats `hh_a01` as a numeric district code (per the in-code comment "1xx=North, 2xx=Central, 3xx=Southern"), but in the actual 2010-11 data `hh_a01` is the district *name* as a string (e.g. "Chitipa", "Phalombe").  `pd.to_numeric(..., errors='coerce')` produces all-NaN, `dropna()` empties the Series, and the merged `m` column ends up as float64 NaN — raising `ValueError: trying to merge on float64 and object columns for key 'm'` on the downstream conversion-table merge.

The intent encoded in the comment is correct — `case_id`'s leading digit IS the region marker.  The fix reads it from the right column.

## Verification

```python
>>> import lsms_library as ll
>>> c = ll.Country('Malawi')
>>> c.food_expenditures(waves=c.waves).reset_index().groupby('t')['i'].nunique()
t
2004-05    11188
2010-11    12193   ← previously missing
2013-14     3996
2016-17     2504
2019-20    14498
```

District-level spot-checks:
- Chitipa (North) → case_id starts with '1' (384/384)
- Lilongwe (Central) → '2' (574/574)
- Phalombe (Southern) → '3' (384/384)
- Total 12,271 HH classified = total HH in 2010-11

Build runs cleanly; the resulting `food_acquired.parquet` has 197,734 rows with the same 8-column schema as sibling waves.

## Note on issue #213 stacking

This is a downstream symptom that surfaces *after* #213's `conversion_table_matching` NaN fix lets the script reach the merge step.  Without #213's fix, the script crashes earlier with a different traceback.