### PR TITLE
feat(EHCVM): wire shared unit codebook to decode Togo + Burkina s07bq03b (#223 Layer 2)

### DIFF
--- a/lsms_library/categorical_mapping/ehcvm_units.org
+++ b/lsms_library/categorical_mapping/ehcvm_units.org
@@ -1,0 +1,192 @@
+#+title: EHCVM (WAEMU) unit codebook (=s07bq03b=)
+
+Code->label map for the standardized EHCVM unit variable =s07bq03b=.
+Loaded into every country's =categorical_mapping= (global, GH #168) but
+inert unless a country's =data_info.yml= references it via
+=mappings: ['ehcvm_units','Code','Preferred Label']= on its =u= index.
+Used to decode the bare unit codes that leak in EHCVM countries whose
+=.dta= lost the =s07bq03b= value labels (Togo, Senegal); the labels
+survive in the sibling countries' =.dta= (same standardized coding).
+
+Provenance + the full curation/resolution log:
+=slurm_logs/ehcvm_unit_codebook_2026-06-07.org=
+(regenerate with =slurm_logs/build_ehcvm_unit_codebook.py=).
+
+#+name: ehcvm_units
+| Code | Preferred Label |
+|------+-----------------|
+| 100 | Kg |
+| 101 | Litre |
+| 102 | Alvéole |
+| 103 | Avec os au Kg |
+| 104 | Avec os en tas |
+| 105 | Bassine |
+| 106 | Bidon |
+| 107 | Boîte |
+| 108 | Boîte de tomate |
+| 109 | Bol |
+| 110 | Botte |
+| 111 | Boule |
+| 112 | Bouquet |
+| 113 | Bouteille |
+| 115 | Calebasse |
+| 116 | Canari |
+| 117 | Cannette |
+| 118 | Carton |
+| 119 | Casier |
+| 120 | Cuillere |
+| 121 | Fagot |
+| 122 | filet (1 kg) |
+| 123 | Gobelet |
+| 124 | Gousse |
+| 125 | Louche |
+| 126 | Morceau |
+| 127 | Moudou |
+| 128 | Panier |
+| 129 | Paquet |
+| 130 | Plaquette |
+| 131 | Pot |
+| 132 | Régime |
+| 133 | Saco |
+| 134 | Sac (10 Kg) |
+| 135 | Sac (100 Kg) |
+| 136 | Sac (25 Kg) |
+| 137 | Sac (5 Kg) |
+| 138 | Sac (50 Kg) |
+| 139 | Sachet |
+| 140 | Sans os au Kg |
+| 141 | Sans os au tas |
+| 142 | Seau |
+| 143 | Tas |
+| 144 | Tasse |
+| 145 | Tine |
+| 146 | Tohoungolo |
+| 147 | Unité |
+| 148 | Verre |
+| 149 | Yorouba |
+| 150 | Gigot |
+| 151 | Carcasse |
+| 201 | Otoka/Fihanfingban |
+| 203 | Yoroukou/Yorougou |
+| 204 | Pome |
+| 205 | Agoua |
+| 206 | Paï |
+| 208 | sogo |
+| 209 | Djogledo |
+| 211 | Ike |
+| 212 | Abotoca |
+| 214 | Ayewa |
+| 216 | Quarantaine |
+| 220 | Tinnabou (bariba ) |
+| 222 | sivlo |
+| 223 | siroba |
+| 224 | sagagou ( en bariba) |
+| 226 | Plastique |
+| 227 | Nobayirou |
+| 228 | Blèvi |
+| 229 | passoire |
+| 230 | Rôba |
+| 232 | Chaîne en bois |
+| 233 | Bidon de 1 litre et démi |
+| 234 | Bidon de 1l |
+| 235 | Bidon de 5l |
+| 236 | Bocal de mayonnaise |
+| 238 | corbar en bariba |
+| 239 | cuisse |
+| 240 | Grappe |
+| 241 | sac de 2,5kg |
+| 242 | Signi |
+| 243 | nimkotirou(BARIBA) |
+| 245 | Grand bocal |
+| 246 | Gbinbou bonnou |
+| 251 | Quart-Yorouba |
+| 252 | Demi-Yorouba |
+| 257 | Boîte de lait |
+| 258 | Plat |
+| 262 | Carreau |
+| 273 | Yéll |
+| 274 | Cube |
+| 302 | Cope |
+| 303 | Cuvette |
+| 305 | bidon de demi litre |
+| 306 | Bâtonnet |
+| 307 | Papier |
+| 308 | Djlèka |
+| 310 | gannouvi |
+| 311 | ibogban |
+| 312 | Sac (11kg) |
+| 313 | Kpanouvi |
+| 315 | Sac (4 kg) |
+| 316 | Feuille |
+| 318 | Poignet |
+| 319 | Sac (0,9 kg) |
+| 320 | Brochette |
+| 321 | Grain |
+| 324 | Si |
+| 325 | sikpanou |
+| 327 | Pincée |
+| 406 | Calma |
+| 407 | Caneca |
+| 409 | Fatia |
+| 411 | Frasco |
+| 412 | Maradura |
+| 413 | Monte |
+| 415 | Pacotinho |
+| 416 | Pé |
+| 417 | Tabuleiro |
+| 418 | Dúzia |
+| 419 | Múndo |
+| 420 | Corda |
+| 421 | Tigela |
+| 424 | Carteira |
+| 456 | Barre |
+| 460 | Moude (Moudé)) |
+| 462 | Paani |
+| 464 | Seau (10 Kg) |
+| 465 | Seau (25 Kg) |
+| 466 | Seau (5 Kg ) |
+| 467 | Tranche |
+| 468 | Gigot |
+| 469 | Piece |
+| 470 | Boite de lait concentré |
+| 506 | Boîte de nescafé |
+| 507 | Cristal (Kantou) |
+| 508 | Feuille |
+| 509 | Koriya /Gassou |
+| 510 | Pot-tarzan |
+| 511 | Sac Filet |
+| 512 | Tiya |
+| 513 | Waygouizé |
+| 561 | barquette |
+| 562 | Cornet |
+| 563 | Cuillère à café |
+| 564 | Cuillère à soupe |
+| 565 | Quart de litre |
+| 566 | Démi litre |
+| 567 | Lakhass |
+| 568 | miche |
+| 569 | Démi-miche |
+| 570 | Tiers de miche |
+| 571 | Quart de miche |
+| 572 | tablette |
+| 573 | demi tablette |
+| 577 | Tablette (30) |
+| 578 | tranche |
+| 579 | Verre à thé |
+| 663 | Agoua |
+| 664 | Kpogban |
+| 986 | filet (5 kg) |
+| 987 | Filet (2,5Kg) |
+| 989 | Sac de 10 Kg |
+| 991 | Bouteille de 5L |
+| 992 | Bouteille de 10 litre |
+| 993 | Bouteille de 1,5 litre |
+| 994 | Bouteille de 1l |
+| 995 | Bouteille de 5 litres |
+| 996 | Bouteille de 1 litre |
+| 997 | Bouteille de 50 cl |
+| 999 | Paquet (1 Kg) |
+| 1000 | Bouteille de 19L |
+| 1001 | 12,5 cl (démi walatt) |
+| 1002 | Bouteille de 25cl |
+| 1003 | Bouteille de 33cl |

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/data_info.yml
@@ -201,7 +201,9 @@ food_acquired:
         j:
             - s07bq01
             - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
