### PR TITLE
feat: plot_features coverage — 8 countries (+ document absents)

### DIFF
--- a/lsms_library/countries/Albania/2002/_/plot_features.py
+++ b/lsms_library/countries/Albania/2002/_/plot_features.py
@@ -1,0 +1,38 @@
+"""Build plot_features for Albania 2002 (GH #167).
+
+Source: Data/agr_a1_cl.dta -- the per-plot agriculture roster (6082 rows,
+~3.86 plots/HH).  Confirmed a plot roster via variable labels:
+``mca1_q0a`` = Plot Code, ``mca1_q03`` = Plot Area (sq meters),
+``mca1_q04`` = Kind of land, ``mca1_q06`` = Quality of land,
+``mca1_q09`` = Irrigated plot, ``mca1_q11`` = Method of acquisition,
+``mca1_q12`` = Legal documentation.  ``i`` = format_id(psu)-format_id(hh),
+matching Albania/2002/_/sample.py & mapping.py:i() (NOT the roster's latent
+``i:hh`` bug).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from albania import plot_features_for_wave
+
+
+src = get_dataframe('../Data/agr_a1_cl.dta', convert_categoricals=True)
+
+colmap = dict(
+    psu           = 'psu',
+    hh            = 'hh',
+    i_style       = 'psu-hh',
+    plot_code     = 'mca1_q0a',
+    area_sqm      = 'mca1_q03',
+    tenure        = 'mca1_q11',   # method of acquisition: Privatised / Inherited / ...
+    tenure_system = 'mca1_q12',   # legal documentation: Deed / Usufruct / None / ...
+    soil_type     = 'mca1_q04',   # kind of land: Annual crop land / Tree crop / Pasture
+    irrigated     = 'mca1_q09',
+)
+
+df = plot_features_for_wave('2002', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2002"
+assert len(df) > 0, "plot_features 2002 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Albania/2005/_/plot_features.py
+++ b/lsms_library/countries/Albania/2005/_/plot_features.py
@@ -1,0 +1,36 @@
+"""Build plot_features for Albania 2005 (GH #167).
+
+Source: Data/agric/part1_roster_a.dta -- the per-plot agriculture roster
+(5456 rows, ~2.96 plots/HH).  Confirmed a plot roster via variable labels:
+``p1a_q00`` = plot code, ``p1a_q7a`` = sq_meters, ``p1a_q9a`` = acquire,
+``p1a_q11a`` = legal (title document), ``p1a_q12a`` = cropping_use,
+``p1a_q13`` = irrigated.  ``i`` = format_id(p0_q00)-format_id(p0_q01),
+matching Albania/2005/_/sample.py & mapping.py:i().
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from albania import plot_features_for_wave
+
+
+src = get_dataframe('../Data/agric/part1_roster_a.dta', convert_categoricals=True)
+
+colmap = dict(
+    psu           = 'p0_q00',
+    hh            = 'p0_q01',
+    i_style       = 'psu-hh',
+    plot_code     = 'p1a_q00',
+    area_sqm      = 'p1a_q7a',
+    tenure        = 'p1a_q9a',    # acquire: privatised / inherited / purchased / ...
+    tenure_system = 'p1a_q11a',   # legal: deed / usufruct / sales receipt / none / ...
+    soil_type     = 'p1a_q12a',   # cropping_use: annual crop / tree crop / pasture / ...
+    irrigated     = 'p1a_q13',
+)
+
+df = plot_features_for_wave('2005', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2005"
+assert len(df) > 0, "plot_features 2005 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Albania/2008/_/plot_features.py
+++ b/lsms_library/countries/Albania/2008/_/plot_features.py
@@ -1,0 +1,35 @@
+"""Build plot_features for Albania 2008 (GH #167).
+
+Source: Data/Modul_17_id_of_agric_household.sav -- the per-plot agriculture
+roster (3977 rows, ~2.39 plots/HH).  Confirmed a plot roster via variable
+labels: ``m17_q00`` = plot code, ``m17_q04`` = area of plot (sq meters),
+``m17_q05`` = type of land.  The 2008 module records no acquisition / legal
+/ irrigation question, so Tenure / TenureSystem / Irrigated are absent for
+this wave (only Area / AreaUnit / SoilType).  ``i`` = format_id(psu)-
+format_id(hh), matching Albania/2008/_/sample.py & mapping.py:i().
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from albania import plot_features_for_wave
+
+
+src = get_dataframe('../Data/Modul_17_id_of_agric_household.sav',
+                    convert_categoricals=True)
+
+colmap = dict(
+    psu       = 'psu',
+    hh        = 'hh',
+    i_style   = 'psu-hh',
+    plot_code = 'm17_q00',
+    area_sqm  = 'm17_q04',
+    soil_type = 'm17_q05',   # type of land: annual crop land / pasture / tree crop / ...
+)
+
+df = plot_features_for_wave('2008', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2008"
+assert len(df) > 0, "plot_features 2008 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Albania/2012/_/plot_features.py
+++ b/lsms_library/countries/Albania/2012/_/plot_features.py
@@ -1,0 +1,39 @@
+"""Build plot_features for Albania 2012 (GH #167).
+
+Source: Data/Modul_17_Identification_of_Agriculture_Hh_Q3-9.sav -- the
+per-plot agriculture roster (4661 rows, ~1.54 plots/HH; one row per plot).
+Confirmed a plot roster via variable labels: ``M17_Q07`` = Area of plot
+(square meters), ``M17_Q08`` = Kind of land, ``M17_Q04`` = Origin of land,
+``M17_Q06`` = Legal title and rights.  This file carries NO plot-code
+column, so plot_id is synthesised as a stable 1..n sequence per household.
+``i`` = format_id(psu*100+hh) (= the globally-unique hhid), matching
+Albania/2012/_/sample.py & mapping.py:i().  No irrigation question in this
+module, so Irrigated is absent for 2012.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from albania import plot_features_for_wave
+
+
+src = get_dataframe('../Data/Modul_17_Identification_of_Agriculture_Hh_Q3-9.sav',
+                    convert_categoricals=True)
+
+colmap = dict(
+    psu           = 'psu',
+    hh            = 'hh',
+    i_style       = 'hhid',     # i = psu*100 + hh
+    plot_code     = None,       # no plot-code column -> synth 1..n per HH
+    area_sqm      = 'M17_Q07',
+    tenure        = 'M17_Q04',  # origin of land: Privatized (L.7501) / Inhereted / ...
+    tenure_system = 'M17_Q06',  # legal title and rights: Deed / Sales receipt / None / ...
+    soil_type     = 'M17_Q08',  # kind of land: Annual crop land / Pasture / Tree crop / ...
+)
+
+df = plot_features_for_wave('2012', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2012"
+assert len(df) > 0, "plot_features 2012 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Albania/_/albania.py
+++ b/lsms_library/countries/Albania/_/albania.py
@@ -1,0 +1,191 @@
+# Shared formatting functions for Albania.
+"""Country-level helpers for Albania.
+
+Currently hosts the ``plot_features`` harmonization shared across the four
+buildable waves (2002, 2005, 2008, 2012).  Each wave's per-plot agriculture
+roster is a clean LONG table (one row per (household, plot)) carrying a plot
+area in **square meters**; this module converts area to the canonical
+hectares and maps the Albanian acquisition / land-use / legal-document
+vocabularies onto the cross-country ``plot_features`` schema
+(``lsms_library/data_info.yml``).
+
+Wave source modules (all confirmed plot rosters via variable labels):
+
+  2002  Data/agr_a1_cl.dta                       (mca1_q* ; plot code mca1_q0a)
+  2005  Data/agric/part1_roster_a.dta            (p1a_q*  ; plot code p1a_q00)
+  2008  Data/Modul_17_id_of_agric_household.sav  (m17_q*  ; plot code m17_q00)
+  2012  Data/Modul_17_..._Hh_Q3-9.sav            (M17_Q*  ; NO plot code -> synth)
+
+The panel waves 2003 (w1/w2_hh_farm.dta) and 2004 (w3_hh_farm.dta) carry only
+a WIDE household-level farm questionnaire with cryptic, undocumented column
+labels ("1 m8a_q03", ...) and no decodable per-plot area / plot identity, so
+they are intentionally NOT wired (see CONTENTS.org).
+"""
+import pandas as pd
+import lsms_library.local_tools as tools
+
+
+# --- canonical-value maps ----------------------------------------------------
+#
+# Tenure: how the household came to hold the plot.  Albania's land was almost
+# entirely state-owned until the 1991 privatisation (Law 7501), so the dominant
+# category is a country-specific ``privatised`` value (the schema explicitly
+# permits extending the spellings list rather than force-fitting).  The rest map
+# onto canonical ``inherited`` / ``owned`` (purchased) / ``squatted`` (cleared /
+# walked-in) / ``other_tenure``.
+_TENURE = {
+    'privatised':              'privatised',
+    'privatized':              'privatised',   # 2012 spelling
+    'privatized (l. 7501)':    'privatised',   # 2012 label text
+    'inherited':               'inherited',
+    'inhereted':               'inherited',     # 2012 typo in source
+    'inhereted (before 1946)': 'inherited',
+    'purchased':               'owned',
+    'cleared':                 'squatted',
+    'tribunal':                'other_tenure',
+    'tribunal decision':       'other_tenure',
+    'other':                   'other_tenure',
+}
+
+# TenureSystem: lasting legal-document / title regime.  Albania records a
+# title-document type rather than a tenure *system*; we surface it under
+# TenureSystem as a country-specific vocabulary (deed / usufruct / sales
+# receipt / will / none / other), per the schema's "countries may extend".
+_TENURE_SYSTEM = {
+    'deed':                         'deed',
+    'deed (from law 7501 in 1991)': 'deed',
+    'deed (from before 1946)':      'deed',
+    'usufruct':                     'usufruct',
+    'sales receipt':                'sales_receipt',
+    'will':                         'will',
+    'tribunal document':            'tribunal_document',
+    'none':                         'none',
+    'other':                        'other_tenure_system',
+}
+
+# SoilType: Albania records "kind of land" (annual crop / tree crop / pasture /
+# forest / pond / other), not a soil texture.  Carried under SoilType verbatim
+# (lower-cased, whitespace-normalised) as the only lasting land-character field
+# available.
+_SOIL = {
+    'annual crop land':         'annual crop land',
+    'annual crop':              'annual crop land',  # 2005 cropping_use wording
+    'tree crop land':           'tree crop',
+    'tree crop':                'tree crop',
+    'pasture':                  'pasture',
+    'pasture/ natural meadow':  'pasture',           # 2005 cropping_use wording
+    'forest':                   'forest',
+    'pond':                     'pond',
+    'left fallow':              'fallow',            # 2005 cropping_use wording
+    'rented/loaned to others':  'rented out',        # 2005 cropping_use wording
+    'loaned to a relative':     'rented out',
+    'given in sharecropping':   'sharecropped out',
+    'other':                    'other',
+}
+
+
+def _clean_label(series):
+    """Lower-case, whitespace-collapse a string/categorical label Series for
+    case-insensitive mapping; NA stays NA."""
+    s = series.astype('string')
+    s = s.str.strip().str.lower().str.replace(r'\s+', ' ', regex=True)
+    return s
+
+
+def _map_labels(series, mapping):
+    """Map cleaned labels through ``mapping``; unmapped non-NA labels pass
+    through (already cleaned) so country-specific values are preserved."""
+    cleaned = _clean_label(series)
+    out = cleaned.map(lambda x: mapping.get(x, x) if pd.notna(x) else pd.NA)
+    return out.astype('string')
+
+
+def plot_features_for_wave(t, src, colmap):
+    """Build canonical ``plot_features`` for one Albania wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (used as the ``t`` index value).
+    src : pd.DataFrame
+        Raw per-plot roster, loaded with ``convert_categoricals=True`` so the
+        attribute columns arrive as human-readable label strings.
+    colmap : dict
+        Column-name map.  Keys::
+
+            psu, hh        — together build the canonical household id ``i``
+            i_style        — 'psu-hh' (2002/2005/2008) or 'hhid' (2012:
+                             psu*100+hh)
+            plot_code      — within-HH plot code column, or None to synthesise
+                             a 1..n sequence per household (2012)
+            area_sqm       — plot area in square meters
+            tenure         — acquisition / origin-of-land question (-> Tenure)
+            tenure_system  — legal-document / title question (-> TenureSystem)
+            soil_type      — kind-of-land question (-> SoilType)
+            irrigated      — yes/no irrigation question (-> Irrigated), or None
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id)`` with the canonical columns
+    that exist for this wave.  ``Area`` is hectares (square meters / 10000);
+    ``AreaUnit`` is always ``'sq. meters'`` (the source unit) where Area is
+    present, NA otherwise.
+    """
+    c = colmap
+    df = src.copy()
+
+    # Household id (matches each wave's sample.py / mapping.py:i()).
+    if c.get('i_style') == 'hhid':
+        i = df.apply(
+            lambda r: tools.format_id(int(r[c['psu']]) * 100 + int(r[c['hh']])),
+            axis=1)
+    else:
+        i = df.apply(
+            lambda r: tools.format_id(r[c['psu']]) + '-' + tools.format_id(r[c['hh']]),
+            axis=1)
+
+    # Plot id: real plot code where present, else a 1..n sequence per HH
+    # (stable in source row order) for waves whose roster carries no code.
+    if c.get('plot_code'):
+        plot_id = df[c['plot_code']].apply(tools.format_id)
+    else:
+        plot_id = (df.groupby(i.values).cumcount() + 1).map(tools.format_id)
+
+    # Area: square meters -> hectares.
+    area_sqm = pd.to_numeric(df[c['area_sqm']], errors='coerce').astype('Float64')
+    area_ha = area_sqm / 10000
+    area_unit = pd.Series('sq. meters', index=df.index, dtype='string')
+    area_unit = area_unit.where(area_ha.notna(), pd.NA)
+
+    cols = {
+        't':        t,
+        'i':        i.values,
+        'plot_id':  plot_id.values,
+        'Area':     area_ha.values,
+        'AreaUnit': area_unit.values,
+    }
+
+    if c.get('tenure') and c['tenure'] in df.columns:
+        cols['Tenure'] = _map_labels(df[c['tenure']], _TENURE).values
+    if c.get('tenure_system') and c['tenure_system'] in df.columns:
+        cols['TenureSystem'] = _map_labels(df[c['tenure_system']], _TENURE_SYSTEM).values
+    if c.get('soil_type') and c['soil_type'] in df.columns:
+        cols['SoilType'] = _map_labels(df[c['soil_type']], _SOIL).values
+    if c.get('irrigated') and c['irrigated'] in df.columns:
+        flag = _clean_label(df[c['irrigated']])
+        irr = flag.map({'yes': True, 'no': False})
+        cols['Irrigated'] = irr.where(flag.notna(), pd.NA).astype('boolean').values
+
+    out = pd.DataFrame(cols).set_index(['t', 'i', 'plot_id'])
+
+    # Collapse the rare genuine (i, plot_id) collisions (3 in 2005: two
+    # distinct plots share a plot code).  Disambiguate by appending a suffix
+    # so each physical plot keeps its own row rather than being dropped.
+    if not out.index.is_unique:
+        out = out.reset_index()
+        dup = out.duplicated(subset=['t', 'i', 'plot_id'], keep=False)
+        seq = out.groupby(['t', 'i', 'plot_id']).cumcount().add(1).map(str)
+        out.loc[dup, 'plot_id'] = out.loc[dup, 'plot_id'] + '_' + seq[dup]
+        out = out.set_index(['t', 'i', 'plot_id'])
+
+    return out

--- a/lsms_library/countries/Albania/_/data_scheme.yml
+++ b/lsms_library/countries/Albania/_/data_scheme.yml
@@ -64,3 +64,26 @@ Data Scheme:
     index: (t, i, Shock)
     Years: str
     materialize: make
+
+  # Lasting per-plot characteristics from each wave's agriculture roster
+  # (GH #167).  Four buildable waves: 2002 (agr_a1_cl.dta), 2005
+  # (agric/part1_roster_a.dta), 2008 (Modul_17_id_of_agric_household.sav),
+  # 2012 (Modul_17_..._Hh_Q3-9.sav).  i matches each wave's sample identity
+  # (psu-hh for 2002/2005/2008; psu*100+hh for 2012); plot_id is the source
+  # plot code (2012 has none -> synthesised 1..n per HH).  Area is converted
+  # from the source square meters to canonical hectares; AreaUnit records the
+  # source unit.  Tenure (acquisition/origin), TenureSystem (legal title doc),
+  # SoilType (kind of land), and Irrigated are populated where the wave's
+  # questionnaire carries them: 2008 has only Area/AreaUnit/SoilType; only
+  # 2002 & 2005 carry an irrigation question.  Panel waves 2003 & 2004 have
+  # only a wide household-level farm module with undecodable column labels and
+  # no per-plot area -> ABSENT (see CONTENTS.org).
+  plot_features:
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    SoilType: str
+    Irrigated: bool
+    materialize: make

--- a/lsms_library/countries/Cambodia/2019-20/_/data_info.yml
+++ b/lsms_library/countries/Cambodia/2019-20/_/data_info.yml
@@ -80,6 +80,35 @@ housing:
         Rooms: s04q03
         Tenure: s04q28
 
+plot_features:
+    # Parcel roster module hh_sec_8.dta. One row per (HHID, parcel),
+    # keyed by parcel_roster__id (1..12; no duplicate parcels per HH).
+    # All categorical columns already carry human-readable value labels
+    # (PRIVATE / RESIDENTIAL / ...), so no mapping is needed except the
+    # Yes/No -> bool coercion for the irrigation flag (s08q07). Area
+    # (s08q10a) is reported in mixed native units (s08q10b: SQUARE
+    # METERS / HECTARES / ACRE / RAI / KONG), carried verbatim in
+    # AreaUnit -- no kg/area standardization is attempted here.
+    #   s08q04 = how the parcel is held (TenureSystem)
+    #   s08q05 = how the parcel was acquired (Tenure)
+    #   s08q06 = current land use
+    #   s08q07 = irrigated? (Yes/No)
+    file: ../Data/hh_sec_8.dta
+    idxvars:
+        i: HHID
+        plot_id: parcel_roster__id
+    myvars:
+        Area: s08q10a
+        AreaUnit: s08q10b
+        Tenure: s08q05
+        TenureSystem: s08q04
+        LandUse: s08q06
+        Irrigated:
+            - s08q07
+            - mapping:
+                'Yes': True
+                'No': False
+
 individual_education:
     # Education module hh_sec_3.dta. pid is `children_out_of_H__id` (a
     # household-relative person sequence that matches the roster PID space,

--- a/lsms_library/countries/Cambodia/_/data_scheme.yml
+++ b/lsms_library/countries/Cambodia/_/data_scheme.yml
@@ -27,6 +27,19 @@ Data Scheme:
     index: (t, i, pid)
     Educational Attainment: str
 
+  plot_features:
+    # Parcel roster, 2019-20 hh_sec_8.dta. Single clean LONG file
+    # (one row per (HHID, parcel)), so YAML path -- no script needed.
+    # Area is in mixed native units carried in AreaUnit; no area
+    # standardization. SoilType is not collected by this module.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    LandUse: str
+    Irrigated: bool
+
   housing:
     index: (t, i)
     Roof: str

--- a/lsms_library/countries/China/1995-97/_/data_info.yml
+++ b/lsms_library/countries/China/1995-97/_/data_info.yml
@@ -50,6 +50,39 @@ cluster_features:
         Region:
             - hid
 
+plot_features:
+    # S05B.DTA is the genuine per-plot farming roster: one row per
+    # (household, plot), keyed by s05bpn ("PLOT NUMBER", 1..10).  3186
+    # rows / 734 households.  Variable labels confirm plot-level detail:
+    #   s05b02 = "AREA OF THE PLOT"  (reported in mu; see PlotArea/AreaUnit)
+    #   s05b09 = "IS IT IRRIGATED?"  (1 yes / 2 no -> Irrigated bool)
+    # The file carries CODES only (no Stata value labels) for the
+    # categorical land-attribute questions (s05b10 quality, s05b11 type,
+    # s05b15/s05b16 land status), and the codebook PDF is not pullable in
+    # this environment, so those codes are NOT decoded here -- only the
+    # well-grounded Area / AreaUnit / Irrigated columns are surfaced.
+    # PlotArea() nulls the ~11 Stata 1.75e+100 missing-sentinel rows and
+    # any non-positive / implausible (>=1000 mu) values.  (Two households
+    # -- hid 30132, 30137 -- carry a few duplicate plot rows in the raw
+    # source; left as-is, they are a tiny share and the index is still
+    # essentially one row per (i, plot_id).)
+    file: ../Data/S05B.DTA
+    idxvars:
+        i: hid
+        plot_id: s05bpn
+    myvars:
+        Area:
+            - s05b02
+            - mapping: PlotArea
+        AreaUnit:
+            - s05b02
+            - mapping: AreaUnit
+        Irrigated:
+            - s05b09
+            - mapping:
+                1: true
+                2: false
+
 individual_education:
     # Education detail S01B.DTA; attainment code s01b10 (grade/level 1-12).
     # pid maps from s01bid (person order); join to roster pid verified at build.

--- a/lsms_library/countries/China/1995-97/_/mapping.py
+++ b/lsms_library/countries/China/1995-97/_/mapping.py
@@ -28,3 +28,20 @@ def Region(value):
         return 7
     else:
         return 8
+
+
+def PlotArea(x):
+    """Clean S05B plot area (question 2, reported in mu).
+
+    A handful of rows carry the Stata sentinel ~1.75e+100 (extreme
+    encoding for a missing/refused value); coerce anything outside a
+    plausible plot range to NA.
+    """
+    import pandas as pd
+    s = pd.to_numeric(x, errors='coerce')
+    return s.where((s > 0) & (s < 1000))
+
+
+def AreaUnit(x):
+    """S05B plot areas are reported in mu (the Chinese land unit)."""
+    return 'mu'

--- a/lsms_library/countries/China/_/data_scheme.yml
+++ b/lsms_library/countries/China/_/data_scheme.yml
@@ -36,3 +36,11 @@ Data Scheme:
   individual_education:
     index: (t, i, pid)
     Educational Attainment: str
+
+  plot_features:
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Irrigated:
+      type: bool
+      optional: true

--- a/lsms_library/countries/GhanaLSS/1991-92/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1991-92/_/data_info.yml
@@ -37,7 +37,7 @@ household_roster:
     file: S1.DTA
     idxvars:
         v: clust
-        i: 
+        i:
             - clust
             - nh
         pid: pid
@@ -47,3 +47,28 @@ household_roster:
         Birthplace: s1q10
         Relationship: rel
         MonthsAway: s1q22
+
+plot_features:
+    # Section 8B (Agricultural land) -- clean per-plot roster, one row per
+    # (household, farm).  farmcd = farm number -> plot_id.  i = [clust, nh],
+    # matching household_roster's i.  This wave has no variable/value labels:
+    # s8bq4 = farm size, s8bq4c = unit code (decoded with the GLSS area-unit
+    # codes 1=Acres,2=Poles,3=Ropes,4=Hectare; verified against the GLSS7
+    # value labels and the code-frequency distribution).  s8bq8 in this wave
+    # is a value field (not a tenure code), and the GLSS3 tenure code is not
+    # recoverable, so Tenure is omitted.  Section 10 is non-farm ENTERPRISES.
+    file: S8B.DTA
+    idxvars:
+        i:
+            - clust
+            - nh
+        plot_id: farmcd
+    myvars:
+        Area: s8bq4
+        AreaUnit:
+            - s8bq4c
+            - mapping:
+                1: Acres
+                2: Poles
+                3: Ropes
+                4: Hectare

--- a/lsms_library/countries/GhanaLSS/1998-99/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1998-99/_/data_info.yml
@@ -80,3 +80,30 @@ individual_education:
                 16: University
                 17: Koranic stage
                 96: Other
+
+plot_features:
+    # Section 8B (Agricultural land) -- clean per-plot roster, one row per
+    # (household, farm).  farmcd = "Farm land number ID" -> plot_id.
+    # i = [clust, nh] (no pre-composed hid column in this wave), matching
+    # household_roster's i.  s8bq4a/s8bq4b = farm size + unit code.  The
+    # .dta carries no value labels, so AreaUnit is decoded with the GLSS
+    # area-unit codes (1=Acres,2=Poles,3=Ropes,4=Hectare; verified against
+    # the GLSS7 g7sec8b value labels and the code-frequency distribution).
+    # s8bq8 ("how land was obtained") is 4 bare codes whose GLSS4 mapping is
+    # not recoverable from the available materials, so Tenure is omitted
+    # here rather than fabricated.  Section 10 is non-farm ENTERPRISES.
+    file: SEC8B.DTA
+    idxvars:
+        i:
+            - clust
+            - nh
+        plot_id: farmcd
+    myvars:
+        Area: s8bq4a
+        AreaUnit:
+            - s8bq4b
+            - mapping:
+                1: Acres
+                2: Poles
+                3: Ropes
+                4: Hectare

--- a/lsms_library/countries/GhanaLSS/2012-13/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2012-13/_/data_info.yml
@@ -58,5 +58,39 @@ individual_education:
     myvars:
         Educational Attainment: s2aq2
 
+plot_features:
+    # Section 8B (Agricultural land) -- clean per-plot roster, one row per
+    # (household, farm).  s8bq3 = "farm number" -> plot_id.  hid is already
+    # the clust/nh composite, matching household_roster's i (=HID here).
+    # Value labels are lowercase in this wave.  Section 10 is non-farm
+    # ENTERPRISES (entno), not plots.
+    file:
+        - PARTB/sec8b.dta
+    idxvars:
+        i: hid
+        plot_id: s8bq3
+    myvars:
+        Area: s8bq4a
+        AreaUnit:
+            # value labels are lowercase in this wave -> Title-case to match
+            # the other waves' AreaUnit vocabulary.
+            - s8bq4b
+            - mapping:
+                acres: Acres
+                poles: Poles
+                ropes: Ropes
+                plot: Plot
+                hectare: Hectare
+                other: Other
+        Tenure:
+            - s8bq8
+            - mapping:
+                bought: owned
+                rented for cash or in kind: rented_in
+                sharecropped by household: sharecropped_in
+                use free of charge: use_right
+                distributed by village/family: communal
+                inherited: inherited
+
 
 

--- a/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
@@ -62,3 +62,27 @@ individual_education:
         # s2aq2 = "highest grade completed"; value labels are embedded in the
         # .dta and decoded automatically by get_dataframe().
         Educational Attainment: s2aq2
+
+plot_features:
+    # Section 8B (Agricultural land) is a clean per-plot roster: one row per
+    # (household, farm).  s8bq3 = "Farm number" -> plot_id.  hid is already
+    # the canonical clust/nh composite, matching household_roster's i.
+    # s8bq4a/s8bq4b = farm size + unit; s8bq8 = how the land was obtained
+    # (mapped to the canonical Tenure vocabulary).  NB Section 10 in GLSS7
+    # is non-farm ENTERPRISES, not plots.
+    file: g7sec8b.dta
+    idxvars:
+        i: hid
+        plot_id: s8bq3
+    myvars:
+        Area: s8bq4a
+        AreaUnit: s8bq4b
+        Tenure:
+            - s8bq8
+            - mapping:
+                Bought: owned
+                Rented for cash or in kind: rented_in
+                Sharecropped by household: sharecropped_in
+                Use free of charge: use_right
+                Distributed by village/family: communal
+                Inherited: inherited

--- a/lsms_library/countries/GhanaLSS/_/data_scheme.yml
+++ b/lsms_library/countries/GhanaLSS/_/data_scheme.yml
@@ -33,6 +33,22 @@ Data Scheme:
   individual_education:
     index: (t, i, pid)
     Educational Attainment: str
+  plot_features:
+    # Section 8B (Agricultural land / farms) is a clean per-plot roster:
+    # one row per (household, farm).  The Section 10 module is non-farm
+    # ENTERPRISES (entno / "Enterprise name"), NOT agricultural plots --
+    # confirmed by reading the variable labels in every wave.  Wired for
+    # 1991-92, 1998-99, 2012-13, 2016-17 (the waves whose Section 8B is a
+    # genuine per-plot roster with a farm identifier + per-plot area).
+    # 1987-88/1988-89 store only household-level land totals (Y09A: ACRFRM
+    # etc.), so they are NOT plot_features.  2005-06 lacks Section 8
+    # agriculture (data jumps sec9 -> sec11).  AreaUnit/Tenure decoded from
+    # the GLSS7 value labels; 1=Acres,2=Poles,3=Ropes,4=Hectare in the
+    # older 4-code waves (no Plot/Other categories).
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
   food_acquired:
     index: (t, i, j)
     Expenditure: float

--- a/lsms_library/countries/Kosovo/2000/_/plot_features.py
+++ b/lsms_library/countries/Kosovo/2000/_/plot_features.py
@@ -1,0 +1,78 @@
+"""Build plot_features for Kosovo 2000 (OPLAND.dta, section 8a).
+
+OPLAND.dta is the operated-land / plot roster: one row per (household,
+plot).  The plot identifier is s8a_q01 ("plot code"), unique within hhid.
+
+Per-plot area is NOT stored in hectares directly: all_ha_1 ("total area
+of holding") is the HOUSEHOLD total (constant within hhid; its per-plot
+sum equals all_ha_1 to machine precision).  The per-plot area is the raw
+value s8a_q03a in the unit named by s8a_q03b (Square m / Hectares /
+Ares), which we convert to hectares.
+
+Canonical columns produced:
+  Area        -- plot area in hectares (s8a_q03a x unit factor)
+  AreaUnit    -- 'Hectares' (Area is normalized to ha)
+  Tenure      -- plot status s8a_q09 (Owned / Rented / Borrowed)
+  TenureSystem-- rent arrangement s8a_q12 (sparse; only rented/borrowed)
+  Irrigated   -- True if irrigated in either reference period
+                 (s8a_q06 1997-98 OR s8a_q07 1999-2000)
+
+No soil-type or GPS variable exists in this module, so SoilType /
+Latitude / Longitude are not emitted.  The 8 "Landless" rows (null
+plot code, zero holding) are dropped -- they carry no plot.
+"""
+import sys
+
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+
+WAVE = '2000'
+
+# convert_categoricals=False keeps integer codes so we can map them to
+# full, un-truncated labels (Stata stored 8-char truncated value labels).
+df = get_dataframe('../Data/OPLAND.dta', convert_categoricals=False)
+
+# Drop the landless / sentinel rows that have no plot identifier.
+df = df[df['s8a_q01'].notna()].copy()
+
+# --- index ---------------------------------------------------------------
+df['t'] = WAVE
+df['i'] = df['hhid'].apply(format_id)
+df['plot_id'] = df['s8a_q01'].astype('Int64').apply(format_id)
+
+# --- Area (hectares) -----------------------------------------------------
+unit_to_ha = {1.0: 0.0001,   # Square metres -> ha
+              2.0: 1.0,      # Hectares
+              3.0: 0.01}     # Ares -> ha
+df['Area'] = df['s8a_q03a'] * df['s8a_q03b'].map(unit_to_ha)
+df['AreaUnit'] = 'Hectares'
+
+# --- Tenure --------------------------------------------------------------
+df['Tenure'] = df['s8a_q09'].map({1.0: 'Owned',
+                                  2.0: 'Rented',
+                                  3.0: 'Borrowed'})
+
+df['TenureSystem'] = df['s8a_q12'].map({1.0: 'Rent',
+                                        2.0: 'Sharecropped',
+                                        3.0: 'No payment',
+                                        4.0: 'Exchange',
+                                        5.0: 'Other'})
+
+# --- Irrigated -----------------------------------------------------------
+# s8a_q06 / s8a_q07: 1 = Yes, 2 = No (two reference periods).
+def _irrig(row):
+    vals = [row['s8a_q06'], row['s8a_q07']]
+    if all(v != v for v in vals):  # both NaN
+        return None
+    return any(v == 1.0 for v in vals)
+
+df['Irrigated'] = df.apply(_irrig, axis=1).astype('boolean')
+
+out = df.set_index(['t', 'i', 'plot_id'])[
+    ['Area', 'AreaUnit', 'Tenure', 'TenureSystem', 'Irrigated']
+]
+
+assert out.index.is_unique, "Non-unique (t,i,plot_id) in Kosovo plot_features"
+assert len(out) > 0, "Kosovo plot_features produced no rows"
+
+to_parquet(out, 'plot_features.parquet')

--- a/lsms_library/countries/Kosovo/_/data_scheme.yml
+++ b/lsms_library/countries/Kosovo/_/data_scheme.yml
@@ -42,6 +42,21 @@ Data Scheme:
     Age: float
     Value: float
 
+  plot_features:
+    # OPLAND.dta section 8a is the plot roster (one row per (hhid, plot)).
+    # plot_id = s8a_q01 (plot code).  Area is per-plot s8a_q03a converted
+    # to hectares via the unit code s8a_q03b (all_ha_1 is the HH holding
+    # total, not per-plot).  No soil-type or GPS variable exists in this
+    # module, so SoilType / Latitude / Longitude are omitted.  Built by a
+    # script because of the unit conversion + two-period irrigation OR.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    Irrigated: bool
+    materialize: make
+
   housing:
     # Kosovo 2000 DWELLING.dta has no Roof/Floor/Walls/Water/Toilet
     # module; only the dwelling-characteristic subset below exists.

--- a/lsms_library/countries/Liberia/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Liberia/2018-19/_/data_info.yml
@@ -88,6 +88,37 @@ shocks:
         HowCoped1: S17_5_B
         HowCoped2: S17_5_C
 
+plot_features:
+    # Section 10 (Land Parcels) of the National Household Forest Survey is
+    # clean LONG: one row per (hhid, parcel_id), no duplicates.  parcel_id
+    # is the per-household parcel identifier (float in source -> format_id
+    # makes it a clean string '1','2',...).  Area=S10_4 ("total area of
+    # parcel - respondent's estimate", native unit) with AreaUnit=S10_4B
+    # (acres / lot(s) / hectares / other -- units are NOT homogeneous, so
+    # Area is left in its native unit and the unit is carried alongside,
+    # following the Uganda/Tanzania pattern).  Tenure=S10_5 (ownership
+    # status) mapped to the canonical Tenure vocabulary.  S10_6A/S10_6B are
+    # use-payment amount / period (NOT GPS, despite the triage note) and
+    # are ~98% NaN, so they are omitted.  No SoilType / Irrigated /
+    # TenureSystem question exists in this instrument (-> those canonical
+    # columns are not declared).
+    file:
+        - "../Data/Household/sect10_public.dta"
+    idxvars:
+        i: hhid
+        plot_id: parcel_id
+    myvars:
+        Area: S10_4
+        AreaUnit: S10_4B
+        Tenure:
+            - S10_5
+            - mapping:
+                "owned by hh": owned
+                "rented in": rented_in
+                "free use (with permission)": use_right
+                "occupy (without permission)": squatted
+                "other specify": other_tenure
+
 interview_date:
     # Cover/identification module sect1_public.dta; interview_date1 is the
     # primary-visit date (datetime64; interview_date2/3 are follow-up visits,

--- a/lsms_library/countries/Liberia/_/data_scheme.yml
+++ b/lsms_library/countries/Liberia/_/data_scheme.yml
@@ -32,6 +32,19 @@ Data Scheme:
     index: (t, i, pid)
     Educational Attainment: str
 
+  plot_features:
+    # 2018-19 Section 10 (Land Parcels), National Household Forest Survey.
+    # Clean LONG: one row per (i, plot_id) where plot_id = parcel_id.
+    # Area=S10_4 in native unit; AreaUnit=S10_4B (acres/lot(s)/hectares/
+    # other -- not homogeneous, so Area is kept native).  Tenure=S10_5
+    # mapped to the canonical vocabulary.  No SoilType / Irrigated /
+    # TenureSystem in this instrument; parcel GPS (S10_6A/B) is actually
+    # use-payment amount/period and ~98% NaN, so it is omitted.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+
   shocks:
     # 2018-19 Section 17 (National Household Forest Survey). LONG form: one
     # row per (household, shock-type). `Shock` is the shock_name label (14

--- a/lsms_library/countries/Tajikistan/2007/_/plot_features.py
+++ b/lsms_library/countries/Tajikistan/2007/_/plot_features.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+"""Build plot_features for Tajikistan 2007 (TLSS round 1, module 12a).
+
+The land module is a genuine per-plot roster split across three subsections,
+each keyed by (hhid, plotcode):
+
+  r1m12a1 -- plots OWNED by the household        (3685 plots; Tenure=owned)
+  r1m12a2 -- plots RENTED/BORROWED IN            ( 269 plots; Tenure=rented_in)
+  r1m12a3 -- plots RENTED/LENT OUT               (  20 plots; Tenure=rented_out)
+
+`plotcode` restarts at 1 within each subsection per household, so the same
+(hhid, plotcode) appears in more than one subsection (231 collisions between
+a1 and a2 alone).  We therefore tag plot_id with the tenure flavour
+("owned-1", "rented_in-1", ...) to keep (t, i, plot_id) unique while
+preserving the per-plot identity.
+
+Per-subsection canonical columns:
+  Area       q3  (numeric; unit not in the data -- TLSS records land in
+                  sotka = 1/100 ha = 100 m^2, the standard Tajik unit ->
+                  AreaUnit hardcoded to 'sotka')
+  SoilType   q4  (land kind: ANNUAL CROP LAND / TREE CROP LAND / PASTURE ...)
+  Irrigated  q6 (a1, a2) / q5 (a3)   Yes/No -> bool
+  Tenure         the subsection itself
+  TenureSystem   a1 q9 only (legal title: CERTIFICATE / ACT / ...); a2/a3
+                 have no title question -> NaN there.
+
+Single round -> single t = 2007.  `i = format_id(hhid)` matches the 2007
+household_roster `i`.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+
+t = '2007'
+AREA_UNIT = 'sotka'  # TLSS land area is recorded in sotka (1/100 ha)
+
+
+def _subsection(fn, tenure, area, soil, irrig, title=None):
+    """Extract one land subsection into the canonical plot_features shape."""
+    df = get_dataframe(fn)
+
+    out = pd.DataFrame(index=df.index)
+    out['i'] = df['hhid'].apply(format_id)
+    # tenure-tagged plot identity (plotcode restarts per subsection)
+    out['plot_id'] = tenure + '-' + df['plotcode'].astype('Int64').astype(str)
+
+    out['Area'] = pd.to_numeric(df[area], errors='coerce').astype(float)
+    out['AreaUnit'] = AREA_UNIT
+    out['Tenure'] = tenure
+    out['TenureSystem'] = (
+        df[title].astype(str).replace('nan', pd.NA) if title else pd.NA
+    )
+    out['SoilType'] = df[soil].astype(str).replace('nan', pd.NA)
+    out['Irrigated'] = df[irrig].astype(str).str.strip().map(
+        {'Yes': True, 'No': False}
+    ).astype('boolean')
+    return out
+
+
+pieces = [
+    _subsection('../Data/r1m12a1.dta', 'owned',
+                area='m12a1q3', soil='m12a1q4', irrig='m12a1q6',
+                title='m12a1q9'),
+    _subsection('../Data/r1m12a2.dta', 'rented_in',
+                area='m12a2q3', soil='m12a2q4', irrig='m12a2q6'),
+    _subsection('../Data/r1m12a3.dta', 'rented_out',
+                area='m12a3q3', soil='m12a3q4', irrig='m12a3q5'),
+]
+
+df = pd.concat(pieces, axis=0, ignore_index=True)
+df['t'] = t
+df = df.set_index(['t', 'i', 'plot_id'])
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2007"
+assert len(df) > 0, "plot_features 2007 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/Tajikistan/_/data_scheme.yml
+++ b/lsms_library/countries/Tajikistan/_/data_scheme.yml
@@ -24,6 +24,21 @@ Data Scheme:
     index: (t, i, pid)
     Educational Attainment: str
 
+  plot_features:
+    # Per-plot land roster from TLSS 2007 module 12a (only round with a
+    # usable plot roster).  Three subsections merged on a tenure-tagged
+    # plot_id: r1m12a1 (owned), r1m12a2 (rented_in), r1m12a3 (rented_out).
+    # Area is in sotka (1/100 ha); TenureSystem (legal title) is present for
+    # owned plots only.  See _/plot_features.py.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    TenureSystem: str
+    SoilType: str
+    Irrigated: bool
+    materialize: make
+
   sample:
     index: (i, t)
     v: str

--- a/lsms_library/countries/Tajikistan/_/plot_features.py
+++ b/lsms_library/countries/Tajikistan/_/plot_features.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""Concatenate wave-level plot_features for Tajikistan.
+
+Only the 2007 round (TLSS round 1, module 12a) carries a usable per-plot
+land roster (plot identity + per-plot area); the 1999 / 2003 / 2009 rounds
+have no plot roster, so only 2007 is wired.  Each wave's _/plot_features.py
+writes a parquet indexed by (t, i, plot_id) with the canonical columns; this
+script builds them on a cold cache, reads them, and concatenates.  `v` is
+joined from sample() by the framework at API time.
+"""
+import os
+import subprocess
+import sys
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+WAVES = ['2007']
+
+X = []
+for t in WAVES:
+    script = f'../{t}/_/plot_features.py'
+    parquet = f'../{t}/_/plot_features.parquet'
+    # Build the wave parquet if it is not already present.
+    try:
+        df = get_dataframe(parquet)
+    except FileNotFoundError:
+        subprocess.run([sys.executable or 'python3', 'plot_features.py'],
+                       cwd=os.path.dirname(script), check=True)
+        df = get_dataframe(parquet)
+    X.append(df)
+
+x = pd.concat(X, axis=0)
+
+assert x.index.is_unique, "Non-unique (t, i, plot_id) after concat"
+
+to_parquet(x, '../var/plot_features.parquet')

--- a/lsms_library/countries/Timor-Leste/2007-08/_/data_info.yml
+++ b/lsms_library/countries/Timor-Leste/2007-08/_/data_info.yml
@@ -52,6 +52,30 @@ sample:
                 0: Rural
                 1: Urban
 
+plot_features:
+    # Land module: plot.dta, one clean LONG row per (hh_id, pcode), no
+    # duplicates.  Variable labels confirmed via pyreadstat metadata:
+    #   q09a04 "Plot area (m2)"; q09a06 "Tenure status of the plot";
+    #   q09a09 "Irrigation of the plot".
+    # AreaUnit is the constant 'square meters' (mapping.py AreaUnit()).
+    # Irrigated: 'Not irrigated' -> False, any irrigation method -> True.
+    # SoilType / TenureSystem absent in the source (q09a05 is land-use,
+    # q09a08 is slope -- neither a soil class).
+    file:
+        - ../Data/plot.dta
+    idxvars:
+        i: hh_id
+        plot_id: pcode
+    myvars:
+        Area: q09a04
+        AreaUnit:
+            - q09a04
+            - mapping: AreaUnit
+        Tenure: q09a06
+        Irrigated:
+            - q09a09
+            - mapping: Irrigated
+
 cluster_features:
     # basicvars.dta; one row per cluster v=cluster. Region=region; Rural from
     # urban (0=Rural, 1=Urban). 300 clusters, constant within cluster.

--- a/lsms_library/countries/Timor-Leste/2007-08/_/mapping.py
+++ b/lsms_library/countries/Timor-Leste/2007-08/_/mapping.py
@@ -21,3 +21,39 @@ def Int_t(value):
         return pd.Timestamp(year=y, month=m, day=d).date()
     except (ValueError, OverflowError):
         return pd.NaT
+
+
+def _scalar(value):
+    """Unwrap a length-1 Series row (df_data_grabber passes a row when the
+    source is given as a single-element list) to its scalar value."""
+    if isinstance(value, pd.Series):
+        return value.iloc[0]
+    return value
+
+
+def AreaUnit(value):
+    """Constant area unit for plot_features.
+
+    The 2007-08 land module records plot area (``q09a04``) in square
+    metres.  ``value`` (the area itself) is ignored; we return the
+    constant unit string, with :class:`pandas.NA` where the area is
+    missing so the unit isn't asserted for a plot with no recorded area.
+    """
+    if pd.isna(_scalar(value)):
+        return pd.NA
+    return 'square meters'
+
+
+def Irrigated(value):
+    """Map the ``q09a09`` irrigation-method label to a boolean.
+
+    ``q09a09`` ("Irrigation of the plot") is a labelled categorical whose
+    values are 'Not irrigated' or an irrigation source ('River', 'Spring',
+    'Tube well', 'Ditch, canal', 'Pond, tank', 'Mixed', 'Other').
+    'Not irrigated' -> ``False``; any irrigation source -> ``True``;
+    missing -> :class:`pandas.NA`.
+    """
+    v = _scalar(value)
+    if pd.isna(v):
+        return pd.NA
+    return str(v).strip().lower() != 'not irrigated'

--- a/lsms_library/countries/Timor-Leste/_/data_scheme.yml
+++ b/lsms_library/countries/Timor-Leste/_/data_scheme.yml
@@ -37,3 +37,23 @@ Data Scheme:
   interview_date:
     index: (t, i)
     Int_t: datetime
+
+  plot_features:
+    # Lasting plot-level characteristics from the 2007-08 TLSLS-2 land
+    # module (plot.dta, q09a*).  One row per (household, plot); plot.dta
+    # is a clean LONG roster keyed on (hh_id, pcode) with no duplicates,
+    # so this is the YAML path.  Source variable labels confirmed:
+    #   pcode  = "Plot number"            -> plot_id
+    #   q09a04 = "Plot area (m2)"         -> Area (AreaUnit = square meters)
+    #   q09a06 = "Tenure status of the plot" -> Tenure
+    #   q09a09 = "Irrigation of the plot" -> Irrigated (bool; non-"Not
+    #            irrigated" source method -> True)
+    # SoilType is NOT declared: q09a05 ("Kind of land") is a land-use
+    # class (Plantation/Tree crop/Grassland/...) and q09a08 is slope,
+    # neither a soil classification.  TenureSystem absent in the source.
+    # The 2001 wave (TLSLS-1) has no plot/land module -> 2007-08 only.
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    Irrigated: bool


### PR DESCRIPTION
Fills `plot_features` for **8 gap countries**, all verified `is_this_feature_sane.ok=True`; `Feature('plot_features')()` assembles clean (20 countries, 469,734 rows, `(country,i,t,v,plot_id)`, no collapse).

| Country | Waves | plot roster | Rows |
|---|---|---|---|
| Albania | 2002/05/08/12 | agric part rosters | 20,176 |
| Cambodia | 2019-20 | hh_sec_8 | 2,951 |
| China | 1995-97 | S05B (area in mu) | 3,177 |
| GhanaLSS | 1991-92/98-99/2012-13/2016-17 | **Section 8B** | 48,349 |
| Kosovo | 2000 | OPLAND | 6,469 |
| Liberia | 2018-19 | NHFS §10 Land Parcels | 2,064 |
| Tajikistan | 2007 | module 12a (owned/rented) | 3,974 |
| Timor-Leste | 2007-08 | plot.dta | 6,308 |

- Each declares the **flexible subset** its parcel roster carries (Area + tenure/soil/irrigation where present).
- **Major brief corrections caught by the agents** (read-actual-labels discipline): GhanaLSS §10 is non-farm *enterprises* — the real parcel roster is **§8B**; Kosovo `all_ha_1` is the HH holding-total → used per-plot `s8a_q03a`; several "WIDE plot" candidates were actually crop-level/HH-totals/migration (→ documented absent, not fabricated).
- WIDE/multi-subsection ones (China, Tajikistan, Kosovo, Albania, GhanaLSS) use script-path; Cambodia/Liberia/Timor are clean YAML.

**Documented absent — issue #(see latest)**: Kazakhstan, Serbia, Azerbaijan, Pakistan (verified) + Guatemala, Guyana, India, Iraq, South Africa (triage). All record land as HH-totals or crop-level, not parcels.

Recon: `slurm_logs/2026-06-06_assets_ineduc/TRIAGE_housing_shocks_plot.md`. Next: #331 SWB-ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)