### PR TITLE
feat(data_access): auto-use s3_write_creds on push + unpushed-blob check

### DIFF
--- a/lsms_library/cli.py
+++ b/lsms_library/cli.py
@@ -164,6 +164,34 @@ def cache_list(
             print(f"{name}: <no cache>")
 
 
+@app.command("unpushed")
+def unpushed(
+    remote: Optional[str] = typer.Option(
+        None, "--remote", help="DVC remote to check (default: core.remote)."),
+    country: Optional[List[str]] = typer.Option(
+        None, "--country", help="Limit the check to a country directory (repeatable)."),
+) -> None:
+    """Report DVC-tracked files whose blobs are missing from the remote.
+
+    Catches the "dvc add'ed locally but never dvc push'ed" trap, where a
+    committed .dvc pointer has no blob on the shared cache — invisible
+    until a build needs the file. Exits non-zero when anything is unpushed.
+    """
+    from .data_access import unpushed_blobs
+
+    targets = list(country) if country else None
+    missing = unpushed_blobs(remote=remote, targets=targets)
+    if not missing:
+        typer.echo("All DVC-tracked blobs are present on the remote.")
+        return
+    typer.echo(
+        f"{len(missing)} path(s) out of sync with the remote "
+        f"(need `dvc push`):")
+    for p in missing:
+        typer.echo(f"  {p}")
+    raise typer.Exit(code=1)
+
+
 @cache_app.command("clear")
 def cache_clear(
     country: Optional[List[str]] = typer.Option(None, "--country", help="Country to clear (repeatable)."),

--- a/lsms_library/data_access.py
+++ b/lsms_library/data_access.py
@@ -54,6 +54,7 @@ import tempfile
 import time
 import urllib.error
 import zipfile
+from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -741,6 +742,115 @@ def _check_write_access(remote: str | None = None) -> bool:
     return True
 
 
+def _default_remote(dvc_dir: Path) -> str | None:
+    """Return the ``core.remote`` configured in ``.dvc/config``, or None."""
+    cfg = configparser.ConfigParser()
+    cfg.read(dvc_dir / "config")
+    if cfg.has_option("core", "remote"):
+        return cfg.get("core", "remote")
+    return None
+
+
+def _resolve_write_credentialpath(dvc_dir: Path) -> tuple[Path | None, bool]:
+    """Resolve a credentials file usable for *writing* to S3.
+
+    Mirrors the write-credential precedence documented on
+    :func:`_check_remote_access`:
+
+    1. ``s3_write_creds`` at :func:`config.s3_write_creds_path`
+       (``~/.config/lsms_library/s3_write_creds``), then the legacy
+       in-tree ``<dvc_dir>/s3_write_creds``;
+    2. env vars — ``LSMS_S3_WRITE_KEY_ID`` / ``LSMS_S3_WRITE_KEY`` (the
+       latter is the secret), or standard ``AWS_ACCESS_KEY_ID`` /
+       ``AWS_SECRET_ACCESS_KEY`` — synthesized into a temp INI file.
+
+    Returns ``(path, is_temp)``.  ``is_temp`` is True when a temporary
+    file was written from env vars and the caller must delete it.
+    Returns ``(None, False)`` when no write credentials are available.
+
+    A boto/INI credentials file is needed (rather than relying on env
+    vars at push time) because the DVC S3 remote pins ``credentialpath``
+    to the *reader* creds, and an explicit credentialpath wins over the
+    boto env-var chain — so a push silently authenticates as the reader
+    unless we point credentialpath at the writer file.
+    """
+    user_write = config.s3_write_creds_path()
+    if user_write.exists() and user_write.stat().st_size > 0:
+        return user_write, False
+    legacy = dvc_dir / "s3_write_creds"
+    if legacy.exists() and legacy.stat().st_size > 0:
+        return legacy, False
+
+    key_id = (os.environ.get("LSMS_S3_WRITE_KEY_ID")
+              or os.environ.get("AWS_ACCESS_KEY_ID"))
+    secret = (os.environ.get("LSMS_S3_WRITE_KEY")
+              or os.environ.get("AWS_SECRET_ACCESS_KEY"))
+    if key_id and secret:
+        tmp = tempfile.NamedTemporaryFile(
+            "w", suffix=".ini", prefix="lsms_s3_write_", delete=False)
+        tmp.write(f"[default]\naws_access_key_id = {key_id}\n"
+                  f"aws_secret_access_key = {secret}\n")
+        tmp.close()
+        return Path(tmp.name), True
+
+    return None, False
+
+
+@contextmanager
+def _s3_writer_credentialpath(remote: str | None, dvc_dir: Path):
+    """Temporarily point an S3 remote's ``credentialpath`` at the writer creds.
+
+    The DVC remote config pins ``credentialpath`` to the read-only
+    ``s3_creds``; ``dvc push`` therefore authenticates as the reader and
+    fails with ``AccessDenied`` even when writer credentials exist.  This
+    context manager resolves the writer creds (see
+    :func:`_resolve_write_credentialpath`) and applies them via a *local*
+    config override (``.dvc/config.local``, git-ignored) for the duration
+    of the block, snapshotting and fully restoring the prior state so the
+    committed ``.dvc/config`` is never touched.
+
+    No-op (yields normally) when the target remote is not an S3 remote or
+    no writer credentials are available — in which case the push proceeds
+    with whatever the existing config provides.
+    """
+    target = remote or _default_remote(dvc_dir)
+    remotes = _parse_dvc_remotes(dvc_dir)
+    cfg = remotes.get(target or "", {})
+    is_s3 = cfg.get("url", "").startswith("s3://")
+
+    write_path: Path | None = None
+    is_temp = False
+    if is_s3 and target:
+        write_path, is_temp = _resolve_write_credentialpath(dvc_dir)
+
+    if not write_path:
+        yield
+        return
+
+    config_local = dvc_dir / "config.local"
+    had_local = config_local.exists()
+    prior = config_local.read_text(encoding="utf-8") if had_local else None
+    try:
+        _run_dvc_with_lock_retry(
+            [_dvc_cmd(), "remote", "modify", "--local",
+             target, "credentialpath", str(write_path)],
+            cwd=str(dvc_dir.parent), timeout=60,
+        )
+        logger.info("Using S3 writer credentials for push to %r", target)
+        yield
+    finally:
+        # Restore .dvc/config.local to its exact prior state.
+        if prior is not None:
+            config_local.write_text(prior, encoding="utf-8")
+        elif config_local.exists():
+            config_local.unlink()
+        if is_temp:
+            try:
+                os.unlink(write_path)
+            except OSError:
+                pass
+
+
 def push_to_cache(path: str | Path,
                   remote: str | None = None,
                   dvc_add: bool = True) -> bool:
@@ -791,10 +901,11 @@ def push_to_cache(path: str | Path,
         push_cmd = [_dvc_cmd(), "push", str(abs_path) + ".dvc"]
         if remote:
             push_cmd.extend(["-r", remote])
-        result = _run_dvc_with_lock_retry(
-            push_cmd,
-            cwd=str(_COUNTRIES_DIR), timeout=600,
-        )
+        with _s3_writer_credentialpath(remote, _COUNTRIES_DIR / ".dvc"):
+            result = _run_dvc_with_lock_retry(
+                push_cmd,
+                cwd=str(_COUNTRIES_DIR), timeout=600,
+            )
         if result.returncode != 0:
             logger.error("dvc push failed: %s", result.stderr.strip())
             return False
@@ -876,11 +987,12 @@ def push_to_cache_batch(paths: list[str | Path],
         if remote:
             push_cmd.extend(["-r", remote])
         logger.info("dvc push: %d files ...", len(abs_paths))
-        result = _run_dvc_with_lock_retry(
-            push_cmd,
-            cwd=str(_COUNTRIES_DIR),
-            timeout=600 + 60 * len(abs_paths),
-        )
+        with _s3_writer_credentialpath(remote, _COUNTRIES_DIR / ".dvc"):
+            result = _run_dvc_with_lock_retry(
+                push_cmd,
+                cwd=str(_COUNTRIES_DIR),
+                timeout=600 + 60 * len(abs_paths),
+            )
         if result.returncode != 0:
             logger.error("dvc push (batch) failed: %s",
                          result.stderr.strip())
@@ -893,6 +1005,53 @@ def push_to_cache_batch(paths: list[str | Path],
         # bugs (TypeError, etc.) propagate.
         logger.error("push_to_cache_batch error: %s", exc)
         return []
+
+
+def unpushed_blobs(remote: str | None = None,
+                   targets: list[str | Path] | None = None) -> list[str]:
+    """Return DVC-tracked paths whose blobs are missing from the remote.
+
+    Wraps ``dvc status --cloud`` (read-only; needs remote *read* access).
+    Catches the "``dvc add``ed locally but never ``dvc push``ed" trap,
+    where a ``.dvc`` pointer is committed but the blob never reached the
+    shared cache — invisible until a build needs the file and fails with
+    "No storage files available".
+
+    Parameters
+    ----------
+    remote : str, optional
+        Remote to compare against (defaults to ``core.remote``).
+    targets : list of str or Path, optional
+        Specific paths (relative to the countries dir, e.g.
+        ``Uganda/2013-14/Data/foo.dta``) to check; defaults to the whole
+        repository.
+
+    Returns
+    -------
+    list[str]
+        Sorted paths that are out of sync with the remote (need a push).
+        Empty when everything tracked is already on the remote.
+    """
+    cmd = [_dvc_cmd(), "status", "--cloud", "--json"]
+    if remote:
+        cmd += ["-r", remote]
+    if targets:
+        cmd += [str(t) for t in targets]
+    result = _run_dvc_with_lock_retry(
+        cmd, cwd=str(_COUNTRIES_DIR), timeout=600,
+    )
+    out = (result.stdout or "").strip()
+    if not out:
+        return []
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        logger.warning("Could not parse `dvc status --cloud` output: %s",
+                       (result.stderr or out)[:200])
+        return []
+    if isinstance(data, dict):
+        return sorted(data.keys())
+    return []
 
 
 def populate_and_push(country: str, wave: str,

--- a/tests/test_data_access.py
+++ b/tests/test_data_access.py
@@ -518,6 +518,12 @@ class TestPushToCache:
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_result.stderr = ""
+        # Isolate from S3 writer-cred injection (covered separately); this
+        # test exercises the dvc add -> push sequence.
+        import contextlib
+        monkeypatch.setattr(data_access, "_s3_writer_credentialpath",
+                            lambda *a, **k: contextlib.nullcontext())
+
         with patch.object(data_access.subprocess, "run",
                           return_value=mock_result) as mock_run:
             assert data_access.push_to_cache("Foo/2020/Data/bar.dta") is True
@@ -543,6 +549,11 @@ class TestPushToCache:
         monkeypatch.setattr("lsms_library.config.microdata_api_key",
                             lambda: None)
 
+        # Isolate from S3 writer-cred injection (covered separately).
+        import contextlib
+        monkeypatch.setattr(data_access, "_s3_writer_credentialpath",
+                            lambda *a, **k: contextlib.nullcontext())
+
         mock_result = MagicMock()
         mock_result.returncode = 0
         with patch.object(data_access.subprocess, "run",
@@ -552,6 +563,70 @@ class TestPushToCache:
             # Only push, no add
             assert mock_run.call_count == 1
             assert "push" in mock_run.call_args_list[0][0][0]
+
+    def test_push_injects_s3_writer_credentialpath(
+            self, dvc_dir, tmp_path, monkeypatch):
+        """push_to_cache temporarily points credentialpath at the writer
+        creds for an S3 remote, then restores .dvc/config.local."""
+        from lsms_library import data_access
+
+        countries = dvc_dir.parent
+        data_dir = countries / "Foo" / "2020" / "Data"
+        data_dir.mkdir(parents=True)
+        (data_dir / "bar.dta").write_bytes(b"fake data")
+        (dvc_dir / "s3_creds").write_text("[default]\nkey=val\n")
+
+        writer = tmp_path / "s3_write_creds"
+        writer.write_text("[default]\naws_access_key_id = AK\n"
+                          "aws_secret_access_key = SK\n")
+        monkeypatch.setenv("LSMS_S3_WRITE_CREDS", str(writer))
+        monkeypatch.setenv("LSMS_S3_WRITE_KEY", "secret")  # _check_write_access
+
+        monkeypatch.setattr(data_access, "_COUNTRIES_DIR", countries)
+        monkeypatch.setattr("lsms_library.config.microdata_api_key",
+                            lambda: None)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+        with patch.object(data_access.subprocess, "run",
+                          return_value=mock_result) as mock_run:
+            assert data_access.push_to_cache(
+                "Foo/2020/Data/bar.dta",
+                remote="ligonresearch_s3", dvc_add=False) is True
+
+        cmds = [c[0][0] for c in mock_run.call_args_list]
+        modify = [c for c in cmds if "remote" in c and "modify" in c]
+        assert modify, f"expected a `dvc remote modify` call, got {cmds}"
+        assert "credentialpath" in modify[0]
+        assert str(writer) in modify[0]
+        # config.local was absent before and must be restored to absent.
+        assert not (dvc_dir / "config.local").exists()
+
+
+class TestUnpushedBlobs:
+    def test_parses_cloud_status_json(self, monkeypatch):
+        from lsms_library import data_access
+
+        result = MagicMock()
+        result.stdout = ('{"Uganda/2013-14/Data/x.dta.dvc": [{"new": "x"}], '
+                         '"Uganda/2015-16/Data/y.dta.dvc": [{"new": "y"}]}')
+        result.stderr = ""
+        monkeypatch.setattr(data_access, "_run_dvc_with_lock_retry",
+                            lambda *a, **k: result)
+        out = data_access.unpushed_blobs()
+        assert out == ["Uganda/2013-14/Data/x.dta.dvc",
+                       "Uganda/2015-16/Data/y.dta.dvc"]
+
+    def test_empty_when_in_sync(self, monkeypatch):
+        from lsms_library import data_access
+
+        result = MagicMock()
+        result.stdout = ""  # dvc prints nothing when the remote is in sync
+        result.stderr = ""
+        monkeypatch.setattr(data_access, "_run_dvc_with_lock_retry",
+                            lambda *a, **k: result)
+        assert data_access.unpushed_blobs() == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Two papercuts surfaced while pushing the Uganda geovar blobs in #161/#336 — both made "get data back into the shared cache" far harder than it should be.

### 1. `push_to_cache[_batch]` ignored `s3_write_creds`

The S3 remote pins `credentialpath = s3_creds` (the **read-only reader** key), and an explicit `credentialpath` wins over the boto env-var chain. So `dvc push` authenticated as `dvc_reader` and died with `AccessDenied` — **even though `~/.config/lsms_library/s3_write_creds` existed**. `permissions()` *detected* the writer file and reported `write`, but the push never *used* it. Net effect: the helper that `add-wave` tells contributors to call simply didn't work, and the only way through was a manual `dvc remote modify --local … credentialpath <writer>` dance.

**Fix:** both push helpers now resolve the writer credentials (the `s3_write_creds` file, or `LSMS_S3_WRITE_KEY[_ID]` / `AWS_*` env synthesized into a temp INI) and apply them for the push via a **transactional** `dvc remote modify --local credentialpath` override — snapshotting and fully restoring `.dvc/config.local` so the committed config is never touched. Verified end to end: `push_to_cache(...)` now uploads with the writer creds and leaves no config residue.

### 2. "tracked-but-never-pushed" blobs were invisible

A committed `.dvc` pointer whose blob never reached the remote is silent until a build needs the file and fails with `No storage files available` (exactly what blocked #161 for weeks).

**Fix:** `data_access.unpushed_blobs()` (wraps `dvc status --cloud`) + an `lsms-library unpushed [--remote R] [--country C ...]` CLI command that lists out-of-sync paths and exits non-zero — usable as a pre-push sanity check or in CI.

## Tests

- Existing `push_to_cache` tests made hermetic (isolated from the dev machine's real creds, which they implicitly depended on).
- New: credentialpath injection + `config.local` restore; `unpushed_blobs` JSON parsing (populated + in-sync).
- `pytest tests/test_data_access.py tests/test_cli.py`: **41 passed** (+ the new cases).

## Follow-on value

This collapses the whole #161 push episode into a single working `push_to_cache_batch(...)` call, and makes the next "downloaded from WB, now push it" round trip a one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
