### PR TITLE
feat: subjective_well_being ladder — 10 countries (#331 feature 1)

### DIFF
--- a/lsms_library/countries/Albania/2002/_/data_info.yml
+++ b/lsms_library/countries/Albania/2002/_/data_info.yml
@@ -69,3 +69,18 @@ interview_date:
     myvars:
         Int_t:
             - m0_date
+
+subjective_well_being:
+    # Module 9 "Subjective Poverty" (subjpov_cl.dta).  m09_q09 "Economic status"
+    # is the welfare-ladder self-placement (1-10; 1 = poorest, 10 = richest).
+    # i=[psu,hh] -> composite via mapping.py:i() to match sample()'s household
+    # identity ('psu-hh') so _join_v_from_sample resolves v.  This is the
+    # housing/interview_date idiom; the roster's bare i=hh is a known wave-2002
+    # defect (the within-cluster number, only 14 unique) that we do NOT copy.
+    # Only the single current-status item is present here.
+    file:
+        - ../Data/subjpov_cl.dta
+    idxvars:
+        i: [psu, hh]
+    myvars:
+        Own Step: m09_q09

--- a/lsms_library/countries/Albania/2003/_/data_info.yml
+++ b/lsms_library/countries/Albania/2003/_/data_info.yml
@@ -54,3 +54,14 @@ household_roster:
                 not related: Not related
 
         MonthsAway: B1_Q08
+
+subjective_well_being:
+    # Section B10A "Subjective Poverty" (w2_hh_all.dta, one row per BHID).
+    # B10A_Q05 "step of poverty" is the welfare-ladder self-placement (1-10;
+    # 1 = poorest, 10 = richest).  i=BHID matches sample()/household_roster.
+    file:
+        - ../Data/w2_hh_all.dta
+    idxvars:
+        i: BHID
+    myvars:
+        Own Step: B10A_Q05

--- a/lsms_library/countries/Albania/2005/_/data_info.yml
+++ b/lsms_library/countries/Albania/2005/_/data_info.yml
@@ -96,3 +96,18 @@ interview_date:
     myvars:
         Int_t:
             - m0_date
+
+subjective_well_being:
+    # Module 7 "Subjective Poverty" (subjective_poverty_cl.dta).  Two
+    # economic-status ladder items are asked: m07_q09_1 = CURRENT step,
+    # m07_q09_2 = the retrospective companion.  Own Step = the current item
+    # (1-10; 1 = poorest, 10 = richest); the retrospective item is dropped.
+    # i=[m0_q00,m0_q01] -> composite via mapping.py:i() to match sample()'s
+    # household identity (the housing/interview_date idiom); the roster's bare
+    # i=m0_q01 is the known within-cluster-number defect we do NOT copy.
+    file:
+        - ../Data/subjective_poverty_cl.dta
+    idxvars:
+        i: [m0_q00, m0_q01]
+    myvars:
+        Own Step: m07_q09_1

--- a/lsms_library/countries/Albania/2008/_/data_info.yml
+++ b/lsms_library/countries/Albania/2008/_/data_info.yml
@@ -99,3 +99,18 @@ housing:
                 live for free: Live for free
                 other: Other
         Rooms: m13a_q08
+
+subjective_well_being:
+    # Module 7 "Subjective Poverty" (Modul_7_subjective_poverty.sav).  Two
+    # "economic status" ladder items: m07_q09 = CURRENT step, m07_q090 = the
+    # retrospective companion.  Own Step = the current item (1-10; 1 = poorest,
+    # 10 = richest); the retrospective item is dropped.  i=[psu,hh] -> composite
+    # via mapping.py:i() to match sample()'s household identity (the
+    # housing/interview_date idiom); the roster's bare i=hh is the known
+    # within-cluster-number defect we do NOT copy.
+    file:
+        - ../Data/Modul_7_subjective_poverty.sav
+    idxvars:
+        i: [psu, hh]
+    myvars:
+        Own Step: m07_q09

--- a/lsms_library/countries/Albania/2012/_/data_info.yml
+++ b/lsms_library/countries/Albania/2012/_/data_info.yml
@@ -75,3 +75,19 @@ housing:
         Toilet: m13a_q10
         Tenure: m13a_q14
         Rooms: m13a_q08
+
+subjective_well_being:
+    # Module 7 "Subjective Poverty" (Modul_7_Subjective_Poverty.sav).  Two
+    # ladder items: M7_Q09 "Step you are today" = CURRENT step, M7_Q9A
+    # "Step in 2008" = the retrospective companion.  Own Step = the current
+    # item (1-10; 1 = poorest, 10 = richest); the retrospective item is
+    # dropped.  The source carries psu + hh but not the global hhid used as
+    # household_roster's i, so i=[psu,hh] -> mapping.py:i() reconstructs
+    # hhid = psu*100 + hh to match the roster/sample (the housing idiom);
+    # _join_v_from_sample then resolves v.
+    file:
+        - ../Data/Modul_7_Subjective_Poverty.sav
+    idxvars:
+        i: [psu, hh]
+    myvars:
+        Own Step: M7_Q09

--- a/lsms_library/countries/Albania/_/data_scheme.yml
+++ b/lsms_library/countries/Albania/_/data_scheme.yml
@@ -52,6 +52,19 @@ Data Scheme:
     Tenure: str
     Rooms: float
 
+  # Module 7 "Subjective Poverty" (household questionnaire; Module 9 in the
+  # 2002 questionnaire numbering).  Self-placement welfare ladder: "imagine a
+  # ladder/scale of economic status; on which step does your household stand
+  # today?".  The native scale is 1-10 (1 = poorest, 10 = richest) in EVERY
+  # wired wave -- NOT the 6 steps suggested in the #331 verifier note (the data
+  # plainly span 1..10).  Own Step keeps the native 1-10 integer; higher =
+  # better off (consistent with the Malawi/Cantril anchor).  Only the CURRENT
+  # placement is carried; the retrospective "step N years ago" companion item
+  # present in 2005/2008/2012 is dropped.  No Neighbors/Friends step is asked.
+  subjective_well_being:
+    index: (t, i)
+    Own Step: int
+
   interview_date:
     index: (t, i)
     Int_t: datetime

--- a/lsms_library/countries/Benin/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Benin/2018-19/_/data_info.yml
@@ -110,6 +110,25 @@ household_roster:
         - i
         - pid
 
+subjective_well_being:
+    # Section 20 'Pauvreté relative', item s20q05: self-placement on a
+    # 4-point relative-welfare ladder.  Mapped to canonical Own Step
+    # (higher = better off, consistent with Malawi/Cantril).
+    # 'Ne sait pas' / 'Refus' / NaN -> NaN (LADDER construct only).
+    file: s20_me_ben2018.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Own Step:
+            - s20q05
+            - mapping:
+                Très pauvre: 1
+                Pauvre: 2
+                Moyen: 3
+                Riche: 4
+
 food_acquired:
     file: s07b_me_ben2018.dta
     idxvars:

--- a/lsms_library/countries/Benin/_/data_scheme.yml
+++ b/lsms_library/countries/Benin/_/data_scheme.yml
@@ -28,6 +28,14 @@ Data Scheme:
     index: (t, i, pid)
     Educational Attainment: str
 
+  subjective_well_being:
+    # EHCVM Section 20 'Pauvreté relative' item s20q05 -> Own Step, a
+    # 4-point relative-welfare ladder (1=Très pauvre ... 4=Riche;
+    # 'Ne sait pas'/NaN -> NaN).  LADDER construct only.  Benin's §20
+    # asks only the own-placement item, so no Neighbors/Friends Step.
+    index: (t, i)
+    Own Step: int
+
   food_acquired:
     # Canonical post-2026-05-05 (GH #169): s axis carries acquisition
     # source (purchased / produced / inkind / other).  The wave-level

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/data_info.yml
@@ -242,3 +242,22 @@ interview_date:
             - menage
     myvars:
         Int_t: s00q23a
+
+subjective_well_being:
+    # EHCVM §20 'Pauvreté relative'.  s20q05 = self-placement on a
+    # 4-point relative-wealth ladder.  Mapped higher = better off
+    # (Très pauvre=1 ... Riche=4); Ne sait pas -> NaN.
+    file: s20_me_bfa2018.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Own Step:
+            - s20q05
+            - mapping:
+                Très pauvre: 1
+                Pauvre: 2
+                Moyen: 3
+                Riche: 4
+                Ne sait pas: null

--- a/lsms_library/countries/Burkina_Faso/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2021-22/_/data_info.yml
@@ -223,3 +223,24 @@ interview_date:
             - menage
     myvars:
         Int_t: s00q23a
+
+subjective_well_being:
+    # EHCVM §20 'Pauvreté relative'.  In the 2021-22 instrument §20 was
+    # split into sub-modules A/B/C; sub-module A (s20a_me) is relative
+    # poverty, and s20aq05 is the ladder item equivalent to 2018-19's
+    # s20q05.  4-point relative-wealth scale, higher = better off
+    # (Très pauvre=1 ... Riche=4); Ne sait pas -> NaN.
+    file: s20a_me_bfa2021.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Own Step:
+            - s20aq05
+            - mapping:
+                Très pauvre: 1
+                Pauvre: 2
+                Moyen: 3
+                Riche: 4
+                Ne sait pas: null

--- a/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
+++ b/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
@@ -34,6 +34,18 @@ Data Scheme:
     index: (t, i, pid)
     Educational Attainment: str
 
+  subjective_well_being:
+    # Cantril-style self-placement ladder from EHCVM Section 20
+    # ('Pauvreté relative').  The ladder item is s20q05 (2018-19) /
+    # s20aq05 (2021-22; §20 was split into sub-modules A/B/C in the
+    # 2021 instrument, A = relative poverty).  4-point categorical scale
+    # mapped higher = better off, consistent with Malawi/Cantril:
+    # Très pauvre=1, Pauvre=2, Moyen=3, Riche=4; Ne sait pas / Refus /
+    # NaN -> NaN.  EHCVM asks only the own-placement item, so unlike
+    # Malawi there are no Neighbors/Friends Step columns.
+    index: (t,i)
+    Own Step: int
+
   panel_ids:
     index: (t, i)
     previous_i: str

--- a/lsms_library/countries/CotedIvoire/2018-19/_/data_info.yml
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/data_info.yml
@@ -113,6 +113,26 @@ household_roster:
         - i
         - pid
 
+subjective_well_being:
+    # EHCVM Section 20 'Pauvreté relative'.  s20q05 = self-placement on a
+    # 4-point relative-welfare ladder (Très pauvre / Pauvre / Moyen / Riche).
+    # Mapped to Own Step so higher = better off, consistent with the
+    # Malawi/Cantril ladder.  Ne sait pas / Refus / NaN -> NaN.
+    file: Menage/s20_me_CIV2018.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+    myvars:
+        Own Step:
+            - s20q05
+            - mapping:
+                Très pauvre: 1
+                Pauvre: 2
+                Moyen: 3
+                Riche: 4
+
 individual_education:
     file: Menage/ehcvm_individu_CIV2018.dta
     idxvars:

--- a/lsms_library/countries/CotedIvoire/_/data_scheme.yml
+++ b/lsms_library/countries/CotedIvoire/_/data_scheme.yml
@@ -29,6 +29,10 @@ Data Scheme:
     index: (t, i, pid)
     Educational Attainment: str
 
+  subjective_well_being:
+    index: (t, i)
+    Own Step: int
+
   shocks:
     index: (t, i, Shock)
     AffectedIncome: bool

--- a/lsms_library/countries/Ethiopia/_/CONTENTS.org
+++ b/lsms_library/countries/Ethiopia/_/CONTENTS.org
@@ -498,3 +498,10 @@ CLOSED: [2023-03-03 Fri 11:26]
 CLOSED: [2023-03-03 Fri 11:26]
 ** DONE other_features.py
 CLOSED: [2023-03-07 Tue 11:32]
+
+* subjective_well_being — not available (2026-06-06)
+No Ethiopia ESS wave (2011-12, 2013-14, 2015-16, 2018-19, 2021-22) carries a
+subjective-well-being / Cantril-ladder / life-satisfaction module. A variable-name
+scan of all 63-75 household section files per wave returned zero matches
+(ladder/well-being/satisfaction/step/life). Resolves the #331 "unknown" → absent.
+(Food-security IS present — see #332.) Tracked in #331.

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -237,3 +237,9 @@ Ghana's LSMS-ISA participation is through the GhanaSPS (Social Panel Survey), no
 ** TODO household_characteristics.py
 ** TODO food_acquired.py
 ** TODO other_features.py
+
+* subjective_well_being — not available (2026-06-06)
+No GLSS wave (1987-88…2016-17) carries a subjective-well-being / life-evaluation /
+subjective-poverty ladder. GLSS7 §13 is "Governance, Peace, Security" (political
+participation + threat perception), not SWB. Confirmed by a variable-label scan of
+all section files. Resolves the #331 "unknown" → absent. Tracked in #331.

--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/data_info.yml
@@ -203,6 +203,31 @@ assets:
         Value: s12q09
         Purchase Price: s12q08
 
+subjective_well_being:
+    # Section 20 'Pauvreté relative', item s20q05: self-placement on a
+    # 4-point welfare ladder.  Portuguese labels (Muito pobre / Pobre /
+    # Medio / Rico) mapped to Own Step 1-4 (higher = better off);
+    # Não sabe / Refus / NaN -> NaN.  Also map the French EHCVM labels
+    # in case other waves/exports localize differently.
+    file: s20_me_gnb2018.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Own Step:
+            - s20q05
+            - mapping:
+                Muito pobre: 1
+                Pobre: 2
+                Medio: 3
+                Médio: 3
+                Rico: 4
+                Très pauvre: 1
+                Pauvre: 2
+                Moyen: 3
+                Riche: 4
+
 individual_education:
     file: ehcvm_individu_gnb2018.dta
     idxvars:

--- a/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
+++ b/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
@@ -29,6 +29,14 @@ Data Scheme:
     index: (t, i, pid)
     Educational Attainment: str
 
+  subjective_well_being:
+    # EHCVM Section 20 'Pauvreté relative' ladder item s20q05: household
+    # self-placement on a 4-point welfare ladder (higher = better off).
+    # Portuguese labels in the Guinea-Bissau .dta: Muito pobre / Pobre /
+    # Medio / Rico (+ Não sabe -> NaN).  LADDER construct only (Own Step).
+    index: (t, i)
+    Own Step: int
+
   shocks:
     index: (t, i, Shock)
     AffectedIncome: bool

--- a/lsms_library/countries/Kazakhstan/1996/_/subjective_well_being.py
+++ b/lsms_library/countries/Kazakhstan/1996/_/subjective_well_being.py
@@ -1,0 +1,75 @@
+"""
+Kazakhstan 1996 subjective_well_being (Cantril / self-anchoring ladder).
+
+Source: ../Data/KZ96OCC_PUF.dta (catalog F20, the individual occupation file).
+Variable ``d_095_`` carries the variable label "personal staircase
+identification" -- a Cantril self-anchoring ladder.  Its Stata value labels are
+{1: 'lowest', 2..8: literal, 9: 'highest'}, i.e. a 1-9 step scale where higher =
+better off (consistent with the Malawi anchor and the Cantril convention).  The
+raw column stores the labelled strings ('lowest', '2', ..., '8', 'highest'); we
+recover the integer step from the value labels.
+
+This is an INDIVIDUAL-level file (one row per respondent within a household,
+keyed by rn = household, personnr = person).  The canonical
+subjective_well_being table is household level (t, i) with i = rn (the household
+key used by household_roster, idxvars i: rn).  We reduce to the household by
+taking the HOUSEHOLD HEAD's ladder step:
+
+  - The roster (KZ96REL.dta) has exactly one head per household (relhead == 1,
+    1996 households).  1992 of those heads appear in the OCC respondent file and
+    1983 give a non-missing ladder step.
+  - The head is the natural representative for a household-level welfare
+    self-placement, and using a single well-defined member avoids arbitrary
+    aggregation (mean/mode) across respondents.
+
+Households whose head did not answer the OCC ladder question are dropped.
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+# 1-9 Cantril ladder.  Raw values are the Stata labels; map back to int step.
+step_mapping = {
+    'lowest': 1,
+    '1': 1,
+    '2': 2,
+    '3': 3,
+    '4': 4,
+    '5': 5,
+    '6': 6,
+    '7': 7,
+    '8': 8,
+    '9': 9,
+    'highest': 9,
+}
+
+# Heads from the roster: relhead == 1, one per household.
+rel = get_dataframe('../Data/KZ96REL.dta')
+heads = rel[rel['relhead'].astype(str).str.split('.').str[0] == '1'][['rn', 'personnr']].copy()
+heads['i'] = heads['rn'].astype(float).astype(int).astype(str)
+heads['personnr'] = heads['personnr'].astype(float).astype(int)
+
+# Individual ladder from the occupation file.
+occ = get_dataframe('../Data/KZ96OCC_PUF.dta')[['rn', 'personnr', 'd_095_']].copy()
+occ['i'] = occ['rn'].astype(float).astype(int).astype(str)
+occ['personnr'] = occ['personnr'].astype(float).astype(int)
+
+
+def to_step(x):
+    if pd.isna(x):
+        return pd.NA
+    return step_mapping.get(str(x).strip(), pd.NA)
+
+
+occ['Own Step'] = occ['d_095_'].map(to_step)
+
+# Restrict to the household head, reduce to one row per household.
+head_step = heads.merge(occ[['i', 'personnr', 'Own Step']],
+                        on=['i', 'personnr'], how='left')
+
+out = head_step[['i', 'Own Step']].copy()
+out['t'] = '1996'
+out = out.dropna(subset=['Own Step'])
+out['Own Step'] = out['Own Step'].astype('Int64')
+out = out.drop_duplicates(subset=['t', 'i']).set_index(['t', 'i']).sort_index()
+
+to_parquet(df=out, fn='subjective_well_being.parquet')

--- a/lsms_library/countries/Kazakhstan/_/CONTENTS.org
+++ b/lsms_library/countries/Kazakhstan/_/CONTENTS.org
@@ -10,3 +10,18 @@ individual level (~dob~ in KZ96REL) and at the community level (KOMMU has
 survey dates ~a4day/a4mon/a4year~, but these are not household-linked).
 ~interview_date~ is therefore not implementable from the available
 microdata.  Tracked in GitHub issue #341.
+
+* subjective_well_being (Cantril ladder) — 1996 (2026-06-06, #331)
+Source: KZ96OCC_PUF.dta (catalog F20, individual occupation file), variable
+~d_095_~ = "personal staircase identification" — a Cantril self-anchoring
+ladder with Stata value labels {1: 'lowest', 2..8 literal, 9: 'highest'},
+i.e. a 1-9 step scale, higher = better off (consistent with the Malawi
+anchor).  Only ~Own Step~ is asked (no Neighbors/Friends item).
+
+The OCC file is INDIVIDUAL level (rn = household, personnr = person).  The
+canonical table is household level (t, i), i = rn.  We reduce by taking the
+HOUSEHOLD HEAD's step: the roster (KZ96REL) has exactly one head per
+household (relhead == 1); 1992 of 1996 heads appear in OCC and 1983 give a
+non-missing step.  Households whose head did not answer are dropped.
+Built via ~1996/_/subjective_well_being.py~ (materialize: make).  Observed
+range 1-8 (no household head reported step 9).

--- a/lsms_library/countries/Kazakhstan/_/data_scheme.yml
+++ b/lsms_library/countries/Kazakhstan/_/data_scheme.yml
@@ -27,6 +27,11 @@ Data Scheme:
     index: (t, i, pid)
     Educational Attainment: str
 
+  subjective_well_being:
+    index: (t, i)
+    Own Step: int
+    materialize: make
+
   sample:
     index: (i, t)
     v: str

--- a/lsms_library/countries/Mali/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Mali/2018-19/_/data_info.yml
@@ -2,6 +2,28 @@ Country: Mali
 Wave: 2018-19
 
 
+subjective_well_being:
+    # EHCVM Section 20 'Pauvreté relative'.  s20q05 = self-placement on a
+    # 4-point relative-welfare ladder (Très pauvre / Pauvre / Moyen / Riche).
+    # Mapped to Own Step so higher = better off, consistent with the
+    # Malawi/Cantril ladder.  Ne sait pas / Refus / NaN -> NaN.
+    # NB: the 2018-19 .dta truncates the "Très pauvre" label to "Tr".
+    file: s20_me_mli2018.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+    myvars:
+        Own Step:
+            - s20q05
+            - mapping:
+                Tr: 1
+                Pauvre: 2
+                Moyen: 3
+                Riche: 4
+
+
 sample:
     dfs:
         - df_cover

--- a/lsms_library/countries/Mali/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Mali/2021-22/_/data_info.yml
@@ -1,6 +1,26 @@
 Country: Mali
 Wave: 2021-22
 
+subjective_well_being:
+    # EHCVM Section 20a 'Pauvreté relative'.  s20aq05 = self-placement on a
+    # 4-point relative-welfare ladder (Très pauvre / Pauvre / Moyen / Riche).
+    # Mapped to Own Step so higher = better off, consistent with the
+    # Malawi/Cantril ladder.  Ne sait pas / Refus / NaN -> NaN.
+    file: s20a_me_mli2021.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+    myvars:
+        Own Step:
+            - s20aq05
+            - mapping:
+                Très pauvre: 1
+                Pauvre: 2
+                Moyen: 3
+                Riche: 4
+
 sample:
     dfs:
         - df_cover

--- a/lsms_library/countries/Mali/_/data_scheme.yml
+++ b/lsms_library/countries/Mali/_/data_scheme.yml
@@ -25,6 +25,13 @@ Data Scheme:
   individual_education:
     index: (t, i, pid)
     Educational Attainment: str
+  subjective_well_being:
+    # EHCVM Section 20 'Pauvreté relative' (s20/s20a).  Self-placement on
+    # a 4-point relative-welfare ladder (Très pauvre / Pauvre / Moyen /
+    # Riche) mapped to Own Step 1-4 so higher = better off, consistent
+    # with the Malawi/Cantril ladder.  EHCVM waves only (2018-19, 2021-22).
+    index: (t, i)
+    Own Step: int
   food_acquired:
     # Canonical post-2026-05-05 (GH #169): s axis carries acquisition
     # source (purchased / produced / inkind / other).  EHCVM 2018-19

--- a/lsms_library/countries/Niger/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Niger/2018-19/_/data_info.yml
@@ -50,6 +50,26 @@ food_acquired:
         Expenditure: s07bq08
         Produced: s07bq04
 
+subjective_well_being:
+    # EHCVM Section 20 'Pauvreté relative'.  s20q05 = self-placement on a
+    # 4-point relative-welfare ladder (Très pauvre / Pauvre / Moyen /
+    # Riche).  Mapped to Own Step so higher = better off, consistent with
+    # the Malawi/Cantril ladder.  Ne sait pas / NaN -> NaN.
+    file: s20_me_ner2018.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+    myvars:
+        Own Step:
+            - s20q05
+            - mapping:
+                Très pauvre: 1
+                Pauvre: 2
+                Moyen: 3
+                Riche: 4
+
 household_roster:
   dfs:
     - df_main

--- a/lsms_library/countries/Niger/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Niger/2021-22/_/data_info.yml
@@ -37,6 +37,26 @@ sample:
         - i
         - t
 
+subjective_well_being:
+    # EHCVM Section 20a 'Pauvreté relative'.  s20aq05 = self-placement on
+    # a 4-point relative-welfare ladder (Très pauvre / Pauvre / Moyen /
+    # Riche).  Mapped to Own Step so higher = better off, consistent with
+    # the Malawi/Cantril ladder.  Ne sait pas / NaN -> NaN.
+    file: s20a_me_ner2021.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+    myvars:
+        Own Step:
+            - s20aq05
+            - mapping:
+                Très pauvre: 1
+                Pauvre: 2
+                Moyen: 3
+                Riche: 4
+
 household_roster:
     dfs:
         - df_main

--- a/lsms_library/countries/Niger/_/data_scheme.yml
+++ b/lsms_library/countries/Niger/_/data_scheme.yml
@@ -74,6 +74,19 @@ Data Scheme:
     Roof: str
     Floor: str
 
+  subjective_well_being:
+    # EHCVM Section 20 'Pauvreté relative' (s20 / s20a).  Self-placement
+    # on a 4-point relative-welfare ladder (Très pauvre / Pauvre / Moyen
+    # / Riche) mapped to Own Step 1-4 so higher = better off, consistent
+    # with the Malawi/Cantril ladder.  EHCVM waves only (2018-19,
+    # 2021-22).  The pre-EHCVM ECVMA waves (2011-12, 2014-15) have no
+    # self-placement welfare ladder: ECVMA2 §15 'Aspirations'
+    # (ECVMA2_MS15P1, MS15Q16 = "Pensez-vous que vous aurez le même
+    # succès dans votre vie") is a binary expectation/aspiration item,
+    # not a current ladder, so it is deliberately NOT wired here.
+    index: (t, i)
+    Own Step: int
+
   interview_date:
     index: (t, i)
     Int_t: datetime

--- a/lsms_library/countries/Senegal/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Senegal/2018-19/_/data_info.yml
@@ -210,6 +210,27 @@ individual_education:
     myvars:
         Educational Attainment: 'educ_hi'
 
+subjective_well_being:
+    # EHCVM §20 'Pauvreté relative' ladder; s20q05 self-placement on a
+    # 4-point welfare scale -> Own Step (higher = better off).
+    # Ne sait pas / Refus / NaN -> NaN.
+    file: s20_me_sen2018.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+    myvars:
+        Own Step:
+            - s20q05
+            - mapping:
+                Très pauvre: 1
+                Pauvre: 2
+                Moyen: 3
+                Riche: 4
+                Ne sait pas: null
+                Refus: null
+
 housing:
     file: s11_me_sen2018.dta
     idxvars:

--- a/lsms_library/countries/Senegal/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Senegal/2021-22/_/data_info.yml
@@ -198,6 +198,28 @@ individual_education:
     myvars:
         Educational Attainment: 'educ_hi'
 
+subjective_well_being:
+    # EHCVM §20 'Pauvreté relative' ladder.  In 2021-22 §20 was split
+    # into a/b/c subsections; the self-placement item moved to s20aq05
+    # (file s20a_me_sen2021.dta) with identical 4-point labels.
+    # -> Own Step (higher = better off).  Ne sait pas / Refus / NaN -> NaN.
+    file: s20a_me_sen2021.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+    myvars:
+        Own Step:
+            - s20aq05
+            - mapping:
+                Très pauvre: 1
+                Pauvre: 2
+                Moyen: 3
+                Riche: 4
+                Ne sait pas: null
+                Refus: null
+
 housing:
     file: s11_me_sen2021.dta
     idxvars:

--- a/lsms_library/countries/Senegal/_/data_scheme.yml
+++ b/lsms_library/countries/Senegal/_/data_scheme.yml
@@ -25,6 +25,17 @@ Data Scheme:
     index: (t, i, pid)
     Educational Attainment: str
 
+  subjective_well_being:
+    # EHCVM Section 20 'Pauvreté relative' self-placement ladder.
+    # Single item: respondent classes the household on a 4-point
+    # welfare scale (Très pauvre / Pauvre / Moyen / Riche) mapped to
+    # Own Step 1-4 (higher = better off, consistent with Malawi/Cantril).
+    # Ne sait pas / Refus / NaN -> NaN.  Source item: s20q05 (2018-19),
+    # s20aq05 (2021-22, after §20 was split into a/b/c subsections).
+    # Only 'Own Step' is asked (no Neighbors/Friends placement).
+    index: (t, i)
+    Own Step: int
+
   shocks:
     index: (t, i, Shock)
     AffectedIncome: bool

--- a/lsms_library/countries/Togo/2018/_/data_info.yml
+++ b/lsms_library/countries/Togo/2018/_/data_info.yml
@@ -124,6 +124,23 @@ individual_education:
     myvars:
         Educational Attainment: 'educ_hi'
 
+subjective_well_being:
+    file: ../Data1/s20_me_tgo2018.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Own Step:
+            - s20q05
+            - mapping:
+                Très pauvre: 1
+                Pauvre: 2
+                Moyen: 3
+                Riche: 4
+                Ne sait pas: null
+                Refus: null
+
 assets:
     file: ../Data1/s12_me_tgo2018.dta
     idxvars:

--- a/lsms_library/countries/Togo/_/data_scheme.yml
+++ b/lsms_library/countries/Togo/_/data_scheme.yml
@@ -25,6 +25,14 @@ Data Scheme:
   individual_education:
     index: (t, i, pid)
     Educational Attainment: str
+  subjective_well_being:
+    # EHCVM §20 'Pauvreté relative' ladder item s20q05: self-placement
+    # on a 4-point welfare ladder (Très pauvre=1, Pauvre=2, Moyen=3,
+    # Riche=4; higher = better off, as in Malawi/Cantril).  Ne sait pas /
+    # Refus / NaN -> NaN.  Only the Own-placement item exists in EHCVM;
+    # no Neighbors/Friends steps (unlike Malawi).
+    index: (t, i)
+    Own Step: int
   food_acquired:
     # Canonical post-2026-05-05 (GH #169): s axis carries acquisition
     # source (purchased / produced / inkind / other).  The wave-level


### PR DESCRIPTION
Wires the **Cantril/welfare ladder** half of #331 (the 'two features' design: `subjective_well_being` = ladder; a future `life_satisfaction` = satisfaction ratings). Was Malawi-only; now 11 countries.

| Country | Waves | Source | Own Step |
|---|---|---|---|
| Senegal/Mali/Burkina Faso/Niger | 2018-19 + 2021-22 | EHCVM §20 `s20q05` / §20a `s20aq05` | 1-4 |
| Côte d'Ivoire/Togo/Benin/Guinea-Bissau | 2018-19 | EHCVM §20 `s20q05` | 1-4 |
| Kazakhstan | 1996 | Cantril `d_095_` (head-reduced) | 1-9 |
| Albania | 2002/03/05/08/12 | Module 7 subjective poverty | 1-10 |

All `is_this_feature_sane.ok=True`; `Feature('subjective_well_being')()` = 11 countries, 139,476 rows, `(country,i,t,v)`, no collapse.

- **One shared EHCVM §20 extractor** covers 8 already-wired ISA countries — the high-leverage pattern from #331. `Très pauvre=1 … Riche=4` (higher=better off).
- Agents caught: 2021-22 §20→§20a sub-module split; Mali's `'Tr'` truncated label; Guinea-Bissau's Portuguese labels; Albania's 10-step (not 6) scale + the #340 roster-`i` bug (worked around via the sample identity); Niger §15 is *aspirations* not a ladder (excluded).
- **Scale differs by survey** (1-4 / 1-9 / 1-10) — documented per country, not rescaled (comparability caveat).
- **4 unknowns resolved:** Benin, Guinea-Bissau present (wired); GhanaLSS, Ethiopia absent (CONTENTS.org + #331).

Design: `slurm_logs/2026-06-06_assets_ineduc/DESIGN_swb_331.md`. **Deferred to `life_satisfaction` (feature 2):** Iraq/Tajikistan/South Africa/Tanzania/Timor/Serbia&Montenegro/Armenia — pending schema sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)