### PR TITLE
feat(Iraq): assets (2 waves)

### DIFF
--- a/lsms_library/countries/Iraq/2006-07/_/data_info.yml
+++ b/lsms_library/countries/Iraq/2006-07/_/data_info.yml
@@ -84,3 +84,13 @@ household_roster:
         Sex: q0102
         Age: q0103
         MonthsAway: q0113
+
+assets:
+    file:
+        - "../Data/2007ihses16_durable_goods.dta"
+    idxvars:
+        i: xhhkey
+        j: q1601_n
+    myvars:
+        Quantity: q1602
+        Value: q1604

--- a/lsms_library/countries/Iraq/2012/_/data_info.yml
+++ b/lsms_library/countries/Iraq/2012/_/data_info.yml
@@ -28,3 +28,14 @@ household_roster:
         Sex: q0102
         Relationship: q0105
         Age: q0104
+
+assets:
+    file:
+        - "../Data/2012ihses18_durables.dta"
+    idxvars:
+        i: questid
+        j: durable_code
+    myvars:
+        Quantity: q1801
+        Value: q1805
+        Purchase Price: q1803

--- a/lsms_library/countries/Iraq/_/data_scheme.yml
+++ b/lsms_library/countries/Iraq/_/data_scheme.yml
@@ -17,3 +17,9 @@ Data Scheme:
     Generation: int
     Distance: int
     Affinity: str
+
+  assets:
+    index: (t, i, j)
+    Quantity: float
+    Value: float
+    Purchase Price: float


### PR DESCRIPTION
Adds the canonical `assets` (durable goods) feature for Iraq, pure-YAML, item-level (no aggregation).

## Waves
| Wave | Source file | i | j (item) | Quantity | Value | Purchase Price |
|------|-------------|---|----------|----------|-------|----------------|
| 2006-07 | `2007ihses16_durable_goods.dta` | `xhhkey` | `q1601_n` | `q1602` | `q1604` | — |
| 2012 | `2012ihses18_durables.dta` | `questid` | `durable_code` | `q1801` | `q1805` | `q1803` |

`j` is the raw string item name. `Age` and `Purchased Recently` are not collected in either Iraq wave, so they are omitted from the country `data_scheme.yml` (declaring them would fail the `declared_columns_present` sanity check since no wave produces them).

## Verification (cold-cache, worktree-pinned venv, real framework build)
- `ll.Country('Iraq').assets()` -> `is_this_feature_sane` **15/15 pass, ok=True**
- shape `(788727, 3)`, waves `['2006-07', '2012']`
- 2006-07: 212,047 rows, 36 items, Purchase Price all NaN (not collected)
- 2012: 576,680 rows, 23 items, 105,752 non-null Purchase Price
- `Feature('assets')(['Iraq'])` -> `(788727, 3)`

Files touched are confined to `Iraq/`. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)