### PR TITLE
feat(Albania): assets (2002)

### DIFF
--- a/lsms_library/countries/Albania/2002/_/assets.py
+++ b/lsms_library/countries/Albania/2002/_/assets.py
@@ -1,0 +1,31 @@
+"""Build assets (durable goods) table for Albania 2002.
+
+Source: durables_cl.dta — LONG, one row per (household, durable item).
+  j     = m3c_q02  (item label, string)
+  Age   = m3c_q03  (years since acquired)
+  Value = m3c_q05  (current estimated value)
+No quantity column is recorded.
+
+CRITICAL: the household id ``i`` must be built as ``format_id(psu)-format_id(hh)``
+to match Albania/2002/_/sample.py.  A naive ``i = hh`` produces ~0% overlap with
+sample() (the household_roster's ``i:hh`` is a latent bug — do NOT mirror it).
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, format_id, to_parquet
+
+t = '2002'
+
+df = get_dataframe('../Data/durables_cl.dta')
+
+assets = pd.DataFrame({
+    't': t,
+    'i': df[['psu', 'hh']].apply(
+        lambda r: format_id(r.iloc[0]) + '-' + format_id(r.iloc[1]), axis=1),
+    'j': df['m3c_q02'].astype(str),
+    'Age': df['m3c_q03'],
+    'Value': df['m3c_q05'],
+})
+
+assets = assets.set_index(['t', 'i', 'j'])
+
+to_parquet(assets, 'assets.parquet')

--- a/lsms_library/countries/Albania/_/data_scheme.yml
+++ b/lsms_library/countries/Albania/_/data_scheme.yml
@@ -33,3 +33,9 @@ Data Scheme:
     Distance: int
     Affinity: str
     Marital: str
+
+  assets:
+    index: (t, i, j)
+    Age: float
+    Value: float
+    materialize: make


### PR DESCRIPTION
## Summary
Adds the canonical `assets` (durable goods) feature for **Albania 2002** via the SCRIPT path (composite household id required).

## Source
`Data/durables_cl.dta` (LONG, one row per household × item):
- `j` = `m3c_q02` (item label, string)
- `Age` = `m3c_q03` (years since acquired)
- `Value` = `m3c_q05` (current estimated value)
- No quantity column.

## Why a script (not YAML)
The household id must be built as `format_id(psu)-format_id(hh)` to match `Albania/2002/_/sample.py`. A naive `i=hh` (as the roster uses — a latent bug) gives ~0% overlap with `sample()`. The new `_/assets.py` mirrors `sample.py`'s composite id and emits `(t,i,j)` with `Age`/`Value`.

## Changes
- `lsms_library/countries/Albania/2002/_/assets.py` (new)
- `lsms_library/countries/Albania/_/data_scheme.yml`: register `assets:` index `(t,i,j)`, columns `Age`/`Value`, `materialize: make`

## REAL build verification (worktree-pinned venv, cold cache, from /tmp)
- `ll.__file__` inside worktree: confirmed
- `is_this_feature_sane`: **15/15 pass, ok=True**
- shape: **(20414, 2)**, index `(i,t,j)`, 3565 households
- **i-orphan vs sample(): 0 = 0.0%** (confirms the psu-hh fix)
- `Feature('assets')(['Albania'])`: (20414, 2), index `(country,i,t,j)`

No merge requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)