### PR TITLE
fix(Uganda/_/food_acquired.py): rewrite for canonical (t,i,j,u,s) wave parquets

### DIFF
--- a/lsms_library/countries/Uganda/_/food_acquired.py
+++ b/lsms_library/countries/Uganda/_/food_acquired.py
@@ -1,22 +1,33 @@
-from lsms_library.local_tools import to_parquet
-from lsms_library.local_tools import get_dataframe
+"""Concatenate wave-level food_acquired data for Uganda.
 
-"""Calculate food prices for different items across rounds; allow
-different prices for different units.  
+Wave-level scripts (each ``Uganda/<wave>/_/food_acquired.py``) call
+``uganda.food_acquired_to_canonical()`` and produce canonical-form
+parquets with index ``[t, i, j, u, s]`` (``s in {'purchased', 'inkind',
+'produced'}``) and columns ``[Quantity, Expenditure, Price]`` (Phase 3
+of GH #169).  This script just concatenates them across waves and
+applies cross-wave id_walk.
+
+The pre-Phase-3 implementation expected wide-form wave parquets and
+did ``df['t'] = t`` followed by ``groupby(['i','t','j','u']).sum()``;
+that broke once the wave-level reshape moved ``t`` into the index
+(pandas 2.x raises ``ValueError: 't' is both an index level and a
+column label``).  Replaced 2026-05-08 to mirror the Ethiopia fix from
+PR #242.
 """
+import json
 
 import pandas as pd
-import numpy as np
+
+from lsms_library.local_tools import get_dataframe, to_parquet
 from uganda import Waves, id_walk
-import json
+
+
 p = []
-for t in ['2005-06','2009-10','2010-11','2011-12','2013-14','2015-16','2018-19','2019-20']:
-    df = get_dataframe('../'+t+'/_/food_acquired.parquet').squeeze()
-    df['t'] = t
-    df.index = df.index.rename({'units':'u'})
-    # There may be occasional repeated reports of purchases of same food
-    df = df.groupby(['i','t','j','u']).sum()
-    df = df.reset_index().set_index(['i','t','j','u'])
+for t in Waves.keys():
+    df = get_dataframe('../' + t + '/_/food_acquired.parquet').squeeze()
+    # Wave parquet already has canonical index [t, i, j, u, s] and
+    # columns [Quantity, Expenditure, Price] from
+    # food_acquired_to_canonical().
     p.append(df)
 
 p = pd.concat(p)


### PR DESCRIPTION
## Summary

Mirror of PR #242's Ethiopia fix, applied to Uganda.  Surfaced by the
``--rebuild-caches`` regression test in PR #243.

Wave-level scripts call ``uganda.food_acquired_to_canonical()`` and
produce canonical-form parquets with index ``[t, i, j, u, s]`` and
columns ``[Quantity, Expenditure, Price]`` (Phase 3 of GH #169).  The
country-level concatenator ``_/food_acquired.py`` was never updated;
it still:

- did ``df['t'] = t`` after reading a parquet that already carries
  ``t`` in its index (pandas 2.x raises ``ValueError: 't' is both an
  index level and a column label``);
- did ``df.groupby(['i','t','j','u']).sum()`` which silently collapsed
  the ``s`` axis even when the prior step didn't crash.

``Country('Uganda').food_acquired()`` raised RuntimeError on any
cache-miss rebuild.  The bug stayed hidden because the country-level
``var/food_acquired.parquet`` was cached from before the Phase-3 wave
migration; every subsequent call read that cache and skipped the
broken script.  This is precisely the latent regression that
the ``--rebuild-caches`` gate in PR #243 is designed to catch.

## Verified end-to-end (Savio, ``LSMS_NO_CACHE=1``, fresh L1+L2 caches)

| Method | Pre-fix | Post-fix |
|---|---|---|
| ``Country('Uganda').food_acquired()`` | ``RuntimeError`` | ``(349115, 3)``, index ``[i, t, v, j, u, s]``, cols ``[Quantity, Expenditure, Price]``, ``s={inkind, produced, purchased}`` |
| ``food_expenditures()`` | cascade | ``(348708, 1)``, 5-level ``[i, t, v, j, s]`` |
| ``food_prices()`` | cascade | ``(349081, 1)``, 6-level ``[i, t, v, j, u, s]`` |
| ``food_quantities()`` | cascade | ``(348742, 1)``, 6-level ``[i, t, v, j, u, s]`` |
| ``nutrition()`` | drift / cascade | ``(23778, 15)``, 3-level ``[i, t, v]`` |

## Out of scope (tracked as follow-up)

The remaining 6 Uganda test failures uncovered by ``--rebuild-caches``
are independent of this fix:

- ``[fct]`` / ``[nutrition]`` value drift cascade from a second broken
  legacy script, ``_/food_prices_quantities_and_expenditures.py``
  (does ``fa.reorder_levels(['i','t','j','u'])`` on a now-5-level
  index).  That script's wide→long reshape job is now done by the
  Phase-3 wave reshape, so it can likely be deleted with
  ``fct``/``nutrition`` consuming canonical parquets directly.
- ``[food_prices]`` and ``[food_quantities]`` API-vs-replication
  failures are stale pre-Phase-3 baselines.
- ``[food_expenditures]`` ``atol=0`` / ``test_food_expenditures_retains_hybrid_v_HH``
  shortfall: tolerance / data drift questions for separate
  investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>