### PR TITLE
fix(country): bool columns wiped to null on cached path — route through _coerce_to_boolean (closes #386)

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -3295,7 +3295,12 @@ def _enforce_declared_dtypes(df: pd.DataFrame, scheme_entry: dict[str, Any]) -> 
                     # Round before casting so float values (e.g. 59.41 from
                     # age_handler) survive the safe-cast check.
                     df[col] = pd.to_numeric(df[col], errors='coerce').round().astype(target)
-                elif target in (pd.Float64Dtype(), pd.BooleanDtype()):
+                elif target == pd.BooleanDtype():
+                    # NOT pd.to_numeric: cached parquets store bools as the
+                    # strings 'True'/'False', and pd.to_numeric('True') -> NaN
+                    # would silently wipe every value (GH #386).
+                    df[col] = _coerce_to_boolean(df[col])
+                elif target == pd.Float64Dtype():
                     df[col] = pd.to_numeric(df[col], errors='coerce').astype(target)
                 else:
                     df[col] = df[col].astype(target)
@@ -3353,7 +3358,12 @@ def _enforce_canonical_dtypes(df: pd.DataFrame, method_name: str) -> None:
                 # age_handler's date-arithmetic path) survive the safe-cast
                 # check in pandas' IntegerArray.__from_sequence__.
                 df[col] = pd.to_numeric(df[col], errors='coerce').round().astype(target)
-            elif target in (pd.Float64Dtype(), pd.BooleanDtype()):
+            elif target == pd.BooleanDtype():
+                # NOT pd.to_numeric: cached parquets store bools as the strings
+                # 'True'/'False', and pd.to_numeric('True') -> NaN would
+                # silently wipe every value (GH #386).
+                df[col] = _coerce_to_boolean(df[col])
+            elif target == pd.Float64Dtype():
                 df[col] = pd.to_numeric(df[col], errors='coerce').astype(target)
             else:
                 df[col] = df[col].astype(target)


### PR DESCRIPTION
**The flagship finding of the 2026-06-07 audit.** `_enforce_declared_dtypes`/`_enforce_canonical_dtypes` ran `BooleanDtype` columns through `pd.to_numeric(errors='coerce')`. Cached parquets store bools as strings `'True'`/`'False'`, and `pd.to_numeric('True')`→`NaN` — so **every bool-declared feature column was silently null on the default (cached) read path**: `food_security` FIES items, `shocks` `Affected*`, `plot_features.Irrigated`, …

The correct `_coerce_to_boolean()` helper (with `_STR_TO_BOOL`) already existed but was **dead code**. This routes the `BooleanDtype` branch through it at both sites; `Float64` stays on `to_numeric`.

**Verified (cached path):** Benin food_security 0/8011→~7990; Benin/Tanzania shocks `Affected*` 0→full; Cambodia `Irrigated` full; all `is_this_feature_sane` ok; Tanzania cached==no-cache (60,463, unique index). `test_age_dtype_consistency`+`test_schema_consistency`: 64 passed, 4 skipped.