### PR TITLE
feat: coverage fill — assets + individual_education (Guatemala, China, Azerbaijan)

### DIFF
--- a/lsms_library/countries/Azerbaijan/1995/_/data_info.yml
+++ b/lsms_library/countries/Azerbaijan/1995/_/data_info.yml
@@ -67,3 +67,13 @@ sample:
     final_index:
         - i
         - t
+
+individual_education:
+    # Education module A03.dta; attainment code `diploma` (Soviet-era levels 1-13).
+    file:
+        - ../Data/A03.dta
+    idxvars:
+        i: [ppid, hid]
+        pid: pid
+    myvars:
+        Educational Attainment: diploma

--- a/lsms_library/countries/Azerbaijan/_/data_scheme.yml
+++ b/lsms_library/countries/Azerbaijan/_/data_scheme.yml
@@ -20,6 +20,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   sample:
     index: (i, t)
     v: str

--- a/lsms_library/countries/Cambodia/2019-20/_/data_info.yml
+++ b/lsms_library/countries/Cambodia/2019-20/_/data_info.yml
@@ -59,3 +59,16 @@ cluster_features:
     myvars:
         Region: s01q02
         Rural: s01q06b
+
+individual_education:
+    # Education module hh_sec_3.dta. pid is `children_out_of_H__id` (a
+    # household-relative person sequence that matches the roster PID space,
+    # despite the misleading name); attainment is s03q04. NB the module also
+    # covers out-of-household children in school (s03q00='Yes'), which are
+    # not roster members and surface as spine orphans.
+    file: ../Data/hh_sec_3.dta
+    idxvars:
+        i: HHID
+        pid: children_out_of_H__id
+    myvars:
+        Educational Attainment: s03q04

--- a/lsms_library/countries/Cambodia/_/data_scheme.yml
+++ b/lsms_library/countries/Cambodia/_/data_scheme.yml
@@ -23,6 +23,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   interview_date:
     index: (t, i)
     Int_t: datetime

--- a/lsms_library/countries/China/1995-97/_/data_info.yml
+++ b/lsms_library/countries/China/1995-97/_/data_info.yml
@@ -49,3 +49,14 @@ cluster_features:
     myvars:
         Region:
             - hid
+
+individual_education:
+    # Education detail S01B.DTA; attainment code s01b10 (grade/level 1-12).
+    # pid maps from s01bid (person order); join to roster pid verified at build.
+    file:
+        - ../Data/S01B.DTA
+    idxvars:
+        i: hid
+        pid: s01bid
+    myvars:
+        Educational Attainment: s01b10

--- a/lsms_library/countries/China/_/data_scheme.yml
+++ b/lsms_library/countries/China/_/data_scheme.yml
@@ -32,3 +32,7 @@ Data Scheme:
     Generation: int
     Distance: int
     Affinity: str
+
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str

--- a/lsms_library/countries/Guatemala/2000/_/data_info.yml
+++ b/lsms_library/countries/Guatemala/2000/_/data_info.yml
@@ -68,3 +68,26 @@ household_roster:
                 11: domestic worker
                 12: pensioner or guest
                 13: other non-relative
+
+individual_education:
+    file:
+        - ECV11P10.DTA
+    idxvars:
+        i: hogar
+        pid: caso
+    myvars:
+        Educational Attainment: p10acp
+
+assets:
+    # Section E14 durables: j is the item name; Quantity=p14a02 (number owned),
+    # Value=p14a05 (estimated value), Age=p14a03 (years owned). Rows for
+    # non-owned items carry NaN.
+    file:
+        - ECV17E14.DTA
+    idxvars:
+        i: hogar
+        j: item
+    myvars:
+        Quantity: p14a02
+        Value: p14a05
+        Age: p14a03

--- a/lsms_library/countries/Guatemala/_/data_scheme.yml
+++ b/lsms_library/countries/Guatemala/_/data_scheme.yml
@@ -25,3 +25,15 @@ Data Scheme:
     Distance: int
     Affinity: str
     Marital: str
+
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
+  assets:
+    # ENCOVI 2000 section E14 (durables): one row per (household, item) over a
+    # fixed 38-item list; non-owned items carry NaN Quantity/Value/Age.
+    index: (t, i, j)
+    Quantity: float
+    Value: float
+    Age: float


### PR DESCRIPTION
Fills 5 (country × feature) matrix cells, all verified passing `is_this_feature_sane()` on a fresh build.

| Cell | Source | Index | Rows |
|---|---|---|---|
| Guatemala `assets` | ECV17E14 (E14 durables) | (t,i,j) | 37,995 |
| Guatemala `individual_education` | ECV11P10 (p10acp) | (t,i,pid) | 31,697 |
| China `individual_education` | S01B (s01b10) | (t,i,pid) | 1,744 |
| Azerbaijan `individual_education` | A03 (diploma) | (t,i,pid) | 9,005 |
| Cambodia `individual_education` | hh_sec_3 (s03q04) | (t,i,pid) | 1,973 |

- China's `pid: s01bid` and Cambodia's `pid: children_out_of_H__id` joins both confirmed against the roster spine.
- Cambodia caveat: the education module also covers out-of-household children in school (~26% spine orphans); sanity check still passes. Filtering is a possible follow-up.
- The `v` index level on the ind_ed tables is added by `_join_v_from_sample()` at API time; not declared in schema, per convention.

**Deferred follow-ups** (recon done, not implemented, with reasons):
- **Pakistan** `individual_education` — only `primgr` (primary grade 0–5) in the F03 section; no highest-level/secondary column. Wiring it would misrepresent attainment cross-country, so deferred until a true attainment variable is identified.
- **GhanaLSS** `assets` — implementable but script-path, multi-file (Section 10 fragmented across 5–8 files per wave); medium-high effort.
- **Tajikistan** `assets` — durables module has opaque, unlabeled column encoding + tiny coverage; needs the WB TJSS codebook.

Related: cross-country attainment-vocabulary harmonization for the new `individual_education` declarers is tracked by #171 (this PR adds raw per-wave labels; harmonization is the follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
