### PR TITLE
fix(Nigeria): drop unsupported compression= kwarg from nonfood_expenditures (closes #388)

### DIFF
--- a/lsms_library/countries/Nigeria/2010-11/_/nonfood_expenditures.py
+++ b/lsms_library/countries/Nigeria/2010-11/_/nonfood_expenditures.py
@@ -71,4 +71,4 @@ x = x.set_index(['j','t','m','i'])
 
 x = x['value'].unstack('i')
 
-to_parquet(x, 'nonfood_expenditures.parquet',compression='gzip')
+to_parquet(x, 'nonfood_expenditures.parquet')

--- a/lsms_library/countries/Nigeria/2012-13/_/nonfood_expenditures.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/nonfood_expenditures.py
@@ -71,4 +71,4 @@ x = x.set_index(['j','t','m','i'])
 
 x = x['value'].unstack('i')
 
-to_parquet(x, 'nonfood_expenditures.parquet',compression='gzip')
+to_parquet(x, 'nonfood_expenditures.parquet')

--- a/lsms_library/countries/Nigeria/2015-16/_/nonfood_expenditures.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/nonfood_expenditures.py
@@ -69,4 +69,4 @@ x = x.set_index(['j','t','m','i'])
 
 x = x['value'].unstack('i')
 
-to_parquet(x, 'nonfood_expenditures.parquet',compression='gzip')
+to_parquet(x, 'nonfood_expenditures.parquet')

--- a/lsms_library/countries/Nigeria/2018-19/_/nonfood_expenditures.py
+++ b/lsms_library/countries/Nigeria/2018-19/_/nonfood_expenditures.py
@@ -68,4 +68,4 @@ x = x.set_index(['j','t','m','i'])
 
 x = x['value'].unstack('i')
 
-to_parquet(x, 'nonfood_expenditures.parquet',compression='gzip')
+to_parquet(x, 'nonfood_expenditures.parquet')


### PR DESCRIPTION
Removes `compression='gzip'` (unsupported by `local_tools.to_parquet`) from the 4 wave scripts. Build-verified: `Country('Nigeria').nonfood_expenditures()` builds, 38,255 rows, is_this_feature_sane ok. Worktree-delegated; coordinator build-verified.