### PR TITLE
feat(Benin): plot_features (GH #167)

### DIFF
--- a/lsms_library/countries/Benin/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Benin/2018-19/_/plot_features.py
@@ -1,0 +1,40 @@
+"""Build plot_features for Benin EHCVM 2018-19 (GH #167; EHCVM cluster).
+
+Single source file: s16a_me_ben2018.dta (agriculture-parcel module,
+7,588 rows).  plot_id = "{field_no}_{parcel_no}" (s16aq02 _ s16aq03);
+unique within each (grappe, menage).  See
+lsms_library/countries/Benin/_/benin.py:plot_features_for_wave for the
+harmonization shared with the Mali EHCVM reference implementation.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from benin import plot_features_for_wave
+
+
+# convert_categoricals=False keeps the integer s16a codes that the
+# categorical_mapping.org harmonize_* tables key on.
+src = get_dataframe('../Data/s16a_me_ben2018.dta', convert_categoricals=False)
+
+colmap = dict(
+    grappe        = 'grappe',
+    menage        = 'menage',
+    field_no      = 's16aq02',
+    parcel_no     = 's16aq03',
+    area_gps      = 's16aq47',
+    gps_measured  = 's16aq45',
+    area_est      = 's16aq09a',
+    area_est_unit = 's16aq09b',
+    tenure        = 's16aq10',
+    tenure_system = 's16aq13',
+    soil_type     = 's16aq18',
+    water_source  = 's16aq17',
+)
+
+df = plot_features_for_wave('2018-19', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2018-19"
+assert len(df) > 0, "plot_features 2018-19 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Benin/_/CONTENTS.org
+++ b/lsms_library/countries/Benin/_/CONTENTS.org
@@ -73,3 +73,28 @@ rather than expecting a =MonthsSpent= column in =household_roster()=.
 
 Benin has no pre-EHCVM waves in the library, so no continuous
 months-of-presence variable is available for any wave.
+
+* plot_features (GH #167)
+
+Lasting parcel-level characteristics from the EHCVM agriculture
+module =s16a_me_ben2018.dta= (single 2018-19 wave; Benin has no
+2021-22 EHCVM-II wave in this repo).  Benin is an EHCVM sibling of
+the Mali reference implementation (PR #284): the shared
+harmonization lives in =Benin/_/benin.py:plot_features_for_wave=,
+mirroring =Mali/_/mali.py=.
+
+- Index =(t, i, plot_id)= where =plot_id = "{field_no}_{parcel_no}"=
+  (=s16aq02 _ s16aq03=), unique within each =(grappe, menage)=.
+- =Area= in hectares: GPS measurement (=s16aq47=, already hectares)
+  where =s16aq45 == 1=, else farmer estimate (=s16aq09a=) converted
+  via =s16aq09b= (1=Hectare ->x1, 2=m^2 ->/10000).  =AreaUnit= is
+  always ='hectares'=.
+- =Tenure= <- =s16aq10= (harmonize_tenure); =SoilType= <- =s16aq18=
+  (harmonize_soil); =Irrigated= <- =s16aq17= (harmonize_water, True
+  where label=='Irrigated'); =TenureSystem= <- =s16aq13=
+  (harmonize_tenure_system, only the three document codes that imply
+  a clear regime; others NaN).
+- Placeholder rows for non-farming households (no field/parcel
+  number) are dropped.  =v= is joined from =sample()= at API time
+  (not baked in).  Latitude / Longitude deferred — EHCVM s16a has no
+  decimal-degree parcel GPS.

--- a/lsms_library/countries/Benin/_/benin.py
+++ b/lsms_library/countries/Benin/_/benin.py
@@ -8,3 +8,154 @@ def i(value):
     Formatting household id
     '''
     return tools.format_id(value.iloc[0])+tools.format_id(value.iloc[1],zeropadding=3)
+
+
+# ---------------------------------------------------------------------------
+# plot_features (GH #167; EHCVM cluster)
+# ---------------------------------------------------------------------------
+#
+# Benin is an EHCVM sibling of the Mali reference implementation.  The
+# single 2018-19 wave uses the s16a agriculture-parcel module with the
+# uniform EHCVM column scheme.  The shared harmonization lives here in
+# ``plot_features_for_wave``; the wave's ``_/plot_features.py`` is a thin
+# loader that hands the raw DataFrame plus a column map to it.  ``i`` is
+# the Benin EHCVM composite household id built with this module's ``i()``
+# formatter so it matches ``sample().i`` natively.
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a ``{int code -> Preferred Label}`` dict from
+    ``categorical_mapping.org`` for one of the plot_features harmonize_*
+    tables.  Codes whose Preferred Label is blank / '---' map to NA so
+    the corresponding column stays NaN.  Mirrors the Mali helper."""
+    raw = tools.get_categorical_mapping(tablename=tablename, idxvars=key,
+                                        **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw Stata integer-code) Series through ``code_map``,
+    returning a string Series with NA where the code is unmapped.  Source
+    files must be loaded with ``convert_categoricals=False`` so the codes
+    arrive as integers."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_features_for_wave(t, source, colmap):
+    """Build canonical ``plot_features`` for one Benin EHCVM wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2018-19"``), used as the ``t`` index value.
+    source : pd.DataFrame
+        Raw s16a agriculture-parcel DataFrame, loaded via
+        ``get_dataframe(..., convert_categoricals=False)`` so the
+        harmonize_* tables can key on the integer codes.
+    colmap : dict
+        Column-name map.  Required keys::
+
+            grappe        — cluster id column (with menage builds ``i``)
+            menage        — within-cluster household number
+            field_no      — within-HH field/champ sequence number
+            parcel_no     — within-field parcel sequence number
+            area_gps      — GPS-measured parcel area (hectares)
+            gps_measured  — 1/2 (Oui/Non) flag for GPS measurement
+            area_est      — farmer-estimated area (in area_est_unit)
+            area_est_unit — 1=Hectare, 2=m^2
+            tenure        — mode-of-tenure question  -> Tenure
+            tenure_system — land-document question    -> TenureSystem
+            soil_type     — soil-type question        -> SoilType
+            water_source  — water-source question     -> Irrigated
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
+        ``Area`` (hectares float), ``AreaUnit`` (always 'hectares'),
+        ``Tenure``, ``TenureSystem``, ``SoilType`` (str), and
+        ``Irrigated`` (nullable bool).
+
+    Notes
+    -----
+    * ``plot_id = "{field_no}_{parcel_no}"`` — unique within
+      ``(grappe, menage)``.
+    * ``Area`` prefers the GPS measurement (already hectares) where
+      ``gps_measured == 1``; otherwise the farmer estimate converted to
+      hectares (m^2 / 10000).  No GPS coordinate columns: EHCVM s16a has
+      no decimal-degree parcel GPS, so Latitude / Longitude are deferred
+      (as in Uganda / Mali).
+    """
+    tenure_map = _harmonized_codes('harmonize_tenure')
+    tenure_system_map = _harmonized_codes('harmonize_tenure_system')
+    soil_map = _harmonized_codes('harmonize_soil')
+    water_map = _harmonized_codes('harmonize_water')
+
+    c = colmap
+
+    # Drop the s16a placeholder rows for non-farming households: rows with
+    # NO field/parcel number and every plot attribute blank.  Keeping them
+    # would emit a content-free "nan_nan" plot_id per household.
+    src = source[source[c['field_no']].notna() & source[c['parcel_no']].notna()].copy()
+
+    # Household id: EHCVM composite (grappe, menage) via benin.i().
+    hh = src.apply(lambda r: i(pd.Series([r[c['grappe']], r[c['menage']]])),
+                   axis=1)
+
+    field = src[c['field_no']].apply(tools.format_id)
+    parcel = src[c['parcel_no']].apply(tools.format_id)
+    plot_id = field.astype(str) + '_' + parcel.astype(str)
+
+    # Area in hectares.  GPS where measured, else farmer estimate
+    # converted from its declared unit (1=Hectare ->x1, 2=m^2 ->/10000).
+    area_gps = pd.to_numeric(src[c['area_gps']], errors='coerce').astype('Float64')
+    gps_flag = src[c['gps_measured']].astype('Int64')
+
+    est_raw = pd.to_numeric(src[c['area_est']], errors='coerce').astype('Float64')
+    est_unit = src[c['area_est_unit']].astype('Int64')
+    est_ha = est_raw.where(est_unit != 2, est_raw / 10000)
+
+    # Prefer GPS where it was actually measured (flag == 1) and present.
+    area_ha = est_ha.copy()
+    use_gps = (gps_flag == 1) & area_gps.notna()
+    area_ha = area_gps.where(use_gps, area_ha)
+
+    area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
+    area_unit = area_unit.where(area_ha.notna(), pd.NA)
+
+    tenure = _map_codes(src[c['tenure']], tenure_map) \
+        if c.get('tenure') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    tenure_system = _map_codes(src[c['tenure_system']], tenure_system_map) \
+        if c.get('tenure_system') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    soil_type = _map_codes(src[c['soil_type']], soil_map) \
+        if c.get('soil_type') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+
+    irrigated = pd.Series(pd.NA, index=src.index, dtype='boolean')
+    if c.get('water_source') in src.columns:
+        water_label = _map_codes(src[c['water_source']], water_map)
+        irrigated = (water_label == 'Irrigated').astype('boolean')
+        irrigated = irrigated.where(water_label.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        't':            t,
+        'i':            hh.values,
+        'plot_id':      plot_id.values,
+        'Area':         area_ha.values,
+        'AreaUnit':     area_unit.values,
+        'Tenure':       tenure.values,
+        'TenureSystem': tenure_system.values,
+        'SoilType':     soil_type.values,
+        'Irrigated':    irrigated.values,
+    })
+    df = df.set_index(['t', 'i', 'plot_id'])
+    return df

