### PR TITLE
feat: units= kwarg on food_prices / food_quantities (Phase 4)

### DIFF
--- a/.claude/skills/add-feature/food-acquired/SKILL.md
+++ b/.claude/skills/add-feature/food-acquired/SKILL.md
@@ -33,16 +33,35 @@ The `s` axis carries acquisition source as canonical values: `purchased`, `produ
 
 Each input row from a survey questionnaire typically becomes **multiple long-form rows** — one per (item, unit, source) tuple where the household has data.  E.g., a household that purchased 5 kg of rice and produced 2 kg of rice emits two rows: one with `s='purchased'`, `Quantity=5`; another with `s='produced'`, `Quantity=2`.
 
-`Price` is **api-derived** (computed in `Country._finalize_result`) — it is *not* stored in the wave-level parquet.  Semantics by source:
+`Price` is an **optional column** on the wave-level parquet — it is populated only when the survey records a unit price directly.  Semantics by source:
 
 | `s`         | Price means                        | Where it comes from                              |
 |-------------|------------------------------------|--------------------------------------------------|
-| `purchased` | market price                       | `Expenditure / Quantity` (back-calculated)       |
+| `purchased` | market price                       | survey-reported where available, else NaN        |
 | `produced`  | farmgate price                     | survey-reported where available, else NaN        |
 | `inkind`    | imputed value of in-kind receipt   | survey-reported where available, else NaN        |
 | `other`     | NaN by default                     | only filled if the country provides a valuation  |
 
-If a country's source data records farmgate prices natively (e.g., Uganda's `farmgate` column), pass them through under `Price` for the `s='produced'` rows.
+If a country's source data records prices natively (e.g., Uganda's `market` column for purchased and `farmgate` column for produced), pass them through under `Price` for the corresponding `s` value.  Consumers access these via `food_prices(units='unitprice')` (per native `u`) or `food_prices(units='kgprice')` (converted to per-kg).
+
+Wave scripts that omit `Price` are fine — `food_prices(units='kgvalue')` (the default) and `food_prices(units='unitvalue')` derive Price from `Expenditure / Quantity_kg` and `Expenditure / Quantity` respectively, so the framework still produces useful per-kg or per-unit prices.  See *Downstream API* below.
+
+### LCU-only goods: `u='Value'`
+
+Some goods have no natural physical unit — the survey records only expenditure in local currency.  Examples: "Meals in restaurants", GhanaLSS 1987-88 / 1988-89 (money-only food data).  Encode these as a synthetic `u='Value'` with `Quantity = Expenditure` and `Expenditure` populated.
+
+These rows flow correctly through:
+
+- `food_expenditures` (sum across `u`, irrespective of physical-unit conversion).
+- `food_prices(units='unitvalue')` — gives 1 (Kwacha per Kwacha; mathematically tautological, sentinel-clear).
+- `food_quantities(units='kgs')` — carried through with `u='Value'` and the LCU quantity preserved (per the carry rule); consumers wanting purely-kg do `df.xs('kg', level='u')`.
+
+They naturally drop out of:
+
+- `food_prices(units='kgvalue' | 'kgprice')` — no kg factor for `u='Value'`, so NaN.
+- `food_prices(units='unitprice')` — no reported `Price` column for value-only goods.
+
+No special-casing required; the canonical schema accommodates `u='Value'` directly.
 
 ### Visit / round handling
 
@@ -190,6 +209,32 @@ These documents may explain *why* certain choices were made (e.g., why a particu
 
 6. **Verify** with `is_this_feature_sane`
 
+## Downstream API: `food_prices(units=...)` and `food_quantities(units=...)`
+
+Phase 4 (PR #224) added a `units=` kwarg to the derived food tables.  When implementing a country's `food_acquired`, anticipate which modes will be useful:
+
+**`food_prices(units=...)` — four modes:**
+
+| Mode          | Formula                                   | Output unit         | When useful                                                  |
+|---------------|-------------------------------------------|---------------------|--------------------------------------------------------------|
+| `'kgvalue'` *(default)* | `Expenditure / Quantity_kg`     | currency / kg       | Cross-country comparisons; demand systems; backward compat.   |
+| `'unitvalue'` | `Expenditure / Quantity` (native)         | currency / native u | Native-unit prices; preserves info `kgvalue` discards.       |
+| `'kgprice'`   | reported `Price` × kg_factor              | currency / kg       | When wave script populates `Price`; gives per-kg prices for produced/inkind rows where Expenditure is NaN. |
+| `'unitprice'` | reported `Price` (native u)               | currency / native u | Surfaces farmgate / market / imputed prices the survey recorded directly. |
+
+**`food_quantities(units=...)` — two modes:**
+
+| Mode      | Formula                              | Output                                                |
+|-----------|--------------------------------------|-------------------------------------------------------|
+| `'kgs'` *(default)* | kg where convertible; native `Quantity` carried with native `u` tag where it isn't | mixed-physical-unit; `u` tag distinguishes |
+| `'units'` | sum of native `Quantity` per `(t, v, i, j, u, s)` | preserves native units |
+
+The default for both is the pre-Phase-4 behavior (kg-denominated).  No silent fallback between modes — `unitprice` returns NaN where `Price` is missing, doesn't fall back to `unitvalue`.
+
+Full design rationale: `slurm_logs/DESIGN_food_prices_units_kwarg_2026-05-06.org`.
+
+**Naming caveat**: `kgvalue` is what the demand-systems literature usually calls "unit value" (Deaton 1988, 1997 — `Expenditure / Quantity` standardized to kg).  Our `unitvalue` mode deliberately departs from that convention to mean per-native-`u`.  Document this distinction in any analysis-facing docstring.
+
 ## Common pitfalls
 
 - **Unit codes change across waves** — the same physical unit (e.g., "Pail Small") may have code 4 in one wave and code 4A in another
@@ -197,3 +242,4 @@ These documents may explain *why* certain choices were made (e.g., why a particu
 - **Regional variation in local units** — a "heap" of tomatoes may be 0.5 kg in one region and 2 kg in another. Survey-provided conversion factors are region-specific for this reason.
 - **Missing conversion factors** — some unit × item combinations may lack conversion factors. The price-ratio method can fill these gaps.
 - **Multiple acquisition sources** — surveys typically ask about purchased, own-produced, received as gift. Each may have different units.
+- **Case-sensitive `u='kg'` lookups in downstream code** — the framework's `_apply_kg_conversion` lowercases unit lookups against `KNOWN_METRIC`, and Phase 4's `food_quantities(units='kgs')` tags converted rows with lowercase `'kg'`.  If a country's source data uses capital `'Kg'`, downstream code that does `df.xs('Kg', level='u')` will silently break against framework-derived input (Uganda nutrition.py / unitvalues.py hit this — fixed in PR #224 with case-insensitive `mask = u.str.lower() == 'kg'`).

--- a/.claude/skills/demand-estimation.md
+++ b/.claude/skills/demand-estimation.md
@@ -44,6 +44,23 @@ Two derivation fallbacks avoid the need for wave-level scripts:
 For these to work, `food_acquired` and `household_roster` must be in
 the country's `data_scheme.yml`.
 
+### `units=` kwarg on prices and quantities (Phase 4)
+
+`food_prices()` and `food_quantities()` accept a `units=` kwarg that
+controls the price / quantity basis.  Defaults preserve the
+pre-Phase-4 behavior (`'kgvalue'` / `'kgs'`).
+
+For demand estimation, `food_prices(units='kgvalue')` (the default —
+`Expenditure / Quantity_kg`) is what the literature calls "unit
+value" (Deaton 1988, 1997).  `food_prices(units='unitvalue')` gives
+per-native-`u` unit values, useful when working in survey units.
+`food_prices(units='unitprice')` returns survey-reported prices
+directly (NaN where not recorded) — surfaces farmgate prices for
+`s='produced'` rows on countries whose wave scripts populate `Price`
+(Uganda Phase 3 onwards).  See
+`slurm_logs/DESIGN_food_prices_units_kwarg_2026-05-06.org` and the
+`add-feature/food-acquired` skill for the full menu.
+
 ## Column aliases
 
 Tanzania's wave scripts produce `value_purchase` / `quant_ttl_consume`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,13 @@ Auto-unlock decrypts `s3_reader_creds.gpg` with an obfuscated passphrase at impo
 
 **`labels=` kwarg (2026-04-18).** Any table with a `j` index level accepts `labels='Aggregate'` (or any column name from the country's `food_items` / `harmonize_food` table). For derived food tables (`food_expenditures`, `food_quantities`), `reaggregate=True` sums collapsed categories. For all other tables (including `food_acquired`), `reaggregate=False` renames without summing, preserving per-unit and per-source row detail.
 
+**`units=` kwarg (2026-05-06, Phase 4).** `food_prices()` and `food_quantities()` accept a `units=` kwarg that controls the price/quantity basis of the returned DataFrame. Other tables reject it.
+
+- `food_prices(units=...)`: `'kgvalue'` (default — `Expenditure / Quantity_kg`, currency per kg, backward-compatible with the pre-Phase-4 implementation), `'unitvalue'` (`Expenditure / Quantity` per native `u`; gives 1 = "Kwacha per Kwacha" for `u='Value'` rows), `'kgprice'` (reported `food_acquired.Price` × kg_factor), `'unitprice'` (reported `Price` per native `u`). The `*price` modes return NaN where the survey did not record a unit price; **no silent fallback** to the `*value` modes.
+- `food_quantities(units=...)`: `'kgs'` (default — kilograms where `u` is convertible, native quantity carried with the native `u` tag where it isn't; the `u` index distinguishes `'kg'` from native rows), `'units'` (sum of native `Quantity` per `(t, v, i, j, u, s)`).
+- The `'kgvalue'` default deliberately departs from the term-of-art "unit value" common in the literature (Deaton 1988, 1997), which usually means `Expenditure / Quantity` standardized to kg. The denominator-explicit naming avoids ambiguity.
+- See `slurm_logs/DESIGN_food_prices_units_kwarg_2026-05-06.org` for full rationale.
+
 **Uganda's derivation path cannot fire** because its `food_acquired` uses `value_home`/`value_away`/`value_own`/`value_inkind` columns, not a single `Expenditure` column. The legacy script `food_prices_quantities_and_expenditures.py` handles the sum and unit conversion via `kgs_per_other_units.json`. The framework falls back to this materialized parquet and applies `_relabel_j` to the result. Blocked on GH #169 (canonical food_acquired columns).
 
 `Country._DEPRECATED` maps removed/deprecated table names to deprecation messages. `__getattr__` checks it before `data_scheme`, returning a method that emits `DeprecationWarning` and calls a compatibility shim. Currently contains `locality` only. See `docs/migration/locality.md`.

--- a/lsms_library/countries/Uganda/_/nutrition.py
+++ b/lsms_library/countries/Uganda/_/nutrition.py
@@ -46,8 +46,10 @@ final_fct = pd.concat([fct, fct_usda]).sort_index().T
 fct_cols = fct.columns.intersection(fct_usda.columns)
 final_fct = final_fct.loc[fct_cols]
 
-#sum all quantities
-q = q.xs('Kg',level='u').sum(axis=1)
+#sum all quantities — case-insensitive 'kg' to handle both
+# legacy parquets (u='Kg') and Phase-4 derived ones (u='kg').
+mask = q.index.get_level_values('u').astype(str).str.lower() == 'kg'
+q = q[mask].droplevel('u').sum(axis=1)
 
 # Deal with any dupes
 q = q.groupby(['i','t','j']).sum()

--- a/lsms_library/countries/Uganda/_/unitvalues.py
+++ b/lsms_library/countries/Uganda/_/unitvalues.py
@@ -10,7 +10,10 @@ import numpy as np
 
 q = get_dataframe('../var/food_quantities.parquet').squeeze()
 # Use_units turns out to almost always be kilograms...
-q = q.xs('Kg',level='u')
+# Case-insensitive 'kg' to handle both legacy parquets (u='Kg') and
+# Phase-4 derived ones (u='kg').
+mask = q.index.get_level_values('u').astype(str).str.lower() == 'kg'
+q = q[mask].droplevel('u')
 q = q.replace(0.0,np.nan).dropna()
 
 x = get_dataframe('../var/food_expenditures.parquet').stack('i')

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -2576,12 +2576,17 @@ class Country:
             return method
 
         if name in self.data_scheme or name in self._FOOD_DERIVED or name in self._ROSTER_DERIVED:
-            def method(waves=None, market=None, labels='Preferred', age_cuts=None):
+            def method(waves=None, market=None, labels='Preferred', age_cuts=None, units=None):
                 if age_cuts is not None and name not in self._ROSTER_DERIVED:
                     raise TypeError(
                         f"{name}() got an unexpected keyword argument 'age_cuts'; "
                         "only roster-derived tables (e.g. household_characteristics) "
                         "accept age_cuts."
+                    )
+                if units is not None and name not in {'food_prices', 'food_quantities'}:
+                    raise TypeError(
+                        f"{name}() got an unexpected keyword argument 'units'; "
+                        "only 'food_prices' and 'food_quantities' accept units."
                     )
                 # For derived food tables, try deriving from food_acquired first
                 # before falling back to wave-level scripts / make
@@ -2595,14 +2600,23 @@ class Country:
                         'food_prices': food_prices_from_acquired,
                         'food_quantities': food_quantities_from_acquired,
                     }[name]
+                    transform_kwargs = {}
+                    if units is not None and name in {'food_prices', 'food_quantities'}:
+                        transform_kwargs['units'] = units
                     derived = None
                     try:
                         fa = self._aggregate_wave_data(waves, 'food_acquired')
                         if isinstance(fa, pd.DataFrame) and not fa.empty:
-                            derived = transform_fn(fa)
+                            derived = transform_fn(fa, **transform_kwargs)
                             scheme_entry = self._materialization_entry(name)
                             derived = self._finalize_result(derived, scheme_entry, name)
                     except (FileNotFoundError, KeyError, ValueError, RuntimeError) as exc:
+                        if units is not None:
+                            # Caller explicitly asked for canonical units= behaviour;
+                            # the legacy fall-through path can't honour that, so
+                            # surface the failure rather than silently returning
+                            # un-units-aware data.
+                            raise
                         logger.info(
                             "Deriving %s from food_acquired failed (%s); "
                             "falling back to legacy aggregation", name, exc)
@@ -2668,6 +2682,30 @@ class Country:
                 "    re-aggregated after renaming.  Raises ``KeyError`` if the\n",
                 "    column is absent.\n",
             ]
+            if name in {'food_prices', 'food_quantities'}:
+                if name == 'food_prices':
+                    doc_parts.append(
+                        "units : {'kgvalue', 'kgprice', 'unitvalue', 'unitprice'}, optional\n"
+                        "    Price basis.  Default ``'kgvalue'`` (Expenditure /\n"
+                        "    Quantity_kg, currency per kg).  Other modes:\n"
+                        "    ``'unitvalue'`` (Expenditure / Quantity, per native\n"
+                        "    u; gives 1 = Kwacha-per-Kwacha for u='Value' rows),\n"
+                        "    ``'kgprice'`` (reported Price × kg_factor),\n"
+                        "    ``'unitprice'`` (reported Price as-is).  See\n"
+                        "    :func:`lsms_library.transformations.food_prices_from_acquired`\n"
+                        "    and ``slurm_logs/DESIGN_food_prices_units_kwarg_2026-05-06.org``.\n"
+                    )
+                else:  # food_quantities
+                    doc_parts.append(
+                        "units : {'kgs', 'units'}, optional\n"
+                        "    Quantity basis.  Default ``'kgs'`` (kilograms\n"
+                        "    where the unit is convertible; native quantity\n"
+                        "    carried with native u-tag where it isn't).\n"
+                        "    ``'units'`` returns native Quantity per (t,v,i,j,u,s).\n"
+                        "    See\n"
+                        "    :func:`lsms_library.transformations.food_quantities_from_acquired`\n"
+                        "    and ``slurm_logs/DESIGN_food_prices_units_kwarg_2026-05-06.org``.\n"
+                    )
             if name in self._ROSTER_DERIVED:
                 doc_parts.append(
                     "age_cuts : tuple of positive numbers, optional\n"

--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -698,66 +698,221 @@ def food_expenditures_from_acquired(df):
     return x
 
 
-def food_quantities_from_acquired(df):
-    """Derive food quantities (in kg) from food_acquired.
+def food_quantities_from_acquired(df, units='kgs'):
+    """Derive food quantities from food_acquired.
 
-    Uses known metric conversions and price-ratio inference to convert
-    local units to kg, then sums per household × item × period × unit ×
-    acquisition source (when ``s`` and ``u`` are present in the input
-    index).
+    Parameters
+    ----------
+    df : pd.DataFrame
+        food_acquired DataFrame with a ``Quantity`` column and a ``u``
+        index level naming the unit each row's quantity is in.
+    units : {'kgs', 'units'}, default 'kgs'
+        Aggregation basis:
 
-    Phase 4 of GH #169: the group-by preserves both ``u`` (the original
-    per-row unit) and ``s`` (acquisition source).  The summed values are
-    in kg (``Quantity_kg``) but the output column is named ``Quantity``;
-    the ``u`` index level records what the original per-row unit was.
+        - ``'kgs'`` (default): convert ``Quantity`` to kilograms where
+          the unit's kg factor is known (via :func:`_get_kg_factors`);
+          tag those rows with ``u='kg'``.  Rows whose unit lacks a
+          factor (e.g. ``u='Value'`` for LCU-only goods such as
+          "meals in restaurants", or ``u='tin'`` when no per-tin kg
+          conversion is known) are *carried through* with their native
+          ``Quantity`` and original ``u`` label, NOT dropped.  The output
+          is therefore mixed-physical-unit; the ``u`` index distinguishes
+          kg from native rows.  Consumers wanting purely-kg rows do
+          ``df.xs('kg', level='u')``.
+        - ``'units'``: sum native ``Quantity`` per ``(t, v, i, j, u, s)``,
+          no kg conversion attempted.
+
+    Returns
+    -------
+    pd.DataFrame
+        Single-column ``Quantity`` DataFrame with ``u`` and ``s``
+        retained in the index (Phase 4 of GH #169 preserves the
+        acquisition-source axis).
+
+    Notes
+    -----
+    The carry rule for unconvertible units in ``'kgs'`` mode is the
+    Phase-4 design call recorded in
+    ``slurm_logs/DESIGN_food_prices_units_kwarg_2026-05-06.org``.  It
+    differs from the original implementation, which silently dropped
+    unconvertible rows from ``food_quantities``.
+
+    The output's group-by preserves both ``u`` (the per-row unit; ``'kg'``
+    for converted rows, native otherwise) and ``s`` (acquisition source),
+    per the GH #169 canonical schema.  Pre-canonical waves where ``s`` is
+    absent silently skip the ``s`` level.
     """
+    valid_units = {'kgs', 'units'}
+    if units not in valid_units:
+        raise ValueError(
+            f"food_quantities units= must be one of {sorted(valid_units)}, "
+            f"got {units!r}"
+        )
+
     df = _normalize_columns(df)
     if 'Quantity' not in df.columns:
         raise ValueError("food_acquired must have a 'Quantity' column")
 
+    idx_names = list(df.index.names)
+    if 'u' not in idx_names:
+        # No u index level → can't tag units; fall back to a single-bucket
+        # aggregation per (t, v, i, j, s).
+        group_by = [n for n in ['t', 'v', 'i', 'j', 's'] if n in idx_names]
+        q = df[['Quantity']].replace(0, np.nan).dropna()
+        if group_by:
+            q = q.groupby(group_by).sum()
+        return q
+
+    if units == 'units':
+        group_by = [n for n in ['t', 'v', 'i', 'j', 'u', 's'] if n in idx_names]
+        q = df[['Quantity']].replace(0, np.nan).dropna()
+        q = q.groupby(group_by).sum()
+        return q
+
+    # units == 'kgs': carry rule
     factors = _get_kg_factors(df)
     v = _apply_kg_conversion(df, factors)
 
-    idx_names = list(v.index.names)
-    # Preserve both `u` and `s` in the output (Phase 4).
-    group_by = [n for n in ['t', 'v', 'i', 'j', 'u', 's'] if n in idx_names]
+    # Per-row: where Quantity_kg is non-NaN, use it and tag u='kg';
+    # otherwise carry native Quantity with native u.  Subsumes the
+    # Phase-4 (b9df8fb4) s-preserving group-by below.
+    converted = v['Quantity_kg'].notna().to_numpy()
+    qty_kg = v['Quantity_kg'].to_numpy()
+    qty_native = v['Quantity'].to_numpy()
+    qty = np.where(converted, qty_kg, qty_native)
 
-    q = v[['Quantity_kg']].rename(columns={'Quantity_kg': 'Quantity'})
-    q = q.replace(0, np.nan).dropna()
-    q = q.groupby(group_by).sum()
-    return q
+    u_native = v.index.get_level_values('u').astype(str).to_numpy()
+    u_new = np.where(converted, 'kg', u_native)
+
+    # Rebuild index with the new u column.
+    new_levels = []
+    for name in v.index.names:
+        if name == 'u':
+            new_levels.append(u_new)
+        else:
+            new_levels.append(v.index.get_level_values(name).to_numpy())
+    new_idx = pd.MultiIndex.from_arrays(new_levels, names=v.index.names)
+
+    out = pd.DataFrame({'Quantity': qty}, index=new_idx)
+    out = out.replace(0, np.nan).dropna()
+    group_by = [n for n in ['t', 'v', 'i', 'j', 'u', 's'] if n in out.index.names]
+    out = out.groupby(group_by).sum()
+    return out
 
 
-def food_prices_from_acquired(df):
-    """Derive food prices (per kg) from food_acquired.
+def food_prices_from_acquired(df, units='kgvalue'):
+    """Derive food prices from food_acquired.
 
-    Unit values are computed as Expenditure / Quantity_kg and returned
-    at the natural grain of the input (``(t, v, i, j, u, s)`` after the
-    Phase 3 canonical reshape, or a legacy subset).  It is the analyst's
-    responsibility to compute medians / means across whatever dimension
-    they care about — returning the raw per-observation prices preserves
-    information and lets the downstream analysis choose its own
-    aggregation.
+    Returned at the natural grain of the input (``(t, v, i, j, u, s)``
+    after the Phase 3 canonical reshape, or a legacy subset) — analysts
+    compute medians / means across whatever dimension they care about,
+    so per-observation Price preserves information.
 
-    For canonical s-axis input, only purchased rows have a meaningful
-    Expenditure (helper sets produced/inkind to NaN).  Their Price is
-    NaN-after-divide and dropped by ``replace([0, inf, -inf], nan).dropna()``.
-    Users who want farmgate prices on produced rows must supply a
-    survey-reported Price column upstream (Uganda Phase 3 path); this
-    function does not synthesize one.  See GH #169 design doc for the
-    s-keyed price semantics.
+    Parameters
+    ----------
+    df : pd.DataFrame
+        food_acquired DataFrame.  Must have ``Quantity``; needs
+        ``Expenditure`` for the ``*value`` modes and ``Price`` for
+        the ``*price`` modes.
+    units : {'kgvalue', 'kgprice', 'unitvalue', 'unitprice'}, default 'kgvalue'
+        Which Price to compute, varying across two axes (denominator and
+        source):
+
+        - ``'kgvalue'`` (default): ``Expenditure / Quantity_kg``
+          (currency / kg, derived).  Backward-compatible with the
+          pre-Phase-4 implementation.
+        - ``'unitvalue'``: ``Expenditure / Quantity`` (currency / native u,
+          derived).  For ``u='Value'`` rows (LCU-only goods) the formula
+          gives 1 — *Kwacha per Kwacha* — mathematically correct but
+          analytically useless; consumers should filter on ``u`` before
+          aggregating.
+        - ``'kgprice'``: reported ``Price`` × kg_factor (currency / kg).
+          NaN where ``Price`` is missing or ``u`` is unconvertible to kg.
+        - ``'unitprice'``: reported ``Price`` (currency / native u).
+          NaN where the survey did not record a unit price.  This
+          mode reflects the canonical ``food_acquired.Price`` column —
+          market price for ``s='purchased'``, farmgate for
+          ``s='produced'``, imputed for ``s='inkind'``.
+
+        See ``slurm_logs/DESIGN_food_prices_units_kwarg_2026-05-06.org``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Single-column ``Price`` DataFrame at the natural grain of the
+        input (typically ``(t, v, i, j, u, s)`` after the s-axis
+        migration).  Zero / infinite / NaN prices are dropped.
+
+    Notes
+    -----
+    The ``'kgvalue'`` default deliberately departs from the term-of-art
+    "unit value" common in the literature (e.g. Deaton 1988, 1997),
+    which usually means ``Expenditure / Quantity`` standardized to kg.
+    The ``'kgvalue'`` / ``'unitvalue'`` naming makes the denominator
+    explicit at the cost of mild inconsistency with prior usage; consult
+    the docstring before substituting one for "unit value" in literature
+    review or reproduction work.
+
+    No silent fallback between modes.  ``'unitprice'`` returns NaN where
+    Price is missing rather than falling back to ``'unitvalue'``; a
+    caller wanting "best available" combines results explicitly with
+    their own provenance tracking.
+
+    For canonical s-axis input, only ``s='purchased'`` rows have a
+    meaningful ``Expenditure`` (the Phase-3 helpers set produced/inkind
+    Expenditure to NaN).  Under ``'kgvalue'`` / ``'unitvalue'`` those
+    rows become NaN-after-divide and drop out.  Under ``'kgprice'`` /
+    ``'unitprice'`` produced/inkind rows survive iff the wave script
+    populated the survey-reported ``Price`` column upstream (Uganda
+    Phase 3 path).  This function does not synthesize a Price.
     """
+    valid_units = {'kgvalue', 'kgprice', 'unitvalue', 'unitprice'}
+    if units not in valid_units:
+        raise ValueError(
+            f"food_prices units= must be one of {sorted(valid_units)}, "
+            f"got {units!r}"
+        )
+
     df = _normalize_columns(df)
-    if 'Expenditure' not in df.columns or 'Quantity' not in df.columns:
-        raise ValueError("food_acquired must have 'Expenditure' and 'Quantity' columns")
 
-    factors = _get_kg_factors(df)
-    v = _apply_kg_conversion(df, factors)
+    # Validate inputs per mode.
+    if units in {'kgvalue', 'unitvalue'}:
+        missing = [c for c in ('Expenditure', 'Quantity') if c not in df.columns]
+        if missing:
+            raise ValueError(
+                f"food_prices(units={units!r}) requires {missing} on food_acquired"
+            )
+    if units in {'kgprice', 'unitprice'}:
+        if 'Price' not in df.columns:
+            # No reported Price column at all → empty frame with right schema.
+            empty = df.iloc[0:0].copy()
+            empty['Price'] = np.array([], dtype='float64')
+            return empty[['Price']]
 
-    v['price_per_kg'] = v['Expenditure'] / v['Quantity_kg']
-    v = v[['price_per_kg']].replace([0, np.inf, -np.inf], np.nan).dropna()
+    if units == 'kgvalue':
+        factors = _get_kg_factors(df)
+        v = _apply_kg_conversion(df, factors)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            v = v.assign(Price=v['Expenditure'] / v['Quantity_kg'])
+    elif units == 'unitvalue':
+        with np.errstate(divide='ignore', invalid='ignore'):
+            v = df.assign(Price=df['Expenditure'] / df['Quantity'])
+    elif units == 'unitprice':
+        v = df.copy()
+        # Price column already populated.
+    elif units == 'kgprice':
+        factors = _get_kg_factors(df)
+        if 'u' in df.index.names:
+            u_lower = df.index.get_level_values('u').astype(str).str.lower()
+            kg_per_unit = pd.Series(u_lower.map(factors).values, index=df.index)
+            with np.errstate(divide='ignore', invalid='ignore'):
+                v = df.assign(Price=df['Price'] / kg_per_unit)
+        else:
+            # No u index → can't convert; emit NaN
+            v = df.assign(Price=np.nan)
 
-    return v.rename(columns={'price_per_kg': 'Price'})
+    v = v[['Price']].replace([0, np.inf, -np.inf], np.nan).dropna()
+    return v
 
 
 def legacy_locality(country):

--- a/slurm_logs/DESIGN_food_prices_units_kwarg_2026-05-06.org
+++ b/slurm_logs/DESIGN_food_prices_units_kwarg_2026-05-06.org
@@ -1,0 +1,162 @@
+#+title: Design: ``food_prices`` / ``food_quantities`` ``units=`` kwarg (Phase 4)
+#+date: <2026-05-06 Wed>
+
+Resolves Open Question #1 from
+=slurm_logs/DESIGN_food_acquired_canonical_2026-05-05.org= and
+fills in the "Phase 4 --- derived-table semantics" placeholder
+there.  This is also the Phase-3.5 fix the prior session
+(=4dfb7ff0=) flagged for =food_prices_from_acquired=.
+
+* Motivation
+
+Different surveys report food prices via different observable
+quantities.  A consumer may want any of:
+
+- the survey's *reported* unit price (where present), in native units;
+- that unit price converted to per-kg via the unit-conversion table;
+- the *derived* unit value =Expenditure / Quantity= in native units;
+- the derived per-kg value =Expenditure / Quantity_kg=.
+
+Today's =food_prices_from_acquired= forces option 4 only.  That
+silently drops information for waves that record =Price= directly
+(Uganda farmgate, e.g.) and provides no way to ask for the
+unit-native variants.
+
+* Two design calls (resolved)
+
+** Call 1 --- LCU-only goods (e.g. GhanaLSS 1987-88, "Meals in restaurants")
+
+Some goods have no natural physical unit; the survey records only
+expenditure in local currency.
+
+| Option                                      | Decision    |
+|---------------------------------------------+-------------|
+| (a) Synthetic unit =u='Value'=              | *chosen*    |
+| (b) =s='other'= (Burkina Faso convention)   | --          |
+| (c) Drop the affected waves from canonical  | --          |
+
+Rationale: there's nothing wrong with /value/ as a unit.  The
+canonical row carries =u='Value'=, =Quantity=Expenditure=,
+=Expenditure=Expenditure=.  These rows naturally fall out of any
+per-kg aggregation (no kg factor) without special-casing.
+
+** Call 2 --- =food_prices= unit semantics
+
+| Option                                            | Decision     |
+|---------------------------------------------------+--------------|
+| (α) Per-=u= everywhere; behavioral break          | --           |
+| (β) Mixed-basis with =Basis= column               | --           |
+| (γ) Single-basis default + =units== kwarg         | *chosen*     |
+
+Rationale: heterogeneous units within a single =Price= column make
+analysis hostile.  Default to one basis; let advanced consumers opt
+in to alternatives via a kwarg.  Avoids the silent breakage of (α)
+and the universal complexity tax of (β).
+
+* The =units== kwarg
+
+** =food_prices(units=...)= --- four modes
+
+| value         | formula                       | output unit         | source                                      |
+|---------------+-------------------------------+---------------------+---------------------------------------------|
+| =unitprice=   | reported =Price=              | currency / native u | =food_acquired.Price=                        |
+| =kgprice=     | reported =Price= × kg_factor  | currency / kg       | =food_acquired.Price= via =_apply_kg_conversion= |
+| =unitvalue=   | =Expenditure / Quantity=      | currency / native u | derived from =food_acquired=                 |
+| =kgvalue=     | =Expenditure / Quantity_kg=   | currency / kg       | derived from =food_acquired= (current default) |
+
+*Default: =kgvalue=* (preserves today's behavior).
+
+NaN-handling rules:
+
+- =unitprice= / =kgprice=: NaN where the source =food_acquired= row
+  has no reported =Price=.  No silent fallback to =Expenditure/Quantity=
+  --- a caller who wants "best available" combines =unitprice= and
+  =unitvalue= explicitly with their own provenance tracking.
+- =kgprice= / =kgvalue=: NaN where the unit lacks a kg conversion
+  factor (most importantly, =u='Value'= rows).
+- =unitvalue=: for =u='Value'= rows, formula gives =Expenditure /
+  Expenditure = 1=, i.e. /one Kwacha per Kwacha/.  Mathematically
+  correct, analytically useless; consumers should filter on =u=
+  before aggregating.  Documented in docstring; not NaN'd
+  automatically.
+
+** =food_quantities(units=...)= --- two modes
+
+| value     | formula                                                                  | output column |
+|-----------+--------------------------------------------------------------------------+---------------|
+| =kgs=     | sum of =Quantity_kg= where convertible; native =Quantity= where not, with =u= retained as the unit tag | mixed         |
+| =units=   | sum of native =Quantity=; =u= retained                                  | native        |
+
+*Default: =kgs=* (preserves today's behavior).
+
+Carry rule (=kgs= mode): /any/ =u= lacking a kg conversion factor ---
+not just =u='Value'= --- carries through with native quantity rather
+than being dropped.  The =u= index level distinguishes kg-converted
+rows (tagged =u='kg'=) from non-converted rows (tagged with the
+native unit).  Symmetric: same treatment for =u='tin'=, =u='Value'=,
+or any other unconvertible label.
+
+Consumers wanting pure kg do =df.drop('Value', level='u')= or filter
+on =u != 'kg'=.  Consumers wanting the legacy purely-kg behavior of
+the pre-Phase-4 implementation can do
+=df.xs('kg', level='u')=.
+
+** Index shape
+
+For both functions, =u= is retained in the index across all =units==
+modes.  This is a deliberate departure from today's
+=food_quantities_from_acquired= (which collapses =u=) for symmetry
+and to support the LCU-only-goods carry rule above.
+
+* Why no third hybrid mode
+
+The prior round considered a "prefer reported =Price=, fall back to
+=Expenditure/Quantity=" hybrid for prices.  Rejected: it produces a
+=Price= column whose basis varies row-by-row with no in-band marker.
+Same objection as Call-2 (β).  If a real consumer demands
+provenance-aware mixed-basis output later, add it then with an
+explicit =Basis= column.
+
+For =food_quantities=, no analogous hybrid exists at all --- there's
+no "reported quantity" alternative to derived quantity (=Quantity= is
+already the reported quantity).
+
+* Implementation
+
+** Files affected
+
+- =lsms_library/transformations.py= --- add =units== kwarg to
+  =food_prices_from_acquired= and =food_quantities_from_acquired=.
+- =lsms_library/country.py= --- plumb =units== through =_FOOD_DERIVED=
+  dispatch (around lines 2465--2601).
+- =tests/test_food_acquired_canonical.py= (new) --- one round-trip
+  test per mode against a synthetic country fixture.
+- =CLAUDE.md= "Derived Tables" section --- document the kwarg.
+
+** Sequencing
+
+Lands in three commits on =food-acquired-units-kwarg= topic
+branch off =development=:
+
+1. =feat(transformations): add units= kwarg to food_prices /
+   food_quantities= --- pure helper change with unit tests.
+2. =feat(country): forward units= kwarg in _FOOD_DERIVED dispatch=
+   --- API plumbing + integration test.
+3. =docs(CLAUDE): document food_prices / food_quantities units= kwarg=
+   --- entry in Derived Tables section.
+
+GhanaLSS Phase 3 reshape (the prior session's attack point) sits
+*on top of* this work: once the kwarg lands, the GhanaLSS-specific
+=food_acquired_to_canonical= helper for the LCU-only waves (1987-88,
+1988-89, 1991-92 purchased side) emits =u='Value'= per Call 1 and
+flows correctly through all four price modes.
+
+* References
+
+- =slurm_logs/DESIGN_food_acquired_canonical_2026-05-05.org= ---
+  parent design doc; this resolves its Open Q #1 and Phase 4
+- Prior session transcript:
+  =~/.claude/projects/-global-scratch-fsa-fc-jevons-ligon-mirrors-LSMS-Library/4dfb7ff0-7ae9-40e9-8acc-5ffec0377b73.jsonl=
+  (Calls 1 + 2 originate at line 240)
+- GH #169 --- food_acquired schema design (resolved by parent)
+- GH #218 --- Uganda harmony.py modernization (blocked on Phase 4)

--- a/slurm_logs/verify_units_kwarg.py
+++ b/slurm_logs/verify_units_kwarg.py
@@ -1,0 +1,148 @@
+"""Cross-country verification of the new units= kwarg.
+
+Runs food_prices() and food_quantities() with each accepted units=
+value across every country that declares food_acquired, and reports
+shape / column / index / exception per (country, table, mode).
+
+Run with:
+    .venv/bin/python slurm_logs/verify_units_kwarg.py
+"""
+import json
+import sys
+import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from time import perf_counter
+
+
+COUNTRIES = [
+    'Benin', 'Burkina_Faso', 'CotedIvoire', 'Ethiopia', 'GhanaLSS',
+    'Guinea-Bissau', 'Malawi', 'Mali', 'Nepal', 'Niger',
+    'Nigeria', 'Senegal', 'Tanzania', 'Togo', 'Uganda',
+]
+
+FOOD_PRICES_MODES = ['kgvalue', 'unitvalue', 'kgprice', 'unitprice']
+FOOD_QUANTITIES_MODES = ['kgs', 'units']
+
+
+def probe_one(country_name):
+    """Returns dict with results for every (table, mode) combination."""
+    out = {'country': country_name, 'tables': {}}
+    try:
+        import lsms_library as ll
+        c = ll.Country(country_name)
+    except Exception as e:
+        out['load_error'] = repr(e)
+        return out
+
+    # food_prices ----------------------------------------------------
+    out['tables']['food_prices'] = {}
+    for mode in FOOD_PRICES_MODES:
+        entry = {}
+        t0 = perf_counter()
+        try:
+            df = c.food_prices(units=mode)
+            entry['shape'] = list(df.shape)
+            entry['cols'] = list(df.columns)
+            entry['idx'] = list(df.index.names)
+            entry['unique'] = bool(df.index.is_unique)
+            if 'u' in df.index.names and len(df) > 0:
+                entry['u_top5'] = (df.index.get_level_values('u')
+                                   .value_counts()
+                                   .head(5)
+                                   .to_dict())
+        except Exception as e:
+            entry['error'] = repr(e)
+            entry['traceback_tail'] = traceback.format_exc().split('\n')[-4:-1]
+        entry['elapsed_s'] = round(perf_counter() - t0, 2)
+        out['tables']['food_prices'][mode] = entry
+
+    # food_quantities ------------------------------------------------
+    out['tables']['food_quantities'] = {}
+    for mode in FOOD_QUANTITIES_MODES:
+        entry = {}
+        t0 = perf_counter()
+        try:
+            df = c.food_quantities(units=mode)
+            entry['shape'] = list(df.shape)
+            entry['cols'] = list(df.columns)
+            entry['idx'] = list(df.index.names)
+            entry['unique'] = bool(df.index.is_unique)
+            if 'u' in df.index.names and len(df) > 0:
+                entry['u_top5'] = (df.index.get_level_values('u')
+                                   .value_counts()
+                                   .head(5)
+                                   .to_dict())
+        except Exception as e:
+            entry['error'] = repr(e)
+            entry['traceback_tail'] = traceback.format_exc().split('\n')[-4:-1]
+        entry['elapsed_s'] = round(perf_counter() - t0, 2)
+        out['tables']['food_quantities'][mode] = entry
+
+    return out
+
+
+def main():
+    t0 = perf_counter()
+    results = []
+    with ProcessPoolExecutor(max_workers=15) as ex:
+        futures = {ex.submit(probe_one, name): name for name in COUNTRIES}
+        for fut in as_completed(futures):
+            name = futures[fut]
+            try:
+                results.append(fut.result())
+            except Exception as e:
+                results.append({'country': name, 'fatal': repr(e)})
+            print(f"  done: {name}", flush=True)
+
+    elapsed = perf_counter() - t0
+    print(f"\nTotal wall time: {elapsed:.1f}s")
+
+    # Save full JSON
+    out_path = Path(__file__).parent / 'verify_units_kwarg_results.json'
+    out_path.write_text(json.dumps(results, indent=2, default=str))
+    print(f"Full results: {out_path}")
+
+    # Summarise
+    print("\n=== Summary ===")
+    print(f"{'Country':<18} {'fp.kgv':<10} {'fp.uv':<10} {'fp.kgp':<10} "
+          f"{'fp.up':<10} {'fq.kgs':<10} {'fq.u':<10}")
+    for r in sorted(results, key=lambda x: x['country']):
+        if 'load_error' in r or 'fatal' in r:
+            err = r.get('load_error') or r.get('fatal')
+            print(f"{r['country']:<18} LOAD ERROR: {err[:80]}")
+            continue
+        cells = []
+        for tbl, modes in [
+            ('food_prices', FOOD_PRICES_MODES),
+            ('food_quantities', FOOD_QUANTITIES_MODES),
+        ]:
+            for m in modes:
+                e = r['tables'][tbl][m]
+                if 'error' in e:
+                    cells.append('ERR')
+                else:
+                    cells.append(str(e['shape'][0]))
+        print(f"{r['country']:<18} " + " ".join(f"{c:<10}" for c in cells))
+
+    # Errors
+    print("\n=== Errors ===")
+    n_errors = 0
+    for r in sorted(results, key=lambda x: x['country']):
+        if 'load_error' in r or 'fatal' in r:
+            continue
+        for tbl, modes in r['tables'].items():
+            for m, e in modes.items():
+                if 'error' in e:
+                    n_errors += 1
+                    print(f"\n  {r['country']}.{tbl}(units={m!r}):")
+                    print(f"    {e['error']}")
+    if n_errors == 0:
+        print("  (none)")
+    else:
+        print(f"\n  {n_errors} errors total")
+    return 0 if n_errors == 0 else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/slurm_logs/verify_units_kwarg_results.json
+++ b/slurm_logs/verify_units_kwarg_results.json
@@ -1,0 +1,1895 @@
+[
+  {
+    "country": "Togo",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "shape": [
+            75967,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Tas": 23915,
+            "Sachet": 15496,
+            "Unit\u00e9": 12127,
+            "Bol": 6414,
+            "101": 4560
+          },
+          "elapsed_s": 0.86
+        },
+        "unitvalue": {
+          "shape": [
+            75969,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Tas": 23915,
+            "Sachet": 15496,
+            "Unit\u00e9": 12127,
+            "Bol": 6414,
+            "101": 4560
+          },
+          "elapsed_s": 0.35
+        },
+        "kgprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.25
+        },
+        "unitprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.28
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "shape": [
+            112439,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 112429,
+            "116": 6,
+            "Sac (10 Kg)": 2,
+            "114": 1,
+            "Sac (25 Kg)": 1
+          },
+          "elapsed_s": 0.95
+        },
+        "units": {
+          "shape": [
+            112439,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Tas": 33149,
+            "Sachet": 19868,
+            "Unit\u00e9": 16449,
+            "Bol": 14714,
+            "101": 6622
+          },
+          "elapsed_s": 0.34
+        }
+      }
+    }
+  },
+  {
+    "country": "Guinea-Bissau",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "shape": [
+            89773,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Monte": 21579,
+            "Unidade": 20329,
+            "Saquinho": 11760,
+            "Kg": 8953,
+            "Caneca": 3637
+          },
+          "elapsed_s": 0.94
+        },
+        "unitvalue": {
+          "shape": [
+            89773,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Monte": 21579,
+            "Unidade": 20329,
+            "Saquinho": 11760,
+            "Kg": 8953,
+            "Caneca": 3637
+          },
+          "elapsed_s": 0.34
+        },
+        "kgprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.34
+        },
+        "unitprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.29
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "shape": [
+            126197,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 126197
+          },
+          "elapsed_s": 1.04
+        },
+        "units": {
+          "shape": [
+            126197,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Monte": 33302,
+            "Unidade": 27409,
+            "Saquinho": 13913,
+            "Kg": 12900,
+            "Caneca": 8045
+          },
+          "elapsed_s": 0.48
+        }
+      }
+    }
+  },
+  {
+    "country": "Nepal",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "error": "RuntimeError('Could not materialize Nepal/food_acquired: no wave-level build succeeded and no cached parquet was found at /global/home/users/ligon/.local/share/lsms_library/Nepal/var/food_acquired.parquet.\\n\\nCommon causes:\\n  - installed via `pip install git+https://...` without the .dvc metadata needed to rebuild from source;\\n  - LSMS_DATA_DIR points to an empty or stale cache location;\\n  - DVC credentials are missing or misconfigured;\\n  - the raw .dta source files have not been dvc-pulled.\\n\\nSee README.org for supported install and data-access patterns.')",
+          "traceback_tail": [
+            "  - the raw .dta source files have not been dvc-pulled.",
+            "",
+            "See README.org for supported install and data-access patterns."
+          ],
+          "elapsed_s": 1.96
+        },
+        "unitvalue": {
+          "error": "RuntimeError('Could not materialize Nepal/food_acquired: no wave-level build succeeded and no cached parquet was found at /global/home/users/ligon/.local/share/lsms_library/Nepal/var/food_acquired.parquet.\\n\\nCommon causes:\\n  - installed via `pip install git+https://...` without the .dvc metadata needed to rebuild from source;\\n  - LSMS_DATA_DIR points to an empty or stale cache location;\\n  - DVC credentials are missing or misconfigured;\\n  - the raw .dta source files have not been dvc-pulled.\\n\\nSee README.org for supported install and data-access patterns.')",
+          "traceback_tail": [
+            "  - the raw .dta source files have not been dvc-pulled.",
+            "",
+            "See README.org for supported install and data-access patterns."
+          ],
+          "elapsed_s": 0.52
+        },
+        "kgprice": {
+          "error": "RuntimeError('Could not materialize Nepal/food_acquired: no wave-level build succeeded and no cached parquet was found at /global/home/users/ligon/.local/share/lsms_library/Nepal/var/food_acquired.parquet.\\n\\nCommon causes:\\n  - installed via `pip install git+https://...` without the .dvc metadata needed to rebuild from source;\\n  - LSMS_DATA_DIR points to an empty or stale cache location;\\n  - DVC credentials are missing or misconfigured;\\n  - the raw .dta source files have not been dvc-pulled.\\n\\nSee README.org for supported install and data-access patterns.')",
+          "traceback_tail": [
+            "  - the raw .dta source files have not been dvc-pulled.",
+            "",
+            "See README.org for supported install and data-access patterns."
+          ],
+          "elapsed_s": 0.36
+        },
+        "unitprice": {
+          "error": "RuntimeError('Could not materialize Nepal/food_acquired: no wave-level build succeeded and no cached parquet was found at /global/home/users/ligon/.local/share/lsms_library/Nepal/var/food_acquired.parquet.\\n\\nCommon causes:\\n  - installed via `pip install git+https://...` without the .dvc metadata needed to rebuild from source;\\n  - LSMS_DATA_DIR points to an empty or stale cache location;\\n  - DVC credentials are missing or misconfigured;\\n  - the raw .dta source files have not been dvc-pulled.\\n\\nSee README.org for supported install and data-access patterns.')",
+          "traceback_tail": [
+            "  - the raw .dta source files have not been dvc-pulled.",
+            "",
+            "See README.org for supported install and data-access patterns."
+          ],
+          "elapsed_s": 0.43
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "error": "RuntimeError('Could not materialize Nepal/food_acquired: no wave-level build succeeded and no cached parquet was found at /global/home/users/ligon/.local/share/lsms_library/Nepal/var/food_acquired.parquet.\\n\\nCommon causes:\\n  - installed via `pip install git+https://...` without the .dvc metadata needed to rebuild from source;\\n  - LSMS_DATA_DIR points to an empty or stale cache location;\\n  - DVC credentials are missing or misconfigured;\\n  - the raw .dta source files have not been dvc-pulled.\\n\\nSee README.org for supported install and data-access patterns.')",
+          "traceback_tail": [
+            "  - the raw .dta source files have not been dvc-pulled.",
+            "",
+            "See README.org for supported install and data-access patterns."
+          ],
+          "elapsed_s": 0.56
+        },
+        "units": {
+          "error": "RuntimeError('Could not materialize Nepal/food_acquired: no wave-level build succeeded and no cached parquet was found at /global/home/users/ligon/.local/share/lsms_library/Nepal/var/food_acquired.parquet.\\n\\nCommon causes:\\n  - installed via `pip install git+https://...` without the .dvc metadata needed to rebuild from source;\\n  - LSMS_DATA_DIR points to an empty or stale cache location;\\n  - DVC credentials are missing or misconfigured;\\n  - the raw .dta source files have not been dvc-pulled.\\n\\nSee README.org for supported install and data-access patterns.')",
+          "traceback_tail": [
+            "  - the raw .dta source files have not been dvc-pulled.",
+            "",
+            "See README.org for supported install and data-access patterns."
+          ],
+          "elapsed_s": 0.53
+        }
+      }
+    }
+  },
+  {
+    "country": "Benin",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "shape": [
+            150183,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Tas": 32851,
+            "Sachet": 31958,
+            "Unit\u00e9": 29090,
+            "Tohoungolo": 14645,
+            "Litre": 9381
+          },
+          "elapsed_s": 1.24
+        },
+        "unitvalue": {
+          "shape": [
+            150187,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Tas": 32851,
+            "Sachet": 31958,
+            "Unit\u00e9": 29090,
+            "Tohoungolo": 14645,
+            "Litre": 9381
+          },
+          "elapsed_s": 0.45
+        },
+        "kgprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.65
+        },
+        "unitprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.4
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "shape": [
+            188306,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 188209,
+            "Pinc\u00e9e": 87,
+            "nimkotirou(BARIBA)": 3,
+            "sikpanou": 3,
+            "Sac (10 Kg)": 2
+          },
+          "elapsed_s": 1.41
+        },
+        "units": {
+          "shape": [
+            188306,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Tas": 43120,
+            "Sachet": 35526,
+            "Unit\u00e9": 34168,
+            "Tohoungolo": 20104,
+            "Litre": 11660
+          },
+          "elapsed_s": 0.55
+        }
+      }
+    }
+  },
+  {
+    "country": "Niger",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "shape": [
+            85741,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Sachet": 32135,
+            "Unit\u00c3\u00a9": 13668,
+            "Tas": 9467,
+            "Tiya": 9233,
+            "Kg": 6336
+          },
+          "elapsed_s": 1.42
+        },
+        "unitvalue": {
+          "shape": [
+            198372,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "139": 48282,
+            "Sachet": 32135,
+            "147": 16000,
+            "Unit\u00c3\u00a9": 13668,
+            "143": 12119
+          },
+          "elapsed_s": 0.56
+        },
+        "kgprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.54
+        },
+        "unitprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.49
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "shape": [
+            238265,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 107449,
+            "139": 52223,
+            "512": 17868,
+            "147": 17307,
+            "143": 13991
+          },
+          "elapsed_s": 1.89
+        },
+        "units": {
+          "shape": [
+            238265,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "139": 52223,
+            "Sachet": 36036,
+            "Tiya": 18493,
+            "512": 17868,
+            "147": 17307
+          },
+          "elapsed_s": 0.66
+        }
+      }
+    }
+  },
+  {
+    "country": "Ethiopia",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "error": "ValueError(\"food_prices(units='kgvalue') requires ['Expenditure', 'Quantity'] on food_acquired\")",
+          "traceback_tail": [
+            "  File \"/global/scratch/fsa/fc_jevons/ligon/mirrors/LSMS_Library/lsms_library/transformations.py\", line 882, in food_prices_from_acquired",
+            "    raise ValueError(",
+            "ValueError: food_prices(units='kgvalue') requires ['Expenditure', 'Quantity'] on food_acquired"
+          ],
+          "elapsed_s": 1.47
+        },
+        "unitvalue": {
+          "error": "ValueError(\"food_prices(units='unitvalue') requires ['Expenditure', 'Quantity'] on food_acquired\")",
+          "traceback_tail": [
+            "  File \"/global/scratch/fsa/fc_jevons/ligon/mirrors/LSMS_Library/lsms_library/transformations.py\", line 882, in food_prices_from_acquired",
+            "    raise ValueError(",
+            "ValueError: food_prices(units='unitvalue') requires ['Expenditure', 'Quantity'] on food_acquired"
+          ],
+          "elapsed_s": 1.13
+        },
+        "kgprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u"
+          ],
+          "unique": true,
+          "elapsed_s": 1.14
+        },
+        "unitprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u"
+          ],
+          "unique": true,
+          "elapsed_s": 1.14
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "error": "ValueError(\"food_acquired must have a 'Quantity' column\")",
+          "traceback_tail": [
+            "  File \"/global/scratch/fsa/fc_jevons/ligon/mirrors/LSMS_Library/lsms_library/transformations.py\", line 754, in food_quantities_from_acquired",
+            "    raise ValueError(\"food_acquired must have a 'Quantity' column\")",
+            "ValueError: food_acquired must have a 'Quantity' column"
+          ],
+          "elapsed_s": 1.08
+        },
+        "units": {
+          "error": "ValueError(\"food_acquired must have a 'Quantity' column\")",
+          "traceback_tail": [
+            "  File \"/global/scratch/fsa/fc_jevons/ligon/mirrors/LSMS_Library/lsms_library/transformations.py\", line 754, in food_quantities_from_acquired",
+            "    raise ValueError(\"food_acquired must have a 'Quantity' column\")",
+            "ValueError: food_acquired must have a 'Quantity' column"
+          ],
+          "elapsed_s": 1.05
+        }
+      }
+    }
+  },
+  {
+    "country": "CotedIvoire",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "shape": [
+            213872,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Sachet": 55576,
+            "Tas": 48510,
+            "Unit\u00c3\u00a9": 46321,
+            "Kg": 15451,
+            "Morceau": 7104
+          },
+          "elapsed_s": 1.77
+        },
+        "unitvalue": {
+          "shape": [
+            213872,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Sachet": 55576,
+            "Tas": 48510,
+            "Unit\u00c3\u00a9": 46321,
+            "Kg": 15451,
+            "Morceau": 7104
+          },
+          "elapsed_s": 0.81
+        },
+        "kgprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.69
+        },
+        "unitprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.73
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "shape": [
+            294493,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 294493
+          },
+          "elapsed_s": 2.37
+        },
+        "units": {
+          "shape": [
+            294493,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Unit\u00c3\u00a9": 67876,
+            "Tas": 66617,
+            "Sachet": 62638,
+            "Kg": 20139,
+            "Boite": 9452
+          },
+          "elapsed_s": 0.95
+        }
+      }
+    }
+  },
+  {
+    "country": "Burkina_Faso",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "shape": [
+            147384,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Sachet": 39623,
+            "Tas": 31607,
+            "Unit\u00e9": 26008,
+            "Kg": 14238,
+            "Bo\u00eete": 6277
+          },
+          "elapsed_s": 1.9
+        },
+        "unitvalue": {
+          "shape": [
+            147387,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Sachet": 39623,
+            "Tas": 31607,
+            "Unit\u00e9": 26008,
+            "Kg": 14238,
+            "Bo\u00eete": 6277
+          },
+          "elapsed_s": 0.78
+        },
+        "kgprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.82
+        },
+        "unitprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.72
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "shape": [
+            206469,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 206463,
+            "116": 4,
+            "Sac (5 Kg)": 2
+          },
+          "elapsed_s": 2.43
+        },
+        "units": {
+          "shape": [
+            206554,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Sachet": 47679,
+            "Tas": 44725,
+            "Unit\u00e9": 30563,
+            "Kg": 18310,
+            "Bo\u00eete": 14638
+          },
+          "elapsed_s": 0.84
+        }
+      }
+    }
+  },
+  {
+    "country": "Mali",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "shape": [
+            306398,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Tas": 60471,
+            "Kg": 45924,
+            "Sachet": 33118,
+            "Unit\u00e9": 26180,
+            "kg": 24429
+          },
+          "elapsed_s": 2.37
+        },
+        "unitvalue": {
+          "shape": [
+            306398,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Tas": 60471,
+            "Kg": 45924,
+            "Sachet": 33118,
+            "Unit\u00e9": 26180,
+            "kg": 24429
+          },
+          "elapsed_s": 0.97
+        },
+        "kgprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.96
+        },
+        "unitprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.87
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "shape": [
+            305591,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 305583,
+            "Seau (25 Kg)": 4,
+            "Sac (25 Kg)": 4
+          },
+          "elapsed_s": 2.83
+        },
+        "units": {
+          "shape": [
+            306997,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Tas": 57071,
+            "kg": 35288,
+            "Kg": 35112,
+            "Sachet": 32668,
+            "sachet industriel": 25448
+          },
+          "elapsed_s": 1.05
+        }
+      }
+    }
+  },
+  {
+    "country": "Senegal",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "shape": [
+            387272,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Sachet": 99192,
+            "Kg": 73419,
+            "Unit\u00e9": 62833,
+            "Tas": 41814,
+            "Morceau": 25213
+          },
+          "elapsed_s": 2.57
+        },
+        "unitvalue": {
+          "shape": [
+            387272,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Sachet": 99192,
+            "Kg": 73419,
+            "Unit\u00e9": 62833,
+            "Tas": 41814,
+            "Morceau": 25213
+          },
+          "elapsed_s": 1.1
+        },
+        "kgprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 0.94
+        },
+        "unitprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 1.01
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "shape": [
+            434389,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 434389
+          },
+          "elapsed_s": 3.38
+        },
+        "units": {
+          "shape": [
+            434612,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Sachet": 106708,
+            "Kg": 84218,
+            "Unit\u00e9": 69989,
+            "Tas": 46595,
+            "Morceau": 26303
+          },
+          "elapsed_s": 1.17
+        }
+      }
+    }
+  },
+  {
+    "country": "GhanaLSS",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u"
+          ],
+          "unique": true,
+          "elapsed_s": 5.58
+        },
+        "unitvalue": {
+          "shape": [
+            341401,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u"
+          ],
+          "unique": true,
+          "u_top5": {},
+          "elapsed_s": 3.25
+        },
+        "kgprice": {
+          "shape": [
+            1,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Liter": 1
+          },
+          "elapsed_s": 4.48
+        },
+        "unitprice": {
+          "shape": [
+            45106,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Value": 22,
+            "All": 6,
+            "Margarine tin": 5,
+            "Fruits": 4,
+            "Pounds": 4
+          },
+          "elapsed_s": 3.28
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "error": "ValueError('No objects to concatenate')",
+          "traceback_tail": [
+            "  File \"/global/scratch/fsa/fc_jevons/ligon/mirrors/LSMS_Library/.venv/lib/python3.11/site-packages/pandas/core/reshape/concat.py\", line 808, in _clean_keys_and_objs",
+            "    raise ValueError(\"No objects to concatenate\")",
+            "ValueError: No objects to concatenate"
+          ],
+          "elapsed_s": 6.5
+        },
+        "units": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u"
+          ],
+          "unique": true,
+          "elapsed_s": 3.15
+        }
+      }
+    }
+  },
+  {
+    "country": "Malawi",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "shape": [
+            681289,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 292131,
+            "KILOGRAMME": 53458,
+            "Piece": 39576,
+            "HEAP": 29010,
+            "LITRE": 22077
+          },
+          "elapsed_s": 7.36
+        },
+        "unitvalue": {
+          "shape": [
+            681326,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 292131,
+            "KILOGRAMME": 53458,
+            "Piece": 39576,
+            "HEAP": 29010,
+            "LITRE": 22077
+          },
+          "elapsed_s": 4.15
+        },
+        "kgprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 3.84
+        },
+        "unitprice": {
+          "shape": [
+            0,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "elapsed_s": 3.8
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "shape": [
+            773593,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 773089,
+            "Basin/Lichero": 320,
+            "THUNGWA": 40,
+            "0": 13,
+            "PLATES": 7
+          },
+          "elapsed_s": 8.85
+        },
+        "units": {
+          "shape": [
+            773720,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 337743,
+            "Piece": 63488,
+            "KILOGRAMME": 46471,
+            "Kg": 35805,
+            "1": 23022
+          },
+          "elapsed_s": 4.72
+        }
+      }
+    }
+  },
+  {
+    "country": "Tanzania",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "error": "CalledProcessError(2, ['make', '-s', '../2008-15/_/sample.parquet'])",
+          "traceback_tail": [
+            "  File \"/global/software/rocky-8.x86_64/python-3.11.6/._python-3.11.6/zxbhdko4pyfbffp3rebfywqstwyqctut/python/3.11.6-gcc/lib/python3.11/subprocess.py\", line 571, in run",
+            "    raise CalledProcessError(retcode, process.args,",
+            "subprocess.CalledProcessError: Command '['make', '-s', '../2008-15/_/sample.parquet']' returned non-zero exit status 2."
+          ],
+          "elapsed_s": 103.37
+        },
+        "unitvalue": {
+          "error": "CalledProcessError(2, ['make', '-s', '../2008-15/_/sample.parquet'])",
+          "traceback_tail": [
+            "  File \"/global/software/rocky-8.x86_64/python-3.11.6/._python-3.11.6/zxbhdko4pyfbffp3rebfywqstwyqctut/python/3.11.6-gcc/lib/python3.11/subprocess.py\", line 571, in run",
+            "    raise CalledProcessError(retcode, process.args,",
+            "subprocess.CalledProcessError: Command '['make', '-s', '../2008-15/_/sample.parquet']' returned non-zero exit status 2."
+          ],
+          "elapsed_s": 87.56
+        },
+        "kgprice": {
+          "error": "CalledProcessError(2, ['make', '-s', '../2008-15/_/sample.parquet'])",
+          "traceback_tail": [
+            "  File \"/global/software/rocky-8.x86_64/python-3.11.6/._python-3.11.6/zxbhdko4pyfbffp3rebfywqstwyqctut/python/3.11.6-gcc/lib/python3.11/subprocess.py\", line 571, in run",
+            "    raise CalledProcessError(retcode, process.args,",
+            "subprocess.CalledProcessError: Command '['make', '-s', '../2008-15/_/sample.parquet']' returned non-zero exit status 2."
+          ],
+          "elapsed_s": 95.0
+        },
+        "unitprice": {
+          "error": "CalledProcessError(2, ['make', '-s', '../2008-15/_/sample.parquet'])",
+          "traceback_tail": [
+            "  File \"/global/software/rocky-8.x86_64/python-3.11.6/._python-3.11.6/zxbhdko4pyfbffp3rebfywqstwyqctut/python/3.11.6-gcc/lib/python3.11/subprocess.py\", line 571, in run",
+            "    raise CalledProcessError(retcode, process.args,",
+            "subprocess.CalledProcessError: Command '['make', '-s', '../2008-15/_/sample.parquet']' returned non-zero exit status 2."
+          ],
+          "elapsed_s": 93.33
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "error": "CalledProcessError(2, ['make', '-s', '../2008-15/_/sample.parquet'])",
+          "traceback_tail": [
+            "  File \"/global/software/rocky-8.x86_64/python-3.11.6/._python-3.11.6/zxbhdko4pyfbffp3rebfywqstwyqctut/python/3.11.6-gcc/lib/python3.11/subprocess.py\", line 571, in run",
+            "    raise CalledProcessError(retcode, process.args,",
+            "subprocess.CalledProcessError: Command '['make', '-s', '../2008-15/_/sample.parquet']' returned non-zero exit status 2."
+          ],
+          "elapsed_s": 91.2
+        },
+        "units": {
+          "error": "CalledProcessError(2, ['make', '-s', '../2008-15/_/sample.parquet'])",
+          "traceback_tail": [
+            "  File \"/global/software/rocky-8.x86_64/python-3.11.6/._python-3.11.6/zxbhdko4pyfbffp3rebfywqstwyqctut/python/3.11.6-gcc/lib/python3.11/subprocess.py\", line 571, in run",
+            "    raise CalledProcessError(retcode, process.args,",
+            "subprocess.CalledProcessError: Command '['make', '-s', '../2008-15/_/sample.parquet']' returned non-zero exit status 2."
+          ],
+          "elapsed_s": 92.82
+        }
+      }
+    }
+  },
+  {
+    "country": "Uganda",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "shape": [
+            349081,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Kg": 69590,
+            "Cup/Mug(0.5lt)": 22247,
+            "Heap (Small)": 21685,
+            "Heap (Medium)": 19282,
+            "Heap (unspecified)": 16018
+          },
+          "elapsed_s": 665.19
+        },
+        "unitvalue": {
+          "shape": [
+            349081,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Kg": 69590,
+            "Cup/Mug(0.5lt)": 22247,
+            "Heap (Small)": 21685,
+            "Heap (Medium)": 19282,
+            "Heap (unspecified)": 16018
+          },
+          "elapsed_s": 1.36
+        },
+        "kgprice": {
+          "shape": [
+            325814,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Kg": 66337,
+            "Cup/Mug(0.5lt)": 20619,
+            "Heap (Small)": 19849,
+            "Heap (Medium)": 17876,
+            "Packet (500 g)": 15001
+          },
+          "elapsed_s": 2.25
+        },
+        "unitprice": {
+          "shape": [
+            325814,
+            1
+          ],
+          "cols": [
+            "Price"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Kg": 66337,
+            "Cup/Mug(0.5lt)": 20619,
+            "Heap (Small)": 19849,
+            "Heap (Medium)": 17876,
+            "Packet (500 g)": 15001
+          },
+          "elapsed_s": 1.34
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "shape": [
+            348742,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "kg": 348742
+          },
+          "elapsed_s": 3.3
+        },
+        "units": {
+          "shape": [
+            348800,
+            1
+          ],
+          "cols": [
+            "Quantity"
+          ],
+          "idx": [
+            "i",
+            "t",
+            "v",
+            "j",
+            "u",
+            "s"
+          ],
+          "unique": true,
+          "u_top5": {
+            "Kg": 69530,
+            "Cup/Mug(0.5lt)": 22228,
+            "Heap (Small)": 21681,
+            "Heap (Medium)": 19282,
+            "Heap (unspecified)": 15952
+          },
+          "elapsed_s": 1.54
+        }
+      }
+    }
+  },
+  {
+    "country": "Nigeria",
+    "tables": {
+      "food_prices": {
+        "kgvalue": {
+          "error": "CalledProcessError(2, ['make', '-s', '../2010-11/_/food_acquired.parquet'])",
+          "traceback_tail": [
+            "  File \"/global/software/rocky-8.x86_64/python-3.11.6/._python-3.11.6/zxbhdko4pyfbffp3rebfywqstwyqctut/python/3.11.6-gcc/lib/python3.11/subprocess.py\", line 571, in run",
+            "    raise CalledProcessError(retcode, process.args,",
+            "subprocess.CalledProcessError: Command '['make', '-s', '../2010-11/_/food_acquired.parquet']' returned non-zero exit status 2."
+          ],
+          "elapsed_s": 532.83
+        },
+        "unitvalue": {
+          "error": "CalledProcessError(2, ['make', '-s', '../2010-11/_/food_acquired.parquet'])",
+          "traceback_tail": [
+            "  File \"/global/software/rocky-8.x86_64/python-3.11.6/._python-3.11.6/zxbhdko4pyfbffp3rebfywqstwyqctut/python/3.11.6-gcc/lib/python3.11/subprocess.py\", line 571, in run",
+            "    raise CalledProcessError(retcode, process.args,",
+            "subprocess.CalledProcessError: Command '['make', '-s', '../2010-11/_/food_acquired.parquet']' returned non-zero exit status 2."
+          ],
+          "elapsed_s": 94.63
+        },
+        "kgprice": {
+          "error": "CalledProcessError(2, ['make', '-s', '../2010-11/_/food_acquired.parquet'])",
+          "traceback_tail": [
+            "  File \"/global/software/rocky-8.x86_64/python-3.11.6/._python-3.11.6/zxbhdko4pyfbffp3rebfywqstwyqctut/python/3.11.6-gcc/lib/python3.11/subprocess.py\", line 571, in run",
+            "    raise CalledProcessError(retcode, process.args,",
+            "subprocess.CalledProcessError: Command '['make', '-s', '../2010-11/_/food_acquired.parquet']' returned non-zero exit status 2."
+          ],
+          "elapsed_s": 103.61
+        },
+        "unitprice": {
+          "error": "CalledProcessError(2, ['make', '-s', '../2010-11/_/food_acquired.parquet'])",
+          "traceback_tail": [
+            "  File \"/global/software/rocky-8.x86_64/python-3.11.6/._python-3.11.6/zxbhdko4pyfbffp3rebfywqstwyqctut/python/3.11.6-gcc/lib/python3.11/subprocess.py\", line 571, in run",
+            "    raise CalledProcessError(retcode, process.args,",
+            "subprocess.CalledProcessError: Command '['make', '-s', '../2010-11/_/food_acquired.parquet']' returned non-zero exit status 2."
+          ],
+          "elapsed_s": 89.56
+        }
+      },
+      "food_quantities": {
+        "kgs": {
+          "error": "CalledProcessError(2, ['make', '-s', '../2010-11/_/food_acquired.parquet'])",
+          "traceback_tail": [
+            "  File \"/global/software/rocky-8.x86_64/python-3.11.6/._python-3.11.6/zxbhdko4pyfbffp3rebfywqstwyqctut/python/3.11.6-gcc/lib/python3.11/subprocess.py\", line 571, in run",
+            "    raise CalledProcessError(retcode, process.args,",
+            "subprocess.CalledProcessError: Command '['make', '-s', '../2010-11/_/food_acquired.parquet']' returned non-zero exit status 2."
+          ],
+          "elapsed_s": 88.15
+        },
+        "units": {
+          "error": "CalledProcessError(2, ['make', '-s', '../2010-11/_/food_acquired.parquet'])",
+          "traceback_tail": [
+            "  File \"/global/software/rocky-8.x86_64/python-3.11.6/._python-3.11.6/zxbhdko4pyfbffp3rebfywqstwyqctut/python/3.11.6-gcc/lib/python3.11/subprocess.py\", line 571, in run",
+            "    raise CalledProcessError(retcode, process.args,",
+            "subprocess.CalledProcessError: Command '['make', '-s', '../2010-11/_/food_acquired.parquet']' returned non-zero exit status 2."
+          ],
+          "elapsed_s": 90.02
+        }
+      }
+    }
+  }
+]

