### PR TITLE
fix(plot_features): Makefile rules (Mali/Niger/Ethiopia/Nigeria) + Malawi 2016-17 DVCFS cwd (GH #167)

### DIFF
--- a/lsms_library/countries/Ethiopia/_/Makefile
+++ b/lsms_library/countries/Ethiopia/_/Makefile
@@ -53,6 +53,19 @@ sample_parquet := $(sample:.py=.parquet)
 ../%/_/sample.parquet:
 	(cd $(@D) && python sample.py)
 
+# plot_features (GH #167).  The framework's grab_data calls
+# `make ../<wave>/_/plot_features.parquet` from this `_/` dir; the
+# pattern rule runs the wave script.  The VAR_DIR rule mirrors the
+# household_characteristics country-level convention above.
+plot_features = $(shell find $(rounds) -name plot_features.py)
+plot_features_parquet := $(plot_features:.py=.parquet)
+
+../%/_/plot_features.parquet: ../%/_/plot_features.py
+	(cd $(@D) && python plot_features.py)
+
+$(VAR_DIR)/plot_features.parquet: plot_features.py $(plot_features_parquet)
+	python plot_features.py
+
 $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet: nutrition.py food_items.org $(VAR_DIR)/food_quantities.parquet
 	python nutrition.py
 

--- a/lsms_library/countries/Malawi/2016-17/_/plot_features.py
+++ b/lsms_library/countries/Malawi/2016-17/_/plot_features.py
@@ -31,7 +31,8 @@ sys.path.append('../../_/')
 import pyreadstat
 
 from lsms_library.local_tools import (get_dataframe, to_parquet, format_id,
-                                       DVCFS, _ensure_dvc_pulled)
+                                       DVCFS, _ensure_dvc_pulled,
+                                       _dvc_working_directory, _COUNTRIES_DIR)
 from malawi import plot_features_for_wave
 
 
