### PR TITLE
fix(Malawi): declare Region/District in sample (5 waves) + fix 2013-14/2016-17 df_geo grain

### DIFF
--- a/lsms_library/countries/Malawi/2004-05/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2004-05/_/data_info.yml
@@ -11,6 +11,18 @@ sample:
         panel_weight: hhwght
         strata: strata
         Rural: reside
+        # Region / District declared at HH grain so that
+        # _add_market_index() resolves market='Region' / 'District'
+        # via sample() (HH-level) rather than via cluster_features
+        # (cluster aggregate).  Both declarations coexist; see PR
+        # description for the design rationale (path A).
+        Region:
+            - region
+            - mapping:
+                North: North
+                Centre: Central
+                South: Southern
+        District: dist
 
 cluster_features:
     file: sec_a.dta

--- a/lsms_library/countries/Malawi/2010-11/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2010-11/_/data_info.yml
@@ -11,6 +11,46 @@ sample:
         panel_weight: hh_wgt
         strata: hh_a01
         Rural: reside
+        # 2010-11 has no separate `region` or `district` column;
+        # hh_a01 is the district *name*.  Declare Region (mapped) and
+        # District (raw) at HH grain so _add_market_index() resolves
+        # market='Region' / 'District' from sample() directly.  Same
+        # source/mapping as cluster_features.df_main below.
+        Region:
+            - hh_a01
+            - mapping:
+                Chitipa: North
+                Karonga: North
+                Nkhatabay: North
+                Rumphi: North
+                Mzimba: North
+                Mzuzu City: North
+                Kasungu: Central
+                Nkhota kota: Central
+                Ntchisi: Central
+                Dowa: Central
+                Salima: Central
+                Lilongwe: Central
+                Mchinji: Central
+                Dedza: Central
+                Ntcheu: Central
+                Lilongwe City: Central
+                Mangochi: Southern
+                Machinga: Southern
+                Zomba: Southern
+                Chiradzulu: Southern
+                Blanytyre: Southern
+                Mwanza: Southern
+                Thyolo: Southern
+                Mulanje: Southern
+                Phalombe: Southern
+                Chikwawa: Southern
+                Nsanje: Southern
+                Balaka: Southern
+                Neno: Southern
+                Zomba City: Southern
+                Blantyre City: Southern
+        District: hh_a01
 
 cluster_features:
     dfs:

--- a/lsms_library/countries/Malawi/2013-14/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2013-14/_/data_info.yml
@@ -11,6 +11,13 @@ sample:
         panel_weight: panelweight
         strata: district
         Rural: reside
+        Region:
+            - region
+            - mapping:
+                North: North
+                Central: Central
+                South: Southern
+        District: district
 
 cluster_features:
     dfs:
@@ -35,14 +42,17 @@ cluster_features:
                     rural: 0
                     urban: 1
     df_geo:
+        # 2013-14 IHPS publishes lat/lon per HOUSEHOLD (jittered per HH),
+        # not per cluster — the file is keyed on y2_hhid, not ea_id.
+        # Merge df_geo onto df_main on i rather than v.
         file: HouseholdGeovariables_IHPS_13.dta
         idxvars:
-            v: ea_id
+            i: y2_hhid
         myvars:
             Latitude: LAT_DD_MOD
             Longitude: LON_DD_MOD
     merge_on:
-        - v
+        - i
     final_index:
         - t
         - v

--- a/lsms_library/countries/Malawi/2016-17/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2016-17/_/data_info.yml
@@ -16,6 +16,14 @@ sample:
         panel_weight: panelweight_2016
         strata: district
         Rural: reside
+        Region:
+            - region
+            - mapping:
+                North: North
+                Central: Central
+                Southern: Southern
+                South: Southern
+        District: district
 
 cluster_features:
     dfs:
@@ -48,14 +56,17 @@ cluster_features:
                     RURAL: 1
                     URBAN: 0
     df_geo:
+        # 2016-17 IHS4 publishes lat/lon per HOUSEHOLD (cross-sectional file
+        # is keyed on case_id, not ea_id).  Panel HHs (~2.5k) lack a geo
+        # file in this wave and end up with NaN lat/lon -- acceptable.
         file: Cross_Sectional/householdgeovariablesihs4.dta
         idxvars:
-            v: ea_id
+            i: case_id
         myvars:
             Latitude: lat_modified
             Longitude: lon_modified
     merge_on:
-        - v
+        - i
     final_index:
         - t
         - v

--- a/lsms_library/countries/Malawi/2019-20/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2019-20/_/data_info.yml
@@ -16,6 +16,14 @@ sample:
         panel_weight: panelweight_2019
         strata: district
         Rural: reside
+        Region:
+            - region
+            - mapping:
+                North: North
+                Central: Central
+                Southern: Southern
+                South: Southern
+        District: district
 
 cluster_features:
     dfs:

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -8,6 +8,8 @@ Data Scheme:
     panel_weight: float
     strata: str
     Rural: str
