### PR TITLE
feat(Ethiopia): plot_features (GH #167)

### DIFF
--- a/lsms_library/countries/Ethiopia/2011-12/_/plot_features.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/plot_features.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Build plot_features for Ethiopia ESS 2011-12 (Wave 1; GH #167).
+
+One row per FIELD (sect3_pp_w1), with parcel-level Tenure broadcast
+from sect2_pp_w1 via the holder-aware join key
+(holder_id, household_id, parcel_id).  See
+lsms_library/countries/Ethiopia/_/ethiopia.py:plot_features_for_wave.
+
+W1 specifics: soil type is NOT asked (SoilType -> NaN); the acquire
+question uses the narrow 1-6 scheme plus alias codes 10/11/12; the
+field area unit code 7 means 'Other' (not 'Tilm' as in W2+).
+GPS coordinates are 100% '**CONFIDENTIAL**' -> Latitude/Longitude
+not emitted.  i = household_id (matches sample().i for W1).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_features_for_wave
+
+
+sect2 = get_dataframe('../Data/sect2_pp_w1.dta', convert_categoricals=False)
+sect3 = get_dataframe('../Data/sect3_pp_w1.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid       = 'household_id',
+    join_hhid  = 'household_id',
+    holder_id  = 'holder_id',
+    parcel_id  = 'parcel_id',
+    field_id   = 'field_id',
+    area_gps   = 'pp_s3q05_a',   # GPS-measured field area, square metres
+    area_unit  = 'pp_s3q02_c',   # farmer-estimate area unit code
+    acquire    = 'pp_s2q03',     # how the parcel was acquired -> Tenure
+    irrigated  = 'pp_s3q12',     # 1 Yes / 2 No
+    # soil_type: not asked in W1 -> SoilType NaN
+)
+
+df = plot_features_for_wave('2011-12', sect2, sect3, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2011-12"
+assert len(df) > 0, "plot_features 2011-12 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Ethiopia/2013-14/_/plot_features.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/plot_features.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""Build plot_features for Ethiopia ESS 2013-14 (Wave 2; GH #167).
+
+One row per FIELD (sect3_pp_w2), with parcel-level Tenure / SoilType
+broadcast from sect2_pp_w2 via the holder-aware join key
+(holder_id, household_id, parcel_id).
+
+i = household_id2 (NOT household_id): the W2 sample() and
+household_roster index on household_id2, and only household_id2
+overlaps the sample spine (99.3% vs 0% for household_id).  GPS
+coordinates are 100% '**CONFIDENTIAL**' -> Latitude/Longitude not
+emitted.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_features_for_wave
+
+
+sect2 = get_dataframe('../Data/sect2_pp_w2.dta', convert_categoricals=False)
+sect3 = get_dataframe('../Data/sect3_pp_w2.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid       = 'household_id2',  # EMITTED i; matches sample().i for W2
+    join_hhid  = 'household_id',   # join key (present in both files)
+    holder_id  = 'holder_id',
+    parcel_id  = 'parcel_id',
+    field_id   = 'field_id',
+    area_gps   = 'pp_s3q05_a',
+    area_unit  = 'pp_s3q02_c',
+    acquire    = 'pp_s2q03',
+    soil_type  = 'pp_s2q14',
+    irrigated  = 'pp_s3q12',
+)
+
+df = plot_features_for_wave('2013-14', sect2, sect3, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2013-14"
+assert len(df) > 0, "plot_features 2013-14 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Ethiopia/2015-16/_/plot_features.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/plot_features.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""Build plot_features for Ethiopia ESS 2015-16 (Wave 3; GH #167).
+
+One row per FIELD (sect3_pp_w3), parcel-level Tenure / SoilType
+broadcast from sect2_pp_w3 via (holder_id, household_id, parcel_id).
+
+i = household_id2 (NOT household_id): the W3 sample()/household_roster
+index on household_id2, and only household_id2 overlaps the sample
+spine (99.3% vs 0% for household_id).  W3 adds acquire codes
+6='Shared Crop in' (sharecropped_in) and 7='Purchased' (owned).
+GPS coordinates 100% '**CONFIDENTIAL**' -> not emitted.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_features_for_wave
+
+
+sect2 = get_dataframe('../Data/sect2_pp_w3.dta', convert_categoricals=False)
+sect3 = get_dataframe('../Data/sect3_pp_w3.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid       = 'household_id2',  # EMITTED i; matches sample().i for W3
+    join_hhid  = 'household_id',
+    holder_id  = 'holder_id',
+    parcel_id  = 'parcel_id',
+    field_id   = 'field_id',
+    area_gps   = 'pp_s3q05_a',
+    area_unit  = 'pp_s3q02_c',
+    acquire    = 'pp_s2q03',
+    soil_type  = 'pp_s2q14',
+    irrigated  = 'pp_s3q12',
+)
+
+df = plot_features_for_wave('2015-16', sect2, sect3, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2015-16"
+assert len(df) > 0, "plot_features 2015-16 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Ethiopia/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Ethiopia/2018-19/_/plot_features.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Build plot_features for Ethiopia ESS 2018-19 (Wave 4; GH #167).
+
+One row per FIELD (sect3_pp_w4), parcel-level Tenure / SoilType
+broadcast from sect2_pp_w4 via (holder_id, household_id, parcel_id).
+W4 uses the s{N}q* variable naming (vs pp_s{N}q* in W1-W3) and the
+full 1-8 acquire / 1-11 area-unit code schemes.  i = household_id
+(matches sample().i for W4).  GPS 100% '**CONFIDENTIAL**' -> not
+emitted.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_features_for_wave
+
+
+sect2 = get_dataframe('../Data/sect2_pp_w4.dta', convert_categoricals=False)
+sect3 = get_dataframe('../Data/sect3_pp_w4.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid       = 'household_id',
+    join_hhid  = 'household_id',
+    holder_id  = 'holder_id',
+    parcel_id  = 'parcel_id',
+    field_id   = 'field_id',
+    area_gps   = 's3q08',    # GPS-measured field area, square metres
+    area_unit  = 's3q02b',   # farmer-estimate area unit code
+    acquire    = 's2q05',    # how acquired -> Tenure
+    soil_type  = 's2q16',
+    irrigated  = 's3q17',    # 1 Yes / 2 No
+)
+
+df = plot_features_for_wave('2018-19', sect2, sect3, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2018-19"
+assert len(df) > 0, "plot_features 2018-19 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Ethiopia/2021-22/_/plot_features.py
+++ b/lsms_library/countries/Ethiopia/2021-22/_/plot_features.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""Build plot_features for Ethiopia ESS 2021-22 (Wave 5; GH #167).
+
+One row per FIELD (sect3_pp_w5), parcel-level Tenure / SoilType
+broadcast from sect2_pp_w5 via (holder_id, household_id, parcel_id).
+Same s{N}q* variable scheme as W4.  i = household_id (matches
+sample().i for W5).  GPS 100% '**CONFIDENTIAL**' -> not emitted.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_features_for_wave
+
+
+sect2 = get_dataframe('../Data/sect2_pp_w5.dta', convert_categoricals=False)
+sect3 = get_dataframe('../Data/sect3_pp_w5.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid       = 'household_id',
+    join_hhid  = 'household_id',
+    holder_id  = 'holder_id',
+    parcel_id  = 'parcel_id',
+    field_id   = 'field_id',
+    area_gps   = 's3q08',
+    area_unit  = 's3q02b',
+    acquire    = 's2q05',
+    soil_type  = 's2q16',
+    irrigated  = 's3q17',
+)
+
+df = plot_features_for_wave('2021-22', sect2, sect3, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2021-22"
+assert len(df) > 0, "plot_features 2021-22 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Ethiopia/_/CONTENTS.org
+++ b/lsms_library/countries/Ethiopia/_/CONTENTS.org
@@ -399,6 +399,98 @@ The household identifier variable changes across waves:
 | 2018-19 | =household_id=   | New ID scheme                    |
 | 2021-22 | =household_id=   | Continues wave 4 ID scheme       |
 
+* plot_features (GH #167)
+
+ESS land characteristics, one row per FIELD, index =(t, i, plot_id)=.
+Built with =materialize: make= because it requires a cross-file join
+that =data_info.yml= cannot express.
+
+** Source granularity and the holder_id join
+
+ESS records farmland at two levels in the post-planting (pp) round:
+  - =sect2_pp_w{N}.dta= : one row per PARCEL, carrying the lasting
+    parcel attributes Tenure (acquisition mode) and SoilType.
+  - =sect3_pp_w{N}.dta= : one row per FIELD, carrying field-level
+    Area and Irrigated.
+We emit one row per field and broadcast the parcel attributes onto
+each of the parcel's fields via a LEFT JOIN.
+
+*** The join key MUST include holder_id
+
+A single household can host several "holders" (decision-makers), each
+of whom numbers their parcels from 1.  Joining on
+=(household_id, parcel_id)= alone collides those and INFLATES the
+result by +265..+1567 rows/wave with =plot_id= collisions.  The
+correct key is =(holder_id, household_id, parcel_id)=.  Verified
+empirically: with =holder_id= in the key the merged field count equals
+the raw sect3 row count EXACTLY in every wave (0 inflation), and
+=plot_id = holder_id_parcel_id_field_id= is globally unique within
+=(t, i)=.  Per-wave field rows: W1 32025, W2 33147, W3 33305,
+W4 19339, W5 14878 (= 132694 total).
+
+** Household id emitted as =i= (W2/W3 use household_id2)
+
+The emitted =i= must match =sample().i=.  The =sample= and
+=household_roster= features index on:
+  - W1 (2011-12): =household_id=
+  - W2 (2013-14): =household_id2=
+  - W3 (2015-16): =household_id2=
+  - W4 (2018-19): =household_id=
+  - W5 (2021-22): =household_id=
+For W2/W3, only =household_id2= overlaps the sample spine (99.3% vs
+0.0% for =household_id=).  plot_features therefore EMITS
+=household_id2= as =i= for W2/W3 (NOT =household_id=), even though the
+sect3<->sect2 JOIN itself uses =household_id= (present in both files
+and consistent within a wave).  Overall orphan rate vs =sample()=
+after id_walk: 1.4% (W1 0.0%, W2 0.7%, W3 0.7%, W4 4.2%, W5 2.0%) --
+a handful of farm households slightly off the cover-page spine.
+
+** GPS redaction
+
+The public ESS plot GPS coordinates are 100% replaced with the literal
+string =**CONFIDENTIAL**= in every wave (=pp_s3q06_a/_b= in W2/W3,
+=s3q09__Latitude/__Longitude= in W4/W5; W1 has no coordinate columns).
+We therefore DEFER Latitude/Longitude -- they are NOT emitted.  Note
+the GPS-*measured field area* (square metres; =pp_s3q05_a= W1-W3,
+=s3q08= W4-W5) is NOT redacted and is the primary Area source.
+
+** Area and the local-unit gap
+
+Area is GPS square-metres / 10000 -> hectares where present
+(=AreaUnit= = 'hectares').  Where only a farmer estimate in a
+non-metric local unit (Timad, Kert, Boy, Senga, Tilm, Medeb, Rope,
+Ermija) exists, we cannot convert -- the local-unit->hectare factors
+are NOT in the repo -- so =Area= is NaN and =AreaUnit= carries the
+native unit name.  GPS area covers ~80-97% of fields per wave.
+
+** W1 missing soil; wave-keyed Tenure
+
+W1 (2011-12) does NOT ask soil type, so =SoilType= is all-NaN there.
+Soil is FAO/WRB-coded and stable W2-W5 (=harmonize_soil=).
+
+The acquisition->Tenure code set EVOLVES across waves, so
+=harmonize_acquire= is WAVE-KEYED: W1-W2 use a narrow 1-6 scheme
+(W1 also re-uses alias codes 10/11/12); W3-W5 add 6='Shared Crop in'
+(sharecropped_in) and 7='Purchased' (owned).  W1 area-unit code 7
+means 'Other' (W2+ it means 'Tilm'), so =harmonize_area_unit= is also
+wave-keyed.
+
+** TenureSystem always NaN
+
+ESS land is state-owned under usufruct with no land-tenure-regime
+analogue to Uganda's mailo/freehold, so =TenureSystem= is left NaN.
+It is declared =optional: true= in =data_scheme.yml= so the all-null
+sanity check exempts it while the canonical column stays declared for
+cross-country alignment.
+
+** Files
+
+  - =Ethiopia/_/ethiopia.py:plot_features_for_wave= -- shared helper.
+  - =Ethiopia/<wave>/_/plot_features.py= -- per-wave drivers.
+  - =Ethiopia/_/plot_features.py= -- country concatenator (+ id_walk).
+  - =Ethiopia/_/categorical_mapping.org= -- =harmonize_acquire=,
+    =harmonize_soil=, =harmonize_area_unit=.
+
 * Files in Ethiopia/<SOMEYEAR>/_/
 ** DONE household_characteristics.py
 CLOSED: [2023-03-03 Fri 11:26]

--- a/lsms_library/countries/Ethiopia/_/categorical_mapping.org
+++ b/lsms_library/countries/Ethiopia/_/categorical_mapping.org
@@ -72,3 +72,160 @@ waves in casing and spelling. This table harmonizes them.
 | Wood Planks              | Wood            |
 | Parquet Of Polished Wood | Wood            |
 | Reed/Bamboo              | Other           |
+
+* plot_features (GH #167)
+
+Harmonization tables for the ESS plot_features feature.  Field-level
+rows (sect3_pp) carry Area / Irrigated; parcel-level attributes
+(Tenure, SoilType) come from sect2_pp and are broadcast onto the
+fields via the (holder_id, household_id, parcel_id) join.  See
+=Ethiopia/_/ethiopia.py:plot_features_for_wave= and the
+=* plot_features (GH #167)= section of =CONTENTS.org=.
+
+** harmonize_acquire (WAVE-KEYED)
+
+The sect2 "how was the parcel acquired" question (=pp_s2q03= W1-W3,
+=s2q05= W4-W5) -> canonical Tenure.  The code set EVOLVES across
+waves: W1-W2 have a narrower 1-6 scheme (W1 additionally re-uses
+10/11/12 as alias codes for 'Moved in Without Permission' / 'Other'),
+while W3-W5 add 6='Shared Crop in' and 7='Purchased'.  Hence the
+lookup is keyed on (Wave, Code).  Decisions (canonical spellings from
+=lsms_library/data_info.yml=):
+  - Granted by Local Leaders -> communal (allocated by local authority)
+  - Inherited                -> inherited
+  - Rent                     -> rented_in
+  - Borrowed for Free        -> use_right (recognized informal,
+                                non-cash arrangement)
+  - Moved in Without Permission -> squatted (occupied without a
+                                recognized transfer; canonical def)
+  - Shared Crop in           -> sharecropped_in
+  - Purchased                -> owned
+  - Other (Specify)          -> other_tenure
+Codes absent for a wave map to NaN (no silent default).
+
+NOTE: this departs from the recon recipe, which coarsely mapped
+"Borrowed for Free"/"Moved in Without Permission" to other_tenure.
+The =use_right= / =squatted= canonical spellings are exact matches
+for those survey categories (see data_info.yml Columns:plot_features
+Tenure notes), so we preserve the finer signal.
+
+#+name: harmonize_acquire
+| Wave    | Code | Preferred Label |
+|---------+------+-----------------|
+| 2011-12 |    1 | communal        |
+| 2011-12 |    2 | inherited       |
+| 2011-12 |    3 | rented_in       |
+| 2011-12 |    4 | use_right       |
+| 2011-12 |    5 | squatted        |
+| 2011-12 |    6 | other_tenure    |
+| 2011-12 |   10 | squatted        |
+| 2011-12 |   11 | other_tenure    |
+| 2011-12 |   12 | other_tenure    |
+| 2013-14 |    1 | communal        |
+| 2013-14 |    2 | inherited       |
+| 2013-14 |    3 | rented_in       |
+| 2013-14 |    4 | use_right       |
+| 2013-14 |    5 | squatted        |
+| 2013-14 |    6 | other_tenure    |
+| 2015-16 |    1 | communal        |
+| 2015-16 |    2 | inherited       |
+| 2015-16 |    3 | rented_in       |
+| 2015-16 |    4 | use_right       |
+| 2015-16 |    5 | squatted        |
+| 2015-16 |    6 | sharecropped_in |
+| 2015-16 |    7 | owned           |
+| 2015-16 |    8 | other_tenure    |
+| 2018-19 |    1 | communal        |
+| 2018-19 |    2 | inherited       |
+| 2018-19 |    3 | rented_in       |
+| 2018-19 |    4 | use_right       |
+| 2018-19 |    5 | squatted        |
+| 2018-19 |    6 | sharecropped_in |
+| 2018-19 |    7 | owned           |
+| 2018-19 |    8 | other_tenure    |
+| 2021-22 |    1 | communal        |
+| 2021-22 |    2 | inherited       |
+| 2021-22 |    3 | rented_in       |
+| 2021-22 |    4 | use_right       |
+| 2021-22 |    5 | squatted        |
+| 2021-22 |    6 | sharecropped_in |
+| 2021-22 |    7 | owned           |
+| 2021-22 |    8 | other_tenure    |
+
+** harmonize_soil
+
+The sect2 soil-type question (=pp_s2q14= W2-W3, =s2q16= W4-W5) ->
+canonical SoilType.  FAO/WRB reference soil groups; stable W2-W5.
+W1 (2011-12) does NOT ask soil type, so SoilType is NaN there.
+Code 7 ('OTHER PARCEL USE (BARN, RESIDENTIAL, ETC.)') is a
+non-cultivation sentinel, mapped to 'other'.
+
+#+name: harmonize_soil
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | leptosol        |
+|    2 | cambisol        |
+|    3 | vertisol        |
+|    4 | luvisol         |
+|    5 | mixed           |
+|    6 | other           |
+|    7 | other           |
+
+** harmonize_area_unit (WAVE-KEYED)
+
+The sect3 field-area unit (=pp_s3q02_c= W1-W3, =s3q02b= W4-W5).
+Only used to label rows where Area is NaN (i.e. the survey recorded
+a farmer estimate in a non-metric local unit but no GPS measurement,
+so we cannot convert to hectares -- local-unit->ha factors are not
+in the repo).  Where GPS sq-m IS present, AreaUnit is forced to
+'hectares' in code regardless of this table.  Code 7 means 'Other'
+in W1 but 'Tilm' in W2-W5, hence wave-keyed.
+
+#+name: harmonize_area_unit
+| Wave    | Code | Preferred Label |
+|---------+------+-----------------|
+| 2011-12 |    1 | Hectare         |
+| 2011-12 |    2 | Square Meters   |
+| 2011-12 |    3 | Timad           |
+| 2011-12 |    4 | Boy             |
+| 2011-12 |    5 | Senga           |
+| 2011-12 |    6 | Kert            |
+| 2011-12 |    7 | Other           |
+| 2013-14 |    1 | Hectare         |
+| 2013-14 |    2 | Square Meters   |
+| 2013-14 |    3 | Timad           |
+| 2013-14 |    4 | Boy             |
+| 2013-14 |    5 | Senga           |
+| 2013-14 |    6 | Kert            |
+| 2013-14 |    7 | Tilm            |
+| 2013-14 |    8 | Other           |
+| 2015-16 |    1 | Hectare         |
+| 2015-16 |    2 | Square Meters   |
+| 2015-16 |    3 | Timad           |
+| 2015-16 |    4 | Boy             |
+| 2015-16 |    5 | Senga           |
+| 2015-16 |    6 | Kert            |
+| 2015-16 |    7 | Tilm            |
+| 2015-16 |    8 | Other           |
+| 2018-19 |    1 | Hectare         |
+| 2018-19 |    2 | Square Meters   |
+| 2018-19 |    3 | Timad           |
+| 2018-19 |    4 | Boy             |
+| 2018-19 |    5 | Senga           |
+| 2018-19 |    6 | Kert            |
+| 2018-19 |    7 | Tilm            |
+| 2018-19 |    8 | Medeb           |
+| 2018-19 |    9 | Rope            |
+| 2018-19 |   10 | Ermija          |
+| 2018-19 |   11 | Other           |
+| 2021-22 |    1 | Hectare         |
+| 2021-22 |    2 | Square Meters   |
+| 2021-22 |    3 | Timad           |
+| 2021-22 |    4 | Boy             |
+| 2021-22 |    5 | Senga           |
+| 2021-22 |    6 | Kert            |
+| 2021-22 |    7 | Tilm            |
+| 2021-22 |    8 | Medeb           |
+| 2021-22 |    9 | Rope            |
+| 2021-22 |   10 | Ermija          |
+| 2021-22 |   11 | Other           |

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -65,6 +65,28 @@ Data Scheme:
     Expenditure: float
     materialize: make
 
+  plot_features:
+    # ESS post-planting parcel/field land characteristics (GH #167).
+    # One row per FIELD (sect3_pp), with parcel-level Tenure / SoilType
+    # broadcast from sect2_pp via the holder-aware join key
+    # (holder_id, household_id, parcel_id).  Cross-file join => script.
+    # Latitude/Longitude deferred: source GPS 100% '**CONFIDENTIAL**'.
+    # TenureSystem always NaN: ESS has no land-tenure-regime analogue.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    # ESS records no land-tenure-regime analogue (all land is state-owned
+    # under usufruct), so TenureSystem is legitimately all-NaN here.
+    # Mark optional so the all-null sanity check exempts it while the
+    # canonical column is still declared for cross-country alignment.
+    TenureSystem:
+      type: str
+      optional: true
+    SoilType: str
+    Irrigated: bool
+    materialize: make
+
   food_expenditures: !make
   food_prices: !make
   food_quantities: !make

--- a/lsms_library/countries/Ethiopia/_/ethiopia.py
+++ b/lsms_library/countries/Ethiopia/_/ethiopia.py
@@ -4,7 +4,8 @@ from collections import defaultdict
 from cfe.df_utils import use_indices
 import warnings
 import json
-from lsms_library.local_tools import get_dataframe, DVCFS
+from lsms_library.local_tools import get_dataframe, DVCFS, format_id, df_from_orgfile
+import os
 
 # Wave list used by harmonized_food_labels() and other helpers.
 # NB: panel_ids no longer uses this dict -- see panel_ids.py for the
@@ -417,3 +418,202 @@ def panel_attrition(df,return_ids=False,waves=None):
         return foo,IDs
     else:
         return foo
+
+
+# ---------------------------------------------------------------------
+# plot_features (GH #167) — ESS post-planting parcel/field join
+# ---------------------------------------------------------------------
+#
+# ESS records farm land at two granularities in the post-planting (pp)
+# round:
+#   - sect2_pp  : one row per PARCEL (holder_id, household_id, parcel_id)
+#                 with the lasting parcel attributes Tenure / SoilType.
+#   - sect3_pp  : one row per FIELD  (holder_id, household_id, parcel_id,
+#                 field_id) with field-level Area / Irrigated.
+# plot_features emits ONE ROW PER FIELD, broadcasting the parcel-level
+# attributes onto each of the parcel's fields via a LEFT JOIN on the
+# composite key (holder_id, household_id, parcel_id).
+#
+# CRITICAL: the join key MUST include holder_id.  A single household can
+# host several "holders" (decision-makers) who each number their parcels
+# from 1; joining on (household_id, parcel_id) alone collides those and
+# inflates the result by +265..+1567 rows/wave.  Verified empirically:
+# with holder_id in the key the merged row count equals the sect3 row
+# count exactly in every wave (0 inflation).
+#
+# plot_id = format_id(holder_id)_format_id(parcel_id)_format_id(field_id)
+# — globally unique within (t, i).
+#
+# GPS: the public ESS GPS coordinates are 100% redacted to the literal
+# string "**CONFIDENTIAL**" in every wave, so Latitude / Longitude are
+# DEFERRED (not emitted).  The GPS-*measured field area* (sq metres) is
+# NOT redacted and is the primary Area source.
+#
+# Area: GPS sq-metres / 10000 -> hectares where present (AreaUnit =
+# 'hectares').  Where only a farmer estimate in a non-metric local unit
+# (Timad/Kert/Boy/...) exists, we cannot convert (local-unit->ha factors
+# are not in the repo), so Area = NaN and AreaUnit = the native unit name.
+
+PLOT_AREA_UNIT_HA = 'hectares'
+
+
+def _eth_orgfile_path():
+    """Resolve Ethiopia/_/categorical_mapping.org from any wave-script CWD."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates = [
+        os.path.join(here, 'categorical_mapping.org'),
+        os.path.abspath(os.path.join('..', '..', '_', 'categorical_mapping.org')),
+        'categorical_mapping.org',
+    ]
+    return next((c for c in candidates if os.path.exists(c)), candidates[0])
+
+
+def _harmonize_wave_keyed(name):
+    """Load a (Wave, Code) -> Preferred Label dict from categorical_mapping.org."""
+    df = df_from_orgfile(_eth_orgfile_path(), name=name,
+                         set_columns=True, to_numeric=True)
+    out = {}
+    for _, row in df.iterrows():
+        wv = str(row['Wave']).strip()
+        c = row['Code']
+        try:
+            c = int(c)
+        except (TypeError, ValueError):
+            pass
+        lab = row.get('Preferred Label')
+        if pd.isna(lab):
+            continue
+        out[(wv, c)] = str(lab).strip()
+    return out
+
+
+def _harmonize_code_label(name):
+    """Load a Code -> Preferred Label dict (not wave-keyed)."""
+    df = df_from_orgfile(_eth_orgfile_path(), name=name,
+                         set_columns=True, to_numeric=True)
+    out = {}
+    for _, row in df.iterrows():
+        c = row['Code']
+        try:
+            c = int(c)
+        except (TypeError, ValueError):
+            pass
+        lab = row.get('Preferred Label')
+        if pd.isna(lab):
+            continue
+        out[c] = str(lab).strip()
+    return out
+
+
+def _map_int_codes(series, code_map):
+    """Map a numeric (raw Stata code) Series through ``code_map``.
+
+    Returns a 'string' Series with pd.NA where the code is absent."""
+    if series is None:
+        return None
+    out = pd.to_numeric(series, errors='coerce').astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_features_for_wave(t, sect2, sect3, colmap):
+    """Build canonical ``plot_features`` for one Ethiopia ESS wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2013-14"``), used as the ``t`` index value AND
+        as the wave key for the wave-keyed harmonize tables.
+    sect2 : pd.DataFrame
+        Raw ``sect2_pp_w{N}.dta`` (parcel roster), loaded with
+        ``convert_categoricals=False`` so categorical columns carry the
+        integer codes the harmonize tables key on.
+    sect3 : pd.DataFrame
+        Raw ``sect3_pp_w{N}.dta`` (field roster), same loading.
+    colmap : dict
+        Per-wave column-name map.  Required keys:
+            hhid       — household id column EMITTED as ``i`` (must match
+                         sample().i: household_id2 for W2/W3, else
+                         household_id).  Carried from sect3.
+            join_hhid  — household id column used in the parcel JOIN key
+                         (always 'household_id', present in both files).
+            holder_id, parcel_id, field_id — join-key + plot_id columns.
+            area_gps   — sect3 GPS field-area column (square metres).
+            area_unit  — sect3 farmer-estimate area-unit code column.
+            acquire    — sect2 "how acquired" code column (-> Tenure).
+        Optional keys (NaN where omitted / not asked):
+            soil_type  — sect2 soil-type code column (absent in W1).
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
+        ``Area`` (hectares, float), ``AreaUnit`` (str), ``Tenure`` (str),
+        ``TenureSystem`` (str, always NaN — ESS has no analogue),
+        ``SoilType`` (str), ``Irrigated`` (nullable bool).  GPS
+        Latitude / Longitude are NOT emitted (source 100% redacted).
+    """
+    c = colmap
+    acquire_map = _harmonize_wave_keyed('harmonize_acquire')
+    area_unit_map = _harmonize_wave_keyed('harmonize_area_unit')
+    soil_map = _harmonize_code_label('harmonize_soil')
+
+    # --- Parcel-level attributes (sect2), keyed for the join ---
+    key = [c['holder_id'], c['join_hhid'], c['parcel_id']]
+    parcel = sect2.copy()
+    # Tenure: wave-keyed acquire code -> canonical tenure.
+    parcel['_Tenure'] = parcel[c['acquire']].pipe(
+        lambda s: pd.to_numeric(s, errors='coerce').astype('Int64').map(
+            lambda code: acquire_map.get((t, int(code))) if pd.notna(code) else pd.NA
+        )).astype('string')
+    if c.get('soil_type') and c['soil_type'] in parcel.columns:
+        parcel['_SoilType'] = _map_int_codes(parcel[c['soil_type']], soil_map)
+    else:
+        parcel['_SoilType'] = pd.Series(pd.NA, index=parcel.index, dtype='string')
+
+    parcel_attrs = (parcel[key + ['_Tenure', '_SoilType']]
+                    .drop_duplicates(subset=key))
+
+    # --- Field-level rows (sect3) ---
+    field = sect3.copy()
+
+    # Area: GPS square-metres -> hectares where present.
+    area_sqm = pd.to_numeric(field[c['area_gps']], errors='coerce')
+    area_ha = (area_sqm / 10000.0).astype('Float64')
+    area_ha = area_ha.where(area_sqm > 0, pd.NA)
+
+    # AreaUnit: 'hectares' where GPS area is present; otherwise the
+    # native farmer-estimate unit name (Area stays NaN there).
+    native_unit = _map_int_codes(field[c['area_unit']], area_unit_map) \
+        if c.get('area_unit') and c['area_unit'] in field.columns \
+        else pd.Series(pd.NA, index=field.index, dtype='string')
+    area_unit = pd.Series(pd.NA, index=field.index, dtype='string')
+    area_unit = area_unit.where(area_ha.isna(), PLOT_AREA_UNIT_HA)
+    area_unit = area_unit.where(area_ha.notna(), native_unit)
+
+    # Irrigated: 1=Yes, 2=No.
+    irr = pd.to_numeric(field[c['irrigated']], errors='coerce').astype('Int64')
+    irrigated = pd.Series(pd.NA, index=field.index, dtype='boolean')
+    irrigated = irrigated.mask(irr == 1, True)
+    irrigated = irrigated.mask(irr == 2, False)
+
+    # Join parcel attributes onto field rows (LEFT, on the holder-aware key).
+    field = field.merge(parcel_attrs, on=key, how='left')
+
+    hh = field[c['hhid']].apply(format_id)
+    plot_id = (field[c['holder_id']].apply(format_id).astype(str) + '_'
+               + field[c['parcel_id']].apply(format_id).astype(str) + '_'
+               + field[c['field_id']].apply(format_id).astype(str))
+
+    out = pd.DataFrame({
+        't':            t,
+        'i':            hh.values,
+        'plot_id':      plot_id.values,
+        'Area':         area_ha.values,
+        'AreaUnit':     area_unit.values,
+        'Tenure':       field['_Tenure'].astype('string').values,
+        'TenureSystem': pd.Series(pd.NA, index=field.index, dtype='string').values,
+        'SoilType':     field['_SoilType'].astype('string').values,
+        'Irrigated':    irrigated.values,
+    })
+    out = out.dropna(subset=['i', 'plot_id'])
+    out = out.set_index(['t', 'i', 'plot_id'])
+    return out

--- a/lsms_library/countries/Ethiopia/_/plot_features.py
+++ b/lsms_library/countries/Ethiopia/_/plot_features.py
@@ -1,0 +1,46 @@
+"""Concatenate wave-level plot_features data for Ethiopia (GH #167).
+
+Each wave's ``Ethiopia/<wave>/_/plot_features.py`` produces a parquet
+with index ``(t, i, plot_id)`` and the canonical plot_features columns
+(Area, AreaUnit, Tenure, TenureSystem, SoilType, Irrigated).  This
+script concatenates them across the five ESS waves and applies the
+cross-wave ``id_walk`` so the household index uses the panel canonical
+id scheme (the same conversion ``sample()`` receives at API time, which
+keeps the ``_join_v_from_sample`` join aligned).
+
+``id_walk`` is idempotent (it sets ``attrs['id_converted']``), so the
+framework's ``_finalize_result`` will skip re-applying it.  The wave
+parquets emit the wave-native household id that matches ``sample().i``
+(``household_id2`` for W2/W3, ``household_id`` elsewhere) — see the
+per-wave scripts and the CONTENTS.org plot_features section.
+
+GPS Latitude/Longitude are NOT emitted: the public ESS plot GPS is
+100% redacted to '**CONFIDENTIAL**'.
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, id_walk, to_parquet
+from ethiopia import Waves
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/plot_features.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built (DVC raises
+        # PathMissingError here, not FileNotFoundError).
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_features: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/plot_features.parquet')


### PR DESCRIPTION
Adds the `plot_features` table for **Ethiopia (ESS)**, the most structurally complex case in the GH #167 rollout (cross-file parcel⋈field join).

## What
- One row per **FIELD** (`sect3_pp`), with parcel-level **Tenure**/**SoilType** broadcast from `sect2_pp` via a LEFT JOIN.
- Index `(t, i, plot_id)`; `plot_id = holder_id_parcel_id_field_id`.
- Columns: `Area` (ha), `AreaUnit`, `Tenure`, `TenureSystem` (NaN — ESS has no analogue, declared `optional`), `SoilType`, `Irrigated`.

## Key correctness decisions (validated empirically)
- **Join key includes `holder_id`** — `(holder_id, household_id, parcel_id)`. Without it, per-holder parcel numbering collides and inflates each wave by +265..+1567 rows. Verified: merged rows == raw sect3 rows in every wave (0 inflation), 0 `(t,i,plot_id)` dups.
- **`i = household_id2` for W2/W3** (matches `sample().i`: 99.3% overlap vs **0%** for `household_id`), `household_id` for W1/W4/W5. This overrides the recon's stated refuter correction (c), which empirical evidence contradicts.
- **GPS Latitude/Longitude DEFERRED** — source is 100% `**CONFIDENTIAL**`. GPS-measured field *area* (sq m) is not redacted and drives `Area`.
- **Area** = GPS sqm/10000 → hectares; farmer-estimate-only non-metric rows → `Area=NaN` with native `AreaUnit` (local-unit→ha factors absent from repo).
- **W1 lacks soil** → `SoilType` NaN.
- Tenure code 4 ("Borrowed for Free") → `use_right`, code 5 ("Moved in Without Permission") → `squatted`, faithful to canonical spelling definitions (refines the recon's coarse `other_tenure`).

## Files
- `Ethiopia/<wave>/_/plot_features.py` ×5 — per-wave drivers.
- `Ethiopia/_/ethiopia.py` — shared `plot_features_for_wave()` helper.
- `Ethiopia/_/plot_features.py` — country concatenator (concat + id_walk).
- `Ethiopia/_/categorical_mapping.org` — wave-keyed `harmonize_acquire` / `harmonize_area_unit`, stable `harmonize_soil`.
- `Ethiopia/_/data_scheme.yml`, `CONTENTS.org`.

## Verification
- `is_this_feature_sane(df, 'Ethiopia', 'plot_features')` → **ok = True** (14 pass, 1 warn, 0 fail).
- **132,694** rows total (W1 32025, W2 33147, W3 33305, W4 19339, W5 14878 — exact recipe match, 0 join inflation).
- 0 global `(t,i,plot_id)` duplicates.
- Orphan vs `sample()` after id_walk: **1.4%** (W1 0.0%, W2 0.7%, W3 0.7%, W4 4.2%, W5 2.0%).
- All Tenure/SoilType values ⊆ canonical spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)