### PR TITLE
feat: individual_education coverage round 2 — Tanzania, Nigeria (+ Pakistan doc)

### DIFF
--- a/lsms_library/countries/Nigeria/2010-11/_/individual_education.py
+++ b/lsms_library/countries/Nigeria/2010-11/_/individual_education.py
@@ -1,0 +1,47 @@
+"""Build Nigeria 2010-11 individual_education (GH individual_education).
+
+Education (GHS section 2) is collected only in the post-harvest round,
+so this single-file feature maps to the PH quarter t=2011Q1, matching
+the post-harvest slice of household_roster (i=hhid, pid=indiv).
+
+Source file:
+  - Post Harvest Wave 1/Household/sect2a_harvestw1.dta (t=2011Q1)
+
+Educational Attainment is the highest qualification (s2aq9), e.g.
+'p6', 'ss3', 'nce', '1st degree'.  Raw per-wave codes are retained
+(canonical individual_education allows raw labels).  Coverage in W1 is
+low (~640 rows): the W1 questionnaire only asked the qualification of
+members who had left school.
+"""
+import sys
+import pandas as pd
+
+sys.path.append('../../../_/')
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+
+def extract_string(x):
+    try:
+        return x.split('. ')[-1].title()
+    except AttributeError:
+        return ''
+
+
+idxvars = dict(
+    i='hhid',
+    t=('hhid', lambda x: '2011Q1'),
+    pid='indiv',
+)
+
+myvars = dict(
+    Attainment=('s2aq9', lambda s: extract_string(s)),
+)
+
+df = df_data_grabber(
+    '../Data/Post Harvest Wave 1/Household/sect2a_harvestw1.dta',
+    idxvars, **myvars,
+)
+df = df.rename(columns={'Attainment': 'Educational Attainment'})
+df = df.replace('', pd.NA).sort_index().dropna(how='all')
+
+to_parquet(df, 'individual_education.parquet')

--- a/lsms_library/countries/Nigeria/2012-13/_/individual_education.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/individual_education.py
@@ -1,0 +1,45 @@
+"""Build Nigeria 2012-13 individual_education.
+
+Education (GHS section 2) is post-harvest only -> t=2013Q1, matching the
+post-harvest slice of household_roster (i=hhid, pid=indiv).
+
+Source file:
+  - Post Harvest Wave 2/Household/sect2a_harvestw2.dta (t=2013Q1)
+
+Educational Attainment = highest qualification (s2aq9), raw labels
+('SS3', 'P6', '1ST DEGREE', ...).  Low coverage (~310 rows): the W2
+questionnaire only recorded the qualification for members who had left
+school.
+"""
+import sys
+import pandas as pd
+
+sys.path.append('../../../_/')
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+
+def extract_string(x):
+    try:
+        return x.split('. ')[-1].title()
+    except AttributeError:
+        return ''
+
+
+idxvars = dict(
+    i='hhid',
+    t=('hhid', lambda x: '2013Q1'),
+    pid='indiv',
+)
+
+myvars = dict(
+    Attainment=('s2aq9', lambda s: extract_string(s)),
+)
+
+df = df_data_grabber(
+    '../Data/Post Harvest Wave 2/Household/sect2a_harvestw2.dta',
+    idxvars, **myvars,
+)
+df = df.rename(columns={'Attainment': 'Educational Attainment'})
+df = df.replace('', pd.NA).sort_index().dropna(how='all')
+
+to_parquet(df, 'individual_education.parquet')

--- a/lsms_library/countries/Nigeria/2015-16/_/individual_education.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/individual_education.py
@@ -1,0 +1,41 @@
+"""Build Nigeria 2015-16 individual_education.
+
+Education (GHS section 2) is post-harvest only -> t=2016Q1, matching the
+post-harvest slice of household_roster (i=hhid, pid=indiv).
+
+Source file:
+  - sect2_harvestw3.dta (t=2016Q1)
+
+Educational Attainment = highest qualification (s2aq9), raw labels
+('43. HIGHER DEGREE', '34. NCE', '11. P1', ...).  extract_string strips
+the 'n. ' numeric prefix.  Near-universal coverage (~17.7k rows).
+"""
+import sys
+import pandas as pd
+
+sys.path.append('../../../_/')
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+
+def extract_string(x):
+    try:
+        return x.split('. ')[-1].title()
+    except AttributeError:
+        return ''
+
+
+idxvars = dict(
+    i='hhid',
+    t=('hhid', lambda x: '2016Q1'),
+    pid='indiv',
+)
+
+myvars = dict(
+    Attainment=('s2aq9', lambda s: extract_string(s)),
+)
+
+df = df_data_grabber('../Data/sect2_harvestw3.dta', idxvars, **myvars)
+df = df.rename(columns={'Attainment': 'Educational Attainment'})
+df = df.replace('', pd.NA).sort_index().dropna(how='all')
+
+to_parquet(df, 'individual_education.parquet')

