### PR TITLE
fix(Iraq): assets sum durable_serial instances per (t,i,j)

### DIFF
--- a/lsms_library/countries/Iraq/2012/_/assets.py
+++ b/lsms_library/countries/Iraq/2012/_/assets.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Iraq 2012 assets — sum physical instances per (i, j).
+
+The source ``2012ihses18_durables.dta`` records one row per *physical
+instance* of a durable, distinguished by ``durable_serial`` (a household
+owning two TVs yields two rows with the same ``durable_code``).  The
+canonical assets index ``(t, i, j)`` requires uniqueness, so the
+framework's downstream dedup would otherwise collapse instances with
+``.first()`` — silently dropping the 2nd+ instances (25,248 rows on this
+wave).
+
+To preserve every instance we AGGREGATE per ``(i, j)`` here: Quantity,
+Value, and Purchase Price are SUMMED across serials (``min_count=1`` so an
+all-NaN group stays NaN rather than collapsing to 0).  This is the YAML
+path's only shortfall — it cannot groupby-sum — so this wave is built via
+the script (``materialize: make``) path instead.  ``t`` is added by the
+framework when it concatenates waves; this script writes the ``(i, j)``
+frame only.
+"""
+from lsms_library.local_tools import to_parquet, get_dataframe
+
+fn = '../Data/2012ihses18_durables.dta'
+
+df = get_dataframe(fn)
+
+# questid -> i (household), durable_code -> j (item); durable_serial is the
+# within-(i, j) physical-instance discriminator we collapse over.
+df = df.rename(columns={
+    'questid': 'i',
+    'durable_code': 'j',
+    'q1801': 'Quantity',
+    'q1805': 'Value',
+    'q1803': 'Purchase Price',
+})
+
+# IDs to strings for stable merge keys (matches df_data_grabber/format_id).
+df['i'] = df['i'].astype(str)
+df['j'] = df['j'].astype(str)
+
+assets = (
+    df[['i', 'j', 'Quantity', 'Value', 'Purchase Price']]
+    .groupby(['i', 'j'])
+    .agg({
+        'Quantity': lambda s: s.sum(min_count=1),
+        'Value': lambda s: s.sum(min_count=1),
+        'Purchase Price': lambda s: s.sum(min_count=1),
+    })
+)
+
+to_parquet(assets, 'assets.parquet')

--- a/lsms_library/countries/Iraq/2012/_/data_info.yml
+++ b/lsms_library/countries/Iraq/2012/_/data_info.yml
@@ -29,13 +29,9 @@ household_roster:
         Relationship: q0105
         Age: q0104
 
-assets:
-    file:
-        - "../Data/2012ihses18_durables.dta"
-    idxvars:
-        i: questid
-        j: durable_code
-    myvars:
-        Quantity: q1801
-        Value: q1805
-        Purchase Price: q1803
+# assets is built via the script path (_/assets.py) so that physical
+# instances of a durable (multiple `durable_serial` rows per
+# (questid, durable_code)) are SUMMED into the canonical (t, i, j) index
+# rather than silently collapsed with .first().  Mark `assets: !make` in
+# the country data_scheme.yml.  The YAML path cannot groupby-sum, hence the
+# script.

--- a/lsms_library/countries/Iraq/_/data_scheme.yml
+++ b/lsms_library/countries/Iraq/_/data_scheme.yml
@@ -23,3 +23,9 @@ Data Scheme:
     Quantity: float
     Value: float
     Purchase Price: float
+    # 2012 is built via the script path (2012/_/assets.py) so durable
+    # physical instances (multiple `durable_serial` rows per
+    # (i, j)) are SUMMED into the canonical (t, i, j) index rather than
+    # silently collapsed with .first().  2006-07 has zero such duplicates
+    # and stays on the YAML path; `load_from_waves` dispatches per wave.
+    materialize: make


### PR DESCRIPTION
## Problem
Iraq 2012 assets silently lost **25,248 rows**. The source `2012ihses18_durables.dta` records one row per *physical instance* of a durable, distinguished by `durable_serial` (a HH owning 2 TVs = 2 rows with the same `durable_code`, distinct `q1801`/`q1805`). The canonical assets index `(t,i,j)` requires uniqueness, so the framework's downstream dedup collapsed instances with `groupby().first()` — dropping the 2nd+ instances. (601,928 source rows − 576,680 distinct `(i,j)` = 25,248 lost.)

Iraq 2006-07 has **0** duplicate `(i,j)` (safe) and is unaffected.

## Fix
Convert Iraq 2012 assets to the **script path** so instances are **summed**, not dropped:
- Add `Iraq/2012/_/assets.py`: extracts `(i, j, Quantity, Value, Purchase Price)` then `groupby(['i','j']).agg(sum, min_count=1)`. `t` added by the framework on wave concat.
- Remove the `assets:` YAML block from `Iraq/2012/_/data_info.yml` so the script path fires (wave `data_info['assets']` is `None`).
- Mark `assets: materialize: make` in `Iraq/_/data_scheme.yml`.

**Canonical dedup rule applied**: Quantity=sum, Value=sum, Purchase Price=sum (Age=min — Iraq has no Age column). Item-level granularity per `(t,i,j)` preserved; only within-item instances collapse, by SUM not `.first()`. 2006-07 kept on YAML path (no dups); `load_from_waves` dispatches per wave.

## Verification (REAL build, worktree-pinned venv, /tmp CWD, `LSMS_NO_CACHE=1`)
- `ll.__file__` confirmed inside worktree.
- `Country('Iraq').assets()` → shape **(788727, 3)**, index `['i','t','j']`.
- **2012 rows = 576,680 == distinct (t,i,j)** ✅ (the 25,248 instances are now SUMMED, not dropped).
- Spot-check HH `110100028` `COOLER` (3 serial instances) → **Quantity=9.0, Value=660000, Purchase Price=860000** (summed; `.first()` would have given 3 / 200000 / 300000).
- `is_this_feature_sane` → **15/15 pass**, 0 warn, 0 fail.
- `Feature('assets')(['Iraq'])` → shape (788727, 3), index `['country','i','t','j']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)