### PR TITLE
feat(transformations): mover sentinel for NaN v in roster_to_characteristics (closes #268)

### DIFF
--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -260,7 +260,9 @@ def format_interval(interval, compact=True):
         return f"{int(lo):02d}-{int(hi) - 1:02d}"
     return f"[{_fmt_bound(lo)}, {_fmt_bound(hi)})"
 
-def roster_to_characteristics(df, age_cuts=(4, 9, 14, 19, 31, 51), drop='pid', final_index=['t', 'v', 'i']):
+def roster_to_characteristics(df, age_cuts=(4, 9, 14, 19, 31, 51), drop='pid',
+                              final_index=['t', 'v', 'i'],
+                              mover_sentinel='Mover'):
     """Collapse a household roster into household-level sex × age counts.
 
     Drives the derived ``household_characteristics`` table: takes a
@@ -289,6 +291,21 @@ def roster_to_characteristics(df, age_cuts=(4, 9, 14, 19, 31, 51), drop='pid', f
         Final groupby level; defaults to the household key ``('t', 'v',
         'i')`` but ``Country._finalize_result`` can pass a different
         tuple when the roster's actual index differs.
+    mover_sentinel : str or None, default ``'Mover'``
+        Value to substitute for NaN entries in any ``final_index``
+        level (in practice always ``v``) before the household
+        groupby.  When non-None, mover / split-off households with a
+        NaN cluster code survive as a distinct bucket identifiable
+        by ``index.get_level_values('v') == mover_sentinel``.  Pass
+        ``None`` to recover the legacy GH #197 behavior where the
+        groupby silently drops these households.
+
+        Default flipped from drop-via-NaN to keep-with-sentinel in
+        GH #268.  ``sample()`` typically carries a valid ``Region``
+        for movers even when ``v`` is missing, so dropping them at
+        this stage loses households we /can/ still assign to a
+        market.  Callers who want the strict legacy drop pass
+        ``mover_sentinel=None``.
 
     Returns
     -------
@@ -344,11 +361,15 @@ def roster_to_characteristics(df, age_cuts=(4, 9, 14, 19, 31, 51), drop='pid', f
     )
     roster_df = dummies(roster_df,['sex_age'])
     roster_df.index = roster_df.index.droplevel(drop)
-    # Pandas' ``groupby(...)`` default is ``dropna=True``, which silently
-    # excludes rows whose index has NaN in any of ``final_index``.  We
-    # keep that drop (the canonical (t, v, i) key assumes v is
-    # meaningful) but warn loudly with the per-wave count so the loss
-    # isn't invisible to the caller.  GH #197.
+    # Pandas' ``groupby(...)`` default is ``dropna=True``, so rows whose
+    # index has NaN in any of ``final_index`` are silently excluded.
+    # The NaN is almost always in ``v``: ``v`` is joined onto the
+    # roster post-hoc via ``_join_v_from_sample`` and ``sample``'s
+    # ``v`` column is NaN for movers / split-offs that lack a cluster
+    # code.  GH #197 flagged the silent drop; GH #268 makes the
+    # keep-with-sentinel path the default (movers survive as a
+    # distinguishable ``v == mover_sentinel`` bucket) and turns the
+    # legacy drop into an opt-in via ``mover_sentinel=None``.
     idx_df = roster_df.index.to_frame(index=False)
     nan_mask = idx_df[final_index].isna().any(axis=1)
     n_nan_rows = int(nan_mask.sum())
@@ -368,15 +389,38 @@ def roster_to_characteristics(df, age_cuts=(4, 9, 14, 19, 31, 51), drop='pid', f
             )
         else:
             per_wave = {'<no-t>': n_nan_rows}
-        _warnings.warn(
-            f"household_characteristics: dropped {n_nan_rows} roster rows "
-            f"with NaN in one of {final_index} (typically v) "
-            f"-- per-wave: {per_wave}.  These are usually movers / "
-            f"split-offs whose sample() row lacks a cluster code; see "
-            f"GH #197.",
-            UserWarning,
-            stacklevel=3,
-        )
+        if mover_sentinel is None:
+            _warnings.warn(
+                f"household_characteristics: dropped {n_nan_rows} roster "
+                f"rows with NaN in one of {final_index} (typically v) "
+                f"-- per-wave: {per_wave}.  These are usually movers / "
+                f"split-offs whose sample() row lacks a cluster code; "
+                f"the groupby below silently excludes them.  To keep "
+                f"them as an identifiable bucket, pass a non-None "
+                f"``mover_sentinel`` (default ``'Mover'``).  See "
+                f"GH #197, GH #268.",
+                UserWarning,
+                stacklevel=3,
+            )
+        else:
+            # GH #268: fill NaN in every final_index level with the
+            # sentinel so movers survive the household groupby as a
+            # distinguishable bucket rather than getting dropped.
+            for level in final_index:
+                if idx_df[level].isna().any():
+                    idx_df[level] = idx_df[level].fillna(mover_sentinel)
+            roster_df.index = pd.MultiIndex.from_frame(idx_df)
+            _warnings.warn(
+                f"household_characteristics: replaced {n_nan_rows} roster "
+                f"rows with NaN in one of {final_index} (typically v) by "
+                f"sentinel {mover_sentinel!r} -- per-wave: {per_wave}.  "
+                f"These are usually movers / split-offs whose sample() row "
+                f"lacks a cluster code.  Filter on "
+                f"index.get_level_values('v') == {mover_sentinel!r} to "
+                f"recover the legacy drop (GH #197, GH #268).",
+                UserWarning,
+                stacklevel=3,
+            )
     result = roster_df.groupby(level=final_index).sum()
     result['log HSize'] = np.log(result.sum(axis=1))
     result.columns = result.columns.get_level_values(0)

--- a/tests/test_roster_to_characteristics_movers.py
+++ b/tests/test_roster_to_characteristics_movers.py
@@ -1,0 +1,159 @@
+"""
+Regression test for GH #268 -- ``roster_to_characteristics`` must
+preserve mover / split-off households (rows with NaN ``v`` in the
+roster's index) under its new default ``mover_sentinel='Mover'``,
+and recover the legacy drop behavior when explicitly opted out via
+``mover_sentinel=None``.
+
+Pre-#268, the function's final ``groupby(level=final_index).sum()``
+relied on pandas' default ``dropna=True``, which silently excluded
+rows whose index had NaN in any of ``('t', 'v', 'i')`` -- in
+practice always ``v``, since ``v`` is joined onto the roster post-hoc
+via ``_join_v_from_sample`` and ``sample``'s ``v`` column is NaN for
+movers / split-offs that lack a cluster code.  ``sample()`` typically
+carries a valid ``Region`` for those households, so dropping them at
+this stage loses households we /can/ still assign to a market.  GH
+#268 flips the default so the household survives as a distinguishable
+``v == 'Mover'`` bucket; callers who want the strict legacy drop
+pass ``mover_sentinel=None``.
+
+These tests run against a synthetic 3-household roster -- no World
+Bank Microdata access required.
+"""
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lsms_library.transformations import roster_to_characteristics
+
+
+def _synthetic_roster():
+    """3-HH roster: two with valid cluster codes, one mover (NaN v).
+    All members report MonthsSpent=12 so the upstream filter doesn't
+    drop any of them."""
+    rows = [
+        # HH1 in cluster V1: two adults
+        (('2020', 'V1', 'HH1', 1), ('MALE',   35, 12)),
+        (('2020', 'V1', 'HH1', 2), ('FEMALE', 33, 12)),
+        # HH2 in cluster V2: one adult + one child
+        (('2020', 'V2', 'HH2', 1), ('FEMALE', 40, 12)),
+        (('2020', 'V2', 'HH2', 2), ('MALE',   10, 12)),
+        # HH3 mover (NaN v): two adults
+        (('2020', pd.NA, 'HH3', 1), ('MALE',   28, 12)),
+        (('2020', pd.NA, 'HH3', 2), ('FEMALE', 27, 12)),
+    ]
+    keys, vals = zip(*rows)
+    idx = pd.MultiIndex.from_tuples(keys, names=['t', 'v', 'i', 'pid'])
+    return pd.DataFrame(list(vals), index=idx,
+                        columns=['sex', 'age', 'monthsspent'])
+
+
+@pytest.fixture
+def roster():
+    return _synthetic_roster()
+
+
+@pytest.fixture
+def roster_no_movers(roster):
+    """Same roster minus the NaN-v rows; used to confirm the new
+    default path is a no-op when there's nothing to fill."""
+    keep = ~roster.index.get_level_values('v').isna()
+    return roster.loc[keep]
+
+
+class TestMoverSentinelDefault:
+    """The new default behavior: NaN v gets ``'Mover'``."""
+
+    def test_mover_household_survives(self, roster):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = roster_to_characteristics(roster)
+        v_values = list(result.index.get_level_values('v'))
+        assert 'Mover' in v_values, (
+            "GH #268: mover HH (NaN v) should survive groupby as "
+            "v='Mover'; got v values: %r" % v_values
+        )
+        # All three HHs (V1, V2, Mover) should be present.
+        assert sorted(v_values) == ['Mover', 'V1', 'V2']
+
+    def test_mover_household_has_correct_counts(self, roster):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = roster_to_characteristics(roster)
+        mover_row = result.xs('Mover', level='v').iloc[0]
+        # HH3 has one 28yo Male and one 27yo Female: both in 19-30.
+        assert mover_row['MALE 19-30'] == 1
+        assert mover_row['FEMALE 19-30'] == 1
+        # log HSize = log(2)
+        assert np.isclose(mover_row['log HSize'], np.log(2))
+
+    def test_warning_message_mentions_replaced_and_sentinel(self, roster):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always", UserWarning)
+            roster_to_characteristics(roster)
+        msgs = [str(w.message) for w in captured
+                if 'household_characteristics' in str(w.message)]
+        assert msgs, "Expected GH #268 warning naming the sentinel"
+        msg = msgs[-1]
+        assert 'replaced' in msg
+        assert "'Mover'" in msg
+
+
+class TestMoverSentinelLegacyDrop:
+    """``mover_sentinel=None`` recovers the GH #197 drop behavior."""
+
+    def test_mover_household_dropped(self, roster):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = roster_to_characteristics(roster, mover_sentinel=None)
+        v_values = list(result.index.get_level_values('v'))
+        assert 'Mover' not in v_values
+        # Only the two non-mover HHs.
+        assert sorted(v_values) == ['V1', 'V2']
+        assert len(result) == 2
+
+    def test_warning_message_says_dropped(self, roster):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always", UserWarning)
+            roster_to_characteristics(roster, mover_sentinel=None)
+        msgs = [str(w.message) for w in captured
+                if 'household_characteristics' in str(w.message)]
+        assert msgs
+        assert 'dropped' in msgs[-1]
+
+
+class TestMoverSentinelIdempotenceWhenCleanInput:
+    """No NaN v -> both code paths produce identical output."""
+
+    def test_default_and_legacy_agree_when_no_movers(self, roster_no_movers):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            r_default = roster_to_characteristics(roster_no_movers)
+            r_legacy = roster_to_characteristics(roster_no_movers,
+                                                  mover_sentinel=None)
+        assert r_default.equals(r_legacy)
+
+    def test_no_warning_when_no_movers(self, roster_no_movers):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always", UserWarning)
+            roster_to_characteristics(roster_no_movers)
+        msgs = [str(w.message) for w in captured
+                if 'household_characteristics' in str(w.message)]
+        # No NaN v means neither the replace nor the drop warning
+        # should fire.
+        assert msgs == []
+
+
+class TestMoverSentinelCustomLabel:
+    """The sentinel is configurable -- pass any string."""
+
+    def test_custom_sentinel_label(self, roster):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = roster_to_characteristics(roster,
+                                                mover_sentinel='split-off')
+        v_values = list(result.index.get_level_values('v'))
+        assert 'split-off' in v_values
+        assert 'Mover' not in v_values

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -433,26 +433,32 @@ class TestUganda2009MarketFallback:
         )
 
     def test_household_characteristics_retains_hybrid_v_HH(self, hc):
-        """household_characteristics(market='Region') should cover the
-        full 2 951 HH (those with populated sample.v, hybrid or real).
+        """household_characteristics(market='Region') should cover every
+        HH in sample (2975 for Uganda 2009-10).
 
-        Pinned to equality on 2026-05-09: warm- and cold-cache probes
-        both produce 2951 exactly (Slurm jobs 34085538 and 34085552).
-        The 24-HH gap from sample's 2975 is the MonthsSpent filter in
-        roster_to_characteristics dropping departed-only HHs (added
-        2026-04-15 to resolve a 1315-HH drift vs RiskSharing_Replication;
-        see CLAUDE.md "MonthsSpent / MonthsAway / WeeksAway"). Any
-        legitimate change to that filter -- or any new attrition path
-        -- will trip this test, which is the intent: surface drift in
-        either direction.
+        Pin history:
+
+        - 2026-05-09: pinned to 2951 (sample 2975 − 24 mover HHs whose
+          NaN ``v`` was being silently dropped by the household
+          groupby, originally attributed in the comment to the
+          MonthsSpent filter).
+        - 2026-05-11 (GH #268): re-pinned to 2975.  The 24 mover HHs
+          previously dropped by the groupby now survive as
+          ``v == 'Mover'`` under the new ``mover_sentinel`` default in
+          ``roster_to_characteristics``.  Sample carried a valid
+          Region for those HHs all along, so they're correctly
+          assignable to a market.
+
+        Any further drift in either direction is meaningful: investigate
+        before re-pinning.
         """
         if "2009-10" not in hc.index.get_level_values("t").unique():
             pytest.skip("no 2009-10 wave")
         hh09 = hc.xs("2009-10", level="t").index.get_level_values("i").nunique()
-        assert hh09 == 2951, (
+        assert hh09 == 2975, (
             f"household_characteristics(market='Region') retained {hh09} HH "
-            f"in 2009-10 — expected exactly 2951 (sample 2975 − 24 "
-            f"departed-only via MonthsSpent filter). Drift in either "
+            f"in 2009-10 — expected exactly 2975 (full sample including "
+            f"mover HHs with v='Mover'; GH #268).  Drift in either "
             f"direction is meaningful: investigate before re-pinning."
         )
 


### PR DESCRIPTION
Closes #268.

## Motivation

GH #197 noted that `roster_to_characteristics`'s final
`groupby(level=final_index).sum()` relies on pandas' default
`dropna=True`, which silently excludes rows whose index has NaN in any
of `(t, v, i)` -- in practice always `v`, since `v` is joined onto the
roster post-hoc via `_join_v_from_sample` and `sample`'s `v` column is
NaN for movers / split-offs that lack a cluster code.

GH #268 argued that those movers are not phantom: `sample()`
typically carries a valid `Region` for them.  The cluster code is the
only thing genuinely missing; we can still legitimately assign such a
HH to a market via the HH-level `_add_market_index` path that uses
`sample().Region` keyed on `(i, t)`.  Dropping them at the roster
aggregation stage loses HHs we *can* place.

## Change

`roster_to_characteristics` gains a `mover_sentinel='Mover'` kwarg.
When non-None (the new default), NaN values in any `final_index` level
get filled with the sentinel before the groupby, so the HH survives as
a distinguishable bucket identifiable by
`index.get_level_values('v') == mover_sentinel`.  When `None`, the
legacy GH #197 drop behavior is recovered.

The warning emitted alongside is updated to match: it now reports
\"replaced N rows\" or \"dropped N rows\" depending on the path, and
tells the caller how to filter on the sentinel to mimic the legacy
drop downstream.

## Empirical impact

For Uganda 2009-10: 24 mover HHs that were previously dropped by the
groupby now survive as \`v='Mover'\`, bringing
\`household_characteristics(market='Region')\` HH-count from 2951 to
2975 (the full sample count).  All 24 carry a valid Region in
\`sample()\`, so they're correctly assignable to a market.

Across Uganda's eight waves, GH #197's warning previously announced
448 dropped roster rows per build; under #268 these become 448
sentinel fills.

## Tests

- \`tests/test_roster_to_characteristics_movers.py\` (new, 8
  assertions): mover HH survives as \`v='Mover'\` with correct
  sex × age bucket counts under the new default;
  \`mover_sentinel=None\` reproduces the legacy drop; clean inputs (no
  NaN v) produce identical output under both code paths and no warning
  fires; custom sentinel label is honored; warning messages mention
  \"replaced\" / \"dropped\" / sentinel value as appropriate.
- \`tests/test_sample.py::TestUganda2009MarketFallback::test_household_characteristics_retains_hybrid_v_HH\`
  re-pinned from 2951 to 2975, with a comment explaining the GH #268
  semantic shift.  The pre-#268 comment had attributed the 24-HH gap
  from sample's 2975 to the MonthsSpent filter; it was actually the
  NaN-v drop in the groupby that this PR removes.

Full related test suite (roster / transformations / household /
characteristic / cluster-fallback / hybrid_v_HH): **236 passed, 5
skipped** (skips due to absent DVC S3 creds in test env), no
failures.

## Backwards compatibility

Callers who depend on the legacy drop semantics (i.e., that
\`household_characteristics()\` returns only HHs with non-NaN v) can
restore the old behavior in one line at the call site:

\`\`\`python
df = uga.household_characteristics(market='Region')
df = df.loc[df.index.get_level_values('v') != 'Mover']
\`\`\`

Or by passing \`mover_sentinel=None\` directly if calling
\`roster_to_characteristics\`.

The signature change is additive (kwarg with a default), so existing
positional or partial-kwarg calls continue to work.