### PR TITLE
fix(Senegal): resolve food_acquired u code-'1' anomaly (#223 Layer 2)

### DIFF
--- a/lsms_library/countries/Senegal/_/categorical_mapping.org
+++ b/lsms_library/countries/Senegal/_/categorical_mapping.org
@@ -326,7 +326,7 @@
 #+NAME: u
 | Original Label                       | Preferred Label        |
 |--------------------------------------+------------------------|
-| 1.0                                  | 1.0                    |
+| 1.0                                  | NA                     |
 | 100. kg                              | Kg                     |
 | 1000. Bouteille de 20 litres         | Bouteille de 20 L      |
 | 1001. 12,5 cl (démi walatt)          | Demi walatt            |

--- a/tests/test_u_code_leak.py
+++ b/tests/test_u_code_leak.py
@@ -75,8 +75,9 @@ _KNOWN_CLEAN = ["Mali", "Niger", "CotedIvoire", "Guinea-Bissau"]
 #   Togo      25 -> 4 (EHCVM codebook decode; residual 114/659/660/662)
 #   Burkina   22 -> 2 (EHCVM codebook decode; residual 254/255)
 #   Nigeria   32 -> 3 (codes decoded from WB .dta labels; residual 131/151/152)
+#   Senegal    1 -> 0 (code '1' data-entry anomaly, 2 rows -> u='NA')
 # Residual codes have no label in any source .dta. Still dirty:
-# Senegal (code '1', unresolved), Malawi, GhanaLSS, EthiopiaRHS.
+# Malawi, GhanaLSS, EthiopiaRHS.
 
 
 def test_clean_countries_have_no_u_code_leaks():


### PR DESCRIPTION
## Summary

Senegal's `s07bq03b` had a data-entry anomaly: **code 1** (not a valid EHCVM unit — those start at 100) in **2 rows of 214,528**, food item 71, with **no value label** in the source `.dta`. Its `#+name:u` table carried an identity row `1.0 → 1.0` that preserved the bare code as a fake unit, leaking it into `food_acquired` `u`.

Map code 1 → **`NA`** (unit unrecoverable) instead.

## Effect (NO_CACHE rebuild)

- Senegal code leaks **1 → 0**; the 2 rows now carry `u='NA'`.
- `food_quantities` kg-resolution **100%** (no regression).

Regression: schema + food + u-leak = **221 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)