--- a/lsms_library/countries/Nigeria/2018-19/_/individual_education.py
+++ b/lsms_library/countries/Nigeria/2018-19/_/individual_education.py
@@ -1,0 +1,42 @@
+"""Build Nigeria 2018-19 individual_education.
+
+Education (GHS section 2) is post-harvest only -> t=2019Q1, matching the
+post-harvest slice of household_roster (i=hhid, pid=indiv).
+
+Source file:
+  - sect2_harvestw4.dta (t=2019Q1)
+
+Educational Attainment = highest qualification (s2aq9), raw labels
+('43. HIGHER DEGREE / POST-GRADUATE DEGREE', '16. PRIMARY 6', ...).
+extract_string strips the 'n. ' numeric prefix.  Near-universal
+coverage (~19.3k rows).
+"""
+import sys
+import pandas as pd
+
+sys.path.append('../../../_/')
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+
+def extract_string(x):
+    try:
+        return x.split('. ')[-1].title()
+    except AttributeError:
+        return ''
+
+
+idxvars = dict(
+    i='hhid',
+    t=('hhid', lambda x: '2019Q1'),
+    pid='indiv',
+)
+
+myvars = dict(
+    Attainment=('s2aq9', lambda s: extract_string(s)),
+)
+
+df = df_data_grabber('../Data/sect2_harvestw4.dta', idxvars, **myvars)
+df = df.rename(columns={'Attainment': 'Educational Attainment'})
+df = df.replace('', pd.NA).sort_index().dropna(how='all')
+
+to_parquet(df, 'individual_education.parquet')

--- a/lsms_library/countries/Nigeria/2023-24/_/individual_education.py
+++ b/lsms_library/countries/Nigeria/2023-24/_/individual_education.py
@@ -1,0 +1,49 @@
+"""Build Nigeria 2023-24 individual_education (GHS-Panel Wave 5).
+
+Education (GHS section 2) is post-harvest only -> t=2024Q1, matching the
+post-harvest slice of household_roster (i=hhid, pid=indiv).
+
+Source file:
+  - Post Harvest Wave 5/Household/sect2_harvestw5.dta (t=2024Q1)
+
+Educational Attainment = s2q3 (highest grade/qualification completed),
+recorded as a numeric code in W5 (1..22 plus 3-digit detail codes like
+101, 201, 5102).  Raw per-wave codes are retained (canonical
+individual_education permits raw labels); the float is rendered as an
+integer string ('6', '101', ...) to keep the column typed as str.
+~11.9k rows.
+"""
+import sys
+import pandas as pd
+
+sys.path.append('../../../_/')
+from lsms_library.local_tools import df_data_grabber, to_parquet
+
+
+def code_to_str(x):
+    if pd.isna(x):
+        return pd.NA
+    try:
+        return str(int(x))
+    except (TypeError, ValueError):
+        return str(x)
+
+
+idxvars = dict(
+    i='hhid',
+    t=('hhid', lambda x: '2024Q1'),
+    pid='indiv',
+)
+
+myvars = dict(
+    Attainment=('s2q3', code_to_str),
+)
+
+df = df_data_grabber(
+    '../Data/Post Harvest Wave 5/Household/sect2_harvestw5.dta',
+    idxvars, **myvars,
+)
+df = df.rename(columns={'Attainment': 'Educational Attainment'})
+df = df.replace('', pd.NA).sort_index().dropna(how='all')
+
+to_parquet(df, 'individual_education.parquet')

--- a/lsms_library/countries/Nigeria/_/Makefile
+++ b/lsms_library/countries/Nigeria/_/Makefile
@@ -148,6 +148,12 @@ plot_features_parquet := $(plot_features:.py=.parquet)
 $(VAR_DIR)/plot_features.parquet: plot_features.py $(plot_features_parquet)
 	python plot_features.py
 
+# individual_education (GHS section 2, post-harvest only).  The
+# framework's grab_data calls `make ../<wave>/_/individual_education.parquet`
+# from this `_/` dir; the pattern rule runs the wave script.
+../%/_/individual_education.parquet: ../%/_/individual_education.py
+	(cd $(@D) && python individual_education.py)
+
 ../2010-11/_/housing.parquet: ../2010-11/_/housing.py
 	(cd ../2010-11/_; python housing.py)
 

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -52,6 +52,20 @@ Data Scheme:
     Distance: int
     Affinity: str
     materialize: make
