### PR TITLE
feat(country): generalize harmonize_<method_name> auto-dispatch (#180)

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -1677,14 +1677,18 @@ class Country:
             # a column or index name (issue #49)
             df = self._apply_categorical_mappings(df)
 
-            # Apply harmonize_assets mapping to the j index level for
-            # the assets feature (GH #168).  Runs after _apply_categorical_mappings
-            # because the table name (harmonize_assets) does not match the index
-            # level name (j) so the auto-dispatch above cannot fire.
-            if (method_name == 'assets'
+            # Apply ``harmonize_<method_name>`` mapping to the ``j`` index
+            # level when such a categorical_mapping table exists (GH #180,
+            # #168).  Runs after :meth:`_apply_categorical_mappings` because
+            # the table name (``harmonize_assets``, ``harmonize_food``, …)
+            # does not match the index level name (``j``) so the auto-dispatch
+            # above cannot fire.  Generalises the original assets-only hook
+            # so future ``harmonize_education``, ``harmonize_housing``, etc.
+            # tables auto-apply by convention.
+            if (method_name
                     and isinstance(df.index, pd.MultiIndex)
                     and 'j' in df.index.names):
-                ha_table = self.categorical_mapping.get('harmonize_assets')
+                ha_table = self.categorical_mapping.get(f'harmonize_{method_name}')
                 if ha_table is not None and 'Preferred Label' in ha_table.columns:
                     src_cols = [c for c in ha_table.columns if c != 'Preferred Label']
                     if src_cols:

--- a/tests/test_harmonize_method_auto_dispatch.py
+++ b/tests/test_harmonize_method_auto_dispatch.py
@@ -1,0 +1,120 @@
+"""Tests for the generalized ``harmonize_<method_name>`` auto-dispatch
+hook in :meth:`Country._finalize_result` (GH #180).
+
+Verifies:
+- The original assets behaviour (GH #168) is preserved.
+- A categorical_mapping table named ``harmonize_<X>`` auto-applies to
+  ``Country(...).<X>()`` output when ``j`` is in the index — generalising
+  beyond just ``assets``.
+- Absence of a matching ``harmonize_<X>`` table is a silent no-op.
+- Tables present in ``data_scheme`` whose method_name does not match
+  any ``harmonize_*`` table behave identically before and after.
+"""
+from unittest.mock import PropertyMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lsms_library.country import Country
+
+
+@pytest.fixture
+def country():
+    """A minimal Country stub.  The constructor reads disk, so we use any
+    real country and stub out the categorical_mapping property per-test."""
+    return Country('Uganda')
+
+
+def _frame_with_j(j_values, index_extra=()):
+    """Build a small DataFrame with ('j', ...) MultiIndex and a single 'v' col."""
+    idx_names = ['j', *index_extra]
+    tuples = [(j, *([0] * len(index_extra))) for j in j_values]
+    idx = pd.MultiIndex.from_tuples(tuples, names=idx_names)
+    return pd.DataFrame({'v': np.arange(len(j_values), dtype='float64')}, index=idx)
+
+
+def _harmonize_table(rows):
+    """Build a minimal harmonize_<X>-shaped DataFrame.
+
+    Each row is (raw_label, preferred_label).  Mimics the categorical_mapping
+    output shape: ``Original Label`` + ``Preferred Label`` columns.
+    """
+    return pd.DataFrame(rows, columns=['Original Label', 'Preferred Label'])
+
+
+def test_assets_behaviour_preserved(country):
+    """GH #168 regression: harmonize_assets still auto-applies to assets."""
+    df = _frame_with_j(['Bicycle (raw)', 'Mobile (raw)', 'unmapped'])
+    fake_mapping = {
+        'harmonize_assets': _harmonize_table([
+            ('Bicycle (raw)', 'Bicycle'),
+            ('Mobile (raw)', 'Mobile Phone'),
+        ]),
+    }
+    with patch.object(type(country), 'categorical_mapping',
+                      new_callable=PropertyMock, return_value=fake_mapping):
+        out = country._finalize_result(df, scheme_entry={}, method_name='assets')
+    j_vals = list(out.index.get_level_values('j'))
+    assert 'Bicycle' in j_vals
+    assert 'Mobile Phone' in j_vals
+    # Unmapped values pass through unchanged
+    assert 'unmapped' in j_vals
+
+
+def test_generalised_to_arbitrary_method_name(country):
+    """A future ``harmonize_education`` table auto-applies to
+    ``Country(X).education()`` output without code change."""
+    df = _frame_with_j(['Pri (raw)', 'Sec (raw)'])
+    fake_mapping = {
+        'harmonize_education': _harmonize_table([
+            ('Pri (raw)', 'Primary'),
+            ('Sec (raw)', 'Secondary'),
+        ]),
+    }
+    with patch.object(type(country), 'categorical_mapping',
+                      new_callable=PropertyMock, return_value=fake_mapping):
+        out = country._finalize_result(df, scheme_entry={}, method_name='education')
+    j_vals = sorted(out.index.get_level_values('j'))
+    assert j_vals == ['Primary', 'Secondary']
+
+
+def test_no_matching_harmonize_table_is_noop(country):
+    """If no ``harmonize_<method_name>`` table exists, the hook silently
+    does nothing — original j values pass through."""
+    df = _frame_with_j(['Foo', 'Bar'])
+    fake_mapping = {
+        # harmonize_assets present but method_name is something else
+        'harmonize_assets': _harmonize_table([('Foo', 'X'), ('Bar', 'Y')]),
+    }
+    with patch.object(type(country), 'categorical_mapping',
+                      new_callable=PropertyMock, return_value=fake_mapping):
+        out = country._finalize_result(df, scheme_entry={}, method_name='cluster_features')
+    j_vals = sorted(out.index.get_level_values('j'))
+    assert j_vals == ['Bar', 'Foo']
+
+
+def test_missing_preferred_label_column_skipped(country):
+    """A ``harmonize_<X>`` table without a ``Preferred Label`` column is
+    skipped (e.g. malformed user table)."""
+    df = _frame_with_j(['Foo', 'Bar'])
+    bad = pd.DataFrame([('Foo', 'X')], columns=['Original Label', 'Other'])
+    fake_mapping = {'harmonize_assets': bad}
+    with patch.object(type(country), 'categorical_mapping',
+                      new_callable=PropertyMock, return_value=fake_mapping):
+        out = country._finalize_result(df, scheme_entry={}, method_name='assets')
+    j_vals = sorted(out.index.get_level_values('j'))
+    # Skipped silently; raw values pass through
+    assert j_vals == ['Bar', 'Foo']
+
+
+def test_no_j_in_index_skipped(country):
+    """The hook only fires when ``j`` is in the MultiIndex."""
+    idx = pd.MultiIndex.from_tuples([('A', 0), ('B', 1)], names=['t', 'i'])
+    df = pd.DataFrame({'v': [1.0, 2.0]}, index=idx)
+    fake_mapping = {'harmonize_assets': _harmonize_table([('A', 'X')])}
+    with patch.object(type(country), 'categorical_mapping',
+                      new_callable=PropertyMock, return_value=fake_mapping):
+        out = country._finalize_result(df, scheme_entry={}, method_name='assets')
+    # No 'j' level → no rename; original index unchanged
+    assert list(out.index.get_level_values('t')) == ['A', 'B']


### PR DESCRIPTION
## Summary

Closes #180. Replaces the hardcoded `method_name == 'assets'` block in `Country._finalize_result` with a generic `f'harmonize_{method_name}'` lookup. Picks **Option A** from the issue body.

Before:
```python
if (method_name == 'assets'
        and isinstance(df.index, pd.MultiIndex)
        and 'j' in df.index.names):
    ha_table = self.categorical_mapping.get('harmonize_assets')
    ...
```

After:
```python
if (method_name
        and isinstance(df.index, pd.MultiIndex)
        and 'j' in df.index.names):
    ha_table = self.categorical_mapping.get(f'harmonize_{method_name}')
    ...
```

## Behavior

- **`assets` (GH #168)** continues to fire on `harmonize_assets` — preserved verbatim, no functional change. New regression test covers this.
- **Future canonical mappings** — `harmonize_education`, `harmonize_housing`, etc. — auto-apply by convention as soon as a country (or the global `lsms_library/categorical_mapping/`) declares the table. No new hooks needed in `country.py`.
- **Tables without a matching `harmonize_<X>`** are unaffected (the `categorical_mapping.get(...)` returns `None`, the if-block short-circuits).
- **`harmonize_food`** (already present in 4+ country `categorical_mapping.org` files) does NOT trigger inadvertently — there's no `method_name == 'food'`. The food-related methods are `food_acquired`, `food_prices`, etc., for which `harmonize_food_acquired` etc. don't exist. Phase 5 (#223) tracks the canonical-vocabulary work for food separately.

## Test plan

- [x] New test file `tests/test_harmonize_method_auto_dispatch.py` (5 cases):
  - `test_assets_behaviour_preserved` — GH #168 regression check.
  - `test_generalised_to_arbitrary_method_name` — verifies a synthetic `harmonize_education` table fires for `method_name='education'`.
  - `test_no_matching_harmonize_table_is_noop` — `harmonize_assets` present but `method_name='cluster_features'` → no-op.
  - `test_missing_preferred_label_column_skipped` — malformed table → silent skip.
  - `test_no_j_in_index_skipped` — DataFrame without `j` index level → no-op.
- [x] Existing tests: `test_schema_consistency`, `test_food_prices_dtype`, `test_food_labels`, `test_canonical_spellings` all green (187 passed, 8 skipped, 4 xpassed).

## Files

- `lsms_library/country.py` — 6 lines changed (the hook generalized + comment updated).
- `tests/test_harmonize_method_auto_dispatch.py` — 124 lines (new test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)