### PR TITLE
fix(Albania): globally-unique roster i for 2002/2005 so v-join works (closes #340)

### DIFF
--- a/lsms_library/countries/Albania/2002/_/data_info.yml
+++ b/lsms_library/countries/Albania/2002/_/data_info.yml
@@ -11,12 +11,18 @@ cluster_features:
         Rural: m0_ur
 
 household_roster:
+    # i=[psu,hh] -> composite via mapping.py:i() ('psu-hh') to match sample()'s
+    # household identity, so _join_v_from_sample resolves v.  Bare i=hh keyed on
+    # the within-cluster household number (only ~14 distinct), which collapsed
+    # the roster and broke the v-join (sample's i is the composite psu-hh; the
+    # within-cluster number is unique only inside a PSU).  v is NOT declared
+    # here -- the framework joins it from sample() (the 2004 / interview_date
+    # idiom).  See GH #340, CONTENTS.org.
     file:
         - ../Data/hhroster_cl.dta
 
     idxvars:
-        v: psu
-        i: hh
+        i: [psu, hh]
         pid: m1_q00
 
     myvars:

--- a/lsms_library/countries/Albania/2005/_/data_info.yml
+++ b/lsms_library/countries/Albania/2005/_/data_info.yml
@@ -21,12 +21,18 @@ cluster_features:
         Rural: m0_ur
 
 household_roster:
+    # i=[m0_q00,m0_q01] -> composite via mapping.py:i() ('m0_q00-m0_q01') to
+    # match sample()'s household identity, so _join_v_from_sample resolves v.
+    # Bare i=m0_q01 keyed on the within-cluster household number (only ~12
+    # distinct), which collapsed the roster and broke the v-join (sample's i is
+    # the composite m0_q00-m0_q01; the within-cluster number is unique only
+    # inside a PSU).  v is NOT declared here -- the framework joins it from
+    # sample() (the 2004 / interview_date idiom).  See GH #340, CONTENTS.org.
     file:
         - ../Data/household_rosterA_cl.dta
 
     idxvars:
-        v: m0_q00
-        i: m0_q01
+        i: [m0_q00, m0_q01]
         pid: m1a_q00
 
     myvars:

--- a/lsms_library/countries/Albania/_/CONTENTS.org
+++ b/lsms_library/countries/Albania/_/CONTENTS.org
@@ -2,14 +2,15 @@
 
 * Known issues
 
-** household_roster 2002 & 2005 collapse to the within-cluster id (BROKEN)
+** household_roster 2002 & 2005 collapsed to the within-cluster id (RESOLVED)
    :PROPERTIES:
    :Discovered: 2026-06-06
+   :Resolved:   2026-06-07 (GH #340)
    :Affects: household_roster (2002, 2005) and everything derived from it
              (household_characteristics, demands), plus the v / weight join
    :END:
 
-The 2002 and 2005 ~household_roster~ blocks key the household index ~i~ on the
+The 2002 and 2005 ~household_roster~ blocks keyed the household index ~i~ on the
 *within-cluster* household number, not the canonical household identity:
 
 - 2002 ~data_info.yml~: ~i: hh~  (hh is 1..N within a PSU; only 14 distinct values)
@@ -19,8 +20,10 @@ But ~sample()~ builds the canonical household id as the *composite*
 ~format_id(psu) + '-' + format_id(hh)~ (2002) / ~format_id(m0_q00) + '-' +
 format_id(m0_q01)~ (2005) — e.g. ~'1-2'~, 3599 households in 2002.
 
-Consequences (observed 2026-06-06 via ~Country('Albania').household_roster()~,
-~LSMS_NO_CACHE=1~):
+Consequence (observed 2026-06-06 via ~Country('Albania').household_roster()~,
+~LSMS_NO_CACHE=1~): 2002/2005 rosters collapsed to ~12–14 "households" and got
+NO ~v~ from ~_join_v_from_sample()~ (their ~i~ didn't match the sample spine).
+2004 was fine.
 
 | wave | persons | unique hh | v joined? | expected hh |
 |------+---------+-----------+-----------+-------------|
@@ -28,14 +31,12 @@ Consequences (observed 2026-06-06 via ~Country('Albania').household_roster()~,
 | 2004 |    8025 |      1898 | yes       | ok          |
 | 2005 |     140 |        12 | no        | ~3840       |
 
-So 2002/2005 rosters are collapsed to ~12–14 "households" and get NO ~v~ from
-~_join_v_from_sample()~ (their ~i~ doesn't match the sample spine).  2004 is fine.
-
-*Fix*: change the 2002/2005 ~household_roster~ ~idxvars~ to the composite
-(add an ~i()~ to each wave's ~mapping.py~ that returns ~format_id(psu)-format_id(hh)~
-/ ~format_id(m0_q00)-format_id(m0_q01)~, and set ~i: [psu, hh]~ / ~i: [m0_q00, m0_q01]~),
-mirroring what ~sample.py~ / the 2005 ~mapping.py:i()~ already do.  This is the
-same fix already applied to ~interview_date~ in those waves (see their
-~data_info.yml~), which keys on the composite and matches sample at 0% orphans.
+*Fix (2026-06-07)*: changed the 2002/2005 ~household_roster~ ~idxvars~ to the
+composite — ~i: [psu, hh]~ / ~i: [m0_q00, m0_q01]~ — which the framework wires to
+each wave's existing ~mapping.py:i()~ (returns ~format_id(...)-format_id(...)~,
+identical to ~sample.py~).  Also dropped the roster's bare ~v: psu~ / ~v: m0_q00~
+so ~_join_v_from_sample()~ fires (it short-circuits when ~v~ is already present).
+This is the 2004 / ~interview_date~ / ~subjective_well_being~ idiom (composite ~i~,
+no ~v~ declared) which matches sample at 0% orphans.
 
 Tracked in GitHub issue #340.


### PR DESCRIPTION
2002/2005 roster keyed the within-PSU household number while sample() builds a composite i → v-join zero-matched → 100% NaN v → rows silently dropped. Fix: roster i: [psu, hh] / [m0_q00, m0_q01] (+ drop bare v so _join_v_from_sample fires). Build-verified: 2002 3599 uniq i ('psu-hh'), 2005 3840, v 100% non-null, household_characteristics regains 2002/2005, is_this_feature_sane ok. Worktree-delegated; coordinator build-verified.