### PR TITLE
fix(Guyana, Azerbaijan, Serbia and Montenegro): repair truncated household_roster i (supersedes #230)

### DIFF
--- a/lsms_library/countries/Azerbaijan/1995/_/data_info.yml
+++ b/lsms_library/countries/Azerbaijan/1995/_/data_info.yml
@@ -5,7 +5,7 @@ household_roster:
         - ../Data/A01A.dta
     idxvars:
         v: ppid
-        i: hid
+        i: [ppid, hid]
         pid: pid
     myvars:
         Sex:

--- a/lsms_library/countries/Guyana/1992/_/data_info.yml
+++ b/lsms_library/countries/Guyana/1992/_/data_info.yml
@@ -47,7 +47,7 @@ household_roster:
         - ../Data/ROSTERN.dta
     idxvars:
         v: ED
-        i: HH
+        i: [ED, HH]
         pid: PID
     myvars:
         Sex:

--- a/lsms_library/countries/Serbia and Montenegro/2002/_/data_info.yml
+++ b/lsms_library/countries/Serbia and Montenegro/2002/_/data_info.yml
@@ -19,7 +19,7 @@ household_roster:
         - "../Data/2002 1 demography.dta"
     idxvars:
         v: mesto
-        i: rbd
+        i: [mesto, rbd]
         pid: clan
     myvars:
         Age: starost

--- a/lsms_library/countries/Serbia and Montenegro/2003/_/data_info.yml
+++ b/lsms_library/countries/Serbia and Montenegro/2003/_/data_info.yml
@@ -19,7 +19,7 @@ household_roster:
         - "../Data/2003 1 demography.dta"
     idxvars:
         v: mesto
-        i: rbd
+        i: [mesto, rbd]
         pid: clan
     myvars:
         Age: brojgod


### PR DESCRIPTION
## Summary

Closes the data-side of #172. Each country's `household_roster`
`data_info.yml` was extracting only the household sub-id (`HH` / `hid` /
`rbd`) as `i`, while the country's `sample()` correctly used the
compound cluster-household form (`[ED, HH]` / `[ppid, hid]` /
`[mesto, rbd]`). After `_finalize_result` adds `v` from `sample()`, the
merge keys never overlapped — e.g. roster `i='1','2',...,'12'` vs
sample `i='1-1','1-2',...,'84-12'` — so every roster row got NaN `v`
and `roster_to_characteristics` dropped the lot.

The fix: change the four wave-level `data_info.yml` files'
`household_roster.idxvars.i` from a single sub-id column to the
compound list. Each wave already has a `_/mapping.py` defining the
canonical `i(value) -> format_id('-'.join(parts))` callable, which
`Wave.formatting_functions` auto-registers and `column_mapping` wires
into the `(cols_list, callable)` form `df_data_grabber` understands.
The `i` produced is a single hyphen-delimited string (e.g. `'1-1'`,
`'12-3'`), matching `sample()` and merging cleanly.

## Verified end-to-end (Savio, `LSMS_NO_CACHE=1`, fresh L1 + L2 caches)

| Country | Pre-fix shape | Post-fix shape | i sample |
|---|---|---|---|
| Guyana | `(0, 15)` | `(1495, 15)` | `'1-1', '1-10', '1-11'` |
| Azerbaijan | `(0, 15)` | `(2016, 15)` | `'1-1', '1-10', '1-11'` |
| Serbia and Montenegro | `(0, 15)` | `(8934, 15)` | `'1-1', '1-10', '1-11'` |

All three pre-fix had the `UserWarning: dropped N roster rows with NaN
in 'v'` symptom. Post-fix: zero warnings, `v` populated on every row.

## What's different from the original #230

The original PR also added a placeholder-NaN-`v` defensive net to
`_finalize_result` and a unit test exercising it. On review: with the
data-side fix in place, the placeholder logic never fires (roster's
`i` now matches `sample()`'s, so `_join_v_from_sample` succeeds
directly). The framework change is dropped from this PR.

The original #230 was closed with an incorrect close-comment
(misreading `df_data_grabber.grabber()`'s handling of list-form
idxvars). Retraction posted there.

## Files

- `lsms_library/countries/Azerbaijan/1995/_/data_info.yml` (1 line)
- `lsms_library/countries/Guyana/1992/_/data_info.yml` (1 line)
- `lsms_library/countries/Serbia and Montenegro/2002/_/data_info.yml` (1 line)
- `lsms_library/countries/Serbia and Montenegro/2003/_/data_info.yml` (1 line)

## Scope notes

- The 7 lost rows for Guyana (1502 → 1495) are roster members whose
  `(ED, HH)` doesn't appear in `sample()` — typical movers /
  splitoffs, captured in the existing `roster_to_characteristics` filter.
- Other countries claimed in #172 (Senegal, Togo, Nepal, Armenia) are
  out of scope here; tracked separately.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>