### PR TITLE
docs: document u-handling for Ethiopia, Tanzania, Uganda, Nepal, GhanaLSS (#223 Tier 2)

### DIFF
--- a/lsms_library/countries/Ethiopia/_/CONTENTS.org
+++ b/lsms_library/countries/Ethiopia/_/CONTENTS.org
@@ -178,7 +178,31 @@ CLOSED: [2023-03-07 Tue 11:25]
 CLOSED: [2023-03-07 Tue 11:32]
 ** DONE food_acquired.py
 CLOSED: [2023-03-07 Tue 21:10]
-Test...
+*** Unit handling
+
+The =u= (unit) index level on =food_acquired= is canonical at
+parquet-write time via in-script title-casing plus a small typo
+patch in =ethiopia.py:food_acquired=.  Source labels are read with
+=convert_categoricals=True= (so they arrive as strings like
+=KILOGRAM=, =Meduim Cup=, =Kubaya 100Ml=), then normalised to
+=Kilogram=, =Medium Cup=, =Kubaya/Cup 100Ml=, etc., before the
+parquet is written.  See =lsms_library/countries/Ethiopia/_/ethiopia.py=
+around lines 220-231 for the exact regex / =str.title()= calls.
+
+No =u= table is wired into =_/categorical_mapping.org=; the
+framework's auto-discovery on =u= would be a no-op (the labels are
+already canonical).
+
+The =_/conversion_to_kgs.json= file is a kg-per-unit factor
+lookup consumed by =food_quantities= derivation -- it is a
+separate concern from =u= label canonicalisation.  Its keys are
+the same canonical unit labels (=Kilogram=, =Litre=, etc.), so
+preserving the in-script normalisation above is what keeps that
+join working.
+
+For the cross-country canonical-=u= roadmap, see GH #223.
+
+*** Test...
 #+begin_src python :results output
 import pandas as pd
 

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -140,6 +140,32 @@ Second, starting in the 1991--92 wave, rather than eliciting expenditures over a
 
 NB: Differences in elicitation across waves may complicate comparisons across those waves.  In particular, the two rounds in the 1980s ask for expenditures "since my last visit", but only for one visit, while subsequent rounds elicit this information across several visits.
 
+*** Unit handling
+
+The =u= (unit) index level on =food_acquired= is canonical at
+parquet-write time via the country-level
+=_/food_acquired.py= script.  At line 22 it reads
+=_/unit_labels.org= (an org table named =unit_label= with columns
+=Preferred Label= and =u=), and at line 52 it applies the inverse
+map to the =u= column with =df.replace(...)= before setting the
+final =(j, t, i, u)= index and writing the parquet.
+
+This is stylistically different from the
+=_/categorical_mapping.org= pattern used by Malawi / Mali /
+Nigeria / Senegal / Burkina_Faso (a separate =unit_labels.org=
+file rather than a =u= table inside =categorical_mapping.org=)
+but functionally equivalent: =u= is canonical at parquet-write
+time, and no =u= table needs to be wired into
+=_/categorical_mapping.org=.  The framework's auto-discovery on
+=u= would be a no-op.
+
+There is no =_/conversion_to_kgs.json= for GhanaLSS; the
+food_quantities pipeline for this country is currently a
+work-in-progress (see =food_prices_quantities_and_expenditures.py=
+TODO below).
+
+For the cross-country canonical-=u= roadmap, see GH #223.
+
 *** Test...
 #+begin_src python :results output
 import pandas as pd

--- a/lsms_library/countries/Nepal/_/CONTENTS.org
+++ b/lsms_library/countries/Nepal/_/CONTENTS.org
@@ -79,3 +79,21 @@ There is no rotating panel or refreshment sample in the NLSS series.
 ** food_acquired
 ** interview_date
 ** assets
