### PR TITLE
feat(Tajikistan): interview_date (4 waves)

### DIFF
--- a/lsms_library/countries/Tajikistan/1999/_/interview_date.py
+++ b/lsms_library/countries/Tajikistan/1999/_/interview_date.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""Tajikistan 1999 interview dates.
+
+Source: ../Data/SSEC1.DTA (one row per *person*; 14142 rows).  The interview
+date (date_day/date_mth/date_yr) is recorded identically for every member of a
+household, so we deduplicate to one row per household.  date_yr is a 2-digit
+year (99 -> 1999).  The household id matches sample()'s `i`: 'pop_pt-hhid'.
+"""
+import sys
+sys.path.append('../../../_')
+sys.path.append('../_')
+import pandas as pd
+from lsms_library.local_tools import df_data_grabber, to_parquet
+from mapping import i as format_i
+
+idxvars = dict(t=('hhid', lambda x: '1999'),
+               i=(['pop_pt', 'hhid'], format_i))
+myvars = dict(day='date_day',
+              month='date_mth',
+              year='date_yr')
+
+df = df_data_grabber('../Data/SSEC1.DTA', idxvars, **myvars)
+
+# date_yr is 2-digit (99); map to 4-digit calendar year.
+df['year'] = df['year'].astype(float) + 1900
+
+df['Int_t'] = pd.to_datetime(
+    dict(year=df['year'], month=df['month'], day=df['day']),
+    errors='coerce',
+)
+df = df.drop(columns=['day', 'month', 'year'])
+
+# One interview date per household.
+df = df[~df.index.duplicated(keep='first')].dropna()
+
+to_parquet(df, 'interview_date.parquet')

--- a/lsms_library/countries/Tajikistan/2003/_/interview_date.py
+++ b/lsms_library/countries/Tajikistan/2003/_/interview_date.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""Tajikistan 2003 interview dates.
+
+Source: ../Data/interview.dta.  Records day_in/month_in but NO year column;
+the survey was fielded in 2003, so the year is hardcoded.  Household id is
+`hhid` (matches sample()'s `i`); `v` is joined from sample() at API time.
+"""
+import sys
+sys.path.append('../../../_')
+import pandas as pd
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+idxvars = dict(t=('hhid', lambda x: '2003'),
+               i='hhid')
+myvars = dict(day='day_in',
+              month='month_in')
+
+df = df_data_grabber('../Data/interview.dta', idxvars, **myvars)
+
+# No year column in the source: the 2003 round was fielded in 2003.
+df['Int_t'] = pd.to_datetime(
+    dict(year=2003, month=df['month'], day=df['day']),
+    errors='coerce',
+)
+df = df.drop(columns=['day', 'month']).dropna()
+
+to_parquet(df, 'interview_date.parquet')

