### PR TITLE
fix(Tajikistan/1999): compound household_roster i to match sample (closes #246 D-1)

### DIFF
--- a/lsms_library/countries/Tajikistan/1999/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/1999/_/data_info.yml
@@ -5,7 +5,7 @@ household_roster:
         - ../Data/SSEC1.DTA
     idxvars:
         v: pop_pt
-        i: hhid
+        i: [pop_pt, hhid]
         pid: iid
     myvars:
         Sex:


### PR DESCRIPTION
## Summary

Closes #246 part (D-1).

Tajikistan 1999 had the same single-col-roster / compound-sample
shape mismatch as the four PR #244 waves: the roster declared
``i: hhid`` (single column) while sample declared
``i: [pop_pt, hhid]`` (compound).  ``_join_v_from_sample`` found zero
overlap and silently dropped all 1999 HH from
``household_characteristics()``.

Identified during the post-#244 universe scan: across all 40
countries' wave-level ``data_info.yml``, exactly two waves still had
``roster.i = string AND sample.i = list``:

  - Tajikistan 1999 (**fixed by this PR** — wave-level ``mapping.py:i``
    already exists and produces canonical compound).
  - Serbia/2007 (structurally different — source roster file lacks
    ``naselje``; stays in #246 (D-2)).

## Verified end-to-end (Savio, fresh L1+L2 caches)

```
Country('Tajikistan').household_characteristics() shape:
  pre-fix:  (10306, 15)  --  3 waves; 1999 silently missing
  post-fix: (12283, 15)  --  4 waves; 1999 recovered (1977 HH)
```

Per-wave post-fix:

| Wave | HH | v populated |
|---|---|---|
| **1999** | **1977** | **1977 / 1977** ← recovered |
| 2003 | 4159 | 4159 / 4159 |
| 2007 | 4644 | 4644 / 4644 |
| 2009 | 1503 | 1503 / 1503 |

The 23-HH gap (raw GSEC1 2,000 → post-fix 1,977) is the standard
``roster_to_characteristics`` filter on incomplete rosters.

## Diff

One line:

```diff
 household_roster:
     idxvars:
         v: pop_pt
-        i: hhid
+        i: [pop_pt, hhid]
         pid: iid
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>