### PR TITLE
feat(Guyana): interview_date (1992)

### DIFF
--- a/lsms_library/countries/Guyana/1992/_/interview_date.py
+++ b/lsms_library/countries/Guyana/1992/_/interview_date.py
@@ -1,0 +1,31 @@
+import pandas as pd
+import sys
+sys.path.append('../../../_/')
+from lsms_library.local_tools import df_data_grabber, format_id, to_parquet
+
+# Guyana 1992 cover page (COVERN.dta) records the enumeration date as
+# day/month/year-of-enumeration (DDE/MDE/YDE).  The household key is the
+# composite (ED, HH); we hyphen-join ED+HH to match sample's "ED-HH" form
+# (e.g. "1-1").  v is the enumeration district ED.  YDE is stored 2-digit
+# (uniformly 93 -> 1993): enumeration ran Mar-Aug 1993 even though the
+# survey is nominally the 1992 round.
+idxvars = dict(ED='ED', HH='HH')
+myvars = dict(day='DDE', month='MDE', year='YDE')
+
+df = df_data_grabber('../Data/COVERN.dta', idxvars, **myvars).reset_index()
+
+# Composite household id "ED-HH" and cluster id v=ED (format_id each part).
+df['i'] = df['ED'].map(format_id) + '-' + df['HH'].map(format_id)
+df['v'] = df['ED'].map(format_id)
+df['t'] = '1992'
+
+# Expand 2-digit year of enumeration to 4-digit (e.g. 93 -> 1993).
+year = df['year'].astype(int)
+year = year.where(year >= 100, year + 1900)
+df['Int_t'] = pd.to_datetime(dict(year=year,
+                                  month=df['month'].astype(int),
+                                  day=df['day'].astype(int)))
+
+df = df.set_index(['t', 'i'])[['v', 'Int_t']]
+
+to_parquet(df, 'interview_date.parquet')

--- a/lsms_library/countries/Guyana/_/data_scheme.yml
+++ b/lsms_library/countries/Guyana/_/data_scheme.yml
@@ -6,6 +6,11 @@ Data Scheme:
     Region: str
     Rural: str
 
+  interview_date:
+    index: (t, i)
+    Int_t: datetime
+    materialize: make
+
   household_roster:
     index: (t, i, pid)
     Sex: str


### PR DESCRIPTION
## Summary
Adds the canonical `interview_date` feature for **Guyana 1992**.

- Source: `Data/COVERN.dta`, columns `DDE`/`MDE`/`YDE` (day/month/year of enumeration).
- `Int_t` (datetime) assembled from those three fields.
- Household key is composite `i = ED-HH` (hyphen-joined to match `sample`'s `ED-HH`); `v = ED`; `t = 1992`.
- Registered `interview_date` in `Guyana/_/data_scheme.yml` (`index: (t, i)`, `Int_t: datetime`, `materialize: make`). Only the produced column (`Int_t`) is declared.

## YDE digit width (confirmed)
`YDE` is **2-digit and uniformly 93**. Expanded to 4-digit via `year + 1900` -> **1993**. Despite the "1992" nominal round label, all enumeration occurred **March–August 1993**.

## Real-build verification (worktree-pinned venv, neutral CWD, `LSMS_NO_CACHE=1`)
- `ll.__file__` confirmed inside the worktree.
- `Country('Guyana').interview_date()`: shape **(1502, 2)**, `is_this_feature_sane` **15/15 pass**.
- Dates parse to plausible values: min `1993-03-22`, max `1993-08-17`.
- 100% sample-match: 1502/1502 households present in `sample`, zero on either side.
- `Feature('interview_date')(['Guyana'])`: shape (1502, 2), index `[country, i, t]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)