--- a/lsms_library/countries/Benin/_/categorical_mapping.org
+++ b/lsms_library/countries/Benin/_/categorical_mapping.org
@@ -104,3 +104,62 @@
 | Tiles              | Tiles           |
 | Dung               | Earth with Dung |
 | Other              | Other           |
+
+# plot_features harmonization tables (GH #167; EHCVM cluster).
+# Keyed on the integer s16a codes — Stata value labels are stable
+# across the EHCVM countries, so keying on codes avoids any French /
+# Portuguese language branch.  Benin has the single 2018-19 wave; the
+# code scheme is identical to the Mali reference (s16aq10 tenure 1..6,
+# s16aq18 soil, s16aq17 water, s16aq13 land-document).  Benin's data
+# carries tenure codes 1..5 (no Co-propriétaire code 7), soil 1..4,
+# water {1,3,4,6}, document {1..5,7}.
+#
+# harmonize_tenure — s16aq10 "mode de faire-valoir" -> canonical Tenure.
+#   2 Prêt gratuit (free loan of land under agreement, typically
+#   non-cash) -> use_right.  5 Gage (pledge / pawned land) and 6 Autre
+#   -> other_tenure.
+# harmonize_soil — s16aq18 -> SoilType (free-form str; English labels).
+# harmonize_water — s16aq17; the Irrigated bool is (label=='Irrigated').
+#   1 puits, 2 canal, 3 ruisseau -> Irrigated; 4 Pluviale -> Rain-fed;
+#   5 Marais -> Wetland; 6 Autre -> blank (NaN, no defensible mapping).
+# harmonize_tenure_system — s16aq13 land-document regime -> canonical
+#   TenureSystem spellings.  Only the three documents that imply a clear
+#   regime are mapped (1 Titre foncier->freehold, 2 Permis d'exploiter->
+#   granted_right_of_occupancy, 4 Bail->leasehold).  Procès-verbal (3),
+#   Convention de vente (5), and Aucun (7) have no defensible regime
+#   mapping and are left out (NaN) rather than force-fit.
+
+#+name: harmonize_tenure
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | owned           |
+|    2 | use_right       |
+|    3 | rented_in       |
+|    4 | sharecropped_in |
+|    5 | other_tenure    |
+|    6 | other_tenure    |
+
+#+name: harmonize_soil
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | sandy           |
+|    2 | loam            |
+|    3 | clay            |
+|    4 | hardpan         |
+|    5 | other           |
+
+#+name: harmonize_water
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Irrigated       |
+|    2 | Irrigated       |
+|    3 | Irrigated       |
+|    4 | Rain-fed        |
+|    5 | Wetland         |
+
+#+name: harmonize_tenure_system
+| Code | Preferred Label            |
+|------+----------------------------|
+|    1 | freehold                   |
+|    2 | granted_right_of_occupancy |
+|    4 | leasehold                  |

