### PR TITLE
feat: food-security non-FIES families (hfias, coping, months-inadequate) — 8 countries (#332)

### DIFF
--- a/lsms_library/countries/Burkina_Faso/2014/_/food_coping.py
+++ b/lsms_library/countries/Burkina_Faso/2014/_/food_coping.py
@@ -8,19 +8,23 @@ alimentaire").  HOUSEHOLD-level (one row per HH, index i = each wave's roster i
 The coping battery ``SA2A..SA2E`` asks, for each strategy, "Au cours des 7
 derniers jours, combien de jours vous, ou une autre personne du ménage, avez-
 vous dû [...]" -- i.e. how many days in the last 7 the household had to resort
-to the behaviour (native day-count 0-7).  The five items are the WFP-standard
-reduced Coping Strategies Index battery, in canonical order:
+to the behaviour (native day-count 0-7).  The five items are the standard
+reduced Coping Strategies Index battery, mapped in questionnaire order:
 
     SA2A  rely on less preferred / less expensive food   -> LessPreferred
-    SA2B  borrow food / rely on help from relatives       -> BorrowFood
-    SA2C  limit portion size at meal-times                -> LimitPortion
+    SA2B  limit portion size at meal-times                -> LimitPortion
+    SA2C  reduce the number of meals eaten per day         -> ReduceMeals
     SA2D  restrict consumption by adults (so kids eat)     -> RestrictAdults
-    SA2E  reduce the number of meals eaten per day         -> ReduceMeals
+    SA2E  borrow food / rely on help from relatives        -> BorrowFood
 
-(The Stata variable labels are truncated at 80 chars to the shared prefix, so
-the discriminating clause isn't recoverable from the .dta; the SA2A..SA2E order
-is the universal WFP rCSI ordering, which the brief's five canonical names
-follow exactly.)
+The Stata variable labels are all truncated at Stata's 80-char cap to the
+identical shared prefix above, so the discriminating clause is NOT recoverable
+from the .dta and no questionnaire ships with the data.  The SA2A..SA2E ->
+Strategy attribution is therefore INFERRED from peer surveys whose labels are
+verifiable and which use this exact a-e ordering: Mali EACI 2014-15 (a
+near-twin francophone-Sahelian WB survey, §17 s17q02a-e, label-verified) and
+Malawi IHS Module H (verified vs the IHS3 questionnaire).  Only the per-strategy
+NAME attribution rests on this inference; the ``Days`` counts are exact.
 
 SA1 (the 7-day gate) is NOT a coping day-count, so it is out of scope here;
 SA3 (meals/day) and SA5/SA6 (12-month provisioning) belong to other features.
@@ -34,13 +38,15 @@ import pandas as pd
 
 from lsms_library.local_tools import get_dataframe, format_id
 
-# SA2{letter} -> canonical rCSI Strategy (WFP-standard ordering).
+# SA2{letter} -> rCSI Strategy, in questionnaire order (a-e) inferred from the
+# Mali EACI 2014-15 / Malawi IHS peer surveys (see module docstring); the
+# Burkina .dta labels are 80-char-truncated and cannot disambiguate directly.
 STRATEGIES = {
     'A': 'LessPreferred',
-    'B': 'BorrowFood',
-    'C': 'LimitPortion',
+    'B': 'LimitPortion',
+    'C': 'ReduceMeals',
     'D': 'RestrictAdults',
-    'E': 'ReduceMeals',
+    'E': 'BorrowFood',
 }
 
 # convert_categoricals=False keeps the SA2 day-counts numeric.

--- a/lsms_library/countries/Burkina_Faso/2014/_/food_coping.py
+++ b/lsms_library/countries/Burkina_Faso/2014/_/food_coping.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+"""Burkina Faso 2014 (EMC) food_coping -- reduced Coping Strategies Index (rCSI).
+
+Source: ``emc2014_p3_securitealimentaire_27022015.dta`` (Part 3 "Sécurité
+alimentaire").  HOUSEHOLD-level (one row per HH, index i = each wave's roster i
+= format_id(zd) + format_id(menage, zeropadding=3), e.g. zd=1, menage=1 -> '1001').
+
+The coping battery ``SA2A..SA2E`` asks, for each strategy, "Au cours des 7
+derniers jours, combien de jours vous, ou une autre personne du ménage, avez-
+vous dû [...]" -- i.e. how many days in the last 7 the household had to resort
+to the behaviour (native day-count 0-7).  The five items are the WFP-standard
+reduced Coping Strategies Index battery, in canonical order:
+
+    SA2A  rely on less preferred / less expensive food   -> LessPreferred
+    SA2B  borrow food / rely on help from relatives       -> BorrowFood
+    SA2C  limit portion size at meal-times                -> LimitPortion
+    SA2D  restrict consumption by adults (so kids eat)     -> RestrictAdults
+    SA2E  reduce the number of meals eaten per day         -> ReduceMeals
+
+(The Stata variable labels are truncated at 80 chars to the shared prefix, so
+the discriminating clause isn't recoverable from the .dta; the SA2A..SA2E order
+is the universal WFP rCSI ordering, which the brief's five canonical names
+follow exactly.)
+
+SA1 (the 7-day gate) is NOT a coping day-count, so it is out of scope here;
+SA3 (meals/day) and SA5/SA6 (12-month provisioning) belong to other features.
+
+``Days`` is the native count of days in the last 7 (int 0-7).  WIDE->LONG: one
+``(t, i, Strategy)`` row per strategy.  Rows where the household was not asked
+(NaN) are dropped.  ``t`` = '2014'.  ``v`` is NOT baked in -- the framework
+joins it from ``sample()`` at API time.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, format_id
+
+# SA2{letter} -> canonical rCSI Strategy (WFP-standard ordering).
+STRATEGIES = {
+    'A': 'LessPreferred',
+    'B': 'BorrowFood',
+    'C': 'LimitPortion',
+    'D': 'RestrictAdults',
+    'E': 'ReduceMeals',
+}
+
+# convert_categoricals=False keeps the SA2 day-counts numeric.
+df = get_dataframe('../Data/emc2014_p3_securitealimentaire_27022015.dta',
+                   convert_categoricals=False)
+
+item_cols = ['SA2' + x for x in STRATEGIES]
+
+wide = df[['zd', 'menage'] + item_cols].copy()
+wide['i'] = (wide['zd'].apply(format_id)
+             + wide['menage'].apply(lambda m: format_id(m, zeropadding=3)))
+
+long = wide.melt(id_vars='i', value_vars=item_cols,
+                 var_name='item', value_name='Days')
+long['Strategy'] = long['item'].str.removeprefix('SA2').map(STRATEGIES)
+long['Days'] = pd.to_numeric(long['Days'], errors='coerce').round().astype('Int64')
+
+long = long.dropna(subset=['Days'])
+
+long['t'] = '2014'
+out = long[['t', 'i', 'Strategy', 'Days']].set_index(['t', 'i', 'Strategy'])
+
+if not out.index.is_unique:
+    out = out.groupby(level=out.index.names).first()
+
+from lsms_library.local_tools import to_parquet
+to_parquet(out, 'food_coping.parquet')

--- a/lsms_library/countries/Burkina_Faso/2014/_/food_coping.py
+++ b/lsms_library/countries/Burkina_Faso/2014/_/food_coping.py
@@ -18,13 +18,22 @@ reduced Coping Strategies Index battery, mapped in questionnaire order:
     SA2E  borrow food / rely on help from relatives        -> BorrowFood
 
 The Stata variable labels are all truncated at Stata's 80-char cap to the
-identical shared prefix above, so the discriminating clause is NOT recoverable
-from the .dta and no questionnaire ships with the data.  The SA2A..SA2E ->
-Strategy attribution is therefore INFERRED from peer surveys whose labels are
-verifiable and which use this exact a-e ordering: Mali EACI 2014-15 (a
-near-twin francophone-Sahelian WB survey, §17 s17q02a-e, label-verified) and
-Malawi IHS Module H (verified vs the IHS3 questionnaire).  Only the per-strategy
-NAME attribution rests on this inference; the ``Days`` counts are exact.
+identical shared prefix above, so the .dta itself cannot disambiguate the five
+items.  The a-e -> Strategy attribution is VERIFIED against the WB EMC 2014
+Passage-3 questionnaire (microdata.worldbank.org catalog 2538,
+Questionnaire_EMC_2014_Passage_3.pdf, section SA), whose SA2 columns read
+verbatim:
+
+    A. "Consommer des aliments moins chers que d'habitude?"       -> LessPreferred
+    B. "Réduire les quantités consommées chaque fois?"            -> LimitPortion
+    C. "Réduire le nombre de repas par jour?"                     -> ReduceMeals
+    D. "Réduire les quantités consommées par les adultes au
+        profit des enfants?"                                      -> RestrictAdults
+    E. "Emprunter de la nourriture, ou compter sur l'aide de
+        parents ou d'amis?"                                       -> BorrowFood
+
+(This order also matches the labels independently verified in the Mali EACI
+2014-15 and Malawi IHS peer surveys.)
 
 SA1 (the 7-day gate) is NOT a coping day-count, so it is out of scope here;
 SA3 (meals/day) and SA5/SA6 (12-month provisioning) belong to other features.
@@ -38,9 +47,10 @@ import pandas as pd
 
 from lsms_library.local_tools import get_dataframe, format_id
 
-# SA2{letter} -> rCSI Strategy, in questionnaire order (a-e) inferred from the
-# Mali EACI 2014-15 / Malawi IHS peer surveys (see module docstring); the
-# Burkina .dta labels are 80-char-truncated and cannot disambiguate directly.
+# SA2{letter} -> rCSI Strategy, in questionnaire order (a-e) verified against
+# the WB EMC 2014 Passage-3 questionnaire (catalog 2538, section SA; see module
+# docstring for the verbatim French).  The .dta labels are 80-char-truncated and
+# cannot disambiguate, but the questionnaire is authoritative.
 STRATEGIES = {
     'A': 'LessPreferred',
     'B': 'LimitPortion',

--- a/lsms_library/countries/Burkina_Faso/2014/_/months_food_inadequate.py
+++ b/lsms_library/countries/Burkina_Faso/2014/_/months_food_inadequate.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Burkina Faso 2014 (EMC) months_food_inadequate -- 12-month provisioning.
+
+Source: ``emc2014_p3_securitealimentaire_27022015.dta`` (Part 3 "Sécurité
+alimentaire").  HOUSEHOLD-level (one row per HH, index i = each wave's roster i
+= format_id(zd) + format_id(menage, zeropadding=3), e.g. zd=1, menage=1 -> '1001').
+
+    SA4        "Au cours des 12 derniers mois, avez-vous fait face à une
+               situation où vous n'aviez pas assez de nourriture [...]" (Oui/Non).
+               The 12-month gate.
+    SA5A..SA5L which of the 12 months the household met this problem
+               (Juillet 2013 .. Juillet 2014), each Oui/Non.  Only asked when
+               SA4 == 'Oui'; NaN for the 'Non' households (skipped out).
+
+Derivation (the which-months battery is present, so MonthsInadequate is the
+count of "Oui" months per the brief):
+    MonthsInadequate = number of SA5A..SA5L == 'Oui', where SA4 == 'Oui';
+                       0 where SA4 == 'Non' (skipped out precisely because they
+                       had no inadequate months); NaN where SA4 is NaN
+                       (question not asked, 10 HH).
+    AnyInadequate    = MonthsInadequate > 0.
+
+``t`` = '2014'.  ``v`` is NOT baked in -- the framework joins it from
+``sample()`` at API time.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+
+df = get_dataframe('../Data/emc2014_p3_securitealimentaire_27022015.dta')
+
+sa5_cols = ['SA5' + c for c in 'ABCDEFGHIJKL']
+
+# Gate: faced a not-enough-food situation in the last 12 months?
+gate = df['SA4'].astype(str).str.strip().str.lower()
+faced = gate.map({'oui': True, 'non': False})  # NaN where not asked
+
+# Count "Oui" month-flags (only populated for the 'Oui' households).
+oui_months = df[sa5_cols].apply(
+    lambda col: col.astype(str).str.strip().str.lower().eq('oui')).sum(axis=1)
+
+# Non households were skipped out of SA5 -> 0 inadequate months; NaN gate -> NaN.
+months = oui_months.where(faced != False, other=0)
+months = months.where(faced.notna(), other=pd.NA)
+
+out = pd.DataFrame(index=df.index)
+out['i'] = (df['zd'].apply(format_id)
+            + df['menage'].apply(lambda m: format_id(m, zeropadding=3)))
+out['t'] = '2014'
+out['MonthsInadequate'] = pd.to_numeric(months, errors='coerce').astype('Int64')
+out['AnyInadequate'] = (out['MonthsInadequate'] > 0).astype('boolean')
+# Preserve NaN gate as <NA> AnyInadequate rather than False.
+out.loc[out['MonthsInadequate'].isna(), 'AnyInadequate'] = pd.NA
+
+out = out.set_index(['t', 'i'])
+
+if not out.index.is_unique:
+    out = out.groupby(level=out.index.names).first()
+
+to_parquet(out, 'months_food_inadequate.parquet')

--- a/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
+++ b/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
@@ -140,11 +140,12 @@ Data Scheme:
     # [...] avez-vous dû [...]" -- a day-count 0-7.  WIDE->LONG: one
     # (t, i, Strategy) row per strategy.  SA2A..SA2E map IN ORDER to
     # LessPreferred / LimitPortion / ReduceMeals / RestrictAdults / BorrowFood.
-    # The Stata labels are all truncated to an identical 80-char prefix and no
-    # questionnaire ships with the data, so this a-e attribution is INFERRED
-    # from the verifiable peer surveys that use the same ordering (Mali EACI
-    # 2014-15 s17q02a-e, label-verified; Malawi IHS Module H).  Days counts are
-    # exact regardless; only the per-strategy name rests on the inference.
+    # The Stata labels are all truncated to an identical 80-char prefix, but the
+    # a-e attribution is VERIFIED against the WB EMC 2014 Passage-3 questionnaire
+    # (catalog 2538, section SA): A "aliments moins chers", B "réduire les
+    # quantités consommées", C "réduire le nombre de repas", D "réduire les
+    # quantités des adultes au profit des enfants", E "emprunter de la
+    # nourriture".  (Matches the Mali EACI / Malawi IHS peer surveys.)
     # HOUSEHOLD-level; i = the 2014 roster i (format_id(zd)+format_id(menage,3)).
     index: (t, i, Strategy)
     Days: int

--- a/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
+++ b/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
@@ -138,10 +138,13 @@ Data Scheme:
     # The EHCVM waves (2018-19, 2021-22) field FIES instead -> food_security.
     # Items SA2A..SA2E ask "au cours des 7 derniers jours, combien de jours
     # [...] avez-vous dû [...]" -- a day-count 0-7.  WIDE->LONG: one
-    # (t, i, Strategy) row per strategy.  SA2A..SA2E map IN ORDER to the five
-    # canonical rCSI strategies LessPreferred / BorrowFood / LimitPortion /
-    # RestrictAdults / ReduceMeals (the Stata labels are 80-char-truncated to
-    # a shared prefix; SA2A..SA2E follow the WFP-standard rCSI ordering).
+    # (t, i, Strategy) row per strategy.  SA2A..SA2E map IN ORDER to
+    # LessPreferred / LimitPortion / ReduceMeals / RestrictAdults / BorrowFood.
+    # The Stata labels are all truncated to an identical 80-char prefix and no
+    # questionnaire ships with the data, so this a-e attribution is INFERRED
+    # from the verifiable peer surveys that use the same ordering (Mali EACI
+    # 2014-15 s17q02a-e, label-verified; Malawi IHS Module H).  Days counts are
+    # exact regardless; only the per-strategy name rests on the inference.
     # HOUSEHOLD-level; i = the 2014 roster i (format_id(zd)+format_id(menage,3)).
     index: (t, i, Strategy)
     Days: int

--- a/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
+++ b/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
@@ -132,6 +132,36 @@ Data Scheme:
     WholeDay: bool
     FIES_score: int
 
+  food_coping:
+    # Reduced Coping Strategies Index (rCSI).  2014 EMC wave ONLY (Part 3
+    # "Sécurité alimentaire", emc2014_p3_securitealimentaire_27022015.dta).
+    # The EHCVM waves (2018-19, 2021-22) field FIES instead -> food_security.
+    # Items SA2A..SA2E ask "au cours des 7 derniers jours, combien de jours
+    # [...] avez-vous dû [...]" -- a day-count 0-7.  WIDE->LONG: one
+    # (t, i, Strategy) row per strategy.  SA2A..SA2E map IN ORDER to the five
+    # canonical rCSI strategies LessPreferred / BorrowFood / LimitPortion /
+    # RestrictAdults / ReduceMeals (the Stata labels are 80-char-truncated to
+    # a shared prefix; SA2A..SA2E follow the WFP-standard rCSI ordering).
+    # HOUSEHOLD-level; i = the 2014 roster i (format_id(zd)+format_id(menage,3)).
+    index: (t, i, Strategy)
+    Days: int
+    materialize: make
+
+  months_food_inadequate:
+    # Months of inadequate food provisioning in the last 12.  2014 EMC wave
+    # ONLY (Part 3 "Sécurité alimentaire",
+    # emc2014_p3_securitealimentaire_27022015.dta).  SA4 ("au cours des 12
+    # derniers mois, avez-vous fait face à une situation où vous n'aviez pas
+    # assez de nourriture", Oui/Non) gates the SA5A..SA5L which-months battery
+    # (12 Oui/Non flags, Juillet 2013..Juillet 2014).  MonthsInadequate =
+    # count of SA5 'Oui' where SA4=Oui; 0 where SA4=Non; NaN where SA4 NaN.
+    # AnyInadequate = MonthsInadequate > 0.  HOUSEHOLD-level; i = the 2014
+    # roster i.  The EHCVM waves field FIES (food_security), not this battery.
+    index: (t, i)
+    MonthsInadequate: int
+    AnyInadequate: bool
+    materialize: make
+
   interview_date:
     index: (t, i)
     Int_t: datetime

--- a/lsms_library/countries/Ethiopia/2011-12/_/food_coping.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/food_coping.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""Build food_coping for Ethiopia ESS 2011-12 (Wave 1; GH #332, Family B).
+
+Source: sect7_hh_w1.dta (Section 7, "Food Security"), question
+hh_s7q02_{a..h} = "In the past 7 days, how many days have you or someone in
+your HH had to: [strategy]?" (0-7, the 8-item Coping Strategies Index).
+
+i = household_id (matches household_roster / sample for W1).  Long form
+index (t, i, Strategy); column Days.  See ethiopia.food_coping_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import food_coping_for_wave
+
+
+df = get_dataframe('../Data/sect7_hh_w1.dta', convert_categoricals=False)
+
+out = food_coping_for_wave('2011-12', df, 'household_id')
+
+assert out.index.is_unique, "Non-unique (t, i, Strategy) index in food_coping 2011-12"
+assert len(out) > 0, "food_coping 2011-12 produced no rows"
+
+to_parquet(out, 'food_coping.parquet')

--- a/lsms_library/countries/Ethiopia/2013-14/_/food_coping.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/food_coping.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""Build food_coping for Ethiopia ESS 2013-14 (Wave 2; GH #332, Family B).
+
+Source: sect7_hh_w2.dta (Section 7, "Food Security"), question
+hh_s7q02_{a..h} = "In the past 7 days, how many days have you or someone in
+your HH had to: [strategy]?" (0-7, the 8-item Coping Strategies Index).
+
+i = household_id2 (matches household_roster / sample for W2).  Long form
+index (t, i, Strategy); column Days.  See ethiopia.food_coping_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import food_coping_for_wave
+
+
+df = get_dataframe('../Data/sect7_hh_w2.dta', convert_categoricals=False)
+
+out = food_coping_for_wave('2013-14', df, 'household_id2')
+
+assert out.index.is_unique, "Non-unique (t, i, Strategy) index in food_coping 2013-14"
+assert len(out) > 0, "food_coping 2013-14 produced no rows"
+
+to_parquet(out, 'food_coping.parquet')

--- a/lsms_library/countries/Ethiopia/2015-16/_/food_coping.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/food_coping.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""Build food_coping for Ethiopia ESS 2015-16 (Wave 3; GH #332, Family B).
+
+Source: sect7_hh_w3.dta (Section 7, "Food Security"), question
+hh_s7q02_{a..h} = "In the past 7 days, how many days have you or someone in
+your HH had to: [strategy]?" (0-7, the 8-item Coping Strategies Index).
+
+i = household_id2 (matches household_roster / sample for W3).  Long form
+index (t, i, Strategy); column Days.  See ethiopia.food_coping_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import food_coping_for_wave
+
+
+df = get_dataframe('../Data/sect7_hh_w3.dta', convert_categoricals=False)
+
+out = food_coping_for_wave('2015-16', df, 'household_id2')
+
+assert out.index.is_unique, "Non-unique (t, i, Strategy) index in food_coping 2015-16"
+assert len(out) > 0, "food_coping 2015-16 produced no rows"
+
+to_parquet(out, 'food_coping.parquet')

--- a/lsms_library/countries/Ethiopia/_/Makefile
+++ b/lsms_library/countries/Ethiopia/_/Makefile
@@ -10,7 +10,8 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 
 var = $(VAR_DIR)/food_expenditures.parquet $(VAR_DIR)/food_quantities.parquet $(VAR_DIR)/food_prices.parquet \
 	  $(VAR_DIR)/household_characteristics.parquet \
-      $(VAR_DIR)/shocks.parquet $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet
+      $(VAR_DIR)/shocks.parquet $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet \
+      $(VAR_DIR)/food_coping.parquet
 
 all: panel_ids.json updated_ids.json $(parquet) $(var)
 
@@ -65,6 +66,19 @@ plot_features_parquet := $(plot_features:.py=.parquet)
 
 $(VAR_DIR)/plot_features.parquet: plot_features.py $(plot_features_parquet)
 	python plot_features.py
+
+# food_coping (GH #332, Family B; ESS §7 CSI/rCSI day-count battery).
+# Mirrors the plot_features convention: the framework's grab_data calls
+# `make ../<wave>/_/food_coping.parquet`, whose pattern rule runs the wave
+# script; the VAR_DIR rule concatenates them via the country script.
+food_coping = $(shell find $(rounds) -name food_coping.py)
+food_coping_parquet := $(food_coping:.py=.parquet)
+
+../%/_/food_coping.parquet: ../%/_/food_coping.py
+	(cd $(@D) && python food_coping.py)
+
+$(VAR_DIR)/food_coping.parquet: food_coping.py $(food_coping_parquet)
+	python food_coping.py
 
 $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet: nutrition.py food_items.org $(VAR_DIR)/food_quantities.parquet
 	python nutrition.py

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -98,7 +98,8 @@ Data Scheme:
     # wave data_info.yml).  W4 (2018-19) §8 is an rCSI/coping-strategy
     # battery (s8q02a..h = number-of-days frequency counts), NOT FIES, so
     # it is deliberately NOT wired here; it belongs to a future rCSI
-    # feature.  W1-3 likewise used the rCSI/coping battery.
+    # feature.  W1-3 carry the rCSI/coping battery in §7 (sect7_hh,
+    # hh_s7q02_*), wired separately as `food_coping` below.
     # Recall period: 12 months for 7 items; WholeDay (s8q06) is 30-day.
     index: (t, i)
     Worried: bool
@@ -110,6 +111,26 @@ Data Scheme:
     Hungry: bool
     WholeDay: bool
     FIES_score: int
+
+  food_coping:
+    # CSI / rCSI coping-strategies battery (GH #332, Family B).  ESS
+    # Section 7 ("Food Security"), household file sect7_hh_w{1,2,3}.dta,
+    # question hh_s7q02_{a..h} = "In the past 7 days, how many days have
+    # you or someone in your HH had to: [strategy]?" (integer 0-7).  This
+    # is the 8-item Coping Strategies Index; it embeds the 5 reduced-CSI
+    # (rCSI) strategies (LessPreferred, BorrowFood, LimitPortion,
+    # RestrictAdults, ReduceMeals) plus 3 survey-specific items
+    # (LimitVariety, NoFood, WholeDay).  Item wording confirmed verbatim
+    # from the ESS3 HH Questionnaire (Section 7, Q2, columns A-H).
+    #
+    # Wired ONLY for the rCSI day-count waves: W1 (2011-12), W2 (2013-14),
+    # W3 (2015-16).  W4 (2018-19) §8 s8q02a..h is a separate coping battery
+    # (future feature); W5 (2021-22) §8 is FAO FIES (wired as
+    # food_security).  Reshape (wide -> long over Strategy) requires a
+    # script => materialize: make.  Recall period: last 7 days.
+    index: (t, i, Strategy)
+    Days: int
+    materialize: make
 
   food_expenditures: !make
   food_prices: !make

--- a/lsms_library/countries/Ethiopia/_/ethiopia.py
+++ b/lsms_library/countries/Ethiopia/_/ethiopia.py
@@ -617,3 +617,72 @@ def plot_features_for_wave(t, sect2, sect3, colmap):
     out = out.dropna(subset=['i', 'plot_id'])
     out = out.set_index(['t', 'i', 'plot_id'])
     return out
+
+
+# food_coping (CSI / rCSI coping-strategies battery; GH #332, Family B).
+#
+# ESS Section 7 ("Food Security"), household-level file sect7_hh_w{1,2,3}.
+# Question hh_s7q02_{a..h} = "In the past 7 days, how many days have you or
+# someone in your HH had to: [strategy]?" (integer 0-7, "IF NO DAYS, RECORD
+# ZERO").  This is the 8-item Coping Strategies Index, which embeds the 5
+# reduced-CSI (rCSI) strategies (LessPreferred, BorrowFood, LimitPortion,
+# RestrictAdults, ReduceMeals) plus three survey-specific items.  Item
+# wording was confirmed verbatim from the ESS3 HH Questionnaire (Section 7,
+# Q2, columns A-H); the W1/W2 .dta labels are byte-identical (Stata
+# truncates them at 80 chars but the prefixes match exactly).
+#
+# Wave wiring: i is the wave-native household id matching household_roster /
+# sample (household_id for W1; household_id2 for W2/W3).  The cross-wave
+# id_walk to panel-canonical ids is applied once at the country level.
+FOOD_COPING_STRATEGIES = {
+    'hh_s7q02_a': 'LessPreferred',   # Rely on less preferred foods? (rCSI)
+    'hh_s7q02_b': 'LimitVariety',    # Limit the variety of foods eaten?
+    'hh_s7q02_c': 'LimitPortion',    # Limit portion size at mealtimes? (rCSI)
+    'hh_s7q02_d': 'ReduceMeals',     # Reduce number of meals eaten in a day? (rCSI)
+    'hh_s7q02_e': 'RestrictAdults',  # Restrict consumption by adults for small children to eat? (rCSI)
+    'hh_s7q02_f': 'BorrowFood',      # Borrow food, or rely on help from a friend/relative? (rCSI)
+    'hh_s7q02_g': 'NoFood',          # Have no food of any kind in your household?
+    'hh_s7q02_h': 'WholeDay',        # Go a whole day and night without eating anything?
+}
+
+
+def food_coping_for_wave(t, df, hhid):
+    """Reshape the ESS Section 7 CSI day-count battery to long form.
+
+    Parameters
+    ----------
+    t : str
+        Wave label (e.g. '2011-12').
+    df : pd.DataFrame
+        Raw sect7_hh_w*.dta frame.
+    hhid : str
+        Source household-id column matching the wave's roster/sample i
+        ('household_id' for W1, 'household_id2' for W2/W3).
+
+    Returns
+    -------
+    pd.DataFrame
+        Index (t, i, Strategy); column ``Days`` (Int64, 0-7).  One row per
+        (household, coping strategy).  Rows with a missing Days value are
+        dropped (the strategy was not answered for that household).
+    """
+    cols = list(FOOD_COPING_STRATEGIES)
+    out = df[[hhid] + cols].copy()
+    out['i'] = out[hhid].apply(format_id)
+    out = out.drop(columns=[hhid])
+
+    long = out.melt(id_vars='i', value_vars=cols,
+                    var_name='_var', value_name='Days')
+    long['Strategy'] = long['_var'].map(FOOD_COPING_STRATEGIES)
+    long = long.drop(columns='_var')
+    long['t'] = t
+
+    long['Days'] = pd.to_numeric(long['Days'], errors='coerce')
+    # Valid domain is 0-7 days within the 7-day recall window.  ESS W3 has
+    # one data-entry outlier (LimitPortion = 8); drop out-of-domain values.
+    long.loc[(long['Days'] < 0) | (long['Days'] > 7), 'Days'] = pd.NA
+    long['Days'] = long['Days'].astype('Int64')
+    long = long.dropna(subset=['i', 'Days'])
+
+    long = long.set_index(['t', 'i', 'Strategy']).sort_index()
+    return long

--- a/lsms_library/countries/Ethiopia/_/food_coping.py
+++ b/lsms_library/countries/Ethiopia/_/food_coping.py
@@ -1,0 +1,46 @@
+"""Concatenate wave-level food_coping data for Ethiopia (GH #332, Family B).
+
+Each wave's ``Ethiopia/<wave>/_/food_coping.py`` produces a parquet with
+index ``(t, i, Strategy)`` and column ``Days`` (0-7), reshaped from the ESS
+Section 7 Coping Strategies Index battery (hh_s7q02_{a..h}).  Only the rCSI
+day-count waves are wired: W1 (2011-12), W2 (2013-14), W3 (2015-16).
+
+W4 (2018-19) §8 is a different rCSI/coping battery (s8q02a..h) and W5
+(2021-22) §8 is FAO FIES (wired separately as ``food_security``); neither
+emits a ``food_coping.py``, so they are silently skipped below.
+
+The wave parquets carry the wave-native household id matching ``sample().i``
+(``household_id2`` for W2/W3, ``household_id`` for W1).  ``id_walk`` converts
+to the panel-canonical id scheme; it is idempotent (sets
+``attrs['id_converted']``) so ``_finalize_result`` will not re-apply it.
+"""
+import json
+import os
+
+import pandas as pd
+
+from lsms_library.local_tools import data_root, get_dataframe, id_walk, to_parquet
+from ethiopia import Waves
+
+
+pieces = []
+for t in Waves.keys():
+    # The wave scripts write their parquet under data_root() (to_parquet
+    # redirects there), so read it back from that canonical location.
+    # Reading the in-tree relative path via get_dataframe would trigger a
+    # slow DVCFS sidecar-tree walk when the file is absent in-tree.
+    fn = os.path.join(str(data_root('Ethiopia')), t, '_', 'food_coping.parquet')
+    if not os.path.exists(fn):
+        # Wave not wired (W4/W5 emit no food_coping.py) -> skip.
+        continue
+    df = get_dataframe(fn)
+    pieces.append(df)
+
+assert pieces, "food_coping: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/food_coping.parquet')

--- a/lsms_library/countries/EthiopiaRHS/_/CONTENTS.org
+++ b/lsms_library/countries/EthiopiaRHS/_/CONTENTS.org
@@ -207,3 +207,14 @@ appear to have village-level split files (=debdemo4=, =dindemo4=,
   region reconciliation; sourcing constructed ERHS weights; optional
   validation of inferred kg factors vs ERHS =conv_*.tab=; validation
   of derived tables vs survey docs.
+
+* Food security (non-FIES families, GH #332) --- not wired
+
+ERHS carries only bespoke, non-standardized food-stress items (IFPRI
+meals-per-day counts and shock-roster coping responses), not a standard
+HFIAS occurrence/frequency scale, an rCSI coping-day battery, or a
+months-of-inadequate-provisioning question.  None maps cleanly onto
+=food_security_hfias=, =food_coping=, or =months_food_inadequate=, so
+those families are left unwired for EthiopiaRHS.  (The separate
+=Ethiopia= LSMS-ISA module wires =food_coping= for W1--3 and FIES
+=food_security= for W5.)

--- a/lsms_library/countries/India/1997-98/_/months_food_inadequate.py
+++ b/lsms_library/countries/India/1997-98/_/months_food_inadequate.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import sys
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+# India 1997-98 §8 VULNERABILITY Part A 'Food security' (SECT08A.DTA).
+#   v08a01      = "Got 2 square meals" (Yes/No), overall adequacy in last 12 months.
+#   v08a02a..l  = January..December; marked 1 for each month in which the HH could
+#                 NOT get 2 square meals.  NaN otherwise.
+# MonthsInadequate = count of flagged months (0-12).
+# AnyInadequate    = HH reported NOT getting 2 square meals (v08a01=='No') OR any
+#                    month flagged (the two are mostly but not perfectly consistent:
+#                    20 'No' HHs flagged 0 months; 5 'Yes' HHs flagged >=1 month).
+# i=hhcode (matches sample() 100%; the roster's i:hh is a latent bug -> use hhcode,
+#   consistent with housing/individual_education/interview_date).  v is NOT baked in;
+#   it is joined from sample() at API time by _join_v_from_sample.
+
+df = get_dataframe('../Data/SECT08A.DTA')
+
+month_cols = [f'v08a02{c}' for c in 'abcdefghijkl']
+
+out = pd.DataFrame(index=df.index)
+out['i'] = df['hhcode'].astype(int).astype(str)
+out['t'] = '1997-98'
+
+months = df[month_cols].notna().sum(axis=1).astype('Int64')
+
+# v08a01 is categorical Yes/No; treat 'No' as inadequate.
+got_meals = df['v08a01'].astype(str).str.strip()
+any_inadequate = (got_meals == 'No') | (months > 0)
+
+out['MonthsInadequate'] = months
+out['AnyInadequate'] = any_inadequate.astype(bool)
+
+out = out.set_index(['t', 'i'])
+
+to_parquet(out, 'months_food_inadequate.parquet')

--- a/lsms_library/countries/India/_/data_scheme.yml
+++ b/lsms_library/countries/India/_/data_scheme.yml
@@ -47,3 +47,9 @@ Data Scheme:
     index: (t, i)
     Int_t: datetime
     materialize: make
+
+  months_food_inadequate:
+    index: (t, i)
+    MonthsInadequate: int
+    AnyInadequate: bool
+    materialize: make

--- a/lsms_library/countries/Iraq/_/CONTENTS.org
+++ b/lsms_library/countries/Iraq/_/CONTENTS.org
@@ -1,0 +1,11 @@
+#+title: Contents
+
+* Food security (non-FIES families, GH #332) --- not wired
+
+The IHSES 2012 questionnaire has no standard food-insecurity-experience
+battery: no FIES, no HFIAS occurrence/frequency scale, no HHS or FCS, no
+rCSI coping-day index, and no months-of-inadequate-provisioning item.
+The only food-stress signal is a single bespoke food-difficulty item
+(=q2005=) embedded in the shocks module, which is already captured by
+the wired =shocks= feature.  =food_security_hfias=, =food_coping=, and
+=months_food_inadequate= are therefore not implementable for Iraq.

--- a/lsms_library/countries/Liberia/2018-19/_/months_food_inadequate.py
+++ b/lsms_library/countries/Liberia/2018-19/_/months_food_inadequate.py
@@ -1,0 +1,41 @@
+import pandas as pd
+import sys
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+# Liberia 2018-19 §16 'Food security' (sect16a_public.dta).
+#   S16_1 = "in the last 12 months, have you been faced with a situation when
+#           you did not have enough food to feed the household?" (yes/no).
+#   S16_2 = "how many months in the past 12 months did you not have enough food
+#           to feed the household?" (count 1-12; only asked when S16_1=='yes',
+#           so NaN for the 'no' households).
+#   S16_3/S16_4 are forest-product coping follow-ups (which months / how
+#           important were wild products) -- NOT a which-months battery, so the
+#           count item S16_2 is the source.  sect16b_public.dta is a long
+#           forest-product roster, unrelated to provisioning adequacy.
+# MonthsInadequate = S16_2, with the 'no' households filled to 0 (they were
+#           skipped out of S16_2 precisely because they had no inadequate
+#           months).  S16_1 NaN (11 HH, question not asked) -> MonthsInadequate
+#           NaN.
+# AnyInadequate    = S16_1=='yes'.
+# i=hhid (matches household_roster / sample 100%); v is NOT baked in -- it is
+#           joined from sample() at API time by _join_v_from_sample.
+
+df = get_dataframe('../Data/Household/sect16a_public.dta')
+
+s1 = df['S16_1'].astype(str).str.strip().str.lower()
+any_inadequate = s1.map({'yes': True, 'no': False})  # NaN where not asked
+
+months = pd.to_numeric(df['S16_2'], errors='coerce')
+# 'no' households were skipped out of S16_2 -> 0 inadequate months.
+months = months.where(any_inadequate != False, other=0)
+
+out = pd.DataFrame(index=df.index)
+out['i'] = df['hhid'].astype('int64').astype(str)
+out['t'] = '2018-19'
+out['MonthsInadequate'] = months.astype('Int64')
+out['AnyInadequate'] = any_inadequate.astype('boolean')
+
+out = out.set_index(['t', 'i'])
+
+to_parquet(out, 'months_food_inadequate.parquet')

--- a/lsms_library/countries/Liberia/_/data_scheme.yml
+++ b/lsms_library/countries/Liberia/_/data_scheme.yml
@@ -49,6 +49,18 @@ Data Scheme:
     HowCoped1: str
     HowCoped2: str
 
+  months_food_inadequate:
+    # 2018-19 §16 'Food security' (sect16a_public.dta). MonthsInadequate=S16_2
+    # ("how many months in the past 12 did you not have enough food to feed the
+    # household", 1-12; the 'no'/S16_1 households are filled to 0). AnyInadequate
+    # =S16_1 ("faced a situation with not enough food in the last 12 months",
+    # yes/no). No which-months battery in this instrument (S16_3/S16_4 are
+    # forest-product coping follow-ups), so the count item is the source.
+    index: (t, i)
+    MonthsInadequate: int
+    AnyInadequate: bool
+    materialize: make
+
   sample:
     index: (i, t)
     v: str

--- a/lsms_library/countries/Malawi/2010-11/_/food_coping.py
+++ b/lsms_library/countries/Malawi/2010-11/_/food_coping.py
@@ -1,0 +1,30 @@
+"""Build food_coping (rCSI day counts) for Malawi IHS3 2010-11 (GH #332).
+
+Module H of the IHS3 household questionnaire carries the 5 rCSI coping
+strategies in hh_h02a..hh_h02e (days 0-7 in the past 7).  The 2010-11
+.dta Stata labels are truncated to the question stem; the strategy order
+(a=LessPreferred, b=LimitPortion, c=ReduceMeals, d=RestrictAdults,
+e=BorrowFood) is taken from the IHS3 Household Questionnaire Module H,
+Page 35, and matches the explicitly-labelled later waves.
+
+See lsms_library/countries/Malawi/_/malawi.py:food_coping_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import food_coping_for_wave
+
+
+WAVE = '2010-11'
+
+# convert_categoricals=False keeps the integer day counts.
+df = get_dataframe('../Data/Full_Sample/Household/hh_mod_h.dta',
+                   convert_categoricals=False)
+
+out = food_coping_for_wave(WAVE, df, idcol='case_id', i_prefix='')
+
+assert out.index.is_unique, f"Non-unique (t,i,Strategy) in food_coping {WAVE}"
+assert len(out) > 0, f"food_coping {WAVE} produced no rows"
+
+to_parquet(out, 'food_coping.parquet')

--- a/lsms_library/countries/Malawi/2010-11/_/months_food_inadequate.py
+++ b/lsms_library/countries/Malawi/2010-11/_/months_food_inadequate.py
@@ -1,0 +1,28 @@
+"""months_food_inadequate for Malawi IHS3 2010-11 (GH #332).
+
+Module H question H04 (hh_h04: 1=Yes / 2=No, faced a food-shortage
+situation in the last 12 months) gates the wide H05 month calendar
+(hh_h05a_01..hh_h05b_15, one cell per month, 'X' = month the HH lacked
+food).  MonthsInadequate = count of 'X' for H04==Yes households (0 else);
+AnyInadequate = (H04==Yes).
+
+See lsms_library/countries/Malawi/_/malawi.py:months_food_inadequate_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import months_food_inadequate_for_wave
+
+
+WAVE = '2010-11'
+
+df = get_dataframe('../Data/Full_Sample/Household/hh_mod_h.dta',
+                   convert_categoricals=False)
+
+out = months_food_inadequate_for_wave(WAVE, df, idcol='case_id', i_prefix='')
+
+assert out.index.is_unique, f"Non-unique (t,i) in months_food_inadequate {WAVE}"
+assert len(out) > 0, f"months_food_inadequate {WAVE} produced no rows"
+
+to_parquet(out, 'months_food_inadequate.parquet')

--- a/lsms_library/countries/Malawi/2013-14/_/food_coping.py
+++ b/lsms_library/countries/Malawi/2013-14/_/food_coping.py
@@ -1,0 +1,28 @@
+"""Build food_coping (rCSI day counts) for Malawi IHPS 2013-14 (GH #332).
+
+Module H (HH_MOD_H_13.dta) carries the 5 rCSI coping strategies in
+hh_h02a..hh_h02e (days 0-7 in the past 7).  Items are explicitly labelled
+in this wave (a=LessPreferred, b=LimitPortion, c=ReduceMeals,
+d=RestrictAdults, e=BorrowFood).  Household id is the IHPS y2_hhid; the
+framework's id_walk (panel_ids) converts it to the canonical i at API
+time, exactly as for food_security / shocks in this wave.
+
+See lsms_library/countries/Malawi/_/malawi.py:food_coping_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import food_coping_for_wave
+
+
+WAVE = '2013-14'
+
+df = get_dataframe('../Data/HH_MOD_H_13.dta', convert_categoricals=False)
+
+out = food_coping_for_wave(WAVE, df, idcol='y2_hhid', i_prefix='')
+
+assert out.index.is_unique, f"Non-unique (t,i,Strategy) in food_coping {WAVE}"
+assert len(out) > 0, f"food_coping {WAVE} produced no rows"
+
+to_parquet(out, 'food_coping.parquet')

--- a/lsms_library/countries/Malawi/2013-14/_/months_food_inadequate.py
+++ b/lsms_library/countries/Malawi/2013-14/_/months_food_inadequate.py
@@ -1,0 +1,27 @@
+"""months_food_inadequate for Malawi IHPS 2013-14 (GH #332).
+
+Module H (HH_MOD_H_13.dta) H04 (hh_h04: 1=Yes / 2=No) gates the wide H05
+month calendar (hh_h05a..hh_h05s, 'X' = month the HH lacked food).
+MonthsInadequate = count of 'X' for H04==Yes households (0 else);
+AnyInadequate = (H04==Yes).  Household id is the IHPS y2_hhid; the
+framework's id_walk converts it at API time (as for food_security).
+
+See lsms_library/countries/Malawi/_/malawi.py:months_food_inadequate_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import months_food_inadequate_for_wave
+
+
+WAVE = '2013-14'
+
+df = get_dataframe('../Data/HH_MOD_H_13.dta', convert_categoricals=False)
+
+out = months_food_inadequate_for_wave(WAVE, df, idcol='y2_hhid', i_prefix='')
+
+assert out.index.is_unique, f"Non-unique (t,i) in months_food_inadequate {WAVE}"
+assert len(out) > 0, f"months_food_inadequate {WAVE} produced no rows"
+
+to_parquet(out, 'months_food_inadequate.parquet')

--- a/lsms_library/countries/Malawi/2016-17/_/food_coping.py
+++ b/lsms_library/countries/Malawi/2016-17/_/food_coping.py
@@ -1,0 +1,29 @@
+"""Build food_coping (rCSI day counts) for Malawi IHS4 2016-17 (GH #332).
+
+Cross-sectional Module H (Cross_Sectional/hh_mod_h.dta) carries the 5
+rCSI coping strategies in hh_h02a..hh_h02e (days 0-7 in the past 7),
+explicitly labelled (a=LessPreferred, b=LimitPortion, c=ReduceMeals,
+d=RestrictAdults, e=BorrowFood).  The cross-sectional household id
+(case_id) is prefixed 'cs-17-' to match this wave's household_roster i
+(the roster prefixes cross-sectional cases via mapping.cs_i).
+
+See lsms_library/countries/Malawi/_/malawi.py:food_coping_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import food_coping_for_wave
+
+
+WAVE = '2016-17'
+
+df = get_dataframe('../Data/Cross_Sectional/hh_mod_h.dta',
+                   convert_categoricals=False)
+
+out = food_coping_for_wave(WAVE, df, idcol='case_id', i_prefix='cs-17-')
+
+assert out.index.is_unique, f"Non-unique (t,i,Strategy) in food_coping {WAVE}"
+assert len(out) > 0, f"food_coping {WAVE} produced no rows"
+
+to_parquet(out, 'food_coping.parquet')

--- a/lsms_library/countries/Malawi/2016-17/_/months_food_inadequate.py
+++ b/lsms_library/countries/Malawi/2016-17/_/months_food_inadequate.py
@@ -1,0 +1,30 @@
+"""months_food_inadequate for Malawi IHS4 2016-17 (GH #332).
+
+Cross-sectional Module H (Cross_Sectional/hh_mod_h.dta) H04 (hh_h04:
+1=Yes / 2=No) gates the wide H05 month calendar (hh_h05a..hh_h05y).
+NOTE: in IHS4/IHS5 every H04==No household has all 25 calendar cells
+pre-filled with 'X' (a skip-pattern artifact); gating the count on
+H04==Yes is essential, else food-secure households would report 25
+months.  case_id is prefixed 'cs-17-' to match the wave's roster i.
+
+See lsms_library/countries/Malawi/_/malawi.py:months_food_inadequate_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import months_food_inadequate_for_wave
+
+
+WAVE = '2016-17'
+
+df = get_dataframe('../Data/Cross_Sectional/hh_mod_h.dta',
+                   convert_categoricals=False)
+
+out = months_food_inadequate_for_wave(WAVE, df, idcol='case_id',
+                                      i_prefix='cs-17-')
+
+assert out.index.is_unique, f"Non-unique (t,i) in months_food_inadequate {WAVE}"
+assert len(out) > 0, f"months_food_inadequate {WAVE} produced no rows"
+
+to_parquet(out, 'months_food_inadequate.parquet')

--- a/lsms_library/countries/Malawi/2019-20/_/food_coping.py
+++ b/lsms_library/countries/Malawi/2019-20/_/food_coping.py
@@ -1,0 +1,29 @@
+"""Build food_coping (rCSI day counts) for Malawi IHS5 2019-20 (GH #332).
+
+Cross-sectional Module H (Cross_Sectional/HH_MOD_H.dta) carries the 5
+rCSI coping strategies in hh_h02a..hh_h02e (days 0-7 in the past 7),
+explicitly labelled (a=LessPreferred, b=LimitPortion, c=ReduceMeals,
+d=RestrictAdults, e=BorrowFood).  The cross-sectional case_id matches
+this wave's household_roster i directly (no prefix).  A lone hh_h02a=20
+data-entry value is dropped by food_coping_for_wave's 0-7 clamp.
+
+See lsms_library/countries/Malawi/_/malawi.py:food_coping_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import food_coping_for_wave
+
+
+WAVE = '2019-20'
+
+df = get_dataframe('../Data/Cross_Sectional/HH_MOD_H.dta',
+                   convert_categoricals=False)
+
+out = food_coping_for_wave(WAVE, df, idcol='case_id', i_prefix='')
+
+assert out.index.is_unique, f"Non-unique (t,i,Strategy) in food_coping {WAVE}"
+assert len(out) > 0, f"food_coping {WAVE} produced no rows"
+
+to_parquet(out, 'food_coping.parquet')

--- a/lsms_library/countries/Malawi/2019-20/_/months_food_inadequate.py
+++ b/lsms_library/countries/Malawi/2019-20/_/months_food_inadequate.py
@@ -1,0 +1,28 @@
+"""months_food_inadequate for Malawi IHS5 2019-20 (GH #332).
+
+Cross-sectional Module H (Cross_Sectional/HH_MOD_H.dta) H04 (hh_h04:
+1=Yes / 2=No) gates the wide H05 month calendar (hh_h05a..hh_h05y).
+As in IHS4, every H04==No household has all 25 cells pre-filled with 'X';
+gating the count on H04==Yes is essential.  case_id matches the wave's
+roster i directly (no prefix).
+
+See lsms_library/countries/Malawi/_/malawi.py:months_food_inadequate_for_wave.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import months_food_inadequate_for_wave
+
+
+WAVE = '2019-20'
+
+df = get_dataframe('../Data/Cross_Sectional/HH_MOD_H.dta',
+                   convert_categoricals=False)
+
+out = months_food_inadequate_for_wave(WAVE, df, idcol='case_id', i_prefix='')
+
+assert out.index.is_unique, f"Non-unique (t,i) in months_food_inadequate {WAVE}"
+assert len(out) > 0, f"months_food_inadequate {WAVE} produced no rows"
+
+to_parquet(out, 'months_food_inadequate.parquet')

--- a/lsms_library/countries/Malawi/_/Makefile
+++ b/lsms_library/countries/Malawi/_/Makefile
@@ -12,7 +12,7 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 # _ROSTER_DERIVED — no country-level parquet is built or consulted.
 # See GH #218.
 
-all: $(parquet) $(VAR_DIR)/food_acquired.parquet
+all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet
 
 food_acquired = $(shell find $(rounds) -name food_acquired.py)
 # Wave-level parquets live in data_root, not in-tree
@@ -23,6 +23,29 @@ $(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/food_acquired.parquet:
 
 $(VAR_DIR)/food_acquired.parquet: food_acquired.py $(food_acquired_parquet)
 	python food_acquired.py
+
+# --- non-FIES food security (GH #332) -------------------------------------
+# food_coping and months_food_inadequate are built only for the four IHS3+/
+# IHPS waves carrying Module H (2010-11, 2013-14, 2016-17, 2019-20).  Each
+# wave script writes its parquet into data_root; the country script
+# concatenates.  2004-05 is ABSENT (its Module H is a food-consumption
+# recall, not the rCSI/months battery).
+nonfies_waves := 2010-11 2013-14 2016-17 2019-20
+
+food_coping_parquet := $(foreach r,$(nonfies_waves),$(LSMS_DATA_ROOT)/$(COUNTRY)/$(r)/_/food_coping.parquet)
+months_food_inadequate_parquet := $(foreach r,$(nonfies_waves),$(LSMS_DATA_ROOT)/$(COUNTRY)/$(r)/_/months_food_inadequate.parquet)
+
+$(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/food_coping.parquet: malawi.py
+	(cd ../$(*)/_/ && python food_coping.py)
+
+$(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/months_food_inadequate.parquet: malawi.py
+	(cd ../$(*)/_/ && python months_food_inadequate.py)
+
+$(VAR_DIR)/food_coping.parquet: food_coping.py $(food_coping_parquet)
+	python food_coping.py
+
+$(VAR_DIR)/months_food_inadequate.parquet: months_food_inadequate.py $(months_food_inadequate_parquet)
+	python months_food_inadequate.py
 
 %.parquet: %.py malawi.py
 	(cd $(@D) && python ./$(<F))

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -108,5 +108,30 @@ Data Scheme:
     SoilType: str
     Irrigated: bool
     materialize: make
+  food_coping:
+    # rCSI coping-strategy day counts (GH #332).  Module H question H02
+    # (hh_h02a..hh_h02e) of the IHS3/IHS4/IHS5 + IHPS-2013 household
+    # questionnaire: how many of the past 7 days the HH used each of the 5
+    # standard reduced-Coping-Strategies-Index strategies.  One row per
+    # (HH, Strategy); Days is 0-7.  Strategy order is stable across all
+    # waves (verified vs the IHS3 questionnaire Module H, Page 35):
+    # a=LessPreferred, b=LimitPortion, c=ReduceMeals, d=RestrictAdults,
+    # e=BorrowFood.  Recall: last 7 days.  ABSENT in 2004-05 (IHS2): its
+    # Module H is a 3-day food-consumption recall, not a coping battery.
+    index: (t, i, Strategy)
+    Days: int
+    materialize: make
+  months_food_inadequate:
+    # Months of inadequate food provisioning (GH #332).  Module H questions
+    # H04 (hh_h04, Yes/No: faced a food-shortage situation in the last 12
+    # months) and H05 (wide month calendar, 'X' = a month the HH lacked
+    # food).  MonthsInadequate = count of marked months (0-12) for H04==Yes
+    # households, 0 otherwise; AnyInadequate = (H04==Yes).  The H05 count is
+    # gated on H04==Yes because IHS4/IHS5 pre-fill all 25 calendar cells for
+    # H04==No households.  Recall: last 12 months.  ABSENT in 2004-05.
+    index: (t, i)
+    MonthsInadequate: int
+    AnyInadequate: bool
+    materialize: make
   food_expenditures:
   food_prices:

--- a/lsms_library/countries/Malawi/_/food_coping.py
+++ b/lsms_library/countries/Malawi/_/food_coping.py
@@ -1,0 +1,35 @@
+"""Concatenate wave-level food_coping parquets for Malawi (GH #332).
+
+Each buildable wave's ``Malawi/<wave>/_/food_coping.py`` produces a
+parquet indexed (t, i, Strategy) with the integer ``Days`` column.  This
+script concatenates them.  Cross-wave id_walk (panel-id chaining) and the
+join of the cluster id ``v`` are applied by the framework at API time in
+_finalize_result -- as for plot_features, no id_walk is run here.
+
+2004-05 (IHS2) is ABSENT: its Module H is a 3-day food-consumption recall
+(item-level), not the rCSI coping battery introduced in IHS3.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+# Only the four buildable IHS3+ / IHPS waves carry Module H rCSI items.
+WAVES = ['2010-11', '2013-14', '2016-17', '2019-20']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/food_coping.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built.  DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "food_coping: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/food_coping.parquet')

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -13,7 +13,7 @@ import pandas as pd
 import numpy as np
 import sys
 sys.path.append('../../../_/')
-from lsms_library.local_tools import conversion_table_matching_global
+from lsms_library.local_tools import conversion_table_matching_global, format_id
 
 
 def _extract_kg_conversion(series):
@@ -557,4 +557,156 @@ def plot_features_for_wave(t, df_c, df_d, colmap):
     # (Module C should be one row per plot; first-wins keeps it unique).
     out = out.groupby(['t', 'i', 'plot_id'], as_index=False).first()
     out = out.set_index(['t', 'i', 'plot_id'])
+    return out
+
+
+# --- non-FIES food security (GH #332) -----------------------------------
+# Module H "Food Security" of the IHS3/IHS4/IHS5 household questionnaire and
+# the IHPS 2013 carries two non-FIES batteries shared verbatim across all
+# four buildable waves (the IHS2 2004-05 instrument is unrelated -- a 3-day
+# food-consumption recall, no coping/months items -- so 2004-05 is ABSENT):
+#
+#   * H02 a-e: rCSI coping-strategy day counts (0-7 days in the past 7 days).
+#     The 5 sub-items are in the SAME order in every wave (verified against
+#     the IHS3 Household Questionnaire Module H, Page 35; the 2010-11 .dta
+#     Stata labels are truncated to the question stem but the questionnaire
+#     order is identical to the explicitly-labelled IHS4/IHS5/IHPS items):
+#         hh_h02a = Rely on less preferred / less expensive foods
+#         hh_h02b = Limit portion size at meal-times
+#         hh_h02c = Reduce number of meals eaten in a day
+#         hh_h02d = Restrict consumption by adults so small children can eat
+#         hh_h02e = Borrow food / rely on help from a friend or relative
+#   * H04 + H05: months of inadequate food provisioning in the last 12
+#     months.  H04 is a Yes(1)/No(2) gate; H05 is a wide month-calendar
+#     (one cell per month, 'X' marks a month the HH lacked enough food).
+
+# Canonical rCSI Strategy names, indexed by the hh_h02 suffix order that is
+# stable across every Malawi wave (a, b, c, d, e).
+_MALAWI_COPING_STRATEGIES = {
+    'a': 'LessPreferred',
+    'b': 'LimitPortion',
+    'c': 'ReduceMeals',
+    'd': 'RestrictAdults',
+    'e': 'BorrowFood',
+}
+
+
+def food_coping_for_wave(t, df, idcol, i_prefix=''):
+    """Build canonical ``food_coping`` for one Malawi Module-H wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2010-11"``), used as the ``t`` index value.
+    df : pd.DataFrame
+        Household Module H rows, loaded with ``convert_categoricals=False``
+        so the day counts stay integer-coded.  Must carry ``idcol`` plus
+        ``hh_h02a`` .. ``hh_h02e``.
+    idcol : str
+        Household-id column (``case_id`` for the cross-sectional waves,
+        ``y2_hhid`` for the 2013-14 IHPS panel).
+    i_prefix : str, optional
+        Prefix to prepend to ``format_id(idcol)`` so ``i`` matches the
+        wave's ``household_roster`` index.  ``'cs-17-'`` for 2016-17 (its
+        cross-sectional half is prefixed in the roster); empty otherwise.
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, Strategy)`` with a single integer
+        column ``Days`` (0-7, days in the past 7 the HH used the strategy).
+        Recall period: last 7 days.
+    """
+    df = df.copy()
+    df['i'] = i_prefix + df[idcol].apply(format_id)
+
+    pieces = []
+    for suffix, strategy in _MALAWI_COPING_STRATEGIES.items():
+        col = f'hh_h02{suffix}'
+        if col not in df.columns:
+            continue
+        days = pd.to_numeric(df[col], errors='coerce')
+        # Day counts live on 0-7; anything outside (e.g. the lone 20 in the
+        # 2019-20 cross-section) is a data-entry error -> NaN.
+        days = days.where((days >= 0) & (days <= 7))
+        piece = pd.DataFrame({'i': df['i'].values,
+                              'Strategy': strategy,
+                              'Days': days.values})
+        pieces.append(piece)
+
+    out = pd.concat(pieces, ignore_index=True)
+    out['t'] = t
+    out = out.dropna(subset=['Days'])
+    out['Days'] = out['Days'].round().astype('Int64')
+    # One row per (HH, strategy); first-wins guards against duplicate HH rows.
+    out = out.groupby(['t', 'i', 'Strategy'], as_index=False).first()
+    out = out.set_index(['t', 'i', 'Strategy'])
+    return out
+
+
+def _months_inadequate_columns(df):
+    """Return the ordered list of wide month-calendar columns (hh_h05*).
+
+    Handles both Module-H layouts: 2010-11 names its 25 month cells
+    ``hh_h05a_01`` .. ``hh_h05b_15``; the later waves use single-letter
+    suffixes ``hh_h05a`` .. ``hh_h05y``.
+    """
+    cols = [c for c in df.columns if c.lower().startswith('hh_h05')]
+    # Exclude any "other specify" / cause companions defensively.
+    cols = [c for c in cols if not c.lower().endswith('_os')]
+    return sorted(cols)
+
+
+def months_food_inadequate_for_wave(t, df, idcol, i_prefix=''):
+    """Build canonical ``months_food_inadequate`` for one Malawi wave.
+
+    Parameters
+    ----------
+    t, df, idcol, i_prefix
+        As in :func:`food_coping_for_wave`.  ``df`` must carry the H04 gate
+        (``hh_h04``: 1=Yes faced shortage, 2=No) and the wide H05 month
+        calendar (cells marked ``'X'`` for months the HH lacked food).
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i)`` with columns ``MonthsInadequate``
+        (Int64 0-12) and ``AnyInadequate`` (nullable bool).  Recall: last
+        12 months.
+
+    Notes
+    -----
+    The H05 calendar is **gated on H04==Yes**.  In IHS4 (2016-17) and IHS5
+    (2019-20) every household that answered H04==No has ALL 25 calendar
+    cells pre-filled with 'X' (a skip-pattern/template artifact -- verified:
+    the count of 25-X households equals the count of H04==No households).
+    Counting X marks unconditionally would therefore report 25 months for
+    food-secure households.  Gating on H04==Yes yields a clean 0-12 count
+    in every wave (the earlier IHS3/IHPS calendars are already blank for
+    H04==No households, so the gate is a no-op there).
+    """
+    df = df.copy()
+    df['i'] = i_prefix + df[idcol].apply(format_id)
+
+    gate = pd.to_numeric(df['hh_h04'], errors='coerce')
+    any_inadequate = pd.Series(pd.NA, index=df.index, dtype='boolean')
+    any_inadequate = any_inadequate.where(gate != 1, True)
+    any_inadequate = any_inadequate.where(gate != 2, False)
+
+    month_cols = _months_inadequate_columns(df)
+    marked = (df[month_cols].astype('string')
+              .apply(lambda s: s.str.strip().str.upper() == 'X')
+              .sum(axis=1))
+    # Only H04==Yes households contribute a genuine month count; everyone
+    # else (No, or unanswered) is zero months.
+    months = marked.where(gate == 1, 0)
+    # Plausibility clamp to the 12-month recall window.
+    months = months.clip(upper=12).astype('Int64')
+
+    out = pd.DataFrame({
+        't': t,
+        'i': df['i'].values,
+        'MonthsInadequate': months.values,
+        'AnyInadequate': any_inadequate.values,
+    })
+    out = out.groupby(['t', 'i'], as_index=False).first()
+    out = out.set_index(['t', 'i'])
     return out

--- a/lsms_library/countries/Malawi/_/months_food_inadequate.py
+++ b/lsms_library/countries/Malawi/_/months_food_inadequate.py
@@ -1,0 +1,32 @@
+"""Concatenate wave-level months_food_inadequate parquets for Malawi (#332).
+
+Each buildable wave's ``Malawi/<wave>/_/months_food_inadequate.py``
+produces a parquet indexed (t, i) with ``MonthsInadequate`` (0-12) and
+``AnyInadequate`` (bool).  This script concatenates them.  Cross-wave
+id_walk and the join of ``v`` are applied by the framework at API time in
+_finalize_result -- as for plot_features, no id_walk is run here.
+
+2004-05 (IHS2) is ABSENT: its Module H is a 3-day food-consumption recall,
+not the H04/H05 months-of-shortage battery introduced in IHS3.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2010-11', '2013-14', '2016-17', '2019-20']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/months_food_inadequate.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        continue
+    pieces.append(df)
+
+assert pieces, "months_food_inadequate: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/months_food_inadequate.parquet')

--- a/lsms_library/countries/Mali/2014-15/_/food_coping.py
+++ b/lsms_library/countries/Mali/2014-15/_/food_coping.py
@@ -1,0 +1,67 @@
+"""Build food_coping (rCSI coping-strategies day-counts) for Mali EACI 2014-15.
+
+Source: EACIMEN_p2.dta, household questionnaire Section 17 ("Sécurité
+alimentaire").  s17q02a..s17q02e are the standard reduced Coping
+Strategies Index (rCSI) battery — "Au cours des 7 derniers jours, nombre
+de jours à ..." — i.e. the number of days (0-7) in the last 7 the
+household used each strategy.  The five items appear in the canonical
+CSI order:
+
+    s17q02a  consommer des aliments moins chers          -> LessPreferred
+    s17q02b  Réduire les quantités consommées (portions) -> LimitPortion
+    s17q02c  Réduire le nombre de repas par jour         -> ReduceMeals
+    s17q02d  Réduire les quantités (adultes, p/ enfants) -> RestrictAdults
+    s17q02e  Emprunter de la nourriture / compter sur l'aide -> BorrowFood
+
+Loaded with convert_categoricals=False so the day-counts arrive as
+integers; the residual code 9 is the survey's "Manquant" (missing)
+sentinel and is dropped to NaN.  Recall window: last 7 days.
+
+Output is long-form: one row per (t, i, Strategy) with column Days
+(Int64, 0-7).  ``i`` is the EACI composite household id built with
+Mali's i() formatter so it matches household_roster().i for this wave.
+``v`` is NOT baked in — the framework joins it from sample().
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import i as mali_i
+
+WAVE = '2014-15'
+
+# Canonical CSI-order -> Strategy name.
+STRATEGY = {
+    's17q02a': 'LessPreferred',
+    's17q02b': 'LimitPortion',
+    's17q02c': 'ReduceMeals',
+    's17q02d': 'RestrictAdults',
+    's17q02e': 'BorrowFood',
+}
+
+src = get_dataframe('../Data/EACIMEN_p2.dta', convert_categoricals=False)
+
+src = src.copy()
+src['i'] = src.apply(lambda r: mali_i(pd.Series([r['grappe'], r['menage']])),
+                     axis=1)
+
+cols = list(STRATEGY)
+long = src.melt(id_vars=['i'], value_vars=cols,
+                var_name='Strategy', value_name='Days')
+long['Strategy'] = long['Strategy'].map(STRATEGY)
+
+# 9 == "Manquant" (missing); valid day-counts are 0-7.
+long['Days'] = pd.to_numeric(long['Days'], errors='coerce')
+long.loc[(long['Days'] < 0) | (long['Days'] > 7), 'Days'] = pd.NA
+long = long.dropna(subset=['Days'])
+long['Days'] = long['Days'].astype('Int64')
+
+long['t'] = WAVE
+df = long.set_index(['t', 'i', 'Strategy'])[['Days']].sort_index()
+
+assert df.index.is_unique, "Non-unique (t, i, Strategy) index in food_coping 2014-15"
+assert len(df) > 0, "food_coping 2014-15 produced no rows"
+
+to_parquet(df, 'food_coping.parquet')

--- a/lsms_library/countries/Mali/_/Makefile
+++ b/lsms_library/countries/Mali/_/Makefile
@@ -25,7 +25,7 @@ panel_ids.json updated_ids.json: panel_ids.py mali.py
 ../%/_/food_coping.parquet: ../%/_/food_coping.py
 	(cd $(@D) && python food_coping.py)
 
-$(VAR_DIR)/food_coping.parquet ../var/food_coping.parquet: food_coping.py ../2014-15/_/food_coping.parquet
+$(VAR_DIR)/food_coping.parquet: food_coping.py ../2014-15/_/food_coping.parquet
 	python food_coping.py
 
 clean:

--- a/lsms_library/countries/Mali/_/Makefile
+++ b/lsms_library/countries/Mali/_/Makefile
@@ -18,6 +18,16 @@ panel_ids.json updated_ids.json: panel_ids.py mali.py
 ../%/_/plot_features.parquet: ../%/_/plot_features.py
 	(cd $(@D) && python plot_features.py)
 
+# food_coping (non-FIES rCSI day-counts, #332).  Only the EACI 2014-15
+# wave carries the Section-17 coping battery.  The wave pattern rule
+# materializes the wave parquet; the country-level concatenator
+# (food_coping.py) aggregates into var/food_coping.parquet.
+../%/_/food_coping.parquet: ../%/_/food_coping.py
+	(cd $(@D) && python food_coping.py)
+
+$(VAR_DIR)/food_coping.parquet ../var/food_coping.parquet: food_coping.py ../2014-15/_/food_coping.parquet
+	python food_coping.py
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Mali/_/data_scheme.yml
+++ b/lsms_library/countries/Mali/_/data_scheme.yml
@@ -94,6 +94,19 @@ Data Scheme:
     HowCoped0: str
     HowCoped1: str
     HowCoped2: str
+  food_coping:
+    # Non-FIES food-security: reduced Coping Strategies Index (rCSI)
+    # day-counts (#332).  EACI 2014-15 household questionnaire Section 17
+    # ("Sécurité alimentaire"), recall = last 7 days.  s17q02a..s17q02e
+    # are "nombre de jours" (0-7) the HH used each of the five canonical
+    # CSI strategies; survey code 9 ("Manquant") is dropped.  Long-form:
+    # one row per (t, i, Strategy).  EACI 2014-15 ONLY — the EHCVM waves
+    # (2018-19, 2021-22) use the FAO FIES instrument (food_security) and
+    # have no day-count coping block.  Built by a wave script + a
+    # country-level concatenator (reshape -> materialize: make).
+    index: (t, i, Strategy)
+    Days: int
+    materialize: make
   plot_features:
     # Lasting parcel-level characteristics from the EHCVM agriculture
     # module s16a (GH #167; Mali is the EHCVM reference implementation).

--- a/lsms_library/countries/Mali/_/food_coping.py
+++ b/lsms_library/countries/Mali/_/food_coping.py
@@ -1,0 +1,38 @@
+"""Concatenate wave-level food_coping (rCSI day-counts) for Mali (#332).
+
+Each wave's ``Mali/<wave>/_/food_coping.py`` writes a parquet indexed by
+``(t, i, Strategy)`` with column ``Days`` (0-7, days in the last 7 the
+household used the coping strategy).  Only the EACI 2014-15 wave carries
+the Section-17 rCSI battery; the EHCVM waves (2018-19, 2021-22) use the
+FAO FIES instrument instead (wired as ``food_security``) and have no
+day-count coping block.  This single-wave concatenator mirrors the
+plot_features pattern for consistency and future-proofing.
+
+``v`` is NOT baked in — the framework joins it from ``sample()`` at API
+time.  ``id_walk`` is likewise left to ``_finalize_result`` (cached
+parquets store pre-transformation data).
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+WAVES = ['2014-15', '2017-18', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/food_coping.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for food_coping (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "food_coping: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, Strategy) after concat"
+
+to_parquet(p, '../var/food_coping.parquet')

--- a/lsms_library/countries/Nepal/_/CONTENTS.org
+++ b/lsms_library/countries/Nepal/_/CONTENTS.org
@@ -97,3 +97,14 @@ Malawi / Mali / Nigeria / Senegal / Burkina_Faso) and document
 the choice in this section.
 
 For the cross-country canonical-=u= roadmap, see GH #223.
+
+* Food security (non-FIES families, GH #332)
+
+NLSS III (2010-11) Section 19 ("Food security and steps taken to
+alleviate food shortage") fields a full coping-strategies battery
+(=v19_1801=..=v19_1814=, a 14-item index) plus a days-of-scarcity
+item (=v19_17=) --- enough in principle to support both =food_coping=
+and =months_food_inadequate=.  NLSS I/II carry only a food-adequacy
+self-assessment.  None is wired: as noted under "Data Acquisition
+Status" above, no Nepal =.dta= is in the repository (NSO-hosted, not
+WB).  Implement once the NLSS III source files are acquired.

--- a/lsms_library/countries/Nigeria/2010-11/_/food_coping.py
+++ b/lsms_library/countries/Nigeria/2010-11/_/food_coping.py
@@ -1,0 +1,25 @@
+"""Build food_coping for Nigeria GHS-Panel wave 1 (2010-11; #332).
+
+Family B (coping-strategies / rCSI).  GHS section 9 ("Food Security")
+is a coping day-count battery: items s9q1a..s9q1i ask "how many days
+in the last 7 had to [strategy]", coded 0-7.  Collected in the
+post-planting round only -> single t = 2010Q3.  Long-form
+(t, i, Strategy) with Days.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import food_coping_for_wave, PP_QUARTER
+
+t = PP_QUARTER['2010-11']
+
+df = get_dataframe('../Data/Post Planting Wave 1/Household/'
+                   'sect9_plantingw1.dta', convert_categoricals=False)
+
+coping = food_coping_for_wave(t, df)
+
+assert coping.index.is_unique, "Non-unique (t, i, Strategy) in food_coping 2010-11"
+assert len(coping) > 0, "food_coping 2010-11 produced no rows"
+
+to_parquet(coping, 'food_coping.parquet')

--- a/lsms_library/countries/Nigeria/2012-13/_/food_coping.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/food_coping.py
@@ -1,0 +1,25 @@
+"""Build food_coping for Nigeria GHS-Panel wave 2 (2012-13; #332).
+
+Family B (coping-strategies / rCSI).  GHS section 9 ("Food Security")
+is a coping day-count battery: items s9q1a..s9q1i ask "how many days
+in the last 7 had to [strategy]", coded 0-7.  Collected in the
+post-planting round only -> single t = 2012Q3.  Long-form
+(t, i, Strategy) with Days.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import food_coping_for_wave, PP_QUARTER
+
+t = PP_QUARTER['2012-13']
+
+df = get_dataframe('../Data/Post Planting Wave 2/Household/'
+                   'sect9_plantingw2.dta', convert_categoricals=False)
+
+coping = food_coping_for_wave(t, df)
+
+assert coping.index.is_unique, "Non-unique (t, i, Strategy) in food_coping 2012-13"
+assert len(coping) > 0, "food_coping 2012-13 produced no rows"
+
+to_parquet(coping, 'food_coping.parquet')

--- a/lsms_library/countries/Nigeria/2015-16/_/food_coping.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/food_coping.py
@@ -1,0 +1,25 @@
+"""Build food_coping for Nigeria GHS-Panel wave 3 (2015-16; #332).
+
+Family B (coping-strategies / rCSI).  GHS section 9 ("Food Security")
+is a coping day-count battery: items s9q1a..s9q1i ask "how many days
+in the last 7 had to [strategy]", coded 0-7.  Collected in the
+post-planting round only -> single t = 2015Q3.  W3 sect9 ships as a
+flat ../Data/sect9_plantingw3.dta.  Long-form (t, i, Strategy) with
+Days.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import food_coping_for_wave, PP_QUARTER
+
+t = PP_QUARTER['2015-16']
+
+df = get_dataframe('../Data/sect9_plantingw3.dta', convert_categoricals=False)
+
+coping = food_coping_for_wave(t, df)
+
+assert coping.index.is_unique, "Non-unique (t, i, Strategy) in food_coping 2015-16"
+assert len(coping) > 0, "food_coping 2015-16 produced no rows"
+
+to_parquet(coping, 'food_coping.parquet')

--- a/lsms_library/countries/Nigeria/_/Makefile
+++ b/lsms_library/countries/Nigeria/_/Makefile
@@ -148,6 +148,20 @@ plot_features_parquet := $(plot_features:.py=.parquet)
 $(VAR_DIR)/plot_features.parquet: plot_features.py $(plot_features_parquet)
 	python plot_features.py
 
+# food_coping (#332, Family B).  Post-planting GHS section-9 coping
+# day-count battery (W1-W3).  The framework's grab_data calls
+# `make ../<wave>/_/food_coping.parquet` from this `_/` dir for each
+# wired wave; the pattern rule runs the wave script.  The VAR_DIR rule
+# concatenates them (mirrors plot_features above).
+food_coping = $(shell find $(rounds) -name food_coping.py)
+food_coping_parquet := $(food_coping:.py=.parquet)
+
+../%/_/food_coping.parquet: ../%/_/food_coping.py
+	(cd $(@D) && python food_coping.py)
+
+$(VAR_DIR)/food_coping.parquet: food_coping.py $(food_coping_parquet)
+	python food_coping.py
+
 # individual_education (GHS section 2, post-harvest only).  The
 # framework's grab_data calls `make ../<wave>/_/individual_education.parquet`
 # from this `_/` dir; the pattern rule runs the wave script.

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -104,4 +104,16 @@ Data Scheme:
     Irrigated: bool
     materialize: make
 
+  food_coping:
+    # Family B (coping-strategies / rCSI), #332.  GHS section 9 ("Food
+    # Security") is a coping day-count battery (items s9q1a..s9q1i: "how
+    # many days in the last 7 had to [strategy]", coded 0-7), NOT an
+    # HFIAS occurrence/frequency scale.  Collected in the post-planting
+    # round only, so each wave maps to a single t = PP quarter
+    # (2010Q3 / 2012Q3 / 2015Q3 for W1-W3) -> materialize: make.  W4+
+    # section 9 switched to FIES (sect9b), wired separately.
+    index: (t, i, Strategy)
+    Days: int
+    materialize: make
+
   nonfood_expenditures: !make

--- a/lsms_library/countries/Nigeria/_/food_coping.py
+++ b/lsms_library/countries/Nigeria/_/food_coping.py
@@ -1,0 +1,33 @@
+"""Concatenate wave-level food_coping for Nigeria (#332, Family B).
+
+Each wired wave's ``Nigeria/<wave>/_/food_coping.py`` writes a parquet
+indexed by ``(t, i, Strategy)`` with an integer ``Days`` column (0-7).
+This script concatenates them into the country-level table.
+
+Only W1-W3 (2010-11/2012-13/2015-16) carry the GHS section-9 coping
+day-count battery; waves without a food_coping.py script are skipped
+(W4+ section 9 switched to FIES, wired separately).  No id_walk is
+applied: Nigeria GHS-Panel hhid is stable across waves.  `v` is
+intentionally absent; the framework joins it from sample() at API time.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import Waves
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/food_coping.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired (script absent or parquet not yet built).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "food_coping: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/food_coping.parquet')

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -50,6 +50,76 @@ PP_QUARTER = {
     '2023-24': '2023Q3',
 }
 
+# ---------------------------------------------------------------------
+# food_coping (#332, Family B: coping-strategies / rCSI)
+# ---------------------------------------------------------------------
+#
+# GHS section 9 ("Food Security") is a coping day-count battery, NOT an
+# HFIAS occurrence/frequency scale.  Items s9q1a..s9q1i ask "HOW MANY
+# DAYS [in the last 7] HAD TO..." for each coping strategy, coded 0-7.
+# Collected in the post-planting round only (sect9_plantingwN.dta), so
+# each wave maps to a single t = PP_QUARTER[wave].  The post-harvest
+# round has no equivalent battery.  sect9b (W4+) is FIES and is wired
+# separately (do not include here).
+#
+# Canonical rCSI strategy names (LessPreferred, LimitVariety,
+# LimitPortion, ReduceMeals, RestrictAdults, BorrowFood) plus the
+# survey-specific severe-coping items (NoFood, SleepHungry,
+# WholeDayNoFood).  Order follows the questionnaire (s9q1a..s9q1i).
+FOOD_COPING_ITEMS = {
+    's9q1a': 'LessPreferred',     # rely on less preferred foods
+    's9q1b': 'LimitVariety',      # limit variety of foods eaten
+    's9q1c': 'LimitPortion',      # limit portion size at meal times
+    's9q1d': 'ReduceMeals',       # reduce number of meals eaten
+    's9q1e': 'RestrictAdults',    # restrict adult consump for children
+    's9q1f': 'BorrowFood',        # borrow food / rely on help
+    's9q1g': 'NoFood',            # no food of any kind in household
+    's9q1h': 'SleepHungry',       # go to sleep hungry
+    's9q1i': 'WholeDayNoFood',    # go a whole day & night without eating
+}
+
+
+def food_coping_for_wave(t, df, id_col='hhid', items=None):
+    """Reshape a sect9 coping battery into long-form food_coping.
+
+    Parameters
+    ----------
+    t : str
+        The single post-planting quarter for this wave (e.g. '2010Q3').
+    df : DataFrame
+        Raw sect9_plantingwN data (one row per household), read with
+        ``convert_categoricals=False`` so the day counts stay numeric.
+    id_col : str
+        Household id column (Nigeria GHS uses 'hhid').
+    items : dict
+        Mapping of source column -> Strategy name; defaults to
+        ``FOOD_COPING_ITEMS``.
+
+    Returns
+    -------
+    DataFrame indexed by (t, i, Strategy) with an integer ``Days``
+    column (0-7).  Rows where the day count is missing are dropped; a
+    household with all-missing items contributes no rows.
+    """
+    items = items or FOOD_COPING_ITEMS
+    present = {src: name for src, name in items.items() if src in df.columns}
+    if not present:
+        raise ValueError(f"food_coping: none of {list(items)} in source for t={t}")
+
+    sub = df[[id_col] + list(present)].copy()
+    sub['i'] = sub[id_col].apply(format_id)
+    sub = sub.drop(columns=[id_col]).rename(columns=present)
+
+    long = sub.melt(id_vars='i', var_name='Strategy', value_name='Days')
+    long['Days'] = pd.to_numeric(long['Days'], errors='coerce')
+    long = long.dropna(subset=['Days'])
+    long['Days'] = long['Days'].round().astype('Int64')
+    long['t'] = t
+
+    long = long.set_index(['t', 'i', 'Strategy']).sort_index()
+    return long[['Days']]
+
+
 HECTARES_PER_ACRE = 0.404686          # 1 acre  = 0.404686 ha
 SQM_PER_HECTARE = 10000.0             # 1 ha    = 10,000 m^2
 

--- a/lsms_library/countries/Tajikistan/2007/_/food_security_hfias.py
+++ b/lsms_library/countries/Tajikistan/2007/_/food_security_hfias.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""Tajikistan 2007 food_security_hfias (HFIAS 9-item Household Food Insecurity
+Access Scale).
+
+Source: ../Data/r1m9.dta -- Module 9a (round 1), the round whose roster
+(r1m1.dta) is the canonical household_roster source for the 2007 wave, so
+i: hhid matches the roster's i.  r1m9 has exactly one row per hhid (4644 HH),
+covering every household in the round-1 roster.
+
+The 9 standard HFIAS occurrence questions, each paired with a frequency-of-
+occurrence follow-up.  Variable labels confirmed via pyreadstat metadata; value
+labels are: occurrence {1: yes, 2: no}; frequency {1: rarely (1-2 times),
+2: sometimes (3-10 times), 3: often (more than 10 times)}.  Recall: past 4 weeks.
+
+  HFIAS item                          occurrence  frequency
+  1 worried not enough food           m9aq14      m9aq15
+  2 unable to eat preferred foods     m9aq17      m9aq18
+  3 ate limited variety of foods      m9aq19      m9aq20
+  4 ate foods did not want to eat     m9aq21      m9aq22
+  5 ate a smaller meal than needed    m9aq23      m9aq24
+  6 ate fewer meals in a day          m9aq25      m9aq26
+  7 no food of any kind in house      m9aq27      m9aq28
+  8 went to sleep hungry              m9aq29      m9aq30
+  9 went a whole day & night w/o food m9aq31      m9aq32
+
+Each item is coded 0-3: 0 if the occurrence answer is no; otherwise the
+frequency code (1=Rarely, 2=Sometimes, 3=Often).  HFIAS_score is the sum of the
+9 items (0-27).  HFIAS_category follows the FANTA (Coates, Swindale & Bilinsky
+2007) algorithm.  Output index (t, i).
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, format_id, to_parquet
+
+ID = 'hhid'
+
+# (occurrence column, frequency column) for HFIAS items 1..9, in order.
+PAIRS = [
+    ('m9aq14', 'm9aq15'),
+    ('m9aq17', 'm9aq18'),
+    ('m9aq19', 'm9aq20'),
+    ('m9aq21', 'm9aq22'),
+    ('m9aq23', 'm9aq24'),
+    ('m9aq25', 'm9aq26'),
+    ('m9aq27', 'm9aq28'),
+    ('m9aq29', 'm9aq30'),
+    ('m9aq31', 'm9aq32'),
+]
+
+YES = {'yes'}
+NO = {'no'}
+FREQ = {
+    'rarely (1-2 times)': 1,
+    'sometimes (3-10 times)': 2,
+    'often (more than 10 times)': 3,
+}
+
+
+def _item_score(occ, freq):
+    """HFIAS item score 0-3 from an occurrence/frequency label pair."""
+    o = str(occ).strip().lower()
+    if o in NO:
+        return 0
+    if o in YES:
+        f = str(freq).strip().lower()
+        return FREQ.get(f, pd.NA)
+    return pd.NA
+
+
+def hfias_category(row):
+    """FANTA HFIAS prevalence category from items a1..a9 (each 0-3)."""
+    a = [row[f'HFIAS{k}'] for k in range(1, 10)]
+    if any(pd.isna(v) for v in a):
+        return pd.NA
+    a1, a2, a3, a4, a5, a6, a7, a8, a9 = a
+    if a5 == 3 or a6 == 3 or a7 in (1, 2, 3) or a8 in (1, 2, 3) or a9 in (1, 2, 3):
+        return 'Severely food insecure'
+    if a3 in (2, 3) or a4 in (2, 3) or a5 in (1, 2) or a6 in (1, 2):
+        return 'Moderately food insecure'
+    if a1 in (2, 3) or a2 in (1, 2, 3) or a3 == 1 or a4 == 1:
+        return 'Mildly food insecure'
+    return 'Food secure'
+
+
+cols = [ID] + [c for pair in PAIRS for c in pair]
+df = get_dataframe('../Data/r1m9.dta')[cols].copy()
+df['i'] = df[ID].apply(format_id)
+
+out = pd.DataFrame({'i': df['i']})
+for k, (occ, freq) in enumerate(PAIRS, start=1):
+    out[f'HFIAS{k}'] = [_item_score(o, f) for o, f in zip(df[occ], df[freq])]
+
+item_cols = [f'HFIAS{k}' for k in range(1, 10)]
+present = out[item_cols].notna().all(axis=1)
+out['HFIAS_score'] = pd.NA
+out.loc[present, 'HFIAS_score'] = out.loc[present, item_cols].sum(axis=1)
+out['HFIAS_category'] = out.apply(hfias_category, axis=1)
+
+out = out[out[item_cols].notna().any(axis=1)].copy()
+
+for c in item_cols + ['HFIAS_score']:
+    out[c] = out[c].astype('Int64')
+
+out['t'] = '2007'
+out = (out[['t', 'i'] + item_cols + ['HFIAS_score', 'HFIAS_category']]
+       .drop_duplicates(subset=['t', 'i'])
+       .set_index(['t', 'i'])
+       .sort_index())
+
+to_parquet(df=out, fn='food_security_hfias.parquet')

--- a/lsms_library/countries/Tajikistan/2009/_/food_security_hfias.py
+++ b/lsms_library/countries/Tajikistan/2009/_/food_security_hfias.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+"""Tajikistan 2009 food_security_hfias (HFIAS 9-item Household Food Insecurity
+Access Scale).
+
+Source: ../Data/m8a.dta -- Module 8a "Subjective Poverty and Food Security"
+(household level, one row per HHID; i matches the roster's i: HHID).
+
+The 9 standard HFIAS occurrence questions, each paired with a frequency-of-
+occurrence follow-up.  Variable labels confirmed via pyreadstat metadata; value
+labels are: occurrence {1: YES, 2: NO}; frequency {1: RARELY (1-2 times),
+2: SOMETIMES (3-10 times), 3: OFTEN (more than 10 times)}.  Recall: past 4 weeks.
+
+  HFIAS item                          occurrence  frequency
+  1 worried not enough food           M8AQ11      M8AQ12
+  2 unable to eat preferred foods     M8AQ14      M8AQ15
+  3 ate limited variety of foods      M8AQ16      M8AQ17
+  4 ate foods did not want to eat     M8AQ18      M8AQ19
+  5 ate a smaller meal than needed    M8AQ20      M8AQ21
+  6 ate fewer meals in a day          M8AQ22      M8AQ23
+  7 no food of any kind in house      M8AQ24      M8AQ25
+  8 went to sleep hungry              M8AQ26      M8AQ27
+  9 went a whole day & night w/o food M8AQ28      M8AQ29
+
+Each item is coded 0-3: 0 if the occurrence answer is NO; otherwise the
+frequency code (1=Rarely, 2=Sometimes, 3=Often).  HFIAS_score is the sum of the
+9 items (0-27).  HFIAS_category follows the FANTA (Coates, Swindale & Bilinsky
+2007) algorithm.  Output index (t, i).
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, format_id, to_parquet
+
+ID = 'HHID'
+
+# (occurrence column, frequency column) for HFIAS items 1..9, in order.
+PAIRS = [
+    ('M8AQ11', 'M8AQ12'),
+    ('M8AQ14', 'M8AQ15'),
+    ('M8AQ16', 'M8AQ17'),
+    ('M8AQ18', 'M8AQ19'),
+    ('M8AQ20', 'M8AQ21'),
+    ('M8AQ22', 'M8AQ23'),
+    ('M8AQ24', 'M8AQ25'),
+    ('M8AQ26', 'M8AQ27'),
+    ('M8AQ28', 'M8AQ29'),
+]
+
+# Occurrence labels mean "did this happen": YES -> use frequency; NO -> 0.
+YES = {'yes'}
+NO = {'no'}
+# Frequency labels -> ordinal 1/2/3.
+FREQ = {
+    'rarely (1-2 times)': 1,
+    'sometimes (3-10 times)': 2,
+    'often (more than 10 times)': 3,
+}
+
+
+def _item_score(occ, freq):
+    """HFIAS item score 0-3 from an occurrence/frequency label pair."""
+    o = str(occ).strip().lower()
+    if o in NO:
+        return 0
+    if o in YES:
+        f = str(freq).strip().lower()
+        return FREQ.get(f, pd.NA)  # YES but freq missing/odd -> NA
+    return pd.NA  # occurrence missing / don't know / refuse
+
+
+def hfias_category(row):
+    """FANTA HFIAS prevalence category from items a1..a9 (each 0-3)."""
+    a = [row[f'HFIAS{k}'] for k in range(1, 10)]
+    if any(pd.isna(v) for v in a):
+        return pd.NA
+    a1, a2, a3, a4, a5, a6, a7, a8, a9 = a
+    # Severe first (categories are mutually exclusive; severe dominates).
+    if a5 == 3 or a6 == 3 or a7 in (1, 2, 3) or a8 in (1, 2, 3) or a9 in (1, 2, 3):
+        return 'Severely food insecure'
+    if a3 in (2, 3) or a4 in (2, 3) or a5 in (1, 2) or a6 in (1, 2):
+        return 'Moderately food insecure'
+    if a1 in (2, 3) or a2 in (1, 2, 3) or a3 == 1 or a4 == 1:
+        return 'Mildly food insecure'
+    return 'Food secure'
+
+
+cols = [ID] + [c for pair in PAIRS for c in pair]
+df = get_dataframe('../Data/m8a.dta')[cols].copy()
+df['i'] = df[ID].apply(format_id)
+
+out = pd.DataFrame({'i': df['i']})
+for k, (occ, freq) in enumerate(PAIRS, start=1):
+    out[f'HFIAS{k}'] = [_item_score(o, f) for o, f in zip(df[occ], df[freq])]
+
+# Score is the sum of the 9 items where all items are present.
+item_cols = [f'HFIAS{k}' for k in range(1, 10)]
+present = out[item_cols].notna().all(axis=1)
+out['HFIAS_score'] = pd.NA
+out.loc[present, 'HFIAS_score'] = out.loc[present, item_cols].sum(axis=1)
+out['HFIAS_category'] = out.apply(hfias_category, axis=1)
+
+# Drop households where the whole battery is missing (not administered).
+out = out[out[item_cols].notna().any(axis=1)].copy()
+
+for c in item_cols + ['HFIAS_score']:
+    out[c] = out[c].astype('Int64')
+
+out['t'] = '2009'
+out = (out[['t', 'i'] + item_cols + ['HFIAS_score', 'HFIAS_category']]
+       .drop_duplicates(subset=['t', 'i'])
+       .set_index(['t', 'i'])
+       .sort_index())
+
+to_parquet(df=out, fn='food_security_hfias.parquet')

--- a/lsms_library/countries/Tajikistan/_/data_scheme.yml
+++ b/lsms_library/countries/Tajikistan/_/data_scheme.yml
@@ -11,6 +11,25 @@ Data Scheme:
     Satisfaction: str
     materialize: make
 
+  food_security_hfias:
+    index: (t, i)
+    HFIAS1: int
+    HFIAS2: int
+    HFIAS3: int
+    HFIAS4: int
+    HFIAS5: int
+    HFIAS6: int
+    HFIAS7: int
+    HFIAS8: int
+    HFIAS9: int
+    HFIAS_score: int
+    HFIAS_category:
+      - Food secure
+      - Mildly food insecure
+      - Moderately food insecure
+      - Severely food insecure
+    materialize: make
+
   cluster_features:
     index: (t, v)
     Region: str

--- a/lsms_library/countries/Tanzania/2008-15/_/food_coping.py
+++ b/lsms_library/countries/Tanzania/2008-15/_/food_coping.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""Tanzania 2008-15 food_coping -- coping-strategies battery (SECTION H).
+
+Source file: ``upd4_hh_h.dta`` -- the multi-round "Food Security" module.  As
+with the other multi-round Tanzania scripts this writes ONE parquet carrying
+all available rounds with ``t`` in the index; ``Wave.grab_data`` filters to the
+requested sub-wave.
+
+The §H coping-strategies battery (CSI / rCSI) asks, for each strategy, "In the
+past 7 days, how many days have you or someone in your household had to [...]".
+The module is HOUSEHOLD-level (one row per (round, r_hhid)); ``i = r_hhid``
+matches the wave's household_roster ``i``.
+
+NB the round-1 (2008-09) survey did NOT field §H -- the multi-round file only
+carries rounds 2/3/4 (waves 2010-11, 2012-13, 2014-15) for this module.
+
+The 8 day-count items ``hh_02_1 .. hh_02_8`` carry the same battery, in the
+same order, as the later NPS waves' ``hh_h02a .. hh_h02h`` (whose full variable
+labels, not truncated at Stata's 80-char limit, give the strategy text -- the
+2008-15 labels are truncated after "had to [").  Positional mapping:
+
+    hh_02_1  RELY ON LESS PREFERRED FOOD                  -> LessPreferred
+    hh_02_2  LIMIT THE VARIETY OF FOODS EATEN             -> LimitVariety
+    hh_02_3  LIMIT PORTION SIZE AT MEAL-TIMES             -> LimitPortion
+    hh_02_4  REDUCE THE NUMBER OF MEALS EATEN IN A DAY    -> ReduceMeals
+    hh_02_5  RESTRICT CONSUMPTION BY ADULTS (small kids)  -> RestrictAdults
+    hh_02_6  BORROW FOOD / RELY ON HELP FROM A FRIEND     -> BorrowFood
+    hh_02_7  HAD NO FOOD OF ANY KIND IN THE HOUSEHOLD     -> NoFood
+    hh_02_8  GO A WHOLE DAY AND NIGHT WITHOUT EATING      -> WholeDayWithout
+
+LessPreferred / LimitPortion / ReduceMeals / RestrictAdults / BorrowFood are
+the five canonical rCSI strategies; LimitVariety / NoFood / WholeDayWithout are
+the survey-specific extras (kept descriptively rather than discarded).
+
+``Days`` is the native count of days in the last 7 (int 0-7).  ``t`` is the
+round mapped to its wave label.
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+round_match = {1: '2008-09', 2: '2010-11', 3: '2012-13', 4: '2014-15'}
+
+# hh_02_N suffix -> canonical (or descriptive) Strategy.  Order matches the
+# later waves' hh_h02a..h (see module docstring).
+STRATEGIES = {
+    1: 'LessPreferred',
+    2: 'LimitVariety',
+    3: 'LimitPortion',
+    4: 'ReduceMeals',
+    5: 'RestrictAdults',
+    6: 'BorrowFood',
+    7: 'NoFood',
+    8: 'WholeDayWithout',
+}
+
+df = get_dataframe('../Data/upd4_hh_h.dta', convert_categoricals=False)
+
+item_cols = [f'hh_02_{n}' for n in STRATEGIES]
+wide = df[['round', 'r_hhid'] + item_cols].rename(columns={'r_hhid': 'i'}).copy()
+wide['i'] = wide['i'].astype(str)
+wide['t'] = wide['round'].astype(float).map(round_match)
+wide = wide.drop(columns=['round'])
+
+# --- WIDE -> LONG on (t, i, Strategy) ------------------------------------
+long = wide.melt(id_vars=['t', 'i'], value_vars=item_cols,
+                 var_name='item', value_name='Days')
+long['Strategy'] = long['item'].str.removeprefix('hh_02_').astype(int).map(STRATEGIES)
+long['Days'] = pd.to_numeric(long['Days'], errors='coerce').round().astype('Int64')
+
+# Drop rows with no genuine count (question not asked / unanswered).
+long = long.dropna(subset=['Days', 't'])
+
+out = long[['t', 'i', 'Strategy', 'Days']].set_index(['t', 'i', 'Strategy'])
+
+if not out.index.is_unique:
+    out = out.groupby(level=out.index.names).first()
+
+to_parquet(out, 'food_coping.parquet')

--- a/lsms_library/countries/Tanzania/2019-20/_/food_coping.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/food_coping.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Tanzania 2019-20 food_coping -- coping-strategies battery (SECTION H).
+
+Source: ``HH_SEC_H.dta`` ("Food Security").  HOUSEHOLD-level (one row per
+household, index ``i = sdd_hhid`` -- matches the wave's household_roster ``i``).
+
+The §H coping battery asks, for each strategy, "In the past 7 days, how many
+days had to: [...]".  The 8 items ``hh_h02a .. hh_h02h`` (full variable labels,
+not truncated):
+
+    hh_h02a  RELY ON LESS PREFERRED FOOD                  -> LessPreferred
+    hh_h02b  LIMIT THE VARIETY OF FOODS EATEN             -> LimitVariety
+    hh_h02c  LIMIT PORTION SIZE AT MEAL-TIMES             -> LimitPortion
+    hh_h02d  REDUCE THE NUMBER OF MEALS EATEN IN A DAY    -> ReduceMeals
+    hh_h02e  RESTRICT CONSUMPTION BY ADULTS (small kids)  -> RestrictAdults
+    hh_h02f  BORROW FOOD / RELY ON HELP FROM A FRIEND     -> BorrowFood
+    hh_h02g  HAD NO FOOD OF ANY KIND IN THE HOUSEHOLD     -> NoFood
+    hh_h02h  GO A WHOLE DAY AND NIGHT WITHOUT EATING      -> WholeDayWithout
+
+LessPreferred / LimitPortion / ReduceMeals / RestrictAdults / BorrowFood are
+the five canonical rCSI strategies; LimitVariety / NoFood / WholeDayWithout are
+the survey-specific extras (kept descriptively).
+
+``Days`` is the native count of days in the last 7 (int 0-7).  ``t`` is added
+here ('2019-20'); the country-level aggregator concatenates waves and applies
+id_walk.  (hh_h08, the separate 12-month-insufficiency item, is out of scope.)
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+# hh_h02{letter} -> canonical (or descriptive) Strategy.
+STRATEGIES = {
+    'a': 'LessPreferred',
+    'b': 'LimitVariety',
+    'c': 'LimitPortion',
+    'd': 'ReduceMeals',
+    'e': 'RestrictAdults',
+    'f': 'BorrowFood',
+    'g': 'NoFood',
+    'h': 'WholeDayWithout',
+}
+
+df = get_dataframe('../Data/HH_SEC_H.dta', convert_categoricals=False)
+
+item_cols = [f'hh_h02{x}' for x in STRATEGIES]
+wide = df[['sdd_hhid'] + item_cols].rename(columns={'sdd_hhid': 'i'}).copy()
+wide['i'] = wide['i'].astype(str)
+
+# --- WIDE -> LONG on (i, Strategy) ---------------------------------------
+long = wide.melt(id_vars='i', value_vars=item_cols,
+                 var_name='item', value_name='Days')
+long['Strategy'] = long['item'].str.removeprefix('hh_h02').map(STRATEGIES)
+long['Days'] = pd.to_numeric(long['Days'], errors='coerce').round().astype('Int64')
+
+long = long.dropna(subset=['Days'])
+
+long['t'] = '2019-20'
+out = long[['t', 'i', 'Strategy', 'Days']].set_index(['t', 'i', 'Strategy'])
+
+if not out.index.is_unique:
+    out = out.groupby(level=out.index.names).first()
+
+to_parquet(out, 'food_coping.parquet')

--- a/lsms_library/countries/Tanzania/2020-21/_/food_coping.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/food_coping.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Tanzania 2020-21 food_coping -- coping-strategies battery (SECTION H).
+
+Source: ``hh_sec_h.dta`` ("Food Security").  HOUSEHOLD-level (one row per
+household, index ``i = y5_hhid`` -- matches the wave's household_roster ``i``).
+
+The §H coping battery asks, for each strategy, "In the past 7 days, how many
+days had to: [...]".  The 8 items ``hh_h02a .. hh_h02h`` (full variable labels,
+identical to the 2019-20 wave):
+
+    hh_h02a  RELY ON LESS PREFERRED FOOD                  -> LessPreferred
+    hh_h02b  LIMIT THE VARIETY OF FOODS EATEN             -> LimitVariety
+    hh_h02c  LIMIT PORTION SIZE AT MEAL-TIMES             -> LimitPortion
+    hh_h02d  REDUCE THE NUMBER OF MEALS EATEN IN A DAY    -> ReduceMeals
+    hh_h02e  RESTRICT CONSUMPTION BY ADULTS (small kids)  -> RestrictAdults
+    hh_h02f  BORROW FOOD / RELY ON HELP FROM A FRIEND     -> BorrowFood
+    hh_h02g  HAD NO FOOD OF ANY KIND IN THE HOUSEHOLD     -> NoFood
+    hh_h02h  GO A WHOLE DAY AND NIGHT WITHOUT EATING      -> WholeDayWithout
+
+LessPreferred / LimitPortion / ReduceMeals / RestrictAdults / BorrowFood are
+the five canonical rCSI strategies; LimitVariety / NoFood / WholeDayWithout are
+the survey-specific extras (kept descriptively).
+
+``Days`` is the native count of days in the last 7 (int 0-7).  ``t`` is added
+here ('2020-21'); the country-level aggregator concatenates waves and applies
+id_walk.  (hh_h08, the separate 12-month-insufficiency item, is out of scope.)
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+# hh_h02{letter} -> canonical (or descriptive) Strategy.
+STRATEGIES = {
+    'a': 'LessPreferred',
+    'b': 'LimitVariety',
+    'c': 'LimitPortion',
+    'd': 'ReduceMeals',
+    'e': 'RestrictAdults',
+    'f': 'BorrowFood',
+    'g': 'NoFood',
+    'h': 'WholeDayWithout',
+}
+
+df = get_dataframe('../Data/hh_sec_h.dta', convert_categoricals=False)
+
+item_cols = [f'hh_h02{x}' for x in STRATEGIES]
+wide = df[['y5_hhid'] + item_cols].rename(columns={'y5_hhid': 'i'}).copy()
+wide['i'] = wide['i'].astype(str)
+
+# --- WIDE -> LONG on (i, Strategy) ---------------------------------------
+long = wide.melt(id_vars='i', value_vars=item_cols,
+                 var_name='item', value_name='Days')
+long['Strategy'] = long['item'].str.removeprefix('hh_h02').map(STRATEGIES)
+long['Days'] = pd.to_numeric(long['Days'], errors='coerce').round().astype('Int64')
+
+long = long.dropna(subset=['Days'])
+
+long['t'] = '2020-21'
+out = long[['t', 'i', 'Strategy', 'Days']].set_index(['t', 'i', 'Strategy'])
+
+if not out.index.is_unique:
+    out = out.groupby(level=out.index.names).first()
+
+to_parquet(out, 'food_coping.parquet')

--- a/lsms_library/countries/Tanzania/_/Makefile
+++ b/lsms_library/countries/Tanzania/_/Makefile
@@ -48,6 +48,15 @@ $(VAR_DIR)/life_satisfaction.parquet: life_satisfaction.py $(life_satisfaction_p
 ../%/_/life_satisfaction.parquet:
 	(cd $(@D) && python life_satisfaction.py)
 
+food_coping = $(shell find $(rounds) -name food_coping.py)
+food_coping_parquet := $(food_coping:.py=.parquet)
+
+$(VAR_DIR)/food_coping.parquet: food_coping.py $(food_coping_parquet)
+	python food_coping.py
+
+../%/_/food_coping.parquet:
+	(cd $(@D) && python food_coping.py)
+
 plot_features = $(shell find $(rounds) -name plot_features.py)
 plot_features_parquet := $(plot_features:.py=.parquet)
 

--- a/lsms_library/countries/Tanzania/_/data_scheme.yml
+++ b/lsms_library/countries/Tanzania/_/data_scheme.yml
@@ -54,6 +54,23 @@ Data Scheme:
     Satisfaction: str
     materialize: make
 
+  food_coping:
+    # Coping-strategies / rCSI battery (Section H "Food Security", item
+    # hh_h02a..hh_h02h / hh_02_1..hh_02_8).  For each strategy the survey
+    # asks "in the past 7 days, how many days had to [...]" -- a day-count
+    # 0-7.  Present in 2010-11, 2012-13, 2014-15 (multi-round upd4_hh_h.dta;
+    # round 1 / 2008-09 did NOT field the module), 2019-20 (HH_SEC_H.dta),
+    # and 2020-21 (hh_sec_h.dta).  HOUSEHOLD-level; i = each wave's roster i
+    # (r_hhid / sdd_hhid / y5_hhid).  WIDE->LONG: one (t, i, Strategy) row
+    # per strategy.  Strategy names: the five canonical rCSI strategies
+    # (LessPreferred, LimitPortion, ReduceMeals, RestrictAdults, BorrowFood)
+    # plus survey-specific LimitVariety / NoFood / WholeDayWithout.  Days =
+    # native count 0-7.  The hh_h08 12-month-insufficiency item is out of
+    # scope (a months-style measure, not a coping-day count).
+    index: (t, i, Strategy)
+    Days: int
+    materialize: make
+
   interview_date:
     index: (t, i)
     Int_t: datetime

--- a/lsms_library/countries/Tanzania/_/food_coping.py
+++ b/lsms_library/countries/Tanzania/_/food_coping.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""Concatenate Tanzania food_coping (Section H coping-strategies battery) across
+waves and apply panel-id walking.
+
+Each wave-level script writes a ``(t, i, Strategy)`` parquet with the household's
+day-counts for each coping strategy.  The 2008-15 folder's parquet carries the
+NPS rounds that fielded §H (rounds 2/3/4 -> waves 2010-11, 2012-13, 2014-15;
+round 1 / 2008-09 did not field the module); the 2019-20 / 2020-21 folders carry
+one wave each.  We load by folder (Waves.keys()), concatenate, then id_walk to
+harmonize household ids across waves.
+"""
+from lsms_library.local_tools import to_parquet, get_dataframe
+from lsms_library.paths import data_root
+
+import sys
+sys.path.append('../../_/')
+import pandas as pd
+from tanzania import Waves, id_walk
+import warnings
+import json
+
+s = {}
+for t in Waves.keys():
+    candidates = [
+        str(data_root('Tanzania') / t / '_' / 'food_coping.parquet'),
+        '../' + t + '/_/food_coping.parquet',
+    ]
+    loaded = False
+    for path in candidates:
+        try:
+            s[t] = get_dataframe(path)
+            loaded = True
+            break
+        except (FileNotFoundError, Exception):
+            continue
+    if not loaded:
+        warnings.warn(f'Could not load food_coping for {t}')
+
+if not s:
+    raise RuntimeError('No food_coping data found for any wave.')
+
+s = pd.concat(s.values())
+
+# Ensure index uses 'i' (not 'j')
+if 'j' in s.index.names and 'i' not in s.index.names:
+    s.index = s.index.rename({'j': 'i'})
+
+target_idx = ['t', 'i', 'Strategy']
+if list(s.index.names) != target_idx:
+    s = s.reset_index()
+    for col in list(s.columns):
+        if col not in target_idx and col != 'Days':
+            s = s.drop(columns=[col], errors='ignore')
+    s = s.set_index(target_idx)
+
+with open('updated_ids.json', 'r') as f:
+    updated_ids = json.load(f)
+
+s = id_walk(s, updated_ids, hh_index='i')
+
+to_parquet(s, '../var/food_coping.parquet')

--- a/lsms_library/countries/Timor-Leste/2001/_/months_food_inadequate.py
+++ b/lsms_library/countries/Timor-Leste/2001/_/months_food_inadequate.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""Timor-Leste 2001 months_food_inadequate (Family C).
+
+Source: Section 13C 'Vulnerability' (../Data/S13C.DTA, one row per identif,
+1800 HHs).  The core item is
+
+  s13c13  "13 months not enough rice/maize past 12m"
+
+an integer count 0-12 of the months in the past 12 during which the household
+could not meet its staple (rice/maize) food needs.  We expose it as
+``MonthsInadequate`` (Int64 0-12) and the boolean ``AnyInadequate``
+(MonthsInadequate > 0).
+
+The companion S13C items (s13c01..s13c12 monthly food-consumption level
+low/average/high, s13c14* members affected, s13c15* coping actions) are NOT
+emitted here -- the (t, i) months count is the canonical Family-C target.
+
+``i`` matches the roster's ``i`` (identif, e.g. '0011A1').
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+T = '2001'
+
+df = get_dataframe('../Data/S13C.DTA')[['identif', 's13c13']].copy()
+df = df.rename(columns={'identif': 'i'})
+
+# clamp implausible values into the 0-12 range (one '13' would not appear here
+# but guard anyway); keep NaN as missing.
+m = pd.to_numeric(df['s13c13'], errors='coerce').round()
+m = m.where(m.between(0, 12))
+df['MonthsInadequate'] = m.astype('Int64')
+df = df[df['MonthsInadequate'].notna()]
+df['AnyInadequate'] = df['MonthsInadequate'] > 0
+
+df['t'] = T
+out = (df[['t', 'i', 'MonthsInadequate', 'AnyInadequate']]
+       .drop_duplicates(subset=['t', 'i'])
+       .set_index(['t', 'i'])
+       .sort_index())
+
+to_parquet(df=out, fn='months_food_inadequate.parquet')

--- a/lsms_library/countries/Timor-Leste/2007-08/_/months_food_inadequate.py
+++ b/lsms_library/countries/Timor-Leste/2007-08/_/months_food_inadequate.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+"""Timor-Leste 2007-08 months_food_inadequate (Family C).
+
+Source: Section 13 vulnerability block carried in the household file
+(../Data/hhold.dta, one row per hh_id, 4477 HHs).  The 2007-08 questionnaire
+keeps the 2001 S13C 'Vulnerability' module as q13b*; the equivalent of the
+2001 s13c13 months count is
+
+  q13b13  "Months of rice/maize shortage"
+
+an integer 0-12 count of months in the past 12 the household could not meet
+its staple food needs.  Exposed as ``MonthsInadequate`` (Int64 0-12) and
+``AnyInadequate`` (MonthsInadequate > 0).
+
+The companion items (q13b01..q13b12 monthly food-consumption level, q13b14*
+members affected, q13b15* coping actions) are not emitted -- the (t, i)
+months count is the canonical Family-C target.
+
+``i`` matches the roster's ``i`` (hh_id via format_id).
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, format_id, to_parquet
+
+T = '2007-08'
+
+df = get_dataframe('../Data/hhold.dta')[['hh_id', 'q13b13']].copy()
+df['i'] = df['hh_id'].apply(format_id)
+
+m = pd.to_numeric(df['q13b13'], errors='coerce').round()
+m = m.where(m.between(0, 12))
+df['MonthsInadequate'] = m.astype('Int64')
+df = df[df['MonthsInadequate'].notna()]
+df['AnyInadequate'] = df['MonthsInadequate'] > 0
+
+df['t'] = T
+out = (df[['t', 'i', 'MonthsInadequate', 'AnyInadequate']]
+       .drop_duplicates(subset=['t', 'i'])
+       .set_index(['t', 'i'])
+       .sort_index())
+
+to_parquet(df=out, fn='months_food_inadequate.parquet')

--- a/lsms_library/countries/Timor-Leste/_/data_scheme.yml
+++ b/lsms_library/countries/Timor-Leste/_/data_scheme.yml
@@ -42,3 +42,9 @@ Data Scheme:
     index: (t, i, Domain)
     Satisfaction: str
     materialize: make
+
+  months_food_inadequate:
+    index: (t, i)
+    MonthsInadequate: int
+    AnyInadequate: bool
+    materialize: make

--- a/lsms_library/countries/Uganda/2009-10/_/months_food_inadequate.py
+++ b/lsms_library/countries/Uganda/2009-10/_/months_food_inadequate.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""months_food_inadequate (Family C) for Uganda 2009-10.
+
+GSEC17 'Welfare and Food Security'.  The food-deprivation item is
+h17q09 ('In the past 12 months, was there a time when you faced a
+situation when you did not have enough food to feed the household?',
+Yes/No).  The which-months follow-up h17q10 is a letter string
+(A=Jan .. L=Dec); MonthsInadequate is the count of distinct month
+letters.  (h17q11 records *reasons*, letters that run beyond L, so it
+is not used here.)
+"""
+from lsms_library.local_tools import to_parquet, get_dataframe
+import pandas as pd
+
+t = '2009-10'
+
+df = get_dataframe('../Data/GSEC17.dta')
+
+MONTH_LETTERS = set('ABCDEFGHIJKL')
+
+def count_months(s):
+    if pd.isna(s):
+        return 0
+    return len({c.upper() for c in str(s)} & MONTH_LETTERS)
+
+any_inadequate = df['h17q09'].map({'Yes': True, 'No': False})
+months = df['h17q10'].apply(count_months).astype('Int64')
+
+# If the household says No to the deprivation item, force 0 months.
+months = months.where(any_inadequate != False, 0)
+
+out = pd.DataFrame({
+    'i': df['HHID'].astype(str).values,
+    't': t,
+    'MonthsInadequate': months.values,
+    'AnyInadequate': any_inadequate.astype('boolean').values,
+})
+
+out = out.dropna(subset=['AnyInadequate']).set_index(['i', 't'])
+out = out.astype({'MonthsInadequate': 'Int64', 'AnyInadequate': 'boolean'})
+
+to_parquet(out, 'months_food_inadequate.parquet')

--- a/lsms_library/countries/Uganda/2010-11/_/months_food_inadequate.py
+++ b/lsms_library/countries/Uganda/2010-11/_/months_food_inadequate.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""months_food_inadequate (Family C) for Uganda 2010-11.
+
+GSEC17A 'Welfare and Food Security'.  The food-deprivation item is
+h17q9 ('In the past 12 months, was there a time when you faced a
+situation when you did not have enough food to feed the household?',
+Yes/No).  This wave's only GSEC17 follow-up (GSEC17B) records *reasons*
+(h17q11b), not which months, so MonthsInadequate is not observed and is
+left <NA>; AnyInadequate carries the binary deprivation item.
+"""
+from lsms_library.local_tools import to_parquet, get_dataframe
+import pandas as pd
+
+t = '2010-11'
+
+df = get_dataframe('../Data/GSEC17A.dta')
+
+any_inadequate = df['h17q9'].map({'Yes': True, 'No': False})
+
+out = pd.DataFrame({
+    'i': df['HHID'].astype(str).values,
+    't': t,
+    'MonthsInadequate': pd.array([pd.NA] * len(df), dtype='Int64'),
+    'AnyInadequate': any_inadequate.astype('boolean').values,
+})
+
+out = out.dropna(subset=['AnyInadequate']).set_index(['i', 't'])
+out = out.astype({'MonthsInadequate': 'Int64', 'AnyInadequate': 'boolean'})
+
+to_parquet(out, 'months_food_inadequate.parquet')

--- a/lsms_library/countries/Uganda/2011-12/_/months_food_inadequate.py
+++ b/lsms_library/countries/Uganda/2011-12/_/months_food_inadequate.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""months_food_inadequate (Family C) for Uganda 2011-12.
+
+GSEC17A 'Welfare and Food Security'.  Deprivation item h17q9
+('In the past 12 months, was there a time when you faced a situation
+when you did not have enough food to feed the household?', Yes/No).
+The which-months follow-up GSEC17B is long-format: one row per month
+(h17q10b = month name) with h17q10a = Yes/No.  MonthsInadequate is the
+count of months flagged Yes.
+"""
+from lsms_library.local_tools import to_parquet, get_dataframe
+import pandas as pd
+
+t = '2011-12'
+
+dep = get_dataframe('../Data/GSEC17A.dta')
+any_inadequate = (
+    dep.assign(AnyInadequate=dep['h17q9'].map({'Yes': True, 'No': False}))
+       .set_index(dep['HHID'].astype(str))['AnyInadequate']
+)
+any_inadequate.index.name = 'i'
+
+mon = get_dataframe('../Data/GSEC17B.dta')
+mon['i'] = mon['HHID'].astype(str)
+mon['flag'] = mon['h17q10a'].map({'Yes': True, 'No': False})
+months = mon.groupby('i')['flag'].sum().astype('Int64')
+months.name = 'MonthsInadequate'
+
+out = pd.concat([any_inadequate, months], axis=1)
+# No month rows but answered the binary -> 0 if not inadequate.
+out['MonthsInadequate'] = out['MonthsInadequate'].fillna(0).astype('Int64')
+out.loc[out['AnyInadequate'] == False, 'MonthsInadequate'] = 0
+
+out = out.reset_index()
+out['t'] = t
+out = out.dropna(subset=['AnyInadequate']).set_index(['i', 't'])
+out = out.astype({'MonthsInadequate': 'Int64', 'AnyInadequate': 'boolean'})
+
+to_parquet(out, 'months_food_inadequate.parquet')

--- a/lsms_library/countries/Uganda/2013-14/_/months_food_inadequate.py
+++ b/lsms_library/countries/Uganda/2013-14/_/months_food_inadequate.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""months_food_inadequate (Family C) for Uganda 2013-14.
+
+GSEC17_1 'Welfare and Food Security'.  Deprivation item h17q9
+('In the past 12 months, was there a time when you faced a situation
+when you did not have enough food to feed the household?', Yes/No).
+The which-months follow-up GSEC17_2 is long-format: one row per month
+(h17q10b = month name) with h17q10a = Yes/No.  MonthsInadequate is the
+count of months flagged Yes.
+"""
+from lsms_library.local_tools import to_parquet, get_dataframe
+import pandas as pd
+
+t = '2013-14'
+
+dep = get_dataframe('../Data/GSEC17_1.dta')
+any_inadequate = (
+    dep.assign(AnyInadequate=dep['h17q9'].map({'Yes': True, 'No': False}))
+       .set_index(dep['HHID'].astype(str))['AnyInadequate']
+)
+any_inadequate.index.name = 'i'
+
+mon = get_dataframe('../Data/GSEC17_2.dta')
+mon['i'] = mon['HHID'].astype(str)
+mon['flag'] = mon['h17q10a'].map({'Yes': True, 'No': False})
+months = mon.groupby('i')['flag'].sum().astype('Int64')
+months.name = 'MonthsInadequate'
+
+out = pd.concat([any_inadequate, months], axis=1)
+out['MonthsInadequate'] = out['MonthsInadequate'].fillna(0).astype('Int64')
+out.loc[out['AnyInadequate'] == False, 'MonthsInadequate'] = 0
+
+out = out.reset_index()
+out['t'] = t
+out = out.dropna(subset=['AnyInadequate']).set_index(['i', 't'])
+out = out.astype({'MonthsInadequate': 'Int64', 'AnyInadequate': 'boolean'})
+
+to_parquet(out, 'months_food_inadequate.parquet')

--- a/lsms_library/countries/Uganda/2015-16/_/months_food_inadequate.py
+++ b/lsms_library/countries/Uganda/2015-16/_/months_food_inadequate.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""months_food_inadequate (Family C) for Uganda 2015-16.
+
+gsec17_1 'Welfare and Food Security'.  Deprivation item h17q9
+('In the past 12 months, was there a time when you faced a situation
+when you did not have enough food to feed the household?', Yes/No).
+The which-months follow-up gsec17_2 is long-format: one row per month
+(h17q10b = month name) with h17q10a = Yes/No.  MonthsInadequate is the
+count of months flagged Yes.  Note this wave uses lowercase 'hhid'.
+"""
+from lsms_library.local_tools import to_parquet, get_dataframe
+import pandas as pd
+
+t = '2015-16'
+
+dep = get_dataframe('../Data/gsec17_1.dta')
+any_inadequate = (
+    dep.assign(AnyInadequate=dep['h17q9'].map({'Yes': True, 'No': False}))
+       .set_index(dep['hhid'].astype(str))['AnyInadequate']
+)
+any_inadequate.index.name = 'i'
+
+mon = get_dataframe('../Data/gsec17_2.dta')
+mon['i'] = mon['hhid'].astype(str)
+mon['flag'] = mon['h17q10a'].map({'Yes': True, 'No': False})
+months = mon.groupby('i')['flag'].sum().astype('Int64')
+months.name = 'MonthsInadequate'
+
+out = pd.concat([any_inadequate, months], axis=1)
+out['MonthsInadequate'] = out['MonthsInadequate'].fillna(0).astype('Int64')
+out.loc[out['AnyInadequate'] == False, 'MonthsInadequate'] = 0
+
+out = out.reset_index()
+out['t'] = t
+out = out.dropna(subset=['AnyInadequate']).set_index(['i', 't'])
+out = out.astype({'MonthsInadequate': 'Int64', 'AnyInadequate': 'boolean'})
+
+to_parquet(out, 'months_food_inadequate.parquet')

--- a/lsms_library/countries/Uganda/_/Makefile
+++ b/lsms_library/countries/Uganda/_/Makefile
@@ -22,7 +22,8 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 var = $(VAR_DIR)/shocks.parquet $(VAR_DIR)/nonfood_expenditures.parquet $(VAR_DIR)/enterprise_income.parquet \
 	  $(VAR_DIR)/assets.parquet $(VAR_DIR)/earnings.parquet $(VAR_DIR)/income.parquet \
 	  $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet \
-	  $(VAR_DIR)/plot_features.parquet
+	  $(VAR_DIR)/plot_features.parquet \
+	  $(VAR_DIR)/months_food_inadequate.parquet
 
 all: $(parquet) $(var)
 
@@ -79,6 +80,12 @@ plot_features_parquet := $(plot_features:.py=.parquet)
 
 $(VAR_DIR)/plot_features.parquet: plot_features.py $(plot_features_parquet)
 	python plot_features.py
+
+months_food_inadequate = $(shell find $(rounds) -name months_food_inadequate.py)
+months_food_inadequate_parquet := $(months_food_inadequate:.py=.parquet)
+
+$(VAR_DIR)/months_food_inadequate.parquet: months_food_inadequate.py $(months_food_inadequate_parquet)
+	python months_food_inadequate.py
 
 $(VAR_DIR)/income.parquet: income.py $(VAR_DIR)/enterprise_income.parquet $(VAR_DIR)/earnings.parquet
 	python income.py

--- a/lsms_library/countries/Uganda/_/data_scheme.yml
+++ b/lsms_library/countries/Uganda/_/data_scheme.yml
@@ -70,6 +70,17 @@ Data Scheme:
     materialize: make
     index: (t, i)
   assets: !make
+  months_food_inadequate:
+    # Family C (non-FIES food security): months in the last 12 the HH
+    # could not meet its food needs.  Source GSEC17 'Welfare and Food
+    # Security' food-deprivation item (h17q9 / h17q09) + which-months
+    # follow-up.  Present in 2009-10, 2010-11, 2011-12, 2013-14,
+    # 2015-16.  MonthsInadequate is <NA> for 2010-11 (no which-months
+    # follow-up that wave; only the binary item was asked).
+    index: (t, i)
+    MonthsInadequate: int
+    AnyInadequate: bool
+    materialize: make
   housing:
     index: (t, i)
     Roof: str

--- a/lsms_library/countries/Uganda/_/months_food_inadequate.py
+++ b/lsms_library/countries/Uganda/_/months_food_inadequate.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""Compile months_food_inadequate (Family C) across Uganda UNPS waves.
+
+Concatenates the per-wave (i, t) parquets and walks household ids onto
+the panel-canonical ids.  Only waves whose GSEC17 'Welfare and Food
+Security' module carries the food-deprivation item are present:
+2009-10, 2010-11, 2011-12, 2013-14, 2015-16.  (2005-06 GSEC17 is a
+land-rights module; 2018-19 / 2019-20 lack the item.)
+"""
+from lsms_library.local_tools import to_parquet, get_dataframe
+import sys
+sys.path.append('../../_/')
+import pandas as pd
+from uganda import id_walk
+import json
+
+WAVES = ['2009-10', '2010-11', '2011-12', '2013-14', '2015-16']
+
+x = {}
+for t in WAVES:
+    print(t, file=sys.stderr)
+    x[t] = get_dataframe('../' + t + '/_/months_food_inadequate.parquet')
+
+x = pd.concat(x.values())
+
+updated_ids = json.load(open('updated_ids.json'))
+x = id_walk(x, updated_ids)
+
+x = x.reset_index().set_index(['i', 't'])
+x = x.astype({'MonthsInadequate': 'Int64', 'AnyInadequate': 'boolean'})
+
+to_parquet(x, '../var/months_food_inadequate.parquet')


### PR DESCRIPTION
Implements the three **non-FIES** food-security families from #332 (the "per-family features" decision), completing the food-security sweep alongside the FIES-canonical `food_security` work in #360.

Stacked on #362 (base `feature/life-satisfaction`); retarget to `development` once the parents merge.

### Families & coverage

**`food_security_hfias`** — HFIAS 9-item Access Scale, index `(t,i)`: `HFIAS1..9` (0–3), `HFIAS_score` (0–27), `HFIAS_category` (FANTA 4-level).
- Tajikistan (2007, 2009) — m8a HFIAS, **6,147 rows**

**`food_coping`** — coping-strategies / rCSI day-counts, index `(t,i,Strategy)`, `Days` (0–7):
- Tanzania (5 waves, §H `hh_h02*`) — **153,315 rows**
- Ethiopia (W1–3, ESS §7 `hh_s7q02_*`) — **111,080 rows**
- Nigeria (W1–3 post-planting, GHS §9 `s9q1a–i`) — **125,839 rows**

**`months_food_inadequate`** — months in last 12 with inadequate provisioning, index `(t,i)`: `MonthsInadequate` (0–12), `AnyInadequate` (bool):
- India (1997-98, §8A `v08a*`) — **2,251 rows**
- Liberia (2018-19, NHFS §16 `S16_*`) — **2,974 rows**
- Timor-Leste (2001, 2007-08, §13C) — **5,793 rows**
- Uganda (5 UNPS waves, GSEC17) — **14,796 rows** (2010-11 binary-only → `MonthsInadequate` `<NA>`)

### Verification
Every country rebuilt from a **cold cache** (`lsms-library cache clear` + `LSMS_NO_CACHE=1`) and checked with `is_this_feature_sane` — all `report.ok == True`, correct index, low orphan. Row counts above are from that clean rebuild. (The only sanity warning is the expected `index_levels_match_scheme`, since `v` is framework-joined from `sample()`.)

### Notes
- New tables are registered in per-country `data_scheme.yml` only (matching the FIES `food_security` precedent — no global `data_info.yml` entry).
- Script-path (`materialize: make`) throughout — each family needs a wide→long reshape and/or scoring.
- **To follow** (separate docs commit): absent/bespoke cases — Nepal `food_coping` (no microdata, NSO-hosted), EthiopiaRHS (meals/day, bespoke), Iraq (`q2005`, bespoke).

Closes part of #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
