### PR TITLE
feat(Nigeria): plot_features (GH #167)

### DIFF
--- a/lsms_library/countries/Nigeria/2010-11/_/plot_features.py
+++ b/lsms_library/countries/Nigeria/2010-11/_/plot_features.py
@@ -1,0 +1,33 @@
+"""Build plot_features for Nigeria GHS-Panel wave 1 (2010-11; GH #167).
+
+Post-planting only -> single t = 2010Q3.  Area (sect11a1) joined onto
+plot detail (sect11b) on (hhid, plotid).  Wave 1's sect11b stops at q28,
+so it carries NO soil type, irrigation, or separate tenure-system
+question; SoilType / Irrigated / TenureSystem are NaN this wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import plot_features_for_wave, PP_QUARTER
+
+t = PP_QUARTER['2010-11']
+
+area = get_dataframe('../Data/Post Planting Wave 1/Agriculture/'
+                     'sect11a1_plantingw1.dta', convert_categoricals=False)
+detail = get_dataframe('../Data/Post Planting Wave 1/Agriculture/'
+                       'sect11b_plantingw1.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='hhid', plot_id='plotid',
+    area_est='s11aq4a', area_unit='s11aq4b', area_gps='s11aq4d',
+    acquire='s11bq4',          # tenure
+    # no soil / irrigation / tenure-system questions in W1
+)
+
+df = plot_features_for_wave(t, area, detail, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2010-11"
+assert len(df) > 0, "plot_features 2010-11 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Nigeria/2012-13/_/plot_features.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/plot_features.py
@@ -1,0 +1,33 @@
+"""Build plot_features for Nigeria GHS-Panel wave 2 (2012-13; GH #167).
+
+Post-planting only -> single t = 2012Q3.  Area (sect11a1) joined onto
+plot detail (sect11b1) on (hhid, plotid).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import plot_features_for_wave, PP_QUARTER
+
+t = PP_QUARTER['2012-13']
+
+area = get_dataframe('../Data/Post Planting Wave 2/Agriculture/'
+                     'sect11a1_plantingw2.dta', convert_categoricals=False)
+detail = get_dataframe('../Data/Post Planting Wave 2/Agriculture/'
+                       'sect11b1_plantingw2.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='hhid', plot_id='plotid',
+    area_est='s11aq4a', area_unit='s11aq4b', area_gps='s11aq4c',
+    acquire='s11b1q4',          # tenure
+    soil_type='s11b1q44',
+    irrigated='s11b1q39',
+    # no separate tenure-system question pre-W5
+)
+
+df = plot_features_for_wave(t, area, detail, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2012-13"
+assert len(df) > 0, "plot_features 2012-13 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Nigeria/2015-16/_/plot_features.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/plot_features.py
@@ -1,0 +1,33 @@
+"""Build plot_features for Nigeria GHS-Panel wave 3 (2015-16; GH #167).
+
+Post-planting only -> single t = 2015Q3.  Area (sect11a1) joined onto
+plot detail (sect11b1) on (hhid, plotid).  W3 acquire scheme has 6 codes
+(adds family inheritance = 5, sharecropped = 6).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import plot_features_for_wave, PP_QUARTER
+
+t = PP_QUARTER['2015-16']
+
+area = get_dataframe('../Data/sect11a1_plantingw3.dta',
+                     convert_categoricals=False)
+detail = get_dataframe('../Data/sect11b1_plantingw3.dta',
+                       convert_categoricals=False)
+
+colmap = dict(
+    hhid='hhid', plot_id='plotid',
+    area_est='s11aq4a', area_unit='s11aq4b', area_gps='s11aq4c',
+    acquire='s11b1q4',          # tenure
+    soil_type='s11b1q44',
+    irrigated='s11b1q39',
+)
+
+df = plot_features_for_wave(t, area, detail, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2015-16"
+assert len(df) > 0, "plot_features 2015-16 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Nigeria/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Nigeria/2018-19/_/plot_features.py
@@ -1,0 +1,36 @@
+"""Build plot_features for Nigeria GHS-Panel wave 4 (2018-19; GH #167).
+
+Post-planting only -> single t = 2018Q3.  Area (sect11a1) joined onto
+plot detail (sect11b1) on (hhid, plotid).
+
+TRAP (recon): in W4 the AREA NUMBER is s11aq4aa.  s11aq4a is a GPS
+yes/no FLAG (1/2), NOT the area -- do not use it.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import plot_features_for_wave, PP_QUARTER
+
+t = PP_QUARTER['2018-19']
+
+area = get_dataframe('../Data/sect11a1_plantingw4.dta',
+                     convert_categoricals=False)
+detail = get_dataframe('../Data/sect11b1_plantingw4.dta',
+                       convert_categoricals=False)
+
+colmap = dict(
+    hhid='hhid', plot_id='plotid',
+    area_est='s11aq4aa',        # NOT s11aq4a (that is a GPS yes/no flag)
+    area_unit='s11aq4b', area_gps='s11aq4c',
+    acquire='s11b1q4',          # tenure (7 codes)
+    soil_type='s11b1q44',
+    irrigated='s11b1q39',
+)
+
+df = plot_features_for_wave(t, area, detail, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2018-19"
+assert len(df) > 0, "plot_features 2018-19 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Nigeria/2023-24/_/plot_features.py
+++ b/lsms_library/countries/Nigeria/2023-24/_/plot_features.py
@@ -1,0 +1,40 @@
+"""Build plot_features for Nigeria GHS-Panel wave 5 (2023-24; GH #167).
+
+Post-planting only -> single t = 2023Q3.  Area (sect11a1) joined onto
+plot detail (sect11b1) on (hhid, plotid).
+
+TRAPS (recon): W5 fully RENUMBERS sect11b1.  Area number/unit are
+s11aq3_number / s11aq3_unit (units add square-foot 8/9 and football
+field 10).  GPS area is s11mq3.  Tenure acquire is s11b1q4 (9 codes);
+the separate tenure-SYSTEM question s11b1q4b appears ONLY in W5.
+Soil = s11b1q61, irrigation = s11b1q56.  Beware: s11b1q39 here is
+"right to bequeath" and s11b1q44 is "main use" -- NOT soil/irrigation.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import plot_features_for_wave, PP_QUARTER
+
+t = PP_QUARTER['2023-24']
+
+area = get_dataframe('../Data/Post Planting Wave 5/Agriculture/'
+                     'sect11a1_plantingw5.dta', convert_categoricals=False)
+detail = get_dataframe('../Data/Post Planting Wave 5/Agriculture/'
+                       'sect11b1_plantingw5.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='hhid', plot_id='plotid',
+    area_est='s11aq3_number', area_unit='s11aq3_unit', area_gps='s11mq3',
+    acquire='s11b1q4',          # tenure (9 codes)
+    tenure_system='s11b1q4b',   # W5 only
+    soil_type='s11b1q61',       # NOT s11b1q44 (= main use in W5)
+    irrigated='s11b1q56',       # NOT s11b1q39 (= right to bequeath in W5)
+)
+
+df = plot_features_for_wave(t, area, detail, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2023-24"
+assert len(df) > 0, "plot_features 2023-24 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Nigeria/_/CONTENTS.org
+++ b/lsms_library/countries/Nigeria/_/CONTENTS.org
@@ -64,3 +64,89 @@ weights but not longitudinal panel weights.
 
 - Wave 5: =ghs_panel_wave_5_basic_information_document_v1.pdf=
   (in =2023-24/Documentation/=)
+
+* plot_features (GH #167)
+
+Lasting plot characteristics from the post-planting Agriculture
+module.  Nigeria GHS-Panel is post-planting / post-harvest; the
+lasting attributes (how acquired, soil type, irrigation, tenure
+system) are recorded only in the POST-PLANTING round, so each wave
+maps to a single =t= = its PP quarter:
+
+| Wave    | t      | rows  |
+|---------+--------+-------|
+| 2010-11 | 2010Q3 |  6086 |
+| 2012-13 | 2012Q3 |  5893 |
+| 2015-16 | 2015Q3 |  5824 |
+| 2018-19 | 2018Q3 | 11076 |
+| 2023-24 | 2023Q3 |  9232 |
+|         | total  | 38111 |
+
+Index =(t, i, plot_id)=; =i= = =hhid=, =plot_id= = =plotid= (unique
+within hhid).  =v= is NOT baked in -- the framework joins it from
+=sample()= at API time.  0% duplicate index, 0% orphan vs
+=sample().i= (6936 distinct households, all present in the spine).
+=is_this_feature_sane= passes all 15 checks.
+
+** Source files
+
+Per wave, area (=sect11a1=) is joined onto plot detail
+(=sect11b= in W1, =sect11b1= in W2--W5) on =(hhid, plotid)=:
+
+| Field        | W1 (2010-11) | W2 (2012-13) | W3 (2015-16) | W4 (2018-19) | W5 (2023-24)  |
+|--------------+--------------+--------------+--------------+--------------+---------------|
+| area number  | s11aq4a      | s11aq4a      | s11aq4a      | s11aq4aa     | s11aq3_number |
+| area unit    | s11aq4b      | s11aq4b      | s11aq4b      | s11aq4b      | s11aq3_unit   |
+| GPS (sqm)    | s11aq4d      | s11aq4c      | s11aq4c      | s11aq4c      | s11mq3        |
+| acquire      | s11bq4       | s11b1q4      | s11b1q4      | s11b1q4      | s11b1q4       |
+| soil type    | --           | s11b1q44     | s11b1q44     | s11b1q44     | s11b1q61      |
+| irrigated    | --           | s11b1q39     | s11b1q39     | s11b1q39     | s11b1q56      |
+| tenure sys.  | --           | --           | --           | --           | s11b1q4b      |
+
+Traps avoided (per recon recipe):
+- W4 =s11aq4a= is a GPS yes/no FLAG, not the area; the area number is
+  =s11aq4aa=.
+- W5 fully renumbers =sect11b1=: =s11b1q39= = "right to bequeath" and
+  =s11b1q44= = "main use", NOT irrigation / soil.  Use =s11b1q56= /
+  =s11b1q61=.
+
+** Area conversion
+
+=Area= is in hectares.  Preference: GPS measurement (m^2 / 10000).
+Where GPS is missing, fall back to the farmer estimate ONLY for
+convertible units: acres (x0.404686), hectares (x1), square metres
+(/10000).  The NON-STANDARD local units (heaps, ridges, stands, plots,
+and W5's square-foot 8/9 and football-field 10) have no in-repo
+conversion factor -- for those rows =Area= is taken from GPS, and where
+GPS is missing =Area= is NaN while =AreaUnit= carries the native label.
+A >1000 ha plausibility clamp drops data-entry errors to NaN.
+Net: ~86.6% of rows have a non-null Area; non-standard units dominate
+W1--W3 (per the refuter, convertible-unit share is W1 29% / W2 28% /
+W3 25% / W4 56% / W5 49%).
+
+** Harmonization (=categorical_mapping.org=)
+
+- =harmonize_acquire= -> Tenure.  WAVE-KEYED =(Wave, Code)=: the
+  acquire scheme evolves (W1/W2 4 codes, W3 6, W4 7, W5 9 with a full
+  re-order), so a flat code map would mislabel rows (the Uganda pilot
+  bug).  purchase->owned, rented->rented_in, inheritance->inherited,
+  sharecropped-in->sharecropped_in, used-free / community / customary
+  ->communal, temporary-exchange / government / gift->other_tenure.
+- =harmonize_tenure_system= -> TenureSystem.  W5 only (=s11b1q4b=);
+  state / community / cooperative extend the canonical spellings.
+- =harmonize_soil= -> SoilType.  Stable W2--W5; W1 has no soil
+  question (SoilType NaN that wave).
+- Irrigated: 1=Yes, 2=No; the 11 ".A" sentinel and any other value
+  -> NaN.
+
+** Caveats / blockers
+
+- W1 (2010-11) carries NO soil type, irrigation, or separate
+  tenure-system question (=sect11b= stops at q28) -> those columns are
+  NaN for the entire wave.
+- TenureSystem is populated for W5 only.
+- Latitude / Longitude DEFERRED: Nigeria records only GPS plot AREA in
+  m^2, no decimal-degree parcel coordinates.
+- No id_walk applied at the country level: GHS-Panel hhids are stable
+  across waves (panel_ids maps previous_i = hhid), so there is no
+  per-wave remapping dict (mirrors Nigeria food_acquired).

--- a/lsms_library/countries/Nigeria/_/categorical_mapping.org
+++ b/lsms_library/countries/Nigeria/_/categorical_mapping.org
@@ -401,3 +401,96 @@
 | Wood                 | Wood            |
 | Terrazzo             | Tiles           |
 | Marble               | Tiles           |
+
+* plot_features harmonization tables (GH #167)
+
+  Lasting plot characteristics from the post-planting Agriculture
+  module sect11b / sect11b1.  See =Nigeria/_/nigeria.py=
+  (=plot_features_for_wave=) and the per-wave
+  =Nigeria/{wave}/_/plot_features.py= scripts.
+
+** harmonize_acquire (WAVE-KEYED)
+
+  The "How was [PLOT] acquired?" code scheme EVOLVES across waves
+  (s11bq4 in W1; s11b1q4 in W2--W5): W1/W2 have 4 codes, W3 has 6,
+  W4 has 7, W5 fully re-orders to 9 codes (e.g. W5 code 2 = "rented
+  in", W4 code 2 = "rented for cash/inkind").  So the lookup MUST be
+  keyed on (Wave, Code) -- a flat Code map would mislabel rows.  This
+  mirrors the Uganda wave-keyed-acquire lesson (GH #167 pilot).
+
+  Canonical Tenure spellings (from lsms_library/data_info.yml):
+  purchase -> owned; rented -> rented_in; inheritance -> inherited;
+  sharecropped in -> sharecropped_in; used-free / distributed-by-
+  community / granted-by-customary-or-community -> communal;
+  temporary-land-exchange / allocated-by-government / gifted ->
+  other_tenure.  Codes absent for a wave map to NaN (no silent
+  default).
+
+#+NAME: harmonize_acquire
+| Wave    | Code | Preferred Label |
+|---------+------+-----------------|
+| 2010-11 |    1 | owned           |
+| 2010-11 |    2 | rented_in       |
+| 2010-11 |    3 | communal        |
+| 2010-11 |    4 | communal        |
+| 2012-13 |    1 | owned           |
+| 2012-13 |    2 | rented_in       |
+| 2012-13 |    3 | communal        |
+| 2012-13 |    4 | communal        |
+| 2015-16 |    1 | owned           |
+| 2015-16 |    2 | rented_in       |
+| 2015-16 |    3 | communal        |
+| 2015-16 |    4 | communal        |
+| 2015-16 |    5 | inherited       |
+| 2015-16 |    6 | sharecropped_in |
+| 2018-19 |    1 | owned           |
+| 2018-19 |    2 | rented_in       |
+| 2018-19 |    3 | communal        |
+| 2018-19 |    4 | communal        |
+| 2018-19 |    5 | inherited       |
+| 2018-19 |    6 | sharecropped_in |
+| 2018-19 |    7 | other_tenure    |
+| 2023-24 |    1 | owned           |
+| 2023-24 |    2 | rented_in       |
+| 2023-24 |    3 | communal        |
+| 2023-24 |    4 | communal        |
+| 2023-24 |    5 | inherited       |
+| 2023-24 |    6 | sharecropped_in |
+| 2023-24 |    7 | other_tenure    |
+| 2023-24 |    8 | other_tenure    |
+| 2023-24 |    9 | other_tenure    |
+
+** harmonize_tenure_system (W5 only: s11b1q4b)
+
+  Only the 2023-24 (W5) questionnaire asks the legal/customary tenure
+  regime separately (s11b1q4b).  Earlier waves leave TenureSystem NaN.
+  Canonical TenureSystem spellings: state / community / cooperative
+  were extended for this cross-country rollout (GH #167).
+
+#+NAME: harmonize_tenure_system
+| Code | Preferred Label     |
+|------+---------------------|
+|    1 | customary           |
+|    2 | freehold            |
+|    3 | leasehold           |
+|    4 | state               |
+|    5 | community           |
+|    6 | cooperative         |
+|   96 | other_tenure_system |
+
+** harmonize_soil (stable W2--W5: s11b1q44 / W5 s11b1q61)
+
+  W1 (2010-11) does not ask soil type -> SoilType NaN that wave.
+  SoilType has no canonical spellings constraint in data_info.yml, so
+  these descriptive labels are carried as-is.
+
+#+NAME: harmonize_soil
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | sandy           |
+|    2 | clay            |
+|    3 | sandy_clay      |
+|    4 | forest_loam     |
+|    5 | loamy           |
+|    6 | other           |
+|   96 | other           |

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -71,4 +71,23 @@ Data Scheme:
     Floor: str
     materialize: make
 
+  plot_features:
+    # Lasting plot characteristics from the post-planting Agriculture
+    # module (GH #167).  Nigeria is post-planting/post-harvest; lasting
+    # attributes are recorded only in the PP round, so each wave maps to
+    # a single t = PP quarter (2010Q3, 2012Q3, 2015Q3, 2018Q3, 2023Q3).
+    # Area (sect11a1) is joined onto plot detail (sect11b/sect11b1) on
+    # (hhid, plotid) -- two files per wave -> materialize: make.
+    # Latitude / Longitude deferred (no decimal-degree parcel coords;
+    # only GPS area in m^2).  W1 lacks soil / irrigation / tenure-system;
+    # TenureSystem populated for W5 only.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    SoilType: str
+    Irrigated: bool
+    materialize: make
+
   nonfood_expenditures: !make

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -1,6 +1,16 @@
 
+import os
 import pandas as pd
 import numpy as np
+
+if __name__ == '__main__':
+    import sys
+    sys.path.append('../../_')
+    sys.path.append('../../../_')
+    from local_tools import format_id
+else:
+    from lsms_library.local_tools import format_id
+
 Waves = {'2010-11': (),
          '2012-13': (),
          '2015-16': (),
@@ -21,4 +31,240 @@ wave_folder_map = {
     '2023Q3': '2023-24',
     '2024Q1': '2023-24',
 }
+
+
+# ---------------------------------------------------------------------
+# plot_features (GH #167)
+# ---------------------------------------------------------------------
+
+# Post-planting quarter assigned as the single `t` for each wave's
+# plot_features.  Lasting plot attributes are recorded only in the
+# post-planting round (the post-harvest sect11 files are crop-level), so
+# each wave contributes exactly one t value.  These are a subset of the
+# quarter-based t values used elsewhere for Nigeria (see `waves`).
+PP_QUARTER = {
+    '2010-11': '2010Q3',
+    '2012-13': '2012Q3',
+    '2015-16': '2015Q3',
+    '2018-19': '2018Q3',
+    '2023-24': '2023Q3',
+}
+
+HECTARES_PER_ACRE = 0.404686          # 1 acre  = 0.404686 ha
+SQM_PER_HECTARE = 10000.0             # 1 ha    = 10,000 m^2
+
+# Native area-unit codes -> descriptive labels (for AreaUnit) and the
+# hectare conversion factor where a standard conversion exists.
+# Non-standard local units (heaps/ridges/stands/plots, and W5's
+# square-foot / football-field) have NO in-repo conversion factor, so
+# Area for those rows comes from the GPS measurement only; where GPS is
+# missing, Area is NaN and AreaUnit carries the native label.
+_AREA_UNIT_LABEL = {
+    1: 'heaps', 2: 'ridges', 3: 'stands', 4: 'plots',
+    5: 'acres', 6: 'hectares', 7: 'square metres',
+    8: 'square foot (100x100)', 9: 'square foot (100x50)',
+    10: 'football field',
+}
+_AREA_UNIT_TO_HA = {        # convertible estimate units only
+    5: HECTARES_PER_ACRE,
+    6: 1.0,
+    7: 1.0 / SQM_PER_HECTARE,
+}
+
+
+def _harmonize_acquire_table():
+    """Return {(Wave, Code): Preferred Label} from harmonize_acquire in
+    Nigeria/_/categorical_mapping.org.  Wave-keyed because the acquire
+    code scheme evolves across waves (GH #167).  Codes absent from the
+    table map to NaN (no silent default)."""
+    from lsms_library.local_tools import df_from_orgfile
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates = [
+        os.path.join(here, 'categorical_mapping.org'),
+        os.path.abspath(os.path.join('..', '..', '_',
+                                     'categorical_mapping.org')),
+        'categorical_mapping.org',
+    ]
+    orgfn = next((c for c in candidates if os.path.exists(c)), candidates[0])
+
+    df = df_from_orgfile(orgfn, name='harmonize_acquire',
+                         set_columns=True, to_numeric=True)
+    out = {}
+    for _, row in df.iterrows():
+        wv = str(row['Wave']).strip()
+        c = row['Code']
+        try:
+            c = int(c)
+        except (TypeError, ValueError):
+            pass
+        lab = row.get('Preferred Label')
+        if pd.isna(lab):
+            continue
+        out[(wv, c)] = str(lab).strip()
+    return out
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a {int Code: Preferred Label} dict from a single-Code-keyed
+    table in categorical_mapping.org (harmonize_soil /
+    harmonize_tenure_system).  NaN labels -> pd.NA."""
+    from lsms_library.local_tools import get_categorical_mapping
+
+    raw = get_categorical_mapping(tablename=tablename, idxvars=key,
+                                  **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw-Stata-code) Series through ``code_map``.
+    Returns a nullable string Series with NaN where the code is unmapped.
+    Sources are loaded with convert_categoricals=False so the codes are
+    integers."""
+    if series is None:
+        return None
+    out = pd.to_numeric(series, errors='coerce').astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_features_for_wave(t, area, detail, colmap):
+    """Build canonical ``plot_features`` for one Nigeria GHS-Panel wave.
+
+    Nigeria is a post-planting / post-harvest survey; lasting plot
+    attributes live only in the post-planting round, so each wave maps
+    to a single ``t`` (the PP quarter).  The area question (sect11a1)
+    and the plot-detail question (sect11b / sect11b1) are separate
+    files joined on (hhid, plotid).
+
+    Parameters
+    ----------
+    t : str
+        PP-quarter wave id (e.g. ``'2010Q3'``), used as the ``t`` index.
+    area : pd.DataFrame
+        Raw sect11a1 (area) frame, loaded with
+        ``get_dataframe(..., convert_categoricals=False)``.
+    detail : pd.DataFrame | None
+        Raw sect11b / sect11b1 (tenure / soil / irrigation) frame, same
+        loading convention.  ``None`` permitted (none of the waves need
+        it, but defensive).
+    colmap : dict
+        Per-wave column-name map.  Keys:
+            hhid, plot_id                  (required, in `area`)
+            area_est, area_unit, area_gps  (in `area`; area_gps in sqm)
+            acquire                        (in `detail`; -> Tenure)
+            tenure_system                  (in `detail`; W5 only)
+            soil_type                      (in `detail`; W2+ only)
+            irrigated                      (in `detail`; W2+ only)
+        Omitted / absent columns yield NaN for the corresponding output.
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
+        ``Area`` (hectares float), ``AreaUnit`` (native unit label),
+        ``Tenure``, ``TenureSystem``, ``SoilType`` (str) and
+        ``Irrigated`` (nullable boolean).  Latitude / Longitude are
+        deferred (Nigeria has no decimal-degree parcel coordinates;
+        only GPS area in m^2).
+    """
+    c = colmap
+    wave_label = wave_folder_map.get(t, t)   # PP quarter -> 'YYYY-YY'
+
+    acquire_map = _harmonize_acquire_table()
+    soil_map = _harmonized_codes('harmonize_soil')
+    tenure_system_map = _harmonized_codes('harmonize_tenure_system')
+
+    a = area.copy()
+    hh = a[c['hhid']].apply(format_id)
+    plot_id = a[c['plot_id']].apply(format_id)
+
+    # --- Area (hectares) ---
+    unit_code = (pd.to_numeric(a[c['area_unit']], errors='coerce').astype('Int64')
+                 if c.get('area_unit') in a.columns
+                 else pd.Series(pd.NA, index=a.index, dtype='Int64'))
+
+    # GPS measurement (square metres) -> hectares.
+    area_ha = pd.Series(pd.NA, index=a.index, dtype='Float64')
+    if c.get('area_gps') in a.columns:
+        gps = pd.to_numeric(a[c['area_gps']], errors='coerce').astype('Float64')
+        area_ha = gps / SQM_PER_HECTARE
+
+    # Fall back to the farmer estimate ONLY for convertible units
+    # (acres / hectares / square metres).  Non-standard units have no
+    # conversion factor -> leave Area NaN (GPS-only).
+    if c.get('area_est') in a.columns:
+        est = pd.to_numeric(a[c['area_est']], errors='coerce').astype('Float64')
+        factor = unit_code.map(_AREA_UNIT_TO_HA).astype('Float64')
+        est_ha = est * factor                 # NaN where unit non-convertible
+        area_ha = area_ha.where(area_ha.notna(), est_ha)
+
+    # Plausibility clamp: > 1000 ha is a data-entry error for a Nigerian
+    # smallholder plot; drop to NaN.
+    area_ha = area_ha.where((area_ha <= 1000) | area_ha.isna(), pd.NA)
+
+    # AreaUnit: native reported unit label (documents the unit even where
+    # Area is NaN for non-standard units / missing GPS).
+    area_unit = unit_code.map(_AREA_UNIT_LABEL).astype('string')
+
+    pieces = pd.DataFrame({
+        'i': hh.values,
+        'plot_id': plot_id.values,
+        'Area': area_ha.values,
+        'AreaUnit': area_unit.values,
+    })
+
+    # --- Detail columns joined on (hhid, plotid) ---
+    tenure = pd.Series(pd.NA, index=a.index, dtype='string')
+    tenure_system = pd.Series(pd.NA, index=a.index, dtype='string')
+    soil_type = pd.Series(pd.NA, index=a.index, dtype='string')
+    irrigated = pd.Series(pd.NA, index=a.index, dtype='boolean')
+
+    if detail is not None and not detail.empty:
+        d = detail.copy()
+        d_hh = d[c['hhid']].apply(format_id)
+        d_plot = d[c['plot_id']].apply(format_id)
+        det = pd.DataFrame({'i': d_hh.values, 'plot_id': d_plot.values})
+
+        if c.get('acquire') in d.columns:
+            acq = pd.to_numeric(d[c['acquire']], errors='coerce').astype('Int64')
+            det['Tenure'] = acq.map(
+                lambda code: acquire_map.get((wave_label, int(code)))
+                if pd.notna(code) else pd.NA).astype('string').values
+        if c.get('tenure_system') in d.columns:
+            det['TenureSystem'] = _map_codes(d[c['tenure_system']],
+                                             tenure_system_map).values
+        if c.get('soil_type') in d.columns:
+            det['SoilType'] = _map_codes(d[c['soil_type']], soil_map).values
+        if c.get('irrigated') in d.columns:
+            irr = pd.to_numeric(d[c['irrigated']], errors='coerce')
+            # 1 = Yes, 2 = No; 11 (.A sentinel) and anything else -> NaN.
+            irr_bool = pd.Series(pd.NA, index=d.index, dtype='boolean')
+            irr_bool = irr_bool.where(~(irr == 1), True)
+            irr_bool = irr_bool.where(~(irr == 2), False)
+            det['Irrigated'] = irr_bool.values
+
+        # Detail is unique on (i, plot_id); drop dup detail rows defensively.
+        det = det.drop_duplicates(subset=['i', 'plot_id'])
+        pieces = pieces.merge(det, on=['i', 'plot_id'], how='left')
+
+    # Ensure all canonical columns exist.
+    for col, dtype in (('Tenure', 'string'), ('TenureSystem', 'string'),
+                       ('SoilType', 'string'), ('Irrigated', 'boolean')):
+        if col not in pieces.columns:
+            pieces[col] = pd.Series(pd.NA, index=pieces.index, dtype=dtype)
+
+    pieces['t'] = t
+    pieces = pieces[['t', 'i', 'plot_id', 'Area', 'AreaUnit', 'Tenure',
+                     'TenureSystem', 'SoilType', 'Irrigated']]
+    pieces = pieces.set_index(['t', 'i', 'plot_id'])
+    return pieces
 

--- a/lsms_library/countries/Nigeria/_/plot_features.py
+++ b/lsms_library/countries/Nigeria/_/plot_features.py
@@ -1,0 +1,34 @@
+"""Concatenate wave-level plot_features for Nigeria (GH #167).
+
+Each wave's ``Nigeria/<wave>/_/plot_features.py`` writes a parquet
+indexed by ``(t, i, plot_id)`` with the canonical columns (Area,
+AreaUnit, Tenure, TenureSystem, SoilType, Irrigated).  This script
+concatenates them into the country-level table.
+
+No id_walk is applied: Nigeria GHS-Panel household ids (hhid) are
+stable across waves -- the panel_ids feature maps previous_i = hhid --
+so there is no per-wave remapping dict.  This mirrors Nigeria's
+food_acquired country-level concatenator.  `v` is intentionally absent;
+the framework joins it from sample() at API time.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import Waves
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/plot_features.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired (script absent or parquet not yet built).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_features: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/plot_features.parquet')


### PR DESCRIPTION
Wire `plot_features` for **Nigeria GHS-Panel** (post-planting/post-harvest) across all 5 waves, per the validated recon recipe (`slurm_logs/2026-06-03_session/RECON_Nigeria.md`, refuter verdict SAFE AS-IS) and the Uganda Phase-1 pilot pattern.

## Design
- Lasting plot attributes are **post-planting only** → each wave maps to a single `t` = PP quarter (2010Q3, 2012Q3, 2015Q3, 2018Q3, 2023Q3).
- Area (`sect11a1`) joined onto plot detail (`sect11b` in W1, `sect11b1` in W2–W5) on `(hhid, plotid)` → `materialize: make`.
- `Area` in hectares: GPS (m²/10000) preferred; farmer-estimate fallback **only** for convertible units (acres/ha/sqm). Non-standard local units (heaps/ridges/stands/plots, W5 sq-foot/football-field) have no factor → Area from GPS, else NaN with native `AreaUnit` label.
- `harmonize_acquire` → Tenure is **WAVE-KEYED `(Wave, Code)`** — the acquire scheme evolves (W1/W2 4-code, W3 6, W4 7, W5 9 fully re-ordered); a flat map would mislabel rows (the Uganda pilot bug).
- TenureSystem: W5 only (`s11b1q4b`). SoilType: stable W2–W5. W1 lacks soil/irrigation/tenure-system → NaN.
- `i = hhid`, `plot_id = plotid`; `v` not baked (framework joins from `sample()`). No country-level id_walk — GHS-Panel hhids are stable across waves.

## Traps avoided
- W4 area number is `s11aq4aa` (`s11aq4a` is a GPS yes/no flag).
- W5 renumbers `sect11b1`: `s11b1q39`=bequeath, `s11b1q44`=main-use → soil=`s11b1q61`, irrigation=`s11b1q56`.

## Verification
- `is_this_feature_sane` passes **all 15 checks**, `ok=True`.
- 38,111 rows: 6086 / 5893 / 5824 / 11076 / 9232 per wave (matches recon estimates exactly).
- 0% duplicate index; **0% orphan** vs `sample().i` (6936 distinct hh, all in spine).
- ~86.6% of rows have non-null Area; median 0.27 ha.
- Tenure / SoilType / TenureSystem all map to canonical spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)