### PR TITLE
feat: wire housing (GhanaLSS, Tajikistan) + shocks (Guatemala) — verified-implementable gaps (#350, #352, #372)

### DIFF
--- a/lsms_library/countries/GhanaLSS/1991-92/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1991-92/_/data_info.yml
@@ -72,3 +72,86 @@ plot_features:
                 2: Poles
                 3: Ropes
                 4: Hectare
+
+housing:
+    # GLSS3 Section 7 dwelling characteristics (S7.DTA).  This wave's .dta has
+    # neither variable nor value labels (missing = ~1.75e100 sentinel), so all
+    # codes are decoded from the GLSS3 Part-A household questionnaire (Section 7):
+    # walls = Part E q35 (s7q35), floor = Part E q36 (s7q36), roof = Part D q37
+    # (s7q37), water source = Part D q22 (s7q22), lighting = Part D q29 (s7q29),
+    # toilet = Part D q34 (s7q34), occupancy = Part B q11 (s7q11; s7q5 is the
+    # FORMER dwelling type, not occupancy), rooms = Part A q2 (s7q2).  Code lists
+    # and code ranges verified against the questionnaire text and the data.
+    # i = [clust, nh] to match household_roster.
+    file: S7.DTA
+    idxvars:
+        i:
+            - clust
+            - nh
+    myvars:
+        Walls:
+            - s7q35
+            - mapping:
+                1: Mud/Earth
+                2: Wood
+                3: Metal Sheet
+                4: Stone/Burnt Bricks
+                5: Cement/Concrete
+                6: Other
+        Floor:
+            - s7q36
+            - mapping:
+                1: Earth/Mud
+                2: Wood
+                3: Stone/Brick
+                4: Fibre-glass
+                5: Cement/Concrete
+                6: Other
+        Roof:
+            - s7q37
+            - mapping:
+                1: Thatch
+                2: Wood
+                3: Metal Sheet
+                4: Cement/Concrete
+                5: Slate/Asbestos
+                6: Other
+        Water:
+            - s7q22
+            - mapping:
+                1: Indoor plumbing
+                2: Inside standpipe
+                3: Water vendor
+                4: Water truck/tanker service
+                5: Neighbouring household
+                6: Private outside standpipe/tap
+                7: Public standpipe
+                8: Well with pump
+                9: Well without pump
+                10: River/lake/spring/pond
+                11: Rainwater
+                12: Other
+        Toilet:
+            - s7q34
+            - mapping:
+                1: Flush toilet
+                2: Pit latrine
+                3: Pan/Bucket
+                4: KVIP
+                5: No toilet
+                6: Other
+        Rooms: s7q2
+        Tenure:
+            - s7q11
+            - mapping:
+                1: Own
+                2: Rent
+                3: Rent-free
+                4: Perching
+        Electricity:
+            - s7q29
+            - mapping:
+                1: Electricity (mains)
+                2: Generator
+                3: Kerosene/Gas lamp
+                4: Candles/Torches

--- a/lsms_library/countries/GhanaLSS/1991-92/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1991-92/_/mapping.py
@@ -33,7 +33,7 @@ def Birthplace(value):
     '''
     if value > 1e99:
         return pd.NA
-    return (lambda x: region_dict[f"{x:3.0f}".strip()])(value)
+    return region_dict.get(f"{value:3.0f}".strip(), pd.NA)
 
 def Relationship(value):
     '''
@@ -47,7 +47,7 @@ def Region(value):
     Formatting region variable
     '''
 
-    return (lambda x: region_dict[f"{x:3.0f}".strip()])(value)
+    return region_dict.get(f"{value:3.0f}".strip(), pd.NA)
     
 
 def v(value):

--- a/lsms_library/countries/GhanaLSS/1991-92/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1991-92/_/mapping.py
@@ -83,4 +83,13 @@ def Int_t(value):
     s = f"{y}-{int(m)}-{int(d)}"
     return pd.to_datetime(s, format='%Y-%m-%d', errors='coerce')
 
+def Rooms(value):
+    '''
+    Number of rooms.  This wave uses a large float sentinel (~1.75e100) for
+    missing/not-applicable; null it and coerce the rest to integer.
+    '''
+    if pd.isna(value) or value > 1e99:
+        return pd.NA
+    return int(value)
+
 Visits = range(1,7)

--- a/lsms_library/countries/GhanaLSS/1998-99/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1998-99/_/data_info.yml
@@ -107,3 +107,87 @@ plot_features:
                 2: Poles
                 3: Ropes
                 4: Hectare
+
+housing:
+    # GLSS4 Section 7 dwelling characteristics (SEC7.DTA).  The .dta has variable
+    # labels but NO value labels, so codes are decoded from the GLSS4 household
+    # questionnaire text (Section 7): walls = Part E q1 (s7eq1), floor = Part E
+    # q2 (s7eq2), roof = Part D q3 (s7eq3); water source = Part D q1 (s7dq1 --
+    # the "Drinking water cost" label is a misnomer; the column holds the 1-12
+    # source code, confirmed by its 1-12 range); lighting = Part D q8 (s7dq8);
+    # toilet = Part D q13 (s7dq13); occupancy = Part B (s7bq1); rooms = Part A
+    # q2 (s7aq2).  Part E walls/floor code lists follow the GLSS3 instrument
+    # (identical structure, verified from the GLSS3 questionnaire).  i =
+    # [clust, nh] to match household_roster.
+    file: SEC7.DTA
+    idxvars:
+        i:
+            - clust
+            - nh
+    myvars:
+        Walls:
+            - s7eq1
+            - mapping:
+                1: Mud/Earth
+                2: Wood
+                3: Metal Sheet
+                4: Stone/Burnt Bricks
+                5: Cement/Concrete
+                6: Other
+        Floor:
+            - s7eq2
+            - mapping:
+                1: Earth/Mud
+                2: Wood
+                3: Stone/Brick
+                4: Fibre-glass
+                5: Cement/Concrete
+                6: Other
+        Roof:
+            - s7eq3
+            - mapping:
+                1: Thatch
+                2: Wood
+                3: Metal Sheet
+                4: Cement/Concrete
+                5: Slate/Asbestos
+                6: Other
+        Water:
+            - s7dq1
+            - mapping:
+                1: Indoor plumbing
+                2: Inside standpipe
+                3: Water vendor
+                4: Water truck/tanker service
+                5: Neighbouring household
+                6: Private outside standpipe/tap
+                7: Public standpipe
+                8: Well with pump
+                9: Well without pump
+                10: River/lake/spring/pond
+                11: Rainwater
+                12: Other
+        Toilet:
+            - s7dq13
+            - mapping:
+                1: Flush toilet
+                2: Pit latrine
+                3: Pan/Bucket
+                4: KVIP
+                5: No toilet
+        Rooms: s7aq2
+        Tenure:
+            - s7bq1
+            - mapping:
+                1: Own
+                2: Rent
+                3: Rent-free
+                4: Perching
+        Electricity:
+            - s7dq8
+            - mapping:
+                1: Electricity (mains)
+                2: Generator
+                3: Kerosene/Gas lamp
+                4: Candles/Torches
+                5: Other

--- a/lsms_library/countries/GhanaLSS/2005-06/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2005-06/_/data_info.yml
@@ -42,3 +42,63 @@ household_roster:
         Birthplace: s1q11
         Relationship: s1q3
         MonthsAway: s1q22
+
+housing:
+    # GLSS5 Section 7 dwelling characteristics (parta/sec7.dta).  Wall/Floor/
+    # Roof = Part F (s7fq1/2/3); Water = Part D q1a; Toilet = Part D q16;
+    # Rooms = Part A q2; Tenure = Part B q1 (occupancy status); Electricity =
+    # Part D q11 (main source of lighting).  Value labels in this wave are
+    # lowercase -> Title-cased / canonicalized below.  i = hhid, matching the
+    # household_roster i for this wave.
+    file: parta/sec7.dta
+    idxvars:
+        i: hhid
+    myvars:
+        Walls:
+            - s7fq1
+            - mapping:
+                mud/ mud brick: Mud/Earth
+                wood/bamboo: Wood/Bamboo
+                metal sheet/slate/asbestos: Metal/Asbestos
+                stone: Stone
+                burned bricks: Burnt Bricks
+                cement/sandcrete blocks: Cement/Concrete
+                landcrete: Landcrete
+                thatch: Thatch
+                cardboard: Cardboard
+                other: Other
+        Floor:
+            - s7fq2
+            - mapping:
+                earth/mud/mud bricks: Earth/Mud
+                wood: Wood
+                stone: Stone
+                cement/concrete: Cement/Concrete
+                burnt bricks: Burnt Bricks
+                vinyl tiles: Vinyl Tiles
+                ceramic/marble/tiles: Ceramic/Marble Tiles
+                terrazo: Terrazzo
+                other: Other
+        Roof:
+            - s7fq3
+            - mapping:
+                palme leaves/raffia/thatch: Thatch
+                wood: Wood
+                corrugated iron sheets: Metal Sheet
+                cement/concrete: Cement/Concrete
+                asbestos/slate: Slate/Asbestos
+                roofing tiles: Roofing Tiles
+                mud bricks/earth: Mud/Earth
+                bamboo: Bamboo
+                other: Other
+        Water: s7dq1a
+        Toilet: s7dq16
+        Rooms: s7aq2
+        Tenure:
+            - s7bq1
+            - mapping:
+                owning: Own
+                renting: Rent
+                rent-free: Rent-free
+                perching: Perching
+        Electricity: s7dq11

--- a/lsms_library/countries/GhanaLSS/2012-13/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2012-13/_/data_info.yml
@@ -92,5 +92,63 @@ plot_features:
                 distributed by village/family: communal
                 inherited: inherited
 
-
-
+housing:
+    # GLSS6 Section 7 dwelling characteristics (PARTA/SEC7.dta).  Wall/Floor/
+    # Roof = Part F (s7fq1/2/3); Water = Part D q1a1; Toilet = Part D q16a;
+    # Rooms = Part A q2; Tenure = Part B q1 (holding agreement); Electricity =
+    # Part D q11 (main source of lighting -- GLSS6 has no separate power-source
+    # question).  All variables carry Title-case value labels in the .dta.
+    file:
+        - PARTA/SEC7.dta
+    idxvars:
+        i: HID
+    myvars:
+        Walls:
+            - s7fq1
+            - mapping:
+                Mud/Mud bricks/Earth: Mud/Earth
+                Wood: Wood
+                Metal sheet/slate/asbestos: Metal/Asbestos
+                Stone: Stone
+                Burnt bricks: Burnt Bricks
+                Cement blocks/concrete: Cement/Concrete
+                Landcrete: Landcrete
+                Bamboo: Bamboo
+                Palm leaves/Thatch(grass/Raffia): Thatch
+                Other: Other
+        Floor:
+            - s7fq2
+            - mapping:
+                Earth/Mud: Earth/Mud
+                Cement/Concrete: Cement/Concrete
+                Stone: Stone
+                Burnt brick: Burnt Bricks
+                Wood: Wood
+                Vinyl tiles: Vinyl Tiles
+                Ceramic/Porcelain/Granite/Marble tiles: Ceramic/Marble Tiles
+                Terrazzo/Terrazzo tiles: Terrazzo
+                Other: Other
+        Roof:
+            - s7fq3
+            - mapping:
+                Mud/Mud bricks/Earth: Mud/Earth
+                Wood: Wood
+                Metal sheet: Metal Sheet
+                Slate/Asbestos: Slate/Asbestos
+                Cement/Concrete: Cement/Concrete
+                Bamboo: Bamboo
+                Palm leaves/Thatch(grass/Raffia): Thatch
+                Roofing tile: Roofing Tiles
+                Other: Other
+        Water: s7dq1a1
+        Toilet: s7dq16a
+        Rooms: s7aq2
+        Tenure:
+            - s7bq1
+            - mapping:
+                Owning: Own
+                Renting: Rent
+                Rent-free: Rent-free
+                Perching: Perching
+                Squatting: Squatting
+        Electricity: s7dq11

--- a/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
@@ -116,3 +116,66 @@ plot_features:
                 Use free of charge: use_right
                 Distributed by village/family: communal
                 Inherited: inherited
+
+housing:
+    # GLSS7 Section 7 dwelling characteristics.  Wall/Floor/Roof live in Part F
+    # (s7fq1/2/3); Water = Part D q1a1; Toilet = Part D q26a; Electricity =
+    # Part D q11a (most-used power source); Rooms = Part A q2; Tenure = Part B
+    # q1 (present holding agreement).  All these variables carry value labels in
+    # the .dta, so get_dataframe(convert_categoricals=True) decodes them; the
+    # mappings below only normalize the decoded GLSS7 labels to canonical forms.
+    file: g7sec7.dta
+    idxvars:
+        i:
+            - clust
+            - nh
+    myvars:
+        Walls:
+            - s7fq1
+            - mapping:
+                Mud/Mud bricks/Earth: Mud/Earth
+                Wood: Wood
+                Metal sheet/slate/asbestos: Metal/Asbestos
+                Stone: Stone
+                Burnt bricks: Burnt Bricks
+                Cement blocks/concrete: Cement/Concrete
+                Landcrete: Landcrete
+                Bamboo: Bamboo
+                Palm leaves/Thatch (grass/Raffia): Thatch
+                Other: Other
+        Floor:
+            - s7fq2
+            - mapping:
+                Earth/Mud: Earth/Mud
+                Cement/Concrete: Cement/Concrete
+                Stone: Stone
+                Burnt brick: Burnt Bricks
+                Wood: Wood
+                Vinyl tiles: Vinyl Tiles
+                Ceramic/Porcelain/Granite/Marble tiles: Ceramic/Marble Tiles
+                Terrazzo/Terrazzo tiles: Terrazzo
+                Other: Other
+        Roof:
+            - s7fq3
+            - mapping:
+                Mud/Mud bricks/Earth: Mud/Earth
+                Wood: Wood
+                Metal sheet: Metal Sheet
+                Slate/Asbestos: Slate/Asbestos
+                Cement/Concrete: Cement/Concrete
+                Bamboo: Bamboo
+                Thatch/Palm leaf or Raffia: Thatch
+                Roofing tile: Roofing Tiles
+                Other: Other
+        Water: s7dq1a1
+        Toilet: s7dq26a
+        Rooms: s7aq2
+        Tenure:
+            - s7bq1
+            - mapping:
+                Owning: Own
+                Renting: Rent
+                Rent-free: Rent-free
+                Perching: Perching
+                Squatting: Squatting
+        Electricity: s7dq11a

--- a/lsms_library/countries/GhanaLSS/_/data_scheme.yml
+++ b/lsms_library/countries/GhanaLSS/_/data_scheme.yml
@@ -81,4 +81,29 @@ Data Scheme:
     WholeDay: bool
     FIES_score: int
 
+  housing:
+    # GLSS Section 7 "Housing" (dwelling characteristics).  Wired for the five
+    # waves whose Section-7 file carries value labels we could verify against
+    # the actual questionnaire/codebook: 1991-92 (S7.DTA), 1998-99 (SEC7.DTA),
+    # 2005-06 (sec7.dta), 2012-13 (SEC7.dta), 2016-17 (g7sec7.dta).  Codes
+    # differ across waves (GLSS3 6-code walls vs GLSS5/6/7 9-10 code walls;
+    # question numbering shifts), so each wave maps its own raw variables ->
+    # human-readable category strings inline.  Roof/Floor/Walls present in
+    # every wired wave; Water/Toilet/Rooms/Tenure/Electricity where available
+    # (1998-99 has no Electricity column, only a 'main source of lighting').
+    # 1987-88/1988-89 DO field a housing module (Y08.DAT: WALLS/FLOOR/ROOF),
+    # but their GLSS1/GLSS2 questionnaires are scanned-image PDFs with no text
+    # layer and the DDI/Basic-info docs carry no value codebook, so the numeric
+    # codes (WALLS 1-8, FLOOR 1-7, ROOF 1-9) cannot be decoded to labels -- those
+    # two waves are intentionally NOT wired (see CONTENTS notes / report).
+    index: (t, i)
+    Roof: str
+    Floor: str
+    Walls: str
+    Water: str
+    Toilet: str
+    Rooms: int
+    Tenure: str
+    Electricity: str
+
   panel_ids: !make

--- a/lsms_library/countries/Guatemala/2000/_/shocks.py
+++ b/lsms_library/countries/Guatemala/2000/_/shocks.py
@@ -1,0 +1,159 @@
+"""Guatemala ENCOVI 2000 -- shocks (Capitulo 3 "Situaciones Adversas").
+
+Two source files:
+  - ECV05H03.DTA (RESUMEN): per-household occurrence roster, WIDE.  Two si/no
+    families of event flags -- p03a01a..p03a01m (13 "general"/community events)
+    and p03a06a..p03a06p (15 "particular"/household events).  These are the
+    authoritative *occurrence* flags (one column per event type per household).
+  - ECV06H03.DTA (DETALLE): one row per (household, problem).  `item` is the
+    event code (101-113 general, 201-215 particular -- aligned 1:1 with the
+    RESUMEN columns); `perdida` is the impact type (1=income, 2=patrimonio/
+    assets, 3=both, 4=none); `accion` is the single coping action taken.
+
+Design (canonical `shocks`, index (t, i, Shock)):
+  - One row per (household, experienced shock).  The row set is the UNION of
+    RESUMEN-experienced (hh,item) pairs and DETALLE (hh,item) rows -- they
+    agree to within ~67 pairs (DETALLE drops some RESUMEN-flagged shocks for
+    which no detail was collected, and has 1 extra).  Using the union keeps
+    every experienced shock as a row.
+  - `Shock` is the item code mapped to an English label (SHOCK_LABELS below).
+  - AffectedIncome / AffectedAssets come from DETALLE.perdida.  ENCOVI's
+    impact item distinguishes income vs. patrimonio (assets) only -- there is
+    NO production/consumption breakdown -- so AffectedProduction /
+    AffectedConsumption are not derivable and are left out (NaN if read).
+  - `Experienced` (bool) carries the RESUMEN occurrence flag (always True for
+    rows in this table by construction; included for parity with the Liberia
+    occurrence-only precedent and to mark the ~67 detail-less shocks).
+  - HowCoped0 is the DETALLE `accion` mapped to English text.  ENCOVI records
+    a SINGLE coping action per problem (no up-to-3 battery), so HowCoped1 /
+    HowCoped2 do not exist in this instrument and are omitted.
+
+i = hogar (matches household_roster / sample); v is NOT baked in -- it is
+joined from sample() at API time.
+"""
+import sys
+sys.path.append('../../../_/')
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+
+# item code -> canonical English Shock label.  Codes & Spanish source labels
+# come from ECV06H03 `item` value labels; the RESUMEN p03a01*/p03a06* columns
+# carry the same event set (mapped to the same codes via RESUMEN_TO_ITEM).
+SHOCK_LABELS = {
+    101: 'Earthquake',
+    102: 'Drought',
+    103: 'Floods',
+    104: 'Storms',
+    105: 'Hurricane',
+    106: 'Pests',
+    107: 'Landslides',
+    108: 'Forest fires',
+    109: 'Business closures',
+    110: 'Mass layoffs',
+    111: 'General price rise',
+    112: 'Public protests',
+    113: 'Other general problem',
+    201: 'Loss of employment',
+    202: 'Drop in household income',
+    203: 'Family business failure',
+    204: 'Illness or serious accident',
+    205: 'Death of a worker',
+    206: 'Death of other household member',
+    207: 'Abandonment by household head',
+    208: 'Fire of dwelling/business',
+    209: 'Crime',
+    210: 'Land dispute',
+    211: 'Family disputes',
+    212: 'Loss of cash/in-kind aid',
+    213: 'Drop in prices of business products',
+    214: 'Loss of harvest',
+    215: 'Other particular problem',
+}
+
+# RESUMEN si/no column -> DETALLE item code (1:1, in questionnaire order).
+RESUMEN_TO_ITEM = {
+    'p03a01a': 101, 'p03a01b': 102, 'p03a01c': 103, 'p03a01d': 104,
+    'p03a01e': 105, 'p03a01f': 106, 'p03a01g': 107, 'p03a01h': 108,
+    'p03a01i': 109, 'p03a01j': 110, 'p03a01k': 111, 'p03a01l': 112,
+    'p03a01m': 113,
+    'p03a06a': 201, 'p03a06b': 202, 'p03a06c': 203, 'p03a06d': 204,
+    'p03a06e': 205, 'p03a06f': 206, 'p03a06g': 207, 'p03a06h': 208,
+    'p03a06i': 209, 'p03a06j': 210, 'p03a06k': 211, 'p03a06l': 212,
+    'p03a06m': 213, 'p03a06n': 214, 'p03a06p': 215,
+}
+
+# accion code -> English coping-action label (from ECV06H03 `accion` labels).
+COPING_LABELS = {
+    1: 'Spent savings or investments',
+    2: 'Pawned goods',
+    3: 'Mortgaged house or land',
+    4: 'Collected on insurance',
+    5: 'Worked more than those already working',
+    6: 'Other household members went out to work',
+    7: 'Borrowed money from a private bank',
+    8: 'Borrowed money from a state bank',
+    9: 'Borrowed money from a relative',
+    10: 'Borrowed money from a friend',
+    11: 'Borrowed money from a moneylender',
+    12: 'Borrowed money at work',
+    13: 'Sold house or land',
+    14: 'Sold animals',
+    15: 'Sold appliances/equipment/machines',
+    16: 'Sold jewelry',
+    17: 'Sold harvest in advance',
+    18: 'Help from government bodies',
+    19: 'Help from private entities',
+    20: 'Help from international entities',
+    21: 'Help from NGOs',
+    22: 'Help from neighbors',
+    23: 'Stopped consuming some products',
+    24: 'Did nothing',
+    25: 'Help from family/relatives',
+    98: 'Other',
+}
+
+# perdida code -> (AffectedIncome, AffectedAssets)
+PERDIDA_AFFECTED = {
+    1: (True, False),   # los ingresos que reciben normalmente
+    2: (False, True),   # del patrimonio
+    3: (True, True),    # de ingresos y patrimonio
+    4: (False, False),  # no ha significado ninguna perdida
+}
+
+# --- RESUMEN: occurrence (long) -------------------------------------------
+R = get_dataframe('../Data/ECV05H03.DTA', convert_categoricals=False)
+occ_rows = []
+for col, code in RESUMEN_TO_ITEM.items():
+    hh = R.loc[R[col] == 1, 'hogar']
+    for h in hh:
+        occ_rows.append((h, code))
+occ = pd.DataFrame(occ_rows, columns=['hogar', 'item'])
+occ['Experienced'] = True
+
+# --- DETALLE: impact + coping (already long) ------------------------------
+D = get_dataframe('../Data/ECV06H03.DTA', convert_categoricals=False)
+D = D[['hogar', 'item', 'perdida', 'accion']].copy()
+aff = D['perdida'].map(PERDIDA_AFFECTED)
+D['AffectedIncome'] = aff.map(lambda x: x[0] if isinstance(x, tuple) else pd.NA)
+D['AffectedAssets'] = aff.map(lambda x: x[1] if isinstance(x, tuple) else pd.NA)
+D['HowCoped0'] = D['accion'].map(COPING_LABELS)
+D = D.drop(columns=['perdida', 'accion'])
+
+# --- union of (hogar, item); DETALLE supplies impact/coping ---------------
+df = occ.merge(D, on=['hogar', 'item'], how='outer')
+# Any (hogar,item) only in DETALLE was still an experienced shock.
+df['Experienced'] = df['Experienced'].fillna(True).astype('boolean')
+
+df['Shock'] = df['item'].map(SHOCK_LABELS)
+df = df.dropna(subset=['Shock'])
+
+df['i'] = df['hogar'].apply(format_id)
+df['t'] = '2000'
+
+out = df[['t', 'i', 'Shock', 'Experienced',
+          'AffectedIncome', 'AffectedAssets', 'HowCoped0']].copy()
+out['AffectedIncome'] = out['AffectedIncome'].astype('boolean')
+out['AffectedAssets'] = out['AffectedAssets'].astype('boolean')
+out = out.set_index(['t', 'i', 'Shock']).sort_index()
+
+to_parquet(out, 'shocks.parquet')

--- a/lsms_library/countries/Guatemala/_/data_scheme.yml
+++ b/lsms_library/countries/Guatemala/_/data_scheme.yml
@@ -37,3 +37,33 @@ Data Scheme:
     Quantity: float
     Value: float
     Age: float
+
+  shocks:
+    # ENCOVI 2000 Capitulo 3 "Situaciones Adversas".  LONG form, one row per
+    # (household, experienced shock).  Built by 2000/_/shocks.py from two files:
+    #   ECV05H03 (RESUMEN) -- per-household si/no occurrence flags, two families
+    #     p03a01a..m (13 "general"/community events) + p03a06a..p (15
+    #     "particular"/household events) = 28 event types.
+    #   ECV06H03 (DETALLE) -- one row per (household, problem) with `item` (the
+    #     event code, aligned 1:1 with the RESUMEN columns), `perdida` (impact
+    #     type) and `accion` (the single coping action taken).
+    # `Shock` is the event mapped to an English label (28 types: Drought,
+    #   Floods, General price rise, Loss of harvest, Illness or serious
+    #   accident, ...).  The row set is the union of RESUMEN-experienced and
+    #   DETALLE (hh,item) pairs.
+    # `Experienced` (bool) is the RESUMEN occurrence flag (True for every row by
+    #   construction; follows the Liberia occurrence-flag precedent).
+    # AffectedIncome / AffectedAssets come from DETALLE.perdida (1=income,
+    #   2=assets/patrimonio, 3=both, 4=none).  ENCOVI's impact item distinguishes
+    #   income vs. assets ONLY -- there is NO production/consumption breakdown,
+    #   so the canonical AffectedProduction/AffectedConsumption columns are not
+    #   declared (DEVIATION from the canonical schema).
+    # HowCoped0 is DETALLE.accion mapped to English text.  ENCOVI records a
+    #   SINGLE coping action per problem (no up-to-3 battery), so HowCoped1/
+    #   HowCoped2 do not exist in this instrument and are omitted (DEVIATION).
+    index: (t, i, Shock)
+    Experienced: bool
+    AffectedIncome: bool
+    AffectedAssets: bool
+    HowCoped0: str
+    materialize: make

--- a/lsms_library/countries/Tajikistan/1999/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/1999/_/data_info.yml
@@ -95,3 +95,56 @@ individual_education:
                 7.0: doctor of science
                 8.0: other
                 9.0: none
+
+housing:
+    # SSEC2 Part 2A (structure) + Part 2B (tenure/toilet).  Value labels are
+    # stripped in the .dta; codes decoded from the household questionnaire
+    # (HH012007-00.pdf, Section 2).  Water (s2bq40) is distance-to-source in
+    # metres, not a source category, so it is omitted; Electricity (s2bq26) is
+    # hours/availability (values up to 500), not a clean indicator, omitted.
+    file:
+        - ../Data/SSEC2.DTA
+    idxvars:
+        v: pop_pt
+        i: [pop_pt, hhid]
+    myvars:
+        Tenure:
+            - s2bq1
+            - mapping:
+                1.0: owned
+                2.0: not owned
+        Walls:
+            - s2aq6
+            - mapping:
+                1.0: brick/stones
+                2.0: concrete plates
+                3.0: mud
+                4.0: wood, logs
+                5.0: other
+        Roof:
+            - s2aq7
+            - mapping:
+                1.0: slate
+                2.0: metal sheets
+                3.0: thatch
+                4.0: tiles
+                5.0: plastic on metal
+                6.0: mud
+                7.0: other
+        Floor:
+            - s2aq8
+            - mapping:
+                1.0: parquet
+                2.0: painted wood
+                3.0: linoleum
+                4.0: concrete
+                5.0: clay/earthen floor
+                6.0: other
+        Rooms: s2aq2
+        Toilet:
+            - s2bq22
+            - mapping:
+                1.0: flush toilet
+                2.0: latrine
+                3.0: other
+                4.0: no toilet

--- a/lsms_library/countries/Tajikistan/2007/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/2007/_/data_info.yml
@@ -82,3 +82,40 @@ individual_education:
         pid: memid
     myvars:
         Educational Attainment: m3bq5
+
+housing:
+    # Module 7: r1m7a (structure + tenure), r1m7b (electricity),
+    # r1m7c (water + toilet).  One row per hhid in each; merged on i.
+    # Source labels are already human-readable strings (verbatim pass-through).
+    dfs:
+        - df_a
+        - df_b
+        - df_c
+    df_a:
+        file: ../Data/r1m7a.dta
+        idxvars:
+            i: hhid
+        myvars:
+            Tenure: m7aq13
+            Walls: m7aq3
+            Roof: m7aq4
+            Floor: m7aq5
+            Rooms: m7aq9
+    df_b:
+        file: ../Data/r1m7b.dta
+        idxvars:
+            i: hhid
+        myvars:
+            Electricity: m7bq9
+    df_c:
+        file: ../Data/r1m7c.dta
+        idxvars:
+            i: hhid
+        myvars:
+            Water: m7cq1
+            Toilet: m7cq24
+    merge_on:
+        - i
+    final_index:
+        - i
+        - t

--- a/lsms_library/countries/Tajikistan/2009/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/2009/_/data_info.yml
@@ -82,3 +82,14 @@ individual_education:
         pid: MEMID
     myvars:
         Educational Attainment: M3BQ4
+
+housing:
+    # 2009 TLSS dropped the physical-structure block (no walls/roof/floor/
+    # rooms/tenure); Module 6 retained utilities only.  m6b M6BQ1 (main
+    # drinking-water source) is the one canonical housing column available.
+    # Source labels are already human-readable strings (verbatim pass-through).
+    file: ../Data/m6b.dta
+    idxvars:
+        i: HHID
+    myvars:
+        Water: M6BQ1

--- a/lsms_library/countries/Tajikistan/_/data_scheme.yml
+++ b/lsms_library/countries/Tajikistan/_/data_scheme.yml
@@ -35,6 +35,24 @@ Data Scheme:
     Region: str
     Rural: str
 
+  housing:
+    # TLSS dwelling module.  1999 (SSEC2) and 2007 (r1m7a/b/c) field a full
+    # structure+utilities block; 2009 (m6b) retained utilities only (the
+    # physical-structure block was dropped), so it contributes Water alone.
+    # 2003 (module6) is skipped: value labels are stripped in the repo .dta
+    # (codes only, no questionnaire in scope to decode them).
+    # 1999 omits Water (s2bq40 is distance-to-source in metres, not a source
+    # category) and Electricity (s2bq26 is hours/availability, not boolean).
+    index: (t, i)
+    Tenure: str
+    Walls: str
+    Roof: str
+    Floor: str
+    Rooms: int
+    Toilet: str
+    Water: str
+    Electricity: str
+
   household_roster:
     index: (t, i, pid)
     Sex: str


### PR DESCRIPTION
Wires the three features that the #350/#352 verification sweep found were **wrongly triaged "absent"** — the data was in-repo all along. Fixing the gaps rather than documenting false absences.

### Features
- **Guatemala `shocks`** (#352) — ENCOVI 2000 Ch.3 "Situaciones Adversas" (`ECV05H03` + `ECV06H03`): 28 event types → `(t,i,Shock)` with `AffectedIncome`/`AffectedAssets` (from `perdida`) + `HowCoped0` (from `accion`). **11,752 rows.** Documented deviations: no production/consumption breakdown, single coping action.
- **GhanaLSS `housing`** (#350) — GLSS §7 across 5 waves (1991-92, 1998-99, 2005-06, 2012-13, 2016-17): Roof/Floor/Walls/Water/Toilet/Rooms/Tenure/Electricity. **49,994 rows.** Early waves (1991-92, 1998-99) decoded from the GLSS3/GLSS4 questionnaires (no value labels in the `.dta`); 1987-88/1988-89 skipped (scanned-image questionnaires, no decodable codebook).
- **Tajikistan `housing`** (#350) — TLSS 1999 `SSEC2` + 2007 `r1m7a/b/c` (dfs-merge) + 2009 `m6b` (Water only). **8,146 rows.** 2003 skipped (value labels stripped in the repo `.dta`).

### Bug fix
- **`fix(GhanaLSS)` closes #372** — 1991-92 `household_roster` raised `KeyError('1')` because `Birthplace`/`Region` used `region_dict[key]` while the GhanaLSS `region` mapping table resolves empty for that wave. Switched to the tolerant `region_dict.get(key, pd.NA)` (already used by `strata()` in the same file). The roster (20,403 rows) and its derived tables now build; the 1991-92 plot-feature orphans are resolved.

All features verified from a **cold cache** with `is_this_feature_sane` (all `ok`). Doc note: 1991-92 `Birthplace`/`Region` are NA pending a GLSS3 region codebook — see follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
