### PR TITLE
feat(individual_education): +9 countries

### DIFF
--- a/lsms_library/countries/Albania/2005/_/data_info.yml
+++ b/lsms_library/countries/Albania/2005/_/data_info.yml
@@ -1,6 +1,16 @@
 Country: Albania
 Wave: 2005
 
+individual_education:
+    file: ../Data/educationB_cl.dta
+    idxvars:
+        i:
+            - m0_q00
+            - m0_q01
+        pid: m2b_q00
+    myvars:
+        Educational Attainment: m2b_q04
+
 cluster_features:
     file: ../Data/identification_cl.dta
     idxvars:

--- a/lsms_library/countries/Albania/2005/_/mapping.py
+++ b/lsms_library/countries/Albania/2005/_/mapping.py
@@ -1,0 +1,12 @@
+# Formatting functions for Albania 2005.
+import lsms_library.local_tools as tools
+
+
+def i(value):
+    """Household id for 2005: PSU (m0_q00) - HH-within-PSU (m0_q01).
+
+    Matches the canonical household identity built by this wave's
+    sample.py (``format_id(m0_q00) + '-' + format_id(m0_q01)``), so the
+    framework's _join_v_from_sample() resolves ``v`` correctly.
+    """
+    return tools.format_id(value.iloc[0]) + '-' + tools.format_id(value.iloc[1])

--- a/lsms_library/countries/Albania/2008/_/data_info.yml
+++ b/lsms_library/countries/Albania/2008/_/data_info.yml
@@ -1,6 +1,16 @@
 Country: Albania
 Wave: 2008
 
+individual_education:
+    file: ../Data/Modul_2B_education.sav
+    idxvars:
+        i:
+            - psu
+            - hh
+        pid: id
+    myvars:
+        Educational Attainment: m2b_q04
+
 household_roster:
     file:
         - ../Data/Modul_1A_household_roster.sav

--- a/lsms_library/countries/Albania/2008/_/mapping.py
+++ b/lsms_library/countries/Albania/2008/_/mapping.py
@@ -1,0 +1,12 @@
+# Formatting functions for Albania 2008.
+import lsms_library.local_tools as tools
+
+
+def i(value):
+    """Household id for 2008: PSU - HH-within-PSU.
+
+    Matches the canonical household identity built by this wave's
+    sample.py (``format_id(psu) + '-' + format_id(hh)``), so the
+    framework's _join_v_from_sample() resolves ``v`` correctly.
+    """
+    return tools.format_id(value.iloc[0]) + '-' + tools.format_id(value.iloc[1])

--- a/lsms_library/countries/Albania/2012/_/data_info.yml
+++ b/lsms_library/countries/Albania/2012/_/data_info.yml
@@ -1,6 +1,16 @@
 Country: Albania
 Wave: 2012
 
+individual_education:
+    file: ../Data/Modul_2B_education.sav
+    idxvars:
+        i:
+            - psu
+            - hh
+        pid: idcode
+    myvars:
+        Educational Attainment: m2b_q04
+
 household_roster:
     file:
         - ../Data/Modul_1A_householdroster.sav

--- a/lsms_library/countries/Albania/2012/_/mapping.py
+++ b/lsms_library/countries/Albania/2012/_/mapping.py
@@ -1,0 +1,13 @@
+# Formatting functions for Albania 2012.
+import lsms_library.local_tools as tools
+
+
+def i(value):
+    """Household id for 2012: hhid = psu*100 + hh.
+
+    The education file (Modul_2B_education.sav) carries psu and hh but not
+    the globally-unique hhid that this wave's sample.py uses as ``i``
+    (built from poverty.sav where hhid == psu*100 + hh).  Reconstruct it
+    so the framework's _join_v_from_sample() resolves ``v`` correctly.
+    """
+    return tools.format_id(int(value.iloc[0]) * 100 + int(value.iloc[1]))

--- a/lsms_library/countries/Albania/_/data_scheme.yml
+++ b/lsms_library/countries/Albania/_/data_scheme.yml
@@ -33,3 +33,7 @@ Data Scheme:
     Distance: int
     Affinity: str
     Marital: str
+
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str

--- a/lsms_library/countries/Ethiopia/2011-12/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2011-12/_/data_info.yml
@@ -56,6 +56,15 @@ household_roster:
         Relationship: hh_s1q02
         MonthsAway: hh_s1q05
 
+individual_education:
+    file: sect2_hh_w1.dta
+    idxvars:
+        i: household_id
+        pid: individual_id
+    myvars:
+        # Highest grade completed (free-text survey labels).
+        Educational Attainment: hh_s2q05
+
 shocks:
     file: sect8_hh_w1.dta
     idxvars:

--- a/lsms_library/countries/Ethiopia/2013-14/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2013-14/_/data_info.yml
@@ -74,6 +74,15 @@ household_roster:
         Relationship: hh_s1q02
         MonthsAway: hh_s1q05
 
