### PR TITLE
feat(SouthAfrica): individual_education (1993)

### DIFF
--- a/lsms_library/countries/South Africa/1993/_/data_info.yml
+++ b/lsms_library/countries/South Africa/1993/_/data_info.yml
@@ -74,3 +74,41 @@ household_roster:
                 17: "Lodger or relative of lodgers"
                 18: "Other family"
                 19: "Other non-family"
+
+individual_education:
+    file:
+        - ../Data/M8_HROST.dta
+    idxvars:
+        v: clustnum
+        i: hhid
+        pid: pcode
+    myvars:
+        Educational Attainment:
+            - educ_c
+            - mapping:
+                # SALDRU PSLSD 1993 educ_c: highest education completed.
+                # No value labels in source (.dta int codes); decoded from
+                # the pre-1994 South African schooling ladder.
+                -4: ~          # sentinel for missing — null out
+                -3: ~          # sentinel for missing — null out
+                -1: ~          # sentinel for missing — null out
+                0: "None"
+                1: "Sub A (Grade 1)"
+                2: "Sub B (Grade 2)"
+                3: "Standard 1 (Grade 3)"
+                4: "Standard 2 (Grade 4)"
+                5: "Standard 3 (Grade 5)"
+                6: "Standard 4 (Grade 6)"
+                7: "Standard 5 (Grade 7)"
+                8: "Standard 6 (Grade 8)"
+                9: "Standard 7 (Grade 9)"
+                10: "Standard 8 (Grade 10)"
+                11: "Standard 9 (Grade 11)"
+                12: "Standard 10 (Matric, Grade 12)"
+                13: "Diploma/certificate with less than Standard 10"
+                14: "Diploma/certificate with Standard 10"
+                15: "Degree"
+                16: "Postgraduate degree or diploma"
+                17: "Other"
+                18: "Don't know"
+                19: "Adult education / literacy"

--- a/lsms_library/countries/South Africa/_/data_scheme.yml
+++ b/lsms_library/countries/South Africa/_/data_scheme.yml
@@ -22,3 +22,7 @@ Data Scheme:
     Generation: int
     Distance: int
     Affinity: str
+
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str


### PR DESCRIPTION
Adds canonical \`individual_education\` for **South Africa 1993** (SALDRU PSLSD).

## What
- Source: roster file \`Data/M8_HROST.dta\`, column \`educ_c\` (highest education completed; int codes 0-19; sentinels -1/-3/-4 nulled). NOT the facility-level M5_EDUC/S1_EDUC3.
- Index \`(t, i, pid)\` with \`i=hhid\`, \`pid=pcode\`; \`v=clustnum\` joined from \`sample()\` at API time — matches the existing \`household_roster\` idiom.
- Declares only the single \`Educational Attainment\` (str) column.
- \`educ_c\` has no value labels in source; an inline \`mapping:\` decodes the pre-1994 South African schooling ladder (None / Sub A-B / Standards 1-10 / diplomas / degrees).

Pure-YAML: block added to \`South Africa/1993/_/data_info.yml\` + registered in \`South Africa/_/data_scheme.yml\`.

## Real-build verification (worktree-pinned venv, cold cache, /tmp CWD)
- \`ll.__file__\` confirmed inside the worktree.
- \`Country('South Africa').individual_education()\` → shape **(43455, 1)**, \`is_this_feature_sane\` **ok=True** (14 pass / 1 expected warn for the \`v\` join).
- \`Feature('individual_education')(['South Africa'])\` → (43455, 1), index \`[country, i, t, v, pid]\`.
- Attainment value_counts exactly match the raw \`educ_c\` distribution (sentinels dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)