### PR TITLE
feat(categorical): additive global<->country merge behind a per-table flag (#223 Layer 2)

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -101,6 +101,61 @@ def _augment_numeric_code_keys(rdict: dict) -> dict:
     return {**extra, **rdict}
 
 
+# Categorical tables whose global (lsms_library/categorical_mapping/) and
+# per-country versions are merged ROW-additively rather than full-override
+# (GH #223 Layer 2 / DESIGN_u_consolidation).  For these, a country inherits
+# the global rows (e.g. universal metric units in a global u.org) and only
+# needs to declare its country-specific rows; a country row wins on a
+# source-label key collision.  Every other table keeps the historical
+# full-table override.  Keep this allow-list small and explicit.
+_ADDITIVE_CATEGORICAL_TABLES = frozenset({'u'})
+
+
+def _categorical_key_column(table: "pd.DataFrame") -> str | None:
+    """The source-label column of a categorical table (first non-Preferred)."""
+    cols = [c for c in table.columns if c != "Preferred Label"]
+    return cols[0] if cols else None
+
+
+def _row_union_categorical(global_t: "pd.DataFrame",
+                           country_t: "pd.DataFrame") -> "pd.DataFrame":
+    """Row-union a global and a country categorical table; country row wins.
+
+    Identity is the source-label key column (first non-``Preferred Label``
+    column).  Country rows override global rows with the same key; new
+    country keys are added; global keys absent from the country table are
+    kept.  Columns are outer-unioned (e.g. per-wave columns), with country
+    values winning on overlap.  Falls back to the country table wholesale
+    when the two key columns don't agree (can't align).
+    """
+    gk = _categorical_key_column(global_t)
+    ck = _categorical_key_column(country_t)
+    if gk is None or ck is None or gk != ck:
+        return country_t
+    # country first + keep='first' => country rows win on key collision;
+    # concat outer-joins columns (NaN-filled), so wave columns survive.
+    combined = pd.concat([country_t, global_t], ignore_index=True, sort=False)
+    combined = combined.drop_duplicates(subset=[ck], keep="first")
+    return combined.reset_index(drop=True)
+
+
+def _merge_categorical_tables(global_maps: dict, country_maps: dict) -> dict:
+    """Merge global and per-country categorical tables.
+
+    Default is full-table override (country replaces global by name).  For
+    names in :data:`_ADDITIVE_CATEGORICAL_TABLES`, the two are row-unioned
+    (see :func:`_row_union_categorical`) when both exist, so the country
+    inherits global rows and overrides only the keys it redeclares.
+    """
+    merged = dict(global_maps)
+    for name, ctab in country_maps.items():
+        if name in _ADDITIVE_CATEGORICAL_TABLES and name in merged:
+            merged[name] = _row_union_categorical(merged[name], ctab)
+        else:
+            merged[name] = ctab
+    return merged
+
+
 class DeprecatedFeatureError(AttributeError):
     """Raised when a removed or deprecated table method is called on Country.
 
@@ -1032,7 +1087,10 @@ class Country:
         Get the categorical mapping for the country.
         Searches current directory, then parent directory.
         Also merges global .org files from lsms_library/categorical_mapping/ (GH #168).
-        Global tables are loaded first; per-country tables override on name collision.
+        Global tables are loaded first; per-country tables override on name
+        collision -- except names in ``_ADDITIVE_CATEGORICAL_TABLES`` (e.g.
+        ``u``), which are row-unioned so a country inherits global rows and
+        overrides only the keys it redeclares (DESIGN_u_consolidation).
         '''
         if '_categorical_mapping_cache' not in self.__dict__:
             # Load global mappings from lsms_library/categorical_mapping/*.org
@@ -1056,7 +1114,8 @@ class Country:
                     country_maps = all_dfs_from_orgfile(org_fn)
                     break
 
-            self.__dict__['_categorical_mapping_cache'] = {**global_maps, **country_maps}
+            self.__dict__['_categorical_mapping_cache'] = _merge_categorical_tables(
+                global_maps, country_maps)
         return self.__dict__['_categorical_mapping_cache']
 
     @property

--- a/tests/test_categorical_merge.py
+++ b/tests/test_categorical_merge.py
@@ -1,0 +1,83 @@
+"""GH #223 Layer 2 / DESIGN_u_consolidation: additive global<->country
+categorical-table merge.
+
+`u` is row-unioned (global metric core + country-specific rows, country
+wins on key collision); every other table keeps full-table override.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from lsms_library.country import (
+    _ADDITIVE_CATEGORICAL_TABLES,
+    _merge_categorical_tables,
+    _row_union_categorical,
+)
+
+
+def _tbl(rows, cols=("Original Label", "Preferred Label")):
+    return pd.DataFrame(rows, columns=list(cols))
+
+
+def test_u_is_additive():
+    assert "u" in _ADDITIVE_CATEGORICAL_TABLES
+
+
+def test_row_union_country_wins_and_inherits_global():
+    glob = _tbl([["kg", "Kg"], ["g", "g"], ["l", "Litre"]])
+    ctry = _tbl([["kg", "KILO"], ["Tas", "Tas"]])   # overrides kg, adds Tas
+    out = _row_union_categorical(glob, ctry)
+    d = out.set_index("Original Label")["Preferred Label"].to_dict()
+    assert d["kg"] == "KILO"      # country wins on collision
+    assert d["g"] == "g"          # inherited from global
+    assert d["l"] == "Litre"      # inherited from global
+    assert d["Tas"] == "Tas"      # country-specific added
+
+
+def test_row_union_preserves_wave_columns():
+    glob = _tbl([["kg", "Kg"], ["g", "g"]])
+    ctry = pd.DataFrame(
+        [["Tas", "Tas", "tas_2018"]],
+        columns=["Original Label", "Preferred Label", "2018-19"],
+    )
+    out = _row_union_categorical(glob, ctry)
+    assert "2018-19" in out.columns
+    row = out[out["Original Label"] == "Tas"].iloc[0]
+    assert row["2018-19"] == "tas_2018"
+    # global rows keep their values; wave column is NaN for them
+    assert out[out["Original Label"] == "kg"]["Preferred Label"].iloc[0] == "Kg"
+
+
+def test_row_union_falls_back_when_key_columns_disagree():
+    glob = _tbl([["kg", "Kg"]], cols=("Original Label", "Preferred Label"))
+    ctry = _tbl([[1, "Kg"]], cols=("Code", "Preferred Label"))
+    out = _row_union_categorical(glob, ctry)
+    # can't align Original Label vs Code -> country wins wholesale
+    assert list(out.columns) == ["Code", "Preferred Label"]
+    assert out["Code"].tolist() == [1]
+
+
+def test_merge_u_additive_other_tables_override():
+    glob = {
+        "u": _tbl([["kg", "Kg"], ["g", "g"]]),
+        "harmonize_assets": _tbl([["bike", "Bicycle"], ["car", "Car"]]),
+    }
+    ctry = {
+        "u": _tbl([["Tas", "Tas"]]),               # additive -> inherits kg/g
+        "harmonize_assets": _tbl([["bike", "Bike"]]),  # override -> replaces
+    }
+    merged = _merge_categorical_tables(glob, ctry)
+    u = merged["u"].set_index("Original Label")["Preferred Label"].to_dict()
+    assert set(u) == {"kg", "g", "Tas"}            # u row-unioned
+    ha = merged["harmonize_assets"]
+    assert ha["Original Label"].tolist() == ["bike"]  # assets fully replaced
+    assert ha["Preferred Label"].tolist() == ["Bike"]
+
+
+def test_merge_global_only_and_country_only_tables_pass_through():
+    glob = {"u": _tbl([["kg", "Kg"]]), "kinship": _tbl([["x", "X"]])}
+    ctry = {"u": _tbl([["Tas", "Tas"]]), "region": _tbl([["n", "North"]])}
+    merged = _merge_categorical_tables(glob, ctry)
+    assert "kinship" in merged and "region" in merged          # both kept
+    assert set(merged["u"].set_index("Original Label")["Preferred Label"]
+               .to_dict()) == {"kg", "Tas"}


### PR DESCRIPTION
## Summary

Step 2 of `DESIGN_u_consolidation` (slurm_logs/, PR #367). Replaces the unconditional `{**global_maps, **country_maps}` full-override merge in `Country.categorical_mapping` with `_merge_categorical_tables`:

- Tables named in **`_ADDITIVE_CATEGORICAL_TABLES`** (initially `{'u'}`) are **row-unioned**: `_row_union_categorical` keys on the source-label column (first non-`Preferred Label`), **country rows win** on key collision, global rows are inherited, and columns (incl. **per-wave** columns) are outer-unioned with country values winning. Falls back to country-wholesale if the two key columns disagree.
- **Every other table keeps full-table override** — blast radius is just `u`; `harmonize_assets` / `canonical_housing_labels` / `kinship` are untouched.

## Framework only — no data change yet

There's no global `categorical_mapping/u.org` yet, so `'u'` has no global table to union → the additive branch is **inert** and every country's `categorical_mapping` is byte-identical to before. Verified: Nigeria `food_acquired` `u`-leaks unchanged at **32** (the post-#366 state). This PR just installs the mechanism; the global `u.org` + the EHCVM proof-of-concept come next (step 3).

## Tests

`tests/test_categorical_merge.py` (6): country-wins, inherit-global, wave-column preservation, key-mismatch fallback, additive-`u`-vs-override-others, passthrough. Plus regression: schema + food + merge = **211 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)