### PR TITLE
fix(food_acquired): keep expenditure-only rows; preserve HH with NaN v in derived tables (closes #246 C-2)

### DIFF
--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -226,7 +226,12 @@ def food_acquired_to_canonical(df, wave):
 
     Notes
     -----
-    - Rows whose Quantity is NaN, zero, or negative are dropped.
+    - Rows are kept where EITHER ``Quantity > 0`` OR ``Expenditure > 0``
+      (matches the shared
+      :func:`lsms_library.transformations.food_acquired_to_canonical`
+      rule).  An expenditure-only row (HH reported food expenditure but
+      no quantity) is legitimate data and is carried through with NaN
+      ``Quantity``.
     - Food labels are normalized via :func:`apply_harmonize_food` at
       ``level='j'`` before returning.
     - ``v`` is intentionally absent — the framework joins it from
@@ -283,8 +288,13 @@ def food_acquired_to_canonical(df, wave):
         )
 
     out = pd.concat(pieces, ignore_index=True)
-    # Drop rows without a positive Quantity.
-    out = out[out['Quantity'].notna() & (out['Quantity'] > 0)]
+    # Keep rows with EITHER positive Quantity OR positive Expenditure.
+    # Matches the shared ``transformations.food_acquired_to_canonical``
+    # rule.  An expenditure-only row is legitimate data and is carried
+    # through with NaN Quantity.
+    qty_ok = out['Quantity'].notna() & (out['Quantity'] > 0)
+    exp_ok = out['Expenditure'].notna() & (out['Expenditure'] > 0)
+    out = out[qty_ok | exp_ok]
     # Sum across genuine source-data duplicates: a household occasionally
     # records multiple ``Other (Specify)`` entries for the same
     # (item, unit, source) triple, lumping distinct foods under one

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -513,12 +513,12 @@ def food_acquired_to_canonical(df):
     * ``s = 'inkind'``    -- ``Quantity = quant_inkind``,
       ``u = unit_inkind``, ``Expenditure = NaN``
 
