### PR TITLE
feat(GhanaLSS): individual_education

### DIFF
--- a/lsms_library/countries/GhanaLSS/1998-99/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1998-99/_/data_info.yml
@@ -35,3 +35,36 @@ household_roster:
         Birthplace: s1q10
         Relationship: rel
         MonthsAway: s1q21
+
+individual_education:
+    file: SEC2A.DTA
+    idxvars:
+        v: clust
+        i:
+            - clust
+            - nh
+        pid: pid
+    myvars:
+        # s2aq2 = "highest level completed" (bare numeric codes in the .dta;
+        # decoded from the GLSS4 household questionnaire, Section 2A).
+        Educational Attainment:
+            - s2aq2
+            - mapping:
+                1: None
+                2: Kindergarten
+                3: Primary
+                4: Middle
+                5: JSS
+                6: SSS
+                7: Voc / Comm
+                8: Sec. (O Level)
+                9: Sixth Form
+                10: Teacher Training
+                11: Technical
+                12: P/Sec. Teacher Training
+                13: Nursing
+                14: P/Sec. Nursing
+                15: Polytechnic
+                16: University
+                17: Koranic stage
+                96: Other

--- a/lsms_library/countries/GhanaLSS/2012-13/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2012-13/_/data_info.yml
@@ -47,7 +47,6 @@ individual_education:
         pid: PID
     myvars:
         Educational Attainment: s2aq2
-        Current_grade: s2aq7
 
 
 

--- a/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
@@ -37,3 +37,16 @@ household_roster:
         Birthplace: s1q11
         Relationship: s1q3
         MonthsAway: s1q22
+
+individual_education:
+    file: g7sec2.dta
+    idxvars:
+        v: clust
+        i:
+            - clust
+            - nh
+        pid: pid
+    myvars:
+        # s2aq2 = "highest grade completed"; value labels are embedded in the
+        # .dta and decoded automatically by get_dataframe().
+        Educational Attainment: s2aq2

--- a/lsms_library/countries/GhanaLSS/_/data_scheme.yml
+++ b/lsms_library/countries/GhanaLSS/_/data_scheme.yml
@@ -13,6 +13,7 @@ Index Info:
   index_info:
     cluster_features: (t, v)
     household_roster: (t, v, i, pid)
+    individual_education: (t, i, pid)
     food_acquired: (t, v, i, j)
 
 Data Scheme:
@@ -29,6 +30,9 @@ Data Scheme:
     Generation: int
     Distance: int
     Affinity: str
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
   food_acquired:
     index: (t, i, j)
     Expenditure: float


### PR DESCRIPTION
Adds canonical \`individual_education\` for GhanaLSS via pure-YAML per-wave blocks (attainment = \`s2aq2\`, highest grade completed). Recipe: \`RECON_individual_education.md\` (set A). Verified per \`REALBUILD_PROTOCOL.md\`.

## Waves wired (3)
- **1998-99** (\`SEC2A.DTA\`): \`s2aq2\` is bare numeric — decoded via inline \`mapping:\` from the GLSS4 household questionnaire Section 2A codebook (1=None … 16=University, 17=Koranic stage, 96=Other).
- **2012-13** (\`PARTA/SEC2a.dta\`): block already existed; removed the extra \`Current_grade\` column so only the canonical \`Educational Attainment\` is declared. Value labels embedded in the .dta.
- **2016-17** (\`g7sec2.dta\`): new block; value labels embedded in the .dta.

Registered \`individual_education: (t, i, pid)\` in \`GhanaLSS/_/data_scheme.yml\`.

## Scope deviations from recipe
- **No 2005-06 wave.** The GhanaLSS dir has no \`2005-06/\` (recipe listed it); the actual fourth dir is \`1991-92\`. **1991-92 has no SEC2A-style attainment file** (only \`S12A1/S12A2\` education-expenditure modules) — omitted, consistent with the recipe's "check". 1987-88/1988-89 have none. Net: 3 buildable waves, not 4.

## REAL build (cold cache, worktree-pinned venv, neutral CWD)
- \`ll.__file__\` confirmed inside the worktree.
- \`Country('GhanaLSS').individual_education()\` → **109,281 rows** (1998-99: 16,582; 2012-13: 50,559; 2016-17: 42,140); \`is_this_feature_sane\` **ok=True** (14 pass, 1 warn = the \`v\` level joined from sample(), expected).
- \`Feature('individual_education')(['GhanaLSS'])\` → (109281, 1), country level present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)