### PR TITLE
feat(Pakistan): interview_date (1991)

### DIFF
--- a/lsms_library/countries/Pakistan/1991/_/interview_date.py
+++ b/lsms_library/countries/Pakistan/1991/_/interview_date.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""Interview dates for Pakistan 1991.
+
+Source: F00A.DTA, interview-1 date triple dayi1/moi1/yri1 (the first-visit
+date; the return-visit *r/*i2/*en/*pr triples are deliberately ignored).
+The year is recorded 2-digit (e.g. 91), so add 1900 to recover 1991.
+"""
+import pandas as pd
+import sys
+sys.path.append('../../../_/')
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+idxvars = dict(i='hid',
+               t=('hid', lambda x: "1991"))
+
+myvars = dict(day='dayi1',
+              month='moi1',
+              year='yri1')
+
+df = df_data_grabber('../Data/F00A.DTA', idxvars, **myvars)
+
+# 2-digit year -> 4-digit (91 -> 1991)
+df['year'] = df['year'] + 1900
+
+df['Int_t'] = pd.to_datetime(
+    dict(year=df['year'], month=df['month'], day=df['day']),
+    errors='coerce')
+
+df = df.drop(columns=['day', 'month', 'year'])
+
+to_parquet(df.dropna(), 'interview_date.parquet')

--- a/lsms_library/countries/Pakistan/_/data_scheme.yml
+++ b/lsms_library/countries/Pakistan/_/data_scheme.yml
@@ -9,6 +9,11 @@ Data Scheme:
       optional: true
     Language: str
 
+  interview_date:
+    index: (t, i)
+    Int_t: datetime
+    materialize: make
+
   household_roster:
     index: (t, i, pid)
     Sex: str


### PR DESCRIPTION
Add the canonical `interview_date` feature for Pakistan 1991.

## Recipe
- Source `Data/F00A.DTA`, interview-1 date triple `dayi1`/`moi1`/`yri1` (first visit; the return-visit `*r`/`*i2`/`*en`/`*pr` triples are deliberately ignored).
- Year is recorded 2-digit (91) -> +1900 recovers 1991.
- Keyed `(t, i)` (i=`hid`); `v`=`clust` is joined from `sample()` at API time per framework convention (not baked into the parquet).
- One NaN-date row dropped via `dropna()` (harmless).

## Files
- `lsms_library/countries/Pakistan/1991/_/interview_date.py` (new wave script, `materialize: make` path)
- `lsms_library/countries/Pakistan/_/data_scheme.yml` (register `interview_date`, index `(t, i)`, `Int_t: datetime`)

## Verification (REAL build, cold cache, worktree-pinned venv from /tmp)
- `ll.__file__` confirmed inside worktree.
- `LSMS_NO_CACHE=1 Country('Pakistan').interview_date()` -> shape (4956, 1), `Int_t` datetime, dates 1991-08-11 etc.
- `is_this_feature_sane` -> ok (14 pass / 1 warn / 0 fail; the warn is the expected `v` extra-index level joined from sample).
- `Feature('interview_date')(['Pakistan'])` -> shape (4956, 1), `country` prepended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)