### PR TITLE
feat(Tajikistan): individual_education

### DIFF
--- a/lsms_library/countries/Tajikistan/1999/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/1999/_/data_info.yml
@@ -72,3 +72,26 @@ sample:
             - mapping:
                 1.0: Urban
                 2.0: Rural
+
+individual_education:
+    # s3q2 "highest diploma or certificate obtained" (Section 3 Education).
+    # Value labels are stripped in the .dta; codes decoded from the household
+    # questionnaire (HH012007-00.pdf) qualification ladder.
+    file: ../Data/SSEC3.DTA
+    idxvars:
+        v: pop_pt
+        i: [pop_pt, hhid]
+        pid: iid
+    myvars:
+        Educational Attainment:
+            - s3q2
+            - mapping:
+                1.0: 8th (9th) class
+                2.0: secondary school
+                3.0: prof-tech school
+                4.0: spec tech school
+                5.0: higher ed institute
+                6.0: candidate of science
+                7.0: doctor of science
+                8.0: other
+                9.0: none

--- a/lsms_library/countries/Tajikistan/2003/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/2003/_/data_info.yml
@@ -72,3 +72,25 @@ sample:
     final_index:
         - i
         - t
+
+individual_education:
+    # m3bq5 "highest diploma obtained" (Module 3b Education).  Value labels are
+    # stripped in this wave's .dta; codes 0-7 match the 2007 file's clean
+    # m3bq5 ladder ("what is the highest diploma you have obtained?") exactly.
+    file: ../Data/module3.dta
+    idxvars:
+        v: tlss_psu
+        i: hhid
+        pid: hhlid
+    myvars:
+        Educational Attainment:
+            - m3bq5
+            - mapping:
+                0.0: none
+                1.0: primary (grades 1-4)
+                2.0: basic (grades 1-8(9))
+                3.0: secondary general (grades 9-10(11))
+                4.0: secondary special
+                5.0: secondary technical
+                6.0: higher education
+                7.0: graduate school/aspirantura

--- a/lsms_library/countries/Tajikistan/2007/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/2007/_/data_info.yml
@@ -72,3 +72,13 @@ sample:
     final_index:
         - i
         - t
+
+individual_education:
+    # m3bq5 "what is the highest diploma you have obtained?" — clean 8-level
+    # diploma labels in the .dta; pass through verbatim (free-text attainment).
+    file: ../Data/r1m3b.dta
+    idxvars:
+        i: hhid
+        pid: memid
+    myvars:
+        Educational Attainment: m3bq5

--- a/lsms_library/countries/Tajikistan/2009/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/2009/_/data_info.yml
@@ -72,3 +72,13 @@ sample:
     final_index:
         - i
         - t
+
+individual_education:
+    # M3BQ4 highest diploma (Module 3b Education); clean diploma labels in the
+    # .dta — pass through verbatim (free-text attainment).
+    file: ../Data/m3b.dta
+    idxvars:
+        i: HHID
+        pid: MEMID
+    myvars:
+        Educational Attainment: M3BQ4

--- a/lsms_library/countries/Tajikistan/_/data_scheme.yml
+++ b/lsms_library/countries/Tajikistan/_/data_scheme.yml
@@ -15,6 +15,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   sample:
     index: (i, t)
     v: str


### PR DESCRIPTION
Adds canonical \`individual_education\` for Tajikistan across all 4 waves (1999, 2003, 2007, 2009). Pure-YAML per wave; declares only the single \`Educational Attainment\` column at index \`(t, i, pid)\` per the set-B free-text recipe (no enforced vocab).

## Per-wave recipe (verified)
| Wave | File | Column | i / pid | Labels |
|------|------|--------|---------|--------|
| 1999 | SSEC3.DTA | s3q2 | [pop_pt,hhid] / iid | stripped; inline TLSS ladder decoded from questionnaire HH012007-00.pdf |
| 2003 | module3.dta | m3bq5 | hhid / hhlid | stripped; inline (codes 0-7 == 2007 clean ladder) |
| 2007 | r1m3b.dta | m3bq5 | hhid / memid | clean 8-level, pass through |
| 2009 | m3b.dta | M3BQ4 | HHID / MEMID | clean, pass through |

## 2003 m3bq5 confirmation
Confirmed it is the highest-diploma field: 2007 r1m3b.dta m3bq5 has the variable label "what is the highest diploma you have obtained?" with codes 0-7 (none -> graduate school/aspirantura). 2003 module3.dta m3bq5 carries the identical 8 codes (0-7) with the same distribution shape; m3bq4 in 2007 is the unrelated "reason never attended" question. Mapping uses the 2007 clean ladder.

## 1999 ladder
Decoded from Section 3 (Education) Q2 of the household questionnaire: 1=8th(9th) class, 2=secondary school, 3=prof-tech school, 4=spec tech school, 5=higher ed institute, 6=candidate of science, 7=doctor of science, 8=other, 9=none.

## Real-build verification (worktree-pinned venv, cold cache, /tmp CWD)
- \`ll.__file__\` inside worktree: confirmed
- \`Country('Tajikistan').individual_education()\` -> (59790, 1); waves 1999/2003/2007/2009 present (7451 / 20300 / 23663 / 8376 rows)
- \`is_this_feature_sane\` ok (14 pass, 1 warn: the expected \`v\` index level joined from sample())
- \`Feature('individual_education')(['Tajikistan'])\` -> (59790, 1)

DO NOT MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)