### PR TITLE
feat(Mali): plot_features (GH #167)

### DIFF
--- a/lsms_library/countries/Mali/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Mali/2018-19/_/plot_features.py
@@ -1,0 +1,41 @@
+"""Build plot_features for Mali EHCVM 2018-19 (GH #167; EHCVM cluster).
+
+Single source file: s16a_me_mli2018.dta (agriculture-parcel module,
+7,323 rows).  plot_id = "{field_no}_{parcel_no}" (s16aq02 _ s16aq03);
+unique within each (grappe, menage).  See
+lsms_library/countries/Mali/_/mali.py:plot_features_for_wave for the
+harmonization shared across all EHCVM waves and the six sibling
+countries.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import plot_features_for_wave
+
+
+# convert_categoricals=False keeps the integer s16a codes that the
+# categorical_mapping.org harmonize_* tables key on.
+src = get_dataframe('../Data/s16a_me_mli2018.dta', convert_categoricals=False)
+
+colmap = dict(
+    grappe        = 'grappe',
+    menage        = 'menage',
+    field_no      = 's16aq02',
+    parcel_no     = 's16aq03',
+    area_gps      = 's16aq47',
+    gps_measured  = 's16aq45',
+    area_est      = 's16aq09a',
+    area_est_unit = 's16aq09b',
+    tenure        = 's16aq10',
+    tenure_system = 's16aq13',
+    soil_type     = 's16aq18',
+    water_source  = 's16aq17',
+)
+
+df = plot_features_for_wave('2018-19', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2018-19"
+assert len(df) > 0, "plot_features 2018-19 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Mali/2021-22/_/plot_features.py
+++ b/lsms_library/countries/Mali/2021-22/_/plot_features.py
@@ -1,0 +1,38 @@
+"""Build plot_features for Mali EHCVM 2021-22 (GH #167; EHCVM cluster).
+
+Single source file: s16a_me_mli2021.dta (agriculture-parcel module,
+9,924 rows).  The 2021-22 instrument uses the SAME column names and
+integer code scheme as 2018-19 (the value labels merely add a "N. "
+numeric prefix), so the colmap is identical.  See
+lsms_library/countries/Mali/_/mali.py:plot_features_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import plot_features_for_wave
+
+
+src = get_dataframe('../Data/s16a_me_mli2021.dta', convert_categoricals=False)
+
+colmap = dict(
+    grappe        = 'grappe',
+    menage        = 'menage',
+    field_no      = 's16aq02',
+    parcel_no     = 's16aq03',
+    area_gps      = 's16aq47',
+    gps_measured  = 's16aq45',
+    area_est      = 's16aq09a',
+    area_est_unit = 's16aq09b',
+    tenure        = 's16aq10',
+    tenure_system = 's16aq13',
+    soil_type     = 's16aq18',
+    water_source  = 's16aq17',
+)
+
+df = plot_features_for_wave('2021-22', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2021-22"
+assert len(df) > 0, "plot_features 2021-22 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Mali/_/CONTENTS.org
+++ b/lsms_library/countries/Mali/_/CONTENTS.org
@@ -72,3 +72,80 @@ variable:
 
 The 2017-18 wave may also predate the EHCVM template; check its
 wave-level =data_info.yml= for the applicable variable name.
+
+* plot_features (GH #167)
+
+Mali is the EHCVM reference implementation for =plot_features=; the
+six other EHCVM countries (Niger, Senegal, Burkina_Faso, Benin, Togo,
+Guinea-Bissau) copy this pattern.
+
+Source: the agriculture-parcel module =s16a_me_mli{2018,2021}.dta=, one
+parcel per row.  Only the two EHCVM waves are wired:
+
+| Wave    | s16a file              | rows | real plot rows |
+|---------+------------------------+------+----------------|
+| 2018-19 | s16a_me_mli2018.dta    | 7323 |           7323 |
+| 2021-22 | s16a_me_mli2021.dta    | 9924 |           6638 |
+
+The pre-EHCVM EACI waves (2014-15, 2017-18) use a different agriculture
+instrument and are deferred to a separate recipe.
+
+Build path: =materialize: make=.  Per-wave =_/plot_features.py= loads the
+single s16a file and calls =mali.plot_features_for_wave(t, src, colmap)=
+(shared helper, mirrors Uganda).  The country-level =_/plot_features.py=
+concatenates the wave parquets.
+
+Column map (identical both waves; codes verified from the .dta value
+labels):
+
+| Canonical    | s16a var       | notes                                     |
+|--------------+----------------+-------------------------------------------|
+| i            | grappe, menage | EHCVM composite via mali.i()              |
+| plot_id      | s16aq02_s16aq03| field_no _ parcel_no                      |
+| Area (ha)    | s16aq47/s16aq09a| GPS where measured else estimate; m^2/1e4 |
+| Tenure       | s16aq10        | -> harmonize_tenure                        |
+| TenureSystem | s16aq13        | -> harmonize_tenure_system (partial)       |
+| SoilType     | s16aq18        | -> harmonize_soil                          |
+| Irrigated    | s16aq17        | codes 1-3 True; 4-5 False; 6 NaN           |
+
+Verification (country parquet, pre-id_walk): is_this_feature_sane OK
+(14 pass / 1 warn — AreaUnit constant 'hectares'); 13,961 rows
+(7323 + 6638); =(t, i, plot_id)= globally unique; Area median 1.18 ha
+(max 1000 ha, a survey-reported large parcel — left unclamped per
+recon); 0.00% orphan rate vs =sample().i= (every plot household matches
+a sampled household).
+
+** Oddities / decisions
+
+- *2021-22 placeholder rows.*  3286 of the 9924 rows have NO field /
+  parcel number (s16aq02 / s16aq03 NaN) and every plot attribute blank
+  — one placeholder per non-farming household.  These are dropped in
+  =plot_features_for_wave= (they would otherwise emit a content-free
+  "nan_nan" plot_id and collide once two such households id_walk to the
+  same baseline id).  2018-19 has none.
+
+- *Tenure code 2 (Prêt gratuit / free land loan)* -> =use_right=.  The
+  recon left this as a communal-vs-other judgment call; =use_right= is
+  the better canonical fit ("held under agreement with a use-rights
+  owner, often non-cash"), which a free loan of land precisely is.
+  Code 5 (Gage / pledge-pawn) and 6 (Autre) -> =other_tenure=.  Mali
+  has NO co-propriétaire code 7 (that is Niger-2021 only).
+
+- *TenureSystem is partial.*  EHCVM has no land-tenure-regime question;
+  s16aq13 records the land *document* held.  Only the three documents
+  implying a clear regime are mapped (Titre foncier -> freehold, Bail ->
+  leasehold, Permis d'exploiter -> granted_right_of_occupancy); Procès-
+  verbal, Convention de vente, Autre, and Aucun are left NaN rather than
+  force-fit.  Result: 96% of rows have TenureSystem = NaN.
+
+- *No parcel GPS.*  s16aq47 is an AREA in hectares, not a coordinate;
+  EHCVM has no decimal-degree parcel GPS, so Latitude / Longitude are
+  deferred (as in Uganda).
+
+- *id_walk deliberately NOT applied at the country level* (unlike
+  Uganda).  Mali's 2021-22 panel has "moved" households whose id maps to
+  the same 2018-19 baseline id as another household; applying id_walk at
+  cache-write time collides those onto identical =(t, i, plot_id)=
+  tuples (9 dups).  The parquet stores the pre-walk (unique) index and
+  lets the framework's idempotent id_walk in =_finalize_result= do the
+  panel remap, consistent with every other Mali table.

--- a/lsms_library/countries/Mali/_/categorical_mapping.org
+++ b/lsms_library/countries/Mali/_/categorical_mapping.org
@@ -342,3 +342,61 @@ print(write_df_to_org(df, 'unit'))
 | Cement             | Cement          |
 | Tiles              | Tiles           |
 | Dung               | Earth with Dung |
+
+# plot_features harmonization tables (GH #167; EHCVM cluster).
+# Keyed on the integer s16a codes — Stata value labels are stable
+# (and Guinea-Bissau carries the SAME codes with Portuguese labels),
+# so keying on codes avoids any French/Portuguese language branch.
+# Mali 2018-19 and 2021-22 use identical code schemes (verified from
+# the .dta value-label metadata); the 2021-22 labels merely add a
+# "N. " numeric prefix to the same six tenure categories.  Mali has
+# NO co-propriétaire code 7 (that is Niger-2021 only).
+#
+# harmonize_tenure — s16aq10 "mode de faire-valoir" -> canonical Tenure.
+#   2 Prêt gratuit (free loan of land under agreement, typically
+#   non-cash) -> use_right, which the canonical schema defines as
+#   "held under agreement with a use-rights owner".  5 Gage (pledge /
+#   pawned land) and 6 Autre -> other_tenure.
+# harmonize_soil — s16aq18 -> SoilType (free-form str; English labels).
+# harmonize_water — s16aq17; the Irrigated bool is (label=='Irrigated').
+# harmonize_tenure_system — s16aq13 land-document regime -> the canonical
+#   TenureSystem spellings.  Only the three documents that imply a clear
+#   regime are mapped (Titre foncier->freehold, Bail->leasehold, Permis
+#   d'exploiter->granted_right_of_occupancy).  Procès-verbal, Convention
+#   de vente, Autre, and Aucun have no defensible regime mapping and are
+#   left out (NaN) rather than force-fit.
+
+#+name: harmonize_tenure
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | owned           |
+|    2 | use_right       |
+|    3 | rented_in       |
+|    4 | sharecropped_in |
+|    5 | other_tenure    |
+|    6 | other_tenure    |
+
+#+name: harmonize_soil
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | sandy           |
+|    2 | loam            |
+|    3 | clay            |
+|    4 | hardpan         |
+|    5 | other           |
+
+#+name: harmonize_water
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Irrigated       |
+|    2 | Irrigated       |
+|    3 | Irrigated       |
+|    4 | Rain-fed        |
+|    5 | Wetland         |
+
+#+name: harmonize_tenure_system
+| Code | Preferred Label            |
+|------+----------------------------|
+|    1 | freehold                   |
+|    2 | granted_right_of_occupancy |
+|    4 | leasehold                  |

--- a/lsms_library/countries/Mali/_/data_scheme.yml
+++ b/lsms_library/countries/Mali/_/data_scheme.yml
@@ -67,3 +67,19 @@ Data Scheme:
     HowCoped0: str
     HowCoped1: str
     HowCoped2: str
+  plot_features:
+    # Lasting parcel-level characteristics from the EHCVM agriculture
+    # module s16a (GH #167; Mali is the EHCVM reference implementation).
+    # EHCVM waves only: 2018-19 and 2021-22.  The pre-EHCVM EACI waves
+    # (2014-15, 2017-18) use a different instrument and are deferred.
+    # plot_id = "{field_no}_{parcel_no}".  Latitude / Longitude are NOT
+    # emitted — EHCVM s16a has no decimal-degree parcel GPS (s16aq47 is
+    # an area, not a coordinate); deferred as in Uganda.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    SoilType: str
+    Irrigated: bool
+    materialize: make

--- a/lsms_library/countries/Mali/_/mali.py
+++ b/lsms_library/countries/Mali/_/mali.py
@@ -56,3 +56,157 @@ def Int_t(value):
 def interview_date(df):
     df['Int_t'] = pd.to_datetime(df['Int_t'])
     return df
+
+
+# ---------------------------------------------------------------------------
+# plot_features (GH #167; EHCVM cluster)
+# ---------------------------------------------------------------------------
+#
+# Mali is the EHCVM reference implementation.  Six more EHCVM countries
+# (Niger, Senegal, Burkina_Faso, Benin, Togo, Guinea-Bissau) copy this
+# pattern: a single per-wave agriculture-parcel file s16a_me_{iso}{year}
+# with a uniform column scheme.  The shared harmonization lives here in
+# ``plot_features_for_wave``; each wave's ``_/plot_features.py`` is a
+# thin loader that hands the raw DataFrame plus a column map to it.
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a ``{int code -> Preferred Label}`` dict from
+    ``categorical_mapping.org`` for one of the plot_features harmonize_*
+    tables.  Codes whose Preferred Label is blank / '---' map to NA so
+    the corresponding column stays NaN.  Mirrors Uganda's helper."""
+    raw = tools.get_categorical_mapping(tablename=tablename, idxvars=key,
+                                        **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw Stata integer-code) Series through ``code_map``,
+    returning a string Series with NA where the code is unmapped.  Source
+    files must be loaded with ``convert_categoricals=False`` so the codes
+    arrive as integers."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_features_for_wave(t, source, colmap):
+    """Build canonical ``plot_features`` for one Mali EHCVM wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2018-19"``), used as the ``t`` index value.
+    source : pd.DataFrame
+        Raw s16a agriculture-parcel DataFrame, loaded via
+        ``get_dataframe(..., convert_categoricals=False)`` so the
+        harmonize_* tables can key on the integer codes.
+    colmap : dict
+        Column-name map.  Required keys::
+
+            grappe        — cluster id column (with menage builds ``i``)
+            menage        — within-cluster household number
+            field_no      — within-HH field/champ sequence number
+            parcel_no     — within-field parcel sequence number
+            area_gps      — GPS-measured parcel area (hectares)
+            gps_measured  — 1/2 (Oui/Non) flag for GPS measurement
+            area_est      — farmer-estimated area (in area_est_unit)
+            area_est_unit — 1=Hectare, 2=m^2
+            tenure        — mode-of-tenure question  -> Tenure
+            tenure_system — land-document question    -> TenureSystem
+            soil_type     — soil-type question        -> SoilType
+            water_source  — water-source question     -> Irrigated
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
+        ``Area`` (hectares float), ``AreaUnit`` (always 'hectares'),
+        ``Tenure``, ``TenureSystem``, ``SoilType`` (str), and
+        ``Irrigated`` (nullable bool).
+
+    Notes
+    -----
+    * ``i`` is the EHCVM composite household id built with Mali's
+      ``i()`` formatter so it matches ``sample().i`` natively.
+    * ``plot_id = "{field_no}_{parcel_no}"`` — unique within
+      ``(grappe, menage)`` (verified 0 collisions both waves).
+    * ``Area`` prefers the GPS measurement (already hectares) where
+      ``gps_measured == 1``; otherwise the farmer estimate converted to
+      hectares (m^2 / 10000).  No GPS coordinate columns: EHCVM s16a has
+      no decimal-degree parcel GPS, so Latitude / Longitude are deferred
+      (as in Uganda).
+    """
+    tenure_map = _harmonized_codes('harmonize_tenure')
+    tenure_system_map = _harmonized_codes('harmonize_tenure_system')
+    soil_map = _harmonized_codes('harmonize_soil')
+    water_map = _harmonized_codes('harmonize_water')
+
+    c = colmap
+
+    # Drop the s16a placeholder rows for non-farming households: one row
+    # per household with NO field/parcel number and every plot attribute
+    # blank (3286 of 9924 in Mali 2021-22; none in 2018-19).  Keeping
+    # them would emit a content-free "nan_nan" plot_id per household and
+    # collide once two such households id_walk to the same baseline id.
+    src = source[source[c['field_no']].notna() & source[c['parcel_no']].notna()].copy()
+
+    # Household id: EHCVM composite (grappe, menage) via mali.i().
+    hh = src.apply(lambda r: i(pd.Series([r[c['grappe']], r[c['menage']]])),
+                   axis=1)
+
+    field = src[c['field_no']].apply(tools.format_id)
+    parcel = src[c['parcel_no']].apply(tools.format_id)
+    plot_id = field.astype(str) + '_' + parcel.astype(str)
+
+    # Area in hectares.  GPS where measured, else farmer estimate
+    # converted from its declared unit (1=Hectare ->x1, 2=m^2 ->/10000).
+    area_gps = pd.to_numeric(src[c['area_gps']], errors='coerce').astype('Float64')
+    gps_flag = src[c['gps_measured']].astype('Int64')
+
+    est_raw = pd.to_numeric(src[c['area_est']], errors='coerce').astype('Float64')
+    est_unit = src[c['area_est_unit']].astype('Int64')
+    est_ha = est_raw.where(est_unit != 2, est_raw / 10000)
+
+    # Prefer GPS where it was actually measured (flag == 1) and present.
+    area_ha = est_ha.copy()
+    use_gps = (gps_flag == 1) & area_gps.notna()
+    area_ha = area_gps.where(use_gps, area_ha)
+
+    area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
+    area_unit = area_unit.where(area_ha.notna(), pd.NA)
+
+    tenure = _map_codes(src[c['tenure']], tenure_map) \
+        if c.get('tenure') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    tenure_system = _map_codes(src[c['tenure_system']], tenure_system_map) \
+        if c.get('tenure_system') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    soil_type = _map_codes(src[c['soil_type']], soil_map) \
+        if c.get('soil_type') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+
+    irrigated = pd.Series(pd.NA, index=src.index, dtype='boolean')
+    if c.get('water_source') in src.columns:
+        water_label = _map_codes(src[c['water_source']], water_map)
+        irrigated = (water_label == 'Irrigated').astype('boolean')
+        irrigated = irrigated.where(water_label.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        't':            t,
+        'i':            hh.values,
+        'plot_id':      plot_id.values,
+        'Area':         area_ha.values,
+        'AreaUnit':     area_unit.values,
+        'Tenure':       tenure.values,
+        'TenureSystem': tenure_system.values,
+        'SoilType':     soil_type.values,
+        'Irrigated':    irrigated.values,
+    })
+    df = df.set_index(['t', 'i', 'plot_id'])
+    return df

--- a/lsms_library/countries/Mali/_/plot_features.py
+++ b/lsms_library/countries/Mali/_/plot_features.py
@@ -1,0 +1,45 @@
+"""Concatenate wave-level plot_features for Mali (GH #167; EHCVM cluster).
+
+Each EHCVM wave's ``Mali/<wave>/_/plot_features.py`` writes a parquet
+indexed by ``(t, i, plot_id)`` with the canonical plot_features columns.
+This script concatenates the waves that have one (2018-19, 2021-22; the
+pre-EHCVM EACI waves 2014-15 / 2017-18 use a different instrument and
+are deferred).  ``v`` is NOT baked in — the framework joins it from
+``sample()`` at API time.
+
+Unlike Uganda's concatenator, this does NOT apply ``id_walk`` here.
+Cached parquets store pre-transformation data; the framework runs
+``id_walk`` in ``_finalize_result`` on every read.  Mali's 2021-22
+panel has a handful of "moved" households whose 2021-22 id maps to the
+SAME 2018-19 baseline id as another household — applying id_walk at
+cache-write time would collide those onto identical ``(t, i, plot_id)``
+tuples (9 dups observed) and bake a non-unique index into the parquet.
+Leaving the index pre-walk keeps it globally unique; the framework's
+idempotent id_walk handles the panel remap (and the inherent panel
+collisions) consistently with every other Mali table.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2014-15', '2017-18', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_features.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for plot_features (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_features: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, plot_id) after concat"
+
+to_parquet(p, '../var/plot_features.parquet')


### PR DESCRIPTION
## Mali plot_features — EHCVM reference implementation (GH #167)

Mali is the EHCVM reference for `plot_features`; the six other EHCVM countries (Niger, Senegal, Burkina_Faso, Benin, Togo, Guinea-Bissau) copy this pattern.

### What
- Per-wave `Mali/{2018-19,2021-22}/_/plot_features.py` loaders over the single `s16a_me_mli{2018,2021}.dta` agriculture-parcel file each.
- Shared helper `mali.plot_features_for_wave` (mirrors Uganda): EHCVM composite `i` via `mali.i()`, `plot_id = field_no_parcel_no`, `Area` in hectares (GPS where measured else estimate, m²/1e4), and code-keyed `harmonize_*` maps for Tenure / TenureSystem / SoilType / Irrigated. Drops the 2021-22 non-farming-household placeholder rows.
- Country concatenator `Mali/_/plot_features.py`: concat the two EHCVM waves. **Does NOT id_walk at cache-write time** — leaves the pre-walk unique index and lets the framework's idempotent id_walk in `_finalize_result` do the panel remap (avoids 9 panel-collision dups that baking id_walk would produce; differs deliberately from Uganda).
- `harmonize_tenure` / `_soil` / `_water` / `_tenure_system` tables added to `categorical_mapping.org`, keyed on integer s16a codes (language-agnostic — Guinea-Bissau will reuse with Portuguese labels).
- Registered `plot_features` (index `(t, i, plot_id)`, `materialize: make`) in `data_scheme.yml`. **`lsms_library/data_info.yml` untouched** (coordinator owns it).

### Verification
- `is_this_feature_sane`: **OK** (14 pass / 1 warn — AreaUnit constant 'hectares').
- 13,961 rows: 2018-19 = 7,323; 2021-22 = 6,638 (after dropping 3,286 placeholder rows).
- `(t, i, plot_id)` globally unique (0 dups).
- Orphan rate vs `sample().i`: **0.00%**.
- Tenure: owned 12,545 / use_right 1,061 / other_tenure 218 / sharecropped_in 78 / rented_in 59. All values ⊆ canonical spellings.
- Area median 1.18 ha (max 1000 ha — a survey-reported large parcel, left unclamped per recon).

### Decisions (see CONTENTS.org)
- Tenure code 2 (Prêt gratuit / free land loan) → `use_right`.
- TenureSystem partial: only Titre foncier→freehold, Bail→leasehold, Permis d'exploiter→granted_right_of_occupancy; rest NaN (no force-fit). 96% NaN.
- Latitude/Longitude deferred (EHCVM has no parcel GPS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)