### PR TITLE
feat(Uganda): wire cluster_features GPS for 4 waves (#161)

### DIFF
--- a/lsms_library/countries/Uganda/2005-06/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2005-06/_/data_info.yml
@@ -58,23 +58,45 @@ sample:
             - 0: "Central"
 
 cluster_features:
-    file: GSEC1.dta
-    idxvars:
-        i: HHID
-        v: comm
-    myvars:
+    dfs:
+        - df_main
+        - df_geo
+    df_main:
+        file: GSEC1.dta
+        idxvars:
+            i: HHID
+            v: comm
+        myvars:
 
-        Region:
-            # Some "Central" households have region coded as 0?  These seem to be households in one of the 34
-            # Enumeration Areas (comm) of Kampala.
-            # See https://microdata.worldbank.org/index.php/catalog/1001/data-dictionary/F41?file_name=2005_GSEC1
-            - region
-            - # Fix some values as above
-               0: "Central"
-        Rural: urban
-        District: h1aq1
-        Rural:
-            - urban
-            - # Value mapping dictionary
-                urban: Urban
-                0: Rural
+            Region:
+                # Some "Central" households have region coded as 0?  These seem to be households in one of the 34
+                # Enumeration Areas (comm) of Kampala.
+                # See https://microdata.worldbank.org/index.php/catalog/1001/data-dictionary/F41?file_name=2005_GSEC1
+                - region
+                - # Fix some values as above
+                   0: "Central"
+            Rural: urban
+            District: h1aq1
+            Rural:
+                - urban
+                - # Value mapping dictionary
+                    urban: Urban
+                    0: Rural
+    # 2005-06 UNPS predates GPS collection; the only coordinates available
+    # for these (panel) households are in the 2009-10 geovar, which shares
+    # the panel HHID space (~83% of 2005-06 households match).  Cluster
+    # location is geographically stable, so 2009 GPS is a sound cluster
+    # centroid for the 2005-06 baseline.  Joined on HHID, collapsed to
+    # cluster grain by final_index (GH #161).
+    df_geo:
+        file: ../Data/2009_UNPS_Geovars_0910.dta
+        idxvars:
+            i: HHID
+        myvars:
+            Latitude: lat_mod
+            Longitude: lon_mod
+    merge_on:
+        - i
+    final_index:
+        - t
+        - v

--- a/lsms_library/countries/Uganda/2013-14/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2013-14/_/data_info.yml
@@ -53,11 +53,29 @@ sample:
         Region: region
 
 cluster_features:
-    file: ../Data/GSEC1.dta
-    idxvars:
-        i: HHID
-        v: h1aq4a # Docs identify this as "Parish"?
-    myvars:
-        Region: region
-        Rural: urban
-        District: h1aq1a  # TODO: 3 digit numeric code; map to string?
+    dfs:
+        - df_main
+        - df_geo
+    df_main:
+        file: ../Data/GSEC1.dta
+        idxvars:
+            i: HHID
+            v: h1aq4a # Docs identify this as "Parish"?
+        myvars:
+            Region: region
+            Rural: urban
+            District: h1aq1a  # TODO: 3 digit numeric code; map to string?
+    # GPS from the public geovar (modified/offset coordinates), joined on
+    # household id then collapsed to cluster grain by final_index (GH #161).
+    df_geo:
+        file: ../Data/unps_geovars_2013_14.dta
+        idxvars:
+            i: hhid
+        myvars:
+            Latitude: pub_lat_mod
+            Longitude: pub_lon_mod
+    merge_on:
+        - i
+    final_index:
+        - t
+        - v

--- a/lsms_library/countries/Uganda/2015-16/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2015-16/_/data_info.yml
@@ -39,11 +39,29 @@ sample:
         Region: region
 
 cluster_features:
-    file: gsec1.dta
-    idxvars:
-        i: HHID
-        v: parish_code
-    myvars:
-        Region: region
-        Rural: urban
-        District: district
+    dfs:
+        - df_main
+        - df_geo
+    df_main:
+        file: gsec1.dta
+        idxvars:
+            i: HHID
+            v: parish_code
+        myvars:
+            Region: region
+            Rural: urban
+            District: district
+    # GPS from the public geovar (modified/offset coordinates), joined on
+    # household id then collapsed to cluster grain by final_index (GH #161).
+    df_geo:
+        file: ../Data/unps_geovars_2015_16.dta
+        idxvars:
+            i: hhid
+        myvars:
+            Latitude: pub_lat_mod
+            Longitude: pub_lon_mod
+    merge_on:
+        - i
+    final_index:
+        - t
+        - v

--- a/lsms_library/countries/Uganda/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2018-19/_/data_info.yml
@@ -51,12 +51,30 @@ sample:
         Region: region
 
 cluster_features:
-    file: GSEC1.dta
-    idxvars:
-        i: hhid
-        #v: parish_code  # BROKEN: Different codes than in previous years, and only 19 values!
-        v: parish_name
-    myvars:
-        Region: region
-        Rural: urban
-        District: distirct_name
+    dfs:
+        - df_main
+        - df_geo
+    df_main:
+        file: GSEC1.dta
+        idxvars:
+            i: hhid
+            #v: parish_code  # BROKEN: Different codes than in previous years, and only 19 values!
+            v: parish_name
+        myvars:
+            Region: region
+            Rural: urban
+            District: distirct_name
+    # GPS from the public geovar (modified/offset coordinates), joined on
+    # household id then collapsed to cluster grain by final_index (GH #161).
+    df_geo:
+        file: ../Data/unps_geovars_2018_19.dta
+        idxvars:
+            i: hhid
+        myvars:
+            Latitude: pub_lat_mod
+            Longitude: pub_lon_mod
+    merge_on:
+        - i
+    final_index:
+        - t
+        - v


### PR DESCRIPTION
## Summary

Wires GPS into Uganda `cluster_features` for the four GPS-capable waves whose geovar files were present in the catalog but never merged: **2005-06, 2013-14, 2015-16, 2018-19**. Previously only 2009-10/2010-11/2011-12 had `Latitude`/`Longitude`; the other four were all-null.

Each wave's `cluster_features` becomes a `dfs: [df_main, df_geo]` merge mirroring the working 2009-10 block — join the public geovar on household id, then collapse to cluster grain via `final_index: (t, v)`.

## GPS populated after wiring (non-null clusters per wave)

| Wave | Before | After |
|------|--------|-------|
| 2005-06 | 0 | 321 |
| 2013-14 | 0 | 702 |
| 2015-16 | 0 | 849 |
| 2018-19 | 0 | 751 (100%) |
| 2019-20 | 0 | 0 (genuinely no geovar) |

Index stays a unique cluster-grain `(t, v)`; no columns added beyond `Latitude`/`Longitude`.

## Geovar columns (verified against the WB source files)

Downloaded the four geovar `.dta` from the WB Microdata Library (catalogs 1001/2663/3460/3795) and confirmed column names + join keys against the cover pages:

- **2013-14 / 2015-16 / 2018-19**: `pub_lat_mod` / `pub_lon_mod`, joined on `hhid` — **100%** HHID overlap with the cover page.
- **2005-06**: `lat_mod` / `lon_mod` from the 2009-10 geovar. 2005-06 UNPS predates GPS collection; the panel shares HHIDs (~83% match) and cluster location is geographically stable, so 2009 coordinates are a sound cluster centroid for the baseline. Documented inline.

## Data availability

The four geovar blobs were **pushed to the `ligonresearch_s3` remote** and verified pullable from a clean cache (no local copy, no repo cache -> `get_dataframe` fetches from S3 successfully). So GPS populates in CI / fresh clones. The `.dvc` pointers were already correct (md5-verified); only the blobs had been missing from the remote.

## Safety: no regression

Verified empirically that if a geovar blob is unavailable, the `df_geo` left-join yields null GPS and the wave is **retained in full** (no row loss) — identical to pre-wiring behavior.

`pytest -k "cluster_features or Uganda"` (structure + feature): **39 passed**.

## Scope

Resolves the GPS-wiring item (**#4**) of #161. #1 (stray `i`), #2 (grain), #3 (District float) were already fixed; #6 (`v`-semantics drift) is a separate structural issue. Minor #7 (2019-20 asymmetric Region/Rural/District nulls) left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
