### PR TITLE
fix(Benin): wire categorical_mapping u table to canonical u index level (#223 Tier 3)

### DIFF
--- a/lsms_library/countries/Benin/_/categorical_mapping.org
+++ b/lsms_library/countries/Benin/_/categorical_mapping.org
@@ -1,5 +1,90 @@
 #+title: Categorical Mappings — Benin
 
+* Food Units
+
+#+name: u
+| Original Label           | Preferred Label  |
+|--------------------------+------------------|
+| Kg                       | Kg               |
+| Litre                    | Litre            |
+| Unité                    | Unité            |
+| Sachet                   | Sachet           |
+| Paquet                   | Paquet           |
+| Boîte                    | Boîte            |
+| Boîte de tomate          | Boîte de tomate  |
+| Bocal de mayonnaise      | Bocal de mayonnaise |
+| Grand bocal              | Grand bocal      |
+| Bol                      | Bol              |
+| Bassine                  | Bassine          |
+| Tas                      | Tas              |
+| Boule                    | Boule            |
+| Bouquet                  | Bouquet          |
+| bouteille                | Bouteille        |
+| Morceau                  | Morceau          |
+| Panier                   | Panier           |
+| Calebasse                | Calebasse        |
+| Régime                   | Régime           |
+| Pot                      | Pot              |
+| Fagot                    | Fagot            |
+| Carton                   | Carton           |
+| Grappe                   | Grappe           |
+| Plastique                | Plastique        |
+| Alvéole/Plateau          | Alvéole/Plateau  |
+| Chaîne en bois           | Chaîne en bois   |
+| Gobelet                  | Gobelet          |
+| passoire                 | Passoire         |
+| Pincée                   | Pincée           |
+| Gousse                   | Gousse           |
+| Louche                   | Louche           |
+| Canette                  | Canette          |
+| Filet                    | Filet            |
+| cuisse                   | Cuisse           |
+| Quarantaine              | Quarantaine      |
+| Bidon                    | Bidon            |
+| Bidon de 1l              | Bidon de 1 L     |
+| Bidon de 5l              | Bidon de 5 L     |
+| Bidon de 1 litre et démi | Bidon de 1,5 L   |
+| bidon de demi litre      | Bidon de 0,5 L   |
+| Sac (5 Kg)               | Sac (5 Kg)       |
+| sac de 2,5kg             | Sac (2,5 Kg)     |
+| Sac (10 Kg)              | Sac (10 Kg)      |
+| Sac (25 Kg)              | Sac (25 Kg)      |
+| Sac (50 Kg)              | Sac (50 Kg)      |
+| Sac (100 Kg)             | Sac (100 Kg)     |
+| Avec os au Kg            | Avec os au Kg    |
+| Avec os au tas           | Avec os au tas   |
+| Sans os au Kg            | Sans os au Kg    |
+| Sans os au tas           | Sans os au tas   |
+| Tohoungolo               | Tohoungolo       |
+| Otoka/Fihanfingban       | Otoka/Fihanfingban |
+| sogo                     | Sogo             |
+| Agoua                    | Agoua            |
+| Pome                     | Pome             |
+| Yoroukou/Yorougou        | Yoroukou/Yorougou |
+| Abotoca                  | Abotoca          |
+| Rôba                     | Rôba             |
+| sagagou ( en bariba)     | Sagagou          |
+| Paï                      | Paï              |
+| Ike                      | Ike              |
+| Nobayirou                | Nobayirou        |
+| Atonnongban              | Atonnongban      |
+| gannouvi                 | Gannouvi         |
+| corbar en bariba         | Corbar           |
+| Si                       | Si               |
+| Blèvi                    | Blèvi            |
+| Tinnabou (bariba )       | Tinnabou         |
+| ibogban                  | Ibogban          |
+| Djogledo                 | Djogledo         |
+| Ayewa                    | Ayewa            |
+| Gbinbou bonnou           | Gbinbou bonnou   |
+| nimkotirou(BARIBA)       | Nimkotirou       |
+| Kpanouvi                 | Kpanouvi         |
+| sikpanou                 | Sikpanou         |
+| siroba                   | Siroba           |
+| sivlo                    | Sivlo            |
+| Djlèka                   | Djlèka           |
+| Signi                    | Signi            |
+
 #+name: Roof
 | Alternate Spelling | Preferred Label |
 |--------------------+-----------------|


### PR DESCRIPTION
## Summary

Issue #223 Phase 5 Tier 3 for **Benin**. Builds the per-Benin `u` table in `_/categorical_mapping.org` covering the 79 distinct `food_acquired` 2018-19 unit values. Mix of French canonical units (`Kg`, `Litre`, `Unité`, `Sachet`, ...) and local-language entries (Bariba/Fon/Yoruba: `Tohoungolo`, `Sagagou`, `Otoka/Fihanfingban`, ...) preserved per the inventory directive (no folding to `Other`).

After this lands, `Country('Benin').food_acquired()` shows 79 distinct canonical labels in the `u` index level (1:1 with raw — every variant maps to a Preferred Label, local-language entries kept as their own PL identity).

## Variant-folding decisions

- **Case/accent normalised**: `bouteille` → `Bouteille`, `sogo` → `Sogo`, `passoire` → `Passoire`, `cuisse` → `Cuisse`, etc.
- **Bariba/Yoruba parenthetical descriptors trimmed**: `sagagou ( en bariba)` → `Sagagou`, `corbar en bariba` → `Corbar`, `Tinnabou (bariba )` → `Tinnabou`, `nimkotirou(BARIBA)` → `Nimkotirou`.
- **`Bidon` volume variants normalised** to Senegal-style `Bidon de X L` canonical: `Bidon de 1l` → `Bidon de 1 L`; `bidon de demi litre` → `Bidon de 0,5 L`; `Bidon de 1 litre et démi` → `Bidon de 1,5 L`.
- **"Avec/Sans os au Kg/tas" descriptors preserved as own PLs** per inventory directive (NOT folded to `Kg` / `Tas` as Burkina Faso did — those carry information about food preparation that downstream analysts may want).
- **`Sac (X Kg)` variants kept distinct by capacity** (5/10/25/50/100 Kg; `sac de 2,5kg` → `Sac (2,5 Kg)`).

## New Preferred Labels introduced (not already in Tier 1/2 vocab)

- French units new to the canonical vocabulary: `Boîte de tomate`, `Bocal de mayonnaise`, `Grand bocal`, `Bassine`, `Fagot`, `Grappe`, `Plastique`, `Alvéole/Plateau`, `Chaîne en bois`, `Pincée`, `Cuisse`, `Quarantaine`, `Passoire`, `Bidon de {0,5/1/1,5/5} L`, `Sac (2,5 Kg)`
- Os/tas descriptors: `Avec os au Kg`, `Avec os au tas`, `Sans os au Kg`, `Sans os au tas`
- Local-language (Bariba/Fon/Yoruba) PLs: `Tohoungolo`, `Sogo`, `Otoka/Fihanfingban`, `Agoua`, `Pome`, `Yoroukou/Yorougou`, `Abotoca`, `Rôba`, `Sagagou`, `Paï`, `Ike`, `Nobayirou`, `Atonnongban`, `Gannouvi`, `Corbar`, `Si`, `Blèvi`, `Tinnabou`, `Ibogban`, `Djogledo`, `Ayewa`, `Gbinbou bonnou`, `Nimkotirou`, `Kpanouvi`, `Sikpanou`, `Siroba`, `Sivlo`, `Djlèka`, `Signi`

## Verification (post-fix)

```
Benin: 79 distinct u
  first 8:  ['Abotoca', 'Agoua', 'Alvéole/Plateau', 'Atonnongban', 'Avec os au Kg',
             'Avec os au tas', 'Ayewa', 'Bassine']
  last 8:   ['Siroba', 'Sivlo', 'Sogo', 'Tas', 'Tinnabou', 'Tohoungolo', 'Unité',
             'Yoroukou/Yorougou']
```

`Agoua` cross-country consistency: also appears in Togo (separate PR), same canonical PL.

## Cache invalidation

Anyone with cached `food_acquired.parquet` pre-dating this commit will see old labels until they wipe:

```bash
lsms-library cache clear --country Benin
```

## Test plan

- [x] 79/79 distinct u values mapped to canonical Preferred Labels
- [x] Local-language entries preserved with case/parenthetical normalization
- [x] No collisions (1:1 between raw and canonical)
- [x] Existing `data_info.yml` already had bare `u: s07bq03b` (no `mappings:` block to drop)
- [ ] CI on this PR

## Related

- #223 — parent issue
- #234 / #235 / #236 — sibling PRs (Tier 2 docs, GB mojibake, CIV/Niger mojibake)
- `afbb61f3` — Malawi-only precedent
- #233 — Tier 1 four-country renames

🤖 Investigation + table delegated to a subagent operating in a worktree; reviewed by @ligon before merge.
