### PR TITLE
refactor(food_acquired): shared canonical filter+dedupe tail (closes #251)

### DIFF
--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -313,26 +313,16 @@ def food_acquired_to_canonical(df, wave):
             "found in input"
         )
 
+    from lsms_library.transformations import _finalize_canonical_food_acquired
+
     out = pd.concat(pieces, ignore_index=True)
-    # Keep rows with EITHER positive Quantity OR positive Expenditure.
-    # Matches the shared ``transformations.food_acquired_to_canonical``
-    # rule.  An expenditure-only row is legitimate data and is carried
-    # through with NaN Quantity.
-    qty_ok = out['Quantity'].notna() & (out['Quantity'] > 0)
-    exp_ok = out['Expenditure'].notna() & (out['Expenditure'] > 0)
-    out = out[qty_ok | exp_ok]
-    # Sum across genuine source-data duplicates: a household occasionally
-    # records multiple ``Other (Specify)`` entries for the same
-    # (item, unit, source) triple, lumping distinct foods under one
-    # canonical key.  Empirically observed in 2013-14 (HH 1508-006: two
-    # OTHER (SPECIFY) rows of qty 20 and 180) and 2019-20 (6 dupes across
-    # 3 households).  Sum is the right aggregation -- the household's
-    # total acquisition under that (item, unit, source) is the sum of the
-    # entries.  ``min_count=1`` keeps all-NaN Expenditure (produced/
-    # inkind) as NaN rather than coercing to 0.
-    out = out.groupby(['t', 'i', 'j', 'u', 's'],
-                      dropna=False).sum(min_count=1)
-    out = out.sort_index()
+    # Filter (qty>0 | exp>0; expenditure-only rows kept with NaN Quantity)
+    # and sum genuine source-data duplicates -- e.g. two ``Other (Specify)``
+    # rows under one (item, unit, source) key (observed 2013-14 HH 1508-006,
+    # 2019-20) -- via the shared tail (GH #251).  Malawi has no Price column,
+    # so Quantity/Expenditure summed with min_count=1 reproduces the prior
+    # blanket ``.sum(min_count=1)`` exactly.
+    out = _finalize_canonical_food_acquired(out)
 
     # Normalize food labels on the canonical 'j' level.
     out = apply_harmonize_food(out, wave, level='j')

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -545,17 +545,13 @@ def food_acquired_to_canonical(df):
     produced  = _make('produced',  'quant_own',      'unit_own')
     inkind    = _make('inkind',    'quant_inkind',   'unit_inkind')
 
-    out = pd.concat([purchased, produced, inkind], ignore_index=True)
-    # Keep rows with EITHER positive Quantity OR positive Expenditure.
-    # An expenditure-only row (HH reported food expenditure but no
-    # quantity) is legitimate data and is carried through with NaN
-    # Quantity.  Matches the shared
-    # ``transformations.food_acquired_to_canonical`` rule.
-    qty_ok = out['Quantity'].notna() & (out['Quantity'] > 0)
-    exp_ok = out['Expenditure'].notna() & (out['Expenditure'] > 0)
-    out = out[qty_ok | exp_ok]
+    from lsms_library.transformations import _finalize_canonical_food_acquired
 
-    out = out.set_index(['t', 'i', 'j', 'u', 's']).sort_index()
+    out = pd.concat([purchased, produced, inkind], ignore_index=True)
+    # Filter (qty>0 | exp>0; expenditure-only rows kept with NaN Quantity)
+    # via the shared tail (GH #251).  dedupe=False: Tanzania's per-source
+    # _make already yields unique canonical keys, so no groupby is needed.
+    out = _finalize_canonical_food_acquired(out, dedupe=False)
     return out
 
 

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -268,33 +268,15 @@ def food_acquired_to_canonical(df):
                       work['value_inkind'],
                       pd.Series(np.nan, index=work.index))
 
