### PR TITLE
fix: surface cluster_features failures + expose District for Malawi 2010-11

### DIFF
--- a/lsms_library/countries/Malawi/2010-11/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2010-11/_/data_info.yml
@@ -61,6 +61,12 @@ cluster_features:
                     Neno: Southern
                     Zomba City: Southern
                     Blantyre City: Southern
+            # 2010-11 has no separate `district` column; hh_a01 is the
+            # district *name* (and is also consumed above as the source
+            # for Region via the district->region mapping).  Surface it
+            # raw here so cluster_features() can satisfy market='District'
+            # lookups for this wave.
+            District: hh_a01
     df_geo:
         file: Full_Sample/Geovariables/HH_level/householdgeovariables.dta
         idxvars:

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -1173,7 +1173,21 @@ class Country:
                 if not c.empty:
                     cf_parts.append(c.reset_index())
             except (FileNotFoundError, KeyError, ValueError) as exc:
-                logger.info("Skipping cluster_features for %s/%s: %s", self.name, wave, exc)
+                # Surface as a warning rather than an info-level log so that
+                # YAML / data-shape config bugs don't silently drop entire
+                # waves from market-keyed lookups.  Pre-2026-05-05 this was a
+                # logger.info that never reached users without explicit log
+                # configuration; the silent drop hid the Malawi 2013-14 /
+                # 2016-17 df_geo schema bug for years.
+                warnings.warn(
+                    f"_market_lookup: skipping cluster_features for "
+                    f"{self.name}/{wave} ({type(exc).__name__}: {exc}). "
+                    f"Rows from this wave will be absent from any "
+                    f"{column!r} lookup; check that this wave's "
+                    f"cluster_features YAML matches its source files.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
                 continue
 
         if not cf_parts:


### PR DESCRIPTION
Two narrow fixes that surfaced while diagnosing why \`Country('Malawi').food_expenditures(market='District')\` returned only 2 of 5 waves.

## 1. `_market_lookup`: silent → loud

`country.py:_market_lookup` previously caught per-wave \`(FileNotFoundError, KeyError, ValueError)\` from \`cluster_features()\` and logged at \`info\` level — invisible to users without explicit logging configuration. Any YAML / data-shape config bug silently dropped that wave from every market-keyed lookup.

This swallowed two real Malawi config issues for years:
- 2013-14 / 2016-17 \`df_geo\` declares \`v: ea_id\` but those geo files are per-HH, not per-cluster — \`KeyError: 'ea_id not in columns of dataframe.'\` was hidden.
- 2010-11 cluster_features YAML never declared \`District\` — \`market='District'\` silently produced an empty result for that wave.

Converted the catch to \`warnings.warn(..., RuntimeWarning, stacklevel=2)\`. Users now see:

```
RuntimeWarning: _market_lookup: skipping cluster_features for Malawi/2013-14
(KeyError: 'ea_id not in columns of dataframe.'). Rows from this wave will be
absent from any 'District' lookup; check that this wave's cluster_features
YAML matches its source files.
```

## 2. Malawi 2010-11: add `District: hh_a01`

\`hh_a01\` in 2010-11 is the district *name* (e.g. "Chitipa") — also the source for \`Region\` via the inline \`{Chitipa: North, …}\` mapping. Adding \`District: hh_a01\` to \`cluster_features.df_main.myvars\` exposes it raw alongside the mapped Region, restoring \`market='District'\` for this wave.

## Verification (LSMS_NO_CACHE=1, after-fix)

| Check | Before | After |
|---|---|---|
| 2010-11 cluster_features shape | 768 × 4 (no District) | 768 × 5, 31 unique District values, 0 NaN |
| \`mwi.food_expenditures(market='District').groupby('t').count()\` | 2 waves: 2004-05, 2019-20 | 3 waves: 2004-05, **2010-11 (137,065)**, 2019-20 |
| 2013-14 / 2016-17 in market lookup output | silently absent | absent + 2 RuntimeWarnings explaining why |

## Out of scope (separate follow-up)

- 2013-14 / 2016-17 \`df_geo\` YAML schema bug (use \`i: y2_hhid\` / \`i: case_id\` instead of \`v: ea_id\`, since those geo files are per-HH). Now visible thanks to fix #1, but a different surgical edit. Will be its own PR.

## Test plan

- [ ] CI \`unit-tests\` passes
- [ ] \`Country('Malawi').food_expenditures(market='District')\` includes 2010-11
- [ ] \`Country('Malawi').food_expenditures(market='Region')\` warns loudly about 2013-14 / 2016-17 (then returns 3 waves: 2004-05, 2010-11, 2019-20)
- [ ] No regression for countries whose cluster_features loads cleanly for every wave (no spurious warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)