### PR TITLE
feat(Tanzania): plot_features 2019-20+2020-21 (GH #167)

### DIFF
--- a/lsms_library/countries/Tanzania/2019-20/_/plot_features.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/plot_features.py
@@ -1,0 +1,34 @@
+"""plot_features for Tanzania NPS 2019-20 (NPS-SDD, Extended Panel; GH #167).
+
+Merges plot area (AG_SEC_02) onto plot detail (AG_SEC_3A) on
+(sdd_hhid, plotnum).  Emits raw sdd_hhid as ``i``; the country-level
+concatenator applies id_walk and the framework joins ``v`` from
+sample().  GPS coordinates in AG_SEC_02 are confidential / redacted and
+are not emitted.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import plot_features_for_wave
+
+
+sec02 = get_dataframe('../Data/AG_SEC_02.dta', convert_categoricals=False)
+sec3a = get_dataframe('../Data/AG_SEC_3A.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid       = 'sdd_hhid',
+    plot       = 'plotnum',
+    area_est   = 'ag2a_04',
+    area_gps   = 'ag2a_09',
+    use        = 'ag3a_03',
+    soil_type  = 'ag3a_10',
+    irrigated  = 'ag3a_18',
+    acquire    = 'ag3a_25',
+    legal_cert = 'ag3a_28a',
+)
+
+df = plot_features_for_wave('2019-20', sec02, sec3a, colmap)
+assert df.index.is_unique, "plot_features 2019-20: (t,i,plot_id) not unique"
+assert len(df) > 0
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Tanzania/2020-21/_/plot_features.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/plot_features.py
@@ -1,0 +1,35 @@
+"""plot_features for Tanzania NPS 2020-21 (NPS Y5, Refresh Panel; GH #167).
+
+Merges plot area (ag_sec_02) onto plot detail (ag_sec_3a) on
+(y5_hhid, plot_id).  Note: unlike 2019-20, BOTH 2020-21 modules key on
+``plot_id`` (there is no ``plotnum`` column).  Emits raw y5_hhid as
+``i``; the country-level concatenator applies id_walk and the framework
+joins ``v`` from sample().  GPS coordinates in ag_sec_02 are
+confidential / redacted and are not emitted.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import plot_features_for_wave
+
+
+sec02 = get_dataframe('../Data/ag_sec_02.dta', convert_categoricals=False)
+sec3a = get_dataframe('../Data/ag_sec_3a.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid       = 'y5_hhid',
+    plot       = 'plot_id',
+    area_est   = 'ag2a_04',
+    area_gps   = 'ag2a_09',
+    use        = 'ag3a_03',
+    soil_type  = 'ag3a_10',
+    irrigated  = 'ag3a_18',
+    acquire    = 'ag3a_25',
+    legal_cert = 'ag3a_28a',
+)
+
+df = plot_features_for_wave('2020-21', sec02, sec3a, colmap)
+assert df.index.is_unique, "plot_features 2020-21: (t,i,plot_id) not unique"
+assert len(df) > 0
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Tanzania/_/CONTENTS.org
+++ b/lsms_library/countries/Tanzania/_/CONTENTS.org
@@ -585,3 +585,66 @@ CLOSED: [2023-03-03 Fri 11:26]
 CLOSED: [2023-03-07 Tue 11:32]
 ** DONE shocks.py
 CLOSED: [2023-03-23 Thu 15:59]
+
+* plot_features (GH #167)
+
+Lasting plot characteristics, index =(t, i, plot_id)=, columns Area
+(hectares, float), AreaUnit, Tenure, TenureSystem, SoilType, Irrigated.
+Built via =materialize: make= as a cross-file merge of two NPS
+agriculture modules per wave:
+
+- =AG_SEC_02= :: plot area --- farmer estimate =ag2a_04= (acres) and
+  GPS-measured =ag2a_09= (acres).  GPS is preferred where present,
+  farmer estimate is the fallback.  Acres are converted to hectares
+  (=x 0.404686=); =AreaUnit= records the original survey unit.  A
+  plausibility clamp drops areas > 2500 acres (~1000 ha; the 2020-21
+  GPS column has a 28710-acre data-entry outlier) and non-positive
+  areas to NaN.
+- =AG_SEC_3A= :: plot detail --- use status =ag3a_03=, soil type
+  =ag3a_10=, irrigation =ag3a_18=, how-acquired =ag3a_25=, certificate
+  of occupancy =ag3a_28a=.
+
+The merge is on (hhid, plot) and is a clean 1:1 in both waves (2305/2305
+and 6560/6560 rows; zero unmatched).
+
+** Buildable waves (2 of 6)
+
+- 2019-20 (NPS-SDD, Extended Panel) :: key =(sdd_hhid, plotnum)=; 2305 plots.
+- 2020-21 (NPS Y5, Refresh Panel)   :: key =(y5_hhid, plot_id)=; 6560 plots.
+  Note: BOTH 2020-21 modules key on =plot_id= (there is no =plotnum=
+  column in 2020-21, unlike 2019-20).
+
+These two waves track disjoint sub-panels by design (see the panel
+design note above), so they share no household IDs.
+
+** Deferred
+
+- 2008-15 (rounds 2008-09 / 2010-11 / 2012-13 / 2014-15) :: NO
+  agriculture source file on disk (only =upd4_hh_*= consumption files
+  are DVC-tracked).  Deferred until the UPD ag file is DVC-added.
+
+** Harmonization
+
+Code -> canonical-label tables live in =Tanzania/_/categorical_mapping.org=
+(=harmonize_tenure=, =harmonize_tenure_system=, =harmonize_soil=).  The
+AG_SEC_3A categorical code scheme is IDENTICAL across the two buildable
+waves (verified against the Stata value labels), so the tables are keyed
+on the integer code, not the label string (2020-21 lowercases several
+labels).  =Tenure= comes from =ag3a_25= with an override to =rented_out=
+where =ag3a_03= use-status is 2 (RENTED OUT) or 3 (GIVEN OUT).
+=TenureSystem= comes from =ag3a_28a= (1 -> granted_right_of_occupancy,
+2 -> customary, 3 NO CERTIFICATE -> NaN); =granted_right_of_occupancy=
+was added to the canonical TenureSystem spellings for this rollout.
+
+** GPS redaction
+
+=AG_SEC_02= carries =ag2a_07__Latitude= / =ag2a_07__Longitude=, but
+these are CONFIDENTIAL / redacted in the WB microdata.  Latitude /
+Longitude are therefore NOT emitted.
+
+** Files
+
+- =Tanzania/_/tanzania.py= :: =plot_features_for_wave()= shared helper
+  (+ =_plot_harmonized_codes=, =_map_plot_codes=).
+- =Tanzania/2019-20/_/plot_features.py=, =Tanzania/2020-21/_/plot_features.py= :: per-wave scripts.
+- =Tanzania/_/plot_features.py= :: country concatenator (concat + id_walk).

--- a/lsms_library/countries/Tanzania/_/Makefile
+++ b/lsms_library/countries/Tanzania/_/Makefile
@@ -39,6 +39,15 @@ $(VAR_DIR)/shocks.parquet: shocks.py $(shocks_parquet)
 ../%/_/shocks.parquet:
 	(cd $(@D) && python shocks.py)
 
+plot_features = $(shell find $(rounds) -name plot_features.py)
+plot_features_parquet := $(plot_features:.py=.parquet)
+
+$(VAR_DIR)/plot_features.parquet: plot_features.py $(plot_features_parquet)
+	python plot_features.py
+
+../%/_/plot_features.parquet:
+	(cd $(@D) && python plot_features.py)
+
 %.parquet: %.py CONTENTS.org tanzania.py
 	(cd $(@D) && python ./$(<F))
 

--- a/lsms_library/countries/Tanzania/_/categorical_mapping.org
+++ b/lsms_library/countries/Tanzania/_/categorical_mapping.org
@@ -447,3 +447,51 @@
 | Sand/Cement                    | Cement          |
 | Concrete Slab                  | Concrete        |
 | Timber                         | Wood            |
+
+* plot_features (GH #167)
+
+# Code -> canonical-label tables consumed by
+# tanzania.plot_features_for_wave (see Tanzania/_/tanzania.py).  Both
+# NPS waves with an agriculture roster (2019-20 NPS-SDD Extended
+# Panel, 2020-21 NPS Y5 Refresh Panel) share an IDENTICAL integer
+# code scheme for the AG_SEC_3A categorical variables (verified by
+# reading the Stata value labels directly), so a single non-wave-keyed
+# (Code) table per concept is sufficient.  We key on the integer code,
+# never on the label string -- 2020-21 lowercases several labels
+# ('loam' vs 'LOAM', 'inheritance' vs 'INHERITANCE').
+
+# harmonize_tenure -- ag3a_25 "How did you acquire this plot?" codes to
+# canonical Tenure spellings.  An override is applied in code from
+# ag3a_03 use-status (2 RENTED OUT / 3 GIVEN OUT -> rented_out).
+#+name: harmonize_tenure
+| Code | Preferred Label  |
+|------+------------------|
+|    1 | inherited        |
+|    2 | inherited        |
+|    3 | other_tenure     |
+|    4 | communal         |
+|    5 | owned            |
+|    6 | other_tenure     |
+|    7 | rented_in        |
+|    8 | sharecropped_in  |
+|    9 | sharecropped_out |
+|   10 | communal         |
+|   11 | other_tenure     |
+
+# harmonize_tenure_system -- ag3a_28a certificate-of-occupancy codes to
+# canonical TenureSystem spellings.  Code 3 (NO CERTIFICATE) is absent
+# from the table and therefore maps to NaN.
+#+name: harmonize_tenure_system
+| Code | Preferred Label            |
+|------+----------------------------|
+|    1 | granted_right_of_occupancy |
+|    2 | customary                  |
+
+# harmonize_soil -- ag3a_10 soil-type codes to canonical SoilType.
+#+name: harmonize_soil
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | sandy           |
+|    2 | loam            |
+|    3 | clay            |
+|    4 | other           |

--- a/lsms_library/countries/Tanzania/_/data_scheme.yml
+++ b/lsms_library/countries/Tanzania/_/data_scheme.yml
@@ -63,3 +63,17 @@ Data Scheme:
     index: (t, i)
     Roof: str
     Floor: str
+
+  plot_features:
+    # Lasting plot characteristics (GH #167).  Cross-file merge of
+    # AG_SEC_02 (area) and AG_SEC_3A (soil/irrigation/tenure) per wave;
+    # only 2019-20 and 2020-21 are buildable (2008-15 lacks an ag
+    # source on disk).  GPS coordinates are redacted in the source.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    SoilType: str
+    Irrigated: bool
+    materialize: make

--- a/lsms_library/countries/Tanzania/_/plot_features.py
+++ b/lsms_library/countries/Tanzania/_/plot_features.py
@@ -1,0 +1,42 @@
+"""Concatenate wave-level plot_features data for Tanzania NPS (GH #167).
+
+Each buildable wave's ``Tanzania/<wave>/_/plot_features.py`` produces a
+parquet with index ``(t, i, plot_id)`` and the canonical columns from
+data_info.yml (Area, AreaUnit, Tenure, TenureSystem, SoilType,
+Irrigated).  This script concatenates the per-wave parquets and applies
+cross-wave id_walk so the household index uses the panel canonical id
+scheme.
+
+Only 2019-20 (NPS-SDD Extended Panel) and 2020-21 (NPS Y5 Refresh
+Panel) are buildable: the 2008-15 multi-round folder has no agriculture
+source file on disk, so those four rounds are deferred.
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import id_walk
+
+
+WAVES = ['2019-20', '2020-21']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_features.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built.  DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_features: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids, hh_index='i')
+
+to_parquet(p, '../var/plot_features.parquet')

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -692,3 +692,137 @@ def panel_ids(Waves):
         wave_matches, check_id_split = update_id(wave_matches,  check_id_split)
         updated_wave[wave_year] = wave_matches
     return recursive_D, updated_wave
+
+
+# ---------------------------------------------------------------------
+# plot_features (GH #167)
+# ---------------------------------------------------------------------
+
+ACRES_PER_HECTARE = 2.471053814671653  # 1 ha = 2.471... acres
+HECTARES_PER_ACRE = 1.0 / ACRES_PER_HECTARE  # 0.404686 ha / acre
+
+
+def _plot_harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a {int code -> Preferred Label} dict from
+    Tanzania/_/categorical_mapping.org.  Codes whose Preferred Label is
+    blank / '---' map to pd.NA (so the column is left NaN)."""
+    from lsms_library.local_tools import get_categorical_mapping
+
+    raw = get_categorical_mapping(tablename=tablename, idxvars=key,
+                                  **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_plot_codes(series, code_map):
+    """Map a numeric (raw Stata) Series through ``code_map`` ({int: str}).
+    Returns a nullable string Series, NaN where the code is unmapped."""
+    if series is None:
+        return None
+    out = pd.to_numeric(series, errors='coerce').astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_features_for_wave(t, sec02, sec3a, colmap):
+    """Build canonical ``plot_features`` for one Tanzania NPS wave.
+
+    The two source modules are merged on (hhid, plot):
+      AG_SEC_02 — plot area: farmer estimate (acres) + GPS-measured (acres).
+      AG_SEC_3A — plot detail: use status, soil type, irrigation, how
+                  acquired, and certificate of occupancy.
+
+    Parameters
+    ----------
+    t : str
+        Wave id ('2019-20' or '2020-21'); used as the ``t`` index value.
+    sec02, sec3a : pd.DataFrame
+        Raw AG_SEC_02 / AG_SEC_3A frames, loaded via
+        ``get_dataframe(..., convert_categoricals=False)`` so categorical
+        columns carry integer codes.
+    colmap : dict with keys
+        hhid       — household id column (sdd_hhid / y5_hhid)
+        plot       — within-HH plot column (plotnum / plot_id)
+        area_est   — farmer-estimated area, acres (ag2a_04)
+        area_gps   — GPS-measured area, acres   (ag2a_09)
+        use        — plot use status            (ag3a_03)
+        soil_type  — soil type                  (ag3a_10)
+        irrigated  — irrigated y/n              (ag3a_18)
+        acquire    — how acquired               (ag3a_25)
+        legal_cert — certificate of occupancy   (ag3a_28a)
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
+        Area (hectares, float), AreaUnit (str, 'acres'), Tenure (str),
+        TenureSystem (str), SoilType (str), Irrigated (bool nullable).
+    GPS coordinates (ag2a_07__Latitude/Longitude) are CONFIDENTIAL /
+    redacted in the source and are deliberately NOT emitted.
+    """
+    c = colmap
+    tenure_map = _plot_harmonized_codes('harmonize_tenure')
+    tenure_system_map = _plot_harmonized_codes('harmonize_tenure_system')
+    soil_map = _plot_harmonized_codes('harmonize_soil')
+
+    # --- AG_SEC_02: area ------------------------------------------------
+    a = sec02[[c['hhid'], c['plot']]].copy()
+    a['_hh'] = sec02[c['hhid']].apply(format_id)
+    a['_plot'] = sec02[c['plot']].apply(format_id)
+    area_gps = pd.to_numeric(sec02[c['area_gps']], errors='coerce').astype('Float64')
+    area_est = pd.to_numeric(sec02[c['area_est']], errors='coerce').astype('Float64')
+    # Plausibility clamp: parcels > 2500 acres (~1000 ha) are data-entry
+    # errors for smallholder plots (the 2020-21 GPS column has a 28710-acre
+    # outlier); drop to NaN so AreaUnit follows rather than poisoning
+    # area-weighted aggregates downstream (GH #167).
+    area_gps = area_gps.where((area_gps <= 2500) & (area_gps > 0) | area_gps.isna(), pd.NA)
+    area_est = area_est.where((area_est <= 2500) & (area_est > 0) | area_est.isna(), pd.NA)
+    # Prefer GPS-measured, fall back to farmer estimate.
+    area_acres = area_gps.where(area_gps.notna(), area_est)
+    a['Area'] = (area_acres * HECTARES_PER_ACRE).values
+    area_unit = pd.Series(['acres'] * len(sec02), index=sec02.index, dtype='string')
+    a['AreaUnit'] = area_unit.where(area_acres.notna(), pd.NA).values
+    area = a[['_hh', '_plot', 'Area', 'AreaUnit']]
+
+    # --- AG_SEC_3A: detail ---------------------------------------------
+    d = pd.DataFrame(index=sec3a.index)
+    d['_hh'] = sec3a[c['hhid']].apply(format_id)
+    d['_plot'] = sec3a[c['plot']].apply(format_id)
+
+    # Tenure from how-acquired, with a use-status override.
+    acq = pd.to_numeric(sec3a[c['acquire']], errors='coerce').astype('Int64')
+    tenure = acq.map(tenure_map).astype('string')
+    use = pd.to_numeric(sec3a[c['use']], errors='coerce').astype('Int64')
+    # ag3a_03 code 2 = RENTED OUT, 3 = GIVEN OUT -> Tenure rented_out.
+    tenure = tenure.where(~use.isin([2, 3]), 'rented_out')
+    d['Tenure'] = tenure.values
+
+    d['TenureSystem'] = _map_plot_codes(sec3a[c['legal_cert']], tenure_system_map).values
+    d['SoilType'] = _map_plot_codes(sec3a[c['soil_type']], soil_map).values
+
+    # Irrigated: ag3a_18 1=YES->True, 2=NO->False, else NaN.
+    irr = pd.to_numeric(sec3a[c['irrigated']], errors='coerce').astype('Int64')
+    irrigated = irr.map({1: True, 2: False}).astype('boolean')
+    d['Irrigated'] = irrigated.values
+
+    # --- merge (1:1 on hhid, plot) -------------------------------------
+    df = area.merge(d, on=['_hh', '_plot'], how='outer', indicator=True)
+    n_unmatched = int((df['_merge'] != 'both').sum())
+    if n_unmatched:
+        warnings.warn(
+            f"plot_features {t}: {n_unmatched} of {len(df)} (hhid, plot) "
+            f"rows did not match across AG_SEC_02 and AG_SEC_3A.")
+    df = df.drop(columns='_merge')
+
+    df['t'] = t
+    df = df.rename(columns={'_hh': 'i', '_plot': 'plot_id'})
+    df = df.set_index(['t', 'i', 'plot_id'])
+    df = df[['Area', 'AreaUnit', 'Tenure', 'TenureSystem', 'SoilType', 'Irrigated']]
+    return df


### PR DESCRIPTION
## Summary

Adds the `plot_features` table for Tanzania NPS (GH #167), index `(t, i, plot_id)`, columns Area (hectares), AreaUnit, Tenure, TenureSystem, SoilType, Irrigated.

Built via `materialize: make` as a cross-file merge of two NPS agriculture modules per wave:
- **AG_SEC_02** — plot area: farmer estimate `ag2a_04` (acres) + GPS-measured `ag2a_09` (acres). GPS preferred, estimate fallback. Acres → hectares (×0.404686). Plausibility clamp drops > 2500 acres / non-positive to NaN.
- **AG_SEC_3A** — use `ag3a_03`, soil `ag3a_10`, irrigation `ag3a_18`, how-acquired `ag3a_25`, certificate `ag3a_28a`.

The merge is a clean 1:1 in both waves (2305/2305 and 6560/6560; zero unmatched).

## Waves

| Wave | Sub-panel | Key | Plots |
|------|-----------|-----|-------|
| 2019-20 | NPS-SDD Extended | `(sdd_hhid, plotnum)` | 2305 |
| 2020-21 | NPS Y5 Refresh | `(y5_hhid, plot_id)` | 6560 |

Both 2020-21 modules key on `plot_id` (no `plotnum`, unlike 2019-20). **2008-15 deferred**: no agriculture source on disk. **GPS coordinates redacted** in source → Lat/Lon not emitted.

## Harmonization

`harmonize_tenure` / `harmonize_tenure_system` / `harmonize_soil` tables in `categorical_mapping.org`, keyed on the integer code (the AG_SEC_3A code scheme is identical across both waves; 2020-21 only differs in label casing). Tenure overridden to `rented_out` where `ag3a_03` is RENTED OUT / GIVEN OUT. `granted_right_of_occupancy` (TenureSystem) was added to the canonical spellings by the coordinator.

## Files

- `tanzania.py`: `plot_features_for_wave()` shared helper.
- `2019-20/_/plot_features.py`, `2020-21/_/plot_features.py`: per-wave scripts.
- `_/plot_features.py`: country concatenator (concat + `id_walk`).
- `data_scheme.yml`, `Makefile`, `categorical_mapping.org`, `CONTENTS.org`.

## Verification

- `is_this_feature_sane`: **ok** — 15 checks, 14 pass / 1 warn (constant `AreaUnit`, expected) / 0 fail.
- 8865 rows, unique `(t, i, plot_id)` index, 0 duplicates.
- **0% orphans** vs `Country('Tanzania').sample().i` (per-wave and overall).
- Area median 0.40 ha, max 158 ha after clamp.
- Built end-to-end through the framework `make` target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)