### PR TITLE
fix(Malawi): standardize + complete the code-keyed #+name:u table (#383)

### DIFF
--- a/lsms_library/countries/Malawi/_/categorical_mapping.org
+++ b/lsms_library/countries/Malawi/_/categorical_mapping.org
@@ -226,38 +226,90 @@
 | Other                                                                                                       | Other                                                    |
 
 #+name: u
-| Preferred Label           | Code |
-|---------------------------+------|
-| Kilogramme                | 01    |
-| 50 kg Bag                 | 02    |
-| Pail (Small)              | 04a   |
-| Pail (Medium)             | 04b   |
-| Pail (Large)              | 04c   |
-| No.10 Plate (Flat)        | 06a   |
-| No.10 Plate (Heaped)      | 06b   |
-| No.12 Plate               | 07    |
-| Bunch (Small)             | 08a   |
-| Bunch (Medium)            | 08b   |
-| Bunch (Large)             | 08c   |
-| Piece (Small)             | 09a   |
-| Piece (Medium)            | 09b   |
-| Piece (Large)             | 09c   |
-| Heap (Small)              | 10a  |
-| Heap (Medium)             | 10b  |
-| Heap (Large)              | 10c  |
-| Heap (Small, special)     | 10d  |
-| Heap (Medium, special)    | 10e  |
-| Heap (Large, special)     | 10f  |
-| Bale                      | 11   |
-| Ox-Cart (Unshelled)       | 14   |
-| Litre                     | 15   |
-| Gram                      | 18   |
-| Millilitre                | 19   |
-| Teaspoon                  | 20   |
-| Satchet/Tube (Small)      | 22a  |
-| Satchet/Tube (Medium)     | 22b  |
-| Satchet/Tube (Large)      | 22c  |
-| Other (Specify)           | 23   |
+| Code | Preferred Label | hh_g03b_label |
+|------+-----------------+---------------|
+| 01 | Kilogramme |  |
+| 02 | 50 kg Bag |  |
+| 04 | Pail | PAIL |
+| 04a | Pail (Small) |  |
+| 04b | Pail (Medium) |  |
+| 04c | Pail (Large) |  |
+| 06 | No 10 Plate | No 10 PLATE |
+| 06a | No.10 Plate (Flat) |  |
+| 06b | No.10 Plate (Heaped) |  |
+| 07 | No.12 Plate |  |
+| 07a | No 12 Plate | No 12 PLATE |
+| 07b | No 12 Plate | No 12 PLATE |
+| 08 | Bunch | bunch |
+| 08a | Bunch (Small) |  |
+| 08b | Bunch (Medium) |  |
+| 08c | Bunch (Large) |  |
+| 09 | Piece | PIECE |
+| 09a | Piece (Small) |  |
+| 09b | Piece (Medium) |  |
+| 09c | Piece (Large) |  |
+| 10 | Heap | HEAP |
+| 10a | Heap (Small) | HEAP |
+| 10b | Heap (Medium) | HEAP |
+| 10c | Heap (Large) | HEAP |
+| 10d | Heap (Small, special) |  |
+| 10e | Heap (Medium, special) |  |
+| 10f | Heap (Large, special) |  |
+| 11 | Bale |  |
+| 14 | Ox-Cart (Unshelled) |  |
+| 15 | Litre | LITRE |
+| 18 | Gram | gram |
+| 19 | Millilitre | MILLILITRE |
+| 20 | Teaspoon | TEASPOON |
+| 22 | Satchet/Tube | SATCHET/TUBE |
+| 22a | Satchet/Tube (Small) | SATCHET/TUBE |
+| 22b | Satchet/Tube (Medium) | SATCHET/TUBE |
+| 22c | Satchet/Tube (Large) | SATCHET/TUBE |
+| 23 | Other (Specify) | OTHER (SPECIFY) |
+| 25 | Tina | TINA |
+| 25a | Tina | TINA |
+| 25b | Tina | TINA |
+| 25c | Tina | TINA |
+| 26 | 5 Litre Bucket(Chigoba) | 5 LITRE BUCKET(Chigoba) |
+| 27a | Basin (Small) | BASIN (SMALL) |
+| 27b | Basin (Small) | BASIN (SMALL) |
+| 27c | Basin (Small) | BASIN (SMALL) |
+| 27d | Basin (Small) | BASIN (SMALL) |
+| 27e | Basin (Small) | BASIN (SMALL) |
+| 28 | Piece (Small) | PIECE (SMALL) |
+| 29 | Piece (Medium) | PIECE (MEDIUM) |
+| 30 | Piece (Large) | PIECE (LARGE) |
+| 31 | Loaf (300g) | LOAF (300G) |
+| 32 | Loaf (600g) | LOAF (600G) |
+| 33 | Loaf (700g) | LOAF (700G) |
+| 34 | Packet (150g) | PACKET (150G) |
+| 35 | Packet (400g) | PACKET (400G) |
+| 36 | Packet (500g) | PACKET (500G) |
+| 37 | Packet (1kg) | PACKET (1KG) |
+| 38 | Heap (Small) | HEAP (SMALL) |
+| 39 | Heap (Medium) | HEAP (MEDIUM) |
+| 40 | Heap (Large) | HEAP (LARGE) |
+| 41 | Satchet/Tube (25g) | SATCHET/TUBE (25G) |
+| 42 | Satchet/Tube (50g) | SATCHET/TUBE (50G) |
+| 43 | Satchet/Tube (100g) | SATCHET/TUBE (100G) |
+| 44 | Cluster | CLUSTER |
+| 44a | Cluster | CLUSTER |
+| 44b | Cluster | CLUSTER |
+| 44c | Cluster | CLUSTER |
+| 50 | Tablespoon | TABLESPOON |
+| 51 | Packet | packet |
+| 54 | Packet(Small) | PACKET(SMALL) |
+| 55 | Packet (Large) | PACKET (LARGE) |
+| 57 | Tina (Small) | TINA (SMALL) |
+| 58 | Tina (Large) | TINA (LARGE) |
+| 59 | Tablespoon | TABLESPOON |
+| 60 | Packet | PACKET |
+| 65 | Packet (250g) | PACKET (250G) |
+| 70 | Packet (25g) | PACKET (25g) |
+| 71 | Tin 100G | TIN 100G |
+| 72 | Tin 250G | TIN 250G |
+| 73 | Tin 500G | TIN 500G |
+| 74 | Tin 1Kg | TIN 1KG |
 
 #+name: district
 | Alternate Spelling     | Preferred Label |

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -122,6 +122,25 @@ def _metric_kg_factor(value):
     return None
 
 