@@ -44,8 +45,13 @@ def _read_usecols(countries_rel, usecols):
     the DVC cache like get_dataframe, but restricts the column set so
     pyreadstat never touches the offending free-text column."""
     _ensure_dvc_pulled(countries_rel)
-    with DVCFS.open(countries_rel) as f:
-        data = f.read()
+    # DVCFS.open resolves ``countries_rel`` against os.getcwd(); under
+    # ``make`` the cwd is the wave ``_/`` dir, which would double the
+    # path (Malawi/2016-17/_/Malawi/2016-17/Data/...).  Pin the cwd to
+    # the countries dir so the relative path resolves regardless of cwd.
+    with _dvc_working_directory(_COUNTRIES_DIR):
+        with DVCFS.open(countries_rel) as f:
+            data = f.read()
     with tempfile.NamedTemporaryFile(suffix='.dta', delete=False) as tmp:
         tmp.write(data)
         tmp_path = tmp.name

--- a/lsms_library/countries/Mali/_/Makefile
+++ b/lsms_library/countries/Mali/_/Makefile
@@ -12,6 +12,12 @@ all: panel_ids.json
 panel_ids.json updated_ids.json: panel_ids.py mali.py
 	python panel_ids.py
 
+# Wave-level plot_features (GH #167).  The framework's grab_data calls
+# `make ../<wave>/_/plot_features.parquet` from this `_/` dir; this
+# pattern rule runs the wave script that materializes it.
+../%/_/plot_features.parquet: ../%/_/plot_features.py
+	(cd $(@D) && python plot_features.py)
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Niger/_/Makefile
+++ b/lsms_library/countries/Niger/_/Makefile
@@ -11,6 +11,12 @@ all: panel_ids.json
 panel_ids.json updated_ids.json: panel_ids.py niger.py
 	python panel_ids.py
 
+# Wave-level plot_features (GH #167).  The framework's grab_data calls
+# `make ../<wave>/_/plot_features.parquet` from this `_/` dir; this
+# pattern rule runs the wave script that materializes it.
+../%/_/plot_features.parquet: ../%/_/plot_features.py
+	(cd $(@D) && python plot_features.py)
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Nigeria/_/Makefile
+++ b/lsms_library/countries/Nigeria/_/Makefile
@@ -135,6 +135,19 @@ housing_parquet := $(housing:.py=.parquet)
 $(VAR_DIR)/housing.parquet: housing.py $(housing_parquet)
 	python housing.py
 
+# plot_features (GH #167).  The framework's grab_data calls
+# `make ../<wave>/_/plot_features.parquet` from this `_/` dir; the
+# pattern rule runs the wave script.  The VAR_DIR rule mirrors the
+# household_roster country-level convention above.
+plot_features = $(shell find $(rounds) -name plot_features.py)
+plot_features_parquet := $(plot_features:.py=.parquet)
+
+../%/_/plot_features.parquet: ../%/_/plot_features.py
+	(cd $(@D) && python plot_features.py)
+
+$(VAR_DIR)/plot_features.parquet: plot_features.py $(plot_features_parquet)
+	python plot_features.py
+
 ../2010-11/_/housing.parquet: ../2010-11/_/housing.py
 	(cd ../2010-11/_; python housing.py)
 

--- a/lsms_library/countries/Togo/_/Makefile
+++ b/lsms_library/countries/Togo/_/Makefile
@@ -34,6 +34,14 @@ $(VAR_DIR)/household_characteristics.parquet: household_characteristics.py $(hou
 	python household_characteristics.py
 
 
+# Wave-level plot_features (GH #167).  The framework's grab_data calls
+# `make ../<wave>/_/plot_features.parquet` from this `_/` dir; this
+# pattern rule runs the wave script that materializes it.  (Same gap as
+# the EHCVM siblings Mali/Niger; the generic %.parquet rule below never
+# fires for it because its food_items.org/malawi.py prereqs are absent.)
+../%/_/plot_features.parquet: ../%/_/plot_features.py
+	(cd $(@D) && python plot_features.py)
+
 %.parquet: %.py food_items.org malawi.py
 	(cd $(@D) && python ./$(<F))
 


### PR DESCRIPTION
## Summary
Five precisely-scoped build fixes so all 12 plot_features countries aggregate through the **real framework build** (the prior direct-script verification hid these bugs).

`Wave.grab_data()` materializes a `materialize: make` table by running `make ../<wave>/_/plot_features.parquet` from the country `_/` dir. Several countries had no rule matching that relative target, so make exited 2 and the wave parquet was never built — silently dropping the country from `Feature('plot_features')`.

### Fixes
1. **Mali / Niger / Ethiopia / Nigeria** `_/Makefile`: added the wave pattern rule
   ```make
   ../%/_/plot_features.parquet: ../%/_/plot_features.py
   	(cd $(@D) && python plot_features.py)
   ```
   For Ethiopia/Nigeria a country-level `$(VAR_DIR)/plot_features.parquet` rule was also added, mirroring their sibling-table convention.
2. **Malawi 2016-17** `_/plot_features.py`: `_read_usecols` opened a latin-1-undecodable `.dta` via `DVCFS.open(<countries-relative path>)`, which resolves against `os.getcwd()`. Under make the cwd is the wave `_/` dir so the path doubled (`Malawi/2016-17/_/Malawi/2016-17/Data/...`) → FileNotFoundError. Wrapped the open in `_dvc_working_directory(_COUNTRIES_DIR)`.

### Scope deviation (1 file beyond the 5 named)
- **Togo `_/Makefile`** — Togo (a 5th EHCVM country, not in the original diagnostic) had the *identical* gap: its generic `%.parquet` rule never fires for plot_features because its `food_items.org`/`malawi.py` prereqs are absent. Without this, Togo stays missing and the 12-country success criterion fails. Applied the same one-line wave pattern rule.

## Verification (real framework build, worktree-pinned venv, cold cache)
`Feature('plot_features')()` →
- **shape (376266, 6)**, **index unique: True**, **12 countries**
- per-country rows: Benin 7588, Burkina_Faso 19784, Ethiopia 132694, Guinea-Bissau 9873, Malawi 68313, Mali 13955, Niger 12413, Nigeria 38042, Senegal 13824, Tanzania 7634, Togo 9553, Uganda 42593

No framework code, tests, baselines, lockfiles, or `data_info.yml` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)