### PR TITLE
feat(Albania): individual_education (3 waves)

### DIFF
--- a/lsms_library/countries/Albania/2005/_/data_info.yml
+++ b/lsms_library/countries/Albania/2005/_/data_info.yml
@@ -1,6 +1,16 @@
 Country: Albania
 Wave: 2005
 
+individual_education:
+    file: ../Data/educationB_cl.dta
+    idxvars:
+        i:
+            - m0_q00
+            - m0_q01
+        pid: m2b_q00
+    myvars:
+        Educational Attainment: m2b_q04
+
 cluster_features:
     file: ../Data/identification_cl.dta
     idxvars:

--- a/lsms_library/countries/Albania/2005/_/mapping.py
+++ b/lsms_library/countries/Albania/2005/_/mapping.py
@@ -1,0 +1,12 @@
+# Formatting functions for Albania 2005.
+import lsms_library.local_tools as tools
+
+
+def i(value):
+    """Household id for 2005: PSU (m0_q00) - HH-within-PSU (m0_q01).
+
+    Matches the canonical household identity built by this wave's
+    sample.py (``format_id(m0_q00) + '-' + format_id(m0_q01)``), so the
+    framework's _join_v_from_sample() resolves ``v`` correctly.
+    """
+    return tools.format_id(value.iloc[0]) + '-' + tools.format_id(value.iloc[1])

--- a/lsms_library/countries/Albania/2008/_/data_info.yml
+++ b/lsms_library/countries/Albania/2008/_/data_info.yml
@@ -1,6 +1,16 @@
 Country: Albania
 Wave: 2008
 
+individual_education:
+    file: ../Data/Modul_2B_education.sav
+    idxvars:
+        i:
+            - psu
+            - hh
+        pid: id
+    myvars:
+        Educational Attainment: m2b_q04
+
 household_roster:
     file:
         - ../Data/Modul_1A_household_roster.sav

--- a/lsms_library/countries/Albania/2008/_/mapping.py
+++ b/lsms_library/countries/Albania/2008/_/mapping.py
@@ -1,0 +1,12 @@
+# Formatting functions for Albania 2008.
+import lsms_library.local_tools as tools
+
+
+def i(value):
+    """Household id for 2008: PSU - HH-within-PSU.
+
+    Matches the canonical household identity built by this wave's
+    sample.py (``format_id(psu) + '-' + format_id(hh)``), so the
+    framework's _join_v_from_sample() resolves ``v`` correctly.
+    """
+    return tools.format_id(value.iloc[0]) + '-' + tools.format_id(value.iloc[1])

--- a/lsms_library/countries/Albania/2012/_/data_info.yml
+++ b/lsms_library/countries/Albania/2012/_/data_info.yml
@@ -1,6 +1,16 @@
 Country: Albania
 Wave: 2012
 
+individual_education:
+    file: ../Data/Modul_2B_education.sav
+    idxvars:
+        i:
+            - psu
+            - hh
+        pid: idcode
+    myvars:
+        Educational Attainment: m2b_q04
+
 household_roster:
     file:
         - ../Data/Modul_1A_householdroster.sav

--- a/lsms_library/countries/Albania/2012/_/mapping.py
+++ b/lsms_library/countries/Albania/2012/_/mapping.py
@@ -1,0 +1,13 @@
+# Formatting functions for Albania 2012.
+import lsms_library.local_tools as tools
+
+
+def i(value):
+    """Household id for 2012: hhid = psu*100 + hh.
+
+    The education file (Modul_2B_education.sav) carries psu and hh but not
+    the globally-unique hhid that this wave's sample.py uses as ``i``
+    (built from poverty.sav where hhid == psu*100 + hh).  Reconstruct it
+    so the framework's _join_v_from_sample() resolves ``v`` correctly.
+    """
+    return tools.format_id(int(value.iloc[0]) * 100 + int(value.iloc[1]))

--- a/lsms_library/countries/Albania/_/data_scheme.yml
+++ b/lsms_library/countries/Albania/_/data_scheme.yml
@@ -33,3 +33,7 @@ Data Scheme:
     Distance: int
     Affinity: str
     Marital: str
+
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str


### PR DESCRIPTION
Adds canonical `individual_education` for Albania waves **2005, 2008, 2012** (the only LSMS waves with an individual-level education module; 2002 is a facility file, 1996/2003/2004 have none).

## What

- Pure-YAML `individual_education:` block in each of `Albania/{2005,2008,2012}/_/data_info.yml`, plus a per-wave `mapping.py` providing an `i()` formatting function.
- Registered in `Albania/_/data_scheme.yml` with index `(t, i, pid)`, single column `Educational Attainment` (str).

## Sources & columns

| Wave | File | Attainment | pid key |
|------|------|-----------|---------|
| 2005 | `educationB_cl.dta` | `m2b_q04` | `m2b_q00` |
| 2008 | `Modul_2B_education.sav` | `m2b_q04` | `id` |
| 2012 | `Modul_2B_education.sav` | `m2b_q04` | `idcode` |

`m2b_q04` ("highest level") arrives already decoded as text labels via `get_dataframe`, so **no inline code->label mapping was needed** (deviation from the recipe's assumed inline `mapping:`; values emitted verbatim, consistent with free-text attainment policy). 2012's vocab differs (Gymnazium/Technicum/Master/Doctorate) but flows through unchanged.

## Why a per-wave `i()` (deviation from "pure-YAML only")

The household identity in each wave's `sample.py` is NOT a single source column in the education file:
- 2005/2008: sample `i = PSU-HH` (e.g. `1-1`); the roster's simpler `i` is in fact mismatched (its `v` join is silently 100% NaN -- a pre-existing latent roster issue, not touched here).
- 2012: sample `i = hhid = psu*100+hh`; the education file carries `psu`/`hh` but not `hhid`.

Each `mapping.py` reconstructs the canonical `i` so `_join_v_from_sample()` resolves `v`. Verified: `v` is 0% NaN (2005/2012), 0.04% (2008).

## REAL-BUILD verification (REALBUILD_PROTOCOL: worktree-pinned venv, /tmp, cold cache)

- `ll.__file__` confirmed inside the worktree.
- `Country('Albania').individual_education()`: **15 checks, 14 pass / 1 warn / 0 fail; SANE OK = True**. Shape `(49754, 1)`. The lone warn is the expected auto-joined `v` index level.
- Rows/wave: 2005=14291, 2008=12655, 2012=22808. All 3 waves present.
- `Feature('individual_education')(['Albania'])`: shape `(49754, 1)`, country level prepended, 3 waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)