+def _norm_unit_code(value):
+    """Canonicalize a raw unit *code* to zero-padded-2 + lowercase suffix.
+
+    Malawi's waves emit the same code in different forms -- 2013-14
+    zero-pads ('01', '04A'), 2016-17/2019-20 don't ('1', '4A', '10A').
+    Normalizing to the questionnaire/table form ('01', '04a', '10a') lets a
+    single #+name:u table decode every wave (GH #383).  Only pure
+    ``<digits><optional-single-letter>`` codes are touched; labels, the 'kg'
+    sentinel, and multi-letter strings pass through unchanged.
+    """
+    if pd.isna(value):
+        return value
+    s = str(value).strip()
+    m = re.fullmatch(r'(\d+)([A-Za-z]?)', s)
+    if not m:
+        return value
+    return m.group(1).zfill(2) + m.group(2).lower()
+
+
 def _titlecase_label(value):
     """Title-case a unit label so case-variants collapse (``'PIECE'`` ->
     ``'Piece'``); leaves the lowercase ``'kg'`` sentinel and sized labels
@@ -394,6 +413,11 @@ def food_acquired_to_canonical(df, wave):
                 q = pd.to_numeric(work[qcol], errors='coerce')
                 work.loc[mask, qcol] = q[mask] * factor[mask].astype(float)
                 work.loc[mask, ucol] = 'kg'
+            # Normalize any remaining raw unit *code* to the canonical
+            # zero-padded-2 + lowercase-suffix form ('1'->'01', '4A'->'04a',
+            # '10A'->'10a') so all waves match the #+name:u table (GH #383),
+            # which then decodes them to Preferred Labels at finalize.
+            work[ucol] = work[ucol].map(_norm_unit_code)
 
     def _make(source_label, quant_col, unit_col, value_col=None):
         if quant_col not in work.columns:

--- a/tests/test_malawi_unit_cleanup.py
+++ b/tests/test_malawi_unit_cleanup.py
@@ -91,6 +91,24 @@ def test_metric_kg_factor_scales_not_relabels():
     assert mf(pd.NA) is None
 
 
+def test_norm_unit_code_canonicalizes_pad_and_case():
+    nc = _load_mod()._norm_unit_code
+    # zero-pad numeric to 2 + lowercase suffix -> table's canonical form
+    assert nc("1") == "01"
+    assert nc("4A") == "04a"
+    assert nc("10A") == "10a"
+    assert nc("04A") == "04a"
+    assert nc("01") == "01"
+    assert nc("10") == "10"
+    assert nc("101") == "101"     # 3-digit stays
+    # non-codes pass through untouched
+    assert nc("kg") == "kg"
+    assert nc("Heap") == "Heap"
+    assert nc("10Kgs") == "10Kgs"  # multi-letter -> not a code
+    import pandas as _pd
+    assert nc(_pd.NA) is _pd.NA
+
+
 def test_metric_factor_rejects_glued_nonmetric_words():
     # The greedy letter-run guard: a number glued to a NON-metric word must
     # not match a metric prefix ('10Giraffes' is not 10 g!).  '5Lions' must


### PR DESCRIPTION
## Summary

Malawi's `food_acquired` `u` bare-code leaks were **two problems**:
1. The `#+name:u` table was keyed on **zero-padded lowercase** codes (`04a`, `10a`), but the newer waves emit **un-padded uppercase** (`4A`, `10A`) — case/padding mismatch.
2. The table (30 codes) was **missing** the survey's many other codes (25–74).

### Fix
- **Rebuilt `#+name:u` as `Code | Preferred Label | hh_g03b_label`**, *merging* the existing curated, size-distinguished labels (`Pail (Small/Medium/Large)`, `Heap (Small/…)`, `No.10 Plate (Flat/Heaped)`) with **52 codes recovered from the WB `.dta` `*_label` companion columns** (Tina, Basin, Piece/Loaf/Packet/Tin size variants, Cluster, Tablespoon…). **82 codes total.** Preferred Labels kept as-is; the raw survey label is documented in the new `hh_g03b_label` column.
- **`_norm_unit_code`** canonicalizes every wave's raw code to zero-padded-2 + lowercase-suffix (`1→01`, `4A→04a`, `10A→10a`) at the `food_acquired_to_canonical` choke point, so a single table decodes all waves.

## Effect (NO_CACHE rebuild)

- code-ish leaks **217 → 79** (bare codes **92 → 44**).
- `food_quantities` kg-resolution **99.9%** (unchanged).
- The **44 residual** bare codes (`00`, `03`, `05`, `12`, `13`, `16`, `17`, `49`, `500` + sub-variants) have **no label in any wave's `.dta`** `*_label` column → need the IHS3 questionnaire unit nomenclature (the remaining **#383** follow-up; no guessing).

## Tests

`_norm_unit_code` canonicalization cases added to `tests/test_malawi_unit_cleanup.py`. Regression: malawi + schema + food = **218 passed**.

Part of #383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)