+individual_education:
+    file: sect2_hh_w2.dta
+    idxvars:
+        i: household_id
+        pid: individual_id
+    myvars:
+        # Highest grade completed (free-text survey labels).
+        Educational Attainment: hh_s2q05
+
 shocks:
     file: sect8_hh_w2.dta
     idxvars:

--- a/lsms_library/countries/Ethiopia/2015-16/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2015-16/_/data_info.yml
@@ -78,6 +78,15 @@ household_roster:
         Relationship: hh_s1q02
         MonthsAway: hh_s1q05
 
+individual_education:
+    file: sect2_hh_w3.dta
+    idxvars:
+        i: household_id
+        pid: individual_id
+    myvars:
+        # Highest grade completed (free-text survey labels).
+        Educational Attainment: hh_s2q05
+
 shocks:
     file: sect8_hh_w3.dta
     idxvars:

--- a/lsms_library/countries/Ethiopia/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2018-19/_/data_info.yml
@@ -49,6 +49,16 @@ household_roster:
         Relationship: s1q01
         WeeksAway: s1q06
 
+individual_education:
+    file: sect2_hh_w4.dta
+    idxvars:
+        i: household_id
+        pid: individual_id
+    myvars:
+        # Highest grade completed (free-text survey labels; W4 labels are
+        # uppercased and code-prefixed, e.g. "1. 1ST GRADE COMPLETE").
+        Educational Attainment: s2q06
+
 shocks:
     file: sect9_hh_w4.dta
     idxvars:

--- a/lsms_library/countries/Ethiopia/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2021-22/_/data_info.yml
@@ -59,6 +59,16 @@ household_roster:
         Relationship: s1q01
         WeeksAway: s1q06
 
+individual_education:
+    file: sect2_hh_w5.dta
+    idxvars:
+        i: household_id
+        pid: individual_id
+    myvars:
+        # Highest grade completed (free-text survey labels; W5 labels are
+        # uppercased and code-prefixed, e.g. "10. 10TH GRADE COMPLETE").
+        Educational Attainment: s2q06
+
 shocks:
     file: sect9_hh_w5.dta
     idxvars:

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -36,6 +36,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   panel_ids:
     index: (t, i)
     previous_i: str

--- a/lsms_library/countries/GhanaLSS/1998-99/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1998-99/_/data_info.yml
@@ -35,3 +35,36 @@ household_roster:
         Birthplace: s1q10
         Relationship: rel
         MonthsAway: s1q21
+
+individual_education:
+    file: SEC2A.DTA
+    idxvars:
+        v: clust
+        i:
+            - clust
+            - nh
+        pid: pid
+    myvars:
+        # s2aq2 = "highest level completed" (bare numeric codes in the .dta;
+        # decoded from the GLSS4 household questionnaire, Section 2A).
+        Educational Attainment:
+            - s2aq2
+            - mapping:
+                1: None
+                2: Kindergarten
+                3: Primary
+                4: Middle
+                5: JSS
+                6: SSS
+                7: Voc / Comm
+                8: Sec. (O Level)
+                9: Sixth Form
+                10: Teacher Training
+                11: Technical
+                12: P/Sec. Teacher Training
+                13: Nursing
+                14: P/Sec. Nursing
+                15: Polytechnic
+                16: University
+                17: Koranic stage
+                96: Other

--- a/lsms_library/countries/GhanaLSS/2012-13/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2012-13/_/data_info.yml
@@ -47,7 +47,6 @@ individual_education:
         pid: PID
     myvars:
         Educational Attainment: s2aq2
-        Current_grade: s2aq7
 
 
 

--- a/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
@@ -37,3 +37,16 @@ household_roster:
         Birthplace: s1q11
         Relationship: s1q3
         MonthsAway: s1q22
+
+individual_education:
+    file: g7sec2.dta
+    idxvars:
+        v: clust
+        i:
+            - clust
+            - nh
+        pid: pid
+    myvars:
+        # s2aq2 = "highest grade completed"; value labels are embedded in the
+        # .dta and decoded automatically by get_dataframe().
+        Educational Attainment: s2aq2

--- a/lsms_library/countries/GhanaLSS/_/data_scheme.yml
+++ b/lsms_library/countries/GhanaLSS/_/data_scheme.yml
@@ -13,6 +13,7 @@ Index Info:
   index_info:
     cluster_features: (t, v)
     household_roster: (t, v, i, pid)
+    individual_education: (t, i, pid)
     food_acquired: (t, v, i, j)
 
 Data Scheme:
@@ -29,6 +30,9 @@ Data Scheme:
     Generation: int
     Distance: int
     Affinity: str
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
   food_acquired:
     index: (t, i, j)
     Expenditure: float