+
+  individual_education:
+    # Highest educational attainment per household member.  GHS
+    # section 2 (education) is collected only in the post-harvest
+    # round, so each wave maps to a single t = PH quarter (2011Q1,
+    # 2013Q1, 2016Q1, 2019Q1, 2024Q1) -> materialize: make.
+    # Educational Attainment = highest qualification (s2aq9 in W1-W4;
+    # numeric code s2q3 in W5), kept as raw per-wave labels/codes.
+    # W1/W2 coverage is low (~640/310 rows): those waves recorded the
+    # qualification only for members who had left school.
+    index: (t, i, pid)
+    Educational Attainment: str
+    materialize: make
+
   panel_ids:
     index: (t, i)
     previous_i: str

--- a/lsms_library/countries/Pakistan/_/CONTENTS.org
+++ b/lsms_library/countries/Pakistan/_/CONTENTS.org
@@ -1,0 +1,20 @@
+#+TITLE: Pakistan — country notes & known data issues
+
+* Known data issues
+
+** individual_education — only primary grade available (2026-06-06)
+PIHS 1991 records educational attainment only as ~primgr~ (primary grade
+completed, codes 0–5) in the F03 section (F03C.DTA).  A scan of the F03*
+education files found no highest-level / secondary / tertiary attainment
+column — ~primgr~ caps at "5 = grade 5 or higher", so a university graduate
+and a primary-school leaver are indistinguishable.
+
+Wiring ~individual_education~ on ~primgr~ alone would **misrepresent
+attainment** cross-country (every Pakistani would appear to have at most
+primary education), so it is intentionally NOT wired.  The household roster
+(F01A.DTA, i=hid, pid=pid) and the (hid, pid) join are fine; only a usable
+highest-attainment variable is missing.
+
+Revisit if a fuller attainment variable is located (e.g. a secondary/tertiary
+column elsewhere in the instrument, or a later PIHS/PSLM wave).  Tracked in
+GitHub issue #344.

--- a/lsms_library/countries/Tanzania/2008-15/_/individual_education.py
+++ b/lsms_library/countries/Tanzania/2008-15/_/individual_education.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""Individual educational attainment for Tanzania 2008-15 (rounds 1-4).
+
+Source file: upd4_hh_c.dta (multi-round education module).
+Variables:
+    r_hhid  household id (matches household_roster i)
+    UPI     individual panel id (matches household_roster pid)
+    hc_04   highest level of education attained (numeric code)
+
+hc_04 is missing (~33%) for members who never attended school
+(hc_03 == 'NO'); those rows carry no attainment value and are dropped
+so the canonical column has no NaN.  Raw per-wave codes are preserved
+(no cross-country harmonization).  Cluster identity (v) is joined from
+sample() at API time, not baked into this parquet.
+"""
+from lsms_library.local_tools import get_dataframe, to_parquet
+import pandas as pd
+
+round_match = {1: '2008-09', 2: '2010-11', 3: '2012-13', 4: '2014-15'}
+
+df = get_dataframe('../Data/upd4_hh_c.dta')
+
+edu = pd.DataFrame({
+    'i': df['r_hhid'].astype(str),
+    't': df['round'].map(round_match),
+    'pid': df['UPI'].astype(float).astype(int).astype(str),
+    'Educational Attainment': df['hc_04'],
+})
+
+# Preserve raw codes as clean strings ("9.0" -> "9"); drop members with
+# no attainment recorded (never attended school) so the column is NaN-free.
+edu['Educational Attainment'] = (
+    edu['Educational Attainment']
+    .astype(float)
+    .astype('Int64')
+    .astype(str)
+    .replace('<NA>', pd.NA)
+)
+edu = edu.dropna(subset=['Educational Attainment'])
+
+edu = edu.set_index(['t', 'i', 'pid'])
+
+if not edu.index.is_unique:
+    edu = edu.groupby(level=edu.index.names).first()
+
+to_parquet(edu, 'individual_education.parquet')

--- a/lsms_library/countries/Tanzania/2019-20/_/individual_education.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/individual_education.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""Individual educational attainment for Tanzania 2019-20.
+
+Source file: HH_SEC_C.dta (education module).
+Variables:
+    sdd_hhid   household id (matches household_roster i)
+    sdd_indid  individual id (matches household_roster pid)
+    hh_c04     highest level of education attained (numeric code)
+
+hh_c04 is missing (~29%) for members who never attended school; those
+rows carry no attainment value and are dropped so the canonical column
+has no NaN.  Raw per-wave codes are preserved (no cross-country
+harmonization).  i/pid are formatted with format_id to match the
+YAML-path household_roster.  v is joined from sample() at API time.
+"""
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+import pandas as pd
+
+t = '2019-20'
+
+df = get_dataframe('../Data/HH_SEC_C.dta')
+
+edu = pd.DataFrame({
+    't': t,
+    'i': df['sdd_hhid'].apply(format_id),
+    'pid': df['sdd_indid'].apply(format_id),
+    'Educational Attainment': df['hh_c04'],
+})
+
+# Preserve raw codes as clean strings ("9.0" -> "9"); drop members with
+# no attainment recorded so the column is NaN-free.
+edu['Educational Attainment'] = (
+    edu['Educational Attainment']
+    .astype(float)
+    .astype('Int64')
+    .astype(str)
+    .replace('<NA>', pd.NA)
+)
+edu = edu.dropna(subset=['Educational Attainment'])
+
+edu = edu.set_index(['t', 'i', 'pid'])
+
+if not edu.index.is_unique:
+    edu = edu.groupby(level=edu.index.names).first()
+
+to_parquet(edu, 'individual_education.parquet')

