### PR TITLE
feat(India): interview_date (1997-98)

### DIFF
--- a/lsms_library/countries/India/1997-98/_/interview_date.py
+++ b/lsms_library/countries/India/1997-98/_/interview_date.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import sys
+sys.path.append('../../../_/')
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+# India 1997-98: interview date in SECT00.DTA.
+# intdate=day, intmonth=month, intyear is 2-DIGIT (98 -> 1998).
+# i=hhcode (matches sample 100%; the roster's i:hh is a latent bug -> use hhcode).
+# v (village) is NOT baked in here; it is joined from sample() at API time by
+# _join_v_from_sample (see CLAUDE.md: only cluster_features owns v).
+idxvars = dict(i='hhcode',
+               t=('hhcode', lambda x: "1997-98"))
+
+myvars = dict(day='intdate',
+              month='intmonth',
+              year='intyear')
+
+df = df_data_grabber('../Data/SECT00.DTA', idxvars, **myvars)
+
+# 2-digit year -> 4-digit (97 -> 1997, 98 -> 1998).
+df['year'] = df['year'].astype('Int64') + 1900
+df['Int_t'] = pd.to_datetime(df[['year', 'month', 'day']], errors='coerce')
+df = df.drop(columns=['year', 'month', 'day'])
+
+to_parquet(df, 'interview_date.parquet')

--- a/lsms_library/countries/India/_/data_scheme.yml
+++ b/lsms_library/countries/India/_/data_scheme.yml
@@ -30,3 +30,8 @@ Data Scheme:
     index: (t, i, pid)
     Cash_per_day: float
     Rural: str
+
+  interview_date:
+    index: (t, i)
+    Int_t: datetime
+    materialize: make


### PR DESCRIPTION
## Summary
Adds the canonical `interview_date` feature for India 1997-98.

- Source: `SECT00.DTA` — `intdate`(day)/`intmonth`/`intyear`. `intyear` is 2-DIGIT (98 -> 1998); fixed with +1900.
- Keyed `(t, i)` via `i=hhcode` (matches `sample` 100%; the roster's `i:hh` is a latent bug, so `hhcode` is used here).
- `v` (village) is NOT baked into the wave parquet — it is joined from `sample()` at API time by `_join_v_from_sample`, per the framework convention.
- Wave script `India/1997-98/_/interview_date.py` emits `Int_t` (datetime); registered in `India/_/data_scheme.yml` with `materialize: make`.

## Files
- `lsms_library/countries/India/1997-98/_/interview_date.py` (new)
- `lsms_library/countries/India/_/data_scheme.yml` (interview_date block)

## Real-build verification (worktree-pinned venv, cold cache, from /tmp)
- `ll.__file__` confirmed inside worktree.
- `LSMS_NO_CACHE=1 Country('India').interview_date()` -> shape (2249, 1), index [i, t, v], col Int_t; dates 1997-01-15 .. 1998-12-19 (2-digit year fix verified).
- `is_this_feature_sane` -> 14 pass, 1 warn (benign: framework-joined `v` extra level), 0 fail. ok=True.
- `Feature('interview_date')(['India'])` -> shape (2249, 1), index [country, i, t, v].
- Wave parquet keyed (t, i), 2251 rows (2 NaT dates dropped at API time -> 2249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)