### PR TITLE
feat(Guinea-Bissau): plot_features (GH #167)

### DIFF
--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/plot_features.py
@@ -1,0 +1,46 @@
+"""Build plot_features for Guinea-Bissau EHCVM 2018-19 (GH #167; EHCVM cluster).
+
+Single source file: s16a_me_gnb2018.dta (agriculture-parcel module,
+9,873 rows).  plot_id = "{field_no}_{parcel_no}" (s16aq02 _ s16aq03);
+unique within each (grappe, menage).  See
+lsms_library/countries/Guinea-Bissau/_/guinea_bissau.py:plot_features_for_wave
+for the harmonization shared with the Mali EHCVM reference.
+
+Guinea-Bissau specific: the s16a value labels are Portuguese
+(Proprietário, Arenoso, ...) but the integer codes match the French
+EHCVM countries, so loading with convert_categoricals=False and keying
+the harmonize_* tables on the codes reuses Mali's mapping unchanged.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from guinea_bissau import plot_features_for_wave
+
+
+# convert_categoricals=False keeps the integer s16a codes that the
+# categorical_mapping.org harmonize_* tables key on (Portuguese labels
+# share the French EHCVM integer codes).
+src = get_dataframe('../Data/s16a_me_gnb2018.dta', convert_categoricals=False)
+
+colmap = dict(
+    grappe        = 'grappe',
+    menage        = 'menage',
+    field_no      = 's16aq02',
+    parcel_no     = 's16aq03',
+    area_gps      = 's16aq47',
+    gps_measured  = 's16aq45',
+    area_est      = 's16aq09a',
+    area_est_unit = 's16aq09b',
+    tenure        = 's16aq10',
+    tenure_system = 's16aq13',
+    soil_type     = 's16aq18',
+    water_source  = 's16aq17',
+)
+
+df = plot_features_for_wave('2018-19', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2018-19"
+assert len(df) > 0, "plot_features 2018-19 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Guinea-Bissau/_/CONTENTS.org
+++ b/lsms_library/countries/Guinea-Bissau/_/CONTENTS.org
@@ -65,3 +65,30 @@ For the cross-country canonical-=u= roadmap, see GH #223.  Guinea-Bissau
 was originally classified Tier 3 (needing a new =u= table built) in
 that issue's inventory, but turned out to be Tier 2 once the mojibake
 fix landed -- the underlying labels are already canonical.
+
+* plot_features (GH #167)
+
+Lasting parcel-level characteristics from the EHCVM agriculture module
+=s16a_me_gnb2018.dta=, indexed by =(t, i, plot_id)= with =plot_id =
+"{field_no}_{parcel_no}"= (=s16aq02= _ =s16aq03=).  Columns: =Area=
+(hectares; GPS =s16aq47= where measured, else farmer estimate =s16aq09a=
+converted via =s16aq09b=), =AreaUnit=, =Tenure= (=s16aq10=),
+=TenureSystem= (=s16aq13=), =SoilType= (=s16aq18=), =Irrigated=
+(=s16aq17=).  Single EHCVM wave =2018-19=; there is no 2021-22 wave.
+
+Guinea-Bissau is an EHCVM sibling of the Mali reference implementation
+(PR #284): the per-wave =_/plot_features.py= is a thin loader handing
+the raw s16a DataFrame plus a column map to the shared
+=guinea_bissau.plot_features_for_wave=.
+
+*** Portuguese labels, same integer codes. ***  The s16a value LABELS
+are in Portuguese (=Proprietário=, =Arenoso=, =Sim/Não=, ...) but the
+underlying INTEGER CODES are IDENTICAL to the French-language EHCVM
+countries.  The source is loaded with =convert_categoricals=False= and
+the =harmonize_*= tables in =_/categorical_mapping.org= key on the
+integer Code, so Mali's code->canonical mapping is reused verbatim with
+NO Portuguese-language branch (e.g. SoilType code 1 =Arenoso= maps to
+=sandy=, the same as the French =sableux=).
+
+Latitude / Longitude are deferred: EHCVM s16a has no decimal-degree
+parcel GPS (=s16aq47= is an area, not a coordinate), as in Uganda.

--- a/lsms_library/countries/Guinea-Bissau/_/categorical_mapping.org
+++ b/lsms_library/countries/Guinea-Bissau/_/categorical_mapping.org
@@ -29,3 +29,66 @@
 | Cement             | Cement          |
 | Tiles              | Tiles           |
 | Dung               | Earth with Dung |
+
+# plot_features harmonize_* tables (GH #167; EHCVM cluster).
+#
+# Guinea-Bissau's s16a value LABELS are Portuguese (Proprietário,
+# Arenoso, Sim/Não, ...) but the underlying INTEGER CODES are IDENTICAL
+# to the French-language EHCVM countries (Mali, Niger, Senegal, ...).
+# These tables therefore key on the integer Code and reuse Mali's
+# code->canonical mapping verbatim — there is NO Portuguese-language
+# branch.  The wave script loads s16a with convert_categoricals=False so
+# the codes arrive as integers; guinea_bissau._map_codes maps them here.
+#
+# harmonize_tenure — s16aq10 "mode d'occupation" -> canonical Tenure.
+#   PT labels: 1 Proprietário->owned, 2 Empréstimo a título gratuito
+#   (free loan)->use_right, 3 Arrendamento->rented_in, 4 Parceria
+#   (sharecrop)->sharecropped_in, 5 Penhora (pledge/pawn) & 6 Outro
+#   ->other_tenure.
+# harmonize_soil — s16aq18 -> SoilType (English labels).  PT: 1 Arenoso
+#   ->sandy, 2 Limoso->loam, 3 Argiloso->clay, 4 Talude->hardpan,
+#   5 Outro->other.
+# harmonize_water — s16aq17; the Irrigated bool is (label=='Irrigated').
+#   PT: 1-3 Irrigação (poço/canal/regato)->Irrigated, 4 Pluvial->Rain-fed,
+#   5 Pântano/wetlands->Wetland, 6 Outro unmapped (NaN -> Irrigated=NA).
+# harmonize_tenure_system — s16aq13 land-document regime -> canonical
+#   TenureSystem spellings.  Only the three documents that imply a clear
+#   regime are mapped (1 Título fundiário->freehold, 2 Licença de
+#   exploração->granted_right_of_occupancy, 4 Locação->leasehold).
+#   3 Registo, 5 Convençao de venda, 6 Outro, 7 Nenhum have no defensible
+#   regime mapping and are left out (NaN) rather than force-fit.
+
+#+name: harmonize_tenure
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | owned           |
+|    2 | use_right       |
+|    3 | rented_in       |
+|    4 | sharecropped_in |
+|    5 | other_tenure    |
+|    6 | other_tenure    |
+
+#+name: harmonize_soil
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | sandy           |
+|    2 | loam            |
+|    3 | clay            |
+|    4 | hardpan         |
+|    5 | other           |
+
+#+name: harmonize_water
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Irrigated       |
+|    2 | Irrigated       |
+|    3 | Irrigated       |
+|    4 | Rain-fed        |
+|    5 | Wetland         |
+
+#+name: harmonize_tenure_system
+| Code | Preferred Label            |
+|------+----------------------------|
+|    1 | freehold                   |
+|    2 | granted_right_of_occupancy |
+|    4 | leasehold                  |

--- a/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
+++ b/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
@@ -66,3 +66,21 @@ Data Scheme:
   interview_date:
     index: (t, i)
     Int_t: datetime
+
+  plot_features:
+    # Lasting parcel-level characteristics from the EHCVM agriculture
+    # module s16a (GH #167; Guinea-Bissau is an EHCVM sibling of the
+    # Mali reference, PR #284).  Single EHCVM wave: 2018-19 (no 2021-22).
+    # s16a value labels are Portuguese but the integer codes match the
+    # French EHCVM countries, so the harmonize_* tables key on the codes.
+    # plot_id = "{field_no}_{parcel_no}".  Latitude / Longitude are NOT
+    # emitted — EHCVM s16a has no decimal-degree parcel GPS (s16aq47 is
+    # an area, not a coordinate); deferred as in Uganda.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    SoilType: str
+    Irrigated: bool
+    materialize: make

--- a/lsms_library/countries/Guinea-Bissau/_/guinea_bissau.py
+++ b/lsms_library/countries/Guinea-Bissau/_/guinea_bissau.py
@@ -1,0 +1,167 @@
+# plot_features helpers for Guinea-Bissau (GH #167; EHCVM cluster)
+#
+# Guinea-Bissau is an EHCVM sibling of Mali (the reference
+# implementation, PR #284).  The single per-wave agriculture-parcel
+# file s16a_me_gnb2018.dta has the same uniform column scheme as the
+# French-language EHCVM countries.
+#
+# *** Guinea-Bissau specific: the s16a value LABELS are in Portuguese
+# (Proprietário, Arenoso, Sim/Não, ...) but the underlying INTEGER
+# CODES are IDENTICAL to the French EHCVM countries (Mali, Niger,
+# Senegal, ...).  We therefore key every harmonize_* table on the
+# integer code and reuse Mali's code->canonical mapping verbatim — no
+# Portuguese-language branch.  Source files are loaded with
+# convert_categoricals=False so the codes arrive as integers. ***
+import pandas as pd
+import numpy as np
+import lsms_library.local_tools as tools
+
+
+def i(value):
+    '''Formatting household id from (grappe, menage).'''
+    if isinstance(value, (pd.Series, np.ndarray, list, tuple)):
+        return tools.format_id(value.iloc[0]) + '0' + tools.format_id(value.iloc[1], zeropadding=2)
+    return tools.format_id(value)
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a ``{int code -> Preferred Label}`` dict from
+    ``categorical_mapping.org`` for one of the plot_features harmonize_*
+    tables.  Codes whose Preferred Label is blank / '---' map to NA so
+    the corresponding column stays NaN.  Mirrors Mali / Uganda's helper."""
+    raw = tools.get_categorical_mapping(tablename=tablename, idxvars=key,
+                                        **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw Stata integer-code) Series through ``code_map``,
+    returning a string Series with NA where the code is unmapped.  Source
+    files must be loaded with ``convert_categoricals=False`` so the codes
+    arrive as integers."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_features_for_wave(t, source, colmap):
+    """Build canonical ``plot_features`` for one Guinea-Bissau EHCVM wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2018-19"``), used as the ``t`` index value.
+    source : pd.DataFrame
+        Raw s16a agriculture-parcel DataFrame, loaded via
+        ``get_dataframe(..., convert_categoricals=False)`` so the
+        harmonize_* tables can key on the integer codes.  (Guinea-Bissau
+        labels are Portuguese; the codes are the same as the French
+        EHCVM countries, so keying on codes language-proofs this.)
+    colmap : dict
+        Column-name map.  Required keys::
+
+            grappe        — cluster id column (with menage builds ``i``)
+            menage        — within-cluster household number
+            field_no      — within-HH field/champ sequence number
+            parcel_no     — within-field parcel sequence number
+            area_gps      — GPS-measured parcel area (hectares)
+            gps_measured  — 1/2 (Sim/Não) flag for GPS measurement
+            area_est      — farmer-estimated area (in area_est_unit)
+            area_est_unit — 1=Hectare, 2=m^2
+            tenure        — mode-of-tenure question  -> Tenure
+            tenure_system — land-document question    -> TenureSystem
+            soil_type     — soil-type question        -> SoilType
+            water_source  — water-source question     -> Irrigated
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
+        ``Area`` (hectares float), ``AreaUnit`` (always 'hectares'),
+        ``Tenure``, ``TenureSystem``, ``SoilType`` (str), and
+        ``Irrigated`` (nullable bool).
+
+    Notes
+    -----
+    * ``i`` is the EHCVM composite household id built with Guinea-Bissau's
+      ``i()`` formatter so it matches ``sample().i`` natively.
+    * ``plot_id = "{field_no}_{parcel_no}"`` — unique within
+      ``(grappe, menage)``.
+    * ``Area`` prefers the GPS measurement (already hectares) where
+      ``gps_measured == 1``; otherwise the farmer estimate converted to
+      hectares (m^2 / 10000).  No GPS coordinate columns: EHCVM s16a has
+      no decimal-degree parcel GPS, so Latitude / Longitude are deferred
+      (as in Uganda / Mali).
+    """
+    tenure_map = _harmonized_codes('harmonize_tenure')
+    tenure_system_map = _harmonized_codes('harmonize_tenure_system')
+    soil_map = _harmonized_codes('harmonize_soil')
+    water_map = _harmonized_codes('harmonize_water')
+
+    c = colmap
+
+    # Drop the s16a placeholder / blank rows for non-farming households:
+    # one row per household with NO field/parcel number and every plot
+    # attribute blank.  Keeping them would emit a content-free
+    # "nan_nan" plot_id per household.
+    src = source[source[c['field_no']].notna() & source[c['parcel_no']].notna()].copy()
+
+    # Household id: EHCVM composite (grappe, menage) via i().
+    hh = src.apply(lambda r: i(pd.Series([r[c['grappe']], r[c['menage']]])),
+                   axis=1)
+
+    field = src[c['field_no']].apply(tools.format_id)
+    parcel = src[c['parcel_no']].apply(tools.format_id)
+    plot_id = field.astype(str) + '_' + parcel.astype(str)
+
+    # Area in hectares.  GPS where measured, else farmer estimate
+    # converted from its declared unit (1=Hectare ->x1, 2=m^2 ->/10000).
+    area_gps = pd.to_numeric(src[c['area_gps']], errors='coerce').astype('Float64')
+    gps_flag = src[c['gps_measured']].astype('Int64')
+
+    est_raw = pd.to_numeric(src[c['area_est']], errors='coerce').astype('Float64')
+    est_unit = src[c['area_est_unit']].astype('Int64')
+    est_ha = est_raw.where(est_unit != 2, est_raw / 10000)
+
+    # Prefer GPS where it was actually measured (flag == 1) and present.
+    area_ha = est_ha.copy()
+    use_gps = (gps_flag == 1) & area_gps.notna()
+    area_ha = area_gps.where(use_gps, area_ha)
+
+    area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
+    area_unit = area_unit.where(area_ha.notna(), pd.NA)
+
+    tenure = _map_codes(src[c['tenure']], tenure_map) \
+        if c.get('tenure') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    tenure_system = _map_codes(src[c['tenure_system']], tenure_system_map) \
+        if c.get('tenure_system') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    soil_type = _map_codes(src[c['soil_type']], soil_map) \
+        if c.get('soil_type') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+
+    irrigated = pd.Series(pd.NA, index=src.index, dtype='boolean')
+    if c.get('water_source') in src.columns:
+        water_label = _map_codes(src[c['water_source']], water_map)
+        irrigated = (water_label == 'Irrigated').astype('boolean')
+        irrigated = irrigated.where(water_label.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        't':            t,
+        'i':            hh.values,
+        'plot_id':      plot_id.values,
+        'Area':         area_ha.values,
+        'AreaUnit':     area_unit.values,
+        'Tenure':       tenure.values,
+        'TenureSystem': tenure_system.values,
+        'SoilType':     soil_type.values,
+        'Irrigated':    irrigated.values,
+    })
+    df = df.set_index(['t', 'i', 'plot_id'])
+    return df

