### PR TITLE
fix(Togo): wire categorical_mapping u table to canonical u index level (#223 Tier 3)

### DIFF
--- a/lsms_library/countries/Togo/_/categorical_mapping.org
+++ b/lsms_library/countries/Togo/_/categorical_mapping.org
@@ -1,5 +1,22 @@
 #+title: Categorical Mappings — Togo
 
+#+name: u
+| Original Label | Preferred Label |
+|----------------+-----------------|
+| Kg             | Kg              |
+| Tas            | Tas             |
+| Sachet         | Sachet          |
+| Unité          | Unité           |
+| Bol            | Bol             |
+| Paquet         | Paquet          |
+| Calebasse      | Calebasse       |
+| Morceau        | Morceau         |
+| Sac (5 Kg)     | Sac (5 Kg)      |
+| Sac (10 Kg)    | Sac (10 Kg)     |
+| Sac (25 Kg)    | Sac (25 Kg)     |
+| Agoua          | Agoua           |
+| Kpogban        | Kpogban         |
+
 #+name: Roof
 | Alternate Spelling | Preferred Label |
 |--------------------+-----------------|


### PR DESCRIPTION
## Summary

Issue #223 Phase 5 Tier 3 for **Togo**. Builds the per-Togo `u` table in `_/categorical_mapping.org` covering the 13 distinct string-label `u` values across `food_acquired` 2018. Mix of French canonical units (`Kg`, `Tas`, `Sachet`, `Unité`, `Bol`, `Paquet`, `Calebasse`, `Morceau`, `Sac (5/10/25 Kg)`) and local-language entries (`Agoua`, `Kpogban`) preserved per the inventory directive.

All 13 string variants already match canonical spelling, so each maps to itself; the table exists to register the values under the framework's auto-discovery rather than rename them. The remaining work was investigating the 25 raw 3-digit codes (see below).

## Decision on raw 3-digit codes (the interesting part)

The inventory flagged ~25 raw 3-digit codes (`'101'`, `'124'`, `'659'`, `'662'`, ...) leaking into the `u` field. The agent investigated and found:

- **100-series codes match the food-item codebook**, not a unit codebook. `101` = Noix de cajou (cashews), `107` = Taro, `124` = Vinaigre, etc. These are food codes that enumerators typed into the unit free-text field.
- **600-series codes** (`659`, `660`, `662`) match no documented Togo codebook anywhere in `Togo/_/`.

Two paths considered:

1. **Pass through unchanged** (chosen): leave them out of the `u` table → framework's auto-discovery treats unmapped values as identity → codes stay as `'101'`, `'124'`, etc. in the index. Preserves the raw information for future resolution. ✓
2. **Map to placeholder**: `'101'` → `Other (101)` etc. Rejected because (a) it's a worse representation of unmapped data than the raw code itself, and (b) for the 100-series, "Other" would obscure that it's actually a food code mis-entered.

Per the directive (preserve all distinct labels) and the analysis above, **pass-through** is the right call. Future work could resolve them if/when a unit-codes codebook surfaces, or if a wave-script audit confirms enumerator error and folds them into `Other Specify` semantically.

## New Preferred Labels introduced

`Agoua` and `Kpogban` (Togolese local units) — also `Agoua` appears in Benin's table (sibling PR), same canonical spelling, nice cross-country consistency.

All other strings (`Kg`, `Tas`, `Sachet`, `Unité`, `Bol`, `Paquet`, `Calebasse`, `Morceau`, `Sac (5 Kg)`, `Sac (10 Kg)`, `Sac (25 Kg)`) match the existing Tier 1/2 canonical vocabulary verbatim.

## Verification (post-fix)

```
Togo: 38 distinct u; 13 string + 25 numeric-code
  string sample: ['Agoua', 'Bol', 'Calebasse', 'Kg', 'Kpogban', 'Morceau', 'Paquet', 'Sac (10 Kg)']
  code sample:   ['101', '102', '103', '104', '105', '106', '107', '111']
```

Every string label is a canonical Preferred Label; raw codes pass through verbatim.

## Surprises

- Source-data dtype is plain `object`/`str` (not categorical with value labels), so `pyreadstat` value labels don't help — codes are literally typed strings.
- 100-series codes overlap exactly with the food-item codebook (`101` = Cashews, `107` = Taro, `124` = Vinegar, ...) → strong evidence of enumerator confusion (food code typed into the unit field).
- 600-series codes match no documented Togo codebook → possibly come from a different (non-included) EHCVM lookup, or are invented free-text.
- `Sac (N Kg)` variants already use the exact canonical Burkina Faso spelling; no normalization needed.

## Cache invalidation

```bash
lsms-library cache clear --country Togo
```

## Test plan

- [x] 13/13 string-label u values map to canonical Preferred Labels
- [x] 25/25 raw 3-digit codes pass through unchanged (auto-discovery identity for unmapped values)
- [x] No collisions; total distinct count preserved (38 in, 38 out)
- [ ] CI on this PR

## Related

- #223 — parent issue
- #234 / #235 / #236 — sibling PRs (Tier 2 docs, GB mojibake, CIV/Niger mojibake)
- `afbb61f3` — Malawi-only precedent
- #233 — Tier 1 four-country renames

🤖 Investigation + table delegated to a subagent operating in a worktree; reviewed by @ligon before merge.
