### PR TITLE
test(uganda/sample): tighten 2009-10 hybrid-v retention to >=2929 (closes #246 C-2)

### DIFF
--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -421,11 +421,15 @@ class TestUganda2009MarketFallback:
         hh09 = fe.xs("2009-10", level="t").index.get_level_values("i").nunique()
         # Sample-level HH count in 2009-10 is 2 975 (full roster).  22 HH have
         # no food-expenditure records and drop out for that reason, not because
-        # of a NaN Region.  The pre-fallback coverage was ~2 240.
-        assert hh09 >= 2900, (
+        # of a NaN Region.  Another 24 are dropped by the MonthsSpent filter
+        # in roster_to_characteristics (departed-only HHs).  The remaining
+        # 2 929 is what the HH-level _add_market_index fallback delivers,
+        # confirmed by Slurm-rebuild on 2026-05-09 with both warm and cold
+        # caches.  The pre-fallback coverage was ~2 240.
+        assert hh09 >= 2929, (
             f"food_expenditures(market='Region') retained only {hh09} HH in "
-            f"2009-10 — expected ≥2900 after _add_market_index HH-level "
-            f"fallback"
+            f"2009-10 — expected ≥2929 after _add_market_index HH-level "
+            f"fallback (sample 2975 − 22 no-food − 24 departed-only)"
         )
 
     def test_household_characteristics_retains_hybrid_v_HH(self, hc):


### PR DESCRIPTION
## Summary

Closes #246 part (C-2) -- the last remaining piece of #246.  The test
was failing on 2026-05-08 (commit f5ff48f9, pre-PR-#245) at 2869 HHs
retained against a threshold of 2900.  PR #245's Phase-3
``_/food_acquired.py`` rewrite fixed the underlying issue: today
on ``development @ fa67d6d7`` the test passes at **2929 HHs** in
both warm- and cold-cache modes, matching the docstring's stated
target ("should retain the 2 929 HH") exactly.

This PR tightens the assertion from ``>=2900`` to ``>=2929`` so that
a future regression dropping even a single HH from the hybrid-v
fallback fails the test loudly, rather than hiding inside the
existing 29-HH cushion.

## Attrition picture (verified by Slurm probe 34085538)

```
=== HH counts (2009-10, Uganda) ===
sample()                                  : 2975
household_roster()                        : 2975
household_characteristics()               : 2951
household_characteristics(market='Region'): 2951
food_expenditures()                       : 2929
food_expenditures(market='Region')        : 2929  >=2929 ✓
```

The 46-HH attrition from sample to fe(market) breaks down as:

| Stage | Lost | Reason |
|---|---:|---|
| sample → roster | 0 | full coverage |
| roster → characteristics | 24 | MonthsSpent filter drops departed-only HHs |
| characteristics → fe | 22 | no food-acquisition records (legitimate) |
| fe → fe(market) | **0** | ``_add_market_index`` HH-level fallback works |

The 24 MonthsSpent-filtered HHs are the result of the same fix that
resolved a 1315-HH drift vs RiskSharing_Replication on
``household_characteristics`` (see CLAUDE.md ``MonthsSpent /
MonthsAway / WeeksAway``).

## Test runs (Slurm 34085543, ``co_carleton``)

```
warm cache:  3 passed in 86.88s
cold cache:  3 passed in 87.62s   (LSMS_NO_CACHE=1, full rebuild from .dta)
```

Both cold and warm cache produce 2929; this is not a cache-state
artifact.

## Out of scope

The companion ``test_household_characteristics_retains_hybrid_v_HH``
also currently asserts ``>=2900``; the probe shows the actual count
is 2951.  Tightening to ``>=2951`` is the obvious natural follow-up
but is held out of this PR per the design conversation -- can be
folded in if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)