### PR TITLE
fix(Burkina_Faso): migrate 2014 food_acquired to canonical s-axis (#107)

### DIFF
--- a/lsms_library/countries/Burkina_Faso/2014/_/mapping.py
+++ b/lsms_library/countries/Burkina_Faso/2014/_/mapping.py
@@ -1,16 +1,18 @@
 """Formatting functions for Burkina Faso 2014 (EMC).
 
-NOTE (2026-05-05, GH #169 Phase 2B): the food_acquired canonical
-reshape is NOT applied here.  Burkina_Faso's 2014 wave runs through
-the legacy script-path build at lsms_library/countries/Burkina_Faso/_/
-food_acquired.py, which bypasses mapping.py post-processors entirely.
-The script emits t='2013_Q4' and the legacy column set
-(quantity, units, total expenses, ...).  Pending a Phase 3 rewrite
-of either the country-level or wave-level food_acquired.py, this
-wave continues to emit non-canonical shape.
+food_acquired canonical reshape (GH #169 / #107): the wave's
+``data_info.yml`` extracts the wide form (Quantity-total, Produced-subset,
+Expenditure); importing ``food_acquired_to_canonical as food_acquired``
+below registers it as the ``mapping.py`` post-processor, so grab_data
+reshapes the wide form into the canonical long form on the ``s``
+(acquisition-source) axis — matching the 2018-19 / 2021-22 waves.  Before
+this, 2014 emitted the legacy wide shape (a ``Produced`` column, no ``s``),
+which leaked into ``Country('Burkina_Faso').food_acquired()`` and broke the
+``food_quantities`` kg derivation (0% resolved).
 """
 
 from lsms_library.local_tools import format_id
+from lsms_library.transformations import food_acquired_to_canonical as food_acquired
 
 
 def strata(x):


### PR DESCRIPTION
## Summary

Burkina's 2014 wave was the last `food_acquired` holdout on the pre-#169 wide shape: 2018-19/2021-22 register `food_acquired_to_canonical` as their `mapping.py` post-processor, but 2014 did not, so it emitted a `Produced` column with no `s` axis. That leaked into `Country('Burkina_Faso').food_acquired()`, mixing schemas across waves.

**Fix:** add `from lsms_library.transformations import food_acquired_to_canonical as food_acquired` to `2014/_/mapping.py` (its `data_info.yml` already extracts the wide Quantity/Produced/Expenditure form). One-line behavioral change + refreshed the stale 2014 NOTE.

## Verified (NO_CACHE rebuild)

`food_acquired` now canonical across all three waves: `[Quantity, Expenditure]`, index `(t, v, i, j, u, s)`, `s ∈ {purchased, produced}`, **no `Produced` column**. Row count 204k→304k (expected — the source split into purchased/produced rows). `test_schema_consistency` + `test_food_labels` + `test_id_walk`: 220 passed.

## Scope — what this does NOT fix

`food_quantities(units='kgs')` for Burkina is still **0% kg-resolved** — a *separate, pre-existing* problem (distinct_u=2 in the triage **before** this change too):
- the `#+name: u` categorical_mapping table is broken — it identity-maps numeric codes (`101.0 → 101.0`); real labels (`Tas`, `Kg`, `Sachet`) come from the `.dta` categoricals, and raw codes leak where they didn't decode;
- `food_quantities` collapses the `u` level to 2 values.

This needs its own pass (fix the `u` table + the food_quantities derivation). **#107 stays open** for that; this PR fixes only the canonical-shape half, which is the prerequisite and makes `food_acquired`/`food_expenditures` correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)