### PR TITLE
fix(EthiopiaRHS): food_acquired u carries units, not item names (closes #347)

### DIFF
--- a/lsms_library/countries/EthiopiaRHS/_/CONTENTS.org
+++ b/lsms_library/countries/EthiopiaRHS/_/CONTENTS.org
@@ -167,20 +167,26 @@ appear to have village-level split files (=debdemo4=, =dindemo4=,
   follow-up like Uganda's evolving table).  Sex strays (1989 codes
   0/6) -> NA via =erhs_sex=.
 - [X] Unit harmonization + kg conversion: =harmonize_unit= (single
-  Code table -- ERHS unit codes are stable across 1994+).  Metric &
-  good-invariant codes -> framework-recognized tokens (1->=kg=,
+  Code table -- ERHS unit codes are stable across 1994+).  Metric
+  codes -> framework-recognized tokens (1->=kg=,
   2->="100 kg"= so the explicit-metric parser yields 100,
-  19->=litre=, 92->=g=; 30->=Birr= currency, shared, no kg factor).
-  ALL other (local volumetric/container) units are made
-  GOOD-SPECIFIC by the =food_acquired= df_edit ("Chinet [Butter]"),
-  so the framework's existing price-ratio inference recovers a
-  per-good kg factor with NO framework change (a kg is good-
-  invariant; a Chinet is not).  Result: =food_quantities(units='kgs')=
-  ~92% converted to kg; =food_prices(units='kgvalue')= 100% non-null.
-  ERHS's own =conv_*.tab= are an optional future cross-check, not a
-  dependency.  1989 unitcode is in-data-unlabelled -> all 1989 units
-  good-specific from raw code (1989 metric units not distinguished;
-  Codeunit1.SPS in Documentation could seed this -- follow-up).
+  19->=litre=, 92->=g=; 30->=Birr= currency, no kg factor).  ALL
+  other (local volumetric/container) codes -> their unit NAME
+  (=Chinet=, =Kunna=, ...).  The =u= index carries the unit label
+  ALONE; the framework's price-ratio inference
+  (=transformations.conversion_to_kgs=) groups by item within each
+  unit and recovers a per-good kg factor with NO framework change.
+  Code 0 is the source's missing-unit sentinel -> empty label
+  (dropped, à la Uganda's =0 | ---=).  1989 unitcode is
+  in-data-unlabelled -> 1989 =u= carries the raw unit *code* (a unit
+  token, no metric distinction; Codeunit1.SPS in Documentation could
+  seed this -- follow-up).
+  *GH #347 (fixed):* an earlier version appended the food label to
+  non-metric units ("Chinet [Butter]") to coax a per-good kg factor;
+  that polluted the =u= axis with ITEM NAMES (e.g. =0 [Butter]=,
+  =5 [Teff]=).  Removed -- =u= is now a clean unit token, like every
+  other country (Uganda/Malawi/EHCVM); the framework's per-item
+  price-ratio inference recovers the factors on its own.
 - [X] =panel_ids= (GH #271, PR #273).  Script-path
   =_/panel_ids.py= -> =panel_ids.json= (4,708 edges);
   =updated_ids.json= empty (no household-split var in ERHS).

--- a/lsms_library/countries/EthiopiaRHS/_/categorical_mapping.org
+++ b/lsms_library/countries/EthiopiaRHS/_/categorical_mapping.org
@@ -313,20 +313,25 @@ labels='Aggregate' for the coarse grouping.
 Unit code -> canonical label.  The ERHS unit code scheme is
 STABLE across the 1994+ waves (only spelling drifts), so a single
 Code column suffices (cf. harmonize_food which needed per-wave
-columns).  Metric & good-invariant codes map to framework-
-recognized tokens (1->kg, 2->"100 kg" so the explicit-metric
-parser yields 100, 19->litre, 92->g) and 30->Birr (currency:
-shared, intentionally no kg factor).  ALL OTHER units are local
-volumetric/containers whose kg-equivalent is good-specific; the
-food_acquired df_edit appends the food label (e.g. "Chinet/Butter")
-so the framework price-ratio inference recovers a per-good factor
-(metric units stay shared -- a kg is good-invariant).  1989
-unitcode is a different, in-data-unlabelled scheme -> 1989 units
-stay raw+good-specific (no metric distinction) pending Codeunit1.SPS.
+columns).  Metric codes map to framework-recognized tokens
+(1->kg, 2->"100 kg" so the explicit-metric parser yields 100,
+19->litre, 92->g) and 30->Birr (currency: intentionally no kg
+factor).  ALL OTHER codes map to their local volumetric/container
+unit NAME (Chinet, Kunna, ...).  The ``u`` index carries this unit
+label ALONE -- NOT a food label (GH #347).  The framework's
+price-ratio kg inference (transformations.conversion_to_kgs) groups
+by item within each unit, so it recovers a per-good kg factor for
+these local units with no food-label tagging.  Code 0 is the
+source's missing-unit sentinel -> empty label (dropped downstream,
+à la Uganda's ``0 | ---``).  1989 unitcode is a different,
+in-data-unlabelled scheme not mapped through this table -> 1989
+``u`` carries the raw unit code (still a unit token, no metric
+distinction) pending Codeunit1.SPS.
 
 #+NAME: harmonize_unit
 | Code | Preferred Label |
 |------+-----------------|
+| 0 |  |
 | 1 | kg |
 | 2 | 100 kg |
 | 3 | Chinet |

--- a/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
+++ b/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
@@ -23,28 +23,19 @@ import lsms_library.local_tools as tools
 waves = ['1989', '1994a', '1994b', '1995', '1997']
 
 
-# Units whose kg-equivalent is good-INvariant (a kg is a kg whatever
-# the food).  Mapped via harmonize_unit to framework-recognized tokens
-# ('kg', '100 kg' for quintal -> explicit-metric parser yields 100,
-# 'litre', 'g'); 'birr' is currency (shared, no kg factor by design).
-# Every OTHER unit is a local volumetric/container measure whose kg
-# value depends on the good, so food_acquired() appends the food label
-# ("Chinet [Butter]") -- making each (unit, good) its own token so the
-# framework price-ratio inference recovers a per-good kg factor with
-# no framework change.
-_SHARED_UNITS = {'kg', '100 kg', 'litre', 'g', 'birr'}
-
-
-def _good_specific_units(u, j):
-    """Append the food label to non-shared (local) units, vectorized.
-
-    `u`, `j` are string Series.  Shared/metric units (``_SHARED_UNITS``)
-    pass through unchanged; everything else becomes ``"<unit> [<food>]"``.
-    """
-    u = u.astype('string').str.strip()
-    j = j.astype('string').str.strip()
-    local = ~u.str.lower().isin(_SHARED_UNITS)
-    return u.where(~local, u + ' [' + j + ']')
+# Unit handling (GH #347).  ``u`` carries the harmonized unit label
+# ALONE -- the ``harmonize_unit`` Preferred Label for the 1994+ waves
+# (1->kg, 2->"100 kg", 3->Chinet, 19->litre, 30->Birr, ...) and the
+# raw in-data unit *code* for 1989 (an unlabelled scheme; still a unit
+# token, not a food label).  An EARLIER design appended the food label
+# to non-metric units ("Chinet [Butter]") to coax the framework's
+# price-ratio kg inference into a per-good factor; that polluted the
+# unit axis with ITEM NAMES (e.g. '0 [Butter]', '5 [Teff]') and is the
+# bug reported in #347.  Removed: ``u`` is now a clean unit token, as
+# in every other country (Uganda/Malawi/EHCVM).  The framework's
+# price-ratio inference (transformations.conversion_to_kgs) already
+# groups by item ``i`` within each unit, so a single unit label per
+# good still recovers sensible factors with no per-good tagging.
 
 
 def _norm_village(v):
@@ -123,11 +114,12 @@ def food_acquired(df):
                 flat = flat[flat[k].notna() & (flat[k].astype('string')
                                                .str.strip() != '')]
         # 1989 unitcode is an in-data-unlabelled scheme (harmonize_unit
-        # not applied) -> none match _SHARED_UNITS, so every 1989 unit
-        # becomes good-specific.  1989 metric units are therefore not
-        # distinguished (documented; would need Codeunit1.SPS).
-        if 'u' in flat.columns and 'j' in flat.columns:
-            flat['u'] = _good_specific_units(flat['u'], flat['j'])
+        # not applied), so ``u`` carries the raw unit *code* here -- a
+        # unit token on the unit axis, NOT a food label (#347).  1989
+        # metric units are therefore not distinguished (documented;
+        # would need Codeunit1.SPS).
+        if 'u' in flat.columns:
+            flat['u'] = flat['u'].astype('string').str.strip()
         return flat.set_index(idx)
 
     w = df.reset_index()
@@ -153,12 +145,14 @@ def food_acquired(df):
     # Drop rows with no household id (i is pd.NA when the HH-number
     # key was missing in the source -- see `i` above) and rows with
     # no unit (a unit is required to place the quantity on the u axis).
+    # ``u`` is the harmonize_unit Preferred Label (e.g. 'kg', 'Chinet',
+    # 'Birr'); the source missing-unit sentinel 0 maps to '' via
+    # harmonize_unit (#347) and is dropped here.  Each row's ``u`` is a
+    # clean unit token -- no food label appended (the framework's
+    # price-ratio inference recovers per-good factors on its own).
+    out['u'] = out['u'].astype('string').str.strip()
     out = out[out['i'].notna()]
     out = out[out['u'].notna() & (out['u'] != '')]
-    # Non-metric (local) units -> good-specific so the framework's
-    # price-ratio inference recovers a per-good kg factor; metric units
-    # stay shared (good-invariant).
-    out['u'] = _good_specific_units(out['u'], out['j'])
     out = out.set_index(['i', 'j', 'u', 's'])
     return out
 


### PR DESCRIPTION
A `_good_specific_units(u,j)` helper was appending the food label onto every non-metric unit (`'<unit> [<food>]'`), polluting the u axis (and code-0 'no unit' rows surfaced as `0 [Butter]`). Removed the helper; u now carries the bare harmonize_unit label (1994+) / raw unit code (1989); added `0→''` to harmonize_unit so empty-u rows drop. Build-verified: no `[item]` brackets remain, is_this_feature_sane ok, AND kg conversion intact — food_prices(kgvalue) 35,779/35,779 non-null, food_quantities(kgs) builds (conversion_to_kgs groups by item, so the per-good tags were unnecessary). Worktree-delegated; coordinator build-verified.