--- a/lsms_library/countries/Tajikistan/2007/_/interview_date.py
+++ b/lsms_library/countries/Tajikistan/2007/_/interview_date.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""Tajikistan 2007 interview dates.
+
+Source: ../Data/r1m0.dta.  Records dateday/datemont but NO year column; the
+round was fielded in 2007, so the year is hardcoded.  The file covers 4644 of
+the 4860 sample households; rows with an unparseable date are dropped.
+Household id is `hhid` (matches sample()'s `i`).  timehour/timemin ignored.
+"""
+import sys
+sys.path.append('../../../_')
+import pandas as pd
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+idxvars = dict(t=('hhid', lambda x: '2007'),
+               i='hhid')
+myvars = dict(day='dateday',
+              month='datemont')
+
+df = df_data_grabber('../Data/r1m0.dta', idxvars, **myvars)
+
+# No year column in the source: the 2007 round was fielded in 2007.
+df['Int_t'] = pd.to_datetime(
+    dict(year=2007, month=df['month'], day=df['day']),
+    errors='coerce',
+)
+df = df.drop(columns=['day', 'month']).dropna()
+
+to_parquet(df, 'interview_date.parquet')

--- a/lsms_library/countries/Tajikistan/2009/_/interview_date.py
+++ b/lsms_library/countries/Tajikistan/2009/_/interview_date.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""Tajikistan 2009 interview dates.
+
+Source: ../Data/m0.dta.  Records HH4_D (day) and HH4_M (month).  The recipe
+expected a usable HH4_Y year column, but in this file HH4_Y is entirely blank
+(every value is the string ' '), so the year is hardcoded to 2009 (the round's
+fielding year; months present are 10/11, consistent with an Oct-Nov 2009
+fieldwork window).  Household id is `HHID` (matches sample()'s `i`).
+"""
+import sys
+sys.path.append('../../../_')
+import pandas as pd
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+idxvars = dict(t=('HHID', lambda x: '2009'),
+               i='HHID')
+myvars = dict(day='HH4_D',
+              month='HH4_M')
+
+df = df_data_grabber('../Data/m0.dta', idxvars, **myvars)
+
+# HH4_Y is blank in the source; the 2009 round was fielded in 2009.
+df['Int_t'] = pd.to_datetime(
+    dict(year=2009, month=df['month'], day=df['day']),
+    errors='coerce',
+)
+df = df.drop(columns=['day', 'month']).dropna()
+
+to_parquet(df, 'interview_date.parquet')

--- a/lsms_library/countries/Tajikistan/_/data_scheme.yml
+++ b/lsms_library/countries/Tajikistan/_/data_scheme.yml
@@ -1,6 +1,11 @@
 Country: Tajikistan
 
 Data Scheme:
+  interview_date:
+    index: (t, i)
+    Int_t: datetime
+    materialize: make
+
   cluster_features:
     index: (t, v)
     Region: str

--- a/lsms_library/countries/Tajikistan/_/interview_date.py
+++ b/lsms_library/countries/Tajikistan/_/interview_date.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""Concatenate wave-level interview_date data for Tajikistan.
+
+Each wave's _/interview_date.py assembles an Int_t (datetime) column indexed
+by (t, i).  This country-level script runs each wave script (so the wave
+parquets exist on a cold build), reads them, and concatenates.  `v` is joined
+from sample() by the framework at API time, yielding the canonical (t, v, i).
+"""
+import os
+import subprocess
+import sys
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+WAVES = ['1999', '2003', '2007', '2009']
+
+X = []
+for t in WAVES:
+    script = f'../{t}/_/interview_date.py'
+    parquet = f'../{t}/_/interview_date.parquet'
+    # Build the wave parquet if it is not already present.
+    try:
+        df = get_dataframe(parquet)
+    except FileNotFoundError:
+        subprocess.run([sys.executable or 'python3', 'interview_date.py'],
+                       cwd=os.path.dirname(script), check=True)
+        df = get_dataframe(parquet)
+    X.append(df)
+
+x = pd.concat(X, axis=0)
+
+to_parquet(x, '../var/interview_date.parquet')


### PR DESCRIPTION
## Summary
Adds the canonical `interview_date` feature for **Tajikistan** (waves 1999, 2003, 2007, 2009). Per-wave `_/interview_date.py` scripts assemble an `Int_t` datetime column indexed by `(t, i)`; a country-level `_/interview_date.py` concatenates them. The framework joins `v` from `sample()` at API time, yielding the canonical `(t, v, i)`. Registered in `Tajikistan/_/data_scheme.yml` with `Int_t: datetime`, `index: (t, i)`, `materialize: make`.

## Per-wave recipe & quirks
- **1999** `SSEC1.DTA`: per-person file (14142 rows) deduped to one row per HH; 2-digit `date_yr` (99 -> 1999); composite `i = pop_pt-hhid` (matches `sample()`).
- **2003** `interview.dta`: `day_in`/`month_in`, **no year column** -> hardcode 2003.
- **2007** `r1m0.dta`: `dateday`/`datemont`, **no year column** -> hardcode 2007; one row with an invalid day/month combo dropped (4643/4644).
- **2009** `m0.dta`: `HH4_D`/`HH4_M`; **`HH4_Y` is entirely blank (`' '`)** in this file, so the year is hardcoded 2009 (deviation from recon, which assumed `HH4_Y` usable). Months 10/11 are consistent with Oct-Nov 2009 fieldwork.

## Real cold build (REALBUILD_PROTOCOL.md, worktree-pinned venv, from /tmp, LSMS_NO_CACHE=1)
- `ll.__file__` inside the worktree (confirmed)
- `is_this_feature_sane` **ok=True** (14 pass, 1 benign warn: extra `v` index level joined by the framework)
- **12306 rows**, index unique; waves present: 1999 (2000), 2003 (4160), 2007 (4643), 2009 (1503)
- `v` joined 100% (12306/12306); `Int_t` dtype datetime
- `Feature('interview_date')(['Tajikistan'])` -> (12306, 1) with `country` level

Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)