### PR TITLE
feat(Kazakhstan): individual_education (1996)

### DIFF
--- a/lsms_library/countries/Kazakhstan/1996/_/data_info.yml
+++ b/lsms_library/countries/Kazakhstan/1996/_/data_info.yml
@@ -34,6 +34,22 @@ household_roster:
                 14: Servant
                 15: Other non-relative
 
+individual_education:
+    file: ../Data/KZ96EDU_PUF.dta
+    idxvars:
+        i: rn
+        pid: personnr
+    myvars:
+        Educational Attainment:
+            - bw003_
+            - mapping:
+                'occ. cou': Occupational courses
+                'PTU with': PTU with secondary education
+                'PTU, FSO': PTU/FSO without secondary education
+                'tech. co': Technical college
+                'univ. an': University and institute
+                'post-gra': Post-graduate
+
 cluster_features:
     file: ../Data/KZ96SMP_PUF.dta
     idxvars:

--- a/lsms_library/countries/Kazakhstan/_/data_scheme.yml
+++ b/lsms_library/countries/Kazakhstan/_/data_scheme.yml
@@ -14,6 +14,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   sample:
     index: (i, t)
     v: str


### PR DESCRIPTION
Adds canonical `individual_education` for Kazakhstan 1996 (set B).

## What
- Pure-YAML `individual_education:` block in `Kazakhstan/1996/_/data_info.yml` reading `../Data/KZ96EDU_PUF.dta`.
- attainment `bw003_` ('graduated from'); `i=rn`, `pid=personnr` (matches the household_roster block). 100% sample-match.
- Labels are truncated to 8 chars in the .dta; hand-expanded via inline `mapping:` (6 levels).
- Declares only the `Educational Attainment` column.
- Registered in `Kazakhstan/_/data_scheme.yml` with index `(t, i, pid)`.

## Verification (REAL build per REALBUILD_PROTOCOL)
Worktree-pinned venv, /tmp CWD, `LSMS_NO_CACHE=1`:
- `Country('Kazakhstan').individual_education()` -> 3190 rows, `is_this_feature_sane` **ok** (the one `v` warning is expected — joined from `sample()` at API time).
- `Feature('individual_education')(['Kazakhstan'])` -> (3190, 1), `country` prepended.
- Attainment values: Technical college (1095), University and institute (735), Occupational courses (605), PTU with secondary education (494), PTU/FSO without secondary education (251), Post-graduate (10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)