### PR TITLE
feat(Liberia): individual_education (2018-19)

### DIFF
--- a/lsms_library/countries/Liberia/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Liberia/2018-19/_/data_info.yml
@@ -13,6 +13,15 @@ household_roster:
         Age: S2_5
         MonthsSpent: S2_7
 
+individual_education:
+    file:
+        - "../Data/Household/sect2_public.dta"
+    idxvars:
+        i: hhid
+        pid: member_id
+    myvars:
+        Educational Attainment: S2_14
+
 cluster_features:
     file:
         - "../Data/Household/sect1_public.dta"

--- a/lsms_library/countries/Liberia/_/data_scheme.yml
+++ b/lsms_library/countries/Liberia/_/data_scheme.yml
@@ -16,6 +16,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   sample:
     index: (i, t)
     v: str


### PR DESCRIPTION
Adds the canonical `individual_education` feature for Liberia (2018-19).

## Approach
Pure-YAML (no script):
- Wave `2018-19/_/data_info.yml`: new `individual_education` block reading `Data/Household/sect2_public.dta`, attainment from `S2_14`, keyed `i=hhid`, `pid=member_id`.
- Country `_/data_scheme.yml`: registered `individual_education` index `(t,i,pid)`, `Educational Attainment: str`.

`Educational Attainment` is free-text — `S2_14` carries clean value labels (grades + AAD / U1-U5) emitted as-is; no harmonize table. `v` is auto-joined from `sample()` at API time.

## Real-build verification (REALBUILD_PROTOCOL, worktree-pinned venv, /tmp CWD, LSMS_NO_CACHE=1)
- `ll.__file__` confirmed inside the worktree.
- `Country('Liberia').individual_education()` -> shape (2904, 1); `is_this_feature_sane` ok=True (14 pass, 1 warn for the auto-joined `v` index level, 0 fail).
- `Feature('individual_education')(['Liberia'])` -> shape (2904, 1), index `[country, i, t, v, pid]`.
- 19 distinct attainment values (grade 1-12, pre-primary/no grade, aad, u1-u5, master and above (u5)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)