### PR TITLE
docs: verified shocks/housing availability — 11 countries (#350, #352)

### DIFF
--- a/lsms_library/countries/Azerbaijan/_/CONTENTS.org
+++ b/lsms_library/countries/Azerbaijan/_/CONTENTS.org
@@ -48,3 +48,12 @@ The original questionnaires (=queshhe.pdf=, =quespope.pdf= under
 =1995/Documentation/=) are DVC-tracked but not yet read into this
 note; if a future maintainer pulls them and confirms the sampling
 plan, please update.
+
+
+* shocks — not available (2026-06-07, verified)
+
+=shocks= (a household adverse-events-and-coping roster, index =(t, i, Shock)=)
+is an ISA/EHCVM-specific module.  Azerbaijan Survey of Living Conditions (SLC) 1995 carries no such roster.  Verified
+this round by full variable-label inspection of the source =.dta= files:
+the nine household sections (roster, dwelling, education, health, employment, migration/displacement, consumption, durables, agriculture) hold no adverse-events roster; the only shock-adjacent content is the war-displacement aid block =A06B=.  Not implementable from current data; revisit only if a coping roster
+is later identified.  Tracked in GitHub issue #352.

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -243,3 +243,12 @@ No GLSS wave (1987-88…2016-17) carries a subjective-well-being / life-evaluati
 subjective-poverty ladder. GLSS7 §13 is "Governance, Peace, Security" (political
 participation + threat perception), not SWB. Confirmed by a variable-label scan of
 all section files. Resolves the #331 "unknown" → absent. Tracked in #331.
+
+
+* housing — implementable, not yet wired (2026-06-07)
+
+Contrary to an earlier triage (GH #350), GLSS DOES field a dwelling module:
+=g7sec7=/=g7sec7i=/=g7sec7j= (GLSS7 Section 7 "Housing"), =S7.DTA=/=SEC7.DTA=
+(earlier waves), plus =04_GHA_EXPHOUS= (housing expenditure).  The data is
+present in-repo but no =housing= feature is wired.  A future =housing=
+extractor is feasible — this is a feature gap, not an absence.

--- a/lsms_library/countries/Guatemala/_/CONTENTS.org
+++ b/lsms_library/countries/Guatemala/_/CONTENTS.org
@@ -275,3 +275,13 @@ fecha/día/mes/año/entrevista found none; ~thogar~ (1–18, household size) and
 the ~p01a*~ block (housing characteristics) are not dates.  ~interview_date~
 is therefore not implementable for Guatemala from the available microdata.
 Tracked in GitHub issue #341.
+
+
+* shocks — implementable, not yet wired (2026-06-07)
+
+Contrary to an earlier triage (GH #352), ENCOVI 2000 DOES field a shocks
+module: Chapter 3 "Situaciones Adversas" (=ECV05H03.DTA= RESUMEN,
+=ECV06H03.DTA= DETALLE) records adverse events (=p03a01b= drought,
+=p03a06n= crop loss, =p03a01k= general price rise) AND coping "accion"
+codes.  Data present in-repo; =shocks= is not yet wired.  Implementable —
+a feature gap, not an absence.

--- a/lsms_library/countries/India/_/CONTENTS.org
+++ b/lsms_library/countries/India/_/CONTENTS.org
@@ -1,0 +1,9 @@
+#+title: Contents
+
+* shocks — not available (2026-06-07, verified)
+
+=shocks= (a household adverse-events-and-coping roster, index =(t, i, Shock)=)
+is an ISA/EHCVM-specific module.  the UP & Bihar Survey of Living Conditions 1997-98 carries no such roster.  Verified
+this round by full variable-label inspection of the source =.dta= files:
+§8 "Vulnerability" decomposes into food-adequacy (=SECT08A=, already wired as =months_food_inadequate=), IRDP credit (=SECT08B=), and government transfers/pensions (=SECT08C=) — none a drought/flood/illness/death/theft event roster; a keyword sweep of all SECT files was otherwise clean.  Not implementable from current data; revisit only if a coping roster
+is later identified.  Tracked in GitHub issue #352.

--- a/lsms_library/countries/Kazakhstan/_/CONTENTS.org
+++ b/lsms_library/countries/Kazakhstan/_/CONTENTS.org
@@ -25,3 +25,12 @@ household (relhead == 1); 1992 of 1996 heads appear in OCC and 1983 give a
 non-missing step.  Households whose head did not answer are dropped.
 Built via ~1996/_/subjective_well_being.py~ (materialize: make).  Observed
 range 1-8 (no household head reported step 9).
+
+
+* shocks — not available (2026-06-07, verified)
+
+=shocks= (a household adverse-events-and-coping roster, index =(t, i, Shock)=)
+is an ISA/EHCVM-specific module.  Kazakhstan LSMS 1996 carries no such roster.  Verified
+this round by full variable-label inspection of the source =.dta= files:
+the only adverse-event content is community-level (=KOMMU= droughts/calamities, keyed by =oblast= not household) or livestock-loss stock-accounting (=AGR2= =w25=); no household-level shock roster with coping.  Not implementable from current data; revisit only if a coping roster
+is later identified.  Tracked in GitHub issue #352.

--- a/lsms_library/countries/Kosovo/_/CONTENTS.org
+++ b/lsms_library/countries/Kosovo/_/CONTENTS.org
@@ -1,0 +1,9 @@
+#+title: Contents
+
+* shocks — not available (2026-06-07, verified)
+
+=shocks= (a household adverse-events-and-coping roster, index =(t, i, Shock)=)
+is an ISA/EHCVM-specific module.  Kosovo LSMS 2000 carries no such roster.  Verified
+this round by full variable-label inspection of the source =.dta= files:
+displacement content is community-level only; the household modules (=MISC= social-protection, =NETWORKS= assistance-received, =HEALTH=, =DWELLING=) hold no adverse-events roster with affected-y/n + coping.  Not implementable from current data; revisit only if a coping roster
+is later identified.  Tracked in GitHub issue #352.

--- a/lsms_library/countries/Pakistan/_/CONTENTS.org
+++ b/lsms_library/countries/Pakistan/_/CONTENTS.org
@@ -18,3 +18,12 @@ highest-attainment variable is missing.
 Revisit if a fuller attainment variable is located (e.g. a secondary/tertiary
 column elsewhere in the instrument, or a later PIHS/PSLM wave).  Tracked in
 GitHub issue #344.
+
+
+* shocks — not available (2026-06-07, verified)
+
+=shocks= (a household adverse-events-and-coping roster, index =(t, i, Shock)=)
+is an ISA/EHCVM-specific module.  Pakistan Integrated Household Survey (PIHS) 1991 carries no such roster.  Verified
+this round by full variable-label inspection of the source =.dta= files:
+all 17 sections (=F01=–=F17=) are accounted for with no shocks chapter — the loan-purpose (§15) and migration-reason (§8) codes are not an events roster.  Not implementable from current data; revisit only if a coping roster
+is later identified.  Tracked in GitHub issue #352.

--- a/lsms_library/countries/Serbia/_/CONTENTS.org
+++ b/lsms_library/countries/Serbia/_/CONTENTS.org
@@ -160,3 +160,12 @@ All wave-level scripts use =dvc.api.open()= and
 =get_dataframe()=.  The =food_acquired.py= script also imports
 =pyreadstat= directly.  These should be migrated to the standard
 =get_dataframe()= pattern per CLAUDE.md.
+
+
+* shocks — not available (2026-06-07, verified)
+
+=shocks= (a household adverse-events-and-coping roster, index =(t, i, Shock)=)
+is an ISA/EHCVM-specific module.  Serbia LSMS 2007 carries no such roster.  Verified
+this round by full variable-label inspection of the source =.dta= files:
+full inspection of all 445 household + 346 individual variables; the lone damage field (=mp20=) sits in the Kosovo-IDP module, not a shocks roster.  Not implementable from current data; revisit only if a coping roster
+is later identified.  Tracked in GitHub issue #352.

--- a/lsms_library/countries/South Africa/_/CONTENTS.org
+++ b/lsms_library/countries/South Africa/_/CONTENTS.org
@@ -1,0 +1,9 @@
+#+title: Contents
+
+* shocks — not available (2026-06-07, verified)
+
+=shocks= (a household adverse-events-and-coping roster, index =(t, i, Shock)=)
+is an ISA/EHCVM-specific module.  PSLSD 1993 carries no such roster.  Verified
+this round by full variable-label inspection of the source =.dta= files:
+all 72 files keyword-scanned; the crime-victimization items (§9 Perceived Quality of Life) and a single "drought relief" subsidy line are not a shocks-and-coping roster.  Not implementable from current data; revisit only if a coping roster
+is later identified.  Tracked in GitHub issue #352.

--- a/lsms_library/countries/Tajikistan/_/CONTENTS.org
+++ b/lsms_library/countries/Tajikistan/_/CONTENTS.org
@@ -1,0 +1,19 @@
+#+title: Contents
+
+* shocks — not available (2026-06-07, verified)
+
+=shocks= (a household adverse-events-and-coping roster, index =(t, i, Shock)=)
+is an ISA/EHCVM-specific module.  the TLSS (1999/2003/2007/2009) carries no such roster.  Verified
+this round by full variable-label inspection of the source =.dta= files:
+the coping batteries that exist (2009 =m8b= 26-item CSI, =m8a=, =m4c=; 1999 =SSEC8=C; 2007 =r1m9=) are tied to food-insecurity / health costs, not a general adverse-events roster with an event trigger.  Not implementable from current data; revisit only if a coping roster
+is later identified.  Tracked in GitHub issue #352.
+
+
+* housing — implementable, not yet wired (2026-06-07)
+
+Contrary to an earlier triage (GH #350), the TLSS fields a full dwelling
+module: 1999 =SSEC2= (=s2aq*= walls/roof/floor/rooms/tenure/water/toilet),
+2007 =r1m7a/b/c= (=m7aq*= structure + utilities), 2009 =m6a/b= (utilities
+only — physical-structure block dropped), 2003 =module6= (structure;
+labels stripped in the repo =.dta=).  Data present in-repo; =housing= is
+simply not yet wired (full for 1999/2007, partial 2009).  Not an absence.


### PR DESCRIPTION
Per-country **data verification** (variable-label inspection of the actual `.dta` files, not triage inference) of the remaining gap countries in #350 (housing) and #352 (shocks). The triage had a notable error rate, so each was checked against source data.

**shocks — verified ABSENT (8):** Azerbaijan, India, Kazakhstan, Kosovo, Pakistan, Serbia, South Africa, Tajikistan. Each CONTENTS.org note records what was inspected (e.g. India §8 'Vulnerability' = food/credit/transfers; Kazakhstan disaster items are community-level; Serbia's only damage field is in the Kosovo-IDP module).

**Reclassified PRESENT-but-unwired (triage was WRONG — 3):**
- **Guatemala** shocks — ENCOVI 2000 Ch.3 'Situaciones Adversas' (`ECV05H03`/`ECV06H03`): adverse events + coping actions.
- **GhanaLSS** housing — GLSS §7 'Housing' (`g7sec7`, `S7.DTA`, `SEC7.DTA`).
- **Tajikistan** housing — TLSS dwelling module (`SSEC2` 1999, `r1m7a/b/c` 2007).

These three are documented as implementable feature-gaps, not absences.

Doc-only; no code/data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)