### PR TITLE
fix(Guinea-Bissau): reverse double-encoded UTF-8 mojibake in food_acquired (#223 — GB reclassified to Tier 2)

### DIFF
--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/mapping.py
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/mapping.py
@@ -2,7 +2,109 @@
 import pandas as pd
 import numpy as np
 import lsms_library.local_tools as tools
-from lsms_library.transformations import food_acquired_to_canonical as food_acquired
+from lsms_library.transformations import food_acquired_to_canonical as _food_acquired_canonical
+
+
+# Lossy-substitution prefixes the source data carries for two specific
+# Portuguese words.  Upstream of pyreadstat, the export pipeline
+# replaced the second byte of certain UTF-8 codepoints with literal
+# ``__`` (0x5f 0x5f) -- so ``Óleo`` (UTF-8: 0xc3 0x93 + 'leo') becomes
+# ``Ã__leo`` and ``Água`` (UTF-8: 0xc3 0x81 + 'gua') becomes
+# ``Ã__gua``.  No byte-level decoding can recover these (the original
+# byte is gone), so we substitute the canonical Portuguese form
+# directly when we see the prefix.  Two known cases drive this:
+# food items ``Óleo de mancarra``, ``Óleo de soja``, ``Óleo de palma``,
+# and ``Água filtrada`` (4 of 135 distinct ``j`` values in
+# food_acquired 2018-19).
+_LOST_PREFIX_REPLACEMENTS = {
+    'Ã__leo': 'Óleo',
+    'Ã__gua': 'Água',
+}
+
+
+def _decode_mojibake(s):
+    """Reverse the UTF-8-as-Latin-1-as-UTF-8 double-encoding that pyreadstat
+    produces for Guinea-Bissau's 2018-19 .dta value labels.
+
+    The .dta file's value-labels block stores Portuguese strings as raw
+    UTF-8 bytes (e.g. ``Pedaço`` = ``b'\\xc3\\xa7'`` for the ``ç``), but
+    the file metadata declares Latin-1 encoding.  pyreadstat respects
+    the metadata, decoding the UTF-8 bytes as Latin-1 and re-encoding
+    them as Python ``str`` -- producing ``PedaÃ§o`` instead of ``Pedaço``.
+    None of pyreadstat's ``encoding=`` options correct this (verified
+    2026-05-07: ``utf-8`` raises, ``cp1252`` / ``iso-8859-1`` give the
+    same mojibake).  The fix is post-decode: encode the mojibake string
+    back to Latin-1 bytes (recovers the original UTF-8 byte sequence),
+    then decode as UTF-8.
+
+    Two j-values in food_acquired 2018-19 carry an additional lossy
+    substitution upstream of pyreadstat where the second byte of
+    certain UTF-8 codepoints was replaced with literal ``__`` (i.e.
+    ``Óleo`` -> ``Ã__leo``, ``Água`` -> ``Ã__gua``).  Those can't be
+    recovered byte-wise, so we handle them via
+    ``_LOST_PREFIX_REPLACEMENTS`` above.
+
+    Strings without non-ASCII characters round-trip cleanly through
+    ``encode('latin-1').decode('utf-8')`` (every byte 0x00-0x7F is
+    valid in both encodings and identical).  So this is safe to apply
+    to all string values; only the mojibake-bearing ones change.
+
+    Returns the input unchanged on any error or when ``s`` isn't a
+    string -- best-effort, never raises.
+    """
+    if not isinstance(s, str):
+        return s
+    for bad, good in _LOST_PREFIX_REPLACEMENTS.items():
+        if s.startswith(bad):
+            return good + s[len(bad):]
+    try:
+        return s.encode('latin-1').decode('utf-8')
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return s
+
+
+def _decode_mojibake_in_df(df):
+    """Apply ``_decode_mojibake`` to every string column and string
+    index level in-place.  Used by per-feature ``df_edit`` hooks below
+    to fix value-label mojibake that affects Portuguese strings in
+    multiple columns at once (food items, units, etc.) -- 40 of 135
+    food items and 4 of 29 units carry it before this fix.
+    """
+    # Index levels
+    new_levels = []
+    new_names = list(df.index.names)
+    changed = False
+    for i, name in enumerate(df.index.names):
+        level = df.index.get_level_values(i)
+        if level.dtype == object or pd.api.types.is_string_dtype(level):
+            mapped = level.map(_decode_mojibake)
+            if not mapped.equals(level):
+                changed = True
+            new_levels.append(mapped)
+        else:
+            new_levels.append(level)
+    if changed:
+        df = df.copy()
+        df.index = pd.MultiIndex.from_arrays(new_levels, names=new_names) \
+            if len(new_levels) > 1 else new_levels[0]
+    # String columns
+    for col in df.columns:
+        if df[col].dtype == object or pd.api.types.is_string_dtype(df[col]):
+            df[col] = df[col].map(_decode_mojibake)
+    return df
+
+
+def food_acquired(df):
+    """``food_acquired`` post-processor: canonical reshape + mojibake fix.
+
+    Wraps ``transformations.food_acquired_to_canonical`` (the Phase 3
+    s-axis reshape) and then sweeps mojibake out of every string
+    column / index level.  See ``_decode_mojibake`` for the encoding
+    rationale.
+    """
+    df = _food_acquired_canonical(df)
+    df = _decode_mojibake_in_df(df)
+    return df
 
 def Sex(value):
     '''

--- a/lsms_library/countries/Guinea-Bissau/_/CONTENTS.org
+++ b/lsms_library/countries/Guinea-Bissau/_/CONTENTS.org
@@ -32,3 +32,36 @@ rather than expecting a =MonthsSpent= column in =household_roster()=.
 
 Guinea-Bissau has no pre-EHCVM waves in the library, so no continuous
 months-of-presence variable is available for any wave.
+
+* Unit handling for =food_acquired=
+
+The =u= (unit) index level on =food_acquired= carries clean canonical
+Portuguese unit names (=Kg=, =Litro=, =Sachet=, =Pacote=, =Unidade=,
+=Pedaço=, =Dúzia=, ...) -- 29 distinct values total.  No =u= table is
+wired into =_/categorical_mapping.org=; the framework's auto-discovery
+on =u= would be a no-op (the labels are already canonical).
+
+The clean labels come from a per-wave mojibake fix in
+=2018-19/_/mapping.py=:
+
+- The .dta file's value-labels block stores Portuguese strings as raw
+  UTF-8 bytes, but its metadata declares Latin-1 encoding.  pyreadstat
+  respects the metadata and produces double-decoded strings (=Pedaço=
+  becomes =PedaÃ§o=, =Dúzia= becomes =DÃºzia=, etc.).
+- The wave's =mapping.py= defines a =food_acquired= post-processor
+  (replacing the default =food_acquired_to_canonical= alias) that calls
+  the canonical reshape and then sweeps mojibake out of every string
+  column / index level via =_decode_mojibake_in_df()=.  See the
+  module's docstring for the encoding analysis.
+- Two food labels carry an additional lossy substitution upstream of
+  pyreadstat (=Óleo= -> =Ã__leo=, =Água= -> =Ã__gua=, with literal
+  underscores replacing the second byte of certain UTF-8 codepoints).
+  These can't be recovered byte-wise, so =mapping.py= ships an explicit
+  =_LOST_PREFIX_REPLACEMENTS= dict for the four affected food items
+  (=Óleo de mancarra=, =Óleo de soja=, =Óleo de palma=,
+  =Água filtrada=).
+
+For the cross-country canonical-=u= roadmap, see GH #223.  Guinea-Bissau
+was originally classified Tier 3 (needing a new =u= table built) in
+that issue's inventory, but turned out to be Tier 2 once the mojibake
+fix landed -- the underlying labels are already canonical.


### PR DESCRIPTION
## Summary

Guinea-Bissau pilot for issue #223 Tier 3 — and a discovery: it's actually Tier 2, just hidden behind mojibake.

The cross-country inventory classified Guinea-Bissau as Tier 3 (needing a new `u` table built from 29 distinct raw labels). Investigating the actual labels reveals that **after a mojibake fix, the 29 unit names are already canonical Portuguese** (`Kg`, `Litro`, `Sachet`, `Pacote`, `Unidade`, `Pedaço`, `Dúzia`, ...) — no `u` table needed.

The mojibake source: `Guinea-Bissau/2018-19/Data/s07b_me_gnb2018.dta` stores its value labels as raw UTF-8 bytes, but its metadata declares Latin-1 encoding. pyreadstat respects the metadata and produces double-decoded strings — `Pedaço` becomes `PedaÃ§o`, `Dúzia` becomes `DÃºzia`, etc. — for 4 of 29 `u` values and 40 of 135 `j` (food item) values.

## Why pyreadstat can't fix this

Verified 2026-05-07: none of pyreadstat's `encoding=` options recover the labels.

| `encoding=` | result |
|---|---|
| (default) | mojibake (current behavior) |
| `'utf-8'` | `ReadstatError: invalid byte sequence` |
| `'cp1252'`, `'iso-8859-1'` | same mojibake |

The fix has to be post-decode.

## Implementation

### `Guinea-Bissau/2018-19/_/mapping.py`

- New `food_acquired(df)` function replaces the bare `from ... import food_acquired_to_canonical as food_acquired` alias. Calls the canonical reshape, then sweeps mojibake via `_decode_mojibake_in_df()`.
- `_decode_mojibake(s)` reverses the double-encode by `.encode('latin-1').decode('utf-8')`. ASCII-only strings round-trip cleanly (every byte 0x00-0x7F is identical in both encodings), so it's safe to apply unconditionally to all string values; only mojibake-bearing ones change.
- `_decode_mojibake_in_df(df)` walks every string-typed column and string index level and applies the per-cell fix.
- An explicit `_LOST_PREFIX_REPLACEMENTS` dict handles 4 food items where the source data carries an *additional lossy substitution* upstream of pyreadstat (`Óleo` → `Ã__leo`, `Água` → `Ã__gua`, with literal `__` underscores replacing the second byte of certain UTF-8 codepoints — irrecoverable byte-wise).

### `Guinea-Bissau/_/CONTENTS.org`

A new "Unit handling for `food_acquired`" section documents:
- The mojibake mechanism
- Why pyreadstat's `encoding=` doesn't fix it
- The wave-scoped post-process strategy
- The lossy `Óleo`/`Água` substitution edge case
- The reclassification from Tier 3 → Tier 2 (no `u` table needed)

## Smoke test

After cache wipe + rebuild from the patched code:

| | before | after |
|---|---|---|
| `food_acquired().index.get_level_values('u').unique()` mojibake | 4 of 29 | **0 of 29** |
| `food_acquired().index.get_level_values('j').unique()` mojibake | 40 of 135 | **0 of 135** |

Recovered labels examples:
- `PedaÃ§o` → `Pedaço`
- `DÃºzia` → `Dúzia`
- `MÃºndo` → `Múndo`
- `PÃ©` → `Pé`
- `Melancia, melÃ£o` → `Melancia, melão`
- `LimÃ£o` → `Limão`
- `Ã__leo de mancarra` → `Óleo de mancarra` (via lost-prefix replacement)
- `Ã__gua filtrada` → `Água filtrada` (via lost-prefix replacement)

## Reclassification of Guinea-Bissau in #223

Original inventory classified GB as Tier 3 (29 distinct raw labels needing a `u` table). After this fix, all 29 labels are already canonical → Tier 2 (no `u` table needed; doc note suffices).

This may apply to **CotedIvoire and Niger** too — both also flagged in the inventory as carrying mojibake. Worth checking before building tables for them. The same `_decode_mojibake` helper would apply (the bytes-to-bytes operation is language-independent), though those countries are French-language; they may have their own lost-prefix variants to handle.

## Test plan

- [x] `Country('Guinea-Bissau').food_acquired()` index `u` shows 0 mojibake (was 4 of 29)
- [x] `Country('Guinea-Bissau').food_acquired()` index `j` shows 0 mojibake (was 40 of 135)
- [x] All 4 `Óleo`/`Água` items recovered correctly
- [x] No regressions in the 25 already-clean `u` values (verified post-fix u count still 29)
- [ ] CI on this PR

## Cache invalidation note

Anyone with a cached `food_acquired.parquet` pre-dating this commit will see mojibake until they run:

```bash
lsms-library cache clear --country Guinea-Bissau
```

## Related

- #223 — parent issue (Phase 5 cross-country roadmap)
- #234 — Tier 2 doc-only PR (just landed; this PR's reclassification adds GB to that bucket retroactively)
- #233 — Tier 1 four-country renames

🤖 Investigation + fix by Claude Sonnet 4.5 in a worktree; reviewed by @ligon before merge.