+
+* Unit handling for =food_acquired=
+
+Not yet applicable: =food_acquired= is not implemented for Nepal
+(no source =.dta= files have been DVC-tracked or downloaded; see
+"Data Acquisition Status" above).  No wave script and no
+country-level script exist for =food_acquired=, so there is
+nothing to canonicalise the =u= index level *of yet*, and no =u=
+table in =_/categorical_mapping.org= is needed.
+
+When the source data is acquired and the wave scripts are
+written, the team should choose one of the established patterns
+(in-script normalisation as in Ethiopia / Tanzania / Uganda /
+GhanaLSS, or a =u= entry in =_/categorical_mapping.org= as in
+Malawi / Mali / Nigeria / Senegal / Burkina_Faso) and document
+the choice in this section.
+
+For the cross-country canonical-=u= roadmap, see GH #223.

--- a/lsms_library/countries/Tanzania/_/CONTENTS.org
+++ b/lsms_library/countries/Tanzania/_/CONTENTS.org
@@ -447,7 +447,34 @@ CLOSED: [2023-03-07 Tue 11:25]
 CLOSED: [2023-03-07 Tue 11:32]
 ** DONE food_acquired.py
 CLOSED: [2023-03-07 Tue 21:10]
-Test...
+*** Unit handling
+
+The =u= (unit) index level on =food_acquired= is canonical at
+parquet-write time via two passes inside =tanzania.py=:
+
+1. =food_acquired()= maps raw upper-case codes to title-case labels
+   (=KILOGRAMS -> Kg=, =GRAMS -> Gram=, =LITRE -> Litre=,
+   =MILLILITRE -> Millilitre=, =PIECES -> Piece=) via an inline
+   =unitlabels= dict.  See
+   =lsms_library/countries/Tanzania/_/tanzania.py= around lines
+   400-405.
+2. =new_harmonize_units()= then *collapses every unit to either
+   =kg= or =piece=*, scaling the corresponding quantity by the
+   per-unit kg factor.  See =tanzania.py= around lines 559-586.
+
+So the =u= axis on the final parquet is a 2-token vocabulary
+({=kg=, =piece=}) -- already canonical by construction.  No =u=
+table is wired into =_/categorical_mapping.org=; the framework's
+auto-discovery on =u= would be a no-op.
+
+Note that the =_/conversion_to_kgs.json= file is *dead code* in
+the current Tanzania pipeline (the =new_harmonize_units= path
+absorbs the kg conversion); the load is commented out at
+=tanzania.py= ~lines 417-422.
+
+For the cross-country canonical-=u= roadmap, see GH #223.
+
+*** Test...
 #+begin_src python :results output
 import pandas as pd
 

--- a/lsms_library/countries/Uganda/_/CONTENTS.org
+++ b/lsms_library/countries/Uganda/_/CONTENTS.org
@@ -207,6 +207,30 @@ For cross-sectional analysis within a single wave, use =weight=.
 For longitudinal/panel analysis across waves, use =panel_weight=
 (and restrict to households where it is non-null and positive).
 
+* Unit handling for =food_acquired=
+
+The =u= (unit) index level on =food_acquired= is canonical at
+parquet-write time via =harmonized_unit_labels()= in
+=lsms_library/countries/Uganda/_/uganda.py= (~line 66), which reads
+=_/unitlabels.csv= -- a two-column =Code, Preferred Label= mapping
+where the canonical labels (=Kg=, =Gram=, =Litre=, =Akendo
+(Small)=, =Sack (120 kgs)=, ...) are already in human-readable
+form.  =food_acquired()= (~line 106) renames the =u= index level
+through this map, so by the time the wave parquet is written the
+=u= index carries clean labels.
+
+No =u= table is wired into =_/categorical_mapping.org=; the
+framework's auto-discovery on =u= would be a no-op (the labels are
+already canonical).
+
+The =_/conversion_to_kgs.json= file is a kg-per-unit factor
+lookup consumed by =food_quantities= derivation -- a separate
+concern from =u= label canonicalisation.  Its keys are the same
+=Preferred Label= strings used above; it is built dynamically by
+=_/kg_per_other_units.py=.
+
+For the cross-country canonical-=u= roadmap, see GH #223.
+
 * Known Issues
 ** TODO Missing panel weight for 2019-20
 :LOGBOOK:


### PR DESCRIPTION
## Summary

