### PR TITLE
fix(Albania): assets aggregate instances per (t,i,j)

### DIFF
--- a/lsms_library/countries/Albania/2002/_/assets.py
+++ b/lsms_library/countries/Albania/2002/_/assets.py
@@ -1,10 +1,17 @@
 """Build assets (durable goods) table for Albania 2002.
 
-Source: durables_cl.dta — LONG, one row per (household, durable item).
+Source: durables_cl.dta — LONG, one row per (household, durable item INSTANCE).
+A household owning 2 refrigerators appears as 2 rows with distinct value/age.
   j     = m3c_q02  (item label, string)
   Age   = m3c_q03  (years since acquired)
   Value = m3c_q05  (current estimated value)
-No quantity column is recorded.
+No quantity column is recorded in the source.
+
+We aggregate per (t, i, j) before writing so the framework's groupby().first()
+does not silently drop 2nd+ instances of the same item in a household:
+  Quantity = count of instances (the count IS the quantity owned)
+  Value    = sum of instance values
+  Age      = min (most recent acquisition)
 
 CRITICAL: the household id ``i`` must be built as ``format_id(psu)-format_id(hh)``
 to match Albania/2002/_/sample.py.  A naive ``i = hh`` produces ~0% overlap with
@@ -21,11 +28,18 @@ assets = pd.DataFrame({
     't': t,
     'i': df[['psu', 'hh']].apply(
         lambda r: format_id(r.iloc[0]) + '-' + format_id(r.iloc[1]), axis=1),
-    'j': df['m3c_q02'].astype(str),
+    # 41 source rows have no recorded item label; bucket them under a sentinel
+    # so they are not silently dropped by groupby(dropna=True) and do not leave
+    # a NaN in the j index level.
+    'j': df['m3c_q02'].astype('string').fillna('Other/Unspecified'),
     'Age': df['m3c_q03'],
     'Value': df['m3c_q05'],
 })
 
-assets = assets.set_index(['t', 'i', 'j'])
+assets = assets.groupby(['t', 'i', 'j']).agg(
+    Quantity=('j', 'size'),
+    Value=('Value', lambda s: s.sum(min_count=1)),
+    Age=('Age', 'min'),
+)
 
 to_parquet(assets, 'assets.parquet')

--- a/lsms_library/countries/Albania/_/data_scheme.yml
+++ b/lsms_library/countries/Albania/_/data_scheme.yml
@@ -36,6 +36,7 @@ Data Scheme:
 
   assets:
     index: (t, i, j)
-    Age: float
+    Quantity: float
     Value: float
+    Age: float
     materialize: make


### PR DESCRIPTION
## Problem
Albania 2002 `assets` silently lost 479 rows. Source `durables_cl.dta` is LONG: one row per (household, durable item *instance*), so a HH owning 2 refrigerators is 2 rows with distinct value/age. `Albania/2002/_/assets.py` set the `(t,i,j)` index without aggregating, so the framework's `groupby().first()` dropped the 2nd+ instances.

## Fix
Aggregate per `(t,i,j)` before `to_parquet` using the canonical assets dedup rule:
- **Quantity** = count of instances (source has no Quantity column; the count IS the quantity owned)
- **Value** = sum (`min_count=1` to preserve NaN where all instances missing)
- **Age** = min (most recent acquisition)

41 source rows have a NaN item label; they are bucketed under `'Other/Unspecified'` so `groupby(dropna=True)` does not drop them and no NaN lands in the `j` index. `Quantity` declared in `Albania/_/data_scheme.yml`.

## Verification (REAL build, worktree-pinned venv, LSMS_NO_CACHE=1, cold cache, from /tmp)
- `ll.__file__` confirmed inside worktree
- `is_this_feature_sane`: **15/15 pass**
- rows = **20448** == distinct (t,i,j) ✓
- `Quantity` sum = **20927** == source row count (every instance accounted for, none dropped) ✓
- i-orphan = **0.0%** ✓
- Spot-check HH `1-4` Refrigerator: 2 source rows (Value 4000+50000, Age 5/1) → Quantity=2, Value=54000, Age=1 ✓
- `Feature('assets')(['Albania'])` shape (20448, 3), country index prepended ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)