### PR TITLE
feat(#223): EHCVM u-tables (CotedIvoire/Niger/Guinea-Bissau) + id_walk empty-frame guard

### DIFF
--- a/lsms_library/countries/CotedIvoire/_/categorical_mapping.org
+++ b/lsms_library/countries/CotedIvoire/_/categorical_mapping.org
@@ -1,5 +1,63 @@
 #+title: Categorical Mappings — CotedIvoire
 
+* Food Units
+
+#+name: u
+| Original Label  | Preferred Label |
+|-----------------+-----------------|
+| Kg              | Kg              |
+| Litre           | Litre           |
+| Unité           | Unité           |
+| Sachet          | Sachet          |
+| Paquet          | Paquet          |
+| Boite           | Boîte           |
+| Boîte de tomate | Boîte de tomate |
+| Bol             | Bol             |
+| Tas             | Tas             |
+| Boule           | Boule           |
+| Bouquet         | Bouquet         |
+| Bouteille       | Bouteille       |
+| Morceau         | Morceau         |
+| Panier          | Panier          |
+| Calebasse       | Calebasse       |
+| Régime          | Régime          |
+| Pot             | Pot             |
+| Gobelet         | Gobelet         |
+| Gousse          | Gousse          |
+| Louche          | Louche          |
+| Canette         | Canette         |
+| Cuvette         | Cuvette         |
+| Cuillière       | Cuillère        |
+| Seau            | Seau            |
+| Verre           | Verre           |
+| Papier          | Papier          |
+| Plaquette       | Plaquette       |
+| Feuille         | Feuille         |
+| Cope            | Cope            |
+| Bâtonnet        | Bâtonnet        |
+| Grain           | Grain           |
+| Yorouba         | Yorouba         |
+| Botte           | Botte           |
+| Tasse           | Tasse           |
+| Carton          | Carton          |
+| Tine            | Tine            |
+| Poignet         | Poignée         |
+| Casier          | Casier          |
+| Brochette       | Brochette       |
+| Bidon           | Bidon           |
+| Sac             | Sac             |
+| Sac (0,9 kg)    | Sac (0,9 Kg)    |
+| Sac (4 kg)      | Sac (4 Kg)      |
+| Sac (5 Kg)      | Sac (5 Kg)      |
+| Sac (11kg)      | Sac (11 Kg)     |
+| Sac (25 Kg)     | Sac (25 Kg)     |
+| Sac (50 Kg)     | Sac (50 Kg)     |
+| Avec os au Kg   | Avec os au Kg   |
+| Avec os au tas  | Avec os au tas  |
+| Sans os au Kg   | Sans os au Kg   |
+| Sans os au tas  | Sans os au tas  |
+| Filet au Kg     | Filet au Kg     |
+
 #+name: Roof
 | Alternate Spelling | Preferred Label |
 |--------------------+-----------------|

--- a/lsms_library/countries/Guinea-Bissau/_/categorical_mapping.org
+++ b/lsms_library/countries/Guinea-Bissau/_/categorical_mapping.org
@@ -1,3 +1,36 @@
+#+name: u
+| Original Label | Preferred Label |
+|----------------+-----------------|
+| Kg             | Kg              |
+| Monte          | Monte           |
+| Unidade        | Unidade         |
+| Saquinho       | Saquinho        |
+| Caneca         | Caneca          |
+| Litro          | Litro           |
+| Garrafa        | Garrafa         |
+| Pacote         | Pacote          |
+| Pedaço         | Pedaço          |
+| Lata           | Lata            |
+| Colher         | Colher          |
+| Múndo          | Múndo           |
+| Pacotinho      | Pacotinho       |
+| Carteira       | Carteira        |
+| Dente          | Dente           |
+| Maradura       | Maradura        |
+| Frasco         | Frasco          |
+| Cacho          | Cacho           |
+| Calma          | Calma           |
+| Corda          | Corda           |
+| Balde          | Balde           |
+| Saco           | Saco            |
+| Tigela         | Tigela          |
+| Pé             | Pé              |
+| Fatia          | Fatia           |
+| Bacia          | Bacia           |
+| Dúzia          | Dúzia           |
+| Tabuleiro      | Tabuleiro       |
+| Copo           | Copo            |
+
 #+NAME: strata
 | Alternate Spelling | Preferred Label |
 |--------------------+-----------------|

--- a/lsms_library/countries/Niger/_/categorical_mapping.org
+++ b/lsms_library/countries/Niger/_/categorical_mapping.org
@@ -1,5 +1,94 @@
 #+title: Categorical Mappings
 
+* Food Units
+
+# Niger's food_acquired `u` index leaks Stata value-label codes: the same
+# unit appears both code-prefixed ('139. Sachet') and clean ('Sachet').
+# Map both forms to the clean canonical label (native French / local
+# names; cross-country harmonization deferred per GH #223).
+
+#+name: u
+| Original Label       | Preferred Label   |
+|----------------------+-------------------|
+| 100. Kg              | Kg                |
+| Kg                   | Kg                |
+| 101. Litre           | Litre             |
+| Litre                | Litre             |
+| 147. Unité           | Unité             |
+| Unité                | Unité             |
+| 139. Sachet          | Sachet            |
+| Sachet               | Sachet            |
+| 129. Paquet          | Paquet            |
+| Paquet               | Paquet            |
+| 143. Tas             | Tas               |
+| Tas                  | Tas               |
+| 126. Morceau         | Morceau           |
+| Morceau              | Morceau           |
+| 113. Bouteille       | Bouteille         |
+| Bouteille            | Bouteille         |
+| 107. Boîte           | Boîte             |
+| Boîte                | Boîte             |
+| 108. Boîte de tomate | Boîte de tomate   |
+| Boîte de tomate      | Boîte de tomate   |
+| 506. Boîte de nescafé | Boîte de nescafé |
+| Boîte de nescafé     | Boîte de nescafé  |
+| 112. Bouquet         | Bouquet           |
+| Bouquet              | Bouquet           |
+| 115. Calebasse       | Calebasse         |
+| Calebasse            | Calebasse         |
+| 125. Louche          | Louche            |
+| Louche               | Louche            |
+| 120. Cueillère       | Cueillère         |
+| Cueillère            | Cueillère         |
+| 124. Gousse          | Gousse            |
+| Gousse               | Gousse            |
+| 117. Cannette        | Cannette          |
+| Cannette             | Cannette          |
+| 111. Boule           | Boule             |
+| Boule                | Boule             |
+| 106. Bidon           | Bidon             |
+| Bidon                | Bidon             |
+| 102. Alvéole         | Alvéole           |
+| Alvéole              | Alvéole           |
+| 131. Pot             | Pot               |
+| Pot                  | Pot               |
+| 127. Moudou          | Moudou            |
+| Moudou               | Moudou            |
+| 146. Tongolo         | Tongolo           |
+| Tongolo              | Tongolo           |
+| 130. Plaquette       | Plaquette         |
+| Plaquette            | Plaquette         |
+| 142. Seau            | Seau              |
+| Seau                 | Seau              |
+| 128. Panier          | Panier            |
+| Panier               | Panier            |
+| 508. Feuille         | Feuille           |
+| Feuille              | Feuille           |
+| 510. Pot-tarzan      | Pot-tarzan        |
+| Pot-tarzan           | Pot-tarzan        |
+| 512. Tiya            | Tiya              |
+| Tiya                 | Tiya              |
+| 103. Avec os au Kg   | Avec os au Kg     |
+| Avec os au Kg        | Avec os au Kg     |
+| 104. Avec os au tas  | Avec os au tas    |
+| Avec os au tas       | Avec os au tas    |
+| 140. Sans os au Kg   | Sans os au Kg     |
+| Sans os au Kg        | Sans os au Kg     |
+| 141. Sans os au tas  | Sans os au tas    |
+| Sans os au tas       | Sans os au tas    |
+| 509. Koriya /Gassou  | Koriya /Gassou    |
+| Tasse                | Tasse             |
+| Botte                | Botte             |
+| Carton               | Carton            |
+| Gobelet              | Gobelet           |
+| Canari               | Canari            |
+| Waygouizé            | Waygouizé         |
+| Cristal (Kantou)     | Cristal (Kantou)  |
+| Sac Filet            | Sac Filet         |
+| Sac (25 Kg)          | Sac (25 Kg)       |
+| Sac (50 Kg)          | Sac (50 Kg)       |
+| Sac (100 Kg)         | Sac (100 Kg)      |
+
 #+NAME: Region
 | Original Label                 | Preferred Label                |
 |--------------------------------+--------------------------------|

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -1613,6 +1613,14 @@ def id_walk(df: pd.DataFrame, updated_ids: dict[str, dict[str, str]], hh_index: 
     :meth:`.set_index`, :meth:`.merge`) is no longer a correctness
     hazard.  See ``tests/test_id_walk.py`` for the regression cases.
     '''
+    # Guard: a frame with no rows (e.g. a wave whose source yielded nothing)
+    # or one lacking a 't' level has no waves to split on; the final
+    # ``pd.concat([])`` would otherwise raise "No objects to concatenate".
+    # Empty-in -> empty-out, and the id_converted flag keeps it idempotent.
+    if df.empty or 't' not in (df.index.names or []):
+        df.attrs['id_converted'] = True
+        return df
+
     #seperate df into different waves:
     dfs = {}
     waves = df.index.get_level_values('t').unique()


### PR DESCRIPTION
## Summary

Finishes the actionable cross-country `food_acquired` unit-label (`u`) work for #223 and fixes a latent `id_walk` crash uncovered along the way.

### EHCVM `u` tables (Tier-3 remainder)

Adds `#+name: u` categorical_mapping tables (`Original Label` / `Preferred Label`) for the three EHCVM countries that still lacked one, so the framework auto-canonicalizes the `food_acquired` `u` index level — mirroring Benin (#237) / Togo (#238). Labels kept native (cross-country vocabulary harmonization stays deferred per the Phase-5 design).

| Country | raw `u` | after | note |
|---|---|---|---|
| CotedIvoire | 52 | 52 | French case/spelling/format (`Boite→Boîte`, `Sac (N kg)→Sac (N Kg)`) |
| Guinea-Bissau | 29 | 29 | Portuguese (already clean; identity-mapped) |
| Niger | 78 | 46 | **fixes the code-leak**: `'139. Sachet'` + `'Sachet'` → `Sachet`; 0 code-prefixed values remain |

Verified by rebuilding each `food_acquired` with cleared cache (`LSMS_NO_CACHE=1`): values now route through the Preferred Labels, no code-prefixed dupes.

### `id_walk` empty-frame guard

`id_walk` split a frame by its `t` level and `pd.concat`'d the parts; an empty wave-result crashed with `"No objects to concatenate"`. Now returns empty / `t`-less frames unchanged (empty-in → empty-out, `id_converted` set for idempotence). This unblocked `GhanaLSS.food_acquired()`, whose 2016-17 wave builds to 0 rows. `tests/test_id_walk.py`: 15 passed.

## Not in this PR (carved out)

- **GhanaLSS Tier-4** → #348. Turned out not to be a mechanical lift: the aggregated `u` surfaces as raw numeric codes the `unit_label` string-map doesn't match, and source data is partial here. Needs per-wave work with full data.
- **EthiopiaRHS** → #347. Separate extraction bug (item names in the `u` field, post-dates #223).
- **Senegal `units.org`**: the May inventory called it stale, but it's actively read by `Senegal/2018-19/_/food_acquired.py` — left in place.

## Tests

`test_id_walk` + `test_schema_consistency` + `test_food_labels`: **218 passed, 4 skipped**.

Advances #223 (closing once this lands, per the carve-outs above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