Tier 2 of issue #223 — five countries already produce canonical `u` (unit) index labels at parquet-write time via different mechanisms; they don't need a `u` table in `_/categorical_mapping.org` and the framework's auto-discovery would be a no-op there.

This PR adds a brief "Unit handling" note to each country's `_/CONTENTS.org` so future readers don't wonder why these countries are missing a `u` table when others (Malawi, Mali, Nigeria, Senegal, Burkina_Faso) have one. Doc-only — no code changes.

## Per-country mechanism

| Country | Mechanism | Code anchor |
|---|---|---|
| **Ethiopia** | wave script `ethiopia.py:food_acquired` title-cases source labels (read with `convert_categoricals=True`) and patches typos before writing the parquet | `lsms_library/countries/Ethiopia/_/ethiopia.py` (~lines 186–266) |
| **Tanzania** | wave script `tanzania.py:food_acquired` decodes uppercase source labels (`KILOGRAMS→Kg`, etc.) then `new_harmonize_units()` collapses every unit to **`'kg'` or `'piece'`** and folds the conversion factor into the quantity column | `tanzania.py` lines ~364-423, 559-586 |
| **Uganda** | wave script `uganda.py:food_acquired` calls `harmonized_unit_labels()` reading `_/unitlabels.csv` (which already has `Code, Preferred Label` columns); `u` ends up as the canonical label | `uganda.py` ~lines 66, 106; `_/unitlabels.csv` |
| **Nepal** | `food_acquired` not yet implemented (no source `.dta` in repo); doc note records this | `Nepal/_/CONTENTS.org` data-acquisition section |
| **GhanaLSS** | country-level `_/food_acquired.py` reads `_/unit_labels.org` (`#+name: unit_label` with `Preferred Label, u`) and applies it via `df.replace(...)` before writing the parquet | `_/food_acquired.py:22, :52` |

## Where countries also have `conversion_to_kgs.json` (Ethiopia, Uganda)

The doc note clarifies that the JSON is a **kg-factor lookup** consumed by `food_quantities` derivation — a separate concern from `u` label canonicalisation. (Tanzania's analogous JSON is dead code; the note flags that too.)

## Reclassification of GhanaLSS

The earlier inventory had GhanaLSS in Tier 4 (structural outlier). On closer inspection, GhanaLSS is conceptually identical to Tier 2 — just stylistically different (the harmonization table lives in a standalone `_/unit_labels.org` rather than in `categorical_mapping.org`). The script already produces canonical `u` labels at parquet-write time, so adding a `u` table to `categorical_mapping.org` would be a no-op for auto-discovery. **Tier 4 is now empty.**

If we ever want stylistic consistency, a follow-up could lift `unit_labels.org` into `categorical_mapping.org` as `#+name: u` — but it's purely cosmetic and not blocking.

## Status of issue #223 after this lands

| Tier | Countries | Status |
|---|---|---|
| Tier 0 | Malawi | ✅ done (commit `afbb61f3`) |
| Tier 1 | Mali, Nigeria, Senegal, Burkina_Faso | ✅ done (PR #233) |
| Tier 2 | Ethiopia, Tanzania, Uganda, Nepal, GhanaLSS | ✅ done (this PR) |
| Tier 3 | Benin, CotedIvoire, Guinea-Bissau, Niger, Togo | not yet — new `u` tables to build |
| Tier 4 | (empty) | — |

So after this lands, **10 of 15 food_acquired countries are addressed**; the remaining 5 are EHCVM countries that need new `u` tables built (Tier 3). Three of the five carry mojibake at the source which is a separate concern.

## Test plan

- [x] `Country({Ethiopia, Tanzania, Uganda, Nepal, GhanaLSS})` instantiates cleanly (verifies the org files still parse)
- [x] No code changes; nothing functional to regress
- [ ] CI on this PR

## Related

- #223 — parent issue
- `afbb61f3` — Malawi precedent
- #233 — Tier 1
- `slurm_logs/DESIGN_food_acquired_canonical_2026-05-05.org` — overall Phase 5 design doc

🤖 Tier 2 work delegated to a subagent operating in a worktree; reviewed by @ligon before merge.
