### PR TITLE
feat(Kosovo): individual_education (2000)

### DIFF
--- a/lsms_library/countries/Kosovo/2000/_/data_info.yml
+++ b/lsms_library/countries/Kosovo/2000/_/data_info.yml
@@ -59,6 +59,22 @@ household_roster:
                   5: Widow/er
                   6: Never ma
 
+individual_education:
+    file: "../Data/EDUC.dta"
+    idxvars:
+        i: hhid
+        pid: s04_q00
+    myvars:
+        Educational Attainment:
+            - s04_q4b
+            - mapping:
+                Pre-Scho: Pre-School
+                Primary: Primary
+                'Second. ': Secondary
+                Gymnasiu: Gymnasium
+                Vocation: Vocational
+                Universi: University
+
 sample:
     file: "../Data/ID.dta"
     idxvars:

--- a/lsms_library/countries/Kosovo/_/data_scheme.yml
+++ b/lsms_library/countries/Kosovo/_/data_scheme.yml
@@ -6,6 +6,10 @@ Data Scheme:
     Region: str
     Rural: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   household_roster:
     index: (t, i, pid)
     Sex: str


### PR DESCRIPTION
Adds the canonical \`individual_education\` feature for Kosovo (2000).

## Recipe
- Source: \`Data/EDUC.dta\`
- Attainment: \`s04_q4b\` (education level; not the numeric grade \`s04_q4a\`)
- Person key: \`s04_q00\` (matches roster pid; not respondent code \`s04_q0a\`)
- \`i=hhid\`, \`pid=s04_q00\`, \`v\` auto-joined from \`sample()\`
- Truncated 8-char .dta labels expanded via inline mapping (\`Gymnasiu\`->\`Gymnasium\`, \`Universi\`->\`University\`, \`'Second. '\`->\`Secondary\`, \`Vocation\`->\`Vocational\`, \`Pre-Scho\`->\`Pre-School\`, \`Primary\`)

## Changes (pure-YAML)
- \`Kosovo/2000/_/data_info.yml\`: \`individual_education\` block
- \`Kosovo/_/data_scheme.yml\`: registration, index \`(t, i, pid)\`

## Real-build verification
Worktree-pinned venv, run from /tmp, \`LSMS_NO_CACHE=1\`:
- \`ll.__file__\` confirmed inside worktree
- \`is_this_feature_sane\` ok (14/15 pass, 1 warn for auto-joined \`v\`)
- \`Country('Kosovo').individual_education()\` -> 14233 rows
- \`Feature('individual_education')(['Kosovo'])\` -> (14233, 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)