### PR TITLE
fix(harmonize_food): wire categorical_mapping unit table to u index level for Mali, Nigeria, Senegal, Burkina_Faso (#223 Tier 1)

### DIFF
--- a/lsms_library/countries/Burkina_Faso/2014/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2014/_/data_info.yml
@@ -157,9 +157,7 @@ food_acquired:
         j:
             - product
             - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
-        u:
-            - uachat
-            - mappings: ['unit', 'Original Label', 'Preferred Label']
+        u: uachat
     myvars:
         Quantity: qachat
         Expenditure: achat

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/data_info.yml
@@ -201,9 +201,7 @@ food_acquired:
         j:
             - s07bq01
             - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
-        u:
-            - s07bq03b
-            - mappings: ['unit', 'Original Label', 'Preferred Label']
+        u: s07bq03b
     myvars:
         Quantity: s07bq03a
         Expenditure: s07bq08

--- a/lsms_library/countries/Burkina_Faso/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2021-22/_/data_info.yml
@@ -182,9 +182,7 @@ food_acquired:
         j:
             - s07bq01
             - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
-        u:
-            - s07bq03b
-            - mappings: ['unit', 'Original Label', 'Preferred Label']
+        u: s07bq03b
     myvars:
         Quantity: s07bq03a
         Expenditure: s07bq08

--- a/lsms_library/countries/Burkina_Faso/_/categorical_mapping.org
+++ b/lsms_library/countries/Burkina_Faso/_/categorical_mapping.org
@@ -303,7 +303,7 @@
 
 * Food Units
 
-#+NAME: unit
+#+NAME: u
 | Original Label            | Preferred Label |
 |---------------------------+-----------------|
 | 101.0                     | 101.0           |

--- a/lsms_library/countries/Mali/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Mali/2018-19/_/data_info.yml
@@ -111,9 +111,7 @@ food_acquired:
         j: 
             - s07bq01
             - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
-        u: 
-            - s07bq03b
-            - mappings: ['unit', 'Original Label', 'Preferred Label']
+        u: s07bq03b
     myvars:
         Quantity: s07bq03a
         Expenditure: s07bq08

--- a/lsms_library/countries/Mali/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Mali/2021-22/_/data_info.yml
@@ -106,9 +106,7 @@ food_acquired:
         j: 
             - s07bq01
             - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
-        u: 
-            - s07bq03b
-            - mappings: ['unit', 'Original Label', 'Preferred Label']
+        u: s07bq03b
     myvars:
         Quantity: s07bq03a
         Expenditure: s07bq08

--- a/lsms_library/countries/Mali/_/categorical_mapping.org
+++ b/lsms_library/countries/Mali/_/categorical_mapping.org
@@ -22,7 +22,7 @@ print(write_df_to_org(df, 'unit'))
 #+end_src
 
 #+RESULTS:
-#+NAME: unit
+#+NAME: u
 |    | Original Label               | Preferred Label |
 |----+------------------------------+-----------------|
 |  0 | Alvéole                      | Alvéole         |

--- a/lsms_library/countries/Nigeria/2010-11/_/food_acquired.py
+++ b/lsms_library/countries/Nigeria/2010-11/_/food_acquired.py
@@ -20,7 +20,7 @@ food_labels = get_categorical_mapping(tablename='harmonize_food',
                                        idxvars='Code',
                                        **{'Preferred Label': 'Preferred Label'})
 
-_unit_raw = get_categorical_mapping(tablename='unit',
+_unit_raw = get_categorical_mapping(tablename='u',
                                      idxvars='Code',
                                      **{'2010-11': '2010-11'})
 unitcodes = {k: v for k, v in _unit_raw.items() if isinstance(v, str)}

--- a/lsms_library/countries/Nigeria/2012-13/_/food_acquired.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/food_acquired.py
@@ -17,7 +17,7 @@ food_labels = get_categorical_mapping(tablename='harmonize_food',
                                        idxvars='Code',
                                        **{'Preferred Label': 'Preferred Label'})
 
-_unit_raw = get_categorical_mapping(tablename='unit',
+_unit_raw = get_categorical_mapping(tablename='u',
                                      idxvars='Code',
                                      **{'2012-13': '2012-13'})
 unitcodes = {k: v for k, v in _unit_raw.items() if isinstance(v, str)}

--- a/lsms_library/countries/Nigeria/2015-16/_/food_acquired.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/food_acquired.py
@@ -17,7 +17,7 @@ food_labels = get_categorical_mapping(tablename='harmonize_food',
                                        idxvars='Code',
                                        **{'Preferred Label': 'Preferred Label'})
 
-_unit_raw = get_categorical_mapping(tablename='unit',
+_unit_raw = get_categorical_mapping(tablename='u',
                                      idxvars='Code',
                                      **{'2015-16': '2015-16'})
 unitcodes = {k: v for k, v in _unit_raw.items() if isinstance(v, str)}

--- a/lsms_library/countries/Nigeria/2018-19/_/food_acquired.py
+++ b/lsms_library/countries/Nigeria/2018-19/_/food_acquired.py
@@ -21,7 +21,7 @@ food_labels = get_categorical_mapping(tablename='harmonize_food',
                                        idxvars='Code',
                                        **{'Preferred Label': 'Preferred Label'})
 
-_unit_raw = get_categorical_mapping(tablename='unit',
+_unit_raw = get_categorical_mapping(tablename='u',
                                      idxvars='Code',
                                      **{'2018-19': '2018-19'})
 unitcodes = {k: v for k, v in _unit_raw.items() if isinstance(v, str)}

--- a/lsms_library/countries/Nigeria/_/categorical_mapping.org
+++ b/lsms_library/countries/Nigeria/_/categorical_mapping.org
@@ -152,7 +152,7 @@
   (e.g., code 10 = "medium derica" in wave 2 but "bin/basket" in
   waves 3-4).  The per-wave columns record the wave-specific meaning.
 
-#+NAME: unit
+#+NAME: u
 | Code | Preferred Label              | 2010-11                      | 2012-13                      | 2015-16                      | 2018-19                      |
 |------+------------------------------+------------------------------+------------------------------+------------------------------+------------------------------|
 |    1 | Kg                           | Kg                           | Kg                           | Kg                           | Kg                           |

--- a/lsms_library/countries/Senegal/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Senegal/2018-19/_/data_info.yml
@@ -178,9 +178,7 @@ food_acquired:
         j:
             - s07bq01
             - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
-        u:
-            - s07bq03b
-            - mappings: ['unit', 'Original Label', 'Preferred Label']
+        u: s07bq03b
     myvars:
         Quantity: s07bq03a
         Expenditure: s07bq08

--- a/lsms_library/countries/Senegal/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Senegal/2021-22/_/data_info.yml
@@ -166,9 +166,7 @@ food_acquired:
         j:
             - s07bq01
             - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
-        u:
-            - s07bq03b
-            - mappings: ['unit', 'Original Label', 'Preferred Label']
+        u: s07bq03b
     myvars:
         Quantity: s07bq03a
         Expenditure: s07bq08

--- a/lsms_library/countries/Senegal/_/categorical_mapping.org
+++ b/lsms_library/countries/Senegal/_/categorical_mapping.org
@@ -323,7 +323,7 @@
 
 * Food Units
 
-#+NAME: unit
+#+NAME: u
 | Original Label                       | Preferred Label        |
 |--------------------------------------+------------------------|
 | 1.0                                  | 1.0                    |

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -219,10 +219,19 @@ def _ensure_dvc_pulled(fn) -> None:
         )
         if any(p.exists() for p in cache_layouts):
             return  # cache hit -- DVCFS.open() will serve from local
-        try:
-            rel_path = abs_path.relative_to(_COUNTRIES_DIR)
-        except ValueError:
-            return  # outside the countries dir, can't fetch
+        # NB: an earlier ``rel_path = abs_path.relative_to(_COUNTRIES_DIR)``
+        # guard lived here -- it was needed when the cache-miss path called
+        # ``Repo.fetch(targets=[str(rel_path)])`` and would have produced a
+        # NoOutputOrStageError otherwise.  The bypass below uses md5 +
+        # cache_layouts directly and has no such requirement; the guard
+        # was actively harmful when ``abs_path`` resolves under a worktree
+        # whose path doesn't share a prefix with the imported
+        # ``_COUNTRIES_DIR`` (e.g. a wave script in a worktree but
+        # importing lsms_library from a separate main checkout via the
+        # venv's ``.pth`` file -- ``relative_to`` raises ``ValueError``
+        # and the function silently bails without fetching).  We don't
+        # need the path to be inside ``_COUNTRIES_DIR`` to fetch the blob;
+        # we only need its md5, which we already have.
 
     except (OSError, yaml.YAMLError, KeyError, IndexError, TypeError):
         # Bad sidecar shape (None / wrong type), missing 'outs'/'md5' key,

--- a/tests/test_dvc_caching.py
+++ b/tests/test_dvc_caching.py
@@ -1279,8 +1279,21 @@ class TestLayer1Caching:
             # bailing to the streaming fallback.
             assert mock_remote.fs.get_file.call_count >= 1
 
-    def test_ensure_dvc_pulled_bails_on_path_outside_countries(self, tmp_path, monkeypatch):
-        """A sidecar at a path outside _COUNTRIES_DIR -> no fetch (no error)."""
+    def test_ensure_dvc_pulled_fetches_sidecar_outside_countries(self, tmp_path, monkeypatch):
+        """A sidecar outside _COUNTRIES_DIR -> bypass still attempts fetch.
+
+        The pre-bypass implementation refused to fetch when ``abs_path``
+        couldn't be made relative to ``_COUNTRIES_DIR`` -- a technical
+        constraint of the old ``Repo.fetch(targets=[str(rel_path)])``
+        call (which resolved the target against the repo root).  The
+        bypass uses the md5 directly for the cache write, so no such
+        constraint applies; refusing was actively harmful when wave
+        scripts ran from a worktree but imported ``lsms_library`` from
+        a separate main checkout (``abs_path`` resolved under the
+        worktree, ``_COUNTRIES_DIR`` pointed at main, ``relative_to``
+        raised ``ValueError``, function silently bailed, cache stayed
+        empty).  See commit 5e2ea913.
+        """
         from lsms_library import local_tools
 
         countries_dir = (tmp_path / "countries").resolve()
@@ -1289,9 +1302,9 @@ class TestLayer1Caching:
         outside.mkdir(parents=True)
         target = outside / "foo.dta"
         sidecar = outside / "foo.dta.dvc"
+        md5 = "0123456789abcdef0123456789abcdef"
         sidecar.write_text(
-            "outs:\n- md5: 0123456789abcdef0123456789abcdef\n"
-            "  size: 0\n  path: foo.dta\n"
+            f"outs:\n- md5: {md5}\n  size: 0\n  path: foo.dta\n"
         )
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
@@ -1301,8 +1314,24 @@ class TestLayer1Caching:
         with patch("lsms_library.local_tools.DVCFS") as mock_dvcfs:
             mock_remote = mock_dvcfs.repo.cloud.get_remote.return_value
             mock_remote.path = "bucket0/repo"
+
+            def fake_get_file(src, dst, *args, **kwargs):
+                Path(dst).parent.mkdir(parents=True, exist_ok=True)
+                Path(dst).write_bytes(b"")
+            mock_remote.fs.get_file.side_effect = fake_get_file
+
+            # Should not raise.
             local_tools._ensure_dvc_pulled(str(target))
-            mock_remote.fs.get_file.assert_not_called()
+
+            # Bypass attempted a fetch from the canonical DVC 2.x layout
+            # and exited after that single call (the rename succeeded
+            # because fake_get_file actually created the file).
+            mock_remote.fs.get_file.assert_called_once()
+            call = mock_remote.fs.get_file.call_args
+            src, dst = call.args[:2]
+            assert src == f"bucket0/repo/{md5[:2]}/{md5[2:]}"
+            # And the final cache file landed at the canonical path.
+            assert (cache_dir / md5[:2] / md5[2:]).exists()
 
     def test_ensure_dvc_pulled_handles_malformed_sidecar(self, tmp_path, monkeypatch):
         """A sidecar with unexpected shape -> bail silently, no fetch."""


### PR DESCRIPTION
## Summary

Phase 5 Tier 1 of issue #223 — applies the same surgical pattern as Malawi-only commit `afbb61f3` to the four countries that already have a populated `#+NAME: unit` table with a `Preferred Label` column in `_/categorical_mapping.org`: rename the table to `#+NAME: u`, drop now-redundant explicit `mappings:` blocks from wave YAMLs, and (for Nigeria) update `tablename='unit'` → `'u'` in wave-script calls.

**Plus a regression fix surfaced during smoke-testing**: a dead `relative_to(_COUNTRIES_DIR)` guard in `_ensure_dvc_pulled` (left over from PR #232's bypass refactor) was silently bailing whenever a wave script ran from a worktree but imported `lsms_library` from main via the venv's `.pth`. See commit `5e2ea913` for details.

## Two commits

### 1. `f80d9235` — Tier 1 unit-table renames

For each of Mali, Nigeria, Senegal, Burkina_Faso:
- Rename `#+NAME: unit` → `#+NAME: u` in `_/categorical_mapping.org` so the framework's auto-discovery (case-insensitive name match between table name and index level) fires for the `u` index level.
- Where the country had explicit `mappings: ['unit', 'Original Label', 'Preferred Label']` blocks in wave YAMLs (Mali, Senegal, Burkina_Faso), drop them — redundant once auto-discovery fires.
- For Nigeria, update `get_categorical_mapping(tablename='unit', ...)` calls in wave scripts to `tablename='u'`.

### 2. `5e2ea913` — drop dead `relative_to(_COUNTRIES_DIR)` guard

PR #232's bypass refactor replaced `Repo.fetch(targets=[str(rel_path)])` with a direct `fs.get_file()` call that doesn't need `rel_path`. The guard was orphaned dead code. It became *actively harmful* when `abs_path` resolves under a path that doesn't share a prefix with the imported `_COUNTRIES_DIR` — concretely, when wave scripts run from a worktree but import `lsms_library` from a separate main checkout via the venv's `.pth` file.

Failure mode: `abs_path.relative_to(_COUNTRIES_DIR)` raises `ValueError`, function silently bails, cache stays empty, caller falls through to `DVCFS.open(fn)` which can't resolve the cwd-relative path either and raises `FileNotFoundError`.

Surfaced by this PR's exercise of Nigeria's wave scripts (which all use cwd-relative `../Data/...` paths). Before the fix: 2012-13 and 2015-16 silently printed `FileNotFoundError` tracebacks (swallowed by an outer try/except but indicative of the cache-miss path failing). After the fix: clean exit, blob fetched in ~1s, cache populated, downstream read served from local disk.

## Per-country smoke-test

| Country | result | sample u values |
|---|---|---|
| Mali | ✅ | `Kg, Autre, Unité, Tas, Gramme, Litre, Sachet, Paquet, Boîte, Sac petit, Verre, Bidon, Centilitre, Sac moyen, Sac large` |
| Senegal | ✅ | `Paquet, Tranche, Unité, Kg, Tablette, Pot, Boîte, Bouteille de 1,5 L, Litre, Sachet, Tiers de miche, Tas, Miche, Cuillère à café, Cube` |
| Burkina_Faso | ✅* | canonical labels mixed with pre-existing raw codes (`'111'`, `'101'`, etc.) — verified pre-existing |
| Nigeria | ✅** | `Country('Nigeria').food_acquired()` now completes (was crashing before the rel_path fix). u shows raw floats (`'6.0'`, `'5.0'`) due to a pre-existing dtype mismatch (CSV column is float64, mapping keys are strings) — independent of this PR's scope; will need a separate follow-up |

\* Burkina_Faso residual raw codes: pre-existing; verified-equivalent before/after (the Tier 1 rename doesn't change the data, only how the framework discovers the mapping).

\** Nigeria residual float dtype: pre-existing; tracked as separate work. The Tier 1 rename + bypass fix correctly establishes that the auto-discovery fires; the dtype-coercion concern is independent.

## Surprises

1. **Initial smoke-test framing was wrong.** The first-pass agent report described Nigeria's failure as "DVC environment limitation" (early waves' source files not fetchable). Investigation showed the bypass *can* fetch them in ~1 s; the actual failure was the rel_path bug above. Lesson noted: trust-but-verify subagent reports against the actual code path before merging.
2. Unlike Malawi, all four Tier 1 countries' `unit` tables already had a `Preferred Label` column — only the `#+NAME:` rename was needed.
3. Nigeria's wave scripts use per-wave columns (`'2010-11'`, `'2018-19'`) for the categorical mapping, not `Preferred Label`, so the `tablename='u'` rename suffices without changing the `Label` kwarg.
4. Burkina_Faso has pre-existing unmapped 3-digit codes in `u` that map to themselves in its `unit` table — out of scope for this PR.

## Cross-country context (from inventory comment on #223)

The remaining countries split into:

- **Tier 2** (Ethiopia, Tanzania, Uganda, Nepal): no code change needed — their `u` is already canonical at parquet-write time via different mechanisms. Their `conversion_to_kgs.json` files are kg-factor lookups (consumed by `food_quantities` derivation), orthogonal to label canonicalisation. Worth a doc note in a follow-up PR.
- **Tier 3** (Benin, CotedIvoire, Guinea-Bissau, Niger, Togo): EHCVM-2018-19 countries that need new `u` tables built. Three carry mojibake to fix at source.
- **Tier 4** (GhanaLSS): structural outlier — its harmonization lives in a separate `unit_labels.org`. Needs lifting into `categorical_mapping.org`.

## Test plan

- [x] `Country('Mali').food_acquired()` produces canonical `u` labels
- [x] `Country('Senegal').food_acquired()` produces canonical `u` labels
- [x] `Country('Burkina_Faso').food_acquired()` produces canonical `u` labels (residual raw codes pre-existing, verified)
- [x] `Country('Nigeria').food_acquired()` completes successfully (residual float dtype pre-existing, separate concern)
- [x] All four Nigeria wave scripts run cleanly with no `FileNotFoundError` tracebacks (was: 2012-13 and 2015-16 printed swallowed tracebacks)
- [ ] Full Nigeria u-mapping verification (deferred: needs separate dtype-coercion fix on the wave script side)
- [ ] CI unit + data tests on this PR

## Related

- #223 — parent issue (Phase 5 cross-country roadmap)
- `afbb61f3` — Malawi-only precedent
- #232 — DVC bypass (introduced the dead-code rel_path guard fixed here)
- #169 — food_acquired canonical schema

🤖 Tier 1 work delegated to a subagent (Claude Sonnet 4.5) operating in a worktree; rel_path fix added by the coordinator after independent end-to-end verification surfaced the regression. Reviewed by @ligon before merge.
