### PR TITLE
fix(Uganda/_/Makefile): drop obsolete household_characteristics build rule

### DIFF
--- a/lsms_library/countries/Uganda/_/Makefile
+++ b/lsms_library/countries/Uganda/_/Makefile
@@ -8,13 +8,15 @@ COUNTRY := $(shell basename "$$(cd .. && pwd)")
 LSMS_DATA_ROOT ?= $(if $(LSMS_DATA_DIR),$(LSMS_DATA_DIR),$(if $(XDG_DATA_HOME),$(XDG_DATA_HOME),$(HOME)/.local/share)/lsms_library)
 VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 
-# food_expenditures, food_quantities, food_prices are produced at runtime
-# from canonical food_acquired.parquet via the framework's auto-derivation
-# path (_FOOD_DERIVED in lsms_library/country.py); they no longer need to
-# be materialized as country-level parquets.  See PR uganda-drop-legacy-fpqe
-# (post-#245).
-var = $(VAR_DIR)/household_characteristics.parquet \
-      $(VAR_DIR)/shocks.parquet $(VAR_DIR)/nonfood_expenditures.parquet $(VAR_DIR)/enterprise_income.parquet \
+# Auto-derived at runtime, NOT materialized as country-level parquets:
+#   - household_characteristics, food_expenditures, food_prices,
+#     food_quantities -- see _ROSTER_DERIVED / _FOOD_DERIVED in
+#     lsms_library/country.py and CLAUDE.md "Derived Tables".
+# Listing them here would re-introduce the obsolete-rule failure that
+# broke master CI on 2026-05-09 (no rule to make target
+# 'household_characteristics.py').  The food_*.py legacy script was
+# already dropped in PR #248/#249 (post-#245).
+var = $(VAR_DIR)/shocks.parquet $(VAR_DIR)/nonfood_expenditures.parquet $(VAR_DIR)/enterprise_income.parquet \
 	  $(VAR_DIR)/assets.parquet $(VAR_DIR)/earnings.parquet $(VAR_DIR)/housing.parquet $(VAR_DIR)/income.parquet \
 	  $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet
 
@@ -67,12 +69,6 @@ food_acquired_parquet := $(food_acquired:.py=.parquet)
 
 $(VAR_DIR)/food_acquired.parquet: food_acquired.py $(food_acquired_parquet)
 	python food_acquired.py
-
-household_characteristics = $(shell find $(rounds) -name household_characteristics.py)
-household_characteristics_parquet := $(household_characteristics:.py=.parquet)
-
-$(VAR_DIR)/household_characteristics.parquet: household_characteristics.py $(household_characteristics_parquet)
-	python household_characteristics.py
 
 housing = $(shell find $(rounds) -name housing.py)
 housing_parquet := $(housing:.py=.parquet)


### PR DESCRIPTION
## Summary

Restores green CI on master.

Master CI's ``data-tests`` job (skipped on PR runs, fires only on
master push) failed at 13:59:16 UTC on the v0.7.2 fast-forward push
with:

```
make: *** No rule to make target 'household_characteristics.py',
needed by '/home/runner/.local/share/lsms_library/Uganda/var/
household_characteristics.parquet'.  Stop.
```

Root cause: ``Uganda/_/Makefile`` still listed
``$(VAR_DIR)/household_characteristics.parquet`` in its ``var`` list
and had a build rule for it -- but ``household_characteristics`` is
now auto-derived at runtime via ``_ROSTER_DERIVED`` in
``country.py``, and there is no ``household_characteristics.py``
source anywhere.  CLAUDE.md is explicit:

> ``household_characteristics``, ``food_expenditures``,
> ``food_prices``, and ``food_quantities`` are auto-derived at
> runtime via ``_ROSTER_DERIVED`` and ``_FOOD_DERIVED`` in
> ``country.py``. **Do NOT register them in ``data_scheme.yml``**.

The food_*.py legacy scripts were dropped post-#245 via #248/#249;
``household_characteristics.py`` was never a legacy script -- it
pre-dated the auto-derivation infrastructure as a Makefile-only
target that quietly broke when the auto-derivation took over.

## Diff

Two surgical edits in ``Uganda/_/Makefile``:

1. Drop ``$(VAR_DIR)/household_characteristics.parquet`` from the
   ``var`` list (line 16 of the old file).
2. Drop the now-orphaned rule block (lines 71-75 of the old file):
   ``$(household_characteristics)`` ``find``, parquet derivation,
   and the ``python household_characteristics.py`` recipe.

The auto-derivation comment immediately above the ``var`` list is
extended to call out the full set of auto-derived tables, so a
future contributor doesn't reintroduce the same trap.

## Other dormant copies

The same obsolete pattern exists in ``Nepal/_/Makefile``,
``GhanaLSS/_/Makefile``, ``Guatemala/_/Makefile``, and
``Ethiopia/_/Makefile`` -- but none are exercised by CI's "Build
Uganda tables" step (the only data-tests step that builds country
parquets via Make).  Worth a follow-up sweep but out of scope here.

## v0.7.2 wheel impact

None.  The wheel was built off ``fbe5b478`` and is shipping as
intended.  The Makefile in question is for ``materialize: make``
fallback rebuilds; it does not affect runtime API behavior or the
package contents.  This PR is pure CI hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)