### PR TITLE
feat: life_satisfaction — 6 countries (#331 feature 2)

### DIFF
--- a/lsms_library/countries/Iraq/2012/_/life_satisfaction.py
+++ b/lsms_library/countries/Iraq/2012/_/life_satisfaction.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Iraq 2012 life_satisfaction -- domain-satisfaction battery (SECTION 23).
+
+Source: ``2012ihses23_life_satisfaction.dta``.  The module is asked of EVERY
+household member aged 15+, so it is INDIVIDUAL-level: ~176k rows, ~7 per
+household.  The canonical ``life_satisfaction`` feature is HOUSEHOLD-level
+(index ``(t, i, Domain)``), so we REDUCE each household to its HEAD: the head
+is identified from the roster (``2012ihses01`` ``q0105 == 'Head'``), which has
+exactly one head per household, and 100% of those heads are present in this
+module.  The head's row is selected on ``(questid, idcode)`` (unique here).
+
+``i = questid`` (the sample/housing/assets key).  The roster's per-row ``hh``
+field is the within-dwelling sequence number, not a household key (GH #256),
+so we join the head's ``idcode`` from the roster on ``questid``.
+
+WIDE -> LONG: the 11 battery items ``q2302_1 .. q2302_11`` each become one
+``(t, i, Domain)`` row.  The questionnaire (HIES-II Part 3, Section 23) fixes
+the item order (the .dta variable labels are Stata-truncated and partly
+misaligned; the questionnaire is authoritative):
+
+    q2302_1  Food                              -> Food
+    q2302_2  Housing                           -> Housing
+    q2302_3  ... income?                       -> Finances
+    q2302_4  Health                            -> Health
+    q2302_5  Work                              -> Job
+    q2302_6  Local security level              -> Safety
+    q2302_7  Education                         -> Education
+    q2302_8  The freedom of choice ... in life -> FreedomOfChoice
+    q2302_9  The control you have over life    -> Control
+    q2302_10 Trust/acceptance in community     -> Community
+    q2302_11 Life overall                      -> Overall
+
+Items 8 (freedom of choice) and 9 (control over life) have no canonical
+Domain in the shared list; they are autonomy items kept under descriptive
+non-canonical Domain names rather than discarded (harmonize the interface,
+not the data).
+
+``Satisfaction`` carries the native ordinal label, normalized from the
+ALL-CAPS source to Title Case.  The non-rating sentinel "DO NOT KNOW/NO
+ANSWER" is nulled (it is not a satisfaction level).  ``t`` is added by the
+framework when it concatenates waves; this script writes the
+``(i, Domain)`` frame only.
+
+2006-07 (IHSES-I) has NO life-satisfaction module, so only 2012 is wired.
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+# q2302_N column suffix -> canonical (or descriptive) Domain.
+DOMAINS = {
+    1: 'Food',
+    2: 'Housing',
+    3: 'Finances',
+    4: 'Health',
+    5: 'Job',
+    6: 'Safety',
+    7: 'Education',
+    8: 'FreedomOfChoice',
+    9: 'Control',
+    10: 'Community',
+    11: 'Overall',
+}
+
+# Native ordinal labels (ALL-CAPS in source) -> human-readable Title Case.
+# "DO NOT KNOW/NO ANSWER" is a non-response, not a rating -> dropped (NA).
+SATISFACTION = {
+    'VERY SATISFIED': 'Very satisfied',
+    'FAIRLY SATISFIED': 'Fairly satisfied',
+    'NOT VERY SATISFIED': 'Not very satisfied',
+    'NOT AT ALL SATISFIED': 'Not at all satisfied',
+}
+
+# --- identify the household head's idcode from the roster -----------------
+roster = get_dataframe('../Data/2012ihses01_household_roster.dta')
+heads = roster.loc[
+    roster['q0105'].astype(str) == 'Head', ['questid', 'idcode']
+].copy()
+
+# --- reduce the individual-level module to the head's row -----------------
+sat = get_dataframe('../Data/2012ihses23_life_satisfaction.dta')
+head_rows = heads.merge(sat, on=['questid', 'idcode'], how='left')
+
+item_cols = [f'q2302_{n}' for n in DOMAINS]
+wide = head_rows[['questid'] + item_cols].rename(columns={'questid': 'i'})
+wide['i'] = wide['i'].astype(str)
+
+# --- WIDE -> LONG on (i, Domain) -----------------------------------------
+long = wide.melt(id_vars='i', value_vars=item_cols,
+                 var_name='item', value_name='Satisfaction')
+long['Domain'] = long['item'].str.removeprefix('q2302_').astype(int).map(DOMAINS)
+long['Satisfaction'] = long['Satisfaction'].astype(str).map(SATISFACTION)
+
+# Drop rows with no genuine rating (NA / "do not know" / item not answered).
+long = long.dropna(subset=['Satisfaction'])
+
+out = long[['i', 'Domain', 'Satisfaction']].set_index(['i', 'Domain'])
+
+to_parquet(out, 'life_satisfaction.parquet')

--- a/lsms_library/countries/Iraq/_/data_scheme.yml
+++ b/lsms_library/countries/Iraq/_/data_scheme.yml
@@ -74,3 +74,23 @@ Data Scheme:
     index: (t, i)
     Int_t: datetime
     materialize: make
+
+  life_satisfaction:
+    # Domain-satisfaction battery. 2012 ONLY (module 2012ihses23, SECTION
+    # 23). The module is INDIVIDUAL-level (asked of every member aged 15+,
+    # ~7 rows/HH), so the wave script (2012/_/life_satisfaction.py) REDUCES
+    # to the household HEAD (roster q0105=='Head'; 100% of heads present in
+    # the module) and reshapes the 11 items q2302_1..q2302_11 WIDE->LONG.
+    #   i=questid (matches sample/housing/assets; the roster's `hh` is the
+    #     within-dwelling sequence number, GH #256). The head's idcode is
+    #     joined from the roster on questid.
+    #   Domain = canonical life aspect from the questionnaire order: Food,
+    #     Housing, Finances(income), Health, Job(work), Safety(local
+    #     security), Education, FreedomOfChoice, Control, Community(trust/
+    #     acceptance), Overall. FreedomOfChoice/Control are autonomy items
+    #     with no canonical slot, kept under descriptive names.
+    #   Satisfaction = native ordinal label, Title-cased (Very satisfied ..
+    #     Not at all satisfied); "DO NOT KNOW/NO ANSWER" -> dropped.
+    # 2006-07 (IHSES-I) has no life-satisfaction module -> not wired.
+    index: (t, i, Domain)
+    Satisfaction: str

--- a/lsms_library/countries/Serbia and Montenegro/2002/_/life_satisfaction.py
+++ b/lsms_library/countries/Serbia and Montenegro/2002/_/life_satisfaction.py
@@ -1,0 +1,50 @@
+"""
+Serbia and Montenegro 2002 life_satisfaction.
+
+Source: ../Data/2002 5 non-food consumption.dta (the household-level non-food
+consumption module).  Variable ``bm2`` carries the variable label
+"How would you describe current financial status of your household?" -- a
+self-rated 5-point ordinal:
+  {1: 'Very bad', 2: 'Bad', 3: 'Neither good nor bad', 4: 'Good', 5: 'Very good'}
+plus a non-substantive {6: 'Doesn t know'} option.
+
+This is the subjective financial-position rating, so it maps to the canonical
+life_satisfaction Domain 'Finances'.  We preserve the survey's native ordinal
+label as the Satisfaction value (do NOT invent a numeric scale).
+
+The file is already HOUSEHOLD level: one row per (mesto, rbd), no duplicates.
+The household id ``i`` matches the roster's ``i`` (idxvars i: [mesto, rbd],
+formatted as 'mesto-rbd' via format_id) -- see ../_/mapping.py and
+household_roster in data_info.yml.
+
+Output is LONG-form, index (t, i, Domain), single column Satisfaction.
+"Doesn t know" / missing responses are dropped (non-substantive).
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, format_id, to_parquet
+
+DOMAIN = 'Finances'
+
+# Native 5-point ordinal labels we keep (drop 'Doesn t know' and missing).
+SUBSTANTIVE = {'Very bad', 'Bad', 'Neither good nor bad', 'Good', 'Very good'}
+
+df = get_dataframe('../Data/2002 5 non-food consumption.dta')[['mesto', 'rbd', 'bm2']].copy()
+
+# Build i to match the roster: 'mesto-rbd' via format_id.
+df['i'] = df.apply(
+    lambda r: format_id('-'.join([str(int(r['mesto'])), str(int(r['rbd']))])),
+    axis=1,
+)
+
+df['Satisfaction'] = df['bm2'].astype(str).str.strip()
+df = df[df['Satisfaction'].isin(SUBSTANTIVE)]
+
+df['t'] = '2002'
+df['Domain'] = DOMAIN
+
+out = (df[['t', 'i', 'Domain', 'Satisfaction']]
+       .drop_duplicates(subset=['t', 'i', 'Domain'])
+       .set_index(['t', 'i', 'Domain'])
+       .sort_index())
+
+to_parquet(df=out, fn='life_satisfaction.parquet')

--- a/lsms_library/countries/Serbia and Montenegro/2003/_/life_satisfaction.py
+++ b/lsms_library/countries/Serbia and Montenegro/2003/_/life_satisfaction.py
@@ -1,0 +1,53 @@
+"""
+Serbia and Montenegro 2003 life_satisfaction.
+
+Source: ../Data/2003 5 non-food consumption.dta (the household-level non-food
+consumption module).  Variable ``bm2`` is the same self-rated household
+financial-status item used in 2002:
+  {'Very bad', 'Bad', 'Neither bad nor good', 'Good', 'Very good'}
+plus a non-substantive 'Dont know' option.
+
+Maps to the canonical life_satisfaction Domain 'Finances'.  We preserve the
+survey's native ordinal label as Satisfaction.  The 2003 wording of the middle
+category is "Neither bad nor good"; it is normalized to the 2002 canonical
+"Neither good nor bad" so the ordinal label set is consistent across waves.
+
+Household level (one row per (mesto, rbd)); ``i`` matches the roster
+(idxvars i: [mesto, rbd], formatted 'mesto-rbd' via format_id).
+
+Output is LONG-form, index (t, i, Domain), single column Satisfaction.
+"Dont know" / missing responses are dropped (non-substantive).
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, format_id, to_parquet
+
+DOMAIN = 'Finances'
+
+# 2003 raw label -> canonical 5-point ordinal (drop 'Dont know' / missing).
+LABEL_MAP = {
+    'Very bad': 'Very bad',
+    'Bad': 'Bad',
+    'Neither bad nor good': 'Neither good nor bad',
+    'Good': 'Good',
+    'Very good': 'Very good',
+}
+
+df = get_dataframe('../Data/2003 5 non-food consumption.dta')[['mesto', 'rbd', 'bm2']].copy()
+
+df['i'] = df.apply(
+    lambda r: format_id('-'.join([str(int(r['mesto'])), str(int(r['rbd']))])),
+    axis=1,
+)
+
+df['Satisfaction'] = df['bm2'].astype(str).str.strip().map(LABEL_MAP)
+df = df[df['Satisfaction'].notna()]
+
+df['t'] = '2003'
+df['Domain'] = DOMAIN
+
+out = (df[['t', 'i', 'Domain', 'Satisfaction']]
+       .drop_duplicates(subset=['t', 'i', 'Domain'])
+       .set_index(['t', 'i', 'Domain'])
+       .sort_index())
+
+to_parquet(df=out, fn='life_satisfaction.parquet')

--- a/lsms_library/countries/Serbia and Montenegro/_/data_scheme.yml
+++ b/lsms_library/countries/Serbia and Montenegro/_/data_scheme.yml
@@ -6,6 +6,11 @@ Data Scheme:
     Region: str
     Rural: str
 
+  life_satisfaction:
+    index: (t, i, Domain)
+    Satisfaction: str
+    materialize: make
+
   household_roster:
     index: (t, i, pid)
     Sex: str

--- a/lsms_library/countries/South Africa/1993/_/life_satisfaction.py
+++ b/lsms_library/countries/South Africa/1993/_/life_satisfaction.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""South Africa 1993 life_satisfaction (SALDRU PSLSD).
+
+Source: S5_PQL.dta -- Section 9 'Perceived Quality of Life'.  One row per
+household (8804 unique hhid; resp_cod records which member answered).
+
+The only genuine satisfaction-RATING item in this module is `satisfie`
+("1 :Level of satisfaction" -- the overall "Taking everything into account,
+how satisfied are you with the way you live?" question), coded 1..5 on the
+standard SALDRU 5-point satisfaction scale.  All other columns are NOT
+satisfaction ratings and are deliberately excluded:
+  - choice1_/2_/3_ + ranks: respondent's life-improvement priorities
+  - safety_h / safety_o:     perceived safety inside / outside the home
+  - crime_q, c_*:            crime victimisation
+  - parents_:                "compared with parents" (relative standing)
+  - new_govt:                expected effect of the new government
+
+So this feature carries a single Domain='Overall'.  Output is LONG on
+(i, Domain); the framework adds t='1993' and joins v from sample().
+satisfie has no .dta value labels; the 5-point scale is decoded from the
+SALDRU PSLSD 1993 questionnaire (Section 9).  Sentinels -1 (refused/no
+answer) and -3 (not applicable) are nulled out.
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+SATISFACTION = {
+    1: "Very satisfied",
+    2: "Satisfied",
+    3: "Neither satisfied nor dissatisfied",
+    4: "Dissatisfied",
+    5: "Very dissatisfied",
+}
+
+df = get_dataframe('../Data/S5_PQL.dta')
+
+s = df[['hhid', 'satisfie']].copy()
+s['hhid'] = s['hhid'].astype(int).astype(str)
+s['Satisfaction'] = s['satisfie'].map(SATISFACTION)  # sentinels -> NaN
+s = s.dropna(subset=['Satisfaction'])
+
+s['Domain'] = 'Overall'
+out = (s.rename(columns={'hhid': 'i'})[['i', 'Domain', 'Satisfaction']]
+        .set_index(['i', 'Domain']))
+
+to_parquet(out, 'life_satisfaction.parquet')

--- a/lsms_library/countries/South Africa/_/data_scheme.yml
+++ b/lsms_library/countries/South Africa/_/data_scheme.yml
@@ -50,3 +50,14 @@ Data Scheme:
   interview_date:
     index: (t, i)
     Int_t: datetime
+
+  life_satisfaction:
+    # 1993 S5_PQL.dta (Section 9 'Perceived Quality of Life'), one row per
+    # household.  Only the overall satisfaction item `satisfie` is a genuine
+    # satisfaction rating (-> Domain='Overall'); safety/crime/priorities/
+    # comparison items in the same module are deliberately excluded.  Built
+    # by the wave script 1993/_/life_satisfaction.py (constant Domain level +
+    # WIDE->LONG reshape need a script, not YAML).
+    index: (t, i, Domain)
+    Satisfaction: str
+    materialize: make

--- a/lsms_library/countries/Tajikistan/2007/_/life_satisfaction.py
+++ b/lsms_library/countries/Tajikistan/2007/_/life_satisfaction.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""Tajikistan 2007 life_satisfaction.
+
+Source: ../Data/r1m9.dta -- Module 9a (round 1), the round whose roster
+(r1m1.dta) is the canonical household_roster source for the 2007 wave, so
+i: hhid matches the roster's i.
+
+The 2007 wave was fielded in multiple rounds; only round 1 (r1m9) and the
+supplementary round (sm9) carry the satisfaction items, and round 2 (r2m9)
+carries none.  We use r1m9 alone because it is the round aligned with the
+canonical roster/sample (t='2007'); folding sm9 in under the same t would
+duplicate (t, i, Domain) for panel households re-interviewed in the supplement.
+
+Genuine satisfaction-rating items kept (variable labels confirmed via
+pyreadstat metadata):
+  m9aq10 "Overall how satisfied are you with your life?"          -> Domain 'Overall'
+  m9aq2  "How satisfied are you with your current financial       -> Domain 'Finances'
+          situation?"
+
+Deliberately EXCLUDED (per the #331 brief):
+  - m9aq9a/m9aq9b are the 6-step subjective-poverty (Cantril-style) ladder ->
+    that is the separate subjective_well_being construct, not a satisfaction rating.
+  - m9aq1/m9aq5 (meals/income), m9aq3/m9aq4 (direction/expectation of financial
+    situation), m9aq6/m9aq7 (adequacy of food consumption/expenditure), m9aq8/m9aq11
+    (concern), m9aq12*-m9aq33* (HFIAS / dietary-diversity / food-security battery),
+    and the Module 9b intra-household decision-making block.
+
+Native ordinal labels are preserved verbatim. Non-substantive responses and
+missing are dropped. Output is LONG-form, index (t, i, Domain).
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, format_id, to_parquet
+
+ITEMS = {
+    'm9aq10': 'Overall',
+    'm9aq2': 'Finances',
+}
+
+NON_SUBSTANTIVE = {"don't know", 'refuse to answer'}
+
+df = get_dataframe('../Data/r1m9.dta')[['hhid'] + list(ITEMS)].copy()
+df['i'] = df['hhid'].apply(format_id)
+
+long = df.melt(id_vars='i', value_vars=list(ITEMS),
+               var_name='item', value_name='Satisfaction')
+long['Domain'] = long['item'].map(ITEMS)
+long['Satisfaction'] = long['Satisfaction'].astype(str).str.strip()
+
+long = long[~long['Satisfaction'].str.lower().isin(NON_SUBSTANTIVE)]
+long = long[~long['Satisfaction'].isin(['nan', 'None', ''])]
+
+long['t'] = '2007'
+
+out = (long[['t', 'i', 'Domain', 'Satisfaction']]
+       .drop_duplicates(subset=['t', 'i', 'Domain'])
+       .set_index(['t', 'i', 'Domain'])
+       .sort_index())
+
+to_parquet(df=out, fn='life_satisfaction.parquet')

--- a/lsms_library/countries/Tajikistan/2009/_/life_satisfaction.py
+++ b/lsms_library/countries/Tajikistan/2009/_/life_satisfaction.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""Tajikistan 2009 life_satisfaction.
+
+Source: ../Data/m8a.dta -- Module 8a "Subjective Poverty and Food Security"
+(household level, one row per HHID, i matches the roster's i: HHID).
+
+Genuine satisfaction-rating items kept (variable labels confirmed via
+pyreadstat metadata):
+  M8AQ9  "Overall how satisfied are you with your life?"          -> Domain 'Overall'
+  M8AQ2  "How satisfied are you with your current financial       -> Domain 'Finances'
+          situation?"
+
+Deliberately EXCLUDED (per the #331 brief):
+  - M8AQ1/M8AQ5 (meals/income amounts), M8AQ3/M8AQ4 (direction of change /
+    expectation of financial situation -- not a satisfaction rating),
+    M8AQ6/M8AQ7 (adequacy of food consumption/expenditure), M8AQ8/M8AQ10
+    (level of concern / aspect of concern -- not satisfaction).
+  - M8AQ11-M8AQ34_* are the HFIAS food-(in)security battery -> food-security family.
+  - This module has NO subjective-poverty / Cantril ladder item here (the ladder
+    lives in the 2007 m9 module as m9aq9a/b and belongs to subjective_well_being).
+
+Native ordinal labels are preserved verbatim as the Satisfaction value (no numeric
+scale invented). Non-substantive responses ("don't know", "refuse to answer") and
+missing are dropped. Output is LONG-form, index (t, i, Domain).
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, format_id, to_parquet
+
+ITEMS = {
+    'M8AQ9': 'Overall',
+    'M8AQ2': 'Finances',
+}
+
+NON_SUBSTANTIVE = {"don't know", 'refuse to answer'}
+
+df = get_dataframe('../Data/m8a.dta')[['HHID'] + list(ITEMS)].copy()
+df['i'] = df['HHID'].apply(format_id)
+
+long = df.melt(id_vars='i', value_vars=list(ITEMS),
+               var_name='item', value_name='Satisfaction')
+long['Domain'] = long['item'].map(ITEMS)
+long['Satisfaction'] = long['Satisfaction'].astype(str).str.strip()
+
+long = long[~long['Satisfaction'].str.lower().isin(NON_SUBSTANTIVE)]
+long = long[~long['Satisfaction'].isin(['nan', 'None', ''])]
+
+long['t'] = '2009'
+
+out = (long[['t', 'i', 'Domain', 'Satisfaction']]
+       .drop_duplicates(subset=['t', 'i', 'Domain'])
+       .set_index(['t', 'i', 'Domain'])
+       .sort_index())
+
+to_parquet(df=out, fn='life_satisfaction.parquet')

--- a/lsms_library/countries/Tajikistan/_/data_scheme.yml
+++ b/lsms_library/countries/Tajikistan/_/data_scheme.yml
@@ -6,6 +6,11 @@ Data Scheme:
     Int_t: datetime
     materialize: make
 
+  life_satisfaction:
+    index: (t, i, Domain)
+    Satisfaction: str
+    materialize: make
+
   cluster_features:
     index: (t, v)
     Region: str

--- a/lsms_library/countries/Tajikistan/_/life_satisfaction.py
+++ b/lsms_library/countries/Tajikistan/_/life_satisfaction.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""Concatenate wave-level life_satisfaction data for Tajikistan.
+
+Only the 2007 and 2009 waves carry a subjective life/financial satisfaction
+module (Module 9a / 8a "Subjective Poverty and Food Security").  Each wave's
+_/life_satisfaction.py emits a LONG-form (t, i, Domain) parquet with a single
+Satisfaction column.  This country-level script runs each wave script (so the
+wave parquets exist on a cold build), reads them, and concatenates.
+"""
+import os
+import subprocess
+import sys
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+WAVES = ['2007', '2009']
+
+X = []
+for t in WAVES:
+    script = f'../{t}/_/life_satisfaction.py'
+    parquet = f'../{t}/_/life_satisfaction.parquet'
+    try:
+        df = get_dataframe(parquet)
+    except FileNotFoundError:
+        subprocess.run([sys.executable or 'python3', 'life_satisfaction.py'],
+                       cwd=os.path.dirname(script), check=True)
+        df = get_dataframe(parquet)
+    X.append(df)
+
+x = pd.concat(X, axis=0)
+
+to_parquet(x, '../var/life_satisfaction.parquet')

--- a/lsms_library/countries/Tanzania/2008-15/_/life_satisfaction.py
+++ b/lsms_library/countries/Tanzania/2008-15/_/life_satisfaction.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+"""Tanzania 2008-15 life_satisfaction -- domain-satisfaction battery (SECTION G).
+
+Source file: ``upd4_hh_g.dta`` -- the multi-round "Subjective Welfare" module
+covering NPS rounds 1-4 (waves 2008-09, 2010-11, 2012-13, 2014-15), stacked
+with a ``round`` column.  As with the other multi-round Tanzania scripts this
+writes ONE parquet carrying all rounds with ``t`` in the index; Wave.grab_data
+filters to the requested sub-wave.
+
+The module is INDIVIDUAL-level (asked of every member aged 15+, ~83.7k rows).
+The canonical feature is HOUSEHOLD-level (index ``(t, i, Domain)``), so each
+household is REDUCED to its HEAD: heads come from the roster ``upd4_hh_b.dta``
+(``hb_05 == 'HEAD'``, exactly one per (round, r_hhid)); the head's row is
+selected by joining on ``(round, r_hhid, r_id)`` (16540 heads match 1:1 across
+all four rounds).
+
+``i = r_hhid`` (matches the wave's household_roster ``i``); ``t`` is the round
+mapped to its wave label.
+
+WIDE -> LONG: the 9 items ``hg_03_1 .. hg_03_9``.  NB the item ORDER differs
+from the 2019-20/2020-21 questionnaire: here the overall-life item is _8 and
+there is a spouse item (_9) instead of transport/health-care-access items.
+Domain mapping from the .dta variable labels:
+
+    hg_03_1  YOUR HEALTH                 -> Health
+    hg_03_2  YOUR FINANCIAL SITUATION    -> Finances
+    hg_03_3  YOUR HOUSING                -> Housing
+    hg_03_4  YOUR JOB                    -> Job
+    hg_03_5  THE HEALTH CARE AVAILABLE   -> HealthCareAccess
+    hg_03_6  THE EDUCATION AVAILABLE     -> Education
+    hg_03_7  YOUR PROTECTION AGAINST ... -> Safety
+    hg_03_8  YOUR LIFE AS A WHOLE        -> Overall
+    hg_03_9  YOUR HUSBAND/WIFE           -> Spouse
+
+HealthCareAccess and Spouse have no canonical Domain in the shared list; they
+are kept under descriptive non-canonical names rather than discarded.
+
+``Satisfaction`` carries the native 7-point ordinal label, Title-cased.  "NOT
+APPLICABLE" is nulled.
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+round_match = {1: '2008-09', 2: '2010-11', 3: '2012-13', 4: '2014-15'}
+
+# hg_03_N suffix -> canonical (or descriptive) Domain.  Note the _8/_9
+# ordering departs from the later waves (see module docstring).
+DOMAINS = {
+    1: 'Health',
+    2: 'Finances',
+    3: 'Housing',
+    4: 'Job',
+    5: 'HealthCareAccess',
+    6: 'Education',
+    7: 'Safety',
+    8: 'Overall',
+    9: 'Spouse',
+}
+
+SATISFACTION = {
+    'VERY SATISFIED': 'Very satisfied',
+    'SATISFIED': 'Satisfied',
+    'SOMEWHAT SATISFIED': 'Somewhat satisfied',
+    'NEITHER SATISFIED NOR DISSATISFIED': 'Neither satisfied nor dissatisfied',
+    'SOMEWHAT DISSATISFIED': 'Somewhat dissatisfied',
+    'DISSATISFIED': 'Dissatisfied',
+    'VERY DISSATISFIED': 'Very dissatisfied',
+}
+
+# --- identify the household head per (round, r_hhid) from the roster ------
+roster = get_dataframe('../Data/upd4_hh_b.dta', convert_categoricals=True)
+heads = roster.loc[
+    roster['hb_05'].astype(str).str.upper() == 'HEAD',
+    ['round', 'r_hhid', 'r_id'],
+].copy()
+heads['round'] = heads['round'].astype(float)
+heads['r_id'] = heads['r_id'].astype(float)
+heads['r_hhid'] = heads['r_hhid'].astype(str)
+
+# --- reduce the individual-level module to the head's row -----------------
+sat = get_dataframe('../Data/upd4_hh_g.dta', convert_categoricals=True)
+sat['round'] = sat['round'].astype(float)
+sat['r_id'] = sat['r_id'].astype(float)
+sat['r_hhid'] = sat['r_hhid'].astype(str)
+
+head_rows = heads.merge(sat, on=['round', 'r_hhid', 'r_id'], how='inner')
+
+item_cols = [f'hg_03_{n}' for n in DOMAINS]
+wide = head_rows[['round', 'r_hhid'] + item_cols].rename(columns={'r_hhid': 'i'})
+wide['t'] = wide['round'].map(round_match)
+wide = wide.drop(columns=['round'])
+
+# --- WIDE -> LONG on (t, i, Domain) --------------------------------------
+long = wide.melt(id_vars=['t', 'i'], value_vars=item_cols,
+                 var_name='item', value_name='Satisfaction')
+long['Domain'] = long['item'].str.removeprefix('hg_03_').astype(int).map(DOMAINS)
+long['Satisfaction'] = (
+    long['Satisfaction'].astype(str).str.upper().map(SATISFACTION)
+)
+
+long = long.dropna(subset=['Satisfaction'])
+
+out = long[['t', 'i', 'Domain', 'Satisfaction']].set_index(['t', 'i', 'Domain'])
+
+if not out.index.is_unique:
+    out = out.groupby(level=out.index.names).first()
+
+to_parquet(out, 'life_satisfaction.parquet')

--- a/lsms_library/countries/Tanzania/2019-20/_/life_satisfaction.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/life_satisfaction.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+"""Tanzania 2019-20 life_satisfaction -- domain-satisfaction battery (SECTION G).
+
+Source: ``HH_SEC_G.dta`` ("Subjective Welfare").  The module is asked of every
+household member aged 15+, so it is INDIVIDUAL-level (~5.6k rows, one
+respondent block per HH member).  The canonical ``life_satisfaction`` feature
+is HOUSEHOLD-level (index ``(t, i, Domain)``), so we REDUCE each household to
+its HEAD: the head is identified from the roster (``HH_SEC_B`` ``hh_b05 ==
+'HEAD'``), which has exactly one head per household, and ~100% of those heads
+are present in this module.  The head's row is selected by joining on
+``(sdd_hhid, sdd_indid)``.
+
+``i = sdd_hhid`` (matches the wave's household_roster ``i``).
+
+WIDE -> LONG: the 9 battery items ``hh_g03_1 .. hh_g03_9`` each become one
+``(t, i, Domain)`` row.  Domain mapping from the .dta variable labels:
+
+    hh_g03_1  YOUR HEALTH                      -> Health
+    hh_g03_2  YOUR FINANCIAL SITUATION         -> Finances
+    hh_g03_3  YOUR HOUSING                     -> Housing
+    hh_g03_4  YOUR JOB                         -> Job
+    hh_g03_5  THE HEALTH CARE AVAILABLE        -> HealthCareAccess
+    hh_g03_6  THE EDUCATION AVAILABLE          -> Education
+    hh_g03_7  YOUR PROTECTION AGAINST CRIME    -> Safety
+    hh_g03_8  YOUR SAFETY IN TRANSPORT         -> TransportSafety
+    hh_g03_9  YOUR LIFE AS A WHOLE             -> Overall
+
+Items 5 and 8 (health-care access, transport safety) have no canonical Domain
+in the shared list; they are kept under descriptive non-canonical names rather
+than discarded (harmonize the interface, not the data).
+
+``Satisfaction`` carries the native 7-point ordinal label, normalized from the
+ALL-CAPS source to Title Case.  The "NOT APPLICABLE" sentinel is nulled (it is
+not a satisfaction level).  ``t`` is added here ('2019-20'); the country-level
+aggregator concatenates waves and applies id_walk.
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+# hh_g03_N suffix -> canonical (or descriptive) Domain.
+DOMAINS = {
+    1: 'Health',
+    2: 'Finances',
+    3: 'Housing',
+    4: 'Job',
+    5: 'HealthCareAccess',
+    6: 'Education',
+    7: 'Safety',
+    8: 'TransportSafety',
+    9: 'Overall',
+}
+
+# Native ordinal labels (ALL-CAPS in source) -> human-readable Title Case.
+# "NOT APPLICABLE" is not a rating -> dropped (NA).
+SATISFACTION = {
+    'VERY SATISFIED': 'Very satisfied',
+    'SATISFIED': 'Satisfied',
+    'SOMEWHAT SATISFIED': 'Somewhat satisfied',
+    'NEITHER SATISFIED NOR DISSATISFIED': 'Neither satisfied nor dissatisfied',
+    'SOMEWHAT DISSATISFIED': 'Somewhat dissatisfied',
+    'DISSATISFIED': 'Dissatisfied',
+    'VERY DISSATISFIED': 'Very dissatisfied',
+}
+
+# --- identify the household head's indid from the roster ------------------
+roster = get_dataframe('../Data/HH_SEC_B.dta', convert_categoricals=True)
+heads = roster.loc[
+    roster['hh_b05'].astype(str).str.upper() == 'HEAD', ['sdd_hhid', 'sdd_indid']
+].copy()
+
+# --- reduce the individual-level module to the head's row -----------------
+sat = get_dataframe('../Data/HH_SEC_G.dta', convert_categoricals=True)
+head_rows = heads.merge(sat, on=['sdd_hhid', 'sdd_indid'], how='inner')
+
+item_cols = [f'hh_g03_{n}' for n in DOMAINS]
+wide = head_rows[['sdd_hhid'] + item_cols].rename(columns={'sdd_hhid': 'i'})
+wide['i'] = wide['i'].astype(str)
+
+# --- WIDE -> LONG on (i, Domain) -----------------------------------------
+long = wide.melt(id_vars='i', value_vars=item_cols,
+                 var_name='item', value_name='Satisfaction')
+long['Domain'] = long['item'].str.removeprefix('hh_g03_').astype(int).map(DOMAINS)
+long['Satisfaction'] = (
+    long['Satisfaction'].astype(str).str.upper().map(SATISFACTION)
+)
+
+# Drop rows with no genuine rating (NA / "not applicable" / unanswered).
+long = long.dropna(subset=['Satisfaction'])
+
+long['t'] = '2019-20'
+out = long[['t', 'i', 'Domain', 'Satisfaction']].set_index(['t', 'i', 'Domain'])
+
+if not out.index.is_unique:
+    out = out.groupby(level=out.index.names).first()
+
+to_parquet(out, 'life_satisfaction.parquet')

--- a/lsms_library/countries/Tanzania/2020-21/_/life_satisfaction.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/life_satisfaction.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""Tanzania 2020-21 life_satisfaction -- domain-satisfaction battery (SECTION G).
+
+Source: ``hh_sec_g.dta`` ("Subjective Welfare").  Individual-level (asked of
+every member aged 15+, ~23.6k rows); the canonical feature is HOUSEHOLD-level
+(index ``(t, i, Domain)``), so we REDUCE each household to its HEAD (roster
+``hh_sec_b`` ``hh_b05 == 'HEAD'``) by joining on ``(y5_hhid, indidy5)``.
+
+``i = y5_hhid`` (matches the wave's household_roster ``i``).
+
+WIDE -> LONG: the 9 items ``hh_g03_1 .. hh_g03_9`` map to the same Domains as
+2019-20 (identical questionnaire):
+
+    hh_g03_1 Health  hh_g03_2 Finances  hh_g03_3 Housing  hh_g03_4 Job
+    hh_g03_5 HealthCareAccess  hh_g03_6 Education  hh_g03_7 Safety
+    hh_g03_8 TransportSafety   hh_g03_9 Overall
+
+The 2020-21 value labels are MIXED CASE in source ("satisfied"/"dissatisfied"
+lower-case for codes 2/6); ``.str.upper()`` normalizes before mapping so the
+output ``Satisfaction`` labels match the other waves' Title Case.  "NOT
+APPLICABLE" is nulled.  ``t`` = '2020-21'.
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+DOMAINS = {
+    1: 'Health',
+    2: 'Finances',
+    3: 'Housing',
+    4: 'Job',
+    5: 'HealthCareAccess',
+    6: 'Education',
+    7: 'Safety',
+    8: 'TransportSafety',
+    9: 'Overall',
+}
+
+SATISFACTION = {
+    'VERY SATISFIED': 'Very satisfied',
+    'SATISFIED': 'Satisfied',
+    'SOMEWHAT SATISFIED': 'Somewhat satisfied',
+    'NEITHER SATISFIED NOR DISSATISFIED': 'Neither satisfied nor dissatisfied',
+    'SOMEWHAT DISSATISFIED': 'Somewhat dissatisfied',
+    'DISSATISFIED': 'Dissatisfied',
+    'VERY DISSATISFIED': 'Very dissatisfied',
+}
+
+# --- identify the household head's indid from the roster ------------------
+roster = get_dataframe('../Data/hh_sec_b.dta', convert_categoricals=True)
+heads = roster.loc[
+    roster['hh_b05'].astype(str).str.upper() == 'HEAD', ['y5_hhid', 'indidy5']
+].copy()
+
+# --- reduce the individual-level module to the head's row -----------------
+sat = get_dataframe('../Data/hh_sec_g.dta', convert_categoricals=True)
+head_rows = heads.merge(sat, on=['y5_hhid', 'indidy5'], how='inner')
+
+item_cols = [f'hh_g03_{n}' for n in DOMAINS]
+wide = head_rows[['y5_hhid'] + item_cols].rename(columns={'y5_hhid': 'i'})
+wide['i'] = wide['i'].astype(str)
+
+# --- WIDE -> LONG on (i, Domain) -----------------------------------------
+long = wide.melt(id_vars='i', value_vars=item_cols,
+                 var_name='item', value_name='Satisfaction')
+long['Domain'] = long['item'].str.removeprefix('hh_g03_').astype(int).map(DOMAINS)
+long['Satisfaction'] = (
+    long['Satisfaction'].astype(str).str.upper().map(SATISFACTION)
+)
+
+long = long.dropna(subset=['Satisfaction'])
+
+long['t'] = '2020-21'
+out = long[['t', 'i', 'Domain', 'Satisfaction']].set_index(['t', 'i', 'Domain'])
+
+if not out.index.is_unique:
+    out = out.groupby(level=out.index.names).first()
+
+to_parquet(out, 'life_satisfaction.parquet')

--- a/lsms_library/countries/Tanzania/_/Makefile
+++ b/lsms_library/countries/Tanzania/_/Makefile
@@ -39,6 +39,15 @@ $(VAR_DIR)/shocks.parquet: shocks.py $(shocks_parquet)
 ../%/_/shocks.parquet:
 	(cd $(@D) && python shocks.py)
 
+life_satisfaction = $(shell find $(rounds) -name life_satisfaction.py)
+life_satisfaction_parquet := $(life_satisfaction:.py=.parquet)
+
+$(VAR_DIR)/life_satisfaction.parquet: life_satisfaction.py $(life_satisfaction_parquet)
+	python life_satisfaction.py
+
+../%/_/life_satisfaction.parquet:
+	(cd $(@D) && python life_satisfaction.py)
+
 plot_features = $(shell find $(rounds) -name plot_features.py)
 plot_features_parquet := $(plot_features:.py=.parquet)
 

--- a/lsms_library/countries/Tanzania/_/data_scheme.yml
+++ b/lsms_library/countries/Tanzania/_/data_scheme.yml
@@ -38,6 +38,22 @@ Data Scheme:
     Educational Attainment: str
     materialize: make
 
+  life_satisfaction:
+    # Domain-satisfaction battery (Section G "Subjective Welfare", item
+    # hh_g03_* / hg_03_*).  Present in ALL Tanzania waves: 2008-09, 2010-11,
+    # 2012-13, 2014-15 (multi-round upd4_hh_g.dta), 2019-20 (HH_SEC_G.dta),
+    # and 2020-21 (hh_sec_g.dta).  The module is INDIVIDUAL-level (asked of
+    # every member 15+); each wave script REDUCES to the household HEAD (roster
+    # hh_b05/hb_05 == 'HEAD') and reshapes the 9 items WIDE->LONG.  Domains:
+    # Health, Finances, Housing, Job, HealthCareAccess, Education, Safety, plus
+    # TransportSafety + Overall (2019-/2020-) or Overall + Spouse (2008-15;
+    # item order differs).  Satisfaction = native 7-point ordinal label,
+    # Title-cased ("Very satisfied".."Very dissatisfied"); "NOT APPLICABLE"
+    # nulled.  NOT the Cantril ladder (that is subjective_well_being).
+    index: (t, i, Domain)
+    Satisfaction: str
+    materialize: make
+
   interview_date:
     index: (t, i)
     Int_t: datetime

--- a/lsms_library/countries/Tanzania/_/life_satisfaction.py
+++ b/lsms_library/countries/Tanzania/_/life_satisfaction.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Concatenate Tanzania life_satisfaction (Section G subjective welfare) across
+waves and apply panel-id walking.
+
+Each wave-level script writes a ``(t, i, Domain)`` parquet with the head's
+domain-satisfaction ratings.  The 2008-15 folder's parquet already carries all
+four NPS rounds as distinct ``t`` values; the 2019-20 / 2020-21 folders carry
+one wave each.  We load by folder (Waves.keys()), concatenate, then id_walk to
+harmonize household ids across waves.
+"""
+from lsms_library.local_tools import to_parquet, get_dataframe
+from lsms_library.paths import data_root
+
+import sys
+sys.path.append('../../_/')
+import pandas as pd
+from tanzania import Waves, id_walk
+import warnings
+import json
+
+s = {}
+for t in Waves.keys():
+    candidates = [
+        str(data_root('Tanzania') / t / '_' / 'life_satisfaction.parquet'),
+        '../' + t + '/_/life_satisfaction.parquet',
+    ]
+    loaded = False
+    for path in candidates:
+        try:
+            s[t] = get_dataframe(path)
+            loaded = True
+            break
+        except (FileNotFoundError, Exception):
+            continue
+    if not loaded:
+        warnings.warn(f'Could not load life_satisfaction for {t}')
+
+if not s:
+    raise RuntimeError('No life_satisfaction data found for any wave.')
+
+s = pd.concat(s.values())
+
+# Ensure index uses 'i' (not 'j')
+if 'j' in s.index.names and 'i' not in s.index.names:
+    s.index = s.index.rename({'j': 'i'})
+
+target_idx = ['t', 'i', 'Domain']
+if list(s.index.names) != target_idx:
+    s = s.reset_index()
+    for col in list(s.columns):
+        if col not in target_idx and col != 'Satisfaction':
+            s = s.drop(columns=[col], errors='ignore')
+    s = s.set_index(target_idx)
+
+with open('updated_ids.json', 'r') as f:
+    updated_ids = json.load(f)
+
+s = id_walk(s, updated_ids, hh_index='i')
+
+to_parquet(s, '../var/life_satisfaction.parquet')

--- a/lsms_library/countries/Timor-Leste/2001/_/life_satisfaction.py
+++ b/lsms_library/countries/Timor-Leste/2001/_/life_satisfaction.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+"""Timor-Leste 2001 life_satisfaction.
+
+Source: Section 13 'Subjective wellbeing'.
+
+  * ../Data/S13A.DTA -- INDIVIDUAL level (one row per adult respondent,
+    ~2-3 rows per household).  The only genuine overall-satisfaction RATING
+    item is ``s13a11`` ("11 satisfied with your life in general"), a 5-point
+    ordinal {very satisfied / rather satisfied / neither satisfied nor
+    unsatisfied / somewhat unsatisfied / very unsatisfied}.  Because the
+    canonical life_satisfaction table is HOUSEHOLD level, we reduce S13A to
+    the household HEAD: the head's ``idperson`` is taken from the roster
+    (S01A1, s01a03 == 'head', 1 head per HH; merge on identif+idperson hits
+    all 1800 households).  -> Domain='Overall'.
+
+    The other S13A columns are NOT satisfaction ratings and are excluded:
+      - s13a01            retrospective "lived better/same/worse 2y ago"
+      - s13a02a..s13a05b  pick-lists of what improved/worsened/priorities
+      - s13a06            corruption perception (more/as much/less)
+      - s13a07..s13a10    Cantril ladder steps (richness / rights, now vs
+                          2y ago) -- these belong to the separate
+                          subjective_well_being (welfare-ladder) construct.
+
+  * ../Data/S13B.DTA -- HOUSEHOLD level (one row per identif, 1800 HHs).
+    Items s13b01..s13b06 are self-evaluated adequacy ("autoevaluation")
+    ratings on a 3-point ordinal {less than adequate / just adequate / more
+    than adequate}.  These are domain satisfaction ratings:
+      s13b01 food          -> Food
+      s13b02 housing       -> Housing
+      s13b03 clothing      -> Clothing
+      s13b04 health care   -> Health
+      s13b05 education     -> Education ('no children' nulled out)
+      s13b06 total income  -> Finances
+    s13b07/s13b08 (poverty-line amounts), s13b09 (religion) are excluded.
+
+Output is LONG, index (t, i, Domain), single column Satisfaction holding the
+survey's native ordinal label (no invented numeric scale).  ``i`` matches the
+roster's ``i`` (identif).
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+T = '2001'
+
+# ---- S13A: overall life satisfaction, reduced to household head -----------
+roster = get_dataframe('../Data/S01A1.DTA')[['identif', 'idperson', 's01a03']]
+heads = roster[roster['s01a03'].astype(str) == 'head'][['identif', 'idperson']]
+
+a = get_dataframe('../Data/S13A.DTA')[['identif', 'idperson', 's13a11']]
+a = heads.merge(a, on=['identif', 'idperson'], how='left')
+a['Satisfaction'] = a['s13a11'].astype(str).str.strip()
+a = a[a['Satisfaction'].ne('nan')]
+a['Domain'] = 'Overall'
+a = a.rename(columns={'identif': 'i'})[['i', 'Domain', 'Satisfaction']]
+
+# ---- S13B: household self-evaluated adequacy ------------------------------
+B_DOMAINS = {
+    's13b01': 'Food',
+    's13b02': 'Housing',
+    's13b03': 'Clothing',
+    's13b04': 'Health',
+    's13b05': 'Education',
+    's13b06': 'Finances',
+}
+ADEQUACY = {'less than adequate', 'just adequate', 'more than adequate'}
+
+b = get_dataframe('../Data/S13B.DTA')[['identif'] + list(B_DOMAINS)].copy()
+b = b.rename(columns={'identif': 'i'})
+long_b = b.melt(id_vars='i', var_name='var', value_name='Satisfaction')
+long_b['Domain'] = long_b['var'].map(B_DOMAINS)
+long_b['Satisfaction'] = long_b['Satisfaction'].astype(str).str.strip()
+# keep only substantive adequacy responses ('no children'/missing dropped)
+long_b = long_b[long_b['Satisfaction'].isin(ADEQUACY)]
+long_b = long_b[['i', 'Domain', 'Satisfaction']]
+
+out = pd.concat([a, long_b], axis=0, ignore_index=True)
+out['t'] = T
+out = (out[['t', 'i', 'Domain', 'Satisfaction']]
+       .drop_duplicates(subset=['t', 'i', 'Domain'])
+       .set_index(['t', 'i', 'Domain'])
+       .sort_index())
+
+to_parquet(df=out, fn='life_satisfaction.parquet')

--- a/lsms_library/countries/Timor-Leste/2007-08/_/life_satisfaction.py
+++ b/lsms_library/countries/Timor-Leste/2007-08/_/life_satisfaction.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+"""Timor-Leste 2007-08 life_satisfaction.
+
+Source: Section 13 'Subjective wellbeing' carried in the household file
+(../Data/hhold.dta, one row per hh_id, 4477 HHs).  The 2007-08 questionnaire
+keeps the 2001 S13B self-evaluation ("autoevaluation") block but drops the
+2001 S13A individual overall-life-satisfaction item -- there is NO overall
+satisfaction question in this wave, so Domain='Overall' is absent here.
+
+Genuine satisfaction (adequacy) ratings, 3-point ordinal
+{Less than adequate / Just adequate / More than adequate}:
+  q13a01 Food consumption   -> Food
+  q13a02 Housing conditions -> Housing
+  q13a03 Clothing           -> Clothing
+  q13a04 Health care        -> Health
+  q13a05 Children education  -> Education ('No children' nulled out)
+  q13a06 Household total income -> Finances
+
+Excluded (NOT satisfaction ratings):
+  q13a07/q13a08 poverty-line amounts; q13a09 "better than 2001" retrospective
+  comparison; q13a10 religion; q13b* monthly food-consumption level / rice
+  shortage / coping actions (food-security content, not satisfaction).
+
+Output is LONG, index (t, i, Domain), Satisfaction = native ordinal label.
+``i`` matches the roster's ``i`` (hh_id as string).
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, format_id, to_parquet
+
+T = '2007-08'
+
+DOMAINS = {
+    'q13a01': 'Food',
+    'q13a02': 'Housing',
+    'q13a03': 'Clothing',
+    'q13a04': 'Health',
+    'q13a05': 'Education',
+    'q13a06': 'Finances',
+}
+ADEQUACY = {'Less than adequate', 'Just adequate', 'More than adequate'}
+
+df = get_dataframe('../Data/hhold.dta')[['hh_id'] + list(DOMAINS)].copy()
+df['i'] = df['hh_id'].apply(format_id)
+long = df.melt(id_vars='i', value_vars=list(DOMAINS),
+               var_name='var', value_name='Satisfaction')
+long['Domain'] = long['var'].map(DOMAINS)
+long['Satisfaction'] = long['Satisfaction'].astype(str).str.strip()
+long = long[long['Satisfaction'].isin(ADEQUACY)]
+long['t'] = T
+
+out = (long[['t', 'i', 'Domain', 'Satisfaction']]
+       .drop_duplicates(subset=['t', 'i', 'Domain'])
+       .set_index(['t', 'i', 'Domain'])
+       .sort_index())
+
+to_parquet(df=out, fn='life_satisfaction.parquet')

--- a/lsms_library/countries/Timor-Leste/_/data_scheme.yml
+++ b/lsms_library/countries/Timor-Leste/_/data_scheme.yml
@@ -37,3 +37,8 @@ Data Scheme:
   interview_date:
     index: (t, i)
     Int_t: datetime
+
+  life_satisfaction:
+    index: (t, i, Domain)
+    Satisfaction: str
+    materialize: make


### PR DESCRIPTION
> **⚠️ STACKED on #360 → #359.** Chain: development → swb-ladder (#359) → food-security-fies (#360) → this. Merge in that order; each diff reduces to its own feature.

Wires the second half of #331's 'two features' design: `life_satisfaction` = life/domain **satisfaction ratings** (distinct from the Cantril ladder in `subjective_well_being`). **New feature**, long-form per the agreed schema.

Schema: index `(t, i, Domain)`, column `Satisfaction` (str, native ordinal label). Individual-level modules reduced to the household head. `Feature('life_satisfaction')()` = 6 countries, 488,952 rows, 15 distinct domains, `(country,i,t,v,Domain)`, no collapse. All `is_this_feature_sane.ok=True`.

| Country | Waves | Domains | Rows |
|---|---|---|---|
| Iraq | 2012 §23 | 11 (Food/Housing/Finances/Health/Job/Safety/Education/…/Overall) | 268,336 |
| Tanzania | 6 waves §G | up to 9/wave (head-reduced) | 152,048 |
| Timor-Leste | 2001/2007-08 §13 | 7 (adequacy block + Overall) | 38,815 |
| Tajikistan | 2007/2009 | Overall + Finances | 12,235 |
| Serbia & Montenegro | 2002/2003 | Finances | 8,794 |
| South Africa | 1993 §9 | Overall | 8,724 |

- **Finances-as-a-domain** absorbs the subjective financial-position ratings (Serbia&Montenegro `bm2`, Tajikistan financial item) — no separate feature, per the agreed design.
- Agents kept survey-specific domains descriptively (Iraq FreedomOfChoice/Control; Tanzania HealthCareAccess/Spouse; Timor Clothing) — preserve-detail.
- Sharp catches: Iraq's truncated/misaligned .dta labels → used the **questionnaire numbering** as authoritative; consistent exclusion of Cantril-ladder items (those are `subjective_well_being`).

**Armenia: absent** — no microdata in repo (`data_available: false`); §H `h1` not reachable. Blocked until WB catalog 2324 is materialized.

Design: `slurm_logs/2026-06-06_assets_ineduc/DESIGN_swb_331.md`. **#331 is now fully implemented** (both features) modulo Armenia's missing data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)