### PR TITLE
feat(u): global categorical_mapping/u.org (kg core) + CotedIvoire PoC (#223 Layer 2 step 3)

### DIFF
--- a/lsms_library/categorical_mapping/u.org
+++ b/lsms_library/categorical_mapping/u.org
@@ -1,0 +1,42 @@
+#+title: Global unit (=u=) canonical mappings
+
+Cross-country defaults for the =u= (unit) index level, merged into every
+country's =categorical_mapping= and row-unioned with the country's own
+=#+name:u= table (country rows win on a source-label collision; see
+=_merge_categorical_tables= / =_ADDITIVE_CATEGORICAL_TABLES= in =country.py=
+and =slurm_logs/DESIGN_u_consolidation_2026-06-07.org=).
+
+Scope (deliberately conservative): the *kilogram* spelling/case variants
+only.  =Kg= is the one metric unit with a cross-country-consistent canonical
+Preferred Label (Benin, Togo, CotedIvoire, Mali, Nigeria, Niger, Senegal,
+Uganda all already emit =Kg=), so unifying its variants imposes no contested
+choice.  Gram / litre / millilitre have *disagreeing* canonical forms across
+countries (=g= vs =Gram=, =l= vs =Litre=, =ml= vs =Millilitre=); harmonizing
+those is the deferred cross-language vocabulary decision (Layer 3) and is
+NOT done here.
+
+Note: this table is keyed on =Original Label=, so it composes additively
+only with country =#+name:u= tables that are also =Original Label=-keyed (or
+countries with no =u= table).  Code-keyed tables (e.g. Nigeria, Mali, Uganda)
+hit the key-column fallback and are unaffected -- standardizing their keying
+is a follow-up.
+
+The reserved lowercase =kg= *conversion sentinel* emitted by
+food_quantities / food_prices is protected from any =u= remap on derived
+tables by =protect_u_sentinels= (GH #361), so this table cannot disturb
+=Feature('food_quantities').xs('kg', level='u')=.
+
+#+name: u
+| Original Label | Preferred Label |
+|----------------+-----------------|
+| Kg             | Kg              |
+| kg             | Kg              |
+| KG             | Kg              |
+| kgs            | Kg              |
+| KGS            | Kg              |
+| Kilogram       | Kg              |
+| kilogram       | Kg              |
+| KILOGRAM       | Kg              |
+| Kilogramme     | Kg              |
+| kilogramme     | Kg              |
+| KILOGRAMME     | Kg              |

--- a/lsms_library/countries/CotedIvoire/_/categorical_mapping.org
+++ b/lsms_library/countries/CotedIvoire/_/categorical_mapping.org
@@ -2,10 +2,11 @@
 
 * Food Units
 
+# 'Kg' is inherited from the global categorical_mapping/u.org (row-additive
+# merge), so it is not redeclared in the table below (GH #223 Layer 2 PoC).
 #+name: u
 | Original Label  | Preferred Label |
 |-----------------+-----------------|
-| Kg              | Kg              |
 | Litre           | Litre           |
 | Unité           | Unité           |
 | Sachet          | Sachet          |

--- a/tests/test_global_u_org.py
+++ b/tests/test_global_u_org.py
@@ -1,0 +1,46 @@
+"""GH #223 Layer 2 step 3: the global categorical_mapping/u.org composes
+additively into each country's `u` table.
+
+These read `Country.categorical_mapping` (org parsing only -- no microdata),
+so they're fast and CI-safe.
+"""
+from __future__ import annotations
+
+import lsms_library as ll
+
+
+def _u_dict(country):
+    u = ll.Country(country, preload_panel_ids=False).categorical_mapping["u"]
+    return u.set_index("Original Label")["Preferred Label"].to_dict()
+
+
+def test_global_u_org_provides_kg_variants():
+    # A no-`u`-table country inherits the global table wholesale.
+    d = _u_dict("Tanzania")
+    assert d.get("Kg") == "Kg"
+    assert d.get("kg") == "Kg"          # canonicalizes lowercase
+    assert d.get("Kilogramme") == "Kg"  # and spelling variants
+
+
+def test_country_u_table_inherits_global_kg_additively():
+    # CotedIvoire no longer declares Kg (PoC removal); it must still be
+    # present via the global table, AND its own rows must survive.
+    d = _u_dict("CotedIvoire")
+    assert d.get("Kg") == "Kg"      # inherited from global u.org
+    assert d.get("Litre") == "Litre"   # CotedIvoire's own row preserved
+    assert d.get("Unité") == "Unité"
+
+
+def test_global_u_does_not_define_contested_metric_canonicals():
+    # Only kilogram is globally canonicalized; gram/litre/ml are deferred
+    # (Layer 3), so the global table must not force them.
+    import re
+    from pathlib import Path
+    from lsms_library.paths import COUNTRIES_ROOT
+    u_org = COUNTRIES_ROOT.parent / "categorical_mapping" / "u.org"
+    text = u_org.read_text(encoding="utf-8")
+    table = [ln for ln in text.splitlines()
+             if ln.strip().startswith("|") and "Preferred Label" not in ln
+             and not set(ln.strip()) <= set("|-+ ")]
+    prefs = {ln.split("|")[2].strip() for ln in table}
+    assert prefs == {"Kg"}, f"global u.org should map only to Kg, got {prefs}"


### PR DESCRIPTION
## Summary

Step 3 of `DESIGN_u_consolidation` — the first cross-country unit table.

- **`lsms_library/categorical_mapping/u.org`**: a `#+name:u` mapping the kilogram spelling/case variants (`kg`, `KG`, `kgs`, `kilogram(me)`, …) → canonical **`Kg`**. `Kg` is the one metric unit with a cross-country-consistent canonical (every country already emits `Kg`), so this imposes no contested choice. `g`/`Gram`, `l`/`Litre`, `ml`/`Millilitre` **disagree** across countries and stay deferred (Layer-3 vocab decision).
- **CotedIvoire PoC**: drops its redundant `Kg` row and inherits it from the global table (proves inherit-and-remove on real data).

## Verified (NO_CACHE rebuild, diffed vs pre-change snapshot)

| Country | effect | food_quantities kg-resolved |
|---|---|---|
| **CotedIvoire** (Original-Label-keyed) | `food_acquired` `u` **byte-identical** (52→52), `Kg` now from global, own rows intact | 100% |
| **Tanzania** (no `u` table) | `kg` → `Kg` (canonicalized) | 100% (no regression) |
| **Ethiopia** (no `u` table) | `Kilogram` → `Kg` (117→116) | 43.6% (unchanged) |
| Benin (own `Kg`) / Nigeria, Malawi (Code-keyed) | unchanged | unchanged |

The reserved `kg` conversion sentinel on derived tables stays protected by `protect_u_sentinels` (#361), so `Feature('food_quantities').xs('kg')` is unaffected.

## Finding: key-column reach

The additive merge composes the global (`Original Label`-keyed) table only with country `u`-tables that are also `Original Label`-keyed, or countries with **no** `u`-table. **Code-keyed** tables (Nigeria, Mali, Uganda, Malawi) hit the key-column fallback and are inert. Standardizing their keying so they inherit the global table is a documented follow-up (and is why Malawi's kg case-dupe didn't collapse here).

## Tests

`tests/test_global_u_org.py` (global-table inheritance, additive composition, kg-only scope). Full regression: **222 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)