### PR TITLE
feat(Senegal): plot_features (GH #167)

### DIFF
--- a/lsms_library/countries/Senegal/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Senegal/2018-19/_/plot_features.py
@@ -1,0 +1,41 @@
+"""Build plot_features for Senegal EHCVM 2018-19 (GH #167; EHCVM cluster).
+
+Single source file: s16a_me_sen2018.dta (agriculture-parcel module).
+plot_id = "{field_no}_{parcel_no}" (s16aq02 _ s16aq03); unique within
+each (grappe, menage).  See
+lsms_library/countries/Senegal/_/senegal.py:plot_features_for_wave for
+the harmonization shared across all EHCVM waves and the sibling
+countries (Mali is the reference implementation, PR #284).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from senegal import plot_features_for_wave
+
+
+# convert_categoricals=False keeps the integer s16a codes that the
+# categorical_mapping.org harmonize_* tables key on.
+src = get_dataframe('../Data/s16a_me_sen2018.dta', convert_categoricals=False)
+
+colmap = dict(
+    grappe        = 'grappe',
+    menage        = 'menage',
+    field_no      = 's16aq02',
+    parcel_no     = 's16aq03',
+    area_gps      = 's16aq47',
+    gps_measured  = 's16aq45',
+    area_est      = 's16aq09a',
+    area_est_unit = 's16aq09b',
+    tenure        = 's16aq10',
+    tenure_system = 's16aq13',
+    soil_type     = 's16aq18',
+    water_source  = 's16aq17',
+)
+
+df = plot_features_for_wave('2018-19', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2018-19"
+assert len(df) > 0, "plot_features 2018-19 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Senegal/2021-22/_/plot_features.py
+++ b/lsms_library/countries/Senegal/2021-22/_/plot_features.py
@@ -1,0 +1,41 @@
+"""Build plot_features for Senegal EHCVM 2021-22 (GH #167; EHCVM cluster).
+
+Single source file: s16a_me_sen2021.dta (agriculture-parcel module).
+The 2021-22 instrument uses the SAME column names and integer code
+scheme as 2018-19, so the colmap is identical.  Senegal-specific delta:
+the s16aq10 value label for code 3 is relabeled "Fermage/colonage"
+(vs. 2018-19 "Fermage"), but the integer CODE is unchanged -> still
+rented_in.  The harmonizer keys on the integer codes, so this relabel
+is transparent.  See
+lsms_library/countries/Senegal/_/senegal.py:plot_features_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from senegal import plot_features_for_wave
+
+
+src = get_dataframe('../Data/s16a_me_sen2021.dta', convert_categoricals=False)
+
+colmap = dict(
+    grappe        = 'grappe',
+    menage        = 'menage',
+    field_no      = 's16aq02',
+    parcel_no     = 's16aq03',
+    area_gps      = 's16aq47',
+    gps_measured  = 's16aq45',
+    area_est      = 's16aq09a',
+    area_est_unit = 's16aq09b',
+    tenure        = 's16aq10',
+    tenure_system = 's16aq13',
+    soil_type     = 's16aq18',
+    water_source  = 's16aq17',
+)
+
+df = plot_features_for_wave('2021-22', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2021-22"
+assert len(df) > 0, "plot_features 2021-22 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Senegal/_/categorical_mapping.org
+++ b/lsms_library/countries/Senegal/_/categorical_mapping.org
@@ -464,3 +464,63 @@
 | Tiles              | Tiles           |
 | Earth              | Earth           |
 | Dung               | Earth with Dung |
+
+# plot_features harmonization tables (GH #167; EHCVM cluster).
+# Copied from the Mali EHCVM reference (PR #284).  Keyed on the integer
+# s16a codes — Stata value labels are stable, so keying on codes avoids
+# any French/Portuguese language branch.  Senegal 2018-19 and 2021-22
+# use identical code schemes (verified from the .dta value-label
+# metadata); the only 2021-22 delta is the s16aq10 code-3 relabel
+# "Fermage" -> "Fermage/colonage" (still rented_in, same code).
+#
+# harmonize_tenure — s16aq10 "mode de faire-valoir" -> canonical Tenure.
+#   1 Propriétaire -> owned; 2 Prêt gratuit (free loan of land under
+#   agreement, typically non-cash) -> use_right, which the canonical
+#   schema defines as "held under agreement with a use-rights owner";
+#   3 Fermage(/colonage) -> rented_in; 4 Métayage -> sharecropped_in;
+#   5 Gage (pledge / pawned land) and 6 Autre -> other_tenure.
+# harmonize_soil — s16aq18 -> SoilType (free-form str; English labels).
+# harmonize_water — s16aq17; the Irrigated bool is (label=='Irrigated').
+#   Codes 1-3 (well/canal/stream) -> Irrigated; 4 Pluviale -> Rain-fed;
+#   5 Marais -> Wetland; 6 Autre is unmapped (NaN).
+# harmonize_tenure_system — s16aq13 land-document regime -> the canonical
+#   TenureSystem spellings.  Only the three documents that imply a clear
+#   regime are mapped (1 Titre foncier -> freehold, 2 Permis d'exploiter
+#   -> granted_right_of_occupancy, 4 Bail -> leasehold).  Procès-verbal,
+#   Convention de vente, Autre, and Aucun have no defensible regime
+#   mapping and are left out (NaN) rather than force-fit.
+
+#+name: harmonize_tenure
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | owned           |
+|    2 | use_right       |
+|    3 | rented_in       |
+|    4 | sharecropped_in |
+|    5 | other_tenure    |
+|    6 | other_tenure    |
+
+#+name: harmonize_soil
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | sandy           |
+|    2 | loam            |
+|    3 | clay            |
+|    4 | hardpan         |
+|    5 | other           |
+
+#+name: harmonize_water
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Irrigated       |
+|    2 | Irrigated       |
+|    3 | Irrigated       |
+|    4 | Rain-fed        |
+|    5 | Wetland         |
+
+#+name: harmonize_tenure_system
+| Code | Preferred Label            |
+|------+----------------------------|
+|    1 | freehold                   |
+|    2 | granted_right_of_occupancy |
+|    4 | leasehold                  |

--- a/lsms_library/countries/Senegal/_/contents.org
+++ b/lsms_library/countries/Senegal/_/contents.org
@@ -32,3 +32,27 @@ rather than expecting a =MonthsSpent= column in =household_roster()=.
 
 Senegal has no pre-EHCVM waves in the library, so no continuous
 months-of-presence variable is available for any wave.
+
+* plot_features (GH #167)
+
+Lasting parcel-level characteristics from the EHCVM agriculture module
+=s16a_me_sen{year}.dta=, copying the validated Mali EHCVM reference
+(PR #284).  Wired for both EHCVM waves (2018-19, 2021-22).  The shared
+harmonizer lives in =Senegal/_/senegal.py:plot_features_for_wave=; each
+wave's =_/plot_features.py= is a thin loader, and =_/plot_features.py=
+at the country level concatenates them.
+
+- Index :: =(t, i, plot_id)= where =i= is the EHCVM composite
+  =(grappe, menage)= and =plot_id = "{s16aq02}_{s16aq03}"= (field _
+  parcel).
+- Columns :: =Area= (hectares; GPS =s16aq47= where measured, else farmer
+  estimate =s16aq09a= converted via =s16aq09b= 1=ha/2=m2), =AreaUnit=
+  ('hectares'), =Tenure= (=s16aq10=), =TenureSystem= (=s16aq13=),
+  =SoilType= (=s16aq18=), =Irrigated= (=s16aq17=).
+- Harmonize_* code maps live in =_/categorical_mapping.org=, keyed on
+  the integer s16a codes (language-independent).
+- Latitude / Longitude deferred: EHCVM s16a has no decimal-degree parcel
+  GPS (=s16aq47= is an area, not a coordinate), as in Uganda.
+- Senegal-specific delta :: the 2021-22 instrument relabels =s16aq10=
+  code 3 "Fermage" -> "Fermage/colonage", but the integer code is
+  unchanged, so it still maps to =rented_in=.

--- a/lsms_library/countries/Senegal/_/data_scheme.yml
+++ b/lsms_library/countries/Senegal/_/data_scheme.yml
@@ -73,3 +73,21 @@ Data Scheme:
     Rural: str
 
   panel_ids: !make
+
+  plot_features:
+    # Lasting parcel-level characteristics from the EHCVM agriculture
+    # module s16a (GH #167; copies the Mali EHCVM reference, PR #284).
+    # EHCVM waves only: 2018-19 and 2021-22.  plot_id =
+    # "{field_no}_{parcel_no}".  Latitude / Longitude are NOT emitted —
+    # EHCVM s16a has no decimal-degree parcel GPS (s16aq47 is an area,
+    # not a coordinate); deferred as in Uganda.  Senegal-specific delta:
+    # 2021-22 relabels s16aq10 code 3 "Fermage/colonage" but the integer
+    # code is unchanged (still rented_in); the harmonizer keys on codes.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    SoilType: str
+    Irrigated: bool
+    materialize: make

--- a/lsms_library/countries/Senegal/_/plot_features.py
+++ b/lsms_library/countries/Senegal/_/plot_features.py
@@ -1,0 +1,40 @@
+"""Concatenate wave-level plot_features for Senegal (GH #167; EHCVM cluster).
+
+Each EHCVM wave's ``Senegal/<wave>/_/plot_features.py`` writes a parquet
+indexed by ``(t, i, plot_id)`` with the canonical plot_features columns.
+This script concatenates the EHCVM waves (2018-19, 2021-22).  ``v`` is
+NOT baked in — the framework joins it from ``sample()`` at API time.
+
+Following the Mali reference (PR #284), this does NOT apply ``id_walk``
+here.  Cached parquets store pre-transformation data; the framework runs
+``id_walk`` in ``_finalize_result`` on every read.  Applying id_walk at
+cache-write time could collide panel households that remap to the same
+baseline id onto identical ``(t, i, plot_id)`` tuples.  Leaving the index
+pre-walk keeps it globally unique; the framework's idempotent id_walk
+handles the panel remap consistently with every other Senegal table.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_features.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for plot_features (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_features: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, plot_id) after concat"
+
+to_parquet(p, '../var/plot_features.parquet')

--- a/lsms_library/countries/Senegal/_/senegal.py
+++ b/lsms_library/countries/Senegal/_/senegal.py
@@ -4,8 +4,20 @@ import pandas as pd
 import numpy as np
 import json
 from ligonlibrary.dataframes import from_dta
+import lsms_library.local_tools as tools
 
 waves = ['2018-19', '2021-22']
+
+
+def i(value):
+    '''
+    Formatting household id from (grappe, menage).
+    Uses '0' separator + zero-padded menage to prevent collisions
+    (e.g., grappe=1,menage=23 vs grappe=12,menage=3).  Matches the
+    wave-level ``mapping.i`` so the composite id is identical to
+    ``sample().i``.
+    '''
+    return tools.format_id(value.iloc[0]) + '0' + tools.format_id(value.iloc[1], zeropadding=2)
 
 
 def _household_roster_from_df(df, sex, age, HHID, sex_converter=None, age_converter=None,
@@ -69,3 +81,159 @@ def panel_ids(df):
 
     df = df[df['previous_i'].notna()]
     return df[['previous_i']]
+
+
+# ---------------------------------------------------------------------------
+# plot_features (GH #167; EHCVM cluster)
+# ---------------------------------------------------------------------------
+#
+# Senegal copies the validated Mali EHCVM reference implementation
+# (PR #284).  A single per-wave agriculture-parcel file
+# s16a_me_sen{year}.dta with the uniform EHCVM column scheme feeds the
+# shared ``plot_features_for_wave`` harmonizer; each wave's
+# ``_/plot_features.py`` is a thin loader that hands the raw DataFrame
+# plus a column map to it.  Senegal-specific delta: the 2021-22
+# instrument relabels s16aq10 code 3 to "Fermage/colonage" (vs. the
+# 2018-19 "Fermage"), but the integer CODE is unchanged -> still
+# rented_in.  The harmonizer keys on the integer codes, so no special
+# handling is needed.
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a ``{int code -> Preferred Label}`` dict from
+    ``categorical_mapping.org`` for one of the plot_features harmonize_*
+    tables.  Codes whose Preferred Label is blank / '---' map to NA so
+    the corresponding column stays NaN.  Mirrors Uganda's helper."""
+    raw = tools.get_categorical_mapping(tablename=tablename, idxvars=key,
+                                        **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw Stata integer-code) Series through ``code_map``,
+    returning a string Series with NA where the code is unmapped.  Source
+    files must be loaded with ``convert_categoricals=False`` so the codes
+    arrive as integers."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_features_for_wave(t, source, colmap):
+    """Build canonical ``plot_features`` for one Senegal EHCVM wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2018-19"``), used as the ``t`` index value.
+    source : pd.DataFrame
+        Raw s16a agriculture-parcel DataFrame, loaded via
+        ``get_dataframe(..., convert_categoricals=False)`` so the
+        harmonize_* tables can key on the integer codes.
+    colmap : dict
+        Column-name map.  Required keys::
+
+            grappe        — cluster id column (with menage builds ``i``)
+            menage        — within-cluster household number
+            field_no      — within-HH field/champ sequence number
+            parcel_no     — within-field parcel sequence number
+            area_gps      — GPS-measured parcel area (hectares)
+            gps_measured  — 1/2 (Oui/Non) flag for GPS measurement
+            area_est      — farmer-estimated area (in area_est_unit)
+            area_est_unit — 1=Hectare, 2=m^2
+            tenure        — mode-of-tenure question  -> Tenure
+            tenure_system — land-document question    -> TenureSystem
+            soil_type     — soil-type question        -> SoilType
+            water_source  — water-source question     -> Irrigated
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
+        ``Area`` (hectares float), ``AreaUnit`` (always 'hectares'),
+        ``Tenure``, ``TenureSystem``, ``SoilType`` (str), and
+        ``Irrigated`` (nullable bool).
+
+    Notes
+    -----
+    * ``i`` is the EHCVM composite household id built with Senegal's
+      ``i()`` formatter so it matches ``sample().i`` natively.
+    * ``plot_id = "{field_no}_{parcel_no}"`` — unique within
+      ``(grappe, menage)``.
+    * ``Area`` prefers the GPS measurement (already hectares) where
+      ``gps_measured == 1``; otherwise the farmer estimate converted to
+      hectares (m^2 / 10000).  No GPS coordinate columns: EHCVM s16a has
+      no decimal-degree parcel GPS, so Latitude / Longitude are deferred
+      (as in Uganda).
+    """
+    tenure_map = _harmonized_codes('harmonize_tenure')
+    tenure_system_map = _harmonized_codes('harmonize_tenure_system')
+    soil_map = _harmonized_codes('harmonize_soil')
+    water_map = _harmonized_codes('harmonize_water')
+
+    c = colmap
+
+    # Drop s16a placeholder rows for non-farming households: rows with NO
+    # field/parcel number and every plot attribute blank.  Keeping them
+    # would emit a content-free "nan_nan" plot_id per household.
+    src = source[source[c['field_no']].notna() & source[c['parcel_no']].notna()].copy()
+
+    # Household id: EHCVM composite (grappe, menage) via senegal.i().
+    hh = src.apply(lambda r: i(pd.Series([r[c['grappe']], r[c['menage']]])),
+                   axis=1)
+
+    field = src[c['field_no']].apply(tools.format_id)
+    parcel = src[c['parcel_no']].apply(tools.format_id)
+    plot_id = field.astype(str) + '_' + parcel.astype(str)
+
+    # Area in hectares.  GPS where measured, else farmer estimate
+    # converted from its declared unit (1=Hectare ->x1, 2=m^2 ->/10000).
+    area_gps = pd.to_numeric(src[c['area_gps']], errors='coerce').astype('Float64')
+    gps_flag = src[c['gps_measured']].astype('Int64')
+
+    est_raw = pd.to_numeric(src[c['area_est']], errors='coerce').astype('Float64')
+    est_unit = src[c['area_est_unit']].astype('Int64')
+    est_ha = est_raw.where(est_unit != 2, est_raw / 10000)
+
+    # Prefer GPS where it was actually measured (flag == 1) and present.
+    area_ha = est_ha.copy()
+    use_gps = (gps_flag == 1) & area_gps.notna()
+    area_ha = area_gps.where(use_gps, area_ha)
+
+    area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
+    area_unit = area_unit.where(area_ha.notna(), pd.NA)
+
+    tenure = _map_codes(src[c['tenure']], tenure_map) \
+        if c.get('tenure') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    tenure_system = _map_codes(src[c['tenure_system']], tenure_system_map) \
+        if c.get('tenure_system') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    soil_type = _map_codes(src[c['soil_type']], soil_map) \
+        if c.get('soil_type') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+
+    irrigated = pd.Series(pd.NA, index=src.index, dtype='boolean')
+    if c.get('water_source') in src.columns:
+        water_label = _map_codes(src[c['water_source']], water_map)
+        irrigated = (water_label == 'Irrigated').astype('boolean')
+        irrigated = irrigated.where(water_label.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        't':            t,
+        'i':            hh.values,
+        'plot_id':      plot_id.values,
+        'Area':         area_ha.values,
+        'AreaUnit':     area_unit.values,
+        'Tenure':       tenure.values,
+        'TenureSystem': tenure_system.values,
+        'SoilType':     soil_type.values,
+        'Irrigated':    irrigated.values,
+    })
+    df = df.set_index(['t', 'i', 'plot_id'])
+    return df


### PR DESCRIPTION
Implements `plot_features` for Senegal (EHCVM), copying the validated Mali reference (PR #284).

## Scope
- Wires `plot_features` for both EHCVM waves: **2018-19** and **2021-22**.
- Source: `Senegal/{wave}/Data/s16a_me_sen{year}.dta` (agriculture-parcel module).
- Index `(t, i, plot_id)`; `i = (grappe, menage)` composite; `plot_id = "{s16aq02}_{s16aq03}"`.
- Columns: `Area` (ha; GPS s16aq47 where measured else estimate s16aq09a converted via s16aq09b), `AreaUnit`, `Tenure` (s16aq10), `TenureSystem` (s16aq13), `SoilType` (s16aq18), `Irrigated` (s16aq17).
- Lat/Lon deferred (EHCVM s16a has no decimal-degree parcel GPS), as in Uganda.

## Files
- `Senegal/_/senegal.py` — `i()` formatter + shared `plot_features_for_wave` harmonizer (keys on integer s16a codes, language-independent).
- `Senegal/{2018-19,2021-22}/_/plot_features.py` — thin per-wave loaders.
- `Senegal/_/plot_features.py` — country concatenator (no id_walk at cache-write time; framework handles it).
- `Senegal/_/categorical_mapping.org` — `harmonize_tenure/soil/water/tenure_system`.
- `Senegal/_/data_scheme.yml` — registered (`materialize: make`).
- `Senegal/_/contents.org` — `* plot_features (GH #167)`.

## EHCVM / Senegal-specific
The 2021-22 instrument relabels `s16aq10` code 3 `Fermage` -> `Fermage/colonage`, but the integer **code is unchanged** -> still `rented_in`. The harmonizer keys on codes, so the relabel is transparent.

## Verification (run directly via venv; `.pth` pins Country() to main checkout)
- 13879 rows: 2018-19 = 7767, 2021-22 = 6112 (== s16a row counts; no placeholder rows to drop in Senegal).
- `(t, i, plot_id)` index unique; 0 `nan_nan` plot_ids.
- `is_this_feature_sane(df, 'Senegal', 'plot_features')` = **ok** (only a benign warn: constant AreaUnit).
- **0% orphan** households vs `Country('Senegal').sample().i` (3333 plot HH all matched natively).
- Tenure/SoilType/TenureSystem values all within canonical sets.

Tenure dist: owned 11095, use_right 2014, other_tenure 381, sharecropped_in 190, rented_in 144, NA 55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)