### PR TITLE
fix(Uganda): declare earnings column as 'Earnings' to match wave output (closes #389)

### DIFF
--- a/lsms_library/countries/Uganda/_/data_scheme.yml
+++ b/lsms_library/countries/Uganda/_/data_scheme.yml
@@ -41,7 +41,7 @@ Data Scheme:
   earnings:
     materialize: make
     index: (t, i)
-    earnings: float
+    Earnings: float
   food_acquired:
     # Canonical post-2026-05-05 (GH #169): s in {purchased, produced, inkind}.
     # Wave scripts call uganda.food_acquired (wide form, source-suffixed


### PR DESCRIPTION
Wave scripts emit `Earnings`; data_scheme declared lowercase `earnings` → declared_columns_present failed. Align the declaration. Build-verified: `Country('Uganda').earnings()` columns=['Earnings'], is_this_feature_sane ok. Worktree-delegated; coordinator build-verified.