### PR TITLE
feat: cluster_features — Iraq, Timor-Leste (closes the foundational gap)

### DIFF
--- a/lsms_library/countries/Iraq/2006-07/_/data_info.yml
+++ b/lsms_library/countries/Iraq/2006-07/_/data_info.yml
@@ -105,3 +105,16 @@ individual_education:
         pid: xpers
     myvars:
         Educational Attainment: q0406
+
+cluster_features:
+    # Cover page; one row per cluster v=xcluster. Region=xgov (governorate);
+    # Rural derived from the xstrat label via mapping.py:Rural. Constant
+    # within cluster (verified, 2961 clusters).
+    file:
+        - "../Data/2007ihses00_cover_page.dta"
+    idxvars:
+        v: xcluster
+    myvars:
+        Region: xgov
+        Rural:
+            - xstrat

--- a/lsms_library/countries/Iraq/2006-07/_/mapping.py
+++ b/lsms_library/countries/Iraq/2006-07/_/mapping.py
@@ -1,0 +1,15 @@
+# Formatting functions for Iraq 2006-07.
+import pandas as pd
+
+
+def Rural(value):
+    '''Urban/Rural from the xstrat label (e.g. "baghdad - rural").
+
+    Every stratum encodes urbanicity as a "... - rural" / "... - urban ..."
+    suffix; this avoids duplicating the 50+-entry strata mapping the sample
+    block uses. Constant within each cluster (verified).
+    '''
+    s = value.iloc[0]
+    if pd.isna(s):
+        return pd.NA
+    return 'Rural' if 'rural' in str(s).lower() else 'Urban'

--- a/lsms_library/countries/Iraq/2012/_/data_info.yml
+++ b/lsms_library/countries/Iraq/2012/_/data_info.yml
@@ -46,3 +46,18 @@ individual_education:
 # rather than silently collapsed with .first().  Mark `assets: !make` in
 # the country data_scheme.yml.  The YAML path cannot groupby-sum, hence the
 # script.
+
+cluster_features:
+    # Cover page; one row per cluster v=cluster. Region=governorate;
+    # Rural from q00_16. Constant within cluster (verified, 2828 clusters).
+    file:
+        - "../Data/2012ihses00_cover_page.dta"
+    idxvars:
+        v: cluster
+    myvars:
+        Region: governorate
+        Rural:
+            - q00_16
+            - mapping:
+                URBAN: Urban
+                RURAL: Rural

--- a/lsms_library/countries/Iraq/_/data_scheme.yml
+++ b/lsms_library/countries/Iraq/_/data_scheme.yml
@@ -9,6 +9,11 @@ Data Scheme:
     strata: str
     Rural: str
 
+  cluster_features:
+    index: (t, v)
+    Region: str
+    Rural: str
+
   household_roster:
     index: (t, i, pid)
     Sex: str

--- a/lsms_library/countries/Timor-Leste/2001/_/data_info.yml
+++ b/lsms_library/countries/Timor-Leste/2001/_/data_info.yml
@@ -47,3 +47,18 @@ sample:
     final_index:
         - i
         - t
+
+cluster_features:
+    # WEIGHT.DTA is already one row per cluster (id4); Region=region,
+    # Rural from urbrural (1=Urban, 2=Rural). 300 clusters.
+    file:
+        - ../Data/WEIGHT.DTA
+    idxvars:
+        v: id4
+    myvars:
+        Region: region
+        Rural:
+            - urbrural
+            - mapping:
+                1: Urban
+                2: Rural

--- a/lsms_library/countries/Timor-Leste/2007-08/_/data_info.yml
+++ b/lsms_library/countries/Timor-Leste/2007-08/_/data_info.yml
@@ -36,3 +36,18 @@ sample:
             - mapping:
                 0: Rural
                 1: Urban
+
+cluster_features:
+    # basicvars.dta; one row per cluster v=cluster. Region=region; Rural from
+    # urban (0=Rural, 1=Urban). 300 clusters, constant within cluster.
+    file:
+        - ../Data/basicvars.dta
+    idxvars:
+        v: cluster
+    myvars:
+        Region: region
+        Rural:
+            - urban
+            - mapping:
+                0: Rural
+                1: Urban

--- a/lsms_library/countries/Timor-Leste/_/data_scheme.yml
+++ b/lsms_library/countries/Timor-Leste/_/data_scheme.yml
@@ -20,6 +20,11 @@ Data Scheme:
     strata: str
     Rural: str
 
+  cluster_features:
+    index: (t, v)
+    Region: str
+    Rural: str
+
   interview_date:
     index: (t, i)
     Int_t: datetime


### PR DESCRIPTION
Fills the last two `cluster_features` gaps (besides no-data Armenia), completing the foundational sample→cluster layer.

| Country | Waves | v | Region | Rural | Cluster-rows |
|---|---|---|---|---|---|
| Iraq | 2006-07, 2012 | xcluster / cluster | xgov / governorate | xstrat-substr / q00_16 | 5,789 |
| Timor-Leste | 2001, 2007-08 | id4 / cluster | region | urbrural / urban | 600 |

All verified `is_this_feature_sane.ok=True`, Region/Rural 0% NaN, constant within cluster (checked). Iraq 2006-07 Rural uses a one-line `mapping.py:Rural` (xstrat "rural" substring) to avoid duplicating the sample block's 50-entry strata mapping. Timor-Leste 2001 reads WEIGHT.DTA directly (already one row per cluster — no dfs merge needed).

After this, `cluster_features` is 33/34 (only Armenia, which has no microdata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)