### PR TITLE
feat(Kosovo): interview_date (2000)

### DIFF
--- a/lsms_library/countries/Kosovo/2000/_/interview_date.py
+++ b/lsms_library/countries/Kosovo/2000/_/interview_date.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import sys
+sys.path.append('../../../_/')
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+idxvars = dict(t=('s0i_dat0', lambda x: "2000"),
+               i='hhid')
+myvars = dict(s0i_dat0='s0i_dat0')
+
+df = df_data_grabber('../Data/ID.dta', idxvars, **myvars)
+# A handful of records carry impossible calendar dates (e.g. 20001032,
+# 20001200, 20001100 -- day/month out of range). Coerce those to NaT.
+df['Int_t'] = pd.to_datetime(df['s0i_dat0'].astype('Int64').astype(str),
+                             format='%Y%m%d', errors='coerce')
+df = df.drop(columns=['s0i_dat0'])
+
+to_parquet(df, 'interview_date.parquet')

--- a/lsms_library/countries/Kosovo/_/data_scheme.yml
+++ b/lsms_library/countries/Kosovo/_/data_scheme.yml
@@ -6,6 +6,11 @@ Data Scheme:
     Region: str
     Rural: str
 
+  interview_date:
+    index: (t, i)
+    Int_t: datetime
+    materialize: make
+
   household_roster:
     index: (t, i, pid)
     Sex: str


### PR DESCRIPTION
Adds the canonical `interview_date` feature for Kosovo (2000).

## Recipe (verified)
- Source: `Kosovo/2000/Data/ID.dta`
- `s0i_dat0` is a single YYYYMMDD integer (e.g. 20001006 = 2000-10-06), parsed with `pd.to_datetime(..., format='%Y%m%d')` into `Int_t` (datetime).
- Keyed `(t, i)`; `v` (psu) is joined by the framework from `sample()`.

## Surprise
3 records carry impossible calendar dates (20001032, 20001200, 20001100 — day/month out of range). Parsed with `errors='coerce'` so they become NaT instead of crashing the build; those rows drop out of the household-level result.

## Real-build verification (worktree-pinned venv, cold cache, neutral CWD)
- `ll.__file__` confirmed inside the worktree.
- `LSMS_NO_CACHE=1 Country('Kosovo').interview_date()` -> 2718 rows, `is_this_feature_sane` **ok** (14 pass / 1 warn / 0 fail; warn is only the extra `v` index level from the sample join). NaT count 0 in final result. Date range 2000-10-02 .. 2000-12-30.
- `Feature('interview_date')(['Kosovo'])` -> (2718, 1), index `['country', 'i', 't', 'v']`.

## Files
- `lsms_library/countries/Kosovo/2000/_/interview_date.py` (new)
- `lsms_library/countries/Kosovo/_/data_scheme.yml` (register interview_date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)