--- a/lsms_library/countries/Benin/_/data_scheme.yml
+++ b/lsms_library/countries/Benin/_/data_scheme.yml
@@ -63,3 +63,20 @@ Data Scheme:
     AffectedConsumption: bool
     HowCoped0: str
     HowCoped1: str
+
+  plot_features:
+    # Lasting parcel-level characteristics from the EHCVM agriculture
+    # module s16a (GH #167; Benin is an EHCVM sibling of the Mali
+    # reference implementation).  Single EHCVM wave: 2018-19 (Benin has
+    # no 2021-22 EHCVM-II wave in this repo).  plot_id =
+    # "{field_no}_{parcel_no}".  Latitude / Longitude are NOT emitted —
+    # EHCVM s16a has no decimal-degree parcel GPS (s16aq47 is an area,
+    # not a coordinate); deferred as in Uganda / Mali.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    SoilType: str
+    Irrigated: bool
+    materialize: make

--- a/lsms_library/countries/Benin/_/plot_features.py
+++ b/lsms_library/countries/Benin/_/plot_features.py
@@ -1,0 +1,38 @@
+"""Concatenate wave-level plot_features for Benin (GH #167; EHCVM cluster).
+
+Benin has a single EHCVM wave in this repo (2018-19; there is no
+2021-22 EHCVM-II wave).  The wave's ``Benin/2018-19/_/plot_features.py``
+writes a parquet indexed by ``(t, i, plot_id)`` with the canonical
+plot_features columns; this script concatenates whatever waves have one.
+``v`` is NOT baked in — the framework joins it from ``sample()`` at API
+time.
+
+Like the Mali concatenator, this does NOT apply ``id_walk`` here.
+Cached parquets store pre-transformation data; the framework runs
+``id_walk`` in ``_finalize_result`` on every read.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2018-19']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_features.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for plot_features (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_features: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, plot_id) after concat"
+
+to_parquet(p, '../var/plot_features.parquet')


### PR DESCRIPTION
## Summary

Implements `plot_features` for **Benin** (EHCVM), copying the Mali reference (PR #284) and adapting. Single 2018-19 wave (Benin has no 2021-22 EHCVM-II wave in this repo).

Source: `Benin/2018-19/Data/s16a_me_ben2018.dta` (7,588 parcel rows).

## Changes
- `Benin/_/benin.py`: adds `plot_features_for_wave()` + `_harmonized_codes`/`_map_codes` helpers, mirroring `Mali/_/mali.py`. Uses Benin's own `i()` formatter (`grappe + menage[zeropad 3]`). `plot_id = "{s16aq02}_{s16aq03}"`, index `(t, i, plot_id)`. Area in hectares (GPS s16aq47 where s16aq45==1, else s16aq09a estimate converted via s16aq09b: 1=ha x1, 2=m^2 /10000). Lat/Lon deferred.
- `Benin/2018-19/_/plot_features.py`: thin per-wave loader (colmap → helper).
- `Benin/_/plot_features.py`: country concatenator (single wave; no `id_walk` at cache-write).
- `Benin/_/categorical_mapping.org`: `harmonize_tenure`, `harmonize_soil`, `harmonize_water`, `harmonize_tenure_system` keyed on integer s16a codes.
- `Benin/_/data_scheme.yml`: registers `plot_features` (`materialize: make`).
- `Benin/_/CONTENTS.org`: `* plot_features (GH #167)` section.

## Verification
- `is_this_feature_sane(df, 'Benin', 'plot_features')` → **ok** (7,588 rows, unique `(t,i,plot_id)`). Only warn: `AreaUnit` constant `'hectares'` (expected, matches Mali).
- Orphan check vs `Country('Benin').sample().i`: **0 orphans** (3,775 plot HH all present in 8,012 sample HH).
- Tenure distribution: owned 5201, use_right 1846, rented_in 285, sharecropped_in 175, other_tenure 81.

## Notes / surprises
- **Irrigated** is True for 7,584/7,588: raw `s16aq17` is genuinely code 1 (well) for nearly every parcel. Honest reflection of the data, not a coding artifact.
- **Area** has implausibly large outliers (max ~711k ha) inherited from raw GPS noise in `s16aq47`; median 1.0 ha is sensible. Confirmed `s16aq47` IS in hectares (gps/est-ha ratio median 1.04). Same raw-data quality issue the Mali reference carries; not unit-converted.
- Benin tenure data lacks code 6 (Autre) and code 7 (co-propriétaire); harmonize tables retain 6→other_tenure harmlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)