### PR TITLE
feat(Timor-Leste): wire interview_date for 2001 and 2007-08 (#207)

### DIFF
--- a/lsms_library/countries/Timor-Leste/2001/_/data_info.yml
+++ b/lsms_library/countries/Timor-Leste/2001/_/data_info.yml
@@ -12,6 +12,13 @@ household_roster:
         Relationship: s01a03
         Age: s01a06a
 
+interview_date:
+    file: ../Data/S00.DTA
+    idxvars:
+        i: identif
+    myvars:
+        Int_t: s00_vis1   # six-digit DDMMYY integer; parsed by Int_t() in mapping.py
+
 sample:
     dfs:
         - df_cover
@@ -21,8 +28,8 @@ sample:
         idxvars:
             i: identif
             v: id4
-        myvars: {}  # interview_date is not declared in data_scheme; stray
-                    # `int_t: s00_vis1` removed (GH #163 item 1).
+        myvars: {}  # cover-page identifiers only; interview_date now wired
+                    # as its own table above (GH #207).
     df_weights:
         file: ../Data/WEIGHT.DTA
         idxvars:

--- a/lsms_library/countries/Timor-Leste/2001/_/mapping.py
+++ b/lsms_library/countries/Timor-Leste/2001/_/mapping.py
@@ -1,0 +1,27 @@
+# Formatting functions for Timor-Leste 2001
+import pandas as pd
+
+
+def Int_t(value):
+    """Parse the ``s00_vis1`` interview-date column.
+
+    The 2001 cover-page file ``S00.DTA`` records the first-visit
+    interview date as a six-digit integer encoded ``DDMMYY`` (e.g.
+    ``260901`` = 26 September 2001).  Convert to a :class:`datetime.date`.
+
+    NaN / non-finite values pass through as :class:`pandas.NaT`.
+    """
+    if pd.isna(value):
+        return pd.NaT
+    try:
+        s = f"{int(value):06d}"
+    except (TypeError, ValueError):
+        return pd.NaT
+    dd, mm, yy = int(s[:2]), int(s[2:4]), int(s[4:6])
+    # 2001 wave: two-digit years <= 30 → 20xx, else 19xx (defensive;
+    # in practice every observation has yy=01 or yy=02).
+    year = 2000 + yy if yy <= 30 else 1900 + yy
+    try:
+        return pd.Timestamp(year=year, month=mm, day=dd).date()
+    except (ValueError, OverflowError):
+        return pd.NaT

--- a/lsms_library/countries/Timor-Leste/2007-08/_/data_info.yml
+++ b/lsms_library/countries/Timor-Leste/2007-08/_/data_info.yml
@@ -12,6 +12,17 @@ household_roster:
         Relationship: q01a02
         Age: q01a05y
 
+interview_date:
+    file: ../Data/basicvars.dta
+    idxvars:
+        i: hh_id
+    myvars:
+        Int_t:
+            - intday
+            - intmonth
+            - intyear
+    converted_categoricals: False
+
 sample:
     file: ../Data/basicvars.dta
     idxvars:

--- a/lsms_library/countries/Timor-Leste/2007-08/_/mapping.py
+++ b/lsms_library/countries/Timor-Leste/2007-08/_/mapping.py
@@ -1,0 +1,23 @@
+# Formatting functions for Timor-Leste 2007-08
+import pandas as pd
+
+
+def Int_t(value):
+    """Combine ``intday``, ``intmonth``, ``intyear`` into a date.
+
+    The 2007-08 ``basicvars.dta`` records the interview date as three
+    integer columns (intday 1-31, intmonth 1-12, intyear 2007-2008).
+    Receives them as a length-3 :class:`pandas.Series` per row.
+
+    NaN / out-of-range components → :class:`pandas.NaT`.
+    """
+    try:
+        d = int(value.iloc[0])
+        m = int(value.iloc[1])
+        y = int(value.iloc[2])
+    except (AttributeError, IndexError, TypeError, ValueError):
+        return pd.NaT
+    try:
+        return pd.Timestamp(year=y, month=m, day=d).date()
+    except (ValueError, OverflowError):
+        return pd.NaT

--- a/lsms_library/countries/Timor-Leste/_/data_scheme.yml
+++ b/lsms_library/countries/Timor-Leste/_/data_scheme.yml
@@ -19,3 +19,7 @@ Data Scheme:
       optional: true
     strata: str
     Rural: str
+
+  interview_date:
+    index: (t, i)
+    Int_t: datetime

--- a/tests/test_timor_leste_interview_date.py
+++ b/tests/test_timor_leste_interview_date.py
@@ -1,0 +1,94 @@
+"""Unit tests for Timor-Leste interview_date formatters (#207).
+
+Covers the per-wave ``Int_t`` formatters in
+``Timor-Leste/{wave}/_/mapping.py`` without invoking the full
+framework pipeline (which requires DVC pulls and is slow on CI).
+The integration check (``Country('Timor-Leste').interview_date()``
+returning sane datetimes) is exercised separately when the parquet
+caches are warm.
+"""
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[1]
+TL_2001 = REPO / "lsms_library/countries/Timor-Leste/2001/_/mapping.py"
+TL_2007 = REPO / "lsms_library/countries/Timor-Leste/2007-08/_/mapping.py"
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def m2001():
+    return _load_module(TL_2001, "tl_2001_mapping")
+
+
+@pytest.fixture(scope="module")
+def m2007():
+    return _load_module(TL_2007, "tl_2007_mapping")
+
+
+# -- 2001: DDMMYY integer parser ---------------------------------------
+
+def test_2001_int_t_full_six_digit(m2001):
+    assert m2001.Int_t(260901) == pd.Timestamp("2001-09-26").date()
+
+
+def test_2001_int_t_five_digit_zero_padded(m2001):
+    """``50101`` → DD=05, MM=01, YY=01 → 2001-01-05."""
+    assert m2001.Int_t(50101) == pd.Timestamp("2001-01-05").date()
+
+
+def test_2001_int_t_nan(m2001):
+    assert m2001.Int_t(np.nan) is pd.NaT
+
+
+def test_2001_int_t_string_input(m2001):
+    """Stata can deliver int columns as strings under some conversions —
+    we still want a sensible answer."""
+    assert m2001.Int_t("260901") == pd.Timestamp("2001-09-26").date()
+
+
+def test_2001_int_t_invalid_returns_nat(m2001):
+    """Non-numeric / out-of-range input drops to NaT rather than raising."""
+    assert m2001.Int_t("nonsense") is pd.NaT
+
+
+def test_2001_int_t_two_digit_year_century_handling(m2001):
+    """Two-digit years <=30 → 20xx; >=31 → 19xx (defensive only — the
+    2001 wave never sees yy outside {01, 02})."""
+    assert m2001.Int_t(101095) == pd.Timestamp("1995-10-10").date()
+    assert m2001.Int_t(101015) == pd.Timestamp("2015-10-10").date()
+
+
+# -- 2007-08: three-component combiner ---------------------------------
+
+def test_2007_int_t_basic(m2007):
+    assert m2007.Int_t(pd.Series([10, 7, 2007])) == pd.Timestamp("2007-07-10").date()
+
+
+def test_2007_int_t_nan_day(m2007):
+    assert m2007.Int_t(pd.Series([np.nan, 7, 2007])) is pd.NaT
+
+
+def test_2007_int_t_invalid_month_returns_nat(m2007):
+    """Month 13 is invalid; pd.Timestamp raises ValueError → NaT."""
+    assert m2007.Int_t(pd.Series([10, 13, 2007])) is pd.NaT
+
+
+def test_2007_int_t_2008_year(m2007):
+    assert m2007.Int_t(pd.Series([15, 3, 2008])) == pd.Timestamp("2008-03-15").date()
+
+
+def test_2007_int_t_string_components(m2007):
+    """Stata sometimes delivers integer columns as string-of-int."""
+    assert m2007.Int_t(pd.Series(["10", "7", "2007"])) == pd.Timestamp("2007-07-10").date()


### PR DESCRIPTION
## Summary

Closes #207. Both Timor-Leste waves now expose `Country('Timor-Leste').interview_date()` per the canonical schema in `lsms_library/data_info.yml` (`index: (t, i), Int_t: datetime`).

## Source columns

- **2001** (`S00.DTA`): `s00_vis1` — first-visit interview date as a six-digit `DDMMYY` integer (e.g. `260901` = 26 Sep 2001). The earlier wiring extracted this as `int_t` but it was stripped in GH #163 item 1 because `interview_date` wasn't declared at the country level — now it is. Parsed by a new `Timor-Leste/2001/_/mapping.py:Int_t()` formatter that handles five-digit zero-padding (`50101` → 5 Jan 2001), NaN, string input, and out-of-range guards.
- **2007-08** (`basicvars.dta`): three integer columns `intday`, `intmonth`, `intyear`. Combined by a new `Timor-Leste/2007-08/_/mapping.py:Int_t()` formatter that mirrors the Mali 2014-15 multi-column pattern.

## Test plan

- [x] `tests/test_timor_leste_interview_date.py` (11 cases, all pass): full-six-digit parse, five-digit zero-padding, NaN, string input, invalid input → NaT, two-digit-year century rule, three-component combine, NaN-component handling, invalid month → NaT, 2008 year, string components.
- [ ] Integration smoke: `Country('Timor-Leste').interview_date()` on a clean rebuild was started but didn't complete within the session's time budget (DVC pulls + framework finalize on a fresh cache, ~5 minutes elapsed without output before I killed it). YAML wiring mirrors the already-working Senegal / Mali / Niger patterns; recommend running this before merging.

## Files

- `lsms_library/countries/Timor-Leste/_/data_scheme.yml` — declare the new table.
- `lsms_library/countries/Timor-Leste/2001/_/data_info.yml` — `interview_date` block + cleanup of stale comment in `sample.df_cover`.
- `lsms_library/countries/Timor-Leste/2007-08/_/data_info.yml` — `interview_date` block.
- `lsms_library/countries/Timor-Leste/2001/_/mapping.py` — new file with `Int_t()` for DDMMYY parsing.
- `lsms_library/countries/Timor-Leste/2007-08/_/mapping.py` — new file with `Int_t()` for three-component combine.
- `tests/test_timor_leste_interview_date.py` — new file (11 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)