### PR TITLE
fix(GhanaLSS): tolerate NaN food codes in 2016-17 food_acquired (KeyError: None)

### DIFF
--- a/lsms_library/countries/GhanaLSS/2016-17/_/food_acquired.py
+++ b/lsms_library/countries/GhanaLSS/2016-17/_/food_acquired.py
@@ -15,7 +15,7 @@ unitsd = defaultdict(lambda:pd.NA,get_categorical_mapping(tablename='units'))
 # food expenditure
 idxvars = dict(i=(['clust','nh'],lambda x: format_id(x.clust)+'/'+format_id(x.nh,zeropadding=2)),
                w=('nh',lambda x: w),
-               j=('freqcd',lambda x: labelsd[format_id(x)]))
+               j=('freqcd',lambda x: labelsd.get(format_id(x), '')))
 
 myvars = dict()
 # Iterate over visits
@@ -48,7 +48,7 @@ labelsd = get_categorical_mapping(tablename='harmonize_food',idxvars={'Code':('C
 # food quantities
 idxvars = dict(i=(['clust','nh'],lambda x: format_id(x.clust)+'/'+format_id(x.nh,zeropadding=2)),
                w=('nh',lambda x: w),
-               j=('foodcd',lambda x: labelsd[format_id(x)]))
+               j=('foodcd',lambda x: labelsd.get(format_id(x), '')))
 
 myvars = {}
 # Iterate over visits


### PR DESCRIPTION
`Feature('food_expenditures')()` crashed on GhanaLSS: `g7sec8h`/`g7sec9b` have rows with NaN `foodcd`/`freqcd`, `format_id(NaN)=None`, and `labelsd[None]` raised `KeyError` — aborting the 2016-17 wave build and failing `Country('GhanaLSS').food_expenditures()` with a `CalledProcessError`.

Fix: `labelsd.get(format_id(x), '')` on both lookups, so the existing `df[df['j'] != '']` filter drops the blank-code rows. All 67/484 real codes still map; only the NaN blanks fall through. GhanaLSS `food_expenditures` now builds (461k rows) instead of crashing.

**Scope note:** this fixes only the *crash*. 2016-17 still emits 0 rows due to a **separate** empty-`units`-map bug (every unit → `<NA>` → `groupby(['…','u'])` drops all rows), and `food_expenditures` covers only 2012-13 of 6 waves — both tracked in #384 (likely entangled with the in-flight #223 u-codes work; deliberately not patched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)