### PR TITLE
fix(Liberia): shocks — keep only experienced events, drop redundant Experienced column

### DIFF
--- a/lsms_library/countries/Liberia/2018-19/_/mapping.py
+++ b/lsms_library/countries/Liberia/2018-19/_/mapping.py
@@ -11,3 +11,20 @@ def Age(value):
         return float(value)
     except (ValueError, TypeError):
         return np.nan
+
+
+def shocks(df):
+    '''Keep only experienced shocks; drop the redundant Experienced flag.
+
+    NHFS Section 17 enumerates all 14 shock types for every household
+    (S17_1 = "severely negatively affected in the past 12 months", yes/no),
+    producing a full household x shock-type cross-product (~40k rows, mostly
+    not-experienced placeholders).  In the canonical (t, i, Shock) table a row
+    exists only for a shock the household actually experienced, so filter to
+    Experienced == True and drop the column: its information is carried by the
+    row's existence, it would otherwise be a constant-True column, and as a
+    bool it is silently nulled on the cached-read path (GH #386) -- which is
+    what made this wave's row count collapse from cache.
+    '''
+    df = df[df['Experienced'] == True]
+    return df.drop(columns='Experienced')

--- a/lsms_library/countries/Liberia/_/data_scheme.yml
+++ b/lsms_library/countries/Liberia/_/data_scheme.yml
@@ -47,17 +47,19 @@ Data Scheme:
 
   shocks:
     # 2018-19 Section 17 (National Household Forest Survey). LONG form: one
-    # row per (household, shock-type). `Shock` is the shock_name label (14
-    # types: drought, floods, food-price rise, death, illness, crop pests,
-    # ...). `Experienced` is S17_1 ("severely negatively affected in the past
-    # 12 months", yes/no). This forest-survey instrument has NO income/asset/
+    # row per (household, EXPERIENCED shock-type). `Shock` is the shock_name
+    # label (14 types: drought, floods, food-price rise, death, illness, crop
+    # pests, ...). The NHFS enumerates all 14 types per HH with S17_1
+    # ("severely negatively affected in the past 12 months", yes/no); the
+    # mapping.py `shocks` post-processor keeps only S17_1==yes and drops the
+    # redundant Experienced flag (a row's existence conveys it, matching the
+    # other countries). This forest-survey instrument has NO income/asset/
     # production/consumption impact breakdown, so the canonical Affected*
     # columns are omitted. Coping is forest-specific: HowCoped0/1/2 are the
     # first/second/third forest products the household collected to recover
     # (S17_5_A/B/C); only populated for the ~38% of experienced shocks where
     # forest products were used (S17_4=yes).
     index: (t, i, Shock)
-    Experienced: bool
     HowCoped0: str
     HowCoped1: str
     HowCoped2: str


### PR DESCRIPTION
NHFS §17 enumerates all 14 shock types per household (S17_1 yes/no), so Liberia `shocks` emitted the full HH×shock **cross-product (~40,796 rows)** — mostly not-experienced placeholders. In the canonical `(t,i,Shock)` table a row should exist only for an *experienced* shock (its existence conveys 'experienced'), making the `Experienced` flag redundant.

Fix: a `mapping.py` `shocks()` post-processor filters `S17_1==yes` and drops the column. Result: **1,358 experienced events**, columns `[HowCoped0/1/2]`, `is_this_feature_sane` clean (the constant-column warn is gone too).

Side benefit: this removes the `bool` column that **#386** was silently nulling on the cached-read path — which had collapsed this wave from 40,796 → 1,379 rows depending on cache state. Cached and no-cache builds now agree (1,358 == 1,358).

Found during the 2026-06-07 feature-audit follow-up.