### PR TITLE
fix(interview_date): harmonize schema across countries (closes #325)

### DIFF
--- a/lsms_library/countries/GhanaLSS/1987-88/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1987-88/_/data_info.yml
@@ -16,6 +16,16 @@ sample:
     myvars:
         v: CLUST
 
+interview_date:
+    file: Y00A.DAT
+    idxvars:
+        i: HID
+    myvars:
+        Int_t:
+            - DAY1
+            - MO1
+            - YR1
+
 household_roster:
     file: Y01A.DAT
     idxvars:

--- a/lsms_library/countries/GhanaLSS/1987-88/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1987-88/_/mapping.py
@@ -74,4 +74,24 @@ def cluster_features(df):
 
     return foo[['Region', 'Rural']]
 
+def Int_t(value):
+    '''
+    Build interview date from first-visit (DAY1, MO1, YR1).  YR1 is a
+    2-digit year (e.g. 87, 88) -> 1987, 1988.  .DAT columns may arrive
+    as strings or ints.
+    '''
+    def _to_int(x):
+        if pd.isna(x):
+            return None
+        try:
+            return int(float(x))
+        except (TypeError, ValueError):
+            return None
+    d, m, y = _to_int(value.iloc[0]), _to_int(value.iloc[1]), _to_int(value.iloc[2])
+    if d is None or m is None or y is None or m < 1 or m > 12 or d < 1 or d > 31:
+        return pd.NaT
+    if y < 100:
+        y += 1900
+    return pd.to_datetime(f"{y}-{m}-{d}", format='%Y-%m-%d', errors='coerce')
+
 Visits = range(1,7)

--- a/lsms_library/countries/GhanaLSS/1988-89/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1988-89/_/data_info.yml
@@ -15,6 +15,16 @@ sample:
     myvars:
         v: CLUST
 
+interview_date:
+    file: Y00A.DAT
+    idxvars:
+        i: HID
+    myvars:
+        Int_t:
+            - DAY1
+            - MO1
+            - YR1
+
 household_roster:
     file: Y01A.DAT
     idxvars:

--- a/lsms_library/countries/GhanaLSS/1988-89/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1988-89/_/mapping.py
@@ -62,4 +62,24 @@ def Region(value):
         value_key = None
     return region_dict.get(value_key, pd.NA)
 
+def Int_t(value):
+    '''
+    Build interview date from first-visit (DAY1, MO1, YR1).  YR1 is a
+    2-digit year (e.g. 88, 89) -> 1988, 1989.  .DAT columns may arrive
+    as strings or ints.
+    '''
+    def _to_int(x):
+        if pd.isna(x):
+            return None
+        try:
+            return int(float(x))
+        except (TypeError, ValueError):
+            return None
+    d, m, y = _to_int(value.iloc[0]), _to_int(value.iloc[1]), _to_int(value.iloc[2])
+    if d is None or m is None or y is None or m < 1 or m > 12 or d < 1 or d > 31:
+        return pd.NaT
+    if y < 100:
+        y += 1900
+    return pd.to_datetime(f"{y}-{m}-{d}", format='%Y-%m-%d', errors='coerce')
+
 Visits = range(1,7)

--- a/lsms_library/countries/GhanaLSS/1991-92/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1991-92/_/data_info.yml
@@ -21,6 +21,18 @@ sample:
         strata: region
         Rural: loc2
 
+interview_date:
+    file: S0A.DTA
+    idxvars:
+        i:
+            - clust
+            - nh
+    myvars:
+        Int_t:
+            - dd
+            - mm
+            - yy
+
 household_roster:
     file: S1.DTA
     idxvars:

--- a/lsms_library/countries/GhanaLSS/1991-92/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1991-92/_/mapping.py
@@ -69,4 +69,18 @@ def Rural(value):
 
     return rural_dict.get(value, pd.NA)
 
+def Int_t(value):
+    '''
+    Build interview date from (dd, mm, yy).  yy is a 2-digit year
+    (e.g. 91, 92) -> 1991, 1992.
+    '''
+    d, m, y = value.iloc[0], value.iloc[1], value.iloc[2]
+    if pd.isna(d) or pd.isna(m) or pd.isna(y):
+        return pd.NaT
+    y = int(y)
+    if y < 100:
+        y += 1900
+    s = f"{y}-{int(m)}-{int(d)}"
+    return pd.to_datetime(s, format='%Y-%m-%d', errors='coerce')
+
 Visits = range(1,7)

--- a/lsms_library/countries/GhanaLSS/1998-99/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1998-99/_/data_info.yml
@@ -21,6 +21,18 @@ sample:
         strata: region
         Rural: loc2
 
+interview_date:
+    file: SEC0A.DTA
+    idxvars:
+        i:
+            - clust
+            - nh
+    myvars:
+        Int_t:
+            - dd
+            - mm
+            - yy
+
 household_roster:
     file: SEC1.DTA
     idxvars:

--- a/lsms_library/countries/GhanaLSS/1998-99/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1998-99/_/mapping.py
@@ -69,4 +69,18 @@ def Rural(value):
 
     return rural_dict.get(value, pd.NA)
 
+def Int_t(value):
+    '''
+    Build interview date from (dd, mm, yy).  yy is a 2-digit year
+    (e.g. 98, 99) -> 1998, 1999.
+    '''
+    d, m, y = value.iloc[0], value.iloc[1], value.iloc[2]
+    if pd.isna(d) or pd.isna(m) or pd.isna(y):
+        return pd.NaT
+    y = int(y)
+    if y < 100:
+        y += 1900
+    s = f"{y}-{int(m)}-{int(d)}"
+    return pd.to_datetime(s, format='%Y-%m-%d', errors='coerce')
+
 Visits = range(1,7)

--- a/lsms_library/countries/GhanaLSS/2005-06/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2005-06/_/data_info.yml
@@ -20,6 +20,16 @@ sample:
         panel_weight: weight
         strata: region
 
+interview_date:
+    file: parta/sec0.dta
+    idxvars:
+        i: hhid
+    myvars:
+        Int_t:
+            - ddate
+            - mdate
+            - ydate
+
 household_roster:
     file: parta/sec1.dta
     idxvars:

--- a/lsms_library/countries/GhanaLSS/2005-06/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/2005-06/_/mapping.py
@@ -64,4 +64,14 @@ def Rural(value):
 
     return value.title()
 
+def Int_t(value):
+    '''
+    Build interview date from numeric (ddate, mdate, ydate).
+    '''
+    d, m, y = value.iloc[0], value.iloc[1], value.iloc[2]
+    if pd.isna(d) or pd.isna(m) or pd.isna(y):
+        return pd.NaT
+    s = f"{int(y)}-{int(m)}-{int(d)}"
+    return pd.to_datetime(s, format='%Y-%m-%d', errors='coerce')
+
 Visits = range(1,7)

--- a/lsms_library/countries/GhanaLSS/2012-13/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2012-13/_/data_info.yml
@@ -38,8 +38,18 @@ household_roster:
         Relationship: s1q3
         MonthsAway: s1q22
 
+interview_date:
+    file: PARTA/SEC0.dta
+    idxvars:
+        i: HID
+    myvars:
+        Int_t:
+            - ddate
+            - mdate
+            - ydate
+
 individual_education:
-    file: 
+    file:
         - PARTA/SEC2a.dta
     idxvars:
         v: clust

--- a/lsms_library/countries/GhanaLSS/2012-13/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/2012-13/_/mapping.py
@@ -8,3 +8,14 @@ def v(value):
     Formatting cluster variable
     '''
     return tools.format_id(value)
+
+
+def Int_t(value):
+    '''
+    Build interview date from numeric (ddate, mdate, ydate).
+    '''
+    d, m, y = value.iloc[0], value.iloc[1], value.iloc[2]
+    if pd.isna(d) or pd.isna(m) or pd.isna(y):
+        return pd.NaT
+    s = f"{int(y)}-{int(m)}-{int(d)}"
+    return pd.to_datetime(s, format='%Y-%m-%d', errors='coerce')

--- a/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
@@ -38,6 +38,18 @@ household_roster:
         Relationship: s1q3
         MonthsAway: s1q22
 
+interview_date:
+    file: g7sec0.dta
+    idxvars:
+        i:
+            - clust
+            - nh
+    myvars:
+        Int_t:
+            - ddate
+            - mdate
+            - ydate
+
 individual_education:
     file: g7sec2.dta
     idxvars:

--- a/lsms_library/countries/GhanaLSS/2016-17/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/2016-17/_/mapping.py
@@ -8,3 +8,16 @@ def v(value):
     Formatting cluster variable
     '''
     return tools.format_id(value)
+
+
+def Int_t(value):
+    '''
+    Build interview date from (ddate, mdate, ydate).
+
+    mdate is a month *name* (e.g. "October"); ddate and ydate are numeric.
+    '''
+    d, m, y = value.iloc[0], value.iloc[1], value.iloc[2]
+    if pd.isna(d) or pd.isna(m) or pd.isna(y):
+        return pd.NaT
+    s = f"{int(y)}-{str(m).strip()}-{int(d)}"
+    return pd.to_datetime(s, errors='coerce')

--- a/lsms_library/countries/Guyana/1992/_/interview_date.py
+++ b/lsms_library/countries/Guyana/1992/_/interview_date.py
@@ -16,7 +16,6 @@ df = df_data_grabber('../Data/COVERN.dta', idxvars, **myvars).reset_index()
 
 # Composite household id "ED-HH" and cluster id v=ED (format_id each part).
 df['i'] = df['ED'].map(format_id) + '-' + df['HH'].map(format_id)
-df['v'] = df['ED'].map(format_id)
 df['t'] = '1992'
 
 # Expand 2-digit year of enumeration to 4-digit (e.g. 93 -> 1993).
@@ -26,6 +25,9 @@ df['Int_t'] = pd.to_datetime(dict(year=year,
                                   month=df['month'].astype(int),
                                   day=df['day'].astype(int)))
 
-df = df.set_index(['t', 'i'])[['v', 'Int_t']]
+# Do NOT emit `v` as a column: the framework joins it from sample() into
+# the index at API time (_join_v_from_sample).  Emitting it as a column
+# suppresses that join and leaves the index at (t, i) (GH #325).
+df = df.set_index(['t', 'i'])[['Int_t']]
 
 to_parquet(df, 'interview_date.parquet')

--- a/lsms_library/countries/Malawi/2004-05/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2004-05/_/data_info.yml
@@ -23,6 +23,19 @@ sample:
         Region: region
         District: dist
 
+interview_date:
+    file: sec_a.dta
+    idxvars:
+        i: case_id
+    myvars:
+        # a14a/b/c = Day / Month / Year of interview (numeric).
+        # Combined into a datetime by malawi_date_ymd (year, month, day order).
+        int_t:
+            - a14c
+            - a14b
+            - a14a
+            - mapping: malawi_date_ymd
+
 cluster_features:
     file: sec_a.dta
     idxvars:

--- a/lsms_library/countries/Malawi/2010-11/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2010-11/_/data_info.yml
@@ -54,6 +54,15 @@ sample:
                 Blantyre City: Southern
         District: hh_a01
 
+interview_date:
+    file: Full_Sample/Household/hh_mod_a_filt.dta
+    idxvars:
+        i: case_id
+    myvars:
+        # hh_a23_1 = "Interview Date [MDY] (Visit 1)", a Stata %td date that
+        # get_dataframe returns as datetime64.  Visit 2 (hh_a23_2) is dropped.
+        int_t: hh_a23_1
+
 cluster_features:
     dfs:
         - df_main

--- a/lsms_library/countries/Malawi/2013-14/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2013-14/_/data_info.yml
@@ -19,6 +19,21 @@ sample:
         Region: region
         District: district
 
+interview_date:
+    file: HH_MOD_A_FILT_13.dta
+    idxvars:
+        i: y2_hhid
+    myvars:
+        # Visit 1, Attempt 1 interview date split across three columns:
+        #   hh_a23a_1 = Day (numeric), hh_a23a_2 = Month (English name e.g.
+        #   'MAY'), hh_a23a_3 = Year.  Combined into a datetime by
+        #   malawi_date_ymd (year, month, day order).
+        int_t:
+            - hh_a23a_3
+            - hh_a23a_2
+            - hh_a23a_1
+            - mapping: malawi_date_ymd
+
 cluster_features:
     dfs:
         - df_main

--- a/lsms_library/countries/Malawi/2016-17/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2016-17/_/data_info.yml
@@ -23,6 +23,22 @@ sample:
         Region: region
         District: district
 
+interview_date:
+    file:
+        - Cross_Sectional/hh_mod_a_filt.dta
+        - Panel/hh_mod_a_filt_16.dta:
+            i: y3_hhid
+            int_t: interviewdate_v1
+    idxvars:
+        i:
+            - case_id
+            - mapping: cs_i
+    myvars:
+        # Cross_Sectional names the date column 'interviewDate'; the Panel
+        # file uses 'interviewdate_v1' (Visit 1), overridden per-file above.
+        # Both are 'YYYY-MM-DD' strings -> datetime via the Int_t coercion.
+        int_t: interviewDate
+
 cluster_features:
     dfs:
         - df_main

--- a/lsms_library/countries/Malawi/2019-20/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2019-20/_/data_info.yml
@@ -23,6 +23,22 @@ sample:
         Region: region
         District: district
 
+interview_date:
+    file:
+        - Cross_Sectional/hh_mod_a_filt.dta
+        - Panel/hh_mod_a_filt_19.dta:
+            i: y4_hhid
+            int_t: interviewdate_v1
+    idxvars:
+        i:
+            - case_id
+            - function: cs_i
+    myvars:
+        # Cross_Sectional names the date column 'interviewDate'; the Panel
+        # file uses 'interviewdate_v1' (Visit 1), overridden per-file above.
+        # Both are 'YYYY-MM-DD' strings -> datetime via the Int_t coercion.
+        int_t: interviewDate
+
 cluster_features:
     dfs:
         - df_main

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -53,8 +53,8 @@ Data Scheme:
     Expenditure: float
     materialize: make
   interview_date:
-    index: (t, visit, i)
-    Int_t: str
+    index: (t, i)
+    Int_t: datetime
   shocks:
     index: (t, i, Shock)
     AffectedIncome: bool

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -73,6 +73,32 @@ def Sex(value):
         return np.nan
 
 
+def malawi_date_ymd(row):
+    """Combine a [year, month, day] row into a Timestamp.
+
+    Used by the ``interview_date`` table for the waves that store the
+    interview date as three separate columns (2004-05 IHS2: numeric
+    a14a/b/c; 2013-14 IHS3: hh_a23a_* with the month as an English name
+    like 'MAY').  Declare the columns in year, month, day order in the
+    wave's data_info.yml ``int_t`` myvar with a trailing
+    ``mapping: malawi_date_ymd``.
+
+    The month component may be numeric (5) or a name ('MAY'); both are
+    handled by building a 'DAY MONTH YEAR' string and letting
+    ``pd.to_datetime`` parse it.  Returns ``pd.NaT`` when any part is
+    missing or the date is unparseable.
+    """
+    y, m, d = row.iloc[0], row.iloc[1], row.iloc[2]
+    if pd.isna(y) or pd.isna(m) or pd.isna(d):
+        return pd.NaT
+    # Month may be numeric (float/int) or an English name.
+    if isinstance(m, str):
+        month = m.strip()
+    else:
+        month = str(int(m))
+    return pd.to_datetime(f"{int(d)} {month} {int(y)}", errors='coerce')
+
+
 def harmonize_food_labels(df, level='i'):
     """Apply the cross-wave union of Malawi's harmonize_food map to ``df``.
 

--- a/lsms_library/countries/Mali/_/data_scheme.yml
+++ b/lsms_library/countries/Mali/_/data_scheme.yml
@@ -44,9 +44,14 @@ Data Scheme:
     index: (t, v, i, j, u, s)
     Quantity: float
     Expenditure: float
+  # EHCVM visits each household across multiple vagues/passages, each with
+  # its own date.  The canonical interview_date is one date per household
+  # (t, v, i); _normalize_dataframe_index drops the undeclared `visit` level
+  # and collapses the duplicate rows via groupby.first(), keeping the first
+  # visit's date.  (GH #325)
   interview_date:
-    index: (t, visit, i)
-    Int_t: str
+    index: (t, v, i)
+    Int_t: datetime
   panel_ids: !make
   assets:
     index: (t, i, j)

--- a/lsms_library/countries/Tanzania/2008-15/_/interview_date.py
+++ b/lsms_library/countries/Tanzania/2008-15/_/interview_date.py
@@ -27,7 +27,12 @@ months_dict = {'JANUARY': 1, 'FEBRUARY': 2, 'MARCH': 3, 'APRIL': 4, 'MAY': 5, 'J
                'JULY': 7, 'AUGUST': 8, 'SEPTEMBER': 9, 'OCTOBER': 10, 'NOVEMBER': 11, 'DECEMBER': 12, None: pd.NA}
 
 df['month'] = df['month'].map(months_dict)
-df['date'] = pd.to_datetime(df[['year', 'month', 'day']], errors='coerce')
+# Emit `int_t` (lowercase) to match the 2019-20 / 2020-21 waves, whose
+# data_info.yml maps `int_t: hh_a18`.  The framework canonicalizes
+# `int_t` -> `Int_t` (datetime) once on concat; emitting capital `Int_t`
+# here instead would leave the two spellings side-by-side and the
+# canonicalization would then collide into a duplicate column (GH #325).
+df['int_t'] = pd.to_datetime(df[['year', 'month', 'day']], errors='coerce')
 df=df.drop(columns=['year','month','day'])
 
 to_parquet(df,'interview_date.parquet')

--- a/lsms_library/countries/Uganda/2005-06/_/interview_date.py
+++ b/lsms_library/countries/Uganda/2005-06/_/interview_date.py
@@ -16,6 +16,6 @@ myvars = dict(day = 'h1bq2a',
               )
 df = df_data_grabber('../Data/GSEC1.dta',idxvars,**myvars)
 
-df['date'] = pd.to_datetime(dict(year=df.year, month=df.month, day=df.day))
+df['Int_t'] = pd.to_datetime(dict(year=df.year, month=df.month, day=df.day))
 df = df.drop(columns = list( myvars.keys()))
 to_parquet(df,'interview_date.parquet')

--- a/lsms_library/countries/Uganda/2009-10/_/interview_date.py
+++ b/lsms_library/countries/Uganda/2009-10/_/interview_date.py
@@ -16,6 +16,6 @@ myvars = dict(day = 'h1bq2a',
               )
 df = df_data_grabber('../Data/GSEC1.dta',idxvars,**myvars)
 
-df['date'] = pd.to_datetime(dict(year=df.year, month=df.month, day=df.day))
+df['Int_t'] = pd.to_datetime(dict(year=df.year, month=df.month, day=df.day))
 df = df.drop(columns = list( myvars.keys()))
 to_parquet(df,'interview_date.parquet')

--- a/lsms_library/countries/Uganda/2010-11/_/interview_date.py
+++ b/lsms_library/countries/Uganda/2010-11/_/interview_date.py
@@ -17,6 +17,6 @@ myvars = dict(day = 'day',
 df = df_data_grabber('../Data/GSEC1.dta',idxvars,**myvars)
 # error = coerce returns NaT when encountering NaN vals in the 3 coloumns or when day/month is out of range
 # 3 instances in April have day as 31
-df['date'] = pd.to_datetime(df[['year', 'month', 'day']], errors='coerce')
+df['Int_t'] = pd.to_datetime(df[['year', 'month', 'day']], errors='coerce')
 df = df.drop(columns = list( myvars.keys()))
 to_parquet(df,'interview_date.parquet')

--- a/lsms_library/countries/Uganda/2011-12/_/interview_date.py
+++ b/lsms_library/countries/Uganda/2011-12/_/interview_date.py
@@ -16,6 +16,6 @@ myvars = dict(day = 'day',
 df = df_data_grabber('../Data/GSEC1.dta',idxvars,**myvars)
 # error = coerce returns NaT when encountering NaN vals in the 3 coloumns or when day/month is out of range
 # 3 instances in April have day as 31
-df['date'] = pd.to_datetime(df[['year', 'month', 'day']], errors='coerce')
+df['Int_t'] = pd.to_datetime(df[['year', 'month', 'day']], errors='coerce')
 df = df.drop(columns=list( myvars.keys()))
 to_parquet(df,'interview_date.parquet')

--- a/lsms_library/countries/Uganda/2013-14/_/interview_date.py
+++ b/lsms_library/countries/Uganda/2013-14/_/interview_date.py
@@ -10,7 +10,7 @@ myvars = dict(year='year',
                 day='day')
 
 df = df_data_grabber('../Data/GSEC1.dta',idxvars,**myvars)
-df['date'] = pd.to_datetime(df[['year', 'month', 'day']])
+df['Int_t'] = pd.to_datetime(df[['year', 'month', 'day']])
 df = df.drop(columns=['year','month','day'])
 
 to_parquet(df,'interview_date.parquet')

--- a/lsms_library/countries/Uganda/2015-16/_/interview_date.py
+++ b/lsms_library/countries/Uganda/2015-16/_/interview_date.py
@@ -12,7 +12,7 @@ myvars = dict(year='year',
                 day='day')
 
 df = df_data_grabber('../Data/gsec1.dta',idxvars,**myvars)
-df['date'] = pd.to_datetime(df[['year', 'month', 'day']])
+df['Int_t'] = pd.to_datetime(df[['year', 'month', 'day']])
 df=df.drop(columns=['year','month','day'])
 
 to_parquet(df,'interview_date.parquet')

--- a/lsms_library/countries/Uganda/2018-19/_/interview_date.py
+++ b/lsms_library/countries/Uganda/2018-19/_/interview_date.py
@@ -12,7 +12,7 @@ myvars = dict(year='year',
                 day='day')
 
 df = df_data_grabber('../Data/GSEC1.dta',idxvars,**myvars)
-df['date'] = pd.to_datetime(df[['year', 'month', 'day']])
+df['Int_t'] = pd.to_datetime(df[['year', 'month', 'day']])
 df=df.drop(columns=['year','month','day'])
 
 to_parquet(df,'interview_date.parquet')

--- a/lsms_library/countries/Uganda/2019-20/_/interview_date.py
+++ b/lsms_library/countries/Uganda/2019-20/_/interview_date.py
@@ -12,7 +12,7 @@ myvars = dict(year='year',
                 day='day')
 
 df = df_data_grabber('../Data1/HH/gsec1.dta',idxvars,**myvars)
-df['date'] = pd.to_datetime(df[['year', 'month', 'day']])
+df['Int_t'] = pd.to_datetime(df[['year', 'month', 'day']])
 df=df.drop(columns=['year','month','day'])
 
 

--- a/lsms_library/countries/Uganda/_/interview_date.py
+++ b/lsms_library/countries/Uganda/_/interview_date.py
@@ -26,4 +26,8 @@ x = id_walk(x, updated_ids)
 
 x = x.reset_index().set_index(['i','t'])
 
+# Canonical column name is Int_t (datetime); wave scripts emit `date`.
+# Rename so the cross-country Feature('interview_date') aligns (GH #325).
+x = x.rename(columns={'date': 'Int_t'})
+
 to_parquet(x.dropna(), '../var/interview_date.parquet')

--- a/lsms_library/feature.py
+++ b/lsms_library/feature.py
@@ -21,6 +21,77 @@ def _load_global_columns() -> dict[str, dict[str, Any]]:
     return data.get("Columns", {})
 
 
+def _canonical_index_levels(table_name: str) -> list[str]:
+    """Return the canonical index level names for *table_name*.
+
+    Reads the global ``Index Info: index_info`` section of data_info.yml,
+    whose values are tuple strings like ``(t, v, i)``.  Returns ``[]`` when
+    the table is not listed (no canonical reshaping is then attempted).
+    """
+    info_path = files("lsms_library") / "data_info.yml"
+    with open(info_path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    spec = data.get("Index Info", {}).get("index_info", {}).get(table_name)
+    if not isinstance(spec, str):
+        return []
+    cleaned = spec.strip()
+    if cleaned.startswith("(") and cleaned.endswith(")"):
+        cleaned = cleaned[1:-1]
+    return [tok.strip() for tok in cleaned.split(",") if tok.strip()]
+
+
+def _harmonize_country_frame(
+    df: pd.DataFrame, canonical_levels: list[str], country: str, table_name: str
+) -> pd.DataFrame:
+    """Coerce a single country's frame toward the canonical shape before concat.
+
+    Defensive net for cross-country assembly (GH #325): a stray extra index
+    level or an all-NaN leaked column on ONE country otherwise makes
+    ``pd.concat`` fall back to an unnamed object index of stringified tuples
+    for the WHOLE feature.  This drops all-NaN columns and removes index
+    levels that are not part of the canonical index (only when every
+    canonical level is present, so legitimately-reduced frames are left
+    alone).  It never fabricates missing levels.
+    """
+    if not isinstance(df, pd.DataFrame) or df.empty:
+        return df
+
+    # Drop columns that are entirely missing (e.g. a `date`/`v` column left
+    # populated only on other countries).  Concat re-introduces them as NaN
+    # where another country supplies values, so no information is lost.
+    all_nan = [c for c in df.columns if df[c].isna().all()]
+    if all_nan:
+        warnings.warn(
+            f"{table_name}: dropping all-NaN column(s) {all_nan} from {country} "
+            "before cross-country concat"
+        )
+        df = df.drop(columns=all_nan)
+
+    # Remove undeclared extra index levels so every country shares the same
+    # MultiIndex names.  Only act when all canonical levels are present and
+    # there is at least one extra (keeps single-country reductions intact).
+    if canonical_levels and isinstance(df.index, pd.MultiIndex):
+        names = list(df.index.names)
+        extra = [n for n in names if n not in canonical_levels]
+        have_all_canonical = all(lvl in names for lvl in canonical_levels)
+        if extra and have_all_canonical and len(names) > len(extra):
+            ordered = [lvl for lvl in canonical_levels if lvl in names] + \
+                      [n for n in names if n not in canonical_levels]
+            try:
+                df = df.reorder_levels(ordered)
+            except (ValueError, TypeError):
+                pass
+            warnings.warn(
+                f"{table_name}: dropping extra index level(s) {extra} from "
+                f"{country} before cross-country concat"
+            )
+            df = df.droplevel(extra)
+            if not df.index.is_unique:
+                df = df.groupby(level=list(df.index.names), observed=True).first()
+
+    return df
+
+
 # Derived tables and the source table they require in data_scheme.yml
 _DERIVED_SOURCE = {
     'household_characteristics': 'household_roster',
@@ -124,6 +195,7 @@ class Feature:
         effective_trust_cache = trust_cache if trust_cache is not None else self.trust_cache
         targets = countries if countries is not None else self.countries
         frames: list[pd.DataFrame] = []
+        canonical_levels = _canonical_index_levels(self.table_name)
 
         for name in targets:
             try:
@@ -135,6 +207,12 @@ class Feature:
                         f"No data for {self.table_name} in {name}"
                     )
                     continue
+                # Coerce toward the canonical shape so one country's stray
+                # column / extra index level can't collapse the whole
+                # concatenated index to object tuples (GH #325).
+                df = _harmonize_country_frame(
+                    df, canonical_levels, name, self.table_name
+                )
                 # Prepend country as an index level
                 df = pd.concat({name: df}, names=["country"])
                 frames.append(df)
@@ -148,4 +226,20 @@ class Feature:
         if not frames:
             return pd.DataFrame()
 
-        return pd.concat(frames)
+        result = pd.concat(frames)
+
+        # Surface (rather than silently return) the pathological case where
+        # heterogeneous per-country indices made pandas fall back to an
+        # unnamed object index of stringified tuples (GH #325).
+        if len(frames) > 1 and list(result.index.names) == [None]:
+            shapes = {
+                f.index.get_level_values(0)[0] if len(f) else "?":
+                    list(f.index.names)
+                for f in frames
+            }
+            warnings.warn(
+                f"{self.table_name}: cross-country index collapsed to an "
+                f"unnamed object index; per-country index names differ: {shapes}"
+            )
+
+        return result


### PR DESCRIPTION
## Summary

`Feature('interview_date')()` previously collapsed to an **unnamed object index of stringified tuples** with leaked all-NaN `v`/`date` columns (242,934 rows / 20 countries). The per-country frames had heterogeneous indices/columns, so `pd.concat` fell back to an object index. This normalizes every declarer to the canonical `(i, t, v)` + single `Int_t` datetime shape.

**Result:** clean `(country, i, t, v)` MultiIndex, single `Int_t` datetime column, unique, 0% NaT, **22 countries, 356,390 rows**.

## Per-country fixes

| Country | Defect | Fix |
|---|---|---|
| **Uganda** | 8 waves emit `date`, no `Int_t` | wave scripts emit `Int_t`; country concatenator gets a defensive `date→Int_t` rename |
| **Tanzania** | 2008-15 emits `date`; siblings emit `int_t` → split columns | 2008-15 emits `int_t` to match siblings → single `Int_t` |
| **Guyana** | `v` emitted as a *column*, suppressing the index join | drop the `v` column; framework joins `v` from `sample()` |
| **Mali** | extra `visit` level; `Int_t: str` | `data_scheme` → `(t, v, i)` / `datetime`; framework drops `visit`, keeps first visit |
| **GhanaLSS** | declared but **unbuildable** | implemented all 7 waves (YAML + per-wave date-combine helpers) |
| **Malawi** | declared but **unbuildable**; `(t, visit, i)`/`str` | implemented all 5 waves; `data_scheme` → `(t, i)` / `datetime` |

## Framework safety net

`Feature.__call__` now harmonizes each country frame toward the canonical index (drops all-NaN leaked columns, drops undeclared extra index levels) before concat, and warns if the index still collapses — so a future stray column degrades gracefully instead of silently nuking the index.

## Testing

Full suite (cache-clearing, `LSMS_NO_CACHE=1` verifications throughout — caught and worked around stale cached parquets): **1660 passed**, 120 skipped.

The single failure — `test_uganda_invariance::…[var/shocks.parquet]` — is a **pre-existing** stale-baseline `content_hash` drift, **not** from this PR: identical hash on clean `development` with these changes stashed, and `shocks` is outside this diff. Same flaky `content_hash` family as #330. Recommend a follow-up to regenerate that baseline.

## Gotcha worth noting

Emitting capital `Int_t` in one wave while siblings emit lowercase `int_t` makes the framework's `int_t→Int_t` canonicalization collide into a **duplicate column** (which then crashes `to_parquet`). Keep wave-level spelling consistent.

Closes #325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)