### PR TITLE
fix(Ethiopia, Nigeria): restore Phase-3 s-axis in food_expenditures

### DIFF
--- a/lsms_library/countries/Ethiopia/_/food_acquired.py
+++ b/lsms_library/countries/Ethiopia/_/food_acquired.py
@@ -1,5 +1,18 @@
-"""Calculate food prices for different items across rounds; allow
-different prices for different units.
+"""Concatenate wave-level food_acquired data for Ethiopia.
+
+Wave-level scripts (each ``Ethiopia/<wave>/_/food_acquired.py``) call
+``ethiopia.food_acquired()``, which delegates to
+``food_acquired_to_canonical()`` and produces canonical-form parquets
+with index ``[t, i, j, u, s]`` (``s in {'purchased', 'produced'}``) and
+columns ``[Quantity, Expenditure]`` (Phase 3 of GH #169).  This script
+just concatenates them across waves and applies cross-wave id_walk and
+the food-label rename.
+
+The pre-Phase-3 implementation expected wide-form wave parquets with
+``units`` / ``units_purchased`` columns and did
+``df['t'] = t`` followed by ``groupby(['j','t','i','units','units_purchased'])``;
+that broke once the wave-level reshape moved ``t`` into the index and
+collapsed the unit columns.  Replaced 2026-05-07.
 """
 import sys
 sys.path.append('../../_/')
@@ -13,34 +26,33 @@ from ethiopia import change_id, Waves, harmonized_food_labels
 def fix_food_labels():
     D = {}
     for w in Waves.keys():
-        D.update(harmonized_food_labels(fn='./food_items.org',key=w))
-
+        D.update(harmonized_food_labels(fn='./food_items.org', key=w))
     return D
 
-def id_walk(df,wave,waves):
 
+def id_walk(df, wave, waves):
     use_waves = list(waves.keys())
     T = use_waves.index(wave)
     for t in use_waves[T::-1]:
         if len(waves[t]):
-            df = change_id(df,'../%s/Data/%s' % (t,waves[t][0]),*waves[t][1:])
+            df = change_id(df, '../%s/Data/%s' % (t, waves[t][0]), *waves[t][1:])
         else:
             df = change_id(df)
-
     return df
+
 
 p = []
 for t in Waves.keys():
-    df = get_dataframe('../'+t+'/_/food_acquired.parquet').squeeze()
-    df['t'] = t
-    # There may be occasional repeated reports of purchases of same food
-    df0 = df.groupby(['j','t','i','units','units_purchased']).sum()
-    #df = df.reset_index().set_index(['j','t','i','units','units_purchased'])
-    df1 = id_walk(df0,t,Waves)
+    df = get_dataframe('../' + t + '/_/food_acquired.parquet').squeeze()
+    # Wave parquet already has canonical index [t, i, j, u, s] and
+    # columns [Quantity, Expenditure] from food_acquired_to_canonical().
+    df1 = id_walk(df, t, Waves)
     p.append(df1)
 
 p = pd.concat(p)
 
-p = p.rename(index=fix_food_labels(),level='i')
+# fix_food_labels() returns a {wave-specific code -> Preferred Label}
+# dict; canonical level for food item codes is 'j'.
+p = p.rename(index=fix_food_labels(), level='j')
 
 to_parquet(p, '../var/food_acquired.parquet')

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -34,15 +34,15 @@ Data Scheme:
     Quantity: float
     Expenditure: float
     materialize: make
-  food_expenditures:
-    index: (t, i, j)
-    Expenditure: float
-  food_prices:
-    index: (t, j)
-    Price: float
-  food_quantities:
-    index: (t, i, j)
-    Quantity: float
+  # food_expenditures, food_prices, food_quantities are auto-derived
+  # at runtime from food_acquired via _FOOD_DERIVED — do NOT register
+  # them here.  Explicit declarations with a non-canonical index spec
+  # like ``index: (t, i, j)`` cause _finalize_result to strip the ``s``
+  # acquisition-source level from the derived result, breaking
+  # cross-country index compatibility in Feature('food_expenditures')()
+  # (it concatenates 4-level Nigeria with 5-level Phase-3 countries
+  # and falls back to a flat single-level index, destroying country
+  # provenance).  Per CLAUDE.md "Derived Tables".
   household_roster:
     index: (t, i, pid)
     Sex: str


### PR DESCRIPTION
## Summary

Two surgical fixes that restore the canonical ``s`` (acquisition-source) axis on Ethiopia's and Nigeria's derived ``food_expenditures`` (and friends), re-enabling concat-aligned cross-country aggregation via ``Feature('food_expenditures')()``.

## Diagnosis

Discovered while sanity-checking ``ll.Feature('food_expenditures')()``: the cross-country DataFrame returned a flat 1-level index instead of the documented ``[country, i, t, v, j, s]``, destroying country provenance. Per-country inspection split the 13 successful countries into two groups:

| Group | nlevels | Index | Countries |
|---|---|---|---|
| Canonical (post Phase-3) | 5 | ``[i, t, v, j, s]`` | Benin, Burkina_Faso, CotedIvoire, Guinea-Bissau, Malawi, Mali, Niger, Senegal, Tanzania, Togo, Uganda |
| **Missing ``s``** | 4 | ``[i, t, v, j]`` | **GhanaLSS, Nigeria** |
| **Build failure** | — | — | **Ethiopia** |

When ``pd.concat`` mixes 4-level and 5-level multi-indexes, it falls back to a flat single-level index — the failure mode we observed.

## Ethiopia (commit b01389be)

Wave-level scripts produce canonical ``[t, i, j, u, s]`` parquets via ``ethiopia.food_acquired() → food_acquired_to_canonical()`` (#169 Phase 3, commit 9c4ba58a). The country-level concatenator was never updated. It still:
- did ``df['t'] = t`` after reading a parquet that already carries ``t`` in its index (pandas 2.x raises ``ValueError: 't' is both an index level and a column label``)
- groupby'd on stale column names ``units`` / ``units_purchased`` that the canonical reshape no longer produces

Result: ``Country('Ethiopia').food_acquired()`` raised RuntimeError; ``food_expenditures()`` was uncomputable; ``Feature('food_expenditures')()`` silently dropped Ethiopia via warn-fallback.

The rewrite drops the redundant ``df['t'] = t``, removes the stale-column groupby (the wave-level reshape already groups by canonical levels), and moves the ``fix_food_labels()`` rename from ``level='i'`` to ``level='j'`` to match the canonical convention (``j`` = food item code).

Verified:
```
Country('Ethiopia').food_expenditures()
  shape=(264056, 1), index=[i, t, v, j, s], s={'purchased'}
```

## Nigeria (commit d7753fbc)

CLAUDE.md (§Derived Tables) is explicit: *"do NOT register them in data_scheme.yml — Country.data_scheme auto-surfaces them when the source table (food_acquired or household_roster) is present."*

Nigeria still had explicit non-canonical entries:
```yaml
food_expenditures:
    index: (t, i, j)
    Expenditure: float
food_prices:
    index: (t, j)
    Price: float
food_quantities:
    index: (t, i, j)
    Quantity: float
```

The ``__getattr__`` auto-derivation path *does* fire (``_FOOD_DERIVED``), but ``_finalize_result`` then enforces the declared ``index: (t, i, j)`` schema and strips the canonical ``s`` level from the output. Removing the entries lets the canonical 5-level result through.

Verified:
```
Country('Nigeria').food_expenditures()
  shape=(482032, 1), index=[i, t, v, j, s], s={'purchased'}
```

## End-to-end verification (post both fixes)

```
Feature('food_expenditures')(['Benin', 'Burkina_Faso', 'CotedIvoire', 'Ethiopia',
                              'Guinea-Bissau', 'Malawi', 'Mali', 'Niger',
                              'Nigeria', 'Senegal', 'Tanzania', 'Togo', 'Uganda'])
  shape=(3343827, 1), nlevels=6, index=[country, i, t, v, j, s]
```

13 of 15 countries align cleanly. ``Nepal`` is silently dropped (no microdata in repo per CLAUDE.md). ``GhanaLSS`` is excluded because its waves predate Phase-3 reshape and its country-level script also has an unrelated ``id_walk`` assertion failure on 1988-89 — tracked in **#109**, with #169 explicitly noting *"GhanaLSS Phase 3 deferred — tracked separately in #109."*

## Out of scope

- GhanaLSS Phase-3 reshape — see #109.
- Nepal microdata import — orthogonal (no WB API key in this repo).

## Test plan

- [x] ``Country('Ethiopia').food_expenditures()`` returns 5-level result with ``s`` axis.
- [x] ``Country('Nigeria').food_expenditures()`` returns 5-level result with ``s`` axis.
- [x] ``Feature('food_expenditures')()`` (excluding Ghana) returns 6-level cross-country result with country index level.
- [ ] CI unit tests pass (will run on push).
- [ ] No regression on other countries' ``food_expenditures`` (manually verified Benin, Mali, Uganda still 5-level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>