### PR TITLE
feat(Niger): plot_features (GH #167)

### DIFF
--- a/lsms_library/countries/Niger/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Niger/2018-19/_/plot_features.py
@@ -1,0 +1,40 @@
+"""Build plot_features for Niger EHCVM 2018-19 (GH #167; EHCVM cluster).
+
+Single source file: s16a_me_ner2018.dta (agriculture-parcel module).
+plot_id = "{field_no}_{parcel_no}" (s16aq02 _ s16aq03); unique within
+each (grappe, menage).  See
+lsms_library/countries/Niger/_/niger.py:plot_features_for_wave for the
+harmonization shared with the Mali EHCVM reference (PR #284).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import plot_features_for_wave
+
+
+# convert_categoricals=False keeps the integer s16a codes that the
+# categorical_mapping.org harmonize_* tables key on.
+src = get_dataframe('../Data/s16a_me_ner2018.dta', convert_categoricals=False)
+
+colmap = dict(
+    grappe        = 'grappe',
+    menage        = 'menage',
+    field_no      = 's16aq02',
+    parcel_no     = 's16aq03',
+    area_gps      = 's16aq47',
+    gps_measured  = 's16aq45',
+    area_est      = 's16aq09a',
+    area_est_unit = 's16aq09b',
+    tenure        = 's16aq10',
+    tenure_system = 's16aq13',
+    soil_type     = 's16aq18',
+    water_source  = 's16aq17',
+)
+
+df = plot_features_for_wave('2018-19', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2018-19"
+assert len(df) > 0, "plot_features 2018-19 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Niger/2021-22/_/plot_features.py
+++ b/lsms_library/countries/Niger/2021-22/_/plot_features.py
@@ -1,0 +1,38 @@
+"""Build plot_features for Niger EHCVM 2021-22 (GH #167; EHCVM cluster).
+
+Single source file: s16a_me_ner2021.dta (agriculture-parcel module).
+The 2021-22 instrument uses the SAME column names and integer code
+scheme as 2018-19, with ONE Niger-specific addition: s16aq10 gains code
+7 = Co-propriétaire, which Niger's harmonize_tenure maps to ``owned``.
+See lsms_library/countries/Niger/_/niger.py:plot_features_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import plot_features_for_wave
+
+
+src = get_dataframe('../Data/s16a_me_ner2021.dta', convert_categoricals=False)
+
+colmap = dict(
+    grappe        = 'grappe',
+    menage        = 'menage',
+    field_no      = 's16aq02',
+    parcel_no     = 's16aq03',
+    area_gps      = 's16aq47',
+    gps_measured  = 's16aq45',
+    area_est      = 's16aq09a',
+    area_est_unit = 's16aq09b',
+    tenure        = 's16aq10',
+    tenure_system = 's16aq13',
+    soil_type     = 's16aq18',
+    water_source  = 's16aq17',
+)
+
+df = plot_features_for_wave('2021-22', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2021-22"
+assert len(df) > 0, "plot_features 2021-22 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Niger/_/CONTENTS.org
+++ b/lsms_library/countries/Niger/_/CONTENTS.org
@@ -99,3 +99,29 @@ the mojibake fix landed -- the underlying labels are canonical
 French names (with a handful of preserved local-language entries for
 which a follow-up =u= table could be added if the harmonization plan
 requires it).
+
+* plot_features (GH #167)
+
+Lasting parcel-level characteristics from the EHCVM agriculture module
+=s16a_me_ner{year}.dta=, harmonized to the canonical =plot_features=
+schema indexed by =(t, i, plot_id)=.  Niger is an EHCVM sibling of the
+Mali reference implementation (PR #284); the shared harmonization lives
+in =niger.py:plot_features_for_wave=, with thin per-wave loaders in
+=2018-19/_/plot_features.py= and =2021-22/_/plot_features.py= and a
+country-level concatenator =_/plot_features.py=.
+
+EHCVM waves only (2018-19, 2021-22).  =plot_id = "{field_no}_{parcel_no}"=
+(=s16aq02_s16aq03=), unique within each =(grappe, menage)=.  =Area= is
+the GPS measurement (=s16aq47=, hectares) where measured, otherwise the
+farmer estimate (=s16aq09a=) converted via its unit (=s16aq09b=: 1 ha,
+2 m^2 -> /10000); =AreaUnit= is always 'hectares'.  =Tenure= (=s16aq10=),
+=TenureSystem= (=s16aq13=), =SoilType= (=s16aq18=), and =Irrigated=
+(=s16aq17=) are mapped via the =harmonize_*= tables in
+=categorical_mapping.org=, keyed on the integer Stata codes.
+
+NIGER-SPECIFIC: the 2021-22 instrument adds =s16aq10= code 7 =
+Co-propriétaire (co-ownership), mapped to =owned=; 2018-19 has codes
+1-6 only (identical to Mali).  Latitude / Longitude are deferred —
+EHCVM s16a records no decimal-degree parcel GPS.  Pre-EHCVM ECVMA waves
+(2011-12, 2014-15) use a different agriculture instrument and are out of
+scope for this recipe.

--- a/lsms_library/countries/Niger/_/categorical_mapping.org
+++ b/lsms_library/countries/Niger/_/categorical_mapping.org
@@ -137,3 +137,57 @@
 | Tiles              | Tiles           |
 | Parquet            | Wood            |
 | Dung               | Earth with Dung |
+
+# plot_features harmonize_* tables (GH #167; EHCVM cluster).  Niger is
+# an EHCVM sibling of the Mali reference (PR #284); these key on the
+# INTEGER s16a codes (sources loaded with convert_categoricals=False).
+#
+# harmonize_tenure — s16aq10 "mode de faire-valoir" -> canonical Tenure.
+#   2 Prêt gratuit (free loan of land under agreement, non-cash) ->
+#   use_right.  5 Gage (pledge / pawned) and 6 Autre -> other_tenure.
+#   NIGER-SPECIFIC: the 2021-22 instrument adds 7 Co-propriétaire (co-
+#   ownership) -> owned (2018-19 has codes 1-6 only, identical to Mali).
+# harmonize_soil — s16aq18 -> SoilType (free-form str; English labels).
+# harmonize_water — s16aq17; the Irrigated bool is (label=='Irrigated').
+# harmonize_tenure_system — s16aq13 land-document regime -> canonical
+#   TenureSystem spellings.  Only the three documents implying a clear
+#   regime are mapped (1 Titre foncier->freehold, 2 Permis d'exploiter->
+#   granted_right_of_occupancy, 4 Bail->leasehold).  Procès-verbal,
+#   Convention de vente, Autre, and Aucun have no defensible regime
+#   mapping and are left out (NaN) rather than force-fit.
+
+#+name: harmonize_tenure
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | owned           |
+|    2 | use_right       |
+|    3 | rented_in       |
+|    4 | sharecropped_in |
+|    5 | other_tenure    |
+|    6 | other_tenure    |
+|    7 | owned           |
+
+#+name: harmonize_soil
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | sandy           |
+|    2 | loam            |
+|    3 | clay            |
+|    4 | hardpan         |
+|    5 | other           |
+
+#+name: harmonize_water
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Irrigated       |
+|    2 | Irrigated       |
+|    3 | Irrigated       |
+|    4 | Rain-fed        |
+|    5 | Wetland         |
+
+#+name: harmonize_tenure_system
+| Code | Preferred Label            |
+|------+----------------------------|
+|    1 | freehold                   |
+|    2 | granted_right_of_occupancy |
+|    4 | leasehold                  |

--- a/lsms_library/countries/Niger/_/data_scheme.yml
+++ b/lsms_library/countries/Niger/_/data_scheme.yml
@@ -77,3 +77,22 @@ Data Scheme:
   interview_date:
     index: (t, i)
     Int_t: datetime
+
+  plot_features:
+    # Lasting parcel-level characteristics from the EHCVM agriculture
+    # module s16a (GH #167; Niger is an EHCVM sibling of the Mali
+    # reference, PR #284).  EHCVM waves only: 2018-19 and 2021-22.  The
+    # pre-EHCVM ECVMA waves (2011-12, 2014-15) use a different
+    # instrument and are deferred.  plot_id = "{field_no}_{parcel_no}".
+    # NIGER-SPECIFIC: 2021-22 s16aq10 adds code 7 (Co-propriétaire) ->
+    # owned.  Latitude / Longitude are NOT emitted — EHCVM s16a has no
+    # decimal-degree parcel GPS (s16aq47 is an area, not a coordinate);
+    # deferred as in Uganda.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    SoilType: str
+    Irrigated: bool
+    materialize: make

--- a/lsms_library/countries/Niger/_/niger.py
+++ b/lsms_library/countries/Niger/_/niger.py
@@ -204,3 +204,136 @@ def age_handler(df, interview_date = None, format_interv = None, age = None, dob
     df['age'] = df.apply(fill_func, axis = 1)
 
     return df
+
+
+# ---------------------------------------------------------------------------
+# plot_features (GH #167; EHCVM cluster)
+# ---------------------------------------------------------------------------
+#
+# Niger is an EHCVM sibling of the Mali reference implementation
+# (PR #284).  The agriculture-parcel module s16a_me_ner{year}.dta uses
+# the same uniform EHCVM column scheme.  The shared harmonization lives
+# in ``plot_features_for_wave``; each wave's ``_/plot_features.py`` is a
+# thin loader that hands the raw DataFrame plus a column map to it.
+#
+# NIGER-SPECIFIC delta: 2021-22 s16aq10 adds code 7 = Co-propriétaire,
+# which Niger's harmonize_tenure maps to ``owned`` (2018-19 has codes
+# 1-6 only, identical to Mali).
+#
+# i() above already produces the EHCVM composite id ('E_' + grappe + '0'
+# + zero-padded menage) when handed a lowercase-named (grappe, menage)
+# Series, matching sample().i natively.
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a ``{int code -> Preferred Label}`` dict from
+    ``categorical_mapping.org`` for one of the plot_features harmonize_*
+    tables.  Codes whose Preferred Label is blank / '---' map to NA so
+    the corresponding column stays NaN.  Mirrors the Mali reference."""
+    raw = tools.get_categorical_mapping(tablename=tablename, idxvars=key,
+                                        **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw Stata integer-code) Series through ``code_map``,
+    returning a string Series with NA where the code is unmapped.  Source
+    files must be loaded with ``convert_categoricals=False`` so the codes
+    arrive as integers."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_features_for_wave(t, source, colmap):
+    """Build canonical ``plot_features`` for one Niger EHCVM wave.
+
+    See ``Mali/_/mali.py:plot_features_for_wave`` for the full contract
+    (this is a direct sibling).  Returns a DataFrame indexed by
+    ``(t, i, plot_id)`` with columns ``Area`` (hectares float),
+    ``AreaUnit`` (always 'hectares'), ``Tenure``, ``TenureSystem``,
+    ``SoilType`` (str), and ``Irrigated`` (nullable bool).
+
+    Niger note: ``i`` is built with Niger's ``i()`` formatter from a
+    lowercase-named (grappe, menage) Series so the EHCVM 'E_' prefix
+    fires and the id matches ``sample().i``.  ``plot_id =
+    "{field_no}_{parcel_no}"`` is unique within ``(grappe, menage)``.
+    """
+    tenure_map = _harmonized_codes('harmonize_tenure')
+    tenure_system_map = _harmonized_codes('harmonize_tenure_system')
+    soil_map = _harmonized_codes('harmonize_soil')
+    water_map = _harmonized_codes('harmonize_water')
+
+    c = colmap
+
+    # Drop s16a placeholder rows for non-farming households: one row per
+    # household with NO field/parcel number and every plot attribute
+    # blank.  Keeping them would emit a content-free "nan_nan" plot_id
+    # per household and collide once two such households id_walk to the
+    # same baseline id (Mali had ~3286 such rows in 2021-22; Niger has
+    # none in either wave, but the guard is kept for parity / safety).
+    src = source[source[c['field_no']].notna() & source[c['parcel_no']].notna()].copy()
+
+    # Household id: EHCVM composite (grappe, menage) via niger.i().  Build
+    # a Series with the original lowercase column names as its index so
+    # i()'s is_ehcvm detection fires and prefixes 'E_'.
+    g_col, m_col = c['grappe'], c['menage']
+    hh = src.apply(lambda r: i(pd.Series([r[g_col], r[m_col]],
+                                         index=[g_col, m_col])),
+                   axis=1)
+
+    field = src[c['field_no']].apply(tools.format_id)
+    parcel = src[c['parcel_no']].apply(tools.format_id)
+    plot_id = field.astype(str) + '_' + parcel.astype(str)
+
+    # Area in hectares.  GPS where measured, else farmer estimate
+    # converted from its declared unit (1=Hectare ->x1, 2=m^2 ->/10000).
+    area_gps = pd.to_numeric(src[c['area_gps']], errors='coerce').astype('Float64')
+    gps_flag = src[c['gps_measured']].astype('Int64')
+
+    est_raw = pd.to_numeric(src[c['area_est']], errors='coerce').astype('Float64')
+    est_unit = src[c['area_est_unit']].astype('Int64')
+    est_ha = est_raw.where(est_unit != 2, est_raw / 10000)
+
+    area_ha = est_ha.copy()
+    use_gps = (gps_flag == 1) & area_gps.notna()
+    area_ha = area_gps.where(use_gps, area_ha)
+
+    area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
+    area_unit = area_unit.where(area_ha.notna(), pd.NA)
+
+    tenure = _map_codes(src[c['tenure']], tenure_map) \
+        if c.get('tenure') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    tenure_system = _map_codes(src[c['tenure_system']], tenure_system_map) \
+        if c.get('tenure_system') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    soil_type = _map_codes(src[c['soil_type']], soil_map) \
+        if c.get('soil_type') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+
+    irrigated = pd.Series(pd.NA, index=src.index, dtype='boolean')
+    if c.get('water_source') in src.columns:
+        water_label = _map_codes(src[c['water_source']], water_map)
+        irrigated = (water_label == 'Irrigated').astype('boolean')
+        irrigated = irrigated.where(water_label.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        't':            t,
+        'i':            hh.values,
+        'plot_id':      plot_id.values,
+        'Area':         area_ha.values,
+        'AreaUnit':     area_unit.values,
+        'Tenure':       tenure.values,
+        'TenureSystem': tenure_system.values,
+        'SoilType':     soil_type.values,
+        'Irrigated':    irrigated.values,
+    })
+    df = df.set_index(['t', 'i', 'plot_id'])
+    return df

--- a/lsms_library/countries/Niger/_/plot_features.py
+++ b/lsms_library/countries/Niger/_/plot_features.py
@@ -1,0 +1,42 @@
+"""Concatenate wave-level plot_features for Niger (GH #167; EHCVM cluster).
+
+Each EHCVM wave's ``Niger/<wave>/_/plot_features.py`` writes a parquet
+indexed by ``(t, i, plot_id)`` with the canonical plot_features columns.
+This script concatenates the waves that have one (2018-19, 2021-22; the
+pre-EHCVM ECVMA waves 2011-12 / 2014-15 use a different agriculture
+instrument and are deferred to a separate recipe).  ``v`` is NOT baked
+in — the framework joins it from ``sample()`` at API time.
+
+As in the Mali reference (PR #284), this does NOT apply ``id_walk``
+here.  Cached parquets store pre-transformation data; the framework runs
+``id_walk`` in ``_finalize_result`` on every read.  Baking id_walk at
+cache-write time risks colliding "moved" panel households onto identical
+``(t, i, plot_id)`` tuples; leaving the index pre-walk keeps it globally
+unique and lets the framework's idempotent id_walk handle the panel
+remap consistently with every other Niger table.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2011-12', '2014-15', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_features.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for plot_features (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_features: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, plot_id) after concat"
+
+to_parquet(p, '../var/plot_features.parquet')


### PR DESCRIPTION
## Summary

Implements \`plot_features\` for **Niger** (EHCVM), copied from the validated Mali reference (PR #284) and adapted. Covers the two EHCVM waves **2018-19** and **2021-22** from the \`s16a_me_ner{year}.dta\` agriculture-parcel module. Pre-EHCVM ECVMA waves (2011-12, 2014-15) use a different instrument and are out of scope.

Canonical index \`(t, i, plot_id)\`; columns \`Area\`, \`AreaUnit\`, \`Tenure\`, \`TenureSystem\`, \`SoilType\`, \`Irrigated\`. \`plot_id = "{field_no}_{parcel_no}"\` (s16aq02_s16aq03). EHCVM composite household id via \`niger.i()\` ('E_' + grappe + '0' + zero-padded menage) matches \`sample().i\` natively. \`v\` is not baked in; no \`id_walk\` in the concatenator (framework handles it in \`_finalize_result\`). Lat/Lon deferred (no parcel GPS in EHCVM s16a).

## Files
- \`Niger/_/niger.py\` — shared \`plot_features_for_wave\` + harmonize helpers (mirrors \`mali.py\`).
- \`Niger/{2018-19,2021-22}/_/plot_features.py\` — thin per-wave loaders.
- \`Niger/_/plot_features.py\` — country-level concatenator.
- \`Niger/_/categorical_mapping.org\` — \`harmonize_{tenure,soil,water,tenure_system}\` keyed on integer s16a codes.
- \`Niger/_/data_scheme.yml\` — registration (\`materialize: make\`).
- \`Niger/_/CONTENTS.org\` — feature note.

## Niger-specific
- 2021-22 \`s16aq10\` adds **code 7 = Co-propriétaire**, mapped to \`owned\` (2018-19 has codes 1-6 only, identical to Mali).

## Verification
Wave scripts run directly against the worktree \`niger.py\` (the \`.pth\` pins \`lsms_library\` to the main checkout, so \`Country('Niger').plot_features()\` was deliberately not called).
- **12,414 rows** (2018-19: 6685, 2021-22: 5729); \`(t, i, plot_id)\` unique.
- \`is_this_feature_sane(country='Niger', feature='plot_features')\` -> **ok** (14 pass / 1 benign constant-AreaUnit warn).
- **0% orphan rate** vs \`sample().i\`.
- Tenure: owned 10232, use_right 1539, other_tenure 401, sharecropped_in 145, rented_in 96, NA 1. SoilType all within canonical set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)