### PR TITLE
feat(Ethiopia): individual_education (5 waves)

### DIFF
--- a/lsms_library/countries/Ethiopia/2011-12/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2011-12/_/data_info.yml
@@ -56,6 +56,15 @@ household_roster:
         Relationship: hh_s1q02
         MonthsAway: hh_s1q05
 
+individual_education:
+    file: sect2_hh_w1.dta
+    idxvars:
+        i: household_id
+        pid: individual_id
+    myvars:
+        # Highest grade completed (free-text survey labels).
+        Educational Attainment: hh_s2q05
+
 shocks:
     file: sect8_hh_w1.dta
     idxvars:

--- a/lsms_library/countries/Ethiopia/2013-14/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2013-14/_/data_info.yml
@@ -74,6 +74,15 @@ household_roster:
         Relationship: hh_s1q02
         MonthsAway: hh_s1q05
 
+individual_education:
+    file: sect2_hh_w2.dta
+    idxvars:
+        i: household_id
+        pid: individual_id
+    myvars:
+        # Highest grade completed (free-text survey labels).
+        Educational Attainment: hh_s2q05
+
 shocks:
     file: sect8_hh_w2.dta
     idxvars:

--- a/lsms_library/countries/Ethiopia/2015-16/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2015-16/_/data_info.yml
@@ -78,6 +78,15 @@ household_roster:
         Relationship: hh_s1q02
         MonthsAway: hh_s1q05
 
+individual_education:
+    file: sect2_hh_w3.dta
+    idxvars:
+        i: household_id
+        pid: individual_id
+    myvars:
+        # Highest grade completed (free-text survey labels).
+        Educational Attainment: hh_s2q05
+
 shocks:
     file: sect8_hh_w3.dta
     idxvars:

--- a/lsms_library/countries/Ethiopia/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2018-19/_/data_info.yml
@@ -49,6 +49,16 @@ household_roster:
         Relationship: s1q01
         WeeksAway: s1q06
 
+individual_education:
+    file: sect2_hh_w4.dta
+    idxvars:
+        i: household_id
+        pid: individual_id
+    myvars:
+        # Highest grade completed (free-text survey labels; W4 labels are
+        # uppercased and code-prefixed, e.g. "1. 1ST GRADE COMPLETE").
+        Educational Attainment: s2q06
+
 shocks:
     file: sect9_hh_w4.dta
     idxvars:

--- a/lsms_library/countries/Ethiopia/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2021-22/_/data_info.yml
@@ -59,6 +59,16 @@ household_roster:
         Relationship: s1q01
         WeeksAway: s1q06
 
+individual_education:
+    file: sect2_hh_w5.dta
+    idxvars:
+        i: household_id
+        pid: individual_id
+    myvars:
+        # Highest grade completed (free-text survey labels; W5 labels are
+        # uppercased and code-prefixed, e.g. "10. 10TH GRADE COMPLETE").
+        Educational Attainment: s2q06
+
 shocks:
     file: sect9_hh_w5.dta
     idxvars:

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -36,6 +36,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   panel_ids:
     index: (t, i)
     previous_i: str


### PR DESCRIPTION
Adds the canonical \`individual_education\` feature for Ethiopia across all 5 waves (pure-YAML, no scripts).

## Recipe (verified against source .dta)
- Source: \`sect2_hh_w{1..5}.dta\`
- Attainment (highest grade completed): \`hh_s2q05\` (W1-W3) / \`s2q06\` (W4-W5) — deliberately NOT the *currently-attending* q08/q09.
- Ids: \`i=household_id\`, \`pid=individual_id\` (unsuffixed pair, not household_id2/individual_id2).
- Free-text survey labels emitted as-is (no harmonize table). W4/W5 labels are uppercased + code-prefixed (e.g. "1. 1ST GRADE COMPLETE") — passed through.

## Changes
- \`individual_education:\` block added to each of the 5 \`Ethiopia/{wave}/_/data_info.yml\`.
- Registered in \`Ethiopia/_/data_scheme.yml\` with index \`(t, i, pid)\`, single column \`Educational Attainment: str\`.

## Real-build verification (worktree-pinned venv, neutral CWD /tmp, LSMS_NO_CACHE=1)
- \`is_this_feature_sane\`: 14 pass / 1 warn / 0 fail → **ok=True**. (Warn is the framework-joined \`v\` index level from \`_join_v_from_sample\`, expected.)
- Shape: (59092, 1). All 5 waves present.
- Rows/wave: 2011-12=8008, 2013-14=8538, 2015-16=12633, 2018-19=16027, 2021-22=13886.
- \`Feature('individual_education')(['Ethiopia'])\` → (59092, 1), country index present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)