+    Region: str
+    District: str
   cluster_features:
     index: (t, v, i)
     Region: str


### PR DESCRIPTION
Implements design path A from the architectural discussion that followed PR #220 ("we go looking for this info in cluster_features but sometimes it's in sample"): keep both \`sample\` and \`cluster_features\` as legitimate homes for market columns. \`sample\` carries the HH-grain answer; \`cluster_features\` carries the cluster aggregate; \`_add_market_index\` already prefers sample first when available.

After this PR, \`Country('Malawi')\` consistently routes Region / District lookups via \`sample\` for every wave; \`cluster_features\` remains as the cluster-level definition and now also builds cleanly for 2013-14 / 2016-17.

## Changes

### Region/District at HH grain in `sample.myvars`

| Wave | source.region | source.district | Mapping needed |
|---|---|---|---|
| 2004-05 | \`sec_a.dta:region\` | \`sec_a.dta:dist\` | Centre→Central, South→Southern |
| 2010-11 | \`hh_mod_a_filt.dta:hh_a01\` (district name) | \`hh_a01\` (raw) | Full 31-district→region map (reproduced from cluster_features.df_main) |
| 2013-14 | \`HH_MOD_A_FILT_13.dta:region\` | \`...:district\` | South→Southern |
| 2016-17 | \`hh_mod_a_filt.dta:region\` (cs+panel) | \`...:district\` | South→Southern |
| 2019-20 | \`hh_mod_a_filt.dta:region\` (cs+panel) | \`...:district\` | South→Southern |

\`Malawi/_/data_scheme.yml\`: declare \`Region: str\`, \`District: str\` under \`sample\`.

### Fix df_geo grain for 2013-14 and 2016-17

\`HouseholdGeovariables_IHPS_13.dta\` and \`Cross_Sectional/householdgeovariablesihs4.dta\` publish lat/lon per HOUSEHOLD, not per cluster, and don't contain \`ea_id\` at all. The YAML's \`idxvars: v: ea_id\` and \`merge_on: [v]\` caused \`KeyError: 'ea_id not in columns of dataframe.'\` at \`cluster_features()\` build time — hidden by a \`logger.info\` that PR #220 just made loud. Switch to \`idxvars: i: <hhid>\` and \`merge_on: [i]\`; lat/lon now joins per-HH onto \`df_main\`. Panel HHs in 2016-17 (~2.5k) lack a panel geo file and end up with NaN lat/lon — acceptable.

## Verification (LSMS_NO_CACHE=1)

\`\`\`
sample() now has Region & District for every wave
  2004-05: shape=(11280, 7)
  2010-11: shape=(12271, 7)
  2013-14: shape=(4000, 7)
  2016-17: shape=(14955, 7)
  2019-20: shape=(14612, 7)

cluster_features() builds for every wave (no df_geo crash)
  2004-05: shape=(110, 3)
  2010-11: shape=(768, 4)
  2013-14: shape=(204, 5)   <- previously KeyError
  2016-17: shape=(880, 5)   <- previously KeyError
  2019-20: shape=(819, 5)

food_expenditures(market='Region') -> all 5 waves; 0 _market_lookup warnings
food_expenditures(market='District') -> all 5 waves; 0 _market_lookup warnings
\`\`\`

## Design rationale

Per the architectural discussion: \`sample\` and \`cluster_features\` can coexist as homes for Region/District because they answer different questions:

- **\`sample.Region\`** is the household's *own* survey answer for Region.
- **\`cluster_features.Region\`** is the cluster-level definition (typically the modal / EA-assigned label).
- \`_add_market_index\` already prefers HH-level (sample) over cluster-level (cluster_features), since the HH-level answer is the "truer" market label for that HH (Uganda has ~145 HH/wave whose self-reported region differs from cluster modal).
- A single cluster CAN, in principle, span two districts — the HH-level vs cluster-modal distinction is meaningful.

This PR materialises that design for Malawi. Once #218's harmony retirement plan progresses, similar declarations may be appropriate for other countries; out of scope here.

## Test plan

- [ ] CI \`unit-tests\` passes
- [ ] \`Country('Malawi').sample()\` includes Region & District for every wave
- [ ] \`Country('Malawi').cluster_features()\` builds for every wave (no KeyError)
- [ ] \`Country('Malawi').food_expenditures(market='Region')\` returns all 5 waves
- [ ] \`Country('Malawi').food_expenditures(market='District')\` returns all 5 waves
- [ ] No \`_market_lookup\` warnings (the new HH-level path covers all waves)

## Related

Builds on:
- #218 (umbrella: harmony.py + per-country food_*.py retirement)
- #219 (Malawi cleanup, step 1 of #218) — open
- #220 (loud cluster_features failures + 2010-11 cluster_features.District) — open

Cumulative state once all three land: Malawi has Region/District in both \`sample\` and \`cluster_features\` for all 5 waves, market='Region'/'District' / 'Rural' all work via the HH-level path with cluster fallback retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)