-    out = pd.concat([purchased, produced, inkind], ignore_index=True)
-    # Keep rows with EITHER positive Quantity OR positive Expenditure.
-    # An expenditure-only row (HH reported food expenditure but no
-    # quantity -- common for "food away from home" in Uganda's GSEC15b)
-    # is legitimate data and is carried through with NaN Quantity.
-    # Matches the shared ``transformations.food_acquired_to_canonical``
-    # rule.  See GH #246 part (C-2) — pre-fix behavior dropped 39 HH per
-    # wave for Uganda 2009-10 (and similarly across waves) whose only
-    # records were expenditure-without-quantity.
-    qty_ok = out['Quantity'].notna() & (out['Quantity'] > 0)
-    exp_ok = out['Expenditure'].notna() & (out['Expenditure'] > 0)
-    out = out[qty_ok | exp_ok]
+    from lsms_library.transformations import _finalize_canonical_food_acquired
 
-    # Aggregate genuine source-data duplicates: a household occasionally
-    # records multiple rows for the same (item, unit) -- e.g., two
-    # ``Other (Specify)`` entries that lump distinct foods under one
-    # canonical key.  Sum is the right aggregation for Quantity and
-    # Expenditure; for Price (a per-unit price) we take the mean across
-    # duplicate rows.  ``min_count=1`` keeps an all-NaN Price as NaN
-    # instead of coercing to 0.  Empirically observed in 2013-14 wave;
-    # mirrors the Malawi handling (commit 28429f14).
-    out = out.groupby(['t', 'i', 'j', 'u', 's'], dropna=False).agg(
-        Quantity=('Quantity', 'sum'),
-        Expenditure=('Expenditure', lambda s: s.sum(min_count=1)),
-        Price=('Price', 'mean'),
-    )
-    out = out.sort_index()
+    out = pd.concat([purchased, produced, inkind], ignore_index=True)
+    # Filter (qty>0 | exp>0; expenditure-only rows kept with NaN Quantity --
+    # GH #246 C-2) and aggregate genuine source-data duplicates (e.g. two
+    # ``Other (Specify)`` rows under one canonical key) via the shared tail
+    # (GH #251): Quantity/Expenditure summed with min_count=1, per-unit
+    # Price averaged.
+    out = _finalize_canonical_food_acquired(out)
     return out
 
 

--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -136,6 +136,75 @@ def food_acquired_to_canonical(df: pd.DataFrame, drop_columns=('visit',)) -> pd.
     return out
 
 
