### PR TITLE
feat: assets coverage — South Africa (Quantity-only)

### DIFF
--- a/lsms_library/countries/South Africa/1993/_/data_info.yml
+++ b/lsms_library/countries/South Africa/1993/_/data_info.yml
@@ -112,3 +112,15 @@ individual_education:
                 17: "Other"
                 18: "Don't know"
                 19: "Adult education / literacy"
+
+assets:
+    # Durable-goods module M2_NFS4.dta: Quantity (dura_n, count owned) per item
+    # (dura_c, 11 codes). No value/age in this instrument -> Quantity-only.
+    # ~10 rows carry dura_n<=0 (data artifacts; left as-is).
+    file:
+        - ../Data/M2_NFS4.dta
+    idxvars:
+        i: hhid
+        j: dura_c
+    myvars:
+        Quantity: dura_n

--- a/lsms_library/countries/South Africa/_/data_scheme.yml
+++ b/lsms_library/countries/South Africa/_/data_scheme.yml
@@ -23,6 +23,12 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  assets:
+    # 1993 module M2_NFS4 records only count-owned (dura_n); no value or
+    # age in this instrument, so only Quantity is declared.
+    index: (t, i, j)
+    Quantity: float
+
   individual_education:
     index: (t, i, pid)
     Educational Attainment: str


### PR DESCRIPTION
Adds `assets` for **South Africa 1993** (M2_NFS4.dta): index (t,i,j), `Quantity=dura_n` per item `dura_c` (11 codes). No value/age in this instrument → Quantity-only. 35,187 rows, `is_this_feature_sane.ok=True`. (~10 rows `dura_n<=0`, data artifacts, left as-is.)

Part of the 2026-06-06 assets-gap sweep. Of the other gaps:
- **China** is implementable (real Qty/Value/Age) but needs a 2-module concat script (S10A2+S10B2) — specs in `slurm_logs/2026-06-06_assets_ineduc/SWEEP_SPECS.md`.
- **Azerbaijan, Cambodia, GhanaLSS, India, Kazakhstan, Tajikistan** are data-limited (binary ownership / ordinal "value" / WIDE-unlabeled / codebook-needed / multi-file) — documented and tracked in **#342**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)