--- a/lsms_library/countries/Guinea-Bissau/_/plot_features.py
+++ b/lsms_library/countries/Guinea-Bissau/_/plot_features.py
@@ -1,0 +1,39 @@
+"""Concatenate wave-level plot_features for Guinea-Bissau (GH #167; EHCVM cluster).
+
+Each EHCVM wave's ``Guinea-Bissau/<wave>/_/plot_features.py`` writes a
+parquet indexed by ``(t, i, plot_id)`` with the canonical plot_features
+columns.  Guinea-Bissau has a single EHCVM wave (2018-19); there is no
+2021-22 wave.  ``v`` is NOT baked in — the framework joins it from
+``sample()`` at API time.
+
+Unlike Uganda's concatenator, this does NOT apply ``id_walk`` here.
+Cached parquets store pre-transformation data; the framework runs
+``id_walk`` in ``_finalize_result`` on every read.  (Mirrors the Mali
+EHCVM reference, where leaving the index pre-walk avoids panel-remap
+collisions on the parquet index.)
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2018-19']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_features.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for plot_features (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_features: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, plot_id) after concat"
+
+to_parquet(p, '../var/plot_features.parquet')


### PR DESCRIPTION
## Summary

Adds `plot_features` to Guinea-Bissau (EHCVM), copied from the Mali reference (PR #284) and adapted. Single wave **2018-19** from `s16a_me_gnb2018.dta` (9,873 parcel rows). No 2021-22 wave exists.

`plot_id = "{field_no}_{parcel_no}"` (s16aq02 _ s16aq03); index `(t, i, plot_id)`. `i = (grappe, menage)` matches `sample().i` natively.

## Guinea-Bissau specific: Portuguese labels, same integer codes

The s16a value **labels** are in Portuguese (`Proprietário`, `Arenoso`, `Sim/Não`, ...) but the underlying **integer codes are identical** to the French-language EHCVM countries. The source is loaded with `convert_categoricals=False` and every `harmonize_*` table keys on the integer code, reusing Mali's code→canonical mapping verbatim — no Portuguese-language branch. (e.g. SoilType code 1 `Arenoso` → `sandy`, same as the French `sableux`.)

## Files

- `_/guinea_bissau.py` — `plot_features_for_wave` helper + `i()` formatter
- `2018-19/_/plot_features.py` — thin wave loader
- `_/plot_features.py` — single-wave concatenator (no `id_walk`; framework runs it in `_finalize_result`)
- `_/categorical_mapping.org` — `harmonize_{tenure,soil,water,tenure_system}`
- `_/data_scheme.yml` — register `plot_features` (`materialize: make`)
- `_/CONTENTS.org` — document Portuguese-labels/same-codes

## Verification (wave script run directly; not via Country() due to .pth → main checkout)

- `is_this_feature_sane`: all pass; 1 expected `warn` (`AreaUnit` constant = 'hectares'), same as Mali.
- `(t, i, plot_id)` index unique (9,873 rows).
- Values ⊆ canonical: Tenure {owned 8576, use_right 891, other_tenure 232, sharecropped_in 95, rented_in 78, NA 1}; SoilType {sandy, loam, clay, hardpan, other}; Irrigated {True, False}; TenureSystem {freehold, granted_right_of_occupancy, leasehold}.
- Portuguese→code→canonical confirmed: `Arenoso`→`sandy`, `Proprietário`→`owned`.
- Orphan vs `sample().i`: **0.00%** (3615 plot HH all present in sample).

🤖 Generated with [Claude Code](https://claude.com/claude-code)