+def _finalize_canonical_food_acquired(out: pd.DataFrame,
+                                      *,
+                                      index_levels=('t', 'i', 'j', 'u', 's'),
+                                      dedupe: bool = True) -> pd.DataFrame:
+    """Shared filter (+ optional dedupe) tail for the country-level
+    ``food_acquired_to_canonical`` builders (Uganda / Tanzania / Malawi).
+
+    Extracted per GH #251 so the canonical filter rule lives in one place
+    rather than being copied into each country file (the 2026-05-08
+    expenditure-only-row fix had to touch all of them).
+
+    Filter
+        Keep rows where ``Quantity > 0`` OR ``Expenditure > 0``.  An
+        expenditure-only row (food reported by value but not quantity) is
+        legitimate and is carried through with NaN ``Quantity``.
+
+    Dedupe (``dedupe=True``)
+        Genuine source-data duplicates on a canonical key — e.g. two
+        ``Other (Specify)`` rows that lump distinct foods under one
+        ``(t, i, j, u, s)`` — are aggregated: ``Quantity`` and
+        ``Expenditure`` summed with ``min_count=1`` (an all-NaN group stays
+        NaN rather than coercing to 0), and a per-unit ``Price`` (when the
+        column is present) averaged across the duplicate rows.  When
+        ``dedupe=False`` the rows are kept as-is (the caller's pre-melt
+        already yields unique keys) and only the filter + reindex apply.
+
+    Note
+        ``food_acquired_to_canonical`` (this module) intentionally does NOT
+        route through this helper: it filters per source *before* the
+        purchased/produced concat and its index carries an optional ``v``
+        level, so its tail has a different shape.  See #251.
+
+    Parameters
+    ----------
+    out : pd.DataFrame
+        Flat long-form frame with the canonical levels (``t, i, j, u, s``)
+        as *columns* plus ``Quantity``, ``Expenditure``, and optionally
+        ``Price``.
+    index_levels : iterable of str
+        Levels to group / index on.  Default ``('t', 'i', 'j', 'u', 's')``.
+    dedupe : bool
+        Aggregate duplicate canonical keys (True) or just filter + reindex
+        (False).
+
+    Returns
+    -------
+    pd.DataFrame
+        Indexed on ``index_levels`` and sorted.
+    """
+    qty_ok = out['Quantity'].notna() & (out['Quantity'] > 0)
+    exp_ok = out['Expenditure'].notna() & (out['Expenditure'] > 0)
+    out = out[qty_ok | exp_ok]
+
+    levels = list(index_levels)
+    if dedupe:
+        aggs = {
+            'Quantity': ('Quantity', lambda s: s.sum(min_count=1)),
+            'Expenditure': ('Expenditure', lambda s: s.sum(min_count=1)),
+        }
+        if 'Price' in out.columns:
+            # Price is per-unit, so it averages (not sums) across dup rows.
+            aggs['Price'] = ('Price', 'mean')
+        out = out.groupby(levels, dropna=False).agg(**aggs)
+    else:
+        out = out.set_index(levels)
+
+    return out.sort_index()
+
+
 def age_intervals(age, age_cuts=(4, 9, 14, 19, 31, 51)):
     """Bucket ages into half-open intervals for household_characteristics.
 

--- a/tests/fixtures/uganda_baseline.json
+++ b/tests/fixtures/uganda_baseline.json
@@ -47,7 +47,7 @@
       "Price",
       "Quantity"
     ],
-    "content_hash": "837a649e6c868e67ef24604bd666f5b1a8817632c9b4b38792017fb61b8f9dfa",
+    "content_hash": "536e202451e41dafc19db5a19f6fd8e297ff35cdc514b71c9923eebcf55e2657",
     "dtypes": {
       "Expenditure": "float64",
       "Price": "float64",
@@ -166,7 +166,7 @@
       "Price",
       "Quantity"
     ],
-    "content_hash": "16acd49786fbfb7bf6b4c395bb9d027fd92272e5682e2ddc358c9b1d571d5465",
+    "content_hash": "73a3cece383ab670f99d82461a85d13a0d305398d9061216a36a9b9e17fdaa35",
     "dtypes": {
       "Expenditure": "float64",
       "Price": "float64",
@@ -285,7 +285,7 @@
       "Price",
       "Quantity"
     ],
-    "content_hash": "386bf361098261db6eb40499ad7caf8a63e93801e40460f61272c337c2524e6d",
+    "content_hash": "9ceaba9074df74f3830fd9e2a20b621adb6d904853ed29b3352b385bbf3a7137",
     "dtypes": {
       "Expenditure": "float64",
       "Price": "float64",
@@ -404,7 +404,7 @@
       "Price",
       "Quantity"
     ],
-    "content_hash": "df46fc328b79aa8011ee05c3243856a3d4a79ea522611880f33b1216f4331b3d",
+    "content_hash": "306479530887845374d9b735e686554f51dea9b95167f0b712ca14986cfcc5b1",
     "dtypes": {
       "Expenditure": "float64",
       "Price": "float64",
@@ -523,7 +523,7 @@
       "Price",
       "Quantity"
     ],
-    "content_hash": "8804bd91911ac217cbcc1743cd10919cba00dd459978d418b0cbd057bc6c4d16",
+    "content_hash": "203f442b1c79c95326016709a91745878625d988cca732c1f568a6b4f076883b",
     "dtypes": {
       "Expenditure": "float64",
       "Price": "float64",
@@ -642,7 +642,7 @@
       "Price",
       "Quantity"
     ],
-    "content_hash": "84f188882ce086017cd19d087f12f554f99a532cbf7fc9a7a565c99da4021209",
+    "content_hash": "24ab0e7290307e096f2c94dd1eb42030f22d2d5e3627e32881933edfcf731ebc",
     "dtypes": {
       "Expenditure": "float64",
       "Price": "float64",
@@ -761,7 +761,7 @@
       "Price",
       "Quantity"
     ],
-    "content_hash": "2a25418040c9e1977acfe6959c169cdc51835c9e06b3a87367c3c473006b1ef5",
+    "content_hash": "3daa0829974d300e9c84f9eb2aac2fcac34337c1e427236da1b30d07854c88b1",
     "dtypes": {
       "Expenditure": "float64",
       "Price": "float64",
@@ -880,7 +880,7 @@
       "Price",
       "Quantity"
     ],
-    "content_hash": "fed48ae5c9c056528f987d392d07c1189311729d285de717c1eeeccee5419af7",
+    "content_hash": "c0072df2f036f41446f1a1e452657f9053f6fd29e700a3592807df2c7ff2691a",
     "dtypes": {
       "Expenditure": "float64",
       "Price": "float64",
@@ -1268,7 +1268,7 @@
       "Price",
       "Quantity"
     ],
-    "content_hash": "bc8eaa2122db2df483ff989eae0841dc9bef095cc9d559bd95e6ddf365abfdc7",
+    "content_hash": "48c64d990d05afdaca6b2aa8bb188738dd50729d277c2e2cea257bac6146b900",
     "dtypes": {
       "Expenditure": "float64",
       "Price": "float64",


### PR DESCRIPTION
## Summary

Closes #251 — extracts the duplicated canonical `food_acquired` **filter + dedupe tail** into one shared helper, and reconciles the divergence the duplication had bred.

New `transformations._finalize_canonical_food_acquired(out, *, index_levels=('t','i','j','u','s'), dedupe=True)`:
- **Filter**: keep `Quantity > 0` OR `Expenditure > 0` (expenditure-only rows kept with NaN Quantity).
- **Dedupe** (`dedupe=True`): aggregate duplicate canonical keys — Quantity & Expenditure summed with `min_count=1`; per-unit Price averaged when the column is present. `dedupe=False` filters + reindexes only.

The three country builders now call it:

| Country | call | result |
|---|---|---|
| Tanzania | `dedupe=False` | **byte-identical** (no groupby) |
| Malawi | `dedupe=True` | **byte-identical** (no Price; Qty/Exp summed `min_count=1` as before) |
| Uganda | `dedupe=True` | **reconciled** (see below) |

## The reconcile (Uganda)

The four tails had drifted: Uganda summed Quantity with a plain `'sum'` while Malawi used `sum(min_count=1)`. Unified to `min_count=1` — matching Malawi *and* Uganda's own comment, which already used `min_count=1` for Expenditure/Price but inconsistently used plain `'sum'` for Quantity.

Effect: **6456 Quantity cells flip `0.0 → NaN`** — expenditure-only canonical groups ("food away from home", no quantity recorded) now correctly carry NaN instead of a misleading 0. **Row counts unchanged** (shapes identical); Expenditure and Price aggregations unchanged. Regenerated the 9 Uganda `food_acquired` baseline fingerprints accordingly (content_hash only; shapes identical).

Verified empirically (cleared cache, `LSMS_NO_CACHE=1`): Tanzania `709c5fc1` and Malawi `9d3c63d8` hashes identical pre/post; Uganda changes exactly the 6456 cells.

## Scope note

`transformations.food_acquired_to_canonical` (used by the EHCVM/other YAML-path countries) keeps its **own** per-source, pre-concat filter — it has no dedupe groupby, no sort, and an optional `v` index level, so its tail is a genuinely different shape. Folding it in would risk broad content-hash churn for little gain; documented in the helper's docstring.

## Tests

`test_id_walk` + `test_food_labels` + `test_schema_consistency`: **220 passed, 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
