### PR TITLE
feat(India): individual_education (1997-98)

### DIFF
--- a/lsms_library/countries/India/1997-98/_/data_info.yml
+++ b/lsms_library/countries/India/1997-98/_/data_info.yml
@@ -47,6 +47,16 @@ household_roster:
       Relationship: v01a03
       MonthsSpent: v01a10
       Educational Attainment: v01a05
+individual_education:
+  file:
+      - ../Data/SECT01A.DTA
+  idxvars:
+      i: hhcode
+      pid: idcode
+      v: village
+  myvars:
+      Educational Attainment: v01a05
+
 employment:
   file:
       - ../Data/SECT02AD.DTA

--- a/lsms_library/countries/India/_/data_scheme.yml
+++ b/lsms_library/countries/India/_/data_scheme.yml
@@ -26,6 +26,10 @@ Data Scheme:
     Distance: int
     Affinity: str
     Educational Attainment: str
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   employment:
     index: (t, i, pid)
     Cash_per_day: float


### PR DESCRIPTION
Adds the canonical `individual_education` feature for India 1997-98.

## Recipe
- Source: `Data/SECT01A.DTA` (roster file).
- Attainment: `v01a05` (free-text/truncated survey labels; no harmonize table — emits survey labels as-is).
- Keys: `i: hhcode` (NOT the roster's `i: hh`, a latent bug resolving only 32/2251 HH), `pid: idcode`, `v: village`.
- Pure-YAML: `individual_education:` block in `India/1997-98/_/data_info.yml` + registration in `India/_/data_scheme.yml` (index `(t, i, pid)`, only `Educational Attainment` declared).

## Real build (worktree-pinned venv, /tmp CWD, LSMS_NO_CACHE=1)
- `ll.__file__` confirmed inside worktree.
- `Country('India').individual_education()`: sane **ok=True** (14 pass, 1 warn, 0 fail).
- Rows: **14493**; distinct households: **2252**.
- i-orphan vs `sample()`: **0.04%** (1 HH) — confirms `hhcode` worked, not the 32/2251 `hh` bug.
- `Feature('individual_education')(['India'])`: shape (14493, 1), `country` level prepended.

The one sanity warn is `v` as an extra index level (joined via idxvars `v: village`); matches the Mali reference pattern (`v: grappe` in idxvars). Not a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)