-    Rows whose ``Quantity`` is NaN, zero, or negative are dropped, except
-    that a purchased row with ``Quantity > 0`` is kept even if
-    ``Expenditure`` is missing/zero (and vice versa for the rare case of
-    a recorded purchase value with no quantity, which we still drop --
-    we require Quantity).  The redundant ``quant_ttl_consume`` /
-    ``unit_ttl_consume`` columns are discarded.
+    Rows are kept where EITHER ``Quantity > 0`` OR ``Expenditure > 0``
+    (matches the shared
+    :func:`lsms_library.transformations.food_acquired_to_canonical` rule).
+    A purchased row with a recorded value but no quantity is legitimate
+    data and is carried through with NaN ``Quantity``.  The redundant
+    ``quant_ttl_consume`` / ``unit_ttl_consume`` columns are discarded.
     '''
     work = df.reset_index()
     # Legacy Tanzania: j=HHID, i=item.  Canonical: i=HHID, j=item.
@@ -546,11 +546,14 @@ def food_acquired_to_canonical(df):
     inkind    = _make('inkind',    'quant_inkind',   'unit_inkind')
 
     out = pd.concat([purchased, produced, inkind], ignore_index=True)
-    # Require a positive Quantity; drop NaN/zero/negative.  The redundant
-    # quant_ttl_consume / unit_ttl_consume axes are simply not represented
-    # in the long form (they were the sum of the three per-source quants).
-    out = out[out['Quantity'].notna()]
-    out = out[out['Quantity'] > 0]
+    # Keep rows with EITHER positive Quantity OR positive Expenditure.
+    # An expenditure-only row (HH reported food expenditure but no
+    # quantity) is legitimate data and is carried through with NaN
+    # Quantity.  Matches the shared
+    # ``transformations.food_acquired_to_canonical`` rule.
+    qty_ok = out['Quantity'].notna() & (out['Quantity'] > 0)
+    exp_ok = out['Expenditure'].notna() & (out['Expenditure'] > 0)
+    out = out[qty_ok | exp_ok]
 
     out = out.set_index(['t', 'i', 'j', 'u', 's']).sort_index()
     return out

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -207,10 +207,12 @@ def food_acquired_to_canonical(df):
       ``Expenditure = value_inkind``, ``Price = NaN`` (Uganda surveys
       do not record an imputed valuation distinct from value_inkind)
 
-    Rows where Quantity is NaN, zero, or negative are dropped.  An
-    ``Expenditure``-only row (positive value but no quantity) is also
-    dropped to keep the canonical schema's "Quantity required" invariant
-    consistent with the other Phase-3 countries (Tanzania, Malawi).
+    Rows are kept where EITHER ``Quantity > 0`` OR ``Expenditure > 0``.
+    Expenditure-only rows (HH reported a food expenditure with no
+    quantity — common in Uganda's GSEC15b for food consumed away from
+    home) are legitimate data and are carried through with NaN
+    ``Quantity``.  Matches the shared
+    :func:`lsms_library.transformations.food_acquired_to_canonical` rule.
 
     Notes
     -----
@@ -267,9 +269,17 @@ def food_acquired_to_canonical(df):
                       pd.Series(np.nan, index=work.index))
 
     out = pd.concat([purchased, produced, inkind], ignore_index=True)
-    # Require a positive Quantity; drop NaN/zero/negative.  The home/away
-    # consumption split is no longer represented in the long form.
-    out = out[out['Quantity'].notna() & (out['Quantity'] > 0)]
+    # Keep rows with EITHER positive Quantity OR positive Expenditure.
+    # An expenditure-only row (HH reported food expenditure but no
+    # quantity -- common for "food away from home" in Uganda's GSEC15b)
+    # is legitimate data and is carried through with NaN Quantity.
+    # Matches the shared ``transformations.food_acquired_to_canonical``
+    # rule.  See GH #246 part (C-2) — pre-fix behavior dropped 39 HH per
+    # wave for Uganda 2009-10 (and similarly across waves) whose only
+    # records were expenditure-without-quantity.
+    qty_ok = out['Quantity'].notna() & (out['Quantity'] > 0)
+    exp_ok = out['Expenditure'].notna() & (out['Expenditure'] > 0)
+    out = out[qty_ok | exp_ok]
 
     # Aggregate genuine source-data duplicates: a household occasionally
     # records multiple rows for the same (item, unit) -- e.g., two

--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -799,7 +799,14 @@ def food_expenditures_from_acquired(df):
     idx_names = list(df.index.names)
     # Preserve `s` in the output (Phase 4).  `u` is dropped — Expenditure
     # is currency-denominated, so summing across units is meaningful.
-    group_by = [n for n in ['t', 'v', 'i', 'j', 's'] if n in idx_names]
+    # `v` is also omitted: with pandas's default ``dropna=True``, a
+    # groupby that includes ``v`` silently drops HH whose cluster ID is
+    # unrecoverable in ``sample()``, even though their food-expenditure
+    # data is valid.  ``_finalize_result`` re-joins ``v`` from sample at
+    # API time and ``_add_market_index`` resolves Region HH-level when
+    # asked, so dropping ``v`` here loses no information.  Closes #246
+    # part (C-2) NaN-``v`` regression.
+    group_by = [n for n in ['t', 'i', 'j', 's'] if n in idx_names]
 
     x = df[['Expenditure']].replace(0, np.nan).dropna()
     x = x.groupby(group_by).sum()
@@ -864,15 +871,18 @@ def food_quantities_from_acquired(df, units='kgs', *, volume_as_mass=True):
     idx_names = list(df.index.names)
     if 'u' not in idx_names:
         # No u index level → can't tag units; fall back to a single-bucket
-        # aggregation per (t, v, i, j, s).
-        group_by = [n for n in ['t', 'v', 'i', 'j', 's'] if n in idx_names]
+        # aggregation per (t, i, j, s).  `v` is omitted from the group_by
+        # to avoid silently dropping HH whose cluster ID is unrecoverable;
+        # ``_finalize_result`` re-joins ``v`` from sample at API time.
+        group_by = [n for n in ['t', 'i', 'j', 's'] if n in idx_names]
         q = df[['Quantity']].replace(0, np.nan).dropna()
         if group_by:
             q = q.groupby(group_by).sum()
         return q
 
     if units == 'units':
-        group_by = [n for n in ['t', 'v', 'i', 'j', 'u', 's'] if n in idx_names]
+        # `v` omitted; see `food_expenditures_from_acquired` for rationale.
+        group_by = [n for n in ['t', 'i', 'j', 'u', 's'] if n in idx_names]
         q = df[['Quantity']].replace(0, np.nan).dropna()
         q = q.groupby(group_by).sum()
         return q
@@ -903,7 +913,8 @@ def food_quantities_from_acquired(df, units='kgs', *, volume_as_mass=True):
 
     out = pd.DataFrame({'Quantity': qty}, index=new_idx)
     out = out.replace(0, np.nan).dropna()
-    group_by = [n for n in ['t', 'v', 'i', 'j', 'u', 's'] if n in out.index.names]
+    # `v` omitted; see `food_expenditures_from_acquired` for rationale.
+    group_by = [n for n in ['t', 'i', 'j', 'u', 's'] if n in out.index.names]
     out = out.groupby(group_by).sum()
     return out
 


### PR DESCRIPTION
## Summary

Closes #246 part (C-2).  Two coordinated fixes that align the
``food_acquired`` pipeline on the design intent — *don't drop HH
whose data is only partial*.

### 1. Keep expenditure-only rows (3 country canonical reshapes)

Uganda / Tanzania / Malawi each have a bespoke
``food_acquired_to_canonical`` whose post-concat filter required
``Quantity > 0`` and silently dropped HH whose only records were
expenditure-without-quantity (HH that reported "spent UGX 14,000
on food away from home" without recording the quantity).  These are
**legitimate survey responses** and the design intent was always to
keep them — the shared
``transformations.food_acquired_to_canonical`` already does this
correctly; the bespoke versions diverged.

Aligned all three on the rule ``Quantity > 0 OR Expenditure > 0``.
Expenditure-only rows are carried through with NaN ``Quantity``;
they appear in ``food_expenditures`` (where they have data) and
correctly don't appear in ``food_prices`` / ``food_quantities``.

### 2. Don't drop HH with NaN ``v`` in runtime derivations

``food_expenditures_from_acquired`` and ``food_quantities_from_acquired``
in ``transformations.py`` had ``v`` in their group-by levels.
pandas's default ``dropna=True`` was silently dropping HH whose
cluster ID is unrecoverable in ``sample()`` — even though their
food data is valid and their HH-level Region IS in sample.

Dropped ``v`` from the group-by.  ``_finalize_result`` re-joins
``v`` from sample at API time and ``_add_market_index``'s HH-level
path resolves Region directly without needing ``v``, so dropping
it from the group-by loses no information.

## Verified end-to-end (Savio, ``LSMS_NO_CACHE=1``, fresh L1+L2)

Uganda 2009-10 ``food_expenditures(market='Region')``:

| State | HH |
|---|---|
| pre-fix | 2,869 |
| filter relaxation alone | 2,908 |
| **filter relaxation + group-by fix** | **2,929** (matches raw GSEC15b.dta) |

Per-method coverage:

| Method | Pre-fix | Post-fix |
|---|---|---|
| ``Country('Uganda').food_acquired()``       | 2,890 HH | 2,929 HH |
| ``food_expenditures()``                     | 2,869 HH | 2,929 HH |
| ``food_expenditures(market='Region')``      | 2,869 HH | 2,929 HH |
| ``food_prices()`` / ``food_quantities()``   | 2,890 HH | 2,890 HH (39 expenditure-only HH correctly lack price/qty) |

Tanzania and Malawi: build cleanly post-fix, no regressions.  The
filter only broadens what's kept, so neither country can lose rows.

``tests/test_sample.py::TestUganda2009MarketFallback`` (3 tests)
flips from FAIL/PASS/PASS to **PASS/PASS/PASS** (the failing
``test_food_expenditures_retains_hybrid_v_HH`` was the C-2 trigger).

## Out of scope (#246 remaining parts)

- (B) ``test_uganda_api_vs_replication.py`` stale baselines for
  food_prices / food_quantities — those tests skip on machines
  without a local replication repo and aren't affected by this PR.
- (C-1) food_expenditures atol=0 drift — same skipif gate.
- (D) Serbia/2007 cross-source granularity mismatch — separate.

## Follow-up issue forthcoming

The four ``food_acquired_to_canonical`` implementations (1 shared +
3 bespoke) all replicate the same post-concat filter + groupby
tail.  Today's filter-rule change touched 4 files for what was
conceptually 1 design change — a maintenance smell.  Will file an
issue tied to #218 to extract that ~5-line tail into a shared
utility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>