### PR TITLE
test(uganda/sample): pin 2009-10 hc retention to == 2951

### DIFF
--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -434,13 +434,26 @@ class TestUganda2009MarketFallback:
 
     def test_household_characteristics_retains_hybrid_v_HH(self, hc):
         """household_characteristics(market='Region') should cover the
-        full 2 951 HH (those with populated sample.v, hybrid or real)."""
+        full 2 951 HH (those with populated sample.v, hybrid or real).
+
+        Pinned to equality on 2026-05-09: warm- and cold-cache probes
+        both produce 2951 exactly (Slurm jobs 34085538 and 34085552).
+        The 24-HH gap from sample's 2975 is the MonthsSpent filter in
+        roster_to_characteristics dropping departed-only HHs (added
+        2026-04-15 to resolve a 1315-HH drift vs RiskSharing_Replication;
+        see CLAUDE.md "MonthsSpent / MonthsAway / WeeksAway"). Any
+        legitimate change to that filter -- or any new attrition path
+        -- will trip this test, which is the intent: surface drift in
+        either direction.
+        """
         if "2009-10" not in hc.index.get_level_values("t").unique():
             pytest.skip("no 2009-10 wave")
         hh09 = hc.xs("2009-10", level="t").index.get_level_values("i").nunique()
-        assert hh09 >= 2900, (
-            f"household_characteristics(market='Region') retained only "
-            f"{hh09} HH in 2009-10 — expected ≥2900 after fallback"
+        assert hh09 == 2951, (
+            f"household_characteristics(market='Region') retained {hh09} HH "
+            f"in 2009-10 — expected exactly 2951 (sample 2975 − 24 "
+            f"departed-only via MonthsSpent filter). Drift in either "
+            f"direction is meaningful: investigate before re-pinning."
         )
 
     def test_no_nan_m_after_fallback(self, fe):


### PR DESCRIPTION
## Summary

Companion to PR #257 (which tightened the ``food_expenditures``
sibling from ``>=2900`` to ``>=2929``).  This PR pins the parallel
``household_characteristics(market='Region')`` 2009-10 retention
test to **equality at 2951**, not just an inequality.

## Why equality

The entire attrition chain is understood at the HH level:

| Stage | HHs | Loss explained by |
|---|---:|---|
| ``sample()`` 2009-10 | 2975 | full sample |
| ``household_roster()`` (HHs) | 2975 | 0 |
| ``household_characteristics()`` | **2951** | MonthsSpent filter drops 24 departed-only HHs |
| ``household_characteristics(market='Region')`` | **2951** | 0 (HH-level fallback works) |

The 24-HH gap is the MonthsSpent filter added 2026-04-15 to resolve
a 1315-HH drift vs the RiskSharing_Replication baseline (see
``CLAUDE.md`` "MonthsSpent / MonthsAway / WeeksAway").

So a legitimate code change shifting this number *should* trip the
test and prompt a re-pin.  Silent drift is what we want to catch;
``>=`` swallows it.

## Verified

```
warm cache (Slurm 34085538):  household_characteristics(market='Region') HHs=2951
cold cache (Slurm 34085552):  household_characteristics(market='Region') HHs=2951
```

Cold-cache probe purged 11 Uganda parquet files (both L2-country
and L2-wave) and ran with ``LSMS_NO_CACHE=1`` -- a full rebuild from
raw ``.dta`` files via the framework.  The 2951 reading is therefore
not a cache artifact.

## If equality proves too tight

Relax to ``>=`` or to a small range and add the new number to the
docstring.  The class docstring already documents the expected
breakdown, so re-pinning is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)