### PR TITLE
fix(u): normalize numeric-code keys in categorical mappings + leak audit (#223 Layer 2)

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -71,6 +71,36 @@ _RESERVED_U_SENTINELS = frozenset({'kg', 'Value'})
 _U_SENTINEL_PROTECTED_METHODS = frozenset({'food_quantities', 'food_prices'})
 
 
+def _augment_numeric_code_keys(rdict: dict) -> dict:
+    """Add int/float-string variants of integer-valued keys to a replace dict.
+
+    A categorical_mapping keyed on numeric codes (e.g. ``Code`` = 1, 2, 3)
+    won't match index data that arrives as float-strings (``'1.0'``) — the
+    "format_id applied to idxvars but not myvars" gotcha that leaks raw unit
+    codes into ``food_acquired``'s ``u`` level (GH #223 Layer 2).  For every
+    key whose value is an integer (whether ``1``, ``'1'``, or ``'1.0'``),
+    register the ``'1'`` and ``'1.0'`` string variants pointing at the same
+    Preferred Label.  Purely additive — the original keys win on collision,
+    and non-numeric labels (``'Tas'``) are left untouched.
+    """
+    extra: dict = {}
+    for k, v in rdict.items():
+        ks = str(k).strip()
+        try:
+            f = float(ks)
+        except (TypeError, ValueError):
+            continue
+        if f != int(f):
+            continue  # genuine non-integer; not a unit code
+        i = int(f)
+        for variant in (str(i), f"{i}.0"):
+            extra.setdefault(variant, v)
+    if not extra:
+        return rdict
+    # Original keys take precedence over synthesized variants.
+    return {**extra, **rdict}
+
+
 class DeprecatedFeatureError(AttributeError):
     """Raised when a removed or deprecated table method is called on Country.
 
@@ -1627,6 +1657,14 @@ class Country:
             if not source_cols:
                 return None
             rdict = table.set_index(source_cols[0])["Preferred Label"].to_dict()
+            # Numeric-code tables (e.g. a `Code` column 1, 2, 3) don't match
+            # data that arrives as float-strings ('1.0') -- the documented
+            # "format_id is applied to idxvars but not myvars" gotcha, which
+            # leaks raw unit codes into food_acquired's `u` level (GH #223
+            # Layer 2).  Additively register int/float-string variants of
+            # every integer-valued key so '1', '1.0' both resolve.  Purely
+            # additive: existing keys win, non-numeric labels are untouched.
+            rdict = _augment_numeric_code_keys(rdict)
             if drop_keys:
                 # Never remap a reserved sentinel (e.g. the 'kg' conversion
                 # tag) away from itself.

--- a/lsms_library/diagnostics.py
+++ b/lsms_library/diagnostics.py
@@ -432,6 +432,42 @@ def _check_float_stringified_index(df: pd.DataFrame) -> Check:
                  "No float-stringified index values")
 
 
+def food_acquired_u_code_leaks(country: str, *,
+                               df: pd.DataFrame | None = None) -> list[str]:
+    """Return ``food_acquired`` ``u`` values that look like leaked unit codes.
+
+    Audit guard for the unit-label harmonization (GH #223 Layer 2).  A clean
+    ``u`` index level holds native unit *labels* (``'Kg'``, ``'Tas'``).  Values
+    that begin with a digit — raw numeric codes (``'116'``, ``'6.0'``),
+    code-prefixed labels (``'1. Kilogram'``), or item-names (``'0 [Butter]'``)
+    — indicate an incomplete / identity ``#+name:u`` table, a missing decode,
+    or an extraction bug, and should be driven to zero as Layer 2 progresses.
+
+    Parameters
+    ----------
+    country : str
+        Country name (passed to :class:`~lsms_library.Country`).  Ignored when
+        *df* is supplied.
+    df : pd.DataFrame, optional
+        A pre-built ``food_acquired`` frame to inspect instead of building one.
+
+    Returns
+    -------
+    list[str]
+        Sorted distinct offending ``u`` values; empty when the level is clean.
+    """
+    import re
+
+    if df is None:
+        from . import Country
+        df = Country(country, preload_panel_ids=False).food_acquired()
+    if not isinstance(df, pd.DataFrame) or "u" not in (df.index.names or []):
+        return []
+    u = df.index.get_level_values("u").astype(str)
+    code = re.compile(r"^\s*\d")  # leading digit => code / code-prefix / item-name
+    return sorted({v for v in u.unique() if code.match(v)})
+
+
 def _check_index_overlap_with_spine(df: pd.DataFrame, country: str) -> Check:
     """Check that household IDs overlap with other_features (the 'spine')."""
     if "i" not in df.index.names:

--- a/tests/test_u_code_leak.py
+++ b/tests/test_u_code_leak.py
@@ -1,0 +1,94 @@
+"""GH #223 Layer 2: numeric unit-code normalization + leak audit.
+
+- ``_augment_numeric_code_keys`` lets a Code-keyed ``#+name:u`` table match
+  data that arrives as float-strings ('1.0').
+- ``diagnostics.food_acquired_u_code_leaks`` flags leaked codes so
+  regressions in already-clean countries surface.
+"""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from lsms_library.country import _augment_numeric_code_keys
+from lsms_library import diagnostics
+
+
+# --- _augment_numeric_code_keys --------------------------------------------
+
+def test_augment_adds_float_and_int_string_variants():
+    # Nigeria pattern: integer Code keys, data arrives as '1.0'.
+    out = _augment_numeric_code_keys({1: "Kg", 2: "g"})
+    assert out["1.0"] == "Kg" and out["1"] == "Kg"
+    assert out["2.0"] == "g" and out["2"] == "g"
+    assert out[1] == "Kg"  # original key preserved
+
+
+def test_augment_leaves_non_numeric_labels_untouched():
+    out = _augment_numeric_code_keys({"Tas": "Tas", "kg": "Kg"})
+    assert out == {"Tas": "Tas", "kg": "Kg"}  # no spurious variants
+
+
+def test_augment_skips_genuine_non_integers():
+    out = _augment_numeric_code_keys({"1.5": "Half"})
+    assert out == {"1.5": "Half"}  # 1.5 is not an integer code
+
+
+def test_augment_original_key_wins_on_collision():
+    # An explicit '1.0' label must not be clobbered by a synthesized variant.
+    out = _augment_numeric_code_keys({1: "FromInt", "1.0": "Explicit"})
+    assert out["1.0"] == "Explicit"
+
+
+# --- food_acquired_u_code_leaks -------------------------------------------
+
+def _fa(u_values):
+    idx = pd.MultiIndex.from_arrays(
+        [["x"] * len(u_values), u_values], names=["i", "u"]
+    )
+    return pd.DataFrame({"Quantity": [1.0] * len(u_values)}, index=idx)
+
+
+def test_leak_detector_flags_codes_prefixes_and_itemnames():
+    df = _fa(["Kg", "Tas", "116", "6.0", "1. Kilogram", "0 [Butter]"])
+    leaks = diagnostics.food_acquired_u_code_leaks("X", df=df)
+    assert leaks == ["0 [Butter]", "1. Kilogram", "116", "6.0"]
+
+
+def test_leak_detector_clean_frame():
+    df = _fa(["Kg", "Tas", "Litre", "Sachet"])
+    assert diagnostics.food_acquired_u_code_leaks("X", df=df) == []
+
+
+def test_leak_detector_no_u_level():
+    df = pd.DataFrame({"Quantity": [1.0]},
+                      index=pd.MultiIndex.from_tuples([("a", "b")], names=["i", "t"]))
+    assert diagnostics.food_acquired_u_code_leaks("X", df=df) == []
+
+
+# --- cross-country regression (skips when caches/data unavailable) ----------
+
+# Clean per the 2026-06-07 audit; must stay clean.
+_KNOWN_CLEAN = ["Mali", "Niger", "CotedIvoire", "Guinea-Bissau"]
+# Tracked dirty (driven down by Layer 2 / #347 / #348): Nigeria, Togo,
+# Burkina_Faso, Senegal, Ethiopia, Malawi, GhanaLSS, EthiopiaRHS.
+
+
+def test_clean_countries_have_no_u_code_leaks():
+    import warnings
+
+    import lsms_library as ll
+
+    checked = 0
+    for c in _KNOWN_CLEAN:
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                fa = ll.Country(c, preload_panel_ids=False).food_acquired()
+        except Exception:
+            continue  # microdata not available in this environment
+        checked += 1
+        leaks = diagnostics.food_acquired_u_code_leaks(c, df=fa)
+        assert not leaks, f"{c}: leaked u codes {leaks[:10]}"
+    if checked == 0:
+        pytest.skip("no food_acquired data available for clean-country audit")


### PR DESCRIPTION
## Summary

First (safety-net) step of the unit-label `u` harmonization (Layer 2). A `categorical_mapping` keyed on integer `Code`s (e.g. Nigeria's `#+name:u`: `1,2,3 → Kg,g,l`) fails to match `food_acquired` `u` data that arrives as **float-strings** (`'1.0'`) — the documented "`format_id` applied to idxvars but not myvars" gotcha, which leaks raw unit codes into the `u` level.

- **`_augment_numeric_code_keys`**: additively registers `'1'` and `'1.0'` string variants for every integer-valued key in a replace dict (original keys win on collision; non-numeric labels untouched). Wired into `_apply_categorical_mappings`, so Code-keyed tables now resolve float-string data.
- **`diagnostics.food_acquired_u_code_leaks(country)`**: audit guard returning the leaked code / code-prefix / item-name `u` values, with a regression test asserting the currently-clean countries stay clean.

## Effect (NO_CACHE rebuild)

| Country | leaked `u` codes before → after |
|---|---|
| **Nigeria** | 81 → **32** (remaining are codes its table doesn't list) |
| Burkina / Senegal / Togo / Mali | unchanged (no regression; Mali stays 0) |

## Scope

This is deliberately the *additive, low-risk* piece. It does **not** fully clean the remaining dirty countries — Burkina/Senegal **identity-mapped** tables, Togo **label-only** table, Nigeria's **missing** codes, GhanaLSS (#348), EthiopiaRHS (#347), Malawi case-dupes. Those need the **structural consolidation**: a global `categorical_mapping/u.org` for universal units + a row-**additive** global↔country merge (flag-controlled, `u` passes `True`) so countries inherit common units and only declare local containers. That's the next Layer-2 PR (design-doc-first).

The audit guard makes regressions in the already-clean set surface automatically and gives a runnable leak report for tracking the consolidation's progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)