### PR TITLE
fix(food): protect reserved 'kg'/'Value' u-sentinels from country remap (closes #361)

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -60,6 +60,16 @@ logger = logging.getLogger(__name__)
 
 JSON_CACHE_METHODS = {'panel_ids', 'updated_ids'}
 
+# Reserved values on the ``u`` index level that are framework sentinels, not
+# survey unit labels: ``'kg'`` is the kg-conversion tag emitted by
+# food_quantities/food_prices; ``'Value'`` marks LCU-only goods.  A country's
+# ``#+name: u`` categorical table must not remap these on *derived* food
+# tables (GH #361) — see ``_apply_categorical_mappings(protect_u_sentinels=)``.
+_RESERVED_U_SENTINELS = frozenset({'kg', 'Value'})
+
+# Derived food tables whose ``u`` level can carry the reserved sentinels.
+_U_SENTINEL_PROTECTED_METHODS = frozenset({'food_quantities', 'food_prices'})
+
 
 class DeprecatedFeatureError(AttributeError):
     """Raised when a removed or deprecated table method is called on Country.
@@ -1580,7 +1590,8 @@ class Country:
         return merged.set_index(df.index.names)
     
 
-    def _apply_categorical_mappings(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _apply_categorical_mappings(self, df: pd.DataFrame,
+                                    protect_u_sentinels: bool = False) -> pd.DataFrame:
         """Auto-apply categorical mappings where table names match columns or indices.
 
         For each column or index level in *df*, check whether
@@ -1588,6 +1599,18 @@ class Country:
         (case-insensitive).  If the table has a ``Preferred Label``
         column, build a replacement dictionary from the first other
         column → ``Preferred Label`` and apply it.
+
+        ``protect_u_sentinels`` (GH #361): when True, the country
+        ``#+name: u`` table is not allowed to remap the framework's reserved
+        ``u`` conversion sentinels (:data:`_RESERVED_U_SENTINELS` — ``'kg'``,
+        ``'Value'``).  Set for *derived* food tables (food_quantities /
+        food_prices), whose ``u`` level carries the lowercase ``'kg'`` tag
+        produced by the kg conversion.  A country whose table happens to map
+        e.g. ``kg → Kg`` (Burkina, to unify raw food_acquired spellings)
+        would otherwise corrupt that sentinel, so cross-country
+        ``xs('kg', level='u')`` silently misses it.  food_acquired itself
+        passes ``protect_u_sentinels=False`` so its raw unit-label
+        canonicalization is unaffected.
         """
         cat_maps = self.categorical_mapping
         if not cat_maps:
@@ -1596,20 +1619,27 @@ class Country:
         # Build case-insensitive lookup
         lower_lookup = {name.lower(): name for name in cat_maps}
 
-        def _build_replace_dict(table: pd.DataFrame) -> dict | None:
+        def _build_replace_dict(table: pd.DataFrame, *,
+                                drop_keys: set | None = None) -> dict | None:
             if "Preferred Label" not in table.columns:
                 return None
             source_cols = [c for c in table.columns if c != "Preferred Label"]
             if not source_cols:
                 return None
-            return table.set_index(source_cols[0])["Preferred Label"].to_dict()
+            rdict = table.set_index(source_cols[0])["Preferred Label"].to_dict()
+            if drop_keys:
+                # Never remap a reserved sentinel (e.g. the 'kg' conversion
+                # tag) away from itself.
+                rdict = {k: v for k, v in rdict.items() if k not in drop_keys}
+            return rdict
 
         # Apply to columns
         for col in df.columns:
             key = lower_lookup.get(col.lower())
             if key is None:
                 continue
-            rdict = _build_replace_dict(cat_maps[key])
+            drop = _RESERVED_U_SENTINELS if (protect_u_sentinels and col == 'u') else None
+            rdict = _build_replace_dict(cat_maps[key], drop_keys=drop)
             if rdict:
                 if hasattr(df[col], 'str'):
                     df[col] = df[col].str.strip()
@@ -1623,7 +1653,9 @@ class Country:
                 key = lower_lookup.get(level_name.lower())
                 if key is None:
                     continue
-                rdict = _build_replace_dict(cat_maps[key])
+                drop = (_RESERVED_U_SENTINELS
+                        if (protect_u_sentinels and level_name == 'u') else None)
+                rdict = _build_replace_dict(cat_maps[key], drop_keys=drop)
                 if rdict:
                     df = df.rename(index=rdict, level=level_name)
 
@@ -1741,8 +1773,13 @@ class Country:
                 df = _expand_kinship(df)
 
             # Auto-apply categorical mappings where table name matches
-            # a column or index name (issue #49)
-            df = self._apply_categorical_mappings(df)
+            # a column or index name (issue #49).  For derived food tables,
+            # protect the reserved 'kg'/'Value' u-sentinels from a country's
+            # #+name: u remap (GH #361).
+            df = self._apply_categorical_mappings(
+                df,
+                protect_u_sentinels=method_name in _U_SENTINEL_PROTECTED_METHODS,
+            )
 
             # Apply ``harmonize_<method_name>`` mapping to the ``j`` index
             # level when such a categorical_mapping table exists (GH #180,

--- a/tests/test_u_sentinel_protection.py
+++ b/tests/test_u_sentinel_protection.py
@@ -1,0 +1,77 @@
+"""GH #361: a country's #+name:u categorical table must not remap the
+reserved 'kg'/'Value' conversion sentinels on derived food tables.
+
+These exercise Country._apply_categorical_mappings directly with a stub
+``self`` carrying a categorical_mapping, so no data access / Country.__init__
+is needed.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from lsms_library.country import Country, _RESERVED_U_SENTINELS
+
+
+class _Stub:
+    """Minimal stand-in exposing only what _apply_categorical_mappings needs."""
+
+    def __init__(self, cat_maps):
+        self.categorical_mapping = cat_maps
+
+
+def _u_table():
+    # Mirrors Burkina: unifies raw 'kg'/'Kg' -> 'Kg', identity on a container.
+    return {
+        "u": pd.DataFrame(
+            {
+                "Original Label": ["kg", "Kg", "Tas"],
+                "Preferred Label": ["Kg", "Kg", "Tas"],
+            }
+        )
+    }
+
+
+def _frame():
+    idx = pd.MultiIndex.from_tuples(
+        [("A", "kg"), ("A", "Tas")], names=["i", "u"]
+    )
+    return pd.DataFrame({"Quantity": [1.0, 2.0]}, index=idx)
+
+
+def test_kg_in_reserved_sentinels():
+    assert "kg" in _RESERVED_U_SENTINELS
+    assert "Value" in _RESERVED_U_SENTINELS
+
+
+def test_protected_keeps_kg_sentinel():
+    """Derived food tables: the lowercase 'kg' conversion tag survives."""
+    out = Country._apply_categorical_mappings(
+        _Stub(_u_table()), _frame(), protect_u_sentinels=True
+    )
+    u = list(out.index.get_level_values("u"))
+    assert u == ["kg", "Tas"], u  # 'kg' untouched; non-sentinel still mapped
+
+
+def test_unprotected_remaps_kg():
+    """food_acquired (unprotected): raw 'kg' unifies to 'Kg' as before."""
+    out = Country._apply_categorical_mappings(
+        _Stub(_u_table()), _frame(), protect_u_sentinels=False
+    )
+    u = list(out.index.get_level_values("u"))
+    assert u == ["Kg", "Tas"], u  # raw-spelling unification preserved
+
+
+def test_protection_only_touches_u_level():
+    """A non-'u' level with a matching table is unaffected by the flag."""
+    cat = {
+        "j": pd.DataFrame(
+            {"Original Label": ["kg"], "Preferred Label": ["MAPPED"]}
+        )
+    }
+    idx = pd.MultiIndex.from_tuples([("A", "kg")], names=["i", "j"])
+    df = pd.DataFrame({"Quantity": [1.0]}, index=idx)
+    out = Country._apply_categorical_mappings(
+        _Stub(cat), df, protect_u_sentinels=True
+    )
+    # 'kg' on the 'j' level is a normal label, not a u-sentinel -> still mapped.
+    assert list(out.index.get_level_values("j")) == ["MAPPED"]


### PR DESCRIPTION
## Summary

Layer-1 of the unit-`u` harmonization. Derived food tables tag converted rows with the framework's reserved lowercase **`'kg'`** sentinel on the `u` index level, but `_finalize_result` re-applies the country `#+name: u` categorical table to that derived output. A country whose table maps a kilogram spelling — e.g. **Burkina's `kg → Kg`**, which legitimately unifies raw `food_acquired` spellings — rewrites the sentinel to `'Kg'`, so `Feature('food_quantities').xs('kg', level='u')` silently misses that country.

**Fix:** `_apply_categorical_mappings` gains `protect_u_sentinels`. For derived food tables (`food_quantities`, `food_prices`) it drops reserved-sentinel keys (`_RESERVED_U_SENTINELS = {'kg','Value'}`) from the `u` replace dict, so the sentinel passes through untouched. `food_acquired` passes the flag `False`, so its raw unit-label canonicalization is unchanged.

## Verified (NO_CACHE rebuild)

| | before | after |
|---|---|---|
| Burkina `food_acquired` u | 66 distinct, `'Kg'` | **unchanged** (66, `'Kg'`, no fragmentation) |
| Burkina `food_quantities` u | `['116','Kg']` (xs('kg') misses it) | **`['116','kg']`**, 100% kg-resolved |
| Malawi `food_quantities` | 99.9% kg | **unaffected** (99.9%) |

New unit tests (`tests/test_u_sentinel_protection.py`) cover protected vs unprotected behavior and that only the `u` level is touched. schema + food + units-kwarg suites: **227 passed**.

## Scope

This is the cheap, framework-level layer (per the u-harmonization plan): it makes the reserved conversion sentinel inviolate on derived tables, fixing cross-country `xs('kg')` for Burkina and any latent case, without touching food_acquired vocab. The deeper layers — finishing per-country canonicalization (#347/#348) and cross-country unit-vocab harmonization — remain separate.

Closes #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)