--- a/lsms_library/countries/Tanzania/2020-21/_/individual_education.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/individual_education.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""Individual educational attainment for Tanzania 2020-21.
+
+Source file: hh_sec_c.dta (education module).
+Variables:
+    y5_hhid   household id (matches household_roster i)
+    indidy5   individual id (matches household_roster pid)
+    hh_c04    highest level of education attained (numeric code)
+
+hh_c04 is missing (~31%) for members who never attended school; those
+rows carry no attainment value and are dropped so the canonical column
+has no NaN.  Raw per-wave codes are preserved (no cross-country
+harmonization).  i/pid are formatted with format_id to match the
+YAML-path household_roster.  v is joined from sample() at API time.
+"""
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+import pandas as pd
+
+t = '2020-21'
+
+df = get_dataframe('../Data/hh_sec_c.dta')
+
+edu = pd.DataFrame({
+    't': t,
+    'i': df['y5_hhid'].apply(format_id),
+    'pid': df['indidy5'].apply(format_id),
+    'Educational Attainment': df['hh_c04'],
+})
+
+# Preserve raw codes as clean strings ("9.0" -> "9"); drop members with
+# no attainment recorded so the column is NaN-free.
+edu['Educational Attainment'] = (
+    edu['Educational Attainment']
+    .astype(float)
+    .astype('Int64')
+    .astype(str)
+    .replace('<NA>', pd.NA)
+)
+edu = edu.dropna(subset=['Educational Attainment'])
+
+edu = edu.set_index(['t', 'i', 'pid'])
+
+if not edu.index.is_unique:
+    edu = edu.groupby(level=edu.index.names).first()
+
+to_parquet(edu, 'individual_education.parquet')

--- a/lsms_library/countries/Tanzania/_/data_scheme.yml
+++ b/lsms_library/countries/Tanzania/_/data_scheme.yml
@@ -33,6 +33,11 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  individual_education:
+    index: (t, i, pid)
+    Educational Attainment: str
+    materialize: make
+
   interview_date:
     index: (t, i)
     Int_t: datetime


### PR DESCRIPTION
Follow-up to #337 (which is merged). Adds the two big ISA `individual_education` fills + documents the one data-limited gap.

| Country | Waves | Source / attainment | Rows | Orphan |
|---|---|---|---|---|
| **Tanzania** | 6 (2008-09…2020-21) | HH_SEC_C `hc_04`/`hh_c04` | 76,268 | 0% all waves |
| **Nigeria** | 5 (2010-11…2023-24) | GHS sect2 (post-harvest) `s2aq9`/`s2q3` | 49,783 | 0% all waves |

Both verified `is_this_feature_sane.ok=True`, 0% NaN attainment. Implemented via **script-path** (`materialize: make`):
- Tanzania: attainment is float-stringified + ~30% legit-NaN (never-attended) → YAML can't clean/drop; 2008-15 is the multi-round folder (script emits all 4 rounds).
- Nigeria: GHS education is post-harvest-only (single `t` per wave); Makefile gets the `individual_education.parquet` pattern rule (plot_features idiom). W1–W4 use `s2aq9`, W5 `s2q3`.

**Caveat (real data property, not a bug):** Nigeria W1/W2 coverage is low (643/313 rows) — those instruments recorded highest qualification only for members who had left school. Orphan% = 0 (IDs align perfectly).

Also includes **Pakistan** `individual_education` documentation (`primgr` = primary-only, intentionally not wired) — issue **#344**.

Raw per-wave attainment codes preserved (cross-country harmonization tracked separately by #171).

🤖 Generated with [Claude Code](https://claude.com/claude-code)