### PR TITLE
feat(Cambodia): interview_date (2019-20)

### DIFF
--- a/lsms_library/countries/Cambodia/2019-20/_/interview_date.py
+++ b/lsms_library/countries/Cambodia/2019-20/_/interview_date.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""Cambodia 2019-20 interview date.
+
+Source: hh_sec_1.dta.  Date columns intvw_day / intvw_month / intvw_year
+are STRING dtype (full 4-digit year), cast to int before to_datetime.
+i = HHID (32-char hex hash, already string).  v is joined from sample()
+at API time, so it is not baked into this parquet.
+"""
+import sys
+sys.path.append('../../../_/')
+import pandas as pd
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+idxvars = dict(i='HHID',
+               t=('intvw_year', lambda x: "2019-20"))
+
+myvars = dict(year='intvw_year',
+              month='intvw_month',
+              day='intvw_day')
+
+df = df_data_grabber('../Data/hh_sec_1.dta', idxvars, **myvars)
+
+for c in ['year', 'month', 'day']:
+    df[c] = pd.to_numeric(df[c], errors='coerce').astype('Int64')
+
+df['Int_t'] = pd.to_datetime(dict(year=df['year'], month=df['month'], day=df['day']),
+                             errors='coerce')
+df = df.drop(columns=['year', 'month', 'day'])
+
+to_parquet(df, 'interview_date.parquet')

--- a/lsms_library/countries/Cambodia/_/Makefile
+++ b/lsms_library/countries/Cambodia/_/Makefile
@@ -8,7 +8,7 @@ LSMS_DATA_ROOT ?= $(if $(LSMS_DATA_DIR),$(LSMS_DATA_DIR),$(if $(XDG_DATA_HOME),$
 VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 
 var = $(VAR_DIR)/food_expenditures.parquet $(VAR_DIR)/food_quantities.parquet $(VAR_DIR)/food_prices.parquet \
-	  $(VAR_DIR)/household_characteristics.parquet
+	  $(VAR_DIR)/household_characteristics.parquet $(VAR_DIR)/interview_date.parquet
 
 all: $(parquet) $(var)
 
@@ -32,6 +32,15 @@ household_characteristics_parquet := $(household_characteristics:.py=.parquet)
 
 $(VAR_DIR)/household_characteristics.parquet: household_characteristics.py $(household_characteristics_parquet)
 	python household_characteristics.py
+
+../2019-20/_/interview_date.parquet: ../2019-20/_/interview_date.py
+	(cd ../2019-20/_; python interview_date.py)
+
+interview_date = $(shell find $(rounds) -name interview_date.py)
+interview_date_parquet := $(interview_date:.py=.parquet)
+
+$(VAR_DIR)/interview_date.parquet: interview_date.py $(interview_date_parquet)
+	python interview_date.py
 
 %.parquet: %.py malawi.py
 	(cd $(@D) && python ./$(<F))

--- a/lsms_library/countries/Cambodia/_/data_scheme.yml
+++ b/lsms_library/countries/Cambodia/_/data_scheme.yml
@@ -22,3 +22,8 @@ Data Scheme:
     Generation: int
     Distance: int
     Affinity: str
+
+  interview_date:
+    index: (t, i)
+    Int_t: datetime
+    materialize: make

--- a/lsms_library/countries/Cambodia/_/interview_date.py
+++ b/lsms_library/countries/Cambodia/_/interview_date.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""Concatenate wave-level interview_date data for Cambodia."""
+import pandas as pd
+from lsms_library.local_tools import to_parquet, get_dataframe
+
+X = []
+for t in ['2019-20']:
+    X.append(get_dataframe('../%s/_/interview_date.parquet' % t))
+
+x = pd.concat(X, axis=0)
+
+to_parquet(x, '../var/interview_date.parquet')


### PR DESCRIPTION
## Summary
Adds the canonical \`interview_date\` feature for **Cambodia (2019-20)**, the country's single LSMS-Plus wave.

- Source: \`hh_sec_1.dta\`; date columns \`intvw_day\`/\`intvw_month\`/\`intvw_year\` are STRING dtype (full 4-digit year), cast to int before \`to_datetime\`.
- \`i = HHID\` (32-char hex hash, already string). \`v\` (\`s01q01\`) is joined from \`sample()\` at API time per the framework convention — not baked into the parquet.
- **1512/1512 households (100% sample match)**; all dates parse cleanly (range Oct 2019 – Jan 2020).

## Files
- \`Cambodia/2019-20/_/interview_date.py\` — wave-level extractor producing \`Int_t\` (datetime), keyed \`(t, i)\`.
- \`Cambodia/_/interview_date.py\` — country-level concatenator -> \`var/interview_date.parquet\`.
- \`Cambodia/_/data_scheme.yml\` — register \`interview_date\` (index \`(t, i)\`; \`Int_t: datetime\`; \`materialize: make\`).
- \`Cambodia/_/Makefile\` — wave + var build rules (the generic \`%.parquet\` fallback rule references a nonexistent \`malawi.py\`, so explicit rules are required).

## Verification (REAL build per REALBUILD_PROTOCOL.md)
Worktree-pinned venv, neutral CWD (/tmp), cold cache (\`LSMS_NO_CACHE=1\`):
- \`ll.__file__\` confirmed inside the worktree.
- \`Country('Cambodia').interview_date()\` -> shape \`(1512, 1)\`, index \`['i','t','v']\`, \`Int_t\` datetime.
- \`is_this_feature_sane(...)\` -> **14 pass / 1 warn / 0 fail, ok=True**. The single warning is the framework-added \`v\` index level (expected; schema declares only \`(t,i)\`).
- \`Feature('interview_date')(['Cambodia'])\` -> shape \`(1512, 1)\` with \`country\` level prepended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)