### PR TITLE
feat(Burkina_Faso): plot_features (GH #167)

### DIFF
--- a/lsms_library/countries/Burkina_Faso/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/plot_features.py
@@ -1,0 +1,41 @@
+"""Build plot_features for Burkina Faso EHCVM 2018-19 (GH #167; EHCVM cluster).
+
+Single source file: s16a_me_bfa2018.dta (agriculture-parcel module).
+plot_id = "{field_no}_{parcel_no}" (s16aq02 _ s16aq03); unique within
+each (grappe, menage).  See
+lsms_library/countries/Burkina_Faso/_/burkina_faso.py:plot_features_for_wave
+for the harmonization shared across both EHCVM waves (copied from the
+Mali EHCVM reference, PR #284).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from burkina_faso import plot_features_for_wave
+
+
+# convert_categoricals=False keeps the integer s16a codes that the
+# categorical_mapping.org harmonize_* tables key on.
+src = get_dataframe('../Data/s16a_me_bfa2018.dta', convert_categoricals=False)
+
+colmap = dict(
+    grappe        = 'grappe',
+    menage        = 'menage',
+    field_no      = 's16aq02',
+    parcel_no     = 's16aq03',
+    area_gps      = 's16aq47',
+    gps_measured  = 's16aq45',
+    area_est      = 's16aq09a',
+    area_est_unit = 's16aq09b',
+    tenure        = 's16aq10',
+    tenure_system = 's16aq13',
+    soil_type     = 's16aq18',
+    water_source  = 's16aq17',
+)
+
+df = plot_features_for_wave('2018-19', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2018-19"
+assert len(df) > 0, "plot_features 2018-19 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Burkina_Faso/2021-22/_/plot_features.py
+++ b/lsms_library/countries/Burkina_Faso/2021-22/_/plot_features.py
@@ -1,0 +1,41 @@
+"""Build plot_features for Burkina Faso EHCVM 2021-22 (GH #167; EHCVM cluster).
+
+Single source file: s16a_me_bfa2021.dta (agriculture-parcel module).
+plot_id = "{field_no}_{parcel_no}" (s16aq02 _ s16aq03); unique within
+each (grappe, menage).  See
+lsms_library/countries/Burkina_Faso/_/burkina_faso.py:plot_features_for_wave
+for the harmonization shared across both EHCVM waves (copied from the
+Mali EHCVM reference, PR #284).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from burkina_faso import plot_features_for_wave
+
+
+# convert_categoricals=False keeps the integer s16a codes that the
+# categorical_mapping.org harmonize_* tables key on.
+src = get_dataframe('../Data/s16a_me_bfa2021.dta', convert_categoricals=False)
+
+colmap = dict(
+    grappe        = 'grappe',
+    menage        = 'menage',
+    field_no      = 's16aq02',
+    parcel_no     = 's16aq03',
+    area_gps      = 's16aq47',
+    gps_measured  = 's16aq45',
+    area_est      = 's16aq09a',
+    area_est_unit = 's16aq09b',
+    tenure        = 's16aq10',
+    tenure_system = 's16aq13',
+    soil_type     = 's16aq18',
+    water_source  = 's16aq17',
+)
+
+df = plot_features_for_wave('2021-22', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2021-22"
+assert len(df) > 0, "plot_features 2021-22 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Burkina_Faso/_/CONTENTS.org
+++ b/lsms_library/countries/Burkina_Faso/_/CONTENTS.org
@@ -64,3 +64,24 @@ months-of-presence variable:
 - 2014 :: =B3A= in the household roster file records the number of
   months the individual spent in the household over the past 12
   months.  See the wave-level =data_info.yml= for details.
+
+* plot_features (GH #167)
+
+Parcel-level lasting characteristics from the EHCVM agriculture module
+=s16a_me_bfa{2018,2021}.dta= (copied from the Mali EHCVM reference, PR
+#284).  EHCVM waves only (2018-19, 2021-22); the pre-EHCVM 2014 EMC wave
+uses a different instrument and is out of scope.
+
+- Index =(t, i, plot_id)= with =plot_id = "{field_no}_{parcel_no}"=
+  (=s16aq02= _ =s16aq03=); =i= is the EHCVM composite =(grappe, menage)=
+  built with Burkina's =i()= formatter so it matches =sample().i=.
+- Columns: =Area= (hectares; GPS =s16aq47= where measured, else farmer
+  estimate =s16aq09a= converted via =s16aq09b= 1=ha/2=m²), =AreaUnit=
+  ('hectares'), =Tenure= (=s16aq10=), =TenureSystem= (=s16aq13=),
+  =SoilType= (=s16aq18=), =Irrigated= (=s16aq17= in {1,2,3}).
+- Harmonize tables =harmonize_tenure=, =harmonize_soil=,
+  =harmonize_water=, =harmonize_tenure_system= live in
+  =categorical_mapping.org=, keyed on the integer s16a codes.
+- Placeholder rows (no field/parcel number) for non-farming households
+  are dropped.  Latitude / Longitude deferred (no decimal-degree parcel
+  GPS in EHCVM s16a).

--- a/lsms_library/countries/Burkina_Faso/_/burkina_faso.py
+++ b/lsms_library/countries/Burkina_Faso/_/burkina_faso.py
@@ -69,3 +69,125 @@ def panel_ids(df):
     menage = df['previous_hid'].apply(lambda x: tools.format_id(x, zeropadding=3))
     df['previous_i'] = grappe + menage
     return df[['previous_i']]
+
+
+# ---------------------------------------------------------------------------
+# plot_features (GH #167; EHCVM cluster)
+# ---------------------------------------------------------------------------
+#
+# Burkina Faso copies the Mali EHCVM reference implementation (PR #284):
+# a single per-wave agriculture-parcel file s16a_me_bfa{year} with a
+# uniform column scheme.  The only country-specific piece is the
+# household-id formatter ``i()`` above — Burkina uses
+# ``format_id(grappe) + format_id(menage, zeropadding=3)`` (no extra '0'
+# separators), which is what ``sample()`` and ``panel_ids`` use, so the
+# emitted ``i`` matches ``sample().i`` natively.
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a ``{int code -> Preferred Label}`` dict from
+    ``categorical_mapping.org`` for one of the plot_features harmonize_*
+    tables.  Codes whose Preferred Label is blank / '---' map to NA so
+    the corresponding column stays NaN.  Mirrors Mali / Uganda."""
+    raw = tools.get_categorical_mapping(tablename=tablename, idxvars=key,
+                                        **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw Stata integer-code) Series through ``code_map``,
+    returning a string Series with NA where the code is unmapped.  Source
+    files must be loaded with ``convert_categoricals=False`` so the codes
+    arrive as integers."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_features_for_wave(t, source, colmap):
+    """Build canonical ``plot_features`` for one Burkina Faso EHCVM wave.
+
+    Mirrors ``Mali/_/mali.py:plot_features_for_wave`` exactly except it
+    uses Burkina's ``i()`` household-id formatter.  Returns a DataFrame
+    indexed by ``(t, i, plot_id)`` with columns ``Area`` (hectares
+    float), ``AreaUnit`` ('hectares'), ``Tenure``, ``TenureSystem``,
+    ``SoilType`` (str), and ``Irrigated`` (nullable bool).
+
+    Required ``colmap`` keys: grappe, menage, field_no, parcel_no,
+    area_gps, gps_measured, area_est, area_est_unit, tenure,
+    tenure_system, soil_type, water_source.
+
+    Latitude / Longitude are deferred — EHCVM s16a has no decimal-degree
+    parcel GPS (s16aq47 is an area, not a coordinate).
+    """
+    tenure_map = _harmonized_codes('harmonize_tenure')
+    tenure_system_map = _harmonized_codes('harmonize_tenure_system')
+    soil_map = _harmonized_codes('harmonize_soil')
+    water_map = _harmonized_codes('harmonize_water')
+
+    c = colmap
+
+    # Drop s16a placeholder rows for non-farming households: one row per
+    # household with NO field/parcel number and every plot attribute
+    # blank.  Keeping them would emit a content-free "nan_nan" plot_id.
+    src = source[source[c['field_no']].notna() & source[c['parcel_no']].notna()].copy()
+
+    # Household id: EHCVM composite (grappe, menage) via burkina i().
+    hh = src.apply(lambda r: i(pd.Series([r[c['grappe']], r[c['menage']]])),
+                   axis=1)
+
+    field = src[c['field_no']].apply(tools.format_id)
+    parcel = src[c['parcel_no']].apply(tools.format_id)
+    plot_id = field.astype(str) + '_' + parcel.astype(str)
+
+    # Area in hectares.  GPS where measured, else farmer estimate
+    # converted from its declared unit (1=Hectare ->x1, 2=m^2 ->/10000).
+    area_gps = pd.to_numeric(src[c['area_gps']], errors='coerce').astype('Float64')
+    gps_flag = src[c['gps_measured']].astype('Int64')
+
+    est_raw = pd.to_numeric(src[c['area_est']], errors='coerce').astype('Float64')
+    est_unit = src[c['area_est_unit']].astype('Int64')
+    est_ha = est_raw.where(est_unit != 2, est_raw / 10000)
+
+    area_ha = est_ha.copy()
+    use_gps = (gps_flag == 1) & area_gps.notna()
+    area_ha = area_gps.where(use_gps, area_ha)
+
+    area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
+    area_unit = area_unit.where(area_ha.notna(), pd.NA)
+
+    tenure = _map_codes(src[c['tenure']], tenure_map) \
+        if c.get('tenure') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    tenure_system = _map_codes(src[c['tenure_system']], tenure_system_map) \
+        if c.get('tenure_system') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    soil_type = _map_codes(src[c['soil_type']], soil_map) \
+        if c.get('soil_type') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+
+    irrigated = pd.Series(pd.NA, index=src.index, dtype='boolean')
+    if c.get('water_source') in src.columns:
+        water_label = _map_codes(src[c['water_source']], water_map)
+        irrigated = (water_label == 'Irrigated').astype('boolean')
+        irrigated = irrigated.where(water_label.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        't':            t,
+        'i':            hh.values,
+        'plot_id':      plot_id.values,
+        'Area':         area_ha.values,
+        'AreaUnit':     area_unit.values,
+        'Tenure':       tenure.values,
+        'TenureSystem': tenure_system.values,
+        'SoilType':     soil_type.values,
+        'Irrigated':    irrigated.values,
+    })
+    df = df.set_index(['t', 'i', 'plot_id'])
+    return df

--- a/lsms_library/countries/Burkina_Faso/_/categorical_mapping.org
+++ b/lsms_library/countries/Burkina_Faso/_/categorical_mapping.org
@@ -420,3 +420,59 @@
 | Sand               | Sand            |
 | Dung               | Earth with Dung |
 | Carpet             | Other           |
+
+# plot_features harmonization tables (GH #167; EHCVM cluster).
+# Copied from the Mali EHCVM reference (PR #284).  Keyed on the integer
+# s16a codes — Stata value labels are stable across EHCVM waves and
+# countries, so keying on codes avoids any French/Portuguese language
+# branch.  Burkina 2018-19 and 2021-22 use identical code schemes.
+# Burkina has NO co-propriétaire code 7 (that is Niger-2021 only).
+#
+# harmonize_tenure — s16aq10 "mode de faire-valoir" -> canonical Tenure.
+#   1 Propriétaire -> owned; 2 Prêt gratuit (free loan under agreement,
+#   typically non-cash) -> use_right ("held under agreement with a
+#   use-rights owner"); 3 Fermage -> rented_in; 4 Métayage ->
+#   sharecropped_in; 5 Gage (pledge/pawn) and 6 Autre -> other_tenure.
+# harmonize_soil — s16aq18 -> SoilType (free-form str; English labels).
+# harmonize_water — s16aq17; the Irrigated bool is (label=='Irrigated').
+# harmonize_tenure_system — s16aq13 land-document regime -> the canonical
+#   TenureSystem spellings.  Only the three documents implying a clear
+#   regime are mapped (1 Titre foncier -> freehold; 2 Permis d'exploiter
+#   -> granted_right_of_occupancy; 4 Bail -> leasehold).  Procès-verbal,
+#   Convention de vente, Autre, and Aucun have no defensible regime
+#   mapping and are left out (NaN) rather than force-fit.
+
+#+name: harmonize_tenure
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | owned           |
+|    2 | use_right       |
+|    3 | rented_in       |
+|    4 | sharecropped_in |
+|    5 | other_tenure    |
+|    6 | other_tenure    |
+
+#+name: harmonize_soil
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | sandy           |
+|    2 | loam            |
+|    3 | clay            |
+|    4 | hardpan         |
+|    5 | other           |
+
+#+name: harmonize_water
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Irrigated       |
+|    2 | Irrigated       |
+|    3 | Irrigated       |
+|    4 | Rain-fed        |
+|    5 | Wetland         |
+
+#+name: harmonize_tenure_system
+| Code | Preferred Label            |
+|------+----------------------------|
+|    1 | freehold                   |
+|    2 | granted_right_of_occupancy |
+|    4 | leasehold                  |

--- a/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
+++ b/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
@@ -82,6 +82,23 @@ Data Scheme:
     HowCoped1: str
     HowCoped2: str
 
+  plot_features:
+    # Lasting parcel-level characteristics from the EHCVM agriculture
+    # module s16a (GH #167; copied from the Mali EHCVM reference, PR
+    # #284).  EHCVM waves only: 2018-19 and 2021-22.  The pre-EHCVM 2014
+    # EMC wave uses a different instrument and is out of scope.
+    # plot_id = "{field_no}_{parcel_no}".  Latitude / Longitude are NOT
+    # emitted — EHCVM s16a has no decimal-degree parcel GPS (s16aq47 is
+    # an area, not a coordinate); deferred as in Uganda.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    SoilType: str
+    Irrigated: bool
+    materialize: make
+
   interview_date:
     index: (t, i)
     Int_t: datetime

--- a/lsms_library/countries/Burkina_Faso/_/plot_features.py
+++ b/lsms_library/countries/Burkina_Faso/_/plot_features.py
@@ -1,0 +1,43 @@
+"""Concatenate wave-level plot_features for Burkina Faso (GH #167; EHCVM cluster).
+
+Each EHCVM wave's ``Burkina_Faso/<wave>/_/plot_features.py`` writes a
+parquet indexed by ``(t, i, plot_id)`` with the canonical plot_features
+columns.  This script concatenates the waves that have one (2018-19,
+2021-22; the pre-EHCVM 2014 EMC wave uses a different instrument and is
+out of scope).  ``v`` is NOT baked in — the framework joins it from
+``sample()`` at API time.
+
+Like Mali's concatenator (PR #284), this does NOT apply ``id_walk``
+here.  Cached parquets store pre-transformation data; the framework runs
+``id_walk`` in ``_finalize_result`` on every read.  Applying id_walk at
+cache-write time would collide panel "moved" households whose 2021-22 id
+maps to the same 2018-19 baseline id, baking a non-unique index into the
+parquet.  Leaving the index pre-walk keeps it globally unique; the
+framework's idempotent id_walk handles the panel remap consistently with
+every other Burkina table.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_features.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for plot_features (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_features: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, plot_id) after concat"
+
+to_parquet(p, '../var/plot_features.parquet')


### PR DESCRIPTION
Adds `plot_features` for Burkina Faso (EHCVM), copying the Mali reference (PR #284) and adapting.

## Scope
- EHCVM waves only: **2018-19** and **2021-22** (source `s16a_me_bfa{YEAR}.dta`).
- Pre-EHCVM **2014 (EMC)** is out of scope — different instrument.

## Implementation
- `_/burkina_faso.py`: shared `plot_features_for_wave()` helper (mirrors `Mali/_/mali.py`) using Burkina's own `i()` formatter — `format_id(grappe) + format_id(menage, zeropadding=3)` — the single source of truth shared with `sample`/`panel_ids`.
- `2018-19/_/plot_features.py`, `2021-22/_/plot_features.py`: thin per-wave loaders → `(t, i, plot_id)` parquets. `plot_id = "{field_no}_{parcel_no}"` (`s16aq02`_`s16aq03`).
- `_/plot_features.py`: country concatenator. **No `id_walk`** — the framework walks at API time (consistent with Mali).
- `_/categorical_mapping.org`: `harmonize_tenure` / `harmonize_soil` / `harmonize_water` / `harmonize_tenure_system`, keyed on integer s16a codes.
- `_/data_scheme.yml`: registered `plot_features` (`materialize: make`).
- `_/CONTENTS.org`: documented.

## Columns
`Area` (ha; GPS `s16aq47` where measured else farmer estimate `s16aq09a` via unit `s16aq09b`), `AreaUnit`, `Tenure` (`s16aq10`), `TenureSystem` (`s16aq13`), `SoilType` (`s16aq18`), `Irrigated` (`s16aq17`). Lat/Lon deferred (no decimal-degree parcel GPS in s16a).

## Verification
Wave scripts + concatenator ran clean; `is_this_feature_sane` passes (only an expected constant-`AreaUnit` warning). `(t,i,plot_id)` unique; all values ⊆ canonical sets. **Composite-i approach confirmed: 0% orphans** vs the cover-page roster under the canonical `i()` formatter (both waves) — the id-padding trap that silently dropped ~16% in recon is avoided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)