-        u: s07bq03b
+        u:
+            - s07bq03b
+            - mappings: ['ehcvm_units', 'Code', 'Preferred Label']
     myvars:
         Quantity: s07bq03a
         Expenditure: s07bq08

--- a/lsms_library/countries/Burkina_Faso/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2021-22/_/data_info.yml
@@ -182,7 +182,9 @@ food_acquired:
         j:
             - s07bq01
             - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
-        u: s07bq03b
+        u:
+            - s07bq03b
+            - mappings: ['ehcvm_units', 'Code', 'Preferred Label']
     myvars:
         Quantity: s07bq03a
         Expenditure: s07bq08

--- a/lsms_library/countries/Burkina_Faso/_/CONTENTS.org
+++ b/lsms_library/countries/Burkina_Faso/_/CONTENTS.org
@@ -27,6 +27,8 @@ Standard EHCVM format, nearly identical to Mali.  Variable names: =s07bq01= (foo
 *** Categorical mapping
 ISSUE: No harmonised =categorical_mapping.org= file yet.  Food labels and units come through as raw categoricals from the =.dta= files.  Many 2014 units remain as French text without standardisation.  The 2018-19/2021-22 unit codes are numeric without categorical labels in some entries.
 
+UPDATE (GH #223 Layer 2): the 2018-19/2021-22 =s07bq03b= numeric unit codes are now decoded via the shared EHCVM codebook (=lsms_library/categorical_mapping/ehcvm_units.org=, unioned from the sibling countries' =.dta= value labels) applied through =mappings: ['ehcvm_units','Code','Preferred Label']= in =data_info.yml=.  The dead identity rows (=101.0->101.0=, ...) were removed from =categorical_mapping.org=.  Code leaks 22 -> 2; residual codes =254, 255= have no label in any EHCVM source.
+
 ** DONE sample
 Sampling design table: cluster, weights, strata, and Rural classification.
 

--- a/lsms_library/countries/Burkina_Faso/_/categorical_mapping.org
+++ b/lsms_library/countries/Burkina_Faso/_/categorical_mapping.org
@@ -303,31 +303,14 @@
 
 * Food Units
 
+# Numeric code rows (101.0->101.0, ...) removed: the s07bq03b codes are now
+# decoded via the shared EHCVM codebook (categorical_mapping/ehcvm_units.org,
+# wired in data_info.yml `mappings:`), so these identity rows are dead
+# (GH #223 Layer 2 wiring).  Codes 254/255 have no label in any EHCVM source
+# and stay undecoded.
 #+NAME: u
 | Original Label            | Preferred Label |
 |---------------------------+-----------------|
-| 101.0                     | 101.0           |
-| 103.0                     | 103.0           |
-| 104.0                     | 104.0           |
-| 106.0                     | 106.0           |
-| 111.0                     | 111.0           |
-| 112.0                     | 112.0           |
-| 113.0                     | 113.0           |
-| 116.0                     | 116.0           |
-| 120.0                     | 120.0           |
-| 124.0                     | 124.0           |
-| 125.0                     | 125.0           |
-| 126.0                     | 126.0           |
-| 128.0                     | 128.0           |
-| 130.0                     | 130.0           |
-| 131.0                     | 131.0           |
-| 132.0                     | 132.0           |
-| 133.0                     | 133.0           |
-| 140.0                     | 140.0           |
-| 141.0                     | 141.0           |
-| 148.0                     | 148.0           |
-| 254.0                     | 254.0           |
-| 255.0                     | 255.0           |
 | Avec os au Kg             | Kg              |
 | Avec os au tas            | Tas             |
 | Bidon                     | Bidon           |

--- a/lsms_library/countries/Togo/2018/_/data_info.yml
+++ b/lsms_library/countries/Togo/2018/_/data_info.yml
@@ -226,7 +226,9 @@ food_acquired:
             - grappe
             - menage
         j: s07bq01
-        u: s07bq03b
+        u:
+            - s07bq03b
+            - mappings: ['ehcvm_units', 'Code', 'Preferred Label']
     myvars:
         Quantity: s07bq03a
         Expenditure: s07bq08

--- a/lsms_library/countries/Togo/_/CONTENTS.org
+++ b/lsms_library/countries/Togo/_/CONTENTS.org
@@ -13,6 +13,25 @@ each grappe is visited in exactly one =vague=, so household
 identifier is =(grappe, menage)= without a vague level.  See
 CLAUDE.md "EHCVM countries" for the cross-country pattern.
 
+* food_acquired units (Benin<->Togo codebook link)
+
+Togo's =s07bq03b= unit variable stores bare numeric codes (100-662): its
+=.dta= lost the Stata value labels, so =convert_categoricals=True= still
+returns codes.  The labels survive in the *sibling EHCVM countries* whose
+=.dta= kept them --- chiefly *Benin*, which uses the identical standardized
+coding (=100=Kg=, =101=Litre=, =107=Boite=, =124=Gousse=, ...).
+
+The decode therefore borrows the sibling labels: the shared codebook
+=lsms_library/categorical_mapping/ehcvm_units.org= (=#+name:ehcvm_units=,
+built by unioning =s07bq03b= value labels across all 8 EHCVM countries ---
+see =slurm_logs/ehcvm_unit_codebook_2026-06-07.org=) is applied to =u= via
+=mappings: ['ehcvm_units','Code','Preferred Label']= in
+=2018/_/data_info.yml=.  Result: code leaks 25 -> 4.
+
+Residual undecoded codes (=114, 659, 660, 662=) have no label in *any*
+EHCVM source =.dta= and are left as codes pending the questionnaire unit
+nomenclature.
+
 * Household Presence / MonthsSpent
 
 The EHCVM questionnaire (used in the 2018 wave) does NOT ask

--- a/tests/test_u_code_leak.py
+++ b/tests/test_u_code_leak.py
@@ -70,8 +70,12 @@ def test_leak_detector_no_u_level():
 
 # Clean per the 2026-06-07 audit; must stay clean.
 _KNOWN_CLEAN = ["Mali", "Niger", "CotedIvoire", "Guinea-Bissau"]
-# Tracked dirty (driven down by Layer 2 / #347 / #348): Nigeria, Togo,
-# Burkina_Faso, Senegal, Ethiopia, Malawi, GhanaLSS, EthiopiaRHS.
+# Tracked dirty (driven down by Layer 2 / #347 / #348). Progress:
+#   Ethiopia  45 -> 0 (prefix strip, #370)
+#   Togo      25 -> 4 (EHCVM codebook decode; residual 114/659/660/662)
+#   Burkina   22 -> 2 (EHCVM codebook decode; residual 254/255)
+# Residual EHCVM codes have no label in any source .dta. Still dirty:
+# Nigeria, Senegal (code '1', unresolved), Malawi, GhanaLSS, EthiopiaRHS.
 
 
 def test_clean_countries_have_no_u_code_leaks():


### PR DESCRIPTION
## Summary

Wires the curated EHCVM unit codebook (#371) so the countries whose `.dta` **lost** their `s07bq03b` value-labels decode their bare unit codes by **borrowing the sibling countries' labels** (same standardized WAEMU coding — the Benin↔Togo link).

- **`categorical_mapping/ehcvm_units.org`** — the live `#+name:ehcvm_units` table (`Code → Preferred Label`, 175 codes), loaded globally (GH #168) but **inert unless referenced**. Provenance + full curation log stay in `slurm_logs/ehcvm_unit_codebook_2026-06-07.org`.
- **Togo 2018, Burkina 2018-19/2021-22** `data_info.yml`: decode `u` via `mappings: ['ehcvm_units','Code','Preferred Label']`.
- **Burkina `categorical_mapping.org`**: removed the 22 dead identity rows (`101.0→101.0`…) now superseded by the codebook decode.

## Effect (NO_CACHE rebuild — no food_quantities regression, both 100%)

| Country | code leaks | residuals (undecodable) |
|---|---|---|
| **Togo** | **25 → 4** | 114, 659, 660, 662 |
| **Burkina** | **22 → 2** | 254, 255 |

Residual codes have **no label in any EHCVM source `.dta`** (left undecoded, documented). Clean EHCVM countries (Benin/CotedIvoire/Mali/Niger/Guinea-Bissau) are **not** wired and unaffected (leak-regression test confirms).

Senegal's lone leak (code `'1'`) is unresolved in the codebook (no label anywhere) — a genuine anomaly, not wired.

## Docs / tests

- Benin↔Togo link + residuals documented in `Togo/_/CONTENTS.org`; Burkina note in its `CONTENTS.org`.
- `test_u_code_leak.py` progress tracking updated. Regression: **230 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)