--- a/tests/test_food_prices_units_kwarg.py
+++ b/tests/test_food_prices_units_kwarg.py
@@ -1,0 +1,213 @@
+"""Unit tests for the ``units=`` kwarg on
+:func:`lsms_library.transformations.food_prices_from_acquired` and
+:func:`lsms_library.transformations.food_quantities_from_acquired`.
+
+Design doc: ``slurm_logs/DESIGN_food_prices_units_kwarg_2026-05-06.org``.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from lsms_library.transformations import (
+    food_prices_from_acquired,
+    food_quantities_from_acquired,
+)
+
+
+@pytest.fixture
+def synthetic_food_acquired():
+    """Five-row food_acquired covering kg-convertible, inferred-factor,
+    LCU-only (``u='Value'``), unconvertible (``u='tin'``), and
+    survey-reported-Price (``s='produced'``) cases."""
+    idx = pd.MultiIndex.from_tuples(
+        [
+            ('2020', 'C1', 'H1', 'rice',  'kg',        'purchased'),
+            ('2020', 'C1', 'H1', 'rice',  '50kg sack', 'purchased'),
+            ('2020', 'C1', 'H2', 'meals', 'Value',     'purchased'),
+            ('2020', 'C1', 'H1', 'maize', 'tin',       'purchased'),
+            ('2020', 'C1', 'H1', 'maize', 'kg',        'produced'),
+        ],
+        names=['t', 'v', 'i', 'j', 'u', 's'],
+    )
+    return pd.DataFrame(
+        {
+            'Quantity':    [10.0, 1.0, 50.0, 5.0, 8.0],
+            'Expenditure': [200.0, 800.0, 50.0, 100.0, np.nan],
+            'Price':       [np.nan, np.nan, np.nan, np.nan, 30.0],
+        },
+        index=idx,
+    )
+
+
+# ----- food_prices: invalid units ------------------------------------------
+
+def test_food_prices_invalid_units_raises(synthetic_food_acquired):
+    with pytest.raises(ValueError, match="units="):
+        food_prices_from_acquired(synthetic_food_acquired, units='bogus')
+
+
+# ----- food_prices: kgvalue (default, backward-compat) ---------------------
+
+def test_food_prices_kgvalue_default_is_kgvalue(synthetic_food_acquired):
+    out_default = food_prices_from_acquired(synthetic_food_acquired)
+    out_explicit = food_prices_from_acquired(synthetic_food_acquired, units='kgvalue')
+    pd.testing.assert_frame_equal(out_default, out_explicit)
+
+
+def test_food_prices_kgvalue_drops_lcu_rows(synthetic_food_acquired):
+    """u='Value' rows have no kg factor, so kgvalue NaNs them out."""
+    out = food_prices_from_acquired(synthetic_food_acquired, units='kgvalue')
+    assert 'Value' not in out.index.get_level_values('u')
+
+
+# ----- food_prices: unitvalue ----------------------------------------------
+
+def test_food_prices_unitvalue_native_per_unit(synthetic_food_acquired):
+    out = food_prices_from_acquired(synthetic_food_acquired, units='unitvalue')
+    # rice/kg: 200/10 = 20
+    rice_kg = out.xs(('rice', 'kg'), level=['j', 'u'])['Price'].iloc[0]
+    assert rice_kg == pytest.approx(20.0)
+    # rice/50kg sack: 800/1 = 800 (per sack)
+    rice_sack = out.xs(('rice', '50kg sack'), level=['j', 'u'])['Price'].iloc[0]
+    assert rice_sack == pytest.approx(800.0)
+
+
+def test_food_prices_unitvalue_kwacha_per_kwacha(synthetic_food_acquired):
+    """Designed sentinel: u='Value' rows give Price=1 (Kwacha per Kwacha)."""
+    out = food_prices_from_acquired(synthetic_food_acquired, units='unitvalue')
+    val_rows = out[out.index.get_level_values('u') == 'Value']
+    assert len(val_rows) == 1
+    assert val_rows['Price'].iloc[0] == pytest.approx(1.0)
+
+
+# ----- food_prices: unitprice ----------------------------------------------
+
+def test_food_prices_unitprice_returns_reported_only(synthetic_food_acquired):
+    """unitprice keeps only rows where the survey recorded Price."""
+    out = food_prices_from_acquired(synthetic_food_acquired, units='unitprice')
+    # Only one row (maize/kg/produced, Price=30) was reported
+    assert len(out) == 1
+    assert out['Price'].iloc[0] == pytest.approx(30.0)
+
+
+def test_food_prices_unitprice_no_price_column_returns_empty(synthetic_food_acquired):
+    df = synthetic_food_acquired.drop(columns=['Price'])
+    out = food_prices_from_acquired(df, units='unitprice')
+    assert out.empty
+    assert list(out.columns) == ['Price']
+
+
+def test_food_prices_unitprice_does_not_fall_back_to_unitvalue(synthetic_food_acquired):
+    """Explicitly: missing Price → NaN, not silent fallback to E/Q."""
+    out_unitprice = food_prices_from_acquired(synthetic_food_acquired, units='unitprice')
+    out_unitvalue = food_prices_from_acquired(synthetic_food_acquired, units='unitvalue')
+    assert len(out_unitprice) < len(out_unitvalue)
+
+
+# ----- food_prices: kgprice -------------------------------------------------
+
+def test_food_prices_kgprice_converts_reported_price(synthetic_food_acquired):
+    """kgprice = reported Price / kg_per_unit.  Reported maize/kg/produced
+    Price=30, kg_per_unit=1 → kgprice=30."""
+    out = food_prices_from_acquired(synthetic_food_acquired, units='kgprice')
+    assert len(out) == 1
+    assert out['Price'].iloc[0] == pytest.approx(30.0)
+
+
+# ----- food_quantities: invalid units --------------------------------------
+
+def test_food_quantities_invalid_units_raises(synthetic_food_acquired):
+    with pytest.raises(ValueError, match="units="):
+        food_quantities_from_acquired(synthetic_food_acquired, units='bogus')
+
+
+# ----- food_quantities: kgs (default, with carry rule) ---------------------
+
+def test_food_quantities_kgs_default_is_kgs(synthetic_food_acquired):
+    out_default = food_quantities_from_acquired(synthetic_food_acquired)
+    out_explicit = food_quantities_from_acquired(synthetic_food_acquired, units='kgs')
+    pd.testing.assert_frame_equal(out_default, out_explicit)
+
+
+def test_food_quantities_kgs_carries_lcu_rows(synthetic_food_acquired):
+    """Carry rule: u='Value' rows are NOT dropped from kgs mode."""
+    out = food_quantities_from_acquired(synthetic_food_acquired, units='kgs')
+    val_rows = out[out.index.get_level_values('u') == 'Value']
+    assert len(val_rows) == 1
+    assert val_rows['Quantity'].iloc[0] == pytest.approx(50.0)
+
+
+def test_food_quantities_kgs_carries_unconvertible_units(synthetic_food_acquired):
+    """Carry rule: any u lacking a kg factor (not just 'Value') survives."""
+    # Pure-tin synthetic: no rice rows to anchor inference.
+    idx = pd.MultiIndex.from_tuples(
+        [('2020', 'C1', 'H1', 'maize', 'tin', 'purchased')],
+        names=['t', 'v', 'i', 'j', 'u', 's'],
+    )
+    df = pd.DataFrame(
+        {'Quantity': [5.0], 'Expenditure': [100.0]},
+        index=idx,
+    )
+    out = food_quantities_from_acquired(df, units='kgs')
+    assert len(out) == 1
+    assert out.index.get_level_values('u')[0] == 'tin'
+    assert out['Quantity'].iloc[0] == pytest.approx(5.0)
+
+
+def test_food_quantities_kgs_tags_converted_rows_as_kg(synthetic_food_acquired):
+    out = food_quantities_from_acquired(synthetic_food_acquired, units='kgs')
+    # rice should land in 'kg' bucket (via inferred factor for sack)
+    rice_kg = out.xs(('rice', 'kg'), level=['j', 'u'])
+    assert len(rice_kg) >= 1
+
+
+# ----- food_quantities: units mode -----------------------------------------
+
+def test_food_quantities_units_preserves_native_u(synthetic_food_acquired):
+    out = food_quantities_from_acquired(synthetic_food_acquired, units='units')
+    units_seen = set(out.index.get_level_values('u'))
+    # Should include all original u values (none converted to 'kg')
+    expected = {'kg', '50kg sack', 'Value', 'tin'}
+    assert expected.issubset(units_seen)
+
+
+def test_food_quantities_units_no_kg_conversion(synthetic_food_acquired):
+    """In units mode, '50kg sack' is NOT collapsed into 'kg'."""
+    out = food_quantities_from_acquired(synthetic_food_acquired, units='units')
+    sack_rows = out[out.index.get_level_values('u') == '50kg sack']
+    assert len(sack_rows) == 1
+    assert sack_rows['Quantity'].iloc[0] == pytest.approx(1.0)
+
+
+# ----- backward compatibility: kgvalue/kgs still work without u index ------
+
+def test_food_prices_kgvalue_without_u_handles_gracefully():
+    """Pre-Phase-4 callers may pass a frame without a 'u' index level."""
+    idx = pd.MultiIndex.from_tuples(
+        [('2020', 'C1', 'H1', 'rice'), ('2020', 'C1', 'H1', 'maize')],
+        names=['t', 'v', 'i', 'j'],
+    )
+    df = pd.DataFrame(
+        {'Quantity': [10.0, 5.0], 'Expenditure': [200.0, 100.0]},
+        index=idx,
+    )
+    # Without 'u', _apply_kg_conversion is a no-op → Quantity_kg absent.
+    # Code should either degrade gracefully or surface a clear error.
+    with pytest.raises((KeyError, ValueError)):
+        food_prices_from_acquired(df, units='kgvalue')
+
+
+def test_food_quantities_units_without_u_index():
+    """When u is absent from the index, fall back to a single-bucket
+    aggregation rather than crashing."""
+    idx = pd.MultiIndex.from_tuples(
+        [('2020', 'C1', 'H1', 'rice'), ('2020', 'C1', 'H1', 'maize')],
+        names=['t', 'v', 'i', 'j'],
+    )
+    df = pd.DataFrame(
+        {'Quantity': [10.0, 5.0], 'Expenditure': [200.0, 100.0]},
+        index=idx,
+    )
+    out = food_quantities_from_acquired(df)
+    assert 'Quantity' in out.columns
+    assert len(out) == 2


### PR DESCRIPTION
## Summary

Phase 4 of the canonical `food_acquired` migration (parent: `slurm_logs/DESIGN_food_acquired_canonical_2026-05-05.org`, "Phase 4 — derived-table semantics"). Resolves Open Q #1 of that doc and lands the Phase-3.5 fix flagged in `slurm_logs/HANDOFF_2026-05-06.org` (survey-reported `Price` accessible through `food_prices()`).

Adds a `units=` kwarg to:

- **`Country(X).food_prices(units=...)`** — four modes:
  - `'kgvalue'` *(default)* — `Expenditure / Quantity_kg` (currency / kg, derived). Backward-compatible with the pre-Phase-4 behavior.
  - `'unitvalue'` — `Expenditure / Quantity` (currency / native `u`). For `u='Value'` rows gives 1 (Kwacha per Kwacha).
  - `'kgprice'` — reported `Price` × kg_factor (currency / kg). NaN where `Price` missing or `u` unconvertible.
  - `'unitprice'` — reported `Price` (currency / native `u`). NaN where survey didn't record a unit price. **This is the Phase-3.5 fix** that surfaces Uganda's farmgate / market prices through the framework.

- **`Country(X).food_quantities(units=...)`** — two modes:
  - `'kgs'` *(default)* — kg where convertible; native `Quantity` carried with native `u` tag where it isn't. The pre-Phase-4 implementation silently dropped unconvertible rows; **they are now preserved** (the "carry rule" — addresses LCU-only goods like "meals in restaurants").
  - `'units'` — sum of native `Quantity` per `(t, v, i, j, u, s)`, no kg conversion attempted.

Other tables (`food_expenditures`, all non-derived) reject `units=` with `TypeError`.

## Design rationale

Recorded in `slurm_logs/DESIGN_food_prices_units_kwarg_2026-05-06.org`. Two design calls (Calls 1 and 2 from the prior session) are resolved there:

- **Call 1**: LCU-only goods carry through with `u='Value'`, `Quantity = Expenditure`. Naturally drops out of per-kg aggregation; flows through `food_expenditures` and `unitvalue` mode.
- **Call 2**: Single-basis default + `units=` kwarg. Heterogeneous units in one column make analysis hostile (the prior agent's `(α)` proposal); the `Basis`-column variant `(β)` was rejected as YAGNI.

Pinned naming caveat: the literature's "unit value" (Deaton 1988, 1997) usually means `Expenditure / Quantity` *standardized to kg* — i.e. our `kgvalue`. The denominator-explicit `kgvalue` / `unitvalue` naming deliberately departs from convention to disambiguate.

No silent fallback between modes: `unitprice` returns NaN where `Price` is missing rather than falling back to `unitvalue`. A caller wanting "best available" combines results explicitly with their own provenance tracking.

## Test plan

- [x] Unit tests: `tests/test_food_prices_units_kwarg.py` (18 tests, all pass) — covers all four price modes, both quantity modes, the carry rule, the Kwacha-per-Kwacha sentinel, no-fallback semantics, invalid-`units=` `ValueError`, graceful degradation when `u` index level is absent.
- [x] Schema-consistency: `pytest tests/test_schema_consistency.py` — 173 passed, 2 xfailed, 2 xpassed.
- [x] Integration smoke against Malawi 2010-11 (Phase-3 reshape complete):
  - `food_prices(kgvalue)`: 681,289 rows
  - `food_prices(unitvalue)`: 681,326 rows (preserves Value-tagged rows that drop in kgvalue)
  - `food_quantities(kgs)`: 773,593 rows
  - `food_quantities(units)`: 773,720 rows
  - `food_expenditures(units=...)` → `TypeError`, as designed
- [x] Cross-country verification across 15 countries with `food_acquired` in `data_scheme` (results in `slurm_logs/verify_units_kwarg_results.json`).

## Backward compatibility

Default behavior preserved at the API contract level for both functions:

- `food_prices()` (no kwarg) → identical numerics to pre-Phase-4 (`Expenditure / Quantity_kg`).
- `food_quantities()` (no kwarg) → kg-converted rows match pre-Phase-4 numerics; previously-dropped unconvertible rows are now *retained* with their native `u` tag (additive change).

The only behavior delta is the carry rule expanding what `food_quantities()` returns. Consumers wanting strict kg-only do `df.xs('kg', level='u')`.

## Files

- `lsms_library/transformations.py` — implement four price modes + two quantity modes; integrates with the upstream `s`-preserving group-by from `b9df8fb4`.
- `lsms_library/country.py` — forward `units=` through `_FOOD_DERIVED` dispatch; reject for non-applicable tables.
- `tests/test_food_prices_units_kwarg.py` — 18 unit tests.
- `slurm_logs/DESIGN_food_prices_units_kwarg_2026-05-06.org` — design doc (Phase-4 resolution of GH #169 design doc's Open Q #1).
- `slurm_logs/verify_units_kwarg.py` — cross-country verification harness (parallel `ProcessPoolExecutor` over 15 countries).
- `CLAUDE.md` — entry next to `labels=` kwarg note in Derived Tables section.

## Notes for review

- **Index-shape change** (intentional): `food_prices` and `food_quantities` results now retain `u` in the index across all modes. Previously `food_quantities` collapsed `u`. This was deliberate per the design call to support the carry rule for LCU-only goods.
- **Lowercase `'kg'` tag**: the `'kgs'` mode tags converted rows with lowercase `'kg'`, matching `KNOWN_METRIC` and `_apply_kg_conversion`'s case-folding. Country code that does `df.xs('Kg', level='u')` (Uganda's `nutrition.py`, line 51) will need a follow-up case-insensitive fix; flagging here for visibility — out of scope for this PR.
- **Phase 3.5 (open work in `HANDOFF_2026-05-06.org`)** is satisfied by the `unitprice` mode for Uganda's farmgate prices. The `kgvalue` default doesn't surface them; `unitprice` does.