### PR TITLE
fix(Nigeria): decode food_acquired unit codes from WB .dta value labels (#223 Layer 2)

### DIFF
--- a/lsms_library/countries/Nigeria/_/CONTENTS.org
+++ b/lsms_library/countries/Nigeria/_/CONTENTS.org
@@ -2,6 +2,28 @@
 * Food Conversion Table
 A food conversion table can be found at https://docs.google.com/spreadsheets/d/1whE_EW5x-jxrsKvYWfefdBppzp_TZhPP61bdEN-FEJ4/
 
+* food_acquired unit codes (GH #223 Layer 2)
+
+The =s10bq2b= / =s7bq2b= unit variable is a numeric code.  The repo's
+source files are *CSV*, which carry **no value labels**, so codes outside
+the questionnaire's printed "FOOD ITEM UNIT CODES" card (1--122, 900) leaked
+as bare numbers into =food_acquired= =u= (32 codes after the #366
+float-code normalization).
+
+Resolution: the WB also ships *Stata =.dta=* versions of the same files,
+and **those carry the value labels** the CSV drops --- descriptive in W1
+(=22 = Basket: Medium (30 kg)=) and code-prefixed in W3/W4 (=200. LOAF=,
+=211. TUBER=).  The 29 decodable codes were added to =categorical_mapping.org=
+=#+name:u= (W1 size-specific codes 22--94; W4 codes 125--340), cleaned to
+canonical labels.  Code leaks 32 -> 3.
+
+Residual codes =131, 151, 152= (W3) have **no label even in the =.dta=** and
+are left as codes.
+
+Future enhancement (not yet wired): the W3/W4 data carry a per-row Kg/L
+conversion factor =s10bq2_cvn= (99.6% coverage) --- an exact Approach-B kg
+factor for =food_quantities=, independent of the unit label.
+
 * Sampling Design
 
 ** Overview

--- a/lsms_library/countries/Nigeria/_/categorical_mapping.org
+++ b/lsms_library/countries/Nigeria/_/categorical_mapping.org
@@ -204,6 +204,35 @@
 |  121 | medium packet/sachet         | ---                          | ---                          | medium packet/sachet         | medium packet/sachet         |
 |  122 | large packet/sachet          | ---                          | ---                          | large packet/sachet          | large packet/sachet          |
 |  900 | other specify                | ---                          | ---                          | other specify                | other specify                |
+| 22 | Basket Medium | Basket Medium | --- | --- | --- |
+| 23 | Basket Big | Basket Big | --- | --- | --- |
+| 32 | Basin Medium | Basin Medium | --- | --- | --- |
+| 33 | Basin Big/Large | Basin Big/Large | --- | --- | --- |
+| 34 | Basin Extra Large | Basin Extra Large | --- | --- | --- |
+| 53 | Yam Tuber Big/Large | Yam Tuber Big/Large | --- | --- | --- |
+| 63 | Bundle Big | Bundle Big | --- | --- | --- |
+| 93 | Jerry Can Big | Jerry Can Big | --- | --- | --- |
+| 94 | Jerry Can Large | Jerry Can Large | --- | --- | --- |
+| 125 | Packet | --- | --- | --- | Packet |
+| 130 | Sack/Bag | --- | --- | --- | Sack/Bag |
+| 140 | Basket | --- | --- | --- | Basket |
+| 150 | Basin | --- | --- | --- | Basin |
+| 170 | Wheelbarrow | --- | --- | --- | Wheelbarrow |
+| 200 | Loaf | --- | --- | --- | Loaf |
+| 211 | Tuber | --- | --- | --- | Tuber |
+| 240 | Bottle/Can | --- | --- | --- | Bottle/Can |
+| 250 | Sachet | --- | --- | --- | Sachet |
+| 251 | Bag of 20 Sachets | --- | --- | --- | Bag of 20 Sachets |
+| 270 | Cube | --- | --- | --- | Cube |
+| 280 | Metric Cup | --- | --- | --- | Metric Cup |
+| 290 | Wrap | --- | --- | --- | Wrap |
+| 300 | Spoon | --- | --- | --- | Spoon |
+| 301 | Tea Spoon | --- | --- | --- | Tea Spoon |
+| 302 | Table Spoon | --- | --- | --- | Table Spoon |
+| 310 | Crate | --- | --- | --- | Crate |
+| 320 | Slice | --- | --- | --- | Slice |
+| 330 | Whole Animal | --- | --- | --- | Whole Animal |
+| 340 | Shot | --- | --- | --- | Shot |
 
 * Geopolitical Zones
 

--- a/tests/test_u_code_leak.py
+++ b/tests/test_u_code_leak.py
@@ -74,8 +74,9 @@ _KNOWN_CLEAN = ["Mali", "Niger", "CotedIvoire", "Guinea-Bissau"]
 #   Ethiopia  45 -> 0 (prefix strip, #370)
 #   Togo      25 -> 4 (EHCVM codebook decode; residual 114/659/660/662)
 #   Burkina   22 -> 2 (EHCVM codebook decode; residual 254/255)
-# Residual EHCVM codes have no label in any source .dta. Still dirty:
-# Nigeria, Senegal (code '1', unresolved), Malawi, GhanaLSS, EthiopiaRHS.
+#   Nigeria   32 -> 3 (codes decoded from WB .dta labels; residual 131/151/152)
+# Residual codes have no label in any source .dta. Still dirty:
+# Senegal (code '1', unresolved), Malawi, GhanaLSS, EthiopiaRHS.
 
 
 def test_clean_countries_have_no_u_code_leaks():


### PR DESCRIPTION
## Summary

Nigeria's repo source files are **CSV** → no value labels, so unit codes outside the questionnaire's printed card (1–122, 900) leaked into `food_acquired` `u` as bare numbers (32, after the #366 float-code normalization). The WB also ships **Stata `.dta`** versions that **do carry the value labels** — descriptive in W1 (`22 = Basket: Medium (30 kg)`) and code-prefixed in W3/W4 (`200. LOAF`, `211. TUBER`).

Added the **29 decodable codes** to `categorical_mapping.org` `#+name:u`, cleaned to canonical labels:
- **W1 (22–94)**: Basket/Basin/Yam Tuber/Jerry Can size variants.
- **W4 (125–340)**: Packet, Loaf, Tuber, Sack/Bag, Wheelbarrow, Bottle/Can, Sachet, Cube, Metric Cup, Wrap, Spoon/Tea Spoon/Table Spoon, Crate, Slice, Whole Animal, Shot, …

## Effect (NO_CACHE rebuild)

- code leaks **32 → 3** (full trajectory: 81 pre-#366 → 32 → 3)
- `food_quantities` kg-resolved **99.8%** (no regression)
- Residual **131 / 151 / 152** (W3) have **no label even in the `.dta`** → left as codes.

## Future enhancement (documented, not wired)

W3/W4 data carry a per-row **`s10bq2_cvn`** Kg/L conversion factor (**99.6% coverage**) — an exact Approach-B kg factor for `food_quantities`, independent of the unit label. Worth its own issue.

Investigation trail (CSV→no labels, DDI→ranges only, questionnaire/food_conv→1–122 only, WB NADA→no categories, **`.dta`→has labels**) recorded in `Nigeria/_/CONTENTS.org`. Regression: **221 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)