### PR TITLE
fix(Serbia/2007): compound i to recover all 5557 HHs (closes #246 D-2)

### DIFF
--- a/lsms_library/countries/Serbia/2007/_/data_info.yml
+++ b/lsms_library/countries/Serbia/2007/_/data_info.yml
@@ -17,7 +17,7 @@ household_roster:
         - "../Data/individual.dta"
     idxvars:
         v: popkrug
-        i: dom
+        i: [opstina, popkrug, dom]
         pid: lice
     myvars:
         Sex: pol
@@ -32,7 +32,7 @@ sample:
     df_hh:
         file: "../Data/domacinstva.dta"
         idxvars:
-            i: [popkrug, naselje, dom]
+            i: [opstina, popkrug, dom]
         myvars:
             v: popkrug
             weight: hhweight


### PR DESCRIPTION
## Summary

Closes #246 part (D-2).  Last structurally-distinct cross-source case
after PR #244 (Guyana/Azerbaijan/Serbia and Montenegro) and PR #253
(Tajikistan/1999).

Serbia/2007 had `roster.i = dom` (single column) while
`sample.i = [popkrug, naselje, dom]`.  `_join_v_from_sample` found
zero overlap and silently dropped all 5557 HHs from
`household_characteristics()`.  The handoff from the 2026-05-08
session flagged this as "structurally different" because
`individual.dta` (roster source) lacks the `naselje` column.

## Probe finding (Slurm job 34085515, `co_carleton`, 1.3s compute)

Cardinality scan over `individual.dta`, `domacinstva.dta`, and
`enumeration_district.dta`:

| Question | Answer |
|---|---|
| Is `(opstina, popkrug) -> naselje` functional in ED? | YES (510/510 tuples) |
| Is `(opstina, popkrug, dom)` unique per sample HH? | YES (5557/5557) |
| Roster grouped by `(opstina, popkrug, dom)`: HH count? | 5557 (matches sample exactly; mean HH size 3.13) |
| Roster keys ↔ sample keys overlap? | 5557 / 5557 / **0 / 0** (perfect bijection) |

So the existing YAML was over-specified.  `(opstina, popkrug, dom)`
-- a tuple `individual.dta` already contains -- does the same job as
`(popkrug, naselje, dom)` and lets roster and sample produce matching
`format_id('-'.join(parts))` strings.  No new code; no cross-source
join needed; the wave-level `mapping.py:i()` is already generic over
component count.

## Diff

```diff
 household_roster:
     idxvars:
         v: popkrug
-        i: dom
+        i: [opstina, popkrug, dom]
         pid: lice

 sample:
     df_hh:
         idxvars:
-            i: [popkrug, naselje, dom]
+            i: [opstina, popkrug, dom]
```

## Verified end-to-end (Slurm job 34085520, 15.3s compute, fresh L2)

```
Country('Serbia').sample()                    -> (5557, 5)  -- 5557/5557 v populated
Country('Serbia').household_roster()          -> (17375, 7) -- kinship decomposed
Country('Serbia').household_characteristics() -> (5557, 15) -- 2007 = 5557 HHs (was 0)
Cross-check roster i <-> sample i overlap     -> 5557 / 5557 / 0 / 0
```

Sample example `i`: `70017-156-1001` (format_id of opstina-popkrug-dom).

## Universe scan after this fix

Across all wave-level `data_info.yml` files, **zero waves** remain
with `roster.i = single string AND sample.i = list`.  PRs #244 + #253
+ this PR exhaust the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)