### PR TITLE
feat(Liberia): assets (2018-19)

### DIFF
--- a/lsms_library/countries/Liberia/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Liberia/2018-19/_/data_info.yml
@@ -37,3 +37,19 @@ sample:
             - mapping:
                 rural: Rural
                 urban: Urban
+
+assets:
+    # Section 15 (durable goods) is LONG: one row per asset type per HH.
+    # j is the clean string `item_name` (NOT `item_id`, a lowercase dupe).
+    # Quantity=S15_2 ("how many owned"); Value=S15_5 (resale price of the
+    # most-recent purchase).  No Age and no separate purchase-price
+    # question in this instrument, so those canonical columns are omitted
+    # (-> NaN).  S15_6/S15_7 (forest-use / sufficiency) are dropped.
+    file:
+        - "../Data/Household/sect15_public.dta"
+    idxvars:
+        i: hhid
+        j: item_name
+    myvars:
+        Quantity: S15_2
+        Value: S15_5

--- a/lsms_library/countries/Liberia/_/data_scheme.yml
+++ b/lsms_library/countries/Liberia/_/data_scheme.yml
@@ -16,6 +16,14 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  assets:
+    # 2018-19 (Section 15) records only count-owned and resale value.
+    # No Age and no purchase-recency / purchase-price questions in this
+    # instrument, so only Quantity and Value are declared.
+    index: (t, i, j)
+    Quantity: float
+    Value: float
+
   sample:
     index: (i, t)
     v: str


### PR DESCRIPTION
Add the canonical \`assets\` feature for Liberia 2018-19, pure-YAML.

## Source
\`Data/Household/sect15_public.dta\` (Section 15, durable goods) — LONG, one row per asset type per household.

| Canonical | Source | Notes |
|-----------|--------|-------|
| i | \`hhid\` | float64 in source; \`format_id\` strips the \`.0\` |
| j | \`item_name\` | clean string (NOT \`item_id\`, a lowercase dupe) |
| Quantity | \`S15_2\` | how many owned |
| Value | \`S15_5\` | resale price of most-recent purchase |

No Age and no separate purchase-recency / purchase-price question in this instrument, so those canonical columns are omitted (only Quantity and Value declared). \`S15_6\`/\`S15_7\` (forest-use / sufficiency) dropped.

## Verification (worktree-pinned venv, neutral cwd)
- \`ll.__file__\` resolved inside the worktree.
- \`is_this_feature_sane(Liberia, assets)\`: **15/15 checks pass, ok=True**.
- shape (16357, 2); 2928 households; 35 distinct items.
- \`Feature('assets')(['Liberia'])\` → (16357, 2).

## Files
- \`Liberia/2018-19/_/data_info.yml\` — \`assets:\` block.
- \`Liberia/_/data_scheme.yml\` — registered \`assets:\` (index (t,i,j); Quantity, Value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)