### PR TITLE
feat(catalog): top-level ll.countries() and ll.features()

### DIFF
--- a/lsms_library/__init__.py
+++ b/lsms_library/__init__.py
@@ -118,6 +118,7 @@ from sys import stderr
 from . import country
 from .country import Country, Wave
 from .feature import Feature
+from .catalog import countries, features
 from . import local_tools as tools
 from . import transformations
 from .dvc_permissions import authenticate

--- a/lsms_library/catalog.py
+++ b/lsms_library/catalog.py
@@ -1,0 +1,146 @@
+"""Top-level catalog helpers: enumerate available countries and features.
+
+Public entry points (re-exported from the package root):
+
+- :func:`countries` — names accepted by :class:`lsms_library.Country`.
+- :func:`features`  — table names accepted by :class:`lsms_library.Feature`.
+
+Both are config-based (they reflect what's *declared*, i.e. what the
+constructors accept), not build-based: a listed country/feature may still
+fail at data-access time if its microdata isn't available.  Each is
+optionally filterable by the other axis.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+
+from .paths import COUNTRIES_ROOT
+from .yaml_utils import load_yaml
+
+
+@lru_cache(maxsize=1)
+def _country_dirs() -> tuple[str, ...]:
+    """Country directory names that carry a ``_/data_scheme.yml``.
+
+    These are exactly the strings accepted by :class:`lsms_library.Country`.
+    Uses ``pathlib`` (not shell globbing) so multi-word names like
+    ``"South Africa"`` survive intact.
+    """
+    out: list[str] = []
+    for p in sorted(COUNTRIES_ROOT.iterdir()):
+        if not p.is_dir() or p.name.startswith("."):
+            continue
+        if (p / "_" / "data_scheme.yml").exists():
+            out.append(p.name)
+    return tuple(out)
+
+
+def _declared_tables(country: str) -> set[str]:
+    """The ``Data Scheme`` table names declared in *country*'s data_scheme.yml."""
+    f = COUNTRIES_ROOT / country / "_" / "data_scheme.yml"
+    if not f.exists():
+        return set()
+    with open(f, encoding="utf-8") as fh:
+        data = load_yaml(fh)
+    if not isinstance(data, dict):
+        return set()
+    scheme = data.get("Data Scheme", {})
+    return set(scheme) if isinstance(scheme, dict) else set()
+
+
+@lru_cache(maxsize=1)
+def _all_features() -> tuple[str, ...]:
+    """Every table name accepted by :class:`lsms_library.Feature`.
+
+    Union of all countries' declared tables, plus auto-derived tables
+    (e.g. ``household_characteristics``), minus the dict-valued properties
+    (``panel_ids`` / ``updated_ids``) that are not ``Feature``-able.
+    """
+    # Lazy imports avoid an import cycle (country/feature import the package).
+    from .country import JSON_CACHE_METHODS
+    from .feature import _DERIVED_SOURCE
+
+    tables: set[str] = set()
+    for c in _country_dirs():
+        tables |= _declared_tables(c)
+    tables |= set(_DERIVED_SOURCE)        # derived features (household_characteristics, food_*)
+    tables -= set(JSON_CACHE_METHODS)     # panel_ids / updated_ids: not Feature-able
+    return tuple(sorted(tables))
+
+
+def countries(feature: str | None = None) -> list[str]:
+    """List country names accepted by :class:`lsms_library.Country`.
+
+    Parameters
+    ----------
+    feature : str, optional
+        Restrict to countries that provide this feature — including
+        features auto-derived from a declared source table (e.g.
+        ``feature='food_quantities'`` finds countries with ``food_acquired``).
+
+    Returns
+    -------
+    list[str]
+        Sorted country names.
+
+    Raises
+    ------
+    ValueError
+        If *feature* is not a known feature (see :func:`features`).
+
+    Examples
+    --------
+    >>> import lsms_library as ll
+    >>> ll.countries()                       # doctest: +SKIP
+    ['Albania', 'Benin', ..., 'Uganda']
+    >>> ll.countries(feature='food_acquired')  # doctest: +SKIP
+    ['Benin', 'Burkina_Faso', ..., 'Uganda']
+    """
+    if feature is None:
+        return list(_country_dirs())
+    valid = _all_features()
+    if feature not in valid:
+        raise ValueError(
+            f"Unknown feature {feature!r}; choose from {list(valid)}"
+        )
+    from .feature import _discover_countries_for_table
+    return sorted(_discover_countries_for_table(feature))
+
+
+def features(country: str | None = None) -> list[str]:
+    """List feature/table names accepted by :class:`lsms_library.Feature`.
+
+    Parameters
+    ----------
+    country : str, optional
+        Restrict to features available for this country — its declared
+        tables plus any auto-derived from them.
+
+    Returns
+    -------
+    list[str]
+        Sorted feature names.
+
+    Raises
+    ------
+    ValueError
+        If *country* is not a known country (see :func:`countries`).
+
+    Examples
+    --------
+    >>> import lsms_library as ll
+    >>> ll.features()                  # doctest: +SKIP
+    ['assets', 'cluster_features', ..., 'subjective_well_being']
+    >>> ll.features(country='Uganda')  # doctest: +SKIP
+    ['assets', 'cluster_features', ..., 'shocks']
+    """
+    if country is None:
+        return list(_all_features())
+    valid = _country_dirs()
+    if country not in valid:
+        raise ValueError(
+            f"Unknown country {country!r}; choose from {list(valid)}"
+        )
+    from .country import Country, JSON_CACHE_METHODS
+    scheme = Country(country, preload_panel_ids=False).data_scheme
+    return sorted(set(scheme) - set(JSON_CACHE_METHODS))

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,70 @@
+"""Tests for the top-level catalog helpers ll.countries() / ll.features()."""
+from __future__ import annotations
+
+import pytest
+
+import lsms_library as ll
+from lsms_library.country import JSON_CACHE_METHODS
+
+
+def test_exported_at_top_level():
+    assert callable(ll.countries)
+    assert callable(ll.features)
+
+
+def test_countries_basic():
+    cs = ll.countries()
+    assert isinstance(cs, list) and cs == sorted(cs)
+    assert len(cs) > 20
+    # multi-word names survive intact (the shell-glob pitfall)
+    assert "South Africa" in cs
+    assert not any(c in {"South", "Africa", "Republic"} for c in cs)
+
+
+def test_countries_are_country_able():
+    for c in ll.countries():
+        # construction must not raise (config-valid); data access is separate
+        ll.Country(c, preload_panel_ids=False)
+
+
+def test_features_basic():
+    fs = ll.features()
+    assert isinstance(fs, list) and fs == sorted(fs)
+    assert "food_acquired" in fs
+    # derived features are listed
+    assert "household_characteristics" in fs
+    assert {"food_expenditures", "food_prices", "food_quantities"} <= set(fs)
+    # dict-valued properties are NOT Feature-able and must be excluded
+    for nf in JSON_CACHE_METHODS:
+        assert nf not in fs
+
+
+def test_features_are_feature_able():
+    for f in ll.features():
+        ll.Feature(f)  # must construct
+
+
+def test_countries_filtered_by_feature():
+    fa = ll.countries(feature="food_acquired")
+    assert "Uganda" in fa and "Malawi" in fa
+    assert set(fa) <= set(ll.countries())
+    # derived feature resolves via its source table
+    assert ll.countries(feature="food_quantities") == fa
+
+
+def test_features_filtered_by_country():
+    uga = ll.features(country="Uganda")
+    assert "food_acquired" in uga
+    assert "household_characteristics" in uga
+    assert set(uga) <= set(ll.features())
+    assert "panel_ids" not in uga
+
+
+def test_bad_feature_raises():
+    with pytest.raises(ValueError):
+        ll.countries(feature="not_a_feature")
+
+
+def test_bad_country_raises():
+    with pytest.raises(ValueError):
+        ll.features(country="Xanadu")


