### PR TITLE
feat(Malawi): plot_features (GH #167)

### DIFF
--- a/lsms_library/countries/Malawi/2010-11/_/plot_features.py
+++ b/lsms_library/countries/Malawi/2010-11/_/plot_features.py
@@ -1,0 +1,45 @@
+"""Build plot_features for Malawi IHS3 2010-11 (GH #167).
+
+Module C (ag_mod_c) carries plot area; Module D (ag_mod_d) carries soil
+type, water source, and the acquire/tenure question ag_d03 (LABELED in
+this wave).  We merge the two on (case_id, ag_c00/ag_d00) -> the plotkey.
+
+See lsms_library/countries/Malawi/_/malawi.py:plot_features_for_wave for
+the harmonization logic shared across the four buildable IHS/IHPS waves.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import plot_features_for_wave
+
+
+WAVE = '2010-11'
+
+# convert_categoricals=False keeps the integer codes that the
+# categorical_mapping.org harmonize_* tables key on.
+df_c = get_dataframe('../Data/Full_Sample/Agriculture/ag_mod_c.dta',
+                     convert_categoricals=False)
+df_d = get_dataframe('../Data/Full_Sample/Agriculture/ag_mod_d.dta',
+                     convert_categoricals=False)
+
+df_c['hhid'] = df_c['case_id'].apply(format_id)
+df_c['plotkey'] = df_c['ag_c00'].apply(format_id)
+df_d['hhid'] = df_d['case_id'].apply(format_id)
+df_d['plotkey'] = df_d['ag_d00'].apply(format_id)
+
+colmap = dict(
+    area_est     = 'ag_c04a',
+    area_unit    = 'ag_c04b',
+    area_gps     = 'ag_c04c',
+    soil_type    = 'ag_d21',
+    water_source = 'ag_d28a',
+    acquire      = 'ag_d03',
+)
+
+df = plot_features_for_wave(WAVE, df_c, df_d, colmap)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot_id) in plot_features {WAVE}"
+assert len(df) > 0, f"plot_features {WAVE} produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Malawi/2013-14/_/plot_features.py
+++ b/lsms_library/countries/Malawi/2013-14/_/plot_features.py
@@ -1,0 +1,41 @@
+"""Build plot_features for Malawi IHPS 2013-14 (GH #167).
+
+Module C (AG_MOD_C_13) carries plot area; Module D (AG_MOD_D_13) carries
+soil type, water source, and the acquire/tenure question ag_d03 (LABELED
+in this wave).  NB: ag_d02 here is the respondent ID, NOT tenure -- we
+use ag_d03.  Merge on (y2_hhid, ag_c00/ag_d00).
+
+See lsms_library/countries/Malawi/_/malawi.py:plot_features_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import plot_features_for_wave
+
+
+WAVE = '2013-14'
+
+df_c = get_dataframe('../Data/AG_MOD_C_13.dta', convert_categoricals=False)
+df_d = get_dataframe('../Data/AG_MOD_D_13.dta', convert_categoricals=False)
+
+df_c['hhid'] = df_c['y2_hhid'].apply(format_id)
+df_c['plotkey'] = df_c['ag_c00'].apply(format_id)
+df_d['hhid'] = df_d['y2_hhid'].apply(format_id)
+df_d['plotkey'] = df_d['ag_d00'].apply(format_id)
+
+colmap = dict(
+    area_est     = 'ag_c04a',
+    area_unit    = 'ag_c04b',
+    area_gps     = 'ag_c04c',
+    soil_type    = 'ag_d21',
+    water_source = 'ag_d28a',
+    acquire      = 'ag_d03',
+)
+
+df = plot_features_for_wave(WAVE, df_c, df_d, colmap)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot_id) in plot_features {WAVE}"
+assert len(df) > 0, f"plot_features {WAVE} produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Malawi/2016-17/_/plot_features.py
+++ b/lsms_library/countries/Malawi/2016-17/_/plot_features.py
@@ -1,0 +1,108 @@
+"""Build plot_features for Malawi IHS4 2016-17 (GH #167).
+
+IHS4 ships a Cross_Sectional half (12,447 HH, keyed on bare case_id) and
+a Panel half (2,508 HH, keyed on dashed y3_hhid).  We build both and
+concat into the single 2016-17 wave t, exactly like the roster.
+
+Two wave-specific wrinkles (validated in the recon refuter pass,
+slurm_logs/2026-06-03_session/RECON_Malawi.md):
+
+1. ID: sample().i is 'cs-17-'-prefixed for the cross-sectional half (the
+   cs_i mapping in mapping.py / data_info.yml).  We apply the same prefix
+   here so XS plots are not orphaned ~100% against sample().i.  The Panel
+   half uses bare y3_hhid which id_walk chains to the canonical id.
+
+2. Tenure: ag_d03 (acquire) is ABSENT from IHS4 ag_mod_d; ag_d02 there is
+   "ID of Respondent", NOT tenure.  So Tenure / TenureSystem are NaN for
+   this wave (no acquire column passed to the helper).
+
+3. Latin-1: Cross_Sectional/ag_mod_d.dta has a bad byte in an unused
+   free-text column that makes a full read raise ReadstatError.  A
+   column-restricted read (usecols=...) succeeds (15,724 rows), so we
+   read only the columns we need for that one file.
+
+Plot key in IHS4 is (gardenid, plotid) -> 'gardenid_plotid'.
+"""
+import os
+import sys
+import tempfile
+
+sys.path.append('../../_/')
+import pyreadstat
+
+from lsms_library.local_tools import (get_dataframe, to_parquet, format_id,
+                                       DVCFS, _ensure_dvc_pulled)
+from malawi import plot_features_for_wave
+
+
+WAVE = '2016-17'
+
+
+def _read_usecols(countries_rel, usecols):
+    """Read only ``usecols`` from a DVC-tracked .dta that a full read
+    cannot decode (latin-1 bad byte in an unused column).  Goes through
+    the DVC cache like get_dataframe, but restricts the column set so
+    pyreadstat never touches the offending free-text column."""
+    _ensure_dvc_pulled(countries_rel)
+    with DVCFS.open(countries_rel) as f:
+        data = f.read()
+    with tempfile.NamedTemporaryFile(suffix='.dta', delete=False) as tmp:
+        tmp.write(data)
+        tmp_path = tmp.name
+    try:
+        df, _ = pyreadstat.read_dta(tmp_path, usecols=usecols,
+                                    apply_value_formats=False)
+        return df
+    finally:
+        os.unlink(tmp_path)
+
+
+def _plotkey(df):
+    return (df['gardenid'].apply(format_id) + '_'
+            + df['plotid'].apply(format_id))
+
+
+colmap = dict(
+    area_est     = 'ag_c04a',
+    area_unit    = 'ag_c04b',
+    area_gps     = 'ag_c04c',
+    soil_type    = 'ag_d21',
+    water_source = 'ag_d28a',
+    # acquire omitted: ag_d03 absent in IHS4 -> Tenure NaN.
+)
+
+pieces = []
+
+# --- Cross-sectional half (cs-17 prefix) ---
+c_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_c.dta',
+                     convert_categoricals=False)
+d_xs = _read_usecols(
+    'Malawi/2016-17/Data/Cross_Sectional/ag_mod_d.dta',
+    usecols=['case_id', 'hhid', 'gardenid', 'plotid',
+             'ag_d02', 'ag_d21', 'ag_d28a'])
+
+c_xs['hhid'] = 'cs-17-' + c_xs['case_id'].apply(format_id)
+c_xs['plotkey'] = _plotkey(c_xs)
+d_xs['hhid'] = 'cs-17-' + d_xs['case_id'].apply(format_id)
+d_xs['plotkey'] = _plotkey(d_xs)
+pieces.append(plot_features_for_wave(WAVE, c_xs, d_xs, colmap))
+
+# --- Panel half (bare y3_hhid) ---
+c_pn = get_dataframe('../Data/Panel/ag_mod_c_16.dta',
+                     convert_categoricals=False)
+d_pn = get_dataframe('../Data/Panel/ag_mod_d_16.dta',
+                     convert_categoricals=False)
+
+c_pn['hhid'] = c_pn['y3_hhid'].apply(format_id)
+c_pn['plotkey'] = _plotkey(c_pn)
+d_pn['hhid'] = d_pn['y3_hhid'].apply(format_id)
+d_pn['plotkey'] = _plotkey(d_pn)
+pieces.append(plot_features_for_wave(WAVE, c_pn, d_pn, colmap))
+
+import pandas as pd
+df = pd.concat(pieces)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot_id) in plot_features {WAVE}"
+assert len(df) > 0, f"plot_features {WAVE} produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Malawi/2019-20/_/plot_features.py
+++ b/lsms_library/countries/Malawi/2019-20/_/plot_features.py
@@ -1,0 +1,72 @@
+"""Build plot_features for Malawi IHS5 2019-20 (GH #167).
+
+IHS5 ships a Cross_Sectional half (keyed on bare case_id) and a Panel
+half (keyed on y4_hhid).  Unlike IHS4, sample().i for the 2019-20 wave
+is NOT cs-prefixed (the cross-sectional case_id is used verbatim), so we
+emit bare ids on both halves and let id_walk chain the panel.
+
+Tenure: ag_d03 (acquire) is ABSENT from IHS5 ag_mod_d; ag_d02 there is
+"ID of Respondent", NOT tenure.  So Tenure / TenureSystem are NaN.
+
+Plot key is (gardenid, plotid) -> 'gardenid_plotid'.
+
+See lsms_library/countries/Malawi/_/malawi.py:plot_features_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import plot_features_for_wave
+
+
+WAVE = '2019-20'
+
+
+def _plotkey(df):
+    return (df['gardenid'].apply(format_id) + '_'
+            + df['plotid'].apply(format_id))
+
+
+colmap = dict(
+    area_est     = 'ag_c04a',
+    area_unit    = 'ag_c04b',
+    area_gps     = 'ag_c04c',
+    soil_type    = 'ag_d21',
+    water_source = 'ag_d28a',
+    # acquire omitted: ag_d03 absent in IHS5 -> Tenure NaN.
+)
+
+pieces = []
+
+# --- Cross-sectional half (bare case_id) ---
+c_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_c.dta',
+                     convert_categoricals=False)
+d_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_d.dta',
+                     convert_categoricals=False)
+
+c_xs['hhid'] = c_xs['case_id'].apply(format_id)
+c_xs['plotkey'] = _plotkey(c_xs)
+d_xs['hhid'] = d_xs['case_id'].apply(format_id)
+d_xs['plotkey'] = _plotkey(d_xs)
+pieces.append(plot_features_for_wave(WAVE, c_xs, d_xs, colmap))
+
+# --- Panel half (y4_hhid) ---
+c_pn = get_dataframe('../Data/Panel/ag_mod_c_19.dta',
+                     convert_categoricals=False)
+d_pn = get_dataframe('../Data/Panel/ag_mod_d_19.dta',
+                     convert_categoricals=False)
+
+c_pn['hhid'] = c_pn['y4_hhid'].apply(format_id)
+c_pn['plotkey'] = _plotkey(c_pn)
+d_pn['hhid'] = d_pn['y4_hhid'].apply(format_id)
+d_pn['plotkey'] = _plotkey(d_pn)
+pieces.append(plot_features_for_wave(WAVE, c_pn, d_pn, colmap))
+
+df = pd.concat(pieces)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot_id) in plot_features {WAVE}"
+assert len(df) > 0, f"plot_features {WAVE} produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Malawi/_/CONTENTS.org
+++ b/lsms_library/countries/Malawi/_/CONTENTS.org
@@ -2,6 +2,52 @@
 
 Brief table of contents and todo list. Malawi has 5 rounds of data, corresponding to IHS2-IHS5 plus IHPS.
 
+* plot_features (GH #167)
+
+Lasting plot-level characteristics.  Schema: =(t, i, plot_id)= index;
+columns =Area= (hectares, float), =AreaUnit= (str, always 'acres'),
+=Tenure= (str), =TenureSystem= (str), =SoilType= (str), =Irrigated=
+(nullable bool).  Latitude / Longitude deferred (Malawi plot GPS is
+offset / redacted in the public release).
+
+Built for the four IHS3+ waves; *2004-05 (IHS2) deferred* -- it has no
+standard plot roster.  Each wave's =Malawi/<wave>/_/plot_features.py=
+merges Module C (area) with Module D (soil / irrigation / tenure) on
+=(hhid, plotkey)= and calls the shared =malawi.plot_features_for_wave=
+helper; the country-level =Malawi/_/plot_features.py= concatenates them.
+=harmonize_tenure= / =harmonize_soil= / =harmonize_irrigation= (Code-keyed)
+live in =categorical_mapping.org=.  Registered =materialize: make= in
+=data_scheme.yml=.
+
+| Wave    | Module C area file                              | Module D file                                   | hhid                  | plotkey            |
+|---------+-------------------------------------------------+-------------------------------------------------+-----------------------+--------------------|
+| 2010-11 | Full_Sample/Agriculture/ag_mod_c.dta            | Full_Sample/Agriculture/ag_mod_d.dta            | case_id               | ag_c00 / ag_d00    |
+| 2013-14 | AG_MOD_C_13.dta                                 | AG_MOD_D_13.dta                                 | y2_hhid               | ag_c00 / ag_d00    |
+| 2016-17 | Cross_Sectional/ag_mod_c.dta + Panel/ag_mod_c_16.dta | Cross_Sectional/ag_mod_d.dta + Panel/ag_mod_d_16.dta | case_id (cs) / y3_hhid | gardenid_plotid    |
+| 2019-20 | Cross_Sectional/ag_mod_c.dta + Panel/ag_mod_c_19.dta | Cross_Sectional/ag_mod_d.dta + Panel/ag_mod_d_19.dta | case_id / y4_hhid     | gardenid_plotid    |
+
+Area: prefer GPS-measured =ag_c04c= (acres) x0.404686; else
+farmer-estimate =ag_c04a= converted via the =ag_c04b= unit code
+(1 Acre, 2 Hectare, 3 Square Meters, 4 Other).  GPS acres > 2500 are
+clamped to NaN (data-entry errors).
+
+Wave-specific notes (validated against the recon refuter pass,
+=slurm_logs/2026-06-03_session/RECON_Malawi.md=):
+- *Tenure* is derived from the labeled acquire question =ag_d03= in
+  *2010-11 & 2013-14 ONLY*.  =ag_d03= is ABSENT from IHS4/IHS5
+  =ag_mod_d=; the =ag_d02= present there is "ID of Respondent", NOT
+  tenure.  So *Tenure / TenureSystem are NaN for 2016-17 & 2019-20*
+  (still a required, non-all-NaN column overall).
+- *2016-17 Cross_Sectional/ag_mod_d.dta* has a latin-1 bad byte in an
+  unused free-text column that makes a full read raise =ReadstatError=.
+  A column-restricted read (=usecols=[case_id, hhid, gardenid, plotid,
+  ag_d02, ag_d21, ag_d28a]=) succeeds (15,724 rows); the wave script
+  uses that path for this one file.
+- *2016-17 cross-sectional id* is =cs-17-=-prefixed in =sample()= (the
+  =cs_i= mapping the roster uses); the wave script applies the same
+  prefix so XS plots are not ~100% orphaned.  All other halves emit the
+  raw wave hhid and rely on framework id_walk / =panel_ids= chaining.
+
 * Housing feature (added 2026-04-12)
 
 Schema: =(t, i)= index, =Roof: str=, =Floor: str=.  Categorical material

--- a/lsms_library/countries/Malawi/_/categorical_mapping.org
+++ b/lsms_library/countries/Malawi/_/categorical_mapping.org
@@ -330,3 +330,55 @@
 | WOOD               | Wood            |
 | Other (Specify)    | Other           |
 | OTHER(SPECIFY)     | Other           |
+
+# plot_features harmonization tables (GH #167).  These are keyed on the
+# raw integer Stata codes (NOT labels), so wave scripts read the source
+# with convert_categoricals=False and map the underlying codes.  This is
+# robust to the cross-wave label drift (Title Case vs UPPER CASE, the
+# 2019-20 '&amp;' HTML entity in soil labels, Chichewa parentheticals).
+#
+# harmonize_tenure — ag_d03 "How did you acquire this plot?" codes.
+#   LABELED and present in 2010-11 & 2013-14 ONLY.  ABSENT from 2016-17
+#   and 2019-20 ag_mod_d (where ag_d02 is "ID of Respondent", NOT
+#   tenure), so Tenure is NaN for those two waves.  TenureSystem is set
+#   to 'leasehold' only for the leasehold acquire code (6); otherwise NaN.
+# harmonize_soil — ag_d21 soil-type codes (all four buildable waves).
+# harmonize_irrigation — ag_d28a water-source codes.  The Irrigated bool
+#   is derived as (code != 7 and code notna): code 7 = 'Rainfed/No
+#   irrigation' is the only non-irrigated value across all waves.
+
+#+name: harmonize_tenure
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | communal        |
+|    2 | inherited       |
+|    3 | inherited       |
+|    4 | owned           |
+|    5 | owned           |
+|    6 | leased          |
+|    7 | rented_in       |
+|    8 | sharecropped_in |
+|    9 | other_tenure    |
+|   10 | other_tenure    |
+|   11 | other_tenure    |
+
+#+name: harmonize_soil
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | sandy           |
+|    2 | sandy_clay      |
+|    3 | clay            |
+|    4 | other           |
+
+#+name: harmonize_irrigation
+| Code | Preferred Label       |
+|------+-----------------------|
+|    1 | Divert stream         |
+|    2 | Bucket                |
+|    3 | Hand pump             |
+|    4 | Treadle pump          |
+|    5 | Motor pump            |
+|    6 | Gravity               |
+|    7 | Rainfed/No irrigation |
+|    8 | Other                 |
+|    9 | Other                 |

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -71,5 +71,24 @@ Data Scheme:
     Value: float
     Purchased Recently: str
     Purchase Price: float
+  plot_features:
+    # Lasting plot-level characteristics for the four buildable IHS/IHPS
+    # waves (2010-11, 2013-14, 2016-17, 2019-20); GH #167.  2004-05 (IHS2)
+    # is deferred -- it has no standard plot roster.  Module C (area) is
+    # merged with Module D (soil / irrigation / tenure) on (hhid, plotkey)
+    # in each wave's plot_features.py.  Tenure is derived from the labeled
+    # acquire question ag_d03 in 2010-11 & 2013-14 ONLY; ag_d03 is absent
+    # from IHS4/IHS5 ag_mod_d (where ag_d02 is "ID of Respondent", not
+    # tenure), so Tenure / TenureSystem are NaN for 2016-17 & 2019-20.
+    # Latitude / Longitude are deferred: Malawi plot GPS is offset /
+    # redacted in the public release.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    SoilType: str
+    Irrigated: bool
+    materialize: make
   food_expenditures:
   food_prices:

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -349,3 +349,196 @@ def apply_harmonize_food(df, wave, level='i'):
                if pd.notna(k) and pd.notna(v)}
     return df.rename(index=labelsd, level=level)
 
+
+
+# ---------------------------------------------------------------------------
+# plot_features (GH #167)
+# ---------------------------------------------------------------------------
+# Lasting plot-level characteristics for the four buildable IHS/IHPS waves
+# (2010-11, 2013-14, 2016-17, 2019-20).  Module C carries plot area (farmer
+# estimate ag_c04a + unit ag_c04b, or GPS-measured ag_c04c in acres);
+# Module D carries soil type (ag_d21), irrigation/water source (ag_d28a),
+# and -- in 2010-11 & 2013-14 ONLY -- the tenure/acquire question ag_d03.
+# 2016-17 & 2019-20 ag_mod_d have NO ag_d03 (ag_d02 there is "ID of
+# Respondent", not tenure), so Tenure is NaN for those two waves.
+#
+# The C<->D merge is on (hhid, plotkey).  2004-05 (IHS2) is DEFERRED -- it
+# has no standard plot roster.  See ../_/CONTENTS.org and the validated
+# recon recipe slurm_logs/2026-06-03_session/RECON_Malawi.md.
+
+ACRES_TO_HECTARES = 0.404686
+
+
+def _malawi_code_map(tablename, here=None):
+    """Load a {int code: Preferred Label} dict from the Malawi
+    categorical_mapping.org table ``tablename`` (Code-keyed).
+
+    Resolves the org file relative to this module first so wave-script
+    CWDs (``Malawi/<wave>/_``) still find it.  Codes whose Preferred
+    Label is missing / '---' map to pd.NA."""
+    import os
+    from lsms_library.local_tools import df_from_orgfile
+
+    if here is None:
+        here = os.path.dirname(os.path.abspath(__file__))
+    candidates = [
+        os.path.join(here, 'categorical_mapping.org'),
+        os.path.abspath(os.path.join('..', '..', '_', 'categorical_mapping.org')),
+        'categorical_mapping.org',
+    ]
+    orgfn = next((c for c in candidates if os.path.exists(c)), candidates[0])
+
+    df = df_from_orgfile(orgfn, name=tablename, set_columns=True, to_numeric=True)
+    out = {}
+    for _, row in df.iterrows():
+        c = row['Code']
+        try:
+            c = int(c)
+        except (TypeError, ValueError):
+            continue
+        lab = row.get('Preferred Label')
+        if pd.isna(lab) or str(lab).strip() in ('---', ''):
+            out[c] = pd.NA
+        else:
+            out[c] = str(lab).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw Stata code) Series through ``code_map``
+    ({int: str}).  Returns a nullable-string Series, NaN where the code
+    is absent from the map.  Source must be loaded with
+    convert_categoricals=False so the codes are numeric."""
+    out = pd.to_numeric(series, errors='coerce').astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_features_for_wave(t, df_c, df_d, colmap):
+    """Build canonical ``plot_features`` for one Malawi IHS/IHPS wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2010-11"``), used as the ``t`` index value.
+    df_c : pd.DataFrame
+        Module C (area) rows, loaded with convert_categoricals=False,
+        with an ``hhid`` column already set to the canonical wave
+        household id string (cs-17 prefix applied for the 2016-17
+        cross-sectional half by the caller) and a ``plotkey`` column
+        uniquely identifying the plot within the household.
+    df_d : pd.DataFrame | None
+        Module D (soil / irrigation / tenure) rows, same ``hhid`` /
+        ``plotkey`` convention.  ``None`` is permitted (Tenure / SoilType
+        / Irrigated then all NaN), but every buildable wave has one.
+    colmap : dict
+        Column-name map.  Keys:
+            area_est   — farmer-estimated area column in df_c (ag_c04a)
+            area_unit  — area unit code column in df_c (ag_c04b)
+            area_gps   — GPS-measured area in acres in df_c (ag_c04c)
+            soil_type  — soil-type code column in df_d (ag_d21)
+            water_source — water-source code column in df_d (ag_d28a)
+            acquire    — tenure/acquire code column in df_d (ag_d03);
+                         omit (or absent) -> Tenure NaN (2016-17/2019-20)
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
+        ``Area`` (hectares, float), ``AreaUnit`` (str, always 'acres'),
+        ``Tenure`` (str), ``TenureSystem`` (str), ``SoilType`` (str),
+        and ``Irrigated`` (nullable bool).  Latitude / Longitude are
+        deferred (Malawi plot GPS is offset / redacted; GH #167).
+    """
+    c = colmap
+
+    # C<->D merge on (hhid, plotkey).  Left-join keeps every area row;
+    # D attributes are NaN where the plot is absent from Module D.
+    df = df_c.copy()
+    if df_d is not None and not df_d.empty:
+        d_cols = ['hhid', 'plotkey'] + [
+            df_d_col for df_d_col in (c.get('soil_type'),
+                                      c.get('water_source'),
+                                      c.get('acquire'))
+            if df_d_col and df_d_col in df_d.columns]
+        df = df.merge(df_d[d_cols].drop_duplicates(['hhid', 'plotkey']),
+                      on=['hhid', 'plotkey'], how='left')
+
+    n = len(df)
+    idx_i = df['hhid'].astype('string')
+    plot_id = df['plotkey'].astype('string')
+
+    # Area: prefer GPS-measured (ag_c04c, acres), else farmer estimate
+    # (ag_c04a) converted via its unit code (ag_c04b: 1=Acre, 2=Hectare,
+    # 3=Square Meters, 4=Other).
+    area_ha = pd.Series(pd.NA, index=df.index, dtype='Float64')
+
+    gps_col = c.get('area_gps')
+    if gps_col and gps_col in df.columns:
+        gps_acres = pd.to_numeric(df[gps_col], errors='coerce').astype('Float64')
+        # Plausibility clamp: > 2500 acres (~1000 ha) is a data-entry
+        # error for Malawi smallholder plots; drop to NaN (GH #167).
+        gps_acres = gps_acres.where((gps_acres <= 2500) | gps_acres.isna(), pd.NA)
+        area_ha = gps_acres * ACRES_TO_HECTARES
+
+    est_col = c.get('area_est')
+    unit_col = c.get('area_unit')
+    if est_col and est_col in df.columns:
+        est = pd.to_numeric(df[est_col], errors='coerce').astype('Float64')
+        unit = (pd.to_numeric(df[unit_col], errors='coerce').astype('Int64')
+                if unit_col and unit_col in df.columns
+                else pd.Series(pd.NA, index=df.index, dtype='Int64'))
+        # acre -> ha, hectare -> ha, sq metre -> ha; OTHER (4) / 0 -> NaN
+        est_ha = pd.Series(pd.NA, index=df.index, dtype='Float64')
+        est_ha = est_ha.where(unit != 1, est * ACRES_TO_HECTARES)
+        est_ha = est_ha.where(unit != 2, est)
+        est_ha = est_ha.where(unit != 3, est / 10000.0)
+        # Clamp implausible estimates too (>1000 ha)
+        est_ha = est_ha.where((est_ha <= 1000) | est_ha.isna(), pd.NA)
+        area_ha = area_ha.where(area_ha.notna(), est_ha)
+
+    area_unit = pd.Series(['acres'] * n, index=df.index, dtype='string')
+    area_unit = area_unit.where(area_ha.notna(), pd.NA)
+
+    # SoilType
+    soil_type = pd.Series(pd.NA, index=df.index, dtype='string')
+    soil_col = c.get('soil_type')
+    if soil_col and soil_col in df.columns:
+        soil_type = _map_codes(df[soil_col], _malawi_code_map('harmonize_soil'))
+
+    # Irrigated: derived from water-source code (ag_d28a).  Code 7 =
+    # 'Rainfed/No irrigation' is the only non-irrigated value; any other
+    # recorded code means the plot is irrigated.  NaN where unrecorded.
+    irrigated = pd.Series(pd.NA, index=df.index, dtype='boolean')
+    water_col = c.get('water_source')
+    if water_col and water_col in df.columns:
+        wcode = pd.to_numeric(df[water_col], errors='coerce').astype('Int64')
+        irrigated = (wcode != 7).astype('boolean')
+        irrigated = irrigated.where(wcode.notna(), pd.NA)
+
+    # Tenure / TenureSystem from the acquire code (ag_d03), present in
+    # 2010-11 & 2013-14 only.  Absent -> all NaN (2016-17 / 2019-20).
+    tenure = pd.Series(pd.NA, index=df.index, dtype='string')
+    tenure_system = pd.Series(pd.NA, index=df.index, dtype='string')
+    acq_col = c.get('acquire')
+    if acq_col and acq_col in df.columns:
+        acode = pd.to_numeric(df[acq_col], errors='coerce').astype('Int64')
+        tenure = _map_codes(acode, _malawi_code_map('harmonize_tenure'))
+        # Leasehold acquire code (6) -> TenureSystem 'leasehold'.
+        tenure_system = pd.Series(pd.NA, index=df.index, dtype='string')
+        tenure_system = tenure_system.where(acode != 6, 'leasehold')
+
+    out = pd.DataFrame({
+        't':            t,
+        'i':            idx_i.values,
+        'plot_id':      plot_id.values,
+        'Area':         area_ha.values,
+        'AreaUnit':     area_unit.values,
+        'Tenure':       tenure.values,
+        'TenureSystem': tenure_system.values,
+        'SoilType':     soil_type.values,
+        'Irrigated':    irrigated.values,
+    })
+    # Collapse any duplicate (hhid, plotkey) area rows defensively
+    # (Module C should be one row per plot; first-wins keeps it unique).
+    out = out.groupby(['t', 'i', 'plot_id'], as_index=False).first()
+    out = out.set_index(['t', 'i', 'plot_id'])
+    return out

