### PR TITLE
fix(country): Wave.data_scheme tolerates a missing _/ dir (closes #274)

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -370,7 +370,17 @@ class Wave:
 
     @property
     def data_scheme(self) -> list[str]:
-        wave_data = [f.stem for f in (self.file_path / "_").iterdir() if f.suffix == '.py' and f.stem not in [f'{self.wave_folder}']]
+        # A wave with no ``_/`` directory simply declares no tables
+        # (e.g. a partially-wired survey where a wave is auto-discovered
+        # from ``Documentation/SOURCE.org`` but not yet wired -- and the
+        # empty ``_/`` dir is absent on a fresh checkout since git does
+        # not track empty directories).  Treat as empty rather than
+        # raising FileNotFoundError, which otherwise poisons every
+        # Country-level ``load_from_waves`` call (GH #274).
+        _wave_dir = self.file_path / "_"
+        if not _wave_dir.is_dir():
+            return []
+        wave_data = [f.stem for f in _wave_dir.iterdir() if f.suffix == '.py' and f.stem not in [f'{self.wave_folder}']]
         # Customed
         replace_dic = { 'other_features': ['cluster_features']}
         # replace the key with the value in the dictionary


### PR DESCRIPTION
Closes #274.

### Bug

Every Country-level table on a partially-wired survey crashed:

```python
ll.Country('EthiopiaRHS').household_characteristics()  # food_expenditures(), household_roster(), ...
# FileNotFoundError: .../EthiopiaRHS/1999/_
```

### Root cause

EthiopiaRHS 1999/2004/2009 are auto-discovered as waves (committed `Documentation/SOURCE.org`) but are unwired — their `_/` and `Data/` dirs are empty, and **git does not track empty directories**, so they are absent on a fresh checkout. `Wave.data_scheme` did `(self.file_path / "_").iterdir()` with no guard → `FileNotFoundError`, and one such stub wave poisons every `load_from_waves` call. (Not seen pre-merge because the scaffold author's working tree still had the empty dirs.)

### Fix

One contained guard in `Wave.data_scheme`: a wave with no `_/` directory declares no tables → return `[]`; `load_from_waves` then skips it (`wave_has_table = False`). No behavior change for wired waves (all have `_/`). General — protects any partially-wired survey, not just EthiopiaRHS.

### Verification (`LSMS_NO_CACHE=1`, simulated fresh checkout — stub waves reduced to just `Documentation/`)

- `Country('EthiopiaRHS').household_characteristics()` → (6243, 15) ✓ (was crashing)
- `food_expenditures()` (37661, 1); `household_roster()` (40786, 6), `is_this_feature_sane` OK; waves correctly = the 5 wired ones.
- `Country('Uganda').household_characteristics()` (24273, 15) — unchanged (no regression).

Targets `development` (per current branch policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
