### PR TITLE
fix(Malawi): tidy other-specify free-text units + collapse label case-dupes (#223 Layer 2)

### DIFF
--- a/lsms_library/countries/Malawi/2010-11/_/food_acquired.py
+++ b/lsms_library/countries/Malawi/2010-11/_/food_acquired.py
@@ -21,7 +21,7 @@ sys.path.append('../../_/')
 import pandas as pd
 import numpy as np
 from malawi import (conversion_table_matching, food_acquired_to_canonical,
-                    normalize_food_label)
+                    normalize_food_label, _clean_freetext_unit)
 
 wave = "2010-11"
 
@@ -112,6 +112,9 @@ for src in ('consumed', 'bought', 'produced', 'gifted'):
                                x[c] or f, axis=1)
     # Apply conversion factor (NaN cfactor -> identity).
     df[quant_col] = df[quant_col].mul(df[cfactor_col].fillna(1))
+    # Tidy the other-specify free text for use as a `u` label (after the
+    # grams/kg parse above): "1 Basket" -> "Basket" (GH #223 Layer 2).
+    df[detail_col] = df[detail_col].map(_clean_freetext_unit)
     # Canonical unit string: 'kg' if a cfactor was applied, else the
     # raw unit-detail text, falling back to the unitcode if absent.
     df[u_col] = np.where(~df[cfactor_col].isna(), 'kg', df[detail_col])

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -11,6 +11,7 @@ food_prices_quantities_and_expenditures.py — see GH #218.
 
 import pandas as pd
 import numpy as np
+import re
 import sys
 sys.path.append('../../../_/')
 from lsms_library.local_tools import conversion_table_matching_global, format_id
@@ -29,6 +30,51 @@ def _extract_kg_conversion(series):
     conv = pd.concat([lower.str.extract(grams).astype(float) * 0.01,
                       lower.str.extract(kgs).astype(float)], axis=0).dropna()
     return conv
+
+
+def _clean_freetext_unit(value):
+    """Tidy a respondent other-specify unit string (GH #223 Layer 2).
+
+    These are free text like ``'1 BASKET'``, ``'1 NSIMA PLATE (PHAZI)'``,
+    ``'1/4'``.  Strip a *leading quantity* (``'1 BASKET'`` -> ``'Basket'``)
+    so the residual is a unit name with a chance of matching; title-case for
+    consistency; a bare quantity with no unit (``'1/4'``, ``'0.5'``) -> NA.
+    Only ever applied to the genuine other-specify column, never to standard
+    or sized labels (``'50 Kg Bag'``), so no legitimate size is dropped.
+    """
+    if pd.isna(value):
+        return value
+    s = str(value).strip()
+    if s.lower() in ('nan', ''):
+        return pd.NA
+    # Pure quantity + metric magnitude ('10Kgs', '149G', '5 kg') -> that unit.
+    _MAG = {'kg': 'Kg', 'kgs': 'Kg', 'kilogram': 'Kg', 'kilograms': 'Kg',
+            'g': 'Gram', 'gram': 'Gram', 'grams': 'Gram',
+            'ml': 'Millilitre', 'mls': 'Millilitre',
+            'millilitre': 'Millilitre', 'millilitres': 'Millilitre',
+            'l': 'Litre', 'ls': 'Litre', 'litre': 'Litre', 'litres': 'Litre'}
+    m = re.fullmatch(r'\d+(?:[.,/]\d+)?\s*([a-z]+)', s, flags=re.I)
+    if m and m.group(1).lower() in _MAG:
+        return _MAG[m.group(1).lower()]
+    # Otherwise strip a leading "N " (with an optional metric magnitude before
+    # the space, so '10G Packet'/'10Kg Pail' -> 'Packet'/'Pail').
+    s = re.sub(r'^\s*\d+(?:[.,/]\d+)?\s*(?:kgs?|g|mls?|l|litres?)?\s+', '',
+               s, flags=re.I).strip()
+    if (not s) or re.fullmatch(r'[\d.,/]+', s):           # bare quantity, no unit
+        return pd.NA
+    return s.title()
+
+
+def _titlecase_label(value):
+    """Title-case a unit label so case-variants collapse (``'PIECE'`` ->
+    ``'Piece'``); leaves the lowercase ``'kg'`` sentinel and sized labels
+    (no leading number is stripped here) intact."""
+    if pd.isna(value):
+        return value
+    s = str(value).strip()
+    if s.lower() in ('nan', ''):
+        return pd.NA
+    return s.title()
 
 
 def handling_unusual_units(df, suffixes=None):
@@ -56,12 +102,19 @@ def handling_unusual_units(df, suffixes=None):
         if detail_col not in df.columns:
             continue
 
-        conv_kg = _extract_kg_conversion(df[detail_col])
+        conv_kg = _extract_kg_conversion(df[detail_col])  # parse "300 grams" first
+
+        # Tidy the other-specify free text for use as a `u` label (after the
+        # kg parse above): "1 Basket" -> "Basket", "1/4" -> NA (#223 Layer 2).
+        df[detail_col] = df[detail_col].map(_clean_freetext_unit)
 
         df[cfactor_col] = df.apply(lambda x, c=cfactor_col: x[c] or conv_kg, axis=1)
         df[quantity_col] = df[quantity_col].mul(df[cfactor_col].fillna(1))
         df[u_col] = np.where(~df[cfactor_col].isna(), 'kg', df[detail_col])
-        df[u_col] = df[u_col].replace('nan', pd.NA).fillna(df[units_col])
+        # Fallback to the standard label, title-cased so 'PIECE'/'Piece'
+        # collapse; the 'kg' sentinel above is untouched.
+        df[u_col] = df[u_col].replace('nan', pd.NA).fillna(
+            df[units_col].map(_titlecase_label))
 
     return df
 


### PR DESCRIPTION
## Summary

Malawi's `food_acquired` `u` mixed three things: standard labels, bare unit codes, and **respondent other-specify free text** (`1 BASKET`, `1 NSIMA PLATE (PHAZI)`, `10G Packet`). The free text leaked as pseudo-codes (leading digit), and the newer waves' uppercasing produced **case-dupes** (`PIECE`/`Piece`, `KG`/`Kg`, `LITRE`/`Litre`).

This PR handles the **free-text + case-dupe** halves (the code-table normalization is a follow-up):

- **`_clean_freetext_unit`** — strip a leading quantity from the other-specify text (`1 Basket`→`Basket`, `10G Packet`→`Packet`), map a pure quantity+magnitude to that unit (`10Kgs`→`Kg`, `149G`→`Gram`), and a bare quantity with no unit (`1/4`, `0.5`)→NA. Applied **only** to the genuine other-specify column — never standard/sized labels like `50 kg Bag` — and **after** the `"300 grams"` kg-parse, so conversions are unaffected. The reserved `kg` sentinel is preserved.
- **`_titlecase_label`** — title-case the standard-label fallback so `PIECE`/`Piece` etc. collapse, leaving `kg` untouched.
- Wired into `handling_unusual_units` (2016-17/2019-20) and the 2010-11 inline unit loop.

## Effect (NO_CACHE rebuild)

| metric | before | after |
|---|---|---|
| code-ish leaks | 217 | **131** |
| case-dupes | 34 | **4** |
| food_quantities kg-resolved | 99.9% | 99.9% |

Residual leaks are **bare unit codes** (a `#+name:u` table case-mismatch + completeness — the "normalize codes" follow-up) and a few **glued** free-text strings (`10Gpacket`). Regression: schema + food + u-leak = **221 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)