### PR TITLE
feat(Togo): plot_features (GH #167)

### DIFF
--- a/lsms_library/countries/Togo/2018/_/plot_features.py
+++ b/lsms_library/countries/Togo/2018/_/plot_features.py
@@ -1,0 +1,47 @@
+"""Build plot_features for Togo EHCVM 2018 (GH #167; EHCVM cluster).
+
+Single source file: ``../Data1/s16a_me_tgo2018.dta`` (agriculture-parcel
+module, 9557 rows).
+
+*** SOURCE LOCATION: the EHCVM agriculture module lives in
+``2018/Data1/`` — NOT ``2018/Data/``, which holds only ``_forEthan``
+extracts.  Future maintainers will instinctively look in ``Data/``. ***
+
+plot_id = "{field_no}_{parcel_no}" (s16aq02 _ s16aq03); unique within
+each (grappe, menage).  See
+lsms_library/countries/Togo/_/togo.py:plot_features_for_wave for the
+harmonization shared across the EHCVM cluster (Mali is the reference,
+PR #284).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from togo import plot_features_for_wave
+
+
+# convert_categoricals=False keeps the integer s16a codes that the
+# categorical_mapping.org harmonize_* tables key on.
+src = get_dataframe('../Data1/s16a_me_tgo2018.dta', convert_categoricals=False)
+
+colmap = dict(
+    grappe        = 'grappe',
+    menage        = 'menage',
+    field_no      = 's16aq02',
+    parcel_no     = 's16aq03',
+    area_gps      = 's16aq47',
+    gps_measured  = 's16aq45',
+    area_est      = 's16aq09a',
+    area_est_unit = 's16aq09b',
+    tenure        = 's16aq10',
+    tenure_system = 's16aq13',
+    soil_type     = 's16aq18',
+    water_source  = 's16aq17',
+)
+
+df = plot_features_for_wave('2018', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2018"
+assert len(df) > 0, "plot_features 2018 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Togo/_/CONTENTS.org
+++ b/lsms_library/countries/Togo/_/CONTENTS.org
@@ -32,3 +32,29 @@ rather than expecting a =MonthsSpent= column in =household_roster()=.
 
 Togo has no pre-EHCVM waves in the library, so no continuous
 months-of-presence variable is available for any wave.
+
+* plot_features (GH #167)
+
+Lasting parcel-level characteristics from the EHCVM agriculture module
+=s16a= (Togo is an EHCVM sibling of the Mali reference, PR #284).
+
+*** SOURCE LOCATION (read this first): the agriculture module lives in
+=2018/Data1/s16a_me_tgo2018.dta= (9557 parcel rows) — *NOT* in
+=2018/Data/=, which holds only =_forEthan= extracts.  Future
+maintainers will instinctively look in =Data/= and find nothing. ***
+
+Index =(t, i, plot_id)= where =i= is the EHCVM composite =(grappe,
+menage)= household id and =plot_id = "{s16aq02}_{s16aq03}"= (field _
+parcel sequence numbers), unique within each household.  =t = "2018"=
+(single EHCVM wave).
+
+Columns: =Area= (hectares; GPS measure =s16aq47= where =s16aq45==1=,
+else farmer estimate =s16aq09a= converted from its unit =s16aq09b=),
+=AreaUnit= (always "hectares"), =Tenure= (=s16aq10=), =TenureSystem=
+(=s16aq13=), =SoilType= (=s16aq18=), =Irrigated= (from water source
+=s16aq17=).  Latitude / Longitude deferred (no decimal-degree parcel
+GPS in EHCVM s16a).  The harmonize_* code maps live in
+=categorical_mapping.org=.
+
+Verification (2026-06-03): 9557 rows, unique =(t, i, plot_id)= index,
+=is_this_feature_sane= passes, 0% orphan households vs =sample()=.

--- a/lsms_library/countries/Togo/_/categorical_mapping.org
+++ b/lsms_library/countries/Togo/_/categorical_mapping.org
@@ -35,3 +35,61 @@
 | Tile               | Tiles           |
 | Dung               | Earth with Dung |
 | Other              | Other           |
+
+# plot_features harmonize_* tables (GH #167; EHCVM cluster).  Togo is an
+# EHCVM sibling of the Mali reference (PR #284).  Codes key on the raw
+# integer Stata codes of the s16a agriculture-parcel module (loaded with
+# convert_categoricals=False); verified against the .dta value-label
+# metadata.  Togo's s16a code schemes match Mali's, with two Togo
+# additions: s16aq13 has a code 7 (Aucun) and s16aq17 has a code 6
+# (Autre); both are left unmapped (NaN) rather than force-fit.
+#
+# harmonize_tenure — s16aq10 "mode d'occupation" -> canonical Tenure.
+#   1 Propriétaire->owned; 2 Prêt gratuit (free loan under agreement,
+#   non-cash)->use_right; 3 Fermage->rented_in; 4 Métayage->sharecropped_in;
+#   5 Gage (pledge/pawned) and 6 Autre->other_tenure.
+# harmonize_soil — s16aq18 -> SoilType.  1 Sableux->sandy, 2 Limoneux->
+#   loam, 3 Argileux->clay, 4 Glacis->hardpan, 5 Autre->other.
+# harmonize_water — s16aq17; Irrigated bool is (label=='Irrigated').
+#   1-3 (Irrigation puits/canal/ruisseau)->Irrigated; 4 Pluviale->Rain-fed;
+#   5 Marais/wetlands->Wetland; 6 Autre unmapped.
+# harmonize_tenure_system — s16aq13 land-document regime -> canonical
+#   TenureSystem.  1 Titre foncier->freehold, 2 Permis d'exploiter->
+#   granted_right_of_occupancy, 4 Bail->leasehold.  Procès-verbal (3),
+#   Convention de vente (5), Autre (6), Aucun (7) have no defensible
+#   regime mapping and are left out (NaN).
+
+#+name: harmonize_tenure
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | owned           |
+|    2 | use_right       |
+|    3 | rented_in       |
+|    4 | sharecropped_in |
+|    5 | other_tenure    |
+|    6 | other_tenure    |
+
+#+name: harmonize_soil
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | sandy           |
+|    2 | loam            |
+|    3 | clay            |
+|    4 | hardpan         |
+|    5 | other           |
+
+#+name: harmonize_water
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Irrigated       |
+|    2 | Irrigated       |
+|    3 | Irrigated       |
+|    4 | Rain-fed        |
+|    5 | Wetland         |
+
+#+name: harmonize_tenure_system
+| Code | Preferred Label            |
+|------+----------------------------|
+|    1 | freehold                   |
+|    2 | granted_right_of_occupancy |
+|    4 | leasehold                  |

--- a/lsms_library/countries/Togo/_/data_scheme.yml
+++ b/lsms_library/countries/Togo/_/data_scheme.yml
@@ -62,3 +62,20 @@ Data Scheme:
   interview_date:
     index: (t, i)
     Int_t: datetime
+
+  plot_features:
+    # Lasting parcel-level characteristics from the EHCVM agriculture
+    # module s16a (GH #167; Mali is the EHCVM reference, PR #284).  Togo
+    # has a single EHCVM wave (2018).  The source file lives in
+    # 2018/Data1/ (NOT 2018/Data/, which holds only _forEthan extracts).
+    # plot_id = "{field_no}_{parcel_no}".  Latitude / Longitude are NOT
+    # emitted — EHCVM s16a has no decimal-degree parcel GPS (s16aq47 is
+    # an area, not a coordinate); deferred as in Uganda.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    SoilType: str
+    Irrigated: bool
+    materialize: make

--- a/lsms_library/countries/Togo/_/plot_features.py
+++ b/lsms_library/countries/Togo/_/plot_features.py
@@ -1,0 +1,39 @@
+"""Concatenate wave-level plot_features for Togo (GH #167; EHCVM cluster).
+
+Togo's single EHCVM wave (2018) writes a parquet indexed by
+``(t, i, plot_id)`` with the canonical plot_features columns from
+``Togo/2018/_/plot_features.py``.  This script concatenates the wired
+waves.  ``v`` is NOT baked in — the framework joins it from
+``sample()`` at API time.
+
+Following the Mali reference (PR #284), this does NOT apply ``id_walk``
+here.  Cached parquets store pre-transformation data; the framework runs
+``id_walk`` in ``_finalize_result`` on every read.  (Togo has a single
+wave with no panel remap, but the no-id_walk convention is kept for
+consistency across the EHCVM cluster.)
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2018']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_features.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for plot_features (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_features: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, plot_id) after concat"
+
+to_parquet(p, '../var/plot_features.parquet')

--- a/lsms_library/countries/Togo/_/togo.py
+++ b/lsms_library/countries/Togo/_/togo.py
@@ -168,3 +168,158 @@ def age_sex_composition(fn,sex='sex',sex_converter=None,
     df.columns.name = 'k'
 
     return df
+
+
+# ---------------------------------------------------------------------------
+# plot_features (GH #167; EHCVM cluster)
+# ---------------------------------------------------------------------------
+#
+# Togo is an EHCVM sibling of the Mali reference implementation
+# (PR #284).  The shared harmonization below replicates Mali's
+# ``plot_features_for_wave``: a single per-wave agriculture-parcel file
+# s16a_me_tgo2018 with the uniform EHCVM column scheme.
+#
+# *** SOURCE LOCATION: Togo's EHCVM agriculture module lives in
+# ``2018/Data1/`` (NOT ``2018/Data/`` — that holds only ``_forEthan``
+# extracts).  Source file: ``2018/Data1/s16a_me_tgo2018.dta`` (9557
+# rows). ***
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a ``{int code -> Preferred Label}`` dict from
+    ``categorical_mapping.org`` for one of the plot_features harmonize_*
+    tables.  Codes whose Preferred Label is blank / '---' map to NA so
+    the corresponding column stays NaN.  Mirrors Mali's helper."""
+    raw = tools.get_categorical_mapping(tablename=tablename, idxvars=key,
+                                        **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw Stata integer-code) Series through ``code_map``,
+    returning a string Series with NA where the code is unmapped.  Source
+    files must be loaded with ``convert_categoricals=False`` so the codes
+    arrive as integers."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_features_for_wave(t, source, colmap):
+    """Build canonical ``plot_features`` for the Togo EHCVM 2018 wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (``"2018"``), used as the ``t`` index value.
+    source : pd.DataFrame
+        Raw s16a agriculture-parcel DataFrame, loaded via
+        ``get_dataframe(..., convert_categoricals=False)`` so the
+        harmonize_* tables can key on the integer codes.
+    colmap : dict
+        Column-name map.  Required keys::
+
+            grappe        — cluster id column (with menage builds ``i``)
+            menage        — within-cluster household number
+            field_no      — within-HH field/champ sequence number
+            parcel_no     — within-field parcel sequence number
+            area_gps      — GPS-measured parcel area (hectares)
+            gps_measured  — 1/2 (Oui/Non) flag for GPS measurement
+            area_est      — farmer-estimated area (in area_est_unit)
+            area_est_unit — 1=Hectare, 2=m^2
+            tenure        — mode-of-tenure question  -> Tenure
+            tenure_system — land-document question    -> TenureSystem
+            soil_type     — soil-type question        -> SoilType
+            water_source  — water-source question     -> Irrigated
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
+        ``Area`` (hectares float), ``AreaUnit`` (always 'hectares'),
+        ``Tenure``, ``TenureSystem``, ``SoilType`` (str), and
+        ``Irrigated`` (nullable bool).
+
+    Notes
+    -----
+    * ``i`` is the EHCVM composite household id built with Togo's
+      ``i()`` formatter so it matches ``sample().i`` natively.
+    * ``plot_id = "{field_no}_{parcel_no}"`` — unique within
+      ``(grappe, menage)``.
+    * ``Area`` prefers the GPS measurement (already hectares) where
+      ``gps_measured == 1``; otherwise the farmer estimate converted to
+      hectares (m^2 / 10000).  No GPS coordinate columns: EHCVM s16a has
+      no decimal-degree parcel GPS, so Latitude / Longitude are deferred
+      (as in Uganda / Mali).
+    """
+    tenure_map = _harmonized_codes('harmonize_tenure')
+    tenure_system_map = _harmonized_codes('harmonize_tenure_system')
+    soil_map = _harmonized_codes('harmonize_soil')
+    water_map = _harmonized_codes('harmonize_water')
+
+    c = colmap
+
+    # Drop the s16a placeholder rows for non-farming households: any row
+    # with NO field/parcel number.  Keeping them would emit a
+    # content-free "nan_nan" plot_id per household.
+    src = source[source[c['field_no']].notna() & source[c['parcel_no']].notna()].copy()
+
+    # Household id: EHCVM composite (grappe, menage) via togo.i().
+    hh = src.apply(lambda r: i(pd.Series([r[c['grappe']], r[c['menage']]])),
+                   axis=1)
+
+    field = src[c['field_no']].apply(tools.format_id)
+    parcel = src[c['parcel_no']].apply(tools.format_id)
+    plot_id = field.astype(str) + '_' + parcel.astype(str)
+
+    # Area in hectares.  GPS where measured, else farmer estimate
+    # converted from its declared unit (1=Hectare ->x1, 2=m^2 ->/10000).
+    area_gps = pd.to_numeric(src[c['area_gps']], errors='coerce').astype('Float64')
+    gps_flag = src[c['gps_measured']].astype('Int64')
+
+    est_raw = pd.to_numeric(src[c['area_est']], errors='coerce').astype('Float64')
+    est_unit = src[c['area_est_unit']].astype('Int64')
+    est_ha = est_raw.where(est_unit != 2, est_raw / 10000)
+
+    # Prefer GPS where it was actually measured (flag == 1) and present.
+    area_ha = est_ha.copy()
+    use_gps = (gps_flag == 1) & area_gps.notna()
+    area_ha = area_gps.where(use_gps, area_ha)
+
+    area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
+    area_unit = area_unit.where(area_ha.notna(), pd.NA)
+
+    tenure = _map_codes(src[c['tenure']], tenure_map) \
+        if c.get('tenure') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    tenure_system = _map_codes(src[c['tenure_system']], tenure_system_map) \
+        if c.get('tenure_system') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    soil_type = _map_codes(src[c['soil_type']], soil_map) \
+        if c.get('soil_type') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+
+    irrigated = pd.Series(pd.NA, index=src.index, dtype='boolean')
+    if c.get('water_source') in src.columns:
+        water_label = _map_codes(src[c['water_source']], water_map)
+        irrigated = (water_label == 'Irrigated').astype('boolean')
+        irrigated = irrigated.where(water_label.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        't':            t,
+        'i':            hh.values,
+        'plot_id':      plot_id.values,
+        'Area':         area_ha.values,
+        'AreaUnit':     area_unit.values,
+        'Tenure':       tenure.values,
+        'TenureSystem': tenure_system.values,
+        'SoilType':     soil_type.values,
+        'Irrigated':    irrigated.values,
+    })
+    df = df.set_index(['t', 'i', 'plot_id'])
+    return df


### PR DESCRIPTION
## Summary

Implements `plot_features` for **Togo** (EHCVM), the West African
harmonized survey. Togo is an EHCVM sibling of the **Mali** reference
implementation (PR #284) — this PR replicates Mali's
`plot_features_for_wave` + harmonize helpers and adapts the column map.

Single EHCVM wave: **2018**.

## Source location (important)

The EHCVM agriculture module lives in **`Togo/2018/Data1/s16a_me_tgo2018.dta`**
(9557 parcel rows) — **NOT** `Togo/2018/Data/`, which holds only
`_forEthan` extracts. The wave script, `togo.py`, and `CONTENTS.org`
all flag this prominently for future maintainers.

## Schema

Index `(t, i, plot_id)` where `i = (grappe, menage)` (EHCVM composite,
matches `sample().i`) and `plot_id = "{s16aq02}_{s16aq03}"`. Columns:
`Area` (ha; GPS `s16aq47` where measured else farmer estimate `s16aq09a`
converted from `s16aq09b`), `AreaUnit`, `Tenure` (`s16aq10`),
`TenureSystem` (`s16aq13`), `SoilType` (`s16aq18`), `Irrigated`
(`s16aq17`). Latitude/Longitude deferred (no decimal-degree parcel GPS
in EHCVM s16a), as in Uganda/Mali. No `id_walk` in the concatenator.

## Verification

Ran wave script + concatenator directly with the worktree venv:

- 9557 rows; `(t, i, plot_id)` index **unique**
- `is_this_feature_sane(df, 'Togo', 'plot_features')` **passes** (only a
  benign warn for the constant `AreaUnit` column, same as Mali)
- All values ⊆ canonical (Tenure/TenureSystem/SoilType/Irrigated)
- **0% orphan** households vs `sample()` (3495 plot HH all present in the
  6171-HH sample spine; `i` formats identical)

## Files

- `Togo/_/togo.py` — `plot_features_for_wave` + harmonize helpers
- `Togo/2018/_/plot_features.py` — wave script
- `Togo/_/plot_features.py` — country concatenator
- `Togo/_/categorical_mapping.org` — `harmonize_tenure/soil/water/tenure_system`
- `Togo/_/data_scheme.yml` — register `plot_features` (`materialize: make`)
- `Togo/_/CONTENTS.org` — documentation (notes the `Data1/` location)

🤖 Generated with [Claude Code](https://claude.com/claude-code)