--- a/lsms_library/countries/India/1997-98/_/data_info.yml
+++ b/lsms_library/countries/India/1997-98/_/data_info.yml
@@ -47,6 +47,16 @@ household_roster:
       Relationship: v01a03
       MonthsSpent: v01a10
       Educational Attainment: v01a05
+individual_education:
+  file:
+      - ../Data/SECT01A.DTA
+  idxvars:
+      i: hhcode
+      pid: idcode
+      v: village
+  myvars:
+      Educational Attainment: v01a05
+
 employment:
   file:
       - ../Data/SECT02AD.DTA

--- a/lsms_library/countries/India/_/data_scheme.yml
+++ b/lsms_library/countries/India/_/data_scheme.yml
@@ -26,6 +26,10 @@ Data Scheme:
     Distance: int
     Affinity: str
     Educational Attainment: str
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   employment:
     index: (t, i, pid)
     Cash_per_day: float

--- a/lsms_library/countries/Kazakhstan/1996/_/data_info.yml
+++ b/lsms_library/countries/Kazakhstan/1996/_/data_info.yml
@@ -34,6 +34,22 @@ household_roster:
                 14: Servant
                 15: Other non-relative
 
+individual_education:
+    file: ../Data/KZ96EDU_PUF.dta
+    idxvars:
+        i: rn
+        pid: personnr
+    myvars:
+        Educational Attainment:
+            - bw003_
+            - mapping:
+                'occ. cou': Occupational courses
+                'PTU with': PTU with secondary education
+                'PTU, FSO': PTU/FSO without secondary education
+                'tech. co': Technical college
+                'univ. an': University and institute
+                'post-gra': Post-graduate
+
 cluster_features:
     file: ../Data/KZ96SMP_PUF.dta
     idxvars:

--- a/lsms_library/countries/Kazakhstan/_/data_scheme.yml
+++ b/lsms_library/countries/Kazakhstan/_/data_scheme.yml
@@ -14,6 +14,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   sample:
     index: (i, t)
     v: str

--- a/lsms_library/countries/Kosovo/2000/_/data_info.yml
+++ b/lsms_library/countries/Kosovo/2000/_/data_info.yml
@@ -59,6 +59,22 @@ household_roster:
                   5: Widow/er
                   6: Never ma
 
+individual_education:
+    file: "../Data/EDUC.dta"
+    idxvars:
+        i: hhid
+        pid: s04_q00
+    myvars:
+        Educational Attainment:
+            - s04_q4b
+            - mapping:
+                Pre-Scho: Pre-School
+                Primary: Primary
+                'Second. ': Secondary
+                Gymnasiu: Gymnasium
+                Vocation: Vocational
+                Universi: University
+
 sample:
     file: "../Data/ID.dta"
     idxvars:

--- a/lsms_library/countries/Kosovo/_/data_scheme.yml
+++ b/lsms_library/countries/Kosovo/_/data_scheme.yml
@@ -6,6 +6,10 @@ Data Scheme:
     Region: str
     Rural: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   household_roster:
     index: (t, i, pid)
     Sex: str

--- a/lsms_library/countries/Liberia/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Liberia/2018-19/_/data_info.yml
@@ -13,6 +13,15 @@ household_roster:
         Age: S2_5
         MonthsSpent: S2_7
 
+individual_education:
+    file:
+        - "../Data/Household/sect2_public.dta"
+    idxvars:
+        i: hhid
+        pid: member_id
+    myvars:
+        Educational Attainment: S2_14
+
 cluster_features:
     file:
         - "../Data/Household/sect1_public.dta"

--- a/lsms_library/countries/Liberia/_/data_scheme.yml
+++ b/lsms_library/countries/Liberia/_/data_scheme.yml
@@ -16,6 +16,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   sample:
     index: (i, t)
     v: str

--- a/lsms_library/countries/South Africa/1993/_/data_info.yml
+++ b/lsms_library/countries/South Africa/1993/_/data_info.yml
@@ -74,3 +74,41 @@ household_roster:
                 17: "Lodger or relative of lodgers"
                 18: "Other family"
                 19: "Other non-family"
