### PR TITLE
test(schema): drop obsolete food_acquired xfail markers (GH #169 done)

### DIFF
--- a/tests/test_schema_consistency.py
+++ b/tests/test_schema_consistency.py
@@ -96,23 +96,6 @@ _TABLE_SCHEMES: dict[str, list[tuple[str, Path, dict]]] = {
     for table in _TABLES_WITH_REQUIREMENTS
 }
 
-# (country, table) pairs whose required-column check is expected to fail
-# while a documented migration is in progress.  When the country's
-# data_scheme.yml is updated to declare the canonical columns, remove the
-# entry here.  When the set is empty, drop the xfail logic entirely.
-_REQUIRED_COLUMN_XFAILS: dict[tuple[str, str], str] = {
-    # food_acquired canonical schema migration (GH #169 / DESIGN_food_acquired_canonical_2026-05-05).
-    # These four countries declare `food_acquired: !make` without column
-    # listings; their wave-level scripts emit non-canonical column names.
-    # xfail removed per country as each is reshaped onto the (s, j, u)
-    # canonical form.
-    ("Ethiopia", "food_acquired"): "food_acquired migration: GH #169",
-    ("Malawi", "food_acquired"): "food_acquired migration: GH #169",
-    ("Tanzania", "food_acquired"): "food_acquired migration: GH #169",
-    ("Uganda", "food_acquired"): "food_acquired migration: GH #169",
-}
-
-
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -125,14 +108,9 @@ class TestRequiredColumns:
         for table, schemes in _TABLE_SCHEMES.items():
             required = _required_columns(table)
             for country, path, spec in schemes:
-                marks = ()
-                xfail_reason = _REQUIRED_COLUMN_XFAILS.get((country, table))
-                if xfail_reason:
-                    marks = (pytest.mark.xfail(reason=xfail_reason, strict=False),)
                 yield pytest.param(
                     country, path, spec, table, required,
                     id=f"{country}:{table}",
-                    marks=marks,
                 )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

The ``pytest --rebuild-caches`` regression run on 2026-05-08 surfaced
4 xpasses in ``test_schema_consistency.py::TestRequiredColumns::
test_required_columns_present``:

```
XPASS [Ethiopia:food_acquired]
XPASS [Malawi:food_acquired]
XPASS [Tanzania:food_acquired]
XPASS [Uganda:food_acquired]
```

All four are marked ``strict=False`` xfail with reason ``"food_acquired
migration: GH #169"``.  The xpass means each country's
``data_scheme.yml`` now declares the canonical required columns —
GH #169's Phase-3 migration is effectively complete for these four.

The original block at line 99-103 said exactly:

> When the set is empty, drop the xfail logic entirely.

So this PR drops both the now-empty ``_REQUIRED_COLUMN_XFAILS`` dict
and the marks-plumbing in ``TestRequiredColumns._cases()``.

## Effect

- 4 soft (``strict=False``) xpasses become hard PASSes.  Any future
  regression in these countries' ``food_acquired`` schemas now fails
  the test loudly instead of silently re-passing under an obsolete
  xfail.

## Verified

```
$ .venv/bin/pytest tests/test_schema_consistency.py -rX -q
177 passed in 1.69s

$ .venv/bin/pytest tests/test_schema_consistency.py -v -k food_acquired
[Ethiopia:food_acquired]      PASSED
[Malawi:food_acquired]        PASSED
[Tanzania:food_acquired]      PASSED
[Uganda:food_acquired]        PASSED
(plus the 9 other countries' food_acquired entries that were already
 passing before the cleanup)
== 15 passed, 162 deselected in 0.63s ==
```

## Test plan

- [x] All 177 schema-consistency tests pass after the cleanup.
- [x] No xpasses remain in this file.
- [ ] CI ``unit-tests`` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>