### PR TITLE
feat: food_security (FIES) — 11 countries (#332, FIES-canonical)

### DIFF
--- a/lsms_library/countries/Benin/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Benin/2018-19/_/data_info.yml
@@ -129,6 +129,65 @@ subjective_well_being:
                 Moyen: 3
                 Riche: 4
 
+food_security:
+    # EHCVM Section 8A 'Sécurité alimentaire' — the FAO 8-item Food
+    # Insecurity Experience Scale (FIES), recall period = last 12 months
+    # ("12 derniers mois").  s08aq01..s08aq08 map IN ORDER to the 8
+    # canonical FIES items (q01=worried, q02=healthy/nutritious,
+    # q03=few foods, q04=skip meal, q05=ate less, q06=ran out,
+    # q07=hungry-not-eat, q08=whole day).  Values Oui->True, Non->False;
+    # "Ne sait pas"/"Refus"/NaN->NaN (full strings, verified in the .dta).
+    # The s08aq07a/s08aq08a frequency follow-ups are ignored.  FCS
+    # (#332) is intentionally out of scope.  FIES_score (count of True
+    # across the 8 items) is computed by mapping.food_security().
+    file: s08a_me_ben2018.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+    myvars:
+        Worried:
+            - s08aq01
+            - mapping:
+                Oui: True
+                Non: False
+        HealthyDiet:
+            - s08aq02
+            - mapping:
+                Oui: True
+                Non: False
+        FewFoods:
+            - s08aq03
+            - mapping:
+                Oui: True
+                Non: False
+        SkippedMeal:
+            - s08aq04
+            - mapping:
+                Oui: True
+                Non: False
+        AteLess:
+            - s08aq05
+            - mapping:
+                Oui: True
+                Non: False
+        RanOut:
+            - s08aq06
+            - mapping:
+                Oui: True
+                Non: False
+        Hungry:
+            - s08aq07
+            - mapping:
+                Oui: True
+                Non: False
+        WholeDay:
+            - s08aq08
+            - mapping:
+                Oui: True
+                Non: False
+
 food_acquired:
     file: s07b_me_ben2018.dta
     idxvars:

--- a/lsms_library/countries/Benin/2018-19/_/mapping.py
+++ b/lsms_library/countries/Benin/2018-19/_/mapping.py
@@ -74,6 +74,29 @@ def household_roster(df):
     return df
 
 
+_FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+               'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+
+def food_security(df):
+    '''Compute FIES_score from the 8 FAO FIES experience items.
+
+    EHCVM §8A items s08aq01..s08aq08 have already been mapped to the 8
+    canonical bool columns by the YAML ``mapping:`` blocks (Oui->True,
+    Non->False, everything else->NaN).  FIES_score is the row-wise count
+    of True across those 8 items.  Per the canonical contract it is NaN
+    only when ALL 8 items are NaN; otherwise NaN items count as 0 (not
+    affirmative).
+    '''
+    items = df[_FIES_ITEMS].apply(lambda c: c.map({True: 1, False: 0}))
+    score = items.sum(axis=1, skipna=True)
+    all_na = items.isna().all(axis=1)
+    score = score.where(~all_na, np.nan)
+    df = df.copy()
+    df['FIES_score'] = score.astype('Int64')
+    return df
+
+
 def shocks(df):
     # Benin 2018-19 records at most 2 coping strategies per household.
     # (A probe over the full survey shows no household with a third

--- a/lsms_library/countries/Benin/_/data_scheme.yml
+++ b/lsms_library/countries/Benin/_/data_scheme.yml
@@ -36,6 +36,25 @@ Data Scheme:
     index: (t, i)
     Own Step: int
 
+  food_security:
+    # FAO 8-item Food Insecurity Experience Scale (FIES).  EHCVM §8A
+    # 'Sécurité alimentaire', recall period = last 12 months.  Single
+    # EHCVM wave (2018-19) reads s08a_me_ben2018.dta; items
+    # s08aq01..s08aq08 map IN ORDER to the 8 canonical FIES items
+    # (Worried..WholeDay).  Values Oui->True, Non->False;
+    # "Ne sait pas"/"Refus"/NaN->NaN.  FCS (#332) is deliberately NOT
+    # wired here; only the FIES binary battery is exposed.
+    index: (t, i)
+    Worried: bool
+    HealthyDiet: bool
+    FewFoods: bool
+    SkippedMeal: bool
+    AteLess: bool
+    RanOut: bool
+    Hungry: bool
+    WholeDay: bool
+    FIES_score: int
+
   food_acquired:
     # Canonical post-2026-05-05 (GH #169): s axis carries acquisition
     # source (purchased / produced / inkind / other).  The wave-level

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/data_info.yml
@@ -243,6 +243,47 @@ interview_date:
     myvars:
         Int_t: s00q23a
 
+food_security:
+    # FAO 8-item FIES, EHCVM §8A.  s08aq01..08 -> Worried..WholeDay in
+    # FAO order (verified from variable labels).  Oui->True, Non->False,
+    # 'Ne sait pas'/'Refus'->NaN.  Recall: last 12 months.  s08aq07a/08a
+    # are frequency follow-ups -- ignored for the binary scale.
+    # FIES_score is computed in mapping.py's food_security() post-processor.
+    file: s08a_me_bfa2018.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Worried:
+            - s08aq01
+            - mapping: &fies_yn
+                Oui: true
+                Non: false
+                Ne sait pas: null
+                Refus: null
+        HealthyDiet:
+            - s08aq02
+            - mapping: *fies_yn
+        FewFoods:
+            - s08aq03
+            - mapping: *fies_yn
+        SkippedMeal:
+            - s08aq04
+            - mapping: *fies_yn
+        AteLess:
+            - s08aq05
+            - mapping: *fies_yn
+        RanOut:
+            - s08aq06
+            - mapping: *fies_yn
+        Hungry:
+            - s08aq07
+            - mapping: *fies_yn
+        WholeDay:
+            - s08aq08
+            - mapping: *fies_yn
+
 subjective_well_being:
     # EHCVM §20 'Pauvreté relative'.  s20q05 = self-placement on a
     # 4-point relative-wealth ladder.  Mapped higher = better off

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/mapping.py
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/mapping.py
@@ -77,6 +77,33 @@ def household_roster(df):
     return df
 
 
+FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+              'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+
+def food_security(df):
+    '''
+    FAO 8-item FIES post-processor (EHCVM §8A).
+
+    The YAML maps s08aq01..08 (Oui/Non) to True/False, with
+    'Ne sait pas'/'Refus' -> None.  Here we coerce each item to a
+    nullable boolean and compute FIES_score = count of True across the
+    8 items.  FIES_score is NaN only when ALL 8 items are NaN; otherwise
+    a NaN item contributes 0 to the count (standard for the raw FIES
+    affirmative-count screener).
+    '''
+    for c in FIES_ITEMS:
+        df[c] = df[c].astype('boolean')
+
+    items = df[FIES_ITEMS]
+    score = items.sum(axis=1, skipna=True)              # True counts as 1
+    all_na = items.isna().all(axis=1)
+    score = score.astype('Int64')
+    score[all_na] = pd.NA
+    df['FIES_score'] = score
+    return df
+
+
 COPING_LABELS = {
     1: "Utilisation de son épargne",
     2: "Aide de parents ou d'amis",

--- a/lsms_library/countries/Burkina_Faso/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2021-22/_/data_info.yml
@@ -224,6 +224,48 @@ interview_date:
     myvars:
         Int_t: s00q23a
 
+food_security:
+    # FAO 8-item FIES, EHCVM §8A.  s08aq01..08 -> Worried..WholeDay in
+    # FAO order (same instrument as 2018-19; §8 was NOT split into
+    # sub-modules unlike §20).  Oui->True, Non->False,
+    # 'Ne sait pas'/'Refus'->NaN.  Recall: last 12 months.  s08aq07a/08a
+    # are frequency follow-ups -- ignored.  FIES_score computed in
+    # mapping.py's food_security() post-processor.
+    file: s08a_me_bfa2021.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Worried:
+            - s08aq01
+            - mapping: &fies_yn
+                Oui: true
+                Non: false
+                Ne sait pas: null
+                Refus: null
+        HealthyDiet:
+            - s08aq02
+            - mapping: *fies_yn
+        FewFoods:
+            - s08aq03
+            - mapping: *fies_yn
+        SkippedMeal:
+            - s08aq04
+            - mapping: *fies_yn
+        AteLess:
+            - s08aq05
+            - mapping: *fies_yn
+        RanOut:
+            - s08aq06
+            - mapping: *fies_yn
+        Hungry:
+            - s08aq07
+            - mapping: *fies_yn
+        WholeDay:
+            - s08aq08
+            - mapping: *fies_yn
+
 subjective_well_being:
     # EHCVM §20 'Pauvreté relative'.  In the 2021-22 instrument §20 was
     # split into sub-modules A/B/C; sub-module A (s20a_me) is relative

--- a/lsms_library/countries/Burkina_Faso/2021-22/_/mapping.py
+++ b/lsms_library/countries/Burkina_Faso/2021-22/_/mapping.py
@@ -4,6 +4,33 @@ import numpy as np
 import lsms_library.local_tools as tools
 from lsms_library.transformations import food_acquired_to_canonical as food_acquired
 
+FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+              'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+
+def food_security(df):
+    '''
+    FAO 8-item FIES post-processor (EHCVM §8A).
+
+    The YAML maps s08aq01..08 (Oui/Non) to True/False, with
+    'Ne sait pas'/'Refus' -> None.  Here we coerce each item to a
+    nullable boolean and compute FIES_score = count of True across the
+    8 items.  FIES_score is NaN only when ALL 8 items are NaN; otherwise
+    a NaN item contributes 0 to the count (standard for the raw FIES
+    affirmative-count screener).
+    '''
+    for c in FIES_ITEMS:
+        df[c] = df[c].astype('boolean')
+
+    items = df[FIES_ITEMS]
+    score = items.sum(axis=1, skipna=True)              # True counts as 1
+    all_na = items.isna().all(axis=1)
+    score = score.astype('Int64')
+    score[all_na] = pd.NA
+    df['FIES_score'] = score
+    return df
+
+
 COPING_LABELS = {
     1: "Utilisation de son épargne",
     2: "Aide de parents ou d'amis",

--- a/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
+++ b/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
@@ -111,6 +111,27 @@ Data Scheme:
     Irrigated: bool
     materialize: make
 
+  food_security:
+    # FAO 8-item Food Insecurity Experience Scale (FIES) from EHCVM
+    # Section 8A 'Sécurité alimentaire'.  s08aq01..s08aq08 map IN ORDER
+    # to the 8 canonical FAO items (Worried..WholeDay); Oui->True,
+    # Non->False, 'Ne sait pas'/'Refus'/NaN->NaN.  Recall period: last
+    # 12 months.  FIES_score = count of True across the 8 items (NaN
+    # only if all 8 are NaN), computed in each wave's food_security()
+    # post-processor in mapping.py.  Both EHCVM waves (2018-19, 2021-22)
+    # use s08a_me_bfa<YYYY>.dta with identical structure; the §20->§20a
+    # sub-module split did NOT extend to §8.
+    index: (t, i)
+    Worried: bool
+    HealthyDiet: bool
+    FewFoods: bool
+    SkippedMeal: bool
+    AteLess: bool
+    RanOut: bool
+    Hungry: bool
+    WholeDay: bool
+    FIES_score: int
+
   interview_date:
     index: (t, i)
     Int_t: datetime

--- a/lsms_library/countries/CotedIvoire/2018-19/_/data_info.yml
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/data_info.yml
@@ -133,6 +133,62 @@ subjective_well_being:
                 Moyen: 3
                 Riche: 4
 
+food_security:
+    # EHCVM Section 8A 'Sécurité alimentaire' — the FAO 8-item Food
+    # Insecurity Experience Scale (FIES), recall period = last 12 months.
+    # s08aq01..s08aq08 map IN ORDER to the 8 canonical FIES items.
+    # Values Oui->True, Non->False; "Ne sait pas"/"Refus"/NaN->NaN.
+    # The s08aq07a/s08aq08a frequency follow-ups are ignored (the binary
+    # scale only uses the yes/no item itself).  FIES_score (count of True
+    # across the 8 items) is computed by mapping.food_security().
+    file: Menage/s08a_me_CIV2018.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+    myvars:
+        Worried:
+            - s08aq01
+            - mapping:
+                Oui: True
+                Non: False
+        HealthyDiet:
+            - s08aq02
+            - mapping:
+                Oui: True
+                Non: False
+        FewFoods:
+            - s08aq03
+            - mapping:
+                Oui: True
+                Non: False
+        SkippedMeal:
+            - s08aq04
+            - mapping:
+                Oui: True
+                Non: False
+        AteLess:
+            - s08aq05
+            - mapping:
+                Oui: True
+                Non: False
+        RanOut:
+            - s08aq06
+            - mapping:
+                Oui: True
+                Non: False
+        Hungry:
+            - s08aq07
+            - mapping:
+                Oui: True
+                Non: False
+        WholeDay:
+            - s08aq08
+            - mapping:
+                Oui: True
+                Non: False
+
 individual_education:
     file: Menage/ehcvm_individu_CIV2018.dta
     idxvars:

--- a/lsms_library/countries/CotedIvoire/2018-19/_/mapping.py
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/mapping.py
@@ -97,6 +97,29 @@ def food_acquired(df):
     return df
 
 
+_FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+               'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+
+def food_security(df):
+    '''Compute FIES_score from the 8 FAO FIES experience items.
+
+    EHCVM §8A items s08aq01..s08aq08 have already been mapped to the 8
+    canonical bool columns by the YAML ``mapping:`` blocks (Oui->True,
+    Non->False, everything else->NaN).  FIES_score is the row-wise count
+    of True across those 8 items.  Per the canonical contract it is NaN
+    only when ALL 8 items are NaN; otherwise NaN items count as 0 (not
+    affirmative).
+    '''
+    items = df[_FIES_ITEMS].apply(lambda c: c.map({True: 1, False: 0}))
+    score = items.sum(axis=1, skipna=True)
+    all_na = items.isna().all(axis=1)
+    score = score.where(~all_na, np.nan)
+    df = df.copy()
+    df['FIES_score'] = score.astype('Int64')
+    return df
+
+
 def pid(value):
     '''Formatting person id from (grappe, menage, individual).'''
     return (tools.format_id(value.iloc[0]) + '0'

--- a/lsms_library/countries/CotedIvoire/_/data_scheme.yml
+++ b/lsms_library/countries/CotedIvoire/_/data_scheme.yml
@@ -33,6 +33,20 @@ Data Scheme:
     index: (t, i)
     Own Step: int
 
+  food_security:
+    # FAO 8-item Food Insecurity Experience Scale (FIES).  EHCVM §8A
+    # 'Sécurité alimentaire', recall period = last 12 months.
+    index: (t, i)
+    Worried: bool
+    HealthyDiet: bool
+    FewFoods: bool
+    SkippedMeal: bool
+    AteLess: bool
+    RanOut: bool
+    Hungry: bool
+    WholeDay: bool
+    FIES_score: int
+
   shocks:
     index: (t, i, Shock)
     AffectedIncome: bool

--- a/lsms_library/countries/Ethiopia/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Ethiopia/2021-22/_/data_info.yml
@@ -169,3 +169,63 @@ interview_date:
         i: household_id
     myvars:
         int_t: InterviewDate
+
+food_security:
+    # FAO FIES 8-item experience scale.  ESS §8 file sect8_hh_w5.dta
+    # carries the full FAO battery, but the question order is NOT the
+    # sequential FAO order — the items are mapped BY LABEL:
+    #   s8q01 worried -> Worried        (12-month recall)
+    #   s8q02 unable healthy/nutritious -> HealthyDiet
+    #   s8q03 only a few kinds of foods -> FewFoods
+    #   s8q04 had to skip a meal        -> SkippedMeal
+    #   s8q05 ate less than should      -> AteLess
+    #   s8q07 ran out of food           -> RanOut
+    #   s8q08 hungry but did not eat    -> Hungry
+    #   s8q06 whole day without eating  -> WholeDay  (30-day recall)
+    # Items recorded as '1. YES'/'2. NO' -> True/False; NaN stays NaN.
+    # FIES_score (count of True over the 8 items) is computed row-wise by
+    # the food_security() df_edit function in mapping.py.
+    file: sect8_hh_w5.dta
+    idxvars:
+        i: household_id
+    myvars:
+        Worried:
+            - s8q01
+            - mapping:
+                '1. YES': true
+                '2. NO': false
+        HealthyDiet:
+            - s8q02
+            - mapping:
+                '1. YES': true
+                '2. NO': false
+        FewFoods:
+            - s8q03
+            - mapping:
+                '1. YES': true
+                '2. NO': false
+        SkippedMeal:
+            - s8q04
+            - mapping:
+                '1. YES': true
+                '2. NO': false
+        AteLess:
+            - s8q05
+            - mapping:
+                '1. YES': true
+                '2. NO': false
+        RanOut:
+            - s8q07
+            - mapping:
+                '1. YES': true
+                '2. NO': false
+        Hungry:
+            - s8q08
+            - mapping:
+                '1. YES': true
+                '2. NO': false
+        WholeDay:
+            - s8q06
+            - mapping:
+                '1. YES': true
+                '2. NO': false

--- a/lsms_library/countries/Ethiopia/2021-22/_/mapping.py
+++ b/lsms_library/countries/Ethiopia/2021-22/_/mapping.py
@@ -1,0 +1,37 @@
+"""Wave-level formatting functions for Ethiopia 2021-22 (W5).
+
+The ``food_security`` function is picked up by name as the ``df_edit``
+hook for the ``food_security`` request (see ``Wave.column_mapping`` /
+``get_formatting_functions``).  It runs on the DataFrame after the 8
+FIES item columns have been mapped to True/False/NaN, and it:
+
+  1. coerces the 8 items to pandas nullable ``boolean`` dtype, and
+  2. adds ``FIES_score`` = count of True across the 8 items (NaN only
+     when all 8 items are NaN).
+"""
+
+import pandas as pd
+
+FIES_ITEMS = [
+    "Worried", "HealthyDiet", "FewFoods", "SkippedMeal",
+    "AteLess", "RanOut", "Hungry", "WholeDay",
+]
+
+
+def food_security(df):
+    """Coerce FIES items to nullable boolean and add FIES_score."""
+    df = df.copy()
+
+    items = [c for c in FIES_ITEMS if c in df.columns]
+    for c in items:
+        df[c] = df[c].astype("boolean")
+
+    # Count of affirmative responses; NaN treated as not-counted for the
+    # sum, but rows where every item is NaN get a NaN score (question not
+    # administered / unit non-response), not a spurious 0.
+    score = df[items].sum(axis=1, skipna=True)
+    all_na = df[items].isna().all(axis=1)
+    score = score.where(~all_na, other=pd.NA)
+    df["FIES_score"] = score.astype("Int64")
+
+    return df

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -91,6 +91,26 @@ Data Scheme:
     Irrigated: bool
     materialize: make
 
+  food_security:
+    # FAO FIES 8-item experience scale (GH #332).  Confirmed ONLY in
+    # W5 (2021-22): ESS §8 file sect8_hh_w5.dta carries the FAO battery
+    # (s8q01..s8q08, mapped BY LABEL — not sequential FAO order; see the
+    # wave data_info.yml).  W4 (2018-19) §8 is an rCSI/coping-strategy
+    # battery (s8q02a..h = number-of-days frequency counts), NOT FIES, so
+    # it is deliberately NOT wired here; it belongs to a future rCSI
+    # feature.  W1-3 likewise used the rCSI/coping battery.
+    # Recall period: 12 months for 7 items; WholeDay (s8q06) is 30-day.
+    index: (t, i)
+    Worried: bool
+    HealthyDiet: bool
+    FewFoods: bool
+    SkippedMeal: bool
+    AteLess: bool
+    RanOut: bool
+    Hungry: bool
+    WholeDay: bool
+    FIES_score: int
+
   food_expenditures: !make
   food_prices: !make
   food_quantities: !make

--- a/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
@@ -62,3 +62,33 @@ individual_education:
         # s2aq2 = "highest grade completed"; value labels are embedded in the
         # .dta and decoded automatically by get_dataframe().
         Educational Attainment: s2aq2
+
+food_security:
+    # GLSS7 Section 9C 'Household Food Insecurity' = the FAO FIES 8-item
+    # battery, 12-month recall.  s9cq1..s9cq8 are in canonical FAO order
+    # (s9cq6 = "household ran out of food" confirms the alignment).
+    # Each item: Yes->True, No->False, "Don't Know"/Refused/NaN->NA
+    # (binarized by the same-named formatting fn in mapping.py).
+    file: g7sec9c.dta
+    idxvars:
+        i:
+            - clust
+            - nh
+    myvars:
+        Worried: s9cq1
+        HealthyDiet: s9cq2
+        FewFoods: s9cq3
+        SkippedMeal: s9cq4
+        AteLess: s9cq5
+        RanOut: s9cq6
+        Hungry: s9cq7
+        WholeDay: s9cq8
+        FIES_score:
+            - s9cq1
+            - s9cq2
+            - s9cq3
+            - s9cq4
+            - s9cq5
+            - s9cq6
+            - s9cq7
+            - s9cq8

--- a/lsms_library/countries/GhanaLSS/2016-17/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/2016-17/_/mapping.py
@@ -21,3 +21,40 @@ def Int_t(value):
         return pd.NaT
     s = f"{int(y)}-{str(m).strip()}-{int(d)}"
     return pd.to_datetime(s, errors='coerce')
+
+
+def _fies_item(value):
+    '''
+    Binarize a single FAO FIES item: Yes->True, No->False,
+    "Don't Know"/Refused/NaN -> NA.
+    '''
+    s = str(value).strip().lower()
+    if s == 'yes':
+        return True
+    if s == 'no':
+        return False
+    return pd.NA
+
+
+# The 8 FAO FIES experience items in canonical order.
+Worried = _fies_item       # s9cq1: worried wouldn't have enough food
+HealthyDiet = _fies_item   # s9cq2: unable to eat healthy/nutritious food
+FewFoods = _fies_item      # s9cq3: ate only a few kinds of foods
+SkippedMeal = _fies_item   # s9cq4: had to skip a meal
+AteLess = _fies_item       # s9cq5: ate less than thought should
+RanOut = _fies_item        # s9cq6: household ran out of food
+Hungry = _fies_item        # s9cq7: hungry but did not eat
+WholeDay = _fies_item      # s9cq8: went a whole day without eating
+
+
+def FIES_score(value):
+    '''
+    Raw FIES score = count of affirmative (Yes) responses across the 8
+    FAO FIES items.  Returns NA only when all 8 items are missing/non-Yes-No.
+
+    `value` is the 8-column row (s9cq1..s9cq8) in FAO order.
+    '''
+    items = [_fies_item(value.iloc[k]) for k in range(8)]
+    if all(pd.isna(x) for x in items):
+        return pd.NA
+    return int(sum(1 for x in items if x is True))

--- a/lsms_library/countries/GhanaLSS/_/data_scheme.yml
+++ b/lsms_library/countries/GhanaLSS/_/data_scheme.yml
@@ -15,6 +15,7 @@ Index Info:
     household_roster: (t, v, i, pid)
     individual_education: (t, i, pid)
     food_acquired: (t, v, i, j)
+    food_security: (t, i)
 
 Data Scheme:
   cluster_features:
@@ -51,5 +52,17 @@ Data Scheme:
   interview_date:
     index: (t, i)
     Int_t: datetime
+
+  food_security:
+    index: (t, i)
+    Worried: bool
+    HealthyDiet: bool
+    FewFoods: bool
+    SkippedMeal: bool
+    AteLess: bool
+    RanOut: bool
+    Hungry: bool
+    WholeDay: bool
+    FIES_score: int
 
   panel_ids: !make

--- a/lsms_library/countries/GhanaLSS/_/ghanalss.py
+++ b/lsms_library/countries/GhanaLSS/_/ghanalss.py
@@ -11,10 +11,18 @@ from collections import defaultdict
 
 def i(value):
     '''
-    Formatting household id
+    Formatting household id as "clust/nh".
+
+    Returns pd.NA when either component is missing (e.g. blank/trailing
+    rows in some source files such as g7sec9c), so such rows drop out of
+    the index rather than raising.
     '''
     if type(value) == pd.Series:
-        return tools.format_id(value.iloc[0])+'/'+tools.format_id(value.iloc[1],zeropadding=2)
+        clust = tools.format_id(value.iloc[0])
+        nh = tools.format_id(value.iloc[1], zeropadding=2)
+        if clust is None or nh is None:
+            return pd.NA
+        return clust + '/' + nh
     else:
         return tools.format_id(value)
 

--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/data_info.yml
@@ -274,3 +274,28 @@ interview_date:
             - menage
     myvars:
         Int_t: s00q23a
+
+food_security:
+    # FAO 8-item Food Insecurity Experience Scale (FIES), EHCVM Section 8A
+    # 'Segurança alimentar'.  Recall period: last 12 months.  Items
+    # s08aq01..s08aq08 map IN ORDER to the canonical FAO items
+    # Worried..WholeDay.  Guinea-Bissau labels are Portuguese:
+    # Sim -> True, Não -> False; Recusa / Não sabe (refused / don't know)
+    # -> NaN.  French Oui/Non handled defensively.  The bool mapping and
+    # the FIES_score (count of True across the 8 items) are computed in
+    # the food_security() hook in mapping.py.  s08aq07a / s08aq08a are
+    # frequency follow-ups and are not part of the binary scale (ignored).
+    file: s08a_me_gnb2018.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Worried: s08aq01
+        HealthyDiet: s08aq02
+        FewFoods: s08aq03
+        SkippedMeal: s08aq04
+        AteLess: s08aq05
+        RanOut: s08aq06
+        Hungry: s08aq07
+        WholeDay: s08aq08

--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/mapping.py
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/mapping.py
@@ -171,6 +171,44 @@ def household_roster(df):
     return df
 
 
+# FAO FIES 8 experience items, in canonical order (s08aq01..s08aq08).
+_FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+               'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+# Yes/No labels for the FIES items.  Guinea-Bissau's s08a value labels are
+# Portuguese (Sim/Não); French Oui/Non included defensively for any
+# differently-localized export.  Recusa (refused) / Não sabe (don't know)
+# and anything else fall through to pd.NA.
+_FIES_YES = {'Sim', 'Oui', 'sim', 'oui'}
+_FIES_NO = {'Não', 'Nao', 'Non', 'não', 'nao', 'non'}
+
+
+def _fies_bool(value):
+    if value in _FIES_YES:
+        return True
+    if value in _FIES_NO:
+        return False
+    return pd.NA
+
+
+def food_security(df):
+    '''FIES post-processor: map the 8 Portuguese Yes/No items to bool and
+    add FIES_score (count of True; NaN only when all 8 items are NaN).
+
+    s08aq01..s08aq08 arrive renamed to the canonical FAO names via
+    data_info.yml.  Sim->True, Não->False, Recusa/Não sabe/NaN->NA.
+    '''
+    for col in _FIES_ITEMS:
+        df[col] = df[col].map(_fies_bool).astype('boolean')
+
+    items = df[_FIES_ITEMS]
+    score = items.sum(axis=1, skipna=True)          # True counts as 1
+    all_na = items.isna().all(axis=1)               # no item answered
+    score = score.where(~all_na, other=pd.NA).astype('Int64')
+    df['FIES_score'] = score
+    return df
+
+
 COPING_LABELS = {
     1: "Utilisation de son épargne",
     2: "Aide de parents ou d'amis",

--- a/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
+++ b/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
@@ -75,6 +75,23 @@ Data Scheme:
     index: (t, i)
     Int_t: datetime
 
+  food_security:
+    # FAO 8-item Food Insecurity Experience Scale (FIES), EHCVM Section
+    # 8A.  Recall period: last 12 months.  Items s08aq01..s08aq08 ->
+    # the 8 canonical FAO experience items (bool); FIES_score = count of
+    # True (0-8, NaN only when all 8 items are NaN).  Portuguese labels
+    # Sim/Não -> True/False; Recusa/Não sabe -> NaN.
+    index: (t, i)
+    Worried: bool
+    HealthyDiet: bool
+    FewFoods: bool
+    SkippedMeal: bool
+    AteLess: bool
+    RanOut: bool
+    Hungry: bool
+    WholeDay: bool
+    FIES_score: int
+
   plot_features:
     # Lasting parcel-level characteristics from the EHCVM agriculture
     # module s16a (GH #167; Guinea-Bissau is an EHCVM sibling of the

--- a/lsms_library/countries/Malawi/2013-14/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2013-14/_/data_info.yml
@@ -164,3 +164,49 @@ assets:
         Quantity: hh_l03
         Age: hh_l04
         Value: hh_l05
+
+food_security:
+    # IHPS 2013 8-item adult food-insecurity battery (HH_MOD_T_13,
+    # hh_t13..hh_t20).  NOTE: NOT the standard FAO FIES wording/order used
+    # in IHS4/IHS5; mapped to the canonical FAO-FIES columns by concept
+    # (see _/mapping.py).  In particular HealthyDiet is sourced from the
+    # lack-of-money item (hh_t15) and RanOut from hh_t14.  Recall: 12 months.
+    # yes->True, no->False, missing->NA.
+    file: HH_MOD_T_13.dta
+    idxvars:
+        i: y2_hhid
+    myvars:
+        Worried:
+            - hh_t13
+            - mapping: fies_yesno
+        HealthyDiet:
+            - hh_t15
+            - mapping: fies_yesno
+        FewFoods:
+            - hh_t16
+            - mapping: fies_yesno
+        SkippedMeal:
+            - hh_t17
+            - mapping: fies_yesno
+        AteLess:
+            - hh_t18
+            - mapping: fies_yesno
+        RanOut:
+            - hh_t14
+            - mapping: fies_yesno
+        Hungry:
+            - hh_t19
+            - mapping: fies_yesno
+        WholeDay:
+            - hh_t20
+            - mapping: fies_yesno
+        FIES_score:
+            - hh_t13
+            - hh_t14
+            - hh_t15
+            - hh_t16
+            - hh_t17
+            - hh_t18
+            - hh_t19
+            - hh_t20
+            - mapping: fies_score

--- a/lsms_library/countries/Malawi/2013-14/_/mapping.py
+++ b/lsms_library/countries/Malawi/2013-14/_/mapping.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+import pandas as pd
+import numpy as np
+
+# --- food_security (8-item adult food-insecurity scale) -----------------
+# HH_MOD_T_13 (IHPS 2013) carries an 8-item adult food-insecurity battery
+# in hh_t13..hh_t20.  NOTE: this is NOT the standard FAO FIES wording/order
+# used in IHS4/IHS5 (2016-17, 2019-20); the items differ in order and the
+# "healthy diet" concept is captured by a lack-of-money item.  The mapping
+# to the canonical FAO-FIES columns (best-fit by concept) is:
+#   hh_t13 worried (would run out)        -> Worried
+#   hh_t15 lacked money/resources for food-> HealthyDiet
+#   hh_t16 diet based on only a few kinds -> FewFoods
+#   hh_t17 did not eat breakfast/lunch/...-> SkippedMeal
+#   hh_t18 ate less than you should       -> AteLess
+#   hh_t14 ran out of food               -> RanOut
+#   hh_t19 hungry but didn't eat          -> Hungry
+#   hh_t20 ate only one meal / went a day -> WholeDay
+# Value labels: {1: YES, 2: NO}.  Binarize yes->True, no->False; missing->NA.
+# Recall period: last 12 months.
+
+def _fies_yesno(x):
+    """Map a single item (string label) to a nullable boolean."""
+    if pd.isna(x):
+        return pd.NA
+    s = str(x).strip().lower()
+    if s in ('yes', '1', 'true', 'oui'):
+        return True
+    if s in ('no', '2', 'false', 'non'):
+        return False
+    return pd.NA
+
+def fies_yesno(row):
+    """Row-wise wrapper: data_info passes a single-column row (Series)."""
+    return _fies_yesno(row.iloc[0])
+
+def fies_score(row):
+    """Count of True across the 8 items in a row; NA only if all 8 missing."""
+    vals = [_fies_yesno(v) for v in row]
+    if all(pd.isna(v) for v in vals):
+        return pd.NA
+    return int(sum(1 for v in vals if v is True))

--- a/lsms_library/countries/Malawi/2016-17/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2016-17/_/data_info.yml
@@ -89,7 +89,49 @@ subjective_well_being:
         Neighbors Step: hh_t06
         Friends Step: hh_t07
 
-    
+food_security:
+    # FAO FIES 8-item battery, IHS4 (hh_t13..hh_t20 in FAO order).
+    # Recall period: last 12 months.  yes->True, no->False,
+    # DON'T KNOW/refused/NaN->NA (see _/mapping.py).
+    file: Cross_Sectional/hh_mod_t.dta
+    idxvars:
+        i: case_id
+    myvars:
+        Worried:
+            - hh_t13
+            - mapping: fies_yesno
+        HealthyDiet:
+            - hh_t14
+            - mapping: fies_yesno
+        FewFoods:
+            - hh_t15
+            - mapping: fies_yesno
+        SkippedMeal:
+            - hh_t16
+            - mapping: fies_yesno
+        AteLess:
+            - hh_t17
+            - mapping: fies_yesno
+        RanOut:
+            - hh_t18
+            - mapping: fies_yesno
+        Hungry:
+            - hh_t19
+            - mapping: fies_yesno
+        WholeDay:
+            - hh_t20
+            - mapping: fies_yesno
+        FIES_score:
+            - hh_t13
+            - hh_t14
+            - hh_t15
+            - hh_t16
+            - hh_t17
+            - hh_t18
+            - hh_t19
+            - hh_t20
+            - mapping: fies_score
+
 household_roster:
     file:
         - Cross_Sectional/hh_mod_b.dta

--- a/lsms_library/countries/Malawi/2016-17/_/mapping.py
+++ b/lsms_library/countries/Malawi/2016-17/_/mapping.py
@@ -5,3 +5,37 @@ from lsms_library.local_tools import format_id
 
 def cs_i(value):
     return 'cs-17-'+format_id(value.iloc[0])
+
+# --- FAO FIES (food_security) -------------------------------------------
+# hh_mod_t carries the FAO Food Insecurity Experience Scale 8-item battery
+# in vars hh_t13..hh_t20 (FAO order).  Value labels: {no, yes, DON'T KNOW,
+# refused}.  Binarize yes->True, no->False; DON'T KNOW / refused / NaN -> NA.
+# Recall period: last 12 months.
+
+def _fies_yesno(x):
+    """Map a single FIES item (string label) to a nullable boolean."""
+    if pd.isna(x):
+        return pd.NA
+    s = str(x).strip().lower()
+    if s in ('yes', '1', 'true', 'oui'):
+        return True
+    if s in ('no', '2', 'false', 'non'):
+        return False
+    # "DON'T KNOW", "refused", and anything unexpected -> missing
+    return pd.NA
+
+def fies_yesno(row):
+    """Row-wise wrapper: data_info passes a single-column row (Series)."""
+    return _fies_yesno(row.iloc[0])
+
+def fies_score(row):
+    """Count of True across the 8 FIES items in a row.
+
+    NA only when every one of the 8 items is missing; otherwise NA items
+    are treated as not-affirmed (count of True), matching the brief's
+    'count of True across the 8 items' definition.
+    """
+    vals = [_fies_yesno(v) for v in row]
+    if all(pd.isna(v) for v in vals):
+        return pd.NA
+    return int(sum(1 for v in vals if v is True))

--- a/lsms_library/countries/Malawi/2019-20/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2019-20/_/data_info.yml
@@ -86,7 +86,50 @@ subjective_well_being:
         Neighbors Step: hh_t06
         Friends Step: hh_t07
 
-    
+food_security:
+    # FAO FIES 8-item battery, IHS5 (hh_t13..hh_t20 in FAO order).
+    # Recall period: last 12 months.  yes->True, no->False,
+    # DON'T KNOW/refused/NaN->NA (see _/mapping.py).
+    file: Cross_Sectional/HH_MOD_T.dta
+    idxvars:
+        i: case_id
+    myvars:
+        Worried:
+            - hh_t13
+            - mapping: fies_yesno
+        HealthyDiet:
+            - hh_t14
+            - mapping: fies_yesno
+        FewFoods:
+            - hh_t15
+            - mapping: fies_yesno
+        SkippedMeal:
+            - hh_t16
+            - mapping: fies_yesno
+        AteLess:
+            - hh_t17
+            - mapping: fies_yesno
+        RanOut:
+            - hh_t18
+            - mapping: fies_yesno
+        Hungry:
+            - hh_t19
+            - mapping: fies_yesno
+        WholeDay:
+            - hh_t20
+            - mapping: fies_yesno
+        FIES_score:
+            - hh_t13
+            - hh_t14
+            - hh_t15
+            - hh_t16
+            - hh_t17
+            - hh_t18
+            - hh_t19
+            - hh_t20
+            - mapping: fies_score
+
+
 household_roster:
     file:
         - Cross_Sectional/HH_MOD_B.dta

--- a/lsms_library/countries/Malawi/2019-20/_/mapping.py
+++ b/lsms_library/countries/Malawi/2019-20/_/mapping.py
@@ -5,3 +5,37 @@ from lsms_library.local_tools import format_id
 
 def cs_i(value):
     return 'cs-19-'+format_id(value.iloc[0])
+
+# --- FAO FIES (food_security) -------------------------------------------
+# HH_MOD_T carries the FAO Food Insecurity Experience Scale 8-item battery
+# in vars hh_t13..hh_t20 (FAO order).  Value labels: {NO, YES, DON'T KNOW,
+# REFUSED}.  Binarize yes->True, no->False; DON'T KNOW / refused / NaN -> NA.
+# Recall period: last 12 months.
+
+def _fies_yesno(x):
+    """Map a single FIES item (string label) to a nullable boolean."""
+    if pd.isna(x):
+        return pd.NA
+    s = str(x).strip().lower()
+    if s in ('yes', '1', 'true', 'oui'):
+        return True
+    if s in ('no', '2', 'false', 'non'):
+        return False
+    # "DON'T KNOW", "refused", and anything unexpected -> missing
+    return pd.NA
+
+def fies_yesno(row):
+    """Row-wise wrapper: data_info passes a single-column row (Series)."""
+    return _fies_yesno(row.iloc[0])
+
+def fies_score(row):
+    """Count of True across the 8 FIES items in a row.
+
+    NA only when every one of the 8 items is missing; otherwise NA items
+    are treated as not-affirmed (count of True), matching the brief's
+    'count of True across the 8 items' definition.
+    """
+    vals = [_fies_yesno(v) for v in row]
+    if all(pd.isna(v) for v in vals):
+        return pd.NA
+    return int(sum(1 for v in vals if v is True))

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -33,6 +33,24 @@ Data Scheme:
     Own Step: int
     Neighbors Step: int
     Friends Step: int
+  food_security:
+    # FAO FIES 8-item experience scale (GH #332).  Sourced from
+    # Module T (hh_t13..hh_t20): standard FAO FIES order in IHS4 (2016-17)
+    # and IHS5 (2019-20); a concept-mapped 8-item battery in IHPS 2013
+    # (2013-14, item order differs -- see that wave's _/mapping.py).
+    # ABSENT in 2004-05 (IHS2) and 2010-11 (IHS3): those waves carry only
+    # the coping-strategies / food-shortage module (Module H), not the
+    # FIES experience battery.  Recall period: last 12 months.
+    index: (t, i)
+    Worried: bool
+    HealthyDiet: bool
+    FewFoods: bool
+    SkippedMeal: bool
+    AteLess: bool
+    RanOut: bool
+    Hungry: bool
+    WholeDay: bool
+    FIES_score: int
   panel_ids:
     index: (t, i)
     previous_i: str

--- a/lsms_library/countries/Mali/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Mali/2018-19/_/data_info.yml
@@ -24,6 +24,67 @@ subjective_well_being:
                 Riche: 4
 
 
+food_security:
+    # EHCVM Section 8A 'Sécurité alimentaire' — the FAO 8-item Food
+    # Insecurity Experience Scale (FIES), recall period = last 12 months
+    # ("12 derniers mois").  s08aq01..s08aq08 map IN ORDER to the 8
+    # canonical FIES items (verified against the .dta variable labels:
+    # q01=worried, q02=healthy/nutritious, q03=few foods, q04=skip meal,
+    # q05=ate less, q06=ran out, q07=hungry-not-eat, q08=whole day).
+    # Values Oui->True, Non->False; "Ne sait pas"/"Refus"/NaN->NaN.  The
+    # values are full strings (NOT truncated like the s20 SWB module).
+    # The s08aq07a/s08aq08a frequency follow-ups are ignored.  FIES_score
+    # (count of True across the 8 items) is computed by
+    # mapping.food_security().
+    file: s08a_me_mli2018.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+    myvars:
+        Worried:
+            - s08aq01
+            - mapping:
+                Oui: True
+                Non: False
+        HealthyDiet:
+            - s08aq02
+            - mapping:
+                Oui: True
+                Non: False
+        FewFoods:
+            - s08aq03
+            - mapping:
+                Oui: True
+                Non: False
+        SkippedMeal:
+            - s08aq04
+            - mapping:
+                Oui: True
+                Non: False
+        AteLess:
+            - s08aq05
+            - mapping:
+                Oui: True
+                Non: False
+        RanOut:
+            - s08aq06
+            - mapping:
+                Oui: True
+                Non: False
+        Hungry:
+            - s08aq07
+            - mapping:
+                Oui: True
+                Non: False
+        WholeDay:
+            - s08aq08
+            - mapping:
+                Oui: True
+                Non: False
+
+
 sample:
     dfs:
         - df_cover

--- a/lsms_library/countries/Mali/2018-19/_/mapping.py
+++ b/lsms_library/countries/Mali/2018-19/_/mapping.py
@@ -135,3 +135,26 @@ def shocks(df):
     df['HowCoped2'] = how_coped[2]
     df = df.drop(columns=cope_cols)
     return df
+
+
+_FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+               'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+
+def food_security(df):
+    '''Compute FIES_score from the 8 FAO FIES experience items.
+
+    EHCVM §8A items s08aq01..s08aq08 have already been mapped to the 8
+    canonical bool columns by the YAML ``mapping:`` blocks (Oui->True,
+    Non->False, everything else->NaN).  FIES_score is the row-wise count
+    of True across those 8 items.  Per the canonical contract it is NaN
+    only when ALL 8 items are NaN; otherwise NaN items count as 0 (not
+    affirmative).
+    '''
+    items = df[_FIES_ITEMS].apply(lambda c: c.map({True: 1, False: 0}))
+    score = items.sum(axis=1, skipna=True)
+    all_na = items.isna().all(axis=1)
+    score = score.where(~all_na, np.nan)
+    df = df.copy()
+    df['FIES_score'] = score.astype('Int64')
+    return df

--- a/lsms_library/countries/Mali/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Mali/2021-22/_/data_info.yml
@@ -21,6 +21,63 @@ subjective_well_being:
                 Moyen: 3
                 Riche: 4
 
+food_security:
+    # EHCVM Section 8A 'Sécurité alimentaire' — the FAO 8-item Food
+    # Insecurity Experience Scale (FIES), recall period = last 12 months
+    # ("12 derniers mois").  §8 is NOT split in 2021-22: items remain in
+    # s08a_me_mli2021.dta as s08aq01..s08aq08, mapping IN ORDER to the 8
+    # canonical FIES items (verified against the .dta variable labels).
+    # Values Oui->True, Non->False; "Ne sait pas"/"Refus"/NaN->NaN (full
+    # strings, not truncated).  s08aq07a/s08aq08a frequency follow-ups are
+    # ignored.  FIES_score is computed by mapping.food_security().
+    file: s08a_me_mli2021.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+    myvars:
+        Worried:
+            - s08aq01
+            - mapping:
+                Oui: True
+                Non: False
+        HealthyDiet:
+            - s08aq02
+            - mapping:
+                Oui: True
+                Non: False
+        FewFoods:
+            - s08aq03
+            - mapping:
+                Oui: True
+                Non: False
+        SkippedMeal:
+            - s08aq04
+            - mapping:
+                Oui: True
+                Non: False
+        AteLess:
+            - s08aq05
+            - mapping:
+                Oui: True
+                Non: False
+        RanOut:
+            - s08aq06
+            - mapping:
+                Oui: True
+                Non: False
+        Hungry:
+            - s08aq07
+            - mapping:
+                Oui: True
+                Non: False
+        WholeDay:
+            - s08aq08
+            - mapping:
+                Oui: True
+                Non: False
+
 sample:
     dfs:
         - df_cover

--- a/lsms_library/countries/Mali/2021-22/_/mapping.py
+++ b/lsms_library/countries/Mali/2021-22/_/mapping.py
@@ -151,3 +151,25 @@ def panel_ids(df):
     df['previous_i'] = df[['previous_v', 'previous_hid']].apply(previous_i, axis=1)
     df = df.reset_index().loc[:, ['i', 'previous_i']].drop_duplicates().set_index('i')
     return df
+
+_FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+               'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+
+def food_security(df):
+    '''Compute FIES_score from the 8 FAO FIES experience items.
+
+    EHCVM §8A items s08aq01..s08aq08 have already been mapped to the 8
+    canonical bool columns by the YAML ``mapping:`` blocks (Oui->True,
+    Non->False, everything else->NaN).  FIES_score is the row-wise count
+    of True across those 8 items.  Per the canonical contract it is NaN
+    only when ALL 8 items are NaN; otherwise NaN items count as 0 (not
+    affirmative).
+    '''
+    items = df[_FIES_ITEMS].apply(lambda c: c.map({True: 1, False: 0}))
+    score = items.sum(axis=1, skipna=True)
+    all_na = items.isna().all(axis=1)
+    score = score.where(~all_na, np.nan)
+    df = df.copy()
+    df['FIES_score'] = score.astype('Int64')
+    return df

--- a/lsms_library/countries/Mali/_/data_scheme.yml
+++ b/lsms_library/countries/Mali/_/data_scheme.yml
@@ -32,6 +32,21 @@ Data Scheme:
     # with the Malawi/Cantril ladder.  EHCVM waves only (2018-19, 2021-22).
     index: (t, i)
     Own Step: int
+  food_security:
+    # FAO 8-item Food Insecurity Experience Scale (FIES).  EHCVM §8A
+    # 'Sécurité alimentaire', recall period = last 12 months.  Both EHCVM
+    # waves (2018-19, 2021-22) read s08a_me_mli<yr>.dta; items
+    # s08aq01..s08aq08 map IN ORDER to the 8 canonical FIES items.
+    index: (t, i)
+    Worried: bool
+    HealthyDiet: bool
+    FewFoods: bool
+    SkippedMeal: bool
+    AteLess: bool
+    RanOut: bool
+    Hungry: bool
+    WholeDay: bool
+    FIES_score: int
   food_acquired:
     # Canonical post-2026-05-05 (GH #169): s axis carries acquisition
     # source (purchased / produced / inkind / other).  EHCVM 2018-19

--- a/lsms_library/countries/Niger/2014-15/_/data_info.yml
+++ b/lsms_library/countries/Niger/2014-15/_/data_info.yml
@@ -103,6 +103,71 @@ shocks:
         HowCoped1: MS10Q05B
         HowCoped2: MS10Q05C
 
+food_security:
+    # FAO Food Insecurity Experience Scale (FIES), ECVMA2 Section 14
+    # 'Sécurité alimentaire' (file ECVMA2_MS14P1, GH #332).
+    # Recall period: last 12 months.  MS14Q01..MS14Q08 map IN ORDER to
+    # the 8 canonical FIES items (verified against the .dta variable
+    # labels 2026-06-07 — same FAO battery as the EHCVM s08aq01..08):
+    #   Q01 inquiet de ne pas avoir suffisamment    -> Worried
+    #   Q02 pas pu manger nourriture saine/nutritive-> HealthyDiet
+    #   Q03 mangé une nourriture peu variée         -> FewFoods
+    #   Q04 dû sauter un repas                        -> SkippedMeal
+    #   Q05 mangé moins que ce que vous pensiez       -> AteLess
+    #   Q06 ménage n'avait plus de nourriture         -> RanOut
+    #   Q07 eu faim mais pas mangé                     -> Hungry
+    #   Q08 passé toute une journée sans manger        -> WholeDay
+    # Oui->True, Non->False; NSP / Refus / NaN -> NaN.
+    # Q09 (enfants <5 présents?) and Q10/Q11 (child-specific HealthyDiet
+    # / Hungry follow-ups) are NOT part of the household 8-item scale and
+    # are IGNORED.  FIES_score computed by food_security() in mapping.py.
+    file: NER_2014_ECVMA-II_v02_M_STATA8/ECVMA2_MS14P1.dta
+    idxvars:
+        i:
+            - GRAPPE
+            - MENAGE
+    myvars:
+        Worried:
+            - MS14Q01
+            - mapping:
+                Oui: True
+                Non: False
+        HealthyDiet:
+            - MS14Q02
+            - mapping:
+                Oui: True
+                Non: False
+        FewFoods:
+            - MS14Q03
+            - mapping:
+                Oui: True
+                Non: False
+        SkippedMeal:
+            - MS14Q04
+            - mapping:
+                Oui: True
+                Non: False
+        AteLess:
+            - MS14Q05
+            - mapping:
+                Oui: True
+                Non: False
+        RanOut:
+            - MS14Q06
+            - mapping:
+                Oui: True
+                Non: False
+        Hungry:
+            - MS14Q07
+            - mapping:
+                Oui: True
+                Non: False
+        WholeDay:
+            - MS14Q08
+            - mapping:
+                Oui: True
+                Non: False
+
 assets:
     file: NER_2014_ECVMA-II_v02_M_STATA8/ECVMA2_MS07P1.dta
     idxvars:

--- a/lsms_library/countries/Niger/2014-15/_/mapping.py
+++ b/lsms_library/countries/Niger/2014-15/_/mapping.py
@@ -1,0 +1,30 @@
+# Formatting functions for Niger 2014-15 (ECVMA2)
+import pandas as pd
+
+
+_FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+               'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+
+def _to_fies_bool(s):
+    '''Coerce a FIES item column to nullable boolean.  The YAML
+    ``mapping: {Oui: True, Non: False}`` runs through df_data_grabber,
+    which leaves UNMAPPED values (NSP / Refus / NaN) UNCHANGED rather
+    than turning them into NaN.  So we keep only genuine True/False and
+    send everything else (residual strings, NaN) to pd.NA.'''
+    return s.map(lambda x: True if x is True else (False if x is False else pd.NA)).astype('boolean')
+
+
+def food_security(df):
+    '''food_security post-processor: coerce the 8 FIES items to nullable
+    boolean and compute FIES_score (count of True across the 8 items;
+    NaN only when ALL 8 items are NaN).  See the food_security block in
+    data_info.yml for the ECVMA2 MS14Q01..Q08 -> FAO item mapping.
+    '''
+    for c in _FIES_ITEMS:
+        df[c] = _to_fies_bool(df[c])
+    items = df[_FIES_ITEMS]
+    all_na = items.isna().all(axis=1)
+    score = items.eq(True).sum(axis=1)
+    df['FIES_score'] = score.where(~all_na).astype('Int64')
+    return df

--- a/lsms_library/countries/Niger/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Niger/2018-19/_/data_info.yml
@@ -267,3 +267,67 @@ interview_date:
             - menage
     myvars:
         int_t: s00q23a
+
+food_security:
+    # FAO Food Insecurity Experience Scale (FIES), EHCVM Section 8A
+    # 'Sécurité alimentaire'.  Recall period: last 12 months.
+    # s08aq01..s08aq08 map IN ORDER to the 8 canonical FIES items
+    # (verified against the .dta variable labels 2026-06-07):
+    #   q01 inquiet de ne pas avoir suffisamment    -> Worried
+    #   q02 pas pu manger nourriture saine/nutritive-> HealthyDiet
+    #   q03 mangé une nourriture peu variée         -> FewFoods
+    #   q04 sauter un repas                          -> SkippedMeal
+    #   q05 mangé moins que ce que vous auriez dû    -> AteLess
+    #   q06 ménage n'avait plus de nourriture        -> RanOut
+    #   q07 faim mais pas mangé                       -> Hungry
+    #   q08 passé toute une journée sans manger       -> WholeDay
+    # Oui->True, Non->False; Ne sait pas / Refus / NaN -> NaN.
+    # s08aq07a/q08a are frequency follow-ups -> IGNORED (binary scale).
+    # FIES_score (count of True across the 8 items, NaN iff all 8 NaN)
+    # is computed by the food_security() post-processor in mapping.py.
+    file: s08a_me_ner2018.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Worried:
+            - s08aq01
+            - mapping:
+                Oui: True
+                Non: False
+        HealthyDiet:
+            - s08aq02
+            - mapping:
+                Oui: True
+                Non: False
+        FewFoods:
+            - s08aq03
+            - mapping:
+                Oui: True
+                Non: False
+        SkippedMeal:
+            - s08aq04
+            - mapping:
+                Oui: True
+                Non: False
+        AteLess:
+            - s08aq05
+            - mapping:
+                Oui: True
+                Non: False
+        RanOut:
+            - s08aq06
+            - mapping:
+                Oui: True
+                Non: False
+        Hungry:
+            - s08aq07
+            - mapping:
+                Oui: True
+                Non: False
+        WholeDay:
+            - s08aq08
+            - mapping:
+                Oui: True
+                Non: False

--- a/lsms_library/countries/Niger/2018-19/_/mapping.py
+++ b/lsms_library/countries/Niger/2018-19/_/mapping.py
@@ -112,6 +112,37 @@ def food_acquired(df):
     df = _decode_mojibake_in_df(df)
     return df
 
+_FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+               'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+
+def _to_fies_bool(s):
+    '''Coerce a FIES item column to nullable boolean.  The YAML
+    ``mapping: {Oui: True, Non: False}`` runs through df_data_grabber,
+    which leaves UNMAPPED values ("Ne sait pas" / "Refus" / NaN)
+    UNCHANGED rather than turning them into NaN.  So we keep only genuine
+    True/False and send everything else (residual strings, NaN) to
+    pd.NA.'''
+    return s.map(lambda x: True if x is True else (False if x is False else pd.NA)).astype('boolean')
+
+
+def food_security(df):
+    '''food_security post-processor: coerce the 8 FIES items to nullable
+    boolean and compute FIES_score.
+
+    FIES_score is the count of True across the 8 items, and is NaN only
+    when ALL 8 items are NaN (the question was not asked at all).
+    Partial NaNs count as not-True (FAO scoring).
+    '''
+    for c in _FIES_ITEMS:
+        df[c] = _to_fies_bool(df[c])
+    items = df[_FIES_ITEMS]
+    all_na = items.isna().all(axis=1)
+    score = items.eq(True).sum(axis=1)
+    df['FIES_score'] = score.where(~all_na).astype('Int64')
+    return df
+
+
 COPING_LABELS = {
     1: "Utilisation de son épargne",
     2: "Aide de parents ou d'amis",

--- a/lsms_library/countries/Niger/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Niger/2021-22/_/data_info.yml
@@ -260,3 +260,61 @@ interview_date:
             - menage
     myvars:
         int_t: s00q23a
+
+food_security:
+    # FAO Food Insecurity Experience Scale (FIES), EHCVM Section 8A
+    # 'Sécurité alimentaire'.  Recall period: last 12 months.
+    # s08aq01..s08aq08 map IN ORDER to the 8 canonical FIES items
+    # (verified against the .dta variable labels 2026-06-07; identical
+    # wording to the 2018-19 wave):
+    #   q01 Worried · q02 HealthyDiet · q03 FewFoods · q04 SkippedMeal
+    #   q05 AteLess · q06 RanOut · q07 Hungry · q08 WholeDay
+    # Oui->True, Non->False; Ne sait pas / Refus / NaN -> NaN.
+    # s08aq07a/q08a are frequency follow-ups -> IGNORED (binary scale).
+    # FIES_score computed by food_security() in mapping.py.
+    file: s08a_me_ner2021.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Worried:
+            - s08aq01
+            - mapping:
+                Oui: True
+                Non: False
+        HealthyDiet:
+            - s08aq02
+            - mapping:
+                Oui: True
+                Non: False
+        FewFoods:
+            - s08aq03
+            - mapping:
+                Oui: True
+                Non: False
+        SkippedMeal:
+            - s08aq04
+            - mapping:
+                Oui: True
+                Non: False
+        AteLess:
+            - s08aq05
+            - mapping:
+                Oui: True
+                Non: False
+        RanOut:
+            - s08aq06
+            - mapping:
+                Oui: True
+                Non: False
+        Hungry:
+            - s08aq07
+            - mapping:
+                Oui: True
+                Non: False
+        WholeDay:
+            - s08aq08
+            - mapping:
+                Oui: True
+                Non: False

--- a/lsms_library/countries/Niger/2021-22/_/mapping.py
+++ b/lsms_library/countries/Niger/2021-22/_/mapping.py
@@ -6,6 +6,35 @@ from lsms_library.transformations import food_acquired_to_canonical as food_acqu
 from collections import defaultdict
 
 
+_FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+               'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+
+def _to_fies_bool(s):
+    '''Coerce a FIES item column to nullable boolean.  The YAML
+    ``mapping: {Oui: True, Non: False}`` runs through df_data_grabber,
+    which leaves UNMAPPED values ("Ne sait pas" / "Refus" / NaN)
+    UNCHANGED rather than turning them into NaN.  So we keep only genuine
+    True/False and send everything else (residual strings, NaN) to
+    pd.NA.'''
+    return s.map(lambda x: True if x is True else (False if x is False else pd.NA)).astype('boolean')
+
+
+def food_security(df):
+    '''food_security post-processor: coerce the 8 FIES items to nullable
+    boolean and compute FIES_score (count of True across the 8 items;
+    NaN only when ALL 8 items are NaN).  See the food_security block in
+    data_info.yml for the EHCVM s08aq01..08 -> FAO item mapping.
+    '''
+    for c in _FIES_ITEMS:
+        df[c] = _to_fies_bool(df[c])
+    items = df[_FIES_ITEMS]
+    all_na = items.isna().all(axis=1)
+    score = items.eq(True).sum(axis=1)
+    df['FIES_score'] = score.where(~all_na).astype('Int64')
+    return df
+
+
 def v(value):
     '''
     Formatting cluster id (grappe is a single column).

--- a/lsms_library/countries/Niger/_/data_scheme.yml
+++ b/lsms_library/countries/Niger/_/data_scheme.yml
@@ -74,6 +74,26 @@ Data Scheme:
     Roof: str
     Floor: str
 
+  food_security:
+    # FAO Food Insecurity Experience Scale (FIES), 8-item household
+    # battery (GH #332).  Recall period: last 12 months.  Sources:
+    #   2014-15 (ECVMA2): §14 file ECVMA2_MS14P1, MS14Q01..Q08
+    #   2018-19 (EHCVM):  §8A file s08a_me_ner2018, s08aq01..08
+    #   2021-22 (EHCVM):  §8A file s08a_me_ner2021, s08aq01..08
+    # 2011-12 has no FIES module and is silent.  The 8 items are in FAO
+    # order; Oui->True, Non->False, Ne sait pas/NSP/Refus/NaN->NaN.
+    # FIES_score = count of True across the 8 items (NaN iff all 8 NaN).
+    index: (t, i)
+    Worried: bool
+    HealthyDiet: bool
+    FewFoods: bool
+    SkippedMeal: bool
+    AteLess: bool
+    RanOut: bool
+    Hungry: bool
+    WholeDay: bool
+    FIES_score: int
+
   subjective_well_being:
     # EHCVM Section 20 'Pauvreté relative' (s20 / s20a).  Self-placement
     # on a 4-point relative-welfare ladder (Très pauvre / Pauvre / Moyen

--- a/lsms_library/countries/Senegal/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Senegal/2018-19/_/data_info.yml
@@ -266,3 +266,43 @@ interview_date:
             - menage
     myvars:
         Int_t: s00q23a
+
+food_security:
+    # FAO FIES 8-item scale, EHCVM §8A 'Sécurité alimentaire'.
+    # Recall period: last 12 months.  s08aq01..s08aq08 map IN ORDER to
+    # the FAO items Worried..WholeDay (verified against variable labels:
+    # q01='inquiets de ne pas avoir suffisamment de nourriture',
+    # q08='passé toute une journée sans manger').  Oui->True, Non->False,
+    # Ne sait pas / Refus / NaN -> NaN.  s08aq07a/s08aq08a are frequency
+    # follow-ups and are ignored.  FIES_score (0-8 count of True) is
+    # added row-wise by the food_security() function in mapping.py.
+    file: s08a_me_sen2018.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Worried:
+            - s08aq01
+            - mapping: &fies_map {Oui: true, Non: false, Ne sait pas: null, Refus: null}
+        HealthyDiet:
+            - s08aq02
+            - mapping: *fies_map
+        FewFoods:
+            - s08aq03
+            - mapping: *fies_map
+        SkippedMeal:
+            - s08aq04
+            - mapping: *fies_map
+        AteLess:
+            - s08aq05
+            - mapping: *fies_map
+        RanOut:
+            - s08aq06
+            - mapping: *fies_map
+        Hungry:
+            - s08aq07
+            - mapping: *fies_map
+        WholeDay:
+            - s08aq08
+            - mapping: *fies_map

--- a/lsms_library/countries/Senegal/2018-19/_/mapping.py
+++ b/lsms_library/countries/Senegal/2018-19/_/mapping.py
@@ -120,6 +120,23 @@ def shocks(df):
     return df
 
 
+FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+              'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+
+def food_security(df):
+    '''
+    Compute FIES_score: count of True across the 8 FAO FIES items.
+    NaN only when ALL eight items are NaN (item not asked / refused).
+    '''
+    items = df[FIES_ITEMS].apply(lambda c: c.map({True: True, False: False}))
+    score = items.sum(axis=1, min_count=1)
+    all_na = items.isna().all(axis=1)
+    score = score.where(~all_na, other=np.nan)
+    df['FIES_score'] = score.astype('Int64')
+    return df
+
+
 def household_roster(df):
     '''
     Formatting dataframe to calculate ages.

--- a/lsms_library/countries/Senegal/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Senegal/2021-22/_/data_info.yml
@@ -256,6 +256,45 @@ interview_date:
     myvars:
         Int_t: s00q23a
 
+food_security:
+    # FAO FIES 8-item scale, EHCVM §8A 'Sécurité alimentaire'.
+    # Recall period: last 12 months.  §8 was NOT split in 2021-22: the
+    # 8 items remain s08aq01..s08aq08 in s08a_me_sen2021.dta, mapping IN
+    # ORDER to the FAO items Worried..WholeDay.  Oui->True, Non->False,
+    # Ne sait pas / Refus / NaN -> NaN.  s08aq07a/s08aq08a are frequency
+    # follow-ups and are ignored.  FIES_score (0-8 count of True) is
+    # added row-wise by the food_security() function in mapping.py.
+    file: s08a_me_sen2021.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Worried:
+            - s08aq01
+            - mapping: &fies_map {Oui: true, Non: false, Ne sait pas: null, Refus: null}
+        HealthyDiet:
+            - s08aq02
+            - mapping: *fies_map
+        FewFoods:
+            - s08aq03
+            - mapping: *fies_map
+        SkippedMeal:
+            - s08aq04
+            - mapping: *fies_map
+        AteLess:
+            - s08aq05
+            - mapping: *fies_map
+        RanOut:
+            - s08aq06
+            - mapping: *fies_map
+        Hungry:
+            - s08aq07
+            - mapping: *fies_map
+        WholeDay:
+            - s08aq08
+            - mapping: *fies_map
+
 # panel_ids is constructed at the country level by
 # Senegal/_/panel_ids.py (declared as !make in data_scheme.yml).
 # Do not reintroduce a wave-level block here.

--- a/lsms_library/countries/Senegal/2021-22/_/mapping.py
+++ b/lsms_library/countries/Senegal/2021-22/_/mapping.py
@@ -63,6 +63,23 @@ def Region(value):
 
 
 
+FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+              'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+
+def food_security(df):
+    '''
+    Compute FIES_score: count of True across the 8 FAO FIES items.
+    NaN only when ALL eight items are NaN (item not asked / refused).
+    '''
+    items = df[FIES_ITEMS].apply(lambda c: c.map({True: True, False: False}))
+    score = items.sum(axis=1, min_count=1)
+    all_na = items.isna().all(axis=1)
+    score = score.where(~all_na, other=np.nan)
+    df['FIES_score'] = score.astype('Int64')
+    return df
+
+
 def previous_i(value):
     '''
     Formatting previous household id from (grappe, menage).

--- a/lsms_library/countries/Senegal/_/data_scheme.yml
+++ b/lsms_library/countries/Senegal/_/data_scheme.yml
@@ -36,6 +36,24 @@ Data Scheme:
     index: (t, i)
     Own Step: int
 
+  food_security:
+    # FAO FIES 8-item experience scale, EHCVM Section 8A 'Sécurité
+    # alimentaire' (recall: last 12 months).  Source items s08aq01..
+    # s08aq08 map IN ORDER to the FAO items Worried..WholeDay.
+    # Oui->True, Non->False, Ne sait pas / Refus / NaN -> NaN.
+    # FIES_score = count of True across the 8 items (0-8), NaN only if
+    # all eight are NaN.  Both EHCVM waves (2018-19, 2021-22).
+    index: (t, i)
+    Worried: bool
+    HealthyDiet: bool
+    FewFoods: bool
+    SkippedMeal: bool
+    AteLess: bool
+    RanOut: bool
+    Hungry: bool
+    WholeDay: bool
+    FIES_score: int
+
   shocks:
     index: (t, i, Shock)
     AffectedIncome: bool

--- a/lsms_library/countries/Togo/2018/_/data_info.yml
+++ b/lsms_library/countries/Togo/2018/_/data_info.yml
@@ -267,3 +267,83 @@ interview_date:
             - menage
     myvars:
         Int_t: s00q23a
+
+food_security:
+    # FAO Food Insecurity Experience Scale (FIES), EHCVM §8A
+    # 'Sécurité alimentaire'.  Recall period: last 12 months.
+    # Items s08aq01..s08aq08 map IN ORDER to the 8 canonical FIES
+    # items (verified against the Stata variable labels):
+    #   s08aq01 worried -> Worried
+    #   s08aq02 healthy/nutritious -> HealthyDiet
+    #   s08aq03 few kinds of foods -> FewFoods
+    #   s08aq04 skip a meal -> SkippedMeal
+    #   s08aq05 ate less -> AteLess
+    #   s08aq06 ran out of food -> RanOut
+    #   s08aq07 hungry but did not eat -> Hungry
+    #   s08aq08 whole day without eating -> WholeDay
+    # Oui->True, Non->False, Ne sait pas / Refus -> NaN.  s08aq07a /
+    # s08aq08a are frequency follow-ups and are ignored for the binary
+    # scale.  FIES_score (0-8) is the row-wise count of True items,
+    # computed by the food_security() formatting function in mapping.py.
+    file: ../Data1/s08a_me_tgo2018.dta
+    idxvars:
+        i:
+            - grappe
+            - menage
+    myvars:
+        Worried:
+            - s08aq01
+            - mapping:
+                Oui: True
+                Non: False
+                Ne sait pas: null
+                Refus: null
+        HealthyDiet:
+            - s08aq02
+            - mapping:
+                Oui: True
+                Non: False
+                Ne sait pas: null
+                Refus: null
+        FewFoods:
+            - s08aq03
+            - mapping:
+                Oui: True
+                Non: False
+                Ne sait pas: null
+                Refus: null
+        SkippedMeal:
+            - s08aq04
+            - mapping:
+                Oui: True
+                Non: False
+                Ne sait pas: null
+                Refus: null
+        AteLess:
+            - s08aq05
+            - mapping:
+                Oui: True
+                Non: False
+                Ne sait pas: null
+                Refus: null
+        RanOut:
+            - s08aq06
+            - mapping:
+                Oui: True
+                Non: False
+                Ne sait pas: null
+                Refus: null
+        Hungry:
+            - s08aq07
+            - mapping:
+                Oui: True
+                Non: False
+                Ne sait pas: null
+                Refus: null
+        WholeDay:
+            - s08aq08
+            - mapping:
+                Oui: True
+                Non: False
+                Ne sait pas: null
+                Refus: null

--- a/lsms_library/countries/Togo/2018/_/mapping.py
+++ b/lsms_library/countries/Togo/2018/_/mapping.py
@@ -81,6 +81,27 @@ def shocks(df):
     return df
 
 
+FIES_ITEMS = ['Worried', 'HealthyDiet', 'FewFoods', 'SkippedMeal',
+              'AteLess', 'RanOut', 'Hungry', 'WholeDay']
+
+
+def food_security(df):
+    '''Compute the harmonized FIES_score from the 8 FAO FIES items.
+
+    The 8 experience items (Worried..WholeDay) arrive as booleans
+    (Oui->True, Non->False, Ne sait pas / Refus -> NaN) from the YAML
+    `mapping:` blocks.  FIES_score is the row-wise count of True items
+    (0-8); it is NaN only when ALL 8 items are NaN (the FIES module was
+    not administered to that household).
+    '''
+    items = df[FIES_ITEMS]
+    score = items.sum(axis=1, skipna=True)
+    all_na = items.isna().all(axis=1)
+    score = score.where(~all_na, other=pd.NA)
+    df['FIES_score'] = score.astype('Int64')
+    return df
+
+
 def household_roster(df):
     '''
     Recover Age from date-of-birth components when s01q04a is null.

--- a/lsms_library/countries/Togo/_/data_scheme.yml
+++ b/lsms_library/countries/Togo/_/data_scheme.yml
@@ -62,6 +62,23 @@ Data Scheme:
       type: str
       optional: true
 
+  food_security:
+    # FAO Food Insecurity Experience Scale (FIES), EHCVM §8A
+    # 'Sécurité alimentaire'.  Recall period: last 12 months.  The 8
+    # experience items s08aq01..s08aq08 map IN ORDER to the canonical
+    # FIES bools; FIES_score (0-8) is the count of True items, computed
+    # by the food_security() function in 2018/_/mapping.py.
+    index: (t, i)
+    Worried: bool
+    HealthyDiet: bool
+    FewFoods: bool
+    SkippedMeal: bool
+    AteLess: bool
+    RanOut: bool
+    Hungry: bool
+    WholeDay: bool
+    FIES_score: int
+
   housing:
     index: (t, i)
     Roof: str


### PR DESCRIPTION
> **⚠️ STACKED ON #359 (SWB-ladder).** This branch is based on `feature/swb-ladder-fill` to avoid 8 EHCVM data_scheme.yml conflicts. **Merge #359 first**; this PR's diff then reduces to just the food_security commits.

Wires `food_security` as the **FAO 8-item FIES scale** (the #332 'FIES-canonical + per-family features' decision) across **11 countries**. Was unwired entirely; now `Feature('food_security')()` = 11 countries, 132,632 rows.

Canonical schema: index `(t,i)`, 8 bool items (Worried/HealthyDiet/FewFoods/SkippedMeal/AteLess/RanOut/Hungry/WholeDay) + `FIES_score` (0-8). All `is_this_feature_sane.ok=True`.

| Source family | Countries (waves) |
|---|---|
| EHCVM §8A `s08aq01-08` | Senegal, Mali, Burkina Faso, Niger (×2-3 waves) · Côte d'Ivoire, Togo, Benin, Guinea-Bissau (2018-19) |
| EHCVM/ECVMA §14 | Niger 2014-15 (`MS14Q01-08`) |
| GLSS7 §9C | GhanaLSS 2016-17 (`s9cq1-8`) |
| Module T | Malawi 2013-14/2016-17/2019-20 (`hh_t13-20`) |
| ESS §8 | Ethiopia W5 2021-22 (`s8q01-08`) |

**Agents mapped items by FAO concept, not blindly by position** — catching: Ethiopia W5 items out of sequence (`s8q06`=WholeDay) + W4 is actually rCSI (excluded); Malawi FIES is Module T not Module H (Module H is rCSI); Malawi 2004-05/2010-11 + Ethiopia W1-3 have no FIES (rCSI/coping). Guinea-Bissau Portuguese labels handled. Burkina sanity-checked the monotone severity gradient.

**Deferred to per-family features (NOT absent):** HFIAS (Nigeria, Tajikistan), rCSI/coping (Tanzania, Nepal, Ethiopia W1-3), months-of-shortage (India, Liberia, Uganda, Timor-Leste), bespoke (EthiopiaRHS, Iraq). True-absent (no FS module): Albania, Armenia, Azerbaijan, Cambodia, China, Guatemala, Guyana, Kosovo, Pakistan, Serbia, Serbia&Montenegro, South Africa.

Brief/design: `slurm_logs/2026-06-06_assets_ineduc/IMPL_BRIEF_food_security_fies.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)