### PR TITLE
feat(Serbia): assets (2007)

### DIFF
--- a/lsms_library/countries/Serbia/2007/_/data_info.yml
+++ b/lsms_library/countries/Serbia/2007/_/data_info.yml
@@ -12,6 +12,18 @@ cluster_features:
                 urban: Urban
                 rural: Rural
 
+assets:
+    file: "../Data/m2_durables.dta"
+    idxvars:
+        i: [opstina, popkrug, dom]
+        j: s26
+    myvars:
+        Quantity: s27
+        Age: s28
+        Value:
+            - s30
+            - mappings: to_float
+
 household_roster:
     file:
         - "../Data/individual.dta"

--- a/lsms_library/countries/Serbia/2007/_/mapping.py
+++ b/lsms_library/countries/Serbia/2007/_/mapping.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from lsms_library.local_tools import format_id
 
 
@@ -5,3 +7,8 @@ def i(value):
     """Format composite household id from popkrug + naselje + dom."""
     parts = [str(int(value.iloc[k])) for k in range(len(value))]
     return format_id('-'.join(parts))
+
+
+def to_float(value):
+    """Coerce a scalar to float (s30 Value loads as object dtype)."""
+    return pd.to_numeric(value, errors='coerce')

--- a/lsms_library/countries/Serbia/_/data_scheme.yml
+++ b/lsms_library/countries/Serbia/_/data_scheme.yml
@@ -22,3 +22,9 @@ Data Scheme:
     panel_weight: float
     strata: str
     Rural: str
+
+  assets:
+    index: (t, i, j)
+    Quantity: float
+    Age: float
+    Value: float


### PR DESCRIPTION
## Summary
Adds the canonical `assets` feature for **Serbia (2007 wave)**, pure-YAML (no wave script). Follows the Malawi assets template and the `add-feature/assets` skill: item-level, no aggregation, `j` is the string item name.

## Recipe
- Source: `Data/m2_durables.dta` (long; one row per asset type per HH).
- `i: [opstina, popkrug, dom]` — list form; the framework builds the composite id (matches `sample()` exactly, **0% orphan**, e.g. `71145-127-1005`).
- `j: s26` — clean English item name (NOT `nazivtpd`, which is mojibake).
- `Quantity: s27`, `Age: s28`, `Value: s30`.
- `s30` loads as object dtype, so a small `to_float` helper was added to the wave's `mapping.py` and referenced via the `mappings:` form.

Serbia 2007 has no *Purchased Recently* / *Purchase Price* columns, so the country `data_scheme.yml` declares only `Quantity/Age/Value` (avoids a spurious `declared_columns_present` failure).

## Verification (worktree-pinned venv, neutral cwd)
- `ll.__file__` resolved inside the worktree.
- `is_this_feature_sane(country='Serbia', feature='assets')`: **15/15 pass, report.ok True**.
- Shape: **48060 rows**, index `(i, t, j)`, 5551 households. `Value` coerced to Float64.
- `Feature('assets')(['Serbia'])` → `(48060, 3)`.
- i-orphan vs `sample()`: **0%** (5551/5557 sample HH own durables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)