### PR TITLE
feat(Iraq): interview_date (2 waves)

### DIFF
--- a/lsms_library/countries/Iraq/2006-07/_/interview_date.py
+++ b/lsms_library/countries/Iraq/2006-07/_/interview_date.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import sys
+sys.path.append('../../../_/')
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+# 2006-07 cover page: visit-1 interview date in q0035d/q0035m/q0035y
+# (4-digit year). i = xhhkey.  v is joined from sample() at API time.
+idxvars = dict(i='xhhkey',
+               t=('xhhkey', lambda x: "2006-07"))
+myvars = dict(day='q0035d',
+              month='q0035m',
+              year='q0035y')
+
+df = df_data_grabber('../Data/2007ihses00_cover_page.dta', idxvars, **myvars)
+df['Int_t'] = pd.to_datetime(df[['year', 'month', 'day']])
+df = df.drop(columns=['year', 'month', 'day'])
+
+to_parquet(df, 'interview_date.parquet')

--- a/lsms_library/countries/Iraq/2012/_/interview_date.py
+++ b/lsms_library/countries/Iraq/2012/_/interview_date.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import sys
+sys.path.append('../../../_/')
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+# 2012 cover page: visit-1 interview date in q00_35_1d/m/y (4-digit year;
+# preferred over the q00_31 interviewer date).  i = questid.
+# v is joined from sample() at API time.
+idxvars = dict(i='questid',
+               t=('questid', lambda x: "2012"))
+myvars = dict(day='q00_35_1d',
+              month='q00_35_1m',
+              year='q00_35_1y')
+
+df = df_data_grabber('../Data/2012ihses00_cover_page.dta', idxvars, **myvars)
+df['Int_t'] = pd.to_datetime(df[['year', 'month', 'day']])
+df = df.drop(columns=['year', 'month', 'day'])
+
+to_parquet(df, 'interview_date.parquet')

--- a/lsms_library/countries/Iraq/_/data_scheme.yml
+++ b/lsms_library/countries/Iraq/_/data_scheme.yml
@@ -17,3 +17,8 @@ Data Scheme:
     Generation: int
     Distance: int
     Affinity: str
+
+  interview_date:
+    index: (t, i)
+    Int_t: datetime
+    materialize: make


### PR DESCRIPTION
Add the canonical `interview_date` feature for Iraq (both waves), keyed `(t, i)` with `Int_t` (datetime). `v` is joined from `sample()` at API time, not baked into the parquet.

## Waves
- **2006-07**: visit-1 date `q0035d`/`q0035m`/`q0035y` from `2007ihses00_cover_page.dta` (i=`xhhkey`). 4-digit year, 17822 HH.
- **2012**: visit-1 date `q00_35_1d`/`q00_35_1m`/`q00_35_1y` from `2012ihses00_cover_page.dta` (i=`questid`; preferred over the `q00_31` interviewer date). 4-digit year, 25146 HH.

Both 100% sample-match. Registered in `Iraq/_/data_scheme.yml` with `materialize: make`; only `Int_t` declared (matches what the scripts produce).

## Real-build verification (REALBUILD_PROTOCOL)
Worktree-pinned venv, run from `/tmp` on a cold cache (`LSMS_NO_CACHE=1`):
- `ll.__file__` confirmed under the worktree.
- `Country('Iraq').interview_date()` -> shape `(42968, 1)`, waves `['2006-07', '2012']`.
- `is_this_feature_sane(...)` -> **ok** (14 pass / 1 warn / 0 fail; the warn is the auto-joined `v` index level).
- `Feature('interview_date')(['Iraq'])` -> shape `(42968, 1)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)