### PR TITLE
feat(Kosovo): assets (2000)

### DIFF
--- a/lsms_library/countries/Kosovo/2000/_/data_info.yml
+++ b/lsms_library/countries/Kosovo/2000/_/data_info.yml
@@ -71,3 +71,12 @@ sample:
             - mapping:
                 Rural: Rural
                 Urban: Urban
+
+assets:
+    file: "../Data/DURGOODS.dta"
+    idxvars:
+        i: hhid
+        j: s10e_01
+    myvars:
+        Age: s10e_02
+        Value: s10e_4a

--- a/lsms_library/countries/Kosovo/_/data_scheme.yml
+++ b/lsms_library/countries/Kosovo/_/data_scheme.yml
@@ -27,3 +27,8 @@ Data Scheme:
       type: str
       optional: true
     Rural: str
+
+  assets:
+    index: (t, i, j)
+    Age: float
+    Value: float


### PR DESCRIPTION
## Summary
Adds the canonical `assets` feature for Kosovo (2000 wave), pure YAML.

## Recipe
Source: `Data/DURGOODS.dta` (long, one row per durable-good item).
- `i`: `hhid`
- `j`: `s10e_01` (clean item description; `s10e_00` is truncated)
- `Age`: `s10e_02` (years since acquisition)
- `Value`: `s10e_4a` (price if sold; currency `s10e_4b` is mixed DM/Dinar, passed raw, not converted)

No quantity column exists in the source, so `Quantity` is omitted. Item-level, no aggregation.

## Changes
- `Kosovo/2000/_/data_info.yml`: `assets:` block
- `Kosovo/_/data_scheme.yml`: register `assets:` (index `(t, i, j)`, cols `Age`/`Value`)

## Verification (worktree-pinned venv, neutral cwd)
- `ll.__file__` resolves to worktree
- `is_this_feature_sane(Kosovo, assets)`: 15/15 pass, **ok=True**
- `Country('Kosovo').assets()`: shape (23544, 2), 21 distinct items, 2871 households
- `Feature('assets')(['Kosovo'])`: shape (23544, 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)