### PR TITLE
fix(country): dedup v_lookup in _add_market_index cluster fallback (closes #266)

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -1417,7 +1417,19 @@ class Country:
             if 'v' not in flat.columns:
                 if 'sample' in self.data_scheme:
                     df_with_v = self._join_v_from_sample(df)
-                    v_lookup = df_with_v.reset_index()[['i', 't', 'v']]
+                    # ``drop_duplicates`` on (i, t) is load-bearing for tables
+                    # whose canonical index has more levels than (i, t) --
+                    # e.g. ``shocks`` (one row per (i, t, Shock)) or any
+                    # future table with similar shape.  Without it, a tall
+                    # input frame produces *k* identical (i, t, v) rows for
+                    # a HH-period with *k* extra-level rows, and the merge
+                    # below becomes a Cartesian product yielding *k^2* output
+                    # rows per HH-period.  See GH #266 for the worked example
+                    # (Uganda shocks: 14,457 rows -> 27,268 with 12,812 dup).
+                    # The parallel logic in ``_location_lookup`` already
+                    # carries the same dedup; this restores the symmetry.
+                    v_lookup = (df_with_v.reset_index()[['i', 't', 'v']]
+                                .drop_duplicates(subset=['i', 't']))
                     flat = flat.merge(v_lookup, on=['i', 't'], how='left')
                 else:
                     warnings.warn(

--- a/tests/test_add_market_index_dedup.py
+++ b/tests/test_add_market_index_dedup.py
@@ -1,0 +1,115 @@
+"""
+Regression test for GH #266 -- ``_add_market_index`` cluster-fallback
+must not multiply rows for tall input tables.
+
+Bug shape (Uganda v0.7.2): ``Country('Uganda').shocks(market='Region')``
+returns 27,268 rows for the same 14,457-row input that
+``Country('Uganda').shocks()`` produces -- each (i, t)-household with
+*k* shocks gets *k^2* output rows instead of *k* because the
+fallback ``v_lookup`` merge inside ``_add_market_index`` does a
+Cartesian product on (i, t) against an un-deduplicated lookup frame.
+
+Root cause: line 1420 of country.py built ``v_lookup`` as
+``df_with_v.reset_index()[['i', 't', 'v']]`` without
+``.drop_duplicates(subset=['i', 't'])``.  For a tall input one row
+per (i, t, Shock), the lookup ends up with *k* copies of every
+(i, t, v) tuple, and the merge on (i, t) yields *k^2* outputs.
+
+The parallel ``_location_lookup`` already carried the dedup; this
+just restores symmetry.
+"""
+import warnings
+
+import pandas as pd
+import pytest
+
+import lsms_library as ll
+
+
+@pytest.fixture(scope="module")
+def uga_shocks_bare():
+    """``Country('Uganda').shocks()`` -- the baseline shape with no
+    market index.  Skips if the underlying microdata isn't reachable
+    in this environment (CI without DVC creds, etc.)."""
+    try:
+        return ll.Country("Uganda").shocks()
+    except Exception as exc:  # noqa: BLE001 - broad catch intentional
+        pytest.skip(f"Uganda shocks unavailable: {exc}")
+
+
+@pytest.fixture(scope="module")
+def uga_shocks_market():
+    """``Country('Uganda').shocks(market='Region')`` -- the path
+    exercising ``_add_market_index``'s cluster-level fallback."""
+    try:
+        return ll.Country("Uganda").shocks(market="Region")
+    except Exception as exc:  # noqa: BLE001 - broad catch intentional
+        pytest.skip(f"Uganda shocks(market='Region') unavailable: {exc}")
+
+
+class TestAddMarketIndexDedup:
+    """All assertions target the GH #266 bug surface in
+    ``Country._add_market_index``.  Uganda shocks is the canonical
+    worked example: 14,457 input rows; the bug previously produced
+    27,268 (12,812 spurious duplicates)."""
+
+    def test_no_duplicate_index_rows(self, uga_shocks_market):
+        """The market-indexed result must have no duplicate index rows.
+        Pre-fix: ``index.duplicated().sum() == 12_812``."""
+        ndup = int(uga_shocks_market.index.duplicated().sum())
+        assert ndup == 0, (
+            f"Uganda shocks(market='Region') has {ndup} duplicate index rows. "
+            f"This is the GH #266 Cartesian-product bug in "
+            f"_add_market_index's cluster-level fallback merge."
+        )
+
+    def test_row_count_not_inflated(self, uga_shocks_bare, uga_shocks_market):
+        """Adding the market index can only drop rows (NaN m), never
+        multiply them.  Pre-fix Uganda: 27,268 vs 14,457 -> 88% inflation."""
+        n_bare = len(uga_shocks_bare)
+        n_market = len(uga_shocks_market)
+        assert n_market <= n_bare, (
+            f"shocks(market='Region') = {n_market} rows exceeds "
+            f"shocks() = {n_bare}.  _add_market_index should never "
+            f"multiply rows -- it may only drop NaN-m rows.  "
+            f"GH #266: pre-fix inflation factor ~1.88x via Cartesian "
+            f"product on tall input."
+        )
+
+    def test_shock_distribution_preserved(self, uga_shocks_bare, uga_shocks_market):
+        """The number of shock rows per (i, t) HH-period in the market
+        version should match (or be a subset of) the bare version.
+        Pre-fix: each k-shock HH-period became k^2.  The k=2 bucket
+        had 1,999 HH-periods pre-fix, 3,998 post-bug (2x).  Post-fix
+        the (k -> count) distribution should equal or be a subset of
+        the bare distribution."""
+        bare_dist = (
+            uga_shocks_bare.reset_index()
+            .groupby(['i', 't'])
+            .size()
+            .value_counts()
+            .sort_index()
+            .to_dict()
+        )
+        market_dist = (
+            uga_shocks_market.reset_index()
+            .groupby(['i', 't'])
+            .size()
+            .value_counts()
+            .sort_index()
+            .to_dict()
+        )
+        # market_dist may have fewer (i, t) HH-periods than bare (if
+        # _add_market_index drops some for NaN m), but for any *k*
+        # value that appears in market_dist, the count must be <= the
+        # bare count for the same *k* -- never higher.  Pre-fix the
+        # market counts were precisely the squares (k=2: 1999 -> 3998,
+        # k=3: 525 -> 1575, etc.).
+        for k, market_n in market_dist.items():
+            bare_n = bare_dist.get(k, 0)
+            assert market_n <= bare_n, (
+                f"shocks(market='Region') has {market_n} HH-periods with "
+                f"k={k} shocks, vs {bare_n} in shocks().  Pre-fix #266 "
+                f"inflated each k to k^2; the market version must be a "
+                f"subset of the bare version."
+            )


### PR DESCRIPTION
## Summary

Closes #266 (reported today by @ligon).

``Country('Uganda').shocks(market='Region')`` on v0.7.2 returned
27,268 rows for the same 14,457-row input that ``shocks()`` produces.
Each (i, t) HH-period with *k* shocks got **k^2** output rows.

Root cause: cluster-level fallback inside ``_add_market_index``
built ``v_lookup`` without deduplicating on (i, t):

```python
v_lookup = df_with_v.reset_index()[['i', 't', 'v']]   # ← no dedup
flat = flat.merge(v_lookup, on=['i', 't'], how='left')
```

For a tall input (``shocks`` is one row per (i, t, Shock)), the
lookup ended up with *k* identical (i, t, v) tuples per HH-period.
The subsequent (i, t) merge became a Cartesian product yielding
*k^2* outputs.  The parallel ``_location_lookup`` already
deduplicated the analogous (i, t) → m lookup (line 1467); this
restores symmetry.

## Fix

```diff
- v_lookup = df_with_v.reset_index()[['i', 't', 'v']]
+ v_lookup = (df_with_v.reset_index()[['i', 't', 'v']]
+             .drop_duplicates(subset=['i', 't']))
```

Plus a 6-line in-source comment documenting the failure mode so
future readers don't reintroduce it.

## Test

``tests/test_add_market_index_dedup.py`` -- 3 assertions on Uganda
shocks:

| Test | Asserts |
|---|---|
| ``test_no_duplicate_index_rows`` | ``index.duplicated().sum() == 0`` (pre-fix: 12,812) |
| ``test_row_count_not_inflated`` | ``len(market) <= len(bare)`` (pre-fix: 27268 > 14457) |
| ``test_shock_distribution_preserved`` | Per-(i, t) k-shock counts in market version <= bare counts (pre-fix: k → k²) |

Each fixture skips gracefully if Uganda microdata isn't reachable
(CI without DVC creds, etc.).

## Why other tables aren't affected

``food_acquired`` / ``food_prices`` / ``food_quantities`` carry
``v`` as an index level upstream, so the buggy branch is skipped.
The bug surfaces specifically for tables that **lack ``v`` upstream
AND have extra index levels beyond (i, t)**.  ``shocks`` is the
textbook case; future tables with this shape would have hit the
same trap.

## Verified end-to-end (Slurm 34192990, ``co_carleton``, ~5 min wall)

```
STEP 1 (new regression test):           3 passed in 1:36
STEP 2 (existing market='Region' tests): 3 passed in 1:59
STEP 3 (explicit shape):
  shocks()                       (14457, 10)  dup=0
  shocks(market='Region')        (14456, 10)  dup=0   ← post-fix
  pre-fix would have been         (27268, 10) dup=12812
```

One row legitimately dropped (NaN m for a single HH-period); zero
duplicates.  ``TestUganda2009MarketFallback`` (which exercises
``_add_market_index``'s sister path) still passes -- no regression.

## Downstream impact (from #266)

Without this fix, all consumers of ``Country.<table>(market=...)``
on tables with ``v``-less upstream + extra index levels see
Cartesian-product output.  Reported impact: inflated
``shock_shares.parquet``, distorted shock-incidence regressions and
variance-decomposition tables in CovariateRiskSharing (AER revision)
when run against 0.7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)