+
+individual_education:
+    file:
+        - ../Data/M8_HROST.dta
+    idxvars:
+        v: clustnum
+        i: hhid
+        pid: pcode
+    myvars:
+        Educational Attainment:
+            - educ_c
+            - mapping:
+                # SALDRU PSLSD 1993 educ_c: highest education completed.
+                # No value labels in source (.dta int codes); decoded from
+                # the pre-1994 South African schooling ladder.
+                -4: ~          # sentinel for missing — null out
+                -3: ~          # sentinel for missing — null out
+                -1: ~          # sentinel for missing — null out
+                0: "None"
+                1: "Sub A (Grade 1)"
+                2: "Sub B (Grade 2)"
+                3: "Standard 1 (Grade 3)"
+                4: "Standard 2 (Grade 4)"
+                5: "Standard 3 (Grade 5)"
+                6: "Standard 4 (Grade 6)"
+                7: "Standard 5 (Grade 7)"
+                8: "Standard 6 (Grade 8)"
+                9: "Standard 7 (Grade 9)"
+                10: "Standard 8 (Grade 10)"
+                11: "Standard 9 (Grade 11)"
+                12: "Standard 10 (Matric, Grade 12)"
+                13: "Diploma/certificate with less than Standard 10"
+                14: "Diploma/certificate with Standard 10"
+                15: "Degree"
+                16: "Postgraduate degree or diploma"
+                17: "Other"
+                18: "Don't know"
+                19: "Adult education / literacy"

--- a/lsms_library/countries/South Africa/_/data_scheme.yml
+++ b/lsms_library/countries/South Africa/_/data_scheme.yml
@@ -22,3 +22,7 @@ Data Scheme:
     Generation: int
     Distance: int
     Affinity: str
+
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str

--- a/lsms_library/countries/Tajikistan/1999/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/1999/_/data_info.yml
@@ -72,3 +72,26 @@ sample:
             - mapping:
                 1.0: Urban
                 2.0: Rural
+
+individual_education:
+    # s3q2 "highest diploma or certificate obtained" (Section 3 Education).
+    # Value labels are stripped in the .dta; codes decoded from the household
+    # questionnaire (HH012007-00.pdf) qualification ladder.
+    file: ../Data/SSEC3.DTA
+    idxvars:
+        v: pop_pt
+        i: [pop_pt, hhid]
+        pid: iid
+    myvars:
+        Educational Attainment:
+            - s3q2
+            - mapping:
+                1.0: 8th (9th) class
+                2.0: secondary school
+                3.0: prof-tech school
+                4.0: spec tech school
+                5.0: higher ed institute
+                6.0: candidate of science
+                7.0: doctor of science
+                8.0: other
+                9.0: none

--- a/lsms_library/countries/Tajikistan/2003/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/2003/_/data_info.yml
@@ -72,3 +72,25 @@ sample:
     final_index:
         - i
         - t
+
+individual_education:
+    # m3bq5 "highest diploma obtained" (Module 3b Education).  Value labels are
+    # stripped in this wave's .dta; codes 0-7 match the 2007 file's clean
+    # m3bq5 ladder ("what is the highest diploma you have obtained?") exactly.
+    file: ../Data/module3.dta
+    idxvars:
+        v: tlss_psu
+        i: hhid
+        pid: hhlid
+    myvars:
+        Educational Attainment:
+            - m3bq5
+            - mapping:
+                0.0: none
+                1.0: primary (grades 1-4)
+                2.0: basic (grades 1-8(9))
+                3.0: secondary general (grades 9-10(11))
+                4.0: secondary special
+                5.0: secondary technical
+                6.0: higher education
+                7.0: graduate school/aspirantura

--- a/lsms_library/countries/Tajikistan/2007/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/2007/_/data_info.yml
@@ -72,3 +72,13 @@ sample:
     final_index:
         - i
         - t
+
+individual_education:
+    # m3bq5 "what is the highest diploma you have obtained?" — clean 8-level
+    # diploma labels in the .dta; pass through verbatim (free-text attainment).
+    file: ../Data/r1m3b.dta
+    idxvars:
+        i: hhid
+        pid: memid
+    myvars:
+        Educational Attainment: m3bq5

--- a/lsms_library/countries/Tajikistan/2009/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/2009/_/data_info.yml
@@ -72,3 +72,13 @@ sample:
     final_index:
         - i
         - t
+
+individual_education:
+    # M3BQ4 highest diploma (Module 3b Education); clean diploma labels in the
+    # .dta — pass through verbatim (free-text attainment).
+    file: ../Data/m3b.dta
+    idxvars:
+        i: HHID
+        pid: MEMID
+    myvars:
+        Educational Attainment: M3BQ4

--- a/lsms_library/countries/Tajikistan/_/data_scheme.yml
+++ b/lsms_library/countries/Tajikistan/_/data_scheme.yml
@@ -15,6 +15,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   sample:
     index: (i, t)
     v: str


### PR DESCRIPTION
Extends individual_education to 9 new countries: Liberia, India, Kosovo, Ethiopia, Kazakhstan, Albania, South Africa, GhanaLSS, Tajikistan. Cold `Feature('individual_education')()`: **863,603 rows across 16 countries**, index unique. Free-text Educational Attainment (cross-country harmonization deferred to Phase 2). Guyana deferred (no value labels). Per-country PRs #302-304,#306,#309,#311-314 merged here. Pre-existing declarer failures (Nepal/Burkina/CotedIvoire/Mali) flagged separately. Details in SESSION_SUMMARY.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)