### PR TITLE
feat: shocks coverage — Iraq, Liberia, Albania (+ document absents)

### DIFF
--- a/lsms_library/countries/Albania/2012/_/shocks.py
+++ b/lsms_library/countries/Albania/2012/_/shocks.py
@@ -1,0 +1,73 @@
+"""Build shocks table for Albania 2012.
+
+Source: ``Modul_6D_Shocks to the household.sav`` — LONG form, one row per
+(household, shock-type).  Columns:
+  psu, hh         : household identifiers
+  M6D_Q00         : shock-type label (Albanian) -> Shock index
+  M6D_Q01         : did the household EVER experience this shock 2008-2012? (Yes/No)
+  M6D_2008..2012  : did it occur in that specific year? (Yes/No, only filled when Q01=Yes)
+
+This module is OCCURRENCE-ONLY: it records *whether* and *in which year(s)* each
+shock happened, but carries NO impact (income/assets/production/consumption)
+nor coping-strategy detail.  None of the canonical Affected* / HowCoped*
+columns exist in the source, so they are not emitted.  The honest payload is
+``Years`` — a comma-separated list of the years in which the shock was reported.
+
+We keep only rows where the shock actually occurred (M6D_Q01 == 'Yes'), so the
+table is a genuine shocks roster ("did the household experience <shock>") rather
+than the full 9-shock-types x 6671-households product.  Filtering also removes
+the 15 duplicate (psu, hh, 'Tjeter'/Other) rows present in the raw product
+(each duplicate is an occurred 'Other' shock paired with a not-occurred one).
+
+CRITICAL: the household id ``i`` must be built as ``format_id(psu*100 + hh)`` to
+match the household identity in Albania/2012/_/sample.py (where i = format_id(hhid)
+and hhid == psu*100 + hh).  This lets _join_v_from_sample() resolve ``v``.  This
+mirrors the composite-i idiom used by housing / individual_education in this wave.
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, format_id, to_parquet
+
+t = '2012'
+
+# English labels for the 9 Albanian shock-type strings (truncated in the source).
+SHOCK_LABELS = {
+    'Semundje serioze': 'Serious illness',
+    'Humbje(Shperdorim) parash/kursimesh': 'Loss/embezzlement of money or savings',
+    'Burgosje e nje anetari te familjes qe si': 'Imprisonment of a family member',
+    'Humbje pune': 'Job loss',
+    'Shpronesim toke': 'Land expropriation',
+    'Shtepia u shkaterrua/dogj': 'Home destroyed/burned',
+    'Vdekje e papritur e nje anetari te famij': 'Sudden death of a family member',
+    'Deme nga permbytje': 'Flood damage',
+    'Tjeter': 'Other',
+}
+
+YEARS = [2008, 2009, 2010, 2011, 2012]
+
+df = get_dataframe('../Data/Modul_6D_Shocks to the household.sav')
+
+# Normalise the yes/no fields to plain strings (they arrive as categoricals).
+df['M6D_Q01'] = df['M6D_Q01'].astype(str)
+for y in YEARS:
+    df[f'M6D_{y}'] = df[f'M6D_{y}'].astype(str)
+
+# Keep only shocks that actually occurred.
+occurred = df[df['M6D_Q01'] == 'Yes'].copy()
+
+# Comma-joined list of years in which each shock was reported.
+def years_string(row):
+    yrs = [str(y) for y in YEARS if row[f'M6D_{y}'] == 'Yes']
+    return ','.join(yrs) if yrs else pd.NA
+
+shocks = pd.DataFrame({
+    't': t,
+    'i': occurred[['psu', 'hh']].apply(
+        lambda r: format_id(int(r.iloc[0]) * 100 + int(r.iloc[1])), axis=1),
+    'Shock': occurred['M6D_Q00'].astype(str).map(
+        lambda x: SHOCK_LABELS.get(x, x)),
+    'Years': occurred.apply(years_string, axis=1).astype('string'),
+})
+
+shocks = shocks.set_index(['t', 'i', 'Shock'])
+
+to_parquet(shocks, 'shocks.parquet')

--- a/lsms_library/countries/Albania/_/data_scheme.yml
+++ b/lsms_library/countries/Albania/_/data_scheme.yml
@@ -55,3 +55,12 @@ Data Scheme:
   interview_date:
     index: (t, i)
     Int_t: datetime
+
+  # Occurrence-only shocks module (2012 wave only; earlier waves have no
+  # shocks module).  No impact (Affected*) or coping (HowCoped*) detail in
+  # the source; ``Years`` is the comma-joined list of years 2008-2012 in
+  # which each experienced shock was reported.
+  shocks:
+    index: (t, i, Shock)
+    Years: str
+    materialize: make

--- a/lsms_library/countries/Cambodia/_/CONTENTS.org
+++ b/lsms_library/countries/Cambodia/_/CONTENTS.org
@@ -128,6 +128,18 @@ features:
 - =hh_sec_8.dta= :: Non-food expenditures
 - =hh_sec_9.dta= :: Housing
 - =hh_sec_10.dta= through =hh_sec_12.dta= :: Assets, savings, credit
-- =hh_sec_13a.dta=, =hh_sec_13b.dta= :: Shocks
+- =hh_sec_13a.dta=, =hh_sec_13b.dta= :: Shocks  *(MISLABEL — see Known data issues; these are migration modules)*
 - =hh_sec_14.dta= through =hh_sec_20b.dta= :: Various additional modules
 - =individual_cover.dta= :: Individual-level cover page
+
+* Known data issues
+
+** shocks — not available (2026-06-06)
+Cambodia 2019-20 LSMS+ has **no shocks-and-coping roster**. A full scan of
+every household section (5–20b) via variable labels found none. Note the
+section list above is mislabeled: =hh_sec_13a/13b= are **migration** modules
+(internal + international labor migration: destination, ISCO occupation,
+earnings), NOT shocks; =hh_sec_11/12= are education/health, not assets/credit.
+The only shock-adjacent content is per-member illness/injury in the health
+module (not a household shock-type × coping roster). `shocks` is therefore not
+implementable. Tracked in GitHub issue #352.

--- a/lsms_library/countries/China/_/CONTENTS.org
+++ b/lsms_library/countries/China/_/CONTENTS.org
@@ -61,3 +61,11 @@ TOTEXP, etc.) found no date/day/month/year/interview columns; S00's
 multiple rows per household are section-response flags, not visit dates.
 ~interview_date~ is therefore not implementable from the available
 microdata.  Tracked in GitHub issue #341.
+
+** shocks — not available (2026-06-06)
+No household shocks-and-coping roster. The `S07*` family is the **non-farm
+enterprise** module (enterprise assets/debts/income), not shocks. A scan of
+all 24 household-level S-modules found only a plot-level crop-disaster field
+(`S05B` `s05b12`/`s05b13`, no coping), which is part of the farming roster —
+not a canonical `(t, i, Shock)` shocks-and-coping module. Not implementable.
+Tracked in GitHub issue #352.

--- a/lsms_library/countries/Guyana/_/CONTENTS.org
+++ b/lsms_library/countries/Guyana/_/CONTENTS.org
@@ -1,0 +1,11 @@
+#+TITLE: Guyana — country notes & known data issues
+
+* Known data issues
+
+** shocks — not available (2026-06-06)
+Guyana 1992 (early-design GLSS) has no shocks-and-coping roster. A scan of
+every 1992 data file found no shock-type × impact × coping module. The
+triage's candidate `DRBLS.dta` is the **durable-goods inventory** (item/year-
+acquired/value triplets), already covered by `assets` — not shocks. The
+closest signals (HEALTHN illness; HHCHAR other-income recall) are not shocks.
+`shocks` is therefore not implementable. Tracked in GitHub issue #352.

--- a/lsms_library/countries/Iraq/2012/_/2012.py
+++ b/lsms_library/countries/Iraq/2012/_/2012.py
@@ -1,0 +1,20 @@
+"""Wave-level df_edit hooks for Iraq 2012 (loaded by Wave.formatting_functions).
+
+A function whose name matches a data_scheme request (here `shocks`) is wired
+up as that request's `df_edit` post-processor in country.Wave.grab_data: it
+runs on the extracted, (t, i, Shock)-indexed frame after the column mapping.
+"""
+
+
+def shocks(df):
+    """Collapse the 23-shock x household cross-product to experienced shocks.
+
+    The 2012ihses20 module records all 23 shock categories for every
+    household, with q2001 ("Has hh experienced..?") flagging the ones that
+    actually occurred.  The non-experienced rows carry NaN impact/coping and
+    are pure padding, so keep only Experienced rows and drop the temporary
+    Experienced column, leaving a true shocks-and-coping roster.
+    """
+    df = df[df['Experienced'] == True]
+    df = df.drop(columns=['Experienced'])
+    return df

--- a/lsms_library/countries/Iraq/2012/_/data_info.yml
+++ b/lsms_library/countries/Iraq/2012/_/data_info.yml
@@ -66,6 +66,63 @@ housing:
         Electricity: q0421_1
         Tenure: q0427
 
+shocks:
+    # Shocks-and-coping roster, module 2012ihses20. LONG form: 23 shock
+    # categories (shock_id, English-labeled) x ~25k households as a full
+    # cross-product. q2001 ("Has hh experienced..?") flags the few that
+    # actually occurred; the `shocks` df_edit hook in _/mapping.py keeps
+    # only q2001=='yes' rows (8812) and drops the temporary Experienced
+    # column, yielding a true experienced-shock roster.
+    #   i=questid (matches sample/housing/assets; the roster/file `hh`
+    #     field is the within-dwelling sequence number, GH #256).
+    #   Shock = shock_id label (-> Shock index level).
+    #   Impact (q2002_1/2/3/5 "Did increase/decrease income/assets/food
+    #     production/food purchases?"): DECREASE|INCREASE -> True (the shock
+    #     moved the dimension), DID NOT CHANGE -> False. q2002_4 (food
+    #     stock) is dropped -- the canonical schema has no Affected* slot
+    #     for it.
+    #   Coping (q2003_1/2/3 "Response to shock"): -> HowCoped0/1/2 (text).
+    file:
+        - "../Data/2012ihses20_shocks.dta"
+    idxvars:
+        i: questid
+        Shock: shock_id
+    myvars:
+        Experienced:
+            # NB: 'yes'/'no' MUST be quoted -- bare yes/no parse to YAML
+            # booleans, which never match the string values in q2001.
+            - q2001
+            - mapping:
+                'yes': True
+                'no': False
+        AffectedIncome:
+            - q2002_1
+            - mapping:
+                DECREASE: True
+                INCREASE: True
+                DID NOT CHANGE: False
+        AffectedAssets:
+            - q2002_2
+            - mapping:
+                DECREASE: True
+                INCREASE: True
+                DID NOT CHANGE: False
+        AffectedProduction:
+            - q2002_3
+            - mapping:
+                DECREASE: True
+                INCREASE: True
+                DID NOT CHANGE: False
+        AffectedConsumption:
+            - q2002_5
+            - mapping:
+                DECREASE: True
+                INCREASE: True
+                DID NOT CHANGE: False
+        HowCoped0: q2003_1
+        HowCoped1: q2003_2
+        HowCoped2: q2003_3
+
 cluster_features:
     # Cover page; one row per cluster v=cluster. Region=governorate;
     # Rural from q00_16. Constant within cluster (verified, 2828 clusters).

--- a/lsms_library/countries/Iraq/_/data_scheme.yml
+++ b/lsms_library/countries/Iraq/_/data_scheme.yml
@@ -38,6 +38,23 @@ Data Scheme:
     # silently collapsed with .first().  2006-07 has zero such duplicates
     # and stays on the YAML path; `load_from_waves` dispatches per wave.
 
+  shocks:
+    # Shocks-and-coping roster. 2012 ONLY (module 2012ihses20): 23 shock
+    # categories x household, filtered to experienced shocks by the
+    # _/mapping.py `shocks` df_edit hook.  i=questid (matches sample).
+    # Impact bools from q2002_1/2/3/5 (income/assets/food production/food
+    # purchases; DECREASE|INCREASE -> True).  HowCoped0/1/2 from q2003_1/2/3.
+    # 2006-07 is NOT wired: its 2007ihses18_risks.dta is one row/HH with no
+    # shock-level structure (no per-shock impact or coping roster).
+    index: (t, i, Shock)
+    AffectedIncome: bool
+    AffectedAssets: bool
+    AffectedProduction: bool
+    AffectedConsumption: bool
+    HowCoped0: str
+    HowCoped1: str
+    HowCoped2: str
+
   housing:
     # Dwelling module: 2007ihses03 (q03xx) / 2012ihses04 (q04xx).
     # All source columns carry English value labels, so values are

--- a/lsms_library/countries/Liberia/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Liberia/2018-19/_/data_info.yml
@@ -63,6 +63,31 @@ assets:
         Quantity: S15_2
         Value: S15_5
 
+shocks:
+    # Section 17 (National Household Forest Survey shocks module) is LONG:
+    # one row per (hhid, shock_name).  shock_name carries the 14 shock-type
+    # labels (drought, floods, large rise in price of food, death of a
+    # member, ...).  S17_1 = "severely negatively affected in the past 12
+    # months" (yes/no) -> Experienced.  S17_5_A/B/C = first/second/third
+    # forest product collected to recover -> HowCoped0/1/2 (populated only
+    # where S17_4=yes, ~38% of experienced shocks).  Rows whose shock_name is
+    # the Stata '.' sentinel (84 HH with the module left blank) format_id to
+    # None and are dropped by the null-index guard.
+    file:
+        - "../Data/Household/sect17_public.dta"
+    idxvars:
+        i: hhid
+        Shock: shock_name
+    myvars:
+        Experienced:
+            - S17_1
+            - mapping:
+                "yes": True
+                "no": False
+        HowCoped0: S17_5_A
+        HowCoped1: S17_5_B
+        HowCoped2: S17_5_C
+
 interview_date:
     # Cover/identification module sect1_public.dta; interview_date1 is the
     # primary-visit date (datetime64; interview_date2/3 are follow-up visits,

--- a/lsms_library/countries/Liberia/_/data_scheme.yml
+++ b/lsms_library/countries/Liberia/_/data_scheme.yml
@@ -32,6 +32,23 @@ Data Scheme:
     index: (t, i, pid)
     Educational Attainment: str
 
+  shocks:
+    # 2018-19 Section 17 (National Household Forest Survey). LONG form: one
+    # row per (household, shock-type). `Shock` is the shock_name label (14
+    # types: drought, floods, food-price rise, death, illness, crop pests,
+    # ...). `Experienced` is S17_1 ("severely negatively affected in the past
+    # 12 months", yes/no). This forest-survey instrument has NO income/asset/
+    # production/consumption impact breakdown, so the canonical Affected*
+    # columns are omitted. Coping is forest-specific: HowCoped0/1/2 are the
+    # first/second/third forest products the household collected to recover
+    # (S17_5_A/B/C); only populated for the ~38% of experienced shocks where
+    # forest products were used (S17_4=yes).
+    index: (t, i, Shock)
+    Experienced: bool
+    HowCoped0: str
+    HowCoped1: str
+    HowCoped2: str
+
   sample:
     index: (i, t)
     v: str

--- a/lsms_library/countries/Timor-Leste/_/CONTENTS.org
+++ b/lsms_library/countries/Timor-Leste/_/CONTENTS.org
@@ -1,0 +1,13 @@
+#+TITLE: Timor-Leste — country notes & known data issues
+
+* Known data issues
+
+** shocks — not available (2026-06-06)
+Neither wave has a shocks-and-coping roster. The triage's candidate (2001
+`S08A*`) is the **labor/employment** section (person-level "worked?/activity
+type"), not shocks; a keyword scan of all 2001 files found no shock-type
+labels. 2007-08 has no shocks section. `shocks` is not implementable.
+Tracked in GitHub issue #352.
+
+(Note: housing, interview_date, individual_education, and cluster_features
+are implemented for Timor-Leste; plot_features is implementable 2007-08.)


### PR DESCRIPTION
Fills `shocks` for the 3 gap countries whose surveys actually carry a shocks-and-coping module; documents the rest as absent (shocks is ISA/EHCVM-specific — most non-ISA surveys omit it). All fills verified `is_this_feature_sane.ok=True`; cross-country `Feature('shocks')()` assembles cleanly (16 countries, 367K rows, `(country,i,t,Shock)`, no collapse).

| Country | Wave | Source | Columns | Rows |
|---|---|---|---|---|
| **Iraq** | 2012 | 2012ihses20_shocks (23 shocks) | AffectedIncome/Assets/Production/Consumption + HowCoped0/1/2 (full canonical) | 8,812 |
| **Liberia** | 2018-19 | sect17 (NHFS §17, 14 shocks) | Experienced + HowCoped0/1/2 | 40,796 |
| **Albania** | 2012 | Modul_6D_Shocks (9 shocks) | Years (occurrence-by-year; no impact/coping in source) | 1,532 |

- Each declares the **flexible subset** its module supports (Iraq full; Liberia occurrence+coping; Albania occurrence-only). `shocks` is in the framework's `_no_v_join` set, so the canonical index is `(t,i,Shock)` with no `v`.
- Iraq keyed on `questid` (roster `hh` is the GH #256 mis-key).

**Documented absent — issue #352** (verified by full-survey scans, with per-country CONTENTS.org notes): **Cambodia** (hh_sec_13a/13b are *migration*, not shocks — CONTENTS.org annotation corrected), **Guyana** (DRBLS=durables), **Timor-Leste** (§8=employment), **China** (S07=enterprise). Plus 9 triage-inferred-absent (Azerbaijan, Guatemala, India, Kazakhstan, Kosovo, Pakistan, Serbia, South Africa, Tajikistan) listed in #352.

Recon: `slurm_logs/2026-06-06_assets_ineduc/TRIAGE_housing_shocks_plot.md`. The verify-or-document discipline caught 5 over-optimistic triage shocks claims (incl. several wrong-file misreads) — nothing fabricated. Next batch: plot_features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)