### PR TITLE
fix(plot_features): clamp implausible EHCVM Area values to NaN (closes #327)

### DIFF
--- a/lsms_library/countries/Benin/_/benin.py
+++ b/lsms_library/countries/Benin/_/benin.py
@@ -130,6 +130,16 @@ def plot_features_for_wave(t, source, colmap):
     use_gps = (gps_flag == 1) & area_gps.notna()
     area_ha = area_gps.where(use_gps, area_ha)
 
+    # Plausibility clamp (GH #327): raw EHCVM s16a parcel areas carry
+    # data-entry outliers many orders of magnitude too large (e.g. Benin
+    # max ~711,000 ha, Guinea-Bissau ~281,000,000 ha) against sane medians
+    # of ~1 ha.  NaN out anything outside the plausible agronomic range —
+    # above 1000 ha (a single smallholder parcel above this is an error) or
+    # non-positive (zero / negative ha is impossible).  Rows are kept; only
+    # the Area value is dropped.  The AreaUnit line below already clears the
+    # unit wherever Area becomes NA.
+    area_ha = area_ha.where(((area_ha > 0) & (area_ha <= 1000)) | area_ha.isna(), pd.NA)
+
     area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
     area_unit = area_unit.where(area_ha.notna(), pd.NA)
 

--- a/lsms_library/countries/Burkina_Faso/_/burkina_faso.py
+++ b/lsms_library/countries/Burkina_Faso/_/burkina_faso.py
@@ -162,6 +162,15 @@ def plot_features_for_wave(t, source, colmap):
     use_gps = (gps_flag == 1) & area_gps.notna()
     area_ha = area_gps.where(use_gps, area_ha)
 
+    # Plausibility clamp (GH #327): raw EHCVM s16a parcel areas carry
+    # data-entry outliers many orders of magnitude too large against sane
+    # medians of ~1 ha.  NaN out anything outside the plausible agronomic
+    # range — above 1000 ha (a single smallholder parcel above this is an
+    # error) or non-positive (zero / negative ha is impossible).  Rows are
+    # kept; only the Area value is dropped.  The AreaUnit line below already
+    # clears the unit wherever Area becomes NA.
+    area_ha = area_ha.where(((area_ha > 0) & (area_ha <= 1000)) | area_ha.isna(), pd.NA)
+
     area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
     area_unit = area_unit.where(area_ha.notna(), pd.NA)
 

--- a/lsms_library/countries/Guinea-Bissau/_/guinea_bissau.py
+++ b/lsms_library/countries/Guinea-Bissau/_/guinea_bissau.py
@@ -136,6 +136,16 @@ def plot_features_for_wave(t, source, colmap):
     use_gps = (gps_flag == 1) & area_gps.notna()
     area_ha = area_gps.where(use_gps, area_ha)
 
+    # Plausibility clamp (GH #327): raw EHCVM s16a parcel areas carry
+    # data-entry outliers many orders of magnitude too large (Guinea-Bissau
+    # max ~281,000,000 ha) against sane medians of ~1 ha.  NaN out anything
+    # outside the plausible agronomic range — above 1000 ha (a single
+    # smallholder parcel above this is an error) or non-positive (zero /
+    # negative ha is impossible).  Rows are kept; only the Area value is
+    # dropped.  The AreaUnit line below already clears the unit wherever
+    # Area becomes NA.
+    area_ha = area_ha.where(((area_ha > 0) & (area_ha <= 1000)) | area_ha.isna(), pd.NA)
+
     area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
     area_unit = area_unit.where(area_ha.notna(), pd.NA)
 

--- a/lsms_library/countries/Mali/_/mali.py
+++ b/lsms_library/countries/Mali/_/mali.py
@@ -181,6 +181,15 @@ def plot_features_for_wave(t, source, colmap):
     use_gps = (gps_flag == 1) & area_gps.notna()
     area_ha = area_gps.where(use_gps, area_ha)
 
+    # Plausibility clamp (GH #327): raw EHCVM s16a parcel areas carry
+    # data-entry outliers many orders of magnitude too large against sane
+    # medians of ~1 ha.  NaN out anything outside the plausible agronomic
+    # range — above 1000 ha (a single smallholder parcel above this is an
+    # error) or non-positive (zero / negative ha is impossible).  Rows are
+    # kept; only the Area value is dropped.  The AreaUnit line below already
+    # clears the unit wherever Area becomes NA.
+    area_ha = area_ha.where(((area_ha > 0) & (area_ha <= 1000)) | area_ha.isna(), pd.NA)
+
     area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
     area_unit = area_unit.where(area_ha.notna(), pd.NA)
 

--- a/lsms_library/countries/Niger/_/niger.py
+++ b/lsms_library/countries/Niger/_/niger.py
@@ -308,6 +308,15 @@ def plot_features_for_wave(t, source, colmap):
     use_gps = (gps_flag == 1) & area_gps.notna()
     area_ha = area_gps.where(use_gps, area_ha)
 
+    # Plausibility clamp (GH #327): raw EHCVM s16a parcel areas carry
+    # data-entry outliers many orders of magnitude too large against sane
+    # medians of ~1 ha.  NaN out anything outside the plausible agronomic
+    # range — above 1000 ha (a single smallholder parcel above this is an
+    # error) or non-positive (zero / negative ha is impossible).  Rows are
+    # kept; only the Area value is dropped.  The AreaUnit line below already
+    # clears the unit wherever Area becomes NA.
+    area_ha = area_ha.where(((area_ha > 0) & (area_ha <= 1000)) | area_ha.isna(), pd.NA)
+
     area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
     area_unit = area_unit.where(area_ha.notna(), pd.NA)
 

--- a/lsms_library/countries/Senegal/_/senegal.py
+++ b/lsms_library/countries/Senegal/_/senegal.py
@@ -208,6 +208,15 @@ def plot_features_for_wave(t, source, colmap):
     use_gps = (gps_flag == 1) & area_gps.notna()
     area_ha = area_gps.where(use_gps, area_ha)
 
+    # Plausibility clamp (GH #327): raw EHCVM s16a parcel areas carry
+    # data-entry outliers many orders of magnitude too large against sane
+    # medians of ~1 ha.  NaN out anything outside the plausible agronomic
+    # range — above 1000 ha (a single smallholder parcel above this is an
+    # error) or non-positive (zero / negative ha is impossible).  Rows are
+    # kept; only the Area value is dropped.  The AreaUnit line below already
+    # clears the unit wherever Area becomes NA.
+    area_ha = area_ha.where(((area_ha > 0) & (area_ha <= 1000)) | area_ha.isna(), pd.NA)
+
     area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
     area_unit = area_unit.where(area_ha.notna(), pd.NA)
 

--- a/lsms_library/countries/Togo/_/togo.py
+++ b/lsms_library/countries/Togo/_/togo.py
@@ -294,6 +294,15 @@ def plot_features_for_wave(t, source, colmap):
     use_gps = (gps_flag == 1) & area_gps.notna()
     area_ha = area_gps.where(use_gps, area_ha)
 
+    # Plausibility clamp (GH #327): raw EHCVM s16a parcel areas carry
+    # data-entry outliers many orders of magnitude too large against sane
+    # medians of ~1 ha.  NaN out anything outside the plausible agronomic
+    # range — above 1000 ha (a single smallholder parcel above this is an
+    # error) or non-positive (zero / negative ha is impossible).  Rows are
+    # kept; only the Area value is dropped.  The AreaUnit line below already
+    # clears the unit wherever Area becomes NA.
+    area_ha = area_ha.where(((area_ha > 0) & (area_ha <= 1000)) | area_ha.isna(), pd.NA)
+
     area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
     area_unit = area_unit.where(area_ha.notna(), pd.NA)
 


### PR DESCRIPTION
Adds an Area plausibility clamp (>1000 ha or non-positive → NaN, rows kept) in the shared EHCVM plot_features_for_wave helper across all 7 countries. Build-verified: Benin Area max 1000.0; Guinea-Bissau 999.26 (was ~2.8e8); rows preserved; is_this_feature_sane ok. Worktree-delegated; coordinator build-verified.