### PR DESCRIPTION
## Summary

Adds two discoverable, parallel catalog helpers re-exported from the package root, so there's **one sanctioned way** to enumerate the strings the `Country` / `Feature` constructors accept — replacing the three semi-private idioms (`cli._available_country_dirs`, `feature._discover_countries_for_table`, `data_access._COUNTRY_CODES`).

```python
import lsms_library as ll
ll.countries()                          # 34 — all Country-able names, sorted
ll.countries(feature='food_acquired')   # 16 — countries providing that feature
ll.features()                           # 23 — all Feature-able table names
ll.features(country='Uganda')           # features available for Uganda
```

## Semantics

- **`countries(feature=None)`**: country dirs carrying a `_/data_scheme.yml` (exactly what `Country()` accepts; pathlib-based so `'South Africa'`/`'Serbia and Montenegro'` survive). `feature=` restricts to providers and resolves auto-derived features to their source (`feature='food_quantities'` → `food_acquired` countries) via `_discover_countries_for_table`.
- **`features(country=None)`**: union of all declared `Data Scheme` tables **∪** auto-derived (`household_characteristics`, `food_expenditures/prices/quantities`) **−** the non-`Feature`-able dict properties (`panel_ids`, `updated_ids`). `country=` delegates to `Country(country).data_scheme`.

## Design choices (from the discussion)

- Return sorted `list[str]`; **config-based** (declared, not build-valid — a listed country may still fail at data-access time, same as the constructors).
- **Raise `ValueError`** on an unknown filter arg (lists valid choices), matching how `Country('Xanadu')` fails loudly.
- `lru_cache` on the no-arg paths; lazy imports inside the functions avoid an import cycle.

## Verified

Round-trip property holds — every `features()` string constructs a `Feature`, every `countries()` string constructs a `Country`; `panel_ids`/`updated_ids` excluded; `household_characteristics` included; multi-word names intact; bad args raise. `tests/test_catalog.py`: 9 passed.

Note: I left `cli._available_country_dirs` as-is — it intentionally lists *all* dirs (incl. non-survey ones) for cache ops, a different semantic from "Country-able".

🤖 Generated with [Claude Code](https://claude.com/claude-code)