--- a/lsms_library/countries/Malawi/_/plot_features.py
+++ b/lsms_library/countries/Malawi/_/plot_features.py
@@ -1,0 +1,36 @@
+"""Concatenate wave-level plot_features parquets for Malawi (GH #167).
+
+Each buildable wave's ``Malawi/<wave>/_/plot_features.py`` produces a
+parquet indexed (t, i, plot_id) with the canonical columns.  This script
+concatenates them.  Cross-wave id_walk (panel-id chaining) and the join
+of the cluster id ``v`` are applied by the framework at API time in
+_finalize_result, so -- unlike Uganda -- no id_walk is run here (Malawi
+has no country-level updated_ids.json; panel linkage flows from the
+``panel_ids`` table).
+
+2004-05 (IHS2) is DEFERRED: it has no standard plot roster.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+# Only the four buildable IHS3+ waves; 2004-05 deferred.
+WAVES = ['2010-11', '2013-14', '2016-17', '2019-20']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_features.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built.  DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_features: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/plot_features.parquet')


### PR DESCRIPTION
## Summary
Adds `plot_features` for Malawi (IHS/IHPS) following the Uganda pattern and the validated recon recipe. Index `(t, i, plot_id)`; columns `Area` (hectares), `AreaUnit`, `Tenure`, `TenureSystem`, `SoilType`, `Irrigated`. Lat/Lon deferred (Malawi plot GPS is offset/redacted).

Buildable waves: **2010-11, 2013-14, 2016-17, 2019-20**. **2004-05 (IHS2) deferred** — no standard plot roster. 2016-17 & 2019-20 combine Cross_Sectional + Panel halves into one wave `t`.

`materialize: make`: each wave's `plot_features.py` merges Module C (area) with Module D (soil/irrigation/tenure) on `(hhid, plotkey)` via the shared `malawi.plot_features_for_wave` helper; `Malawi/_/plot_features.py` concatenates the waves.

## Refuter-validated specifics
- **Tenure** from labeled `ag_d03` for **2010-11 & 2013-14 ONLY**. `ag_d03` is absent from IHS4/IHS5 `ag_mod_d` (`ag_d02` there is "ID of Respondent", not tenure) → Tenure/TenureSystem NaN for 2016-17 & 2019-20 (still a required, non-all-NaN column overall).
- **Latin-1**: 2016-17 `Cross_Sectional/ag_mod_d.dta` has a bad byte in an unused free-text column; read with a column-restricted `usecols` list (15,724 rows) rather than skipping it.
- **cs-17 id**: 2016-17 cross-sectional `sample().i` is `cs-17-`-prefixed; the wave script applies the same prefix so XS plots are not orphaned. Other halves emit raw wave hhid and rely on framework `id_walk` / `panel_ids`.

## Verification
Each wave built directly with the worktree venv + concatenated. `is_this_feature_sane` **ok** (1 warn: constant `AreaUnit`, near-constant `TenureSystem`).

| Wave | Rows | C↔D unmatched | Orphan vs sample().i (after id_walk) |
|------|------|---------------|--------------------------------------|
| 2010-11 | 18,990 | 0.0% (1) | 0% |
| 2013-14 | 6,331 | 0.0% (2) | 0% |
| 2016-17 | 19,760 | XS 0.2% / Panel 0.0% | 0% (XS cs-17 **0%**) |
| 2019-20 | 23,261 | 0.0% | 0% |

Total 68,342 rows; `(t, i, plot_id)` unique. Tenure: 25,262 non-null (2010-11 + 2013-14 only), NaN for 2016-17/2019-20 as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)