### PR TITLE
fix(Ethiopia): strip code-prefix from food_acquired u (closes #115; #223 Layer 2)

### DIFF
--- a/lsms_library/countries/Ethiopia/_/ethiopia.py
+++ b/lsms_library/countries/Ethiopia/_/ethiopia.py
@@ -225,6 +225,15 @@ def food_acquired(fn,myvars):
     # still references for kg conversion.
     df['units_purchased'] = df['units_purchased'].str.title()
     df['units'] = df['units'].str.title()
+    # Strip the survey's "NNN. " code prefix that ESS embeds in the unit
+    # value labels (e.g. "1. Kilogram", "171. Sini Small") so `u` carries a
+    # clean label, not a code-prefixed string (GH #223 Layer 2).  Applied
+    # only to the unit columns -- item names / IDs may legitimately start
+    # with a digit.  "1. Kilogram" -> "Kilogram" then resolves via KNOWN_METRIC
+    # / the global u.org (-> "Kg"); container labels stay native.
+    for _col in ('units', 'units_purchased'):
+        df[_col] = (df[_col].str.replace(r'^\s*\d+\.\s*', '', regex=True)
+                            .str.strip())
     rep = {r'\s+':' ',
            'Meduim': 'Medium',
            'Kubaya ':'Kubaya/Cup ',


### PR DESCRIPTION
## Summary

ESS embeds the unit *code* inside its value labels (`"1. Kilogram"`, `"171. Sini Small"`), so Ethiopia's canonical `u` carried **45 code-prefixed** strings. Strip the `NNN. ` prefix on the unit columns in `ethiopia.food_acquired` (targeted to `units`/`units_purchased` — item names and IDs may legitimately begin with a digit).

## Effect (NO_CACHE rebuild)

- **code-prefix leaks 45 → 0**; `n_u` 117 → 75 (prefixed variants collapse, e.g. several `"1. Kilogram"` → `Kilogram`).
- **`food_quantities(units='kgs')` kg-resolution 43.6% → 100%** — the prefix was *blocking* `KNOWN_METRIC` (`"1. kilogram"` never matched), so stripping it lets `Kilogram` resolve (→ `Kg` via the global `u.org`) and the rest convert via price-ratio inference. **This resolves #115.**

## Safety

`conversion_to_kgs.json` is consumed only by the **retired** `food_prices_quantities_and_expenditures.py` (its keys — `Cup`, `Grams`, `Kg` — already didn't match the prefixed `u` values); the active kg path is `transformations.conversion_to_kgs`. So the strip doesn't desync any live conversion. Regression: schema + food + u-leak = **213 passed**.

Part of the Layer-2 per-country bucket sweep. Togo / Senegal / Nigeria (bare survey codes, need the unit codebook) and Malawi (mixed) follow.

Closes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)