### PR TITLE
feat: individual_education coverage — Serbia, Guyana, Iraq

### DIFF
--- a/lsms_library/countries/Guyana/1992/_/data_info.yml
+++ b/lsms_library/countries/Guyana/1992/_/data_info.yml
@@ -80,3 +80,14 @@ household_roster:
                8: Bro/Sis/B-in-law/S-in-law/Other relative
                9: Servant/Employee/Other non-relative
 
+individual_education:
+    # Dedicated education module EDUCN.dta; HS = highest school (codes 1-17).
+    # i=[ED,HH], pid=PID match the roster (~0.3% spine orphans).
+    file:
+        - ../Data/EDUCN.dta
+    idxvars:
+        i: [ED, HH]
+        pid: PID
+    myvars:
+        Educational Attainment: HS
+

--- a/lsms_library/countries/Guyana/_/data_scheme.yml
+++ b/lsms_library/countries/Guyana/_/data_scheme.yml
@@ -26,6 +26,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   sample:
     index: (i, t)
     v: str

--- a/lsms_library/countries/Iraq/2006-07/_/data_info.yml
+++ b/lsms_library/countries/Iraq/2006-07/_/data_info.yml
@@ -94,3 +94,14 @@ assets:
     myvars:
         Quantity: q1602
         Value: q1604
+
+individual_education:
+    # Education module; q0406 = highest attainment (13 English-labeled levels).
+    # i=xhhkey, pid=xpers match the roster (0% spine orphans).
+    file:
+        - "../Data/2007ihses04_education.dta"
+    idxvars:
+        i: xhhkey
+        pid: xpers
+    myvars:
+        Educational Attainment: q0406

--- a/lsms_library/countries/Iraq/2012/_/data_info.yml
+++ b/lsms_library/countries/Iraq/2012/_/data_info.yml
@@ -29,6 +29,17 @@ household_roster:
         Relationship: q0105
         Age: q0104
 
+individual_education:
+    # Education module; q0503 = highest attainment (12 English-labeled levels).
+    # i=hh, pid=idcode match the roster (0% spine orphans).
+    file:
+        - "../Data/2012ihses05_education.dta"
+    idxvars:
+        i: hh
+        pid: idcode
+    myvars:
+        Educational Attainment: q0503
+
 # assets is built via the script path (_/assets.py) so that physical
 # instances of a durable (multiple `durable_serial` rows per
 # (questid, durable_code)) are SUMMED into the canonical (t, i, j) index

--- a/lsms_library/countries/Iraq/_/data_scheme.yml
+++ b/lsms_library/countries/Iraq/_/data_scheme.yml
@@ -18,6 +18,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   assets:
     index: (t, i, j)
     Quantity: float

--- a/lsms_library/countries/Serbia/2007/_/data_info.yml
+++ b/lsms_library/countries/Serbia/2007/_/data_info.yml
@@ -65,3 +65,14 @@ sample:
     final_index:
         - i
         - t
+
+individual_education:
+    # Education embedded in the roster file individual.dta; obrazovanje is the
+    # attainment code (00-11). pid=lice matches the roster (0% spine orphans).
+    file:
+        - "../Data/individual.dta"
+    idxvars:
+        i: [opstina, popkrug, dom]
+        pid: lice
+    myvars:
+        Educational Attainment: obrazovanje

--- a/lsms_library/countries/Serbia/_/data_scheme.yml
+++ b/lsms_library/countries/Serbia/_/data_scheme.yml
@@ -15,6 +15,10 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+
   sample:
     index: (i, t)
     v: str


### PR DESCRIPTION
Fills 3 more `individual_education` cells (4 country-waves), all verified `is_this_feature_sane.ok=True`, 0% NaN, pid joins confirmed against the roster spine.

| Cell | Source | i / pid | Rows | Orphan |
|---|---|---|---|---|
| Serbia 2007 | individual.dta (embedded) `obrazovanje` | [opstina,popkrug,dom] / lice | 17,375 | 0% |
| Guyana 1992 | EDUCN.dta `HS` | [ED,HH] / PID | 4,137 | ~0.3% |
| Iraq 2006-07 + 2012 | 2007ihses04 `q0406` / 2012ihses05 `q0503` | per-wave | 52,692 | 0% |

Raw per-wave attainment labels (cross-country harmonization is tracked by #171, not this PR).

Part of the 2026-06-06 lock-free parallel matrix-fill sweep. Fully-specified follow-ups (Nigeria pp-ph, Tanzania multi-round, interview_date helpers, assets) are documented in `slurm_logs/2026-06-06_assets_ineduc/SWEEP_SPECS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)