### PR TITLE
fix(assets): EHCVM Age()/assets name collision — 'float' object is not iterable (closes #321)

### DIFF
--- a/lsms_library/countries/Benin/2018-19/_/mapping.py
+++ b/lsms_library/countries/Benin/2018-19/_/mapping.py
@@ -43,7 +43,16 @@ def Age(value):
 
     The list [s01q04a, s01q03a(day), s01q03b(month), s01q03c(year)] is
     passed to household_roster() via tools.age_handler().
+
+    The function name ``Age`` collides with the ``assets`` myvar
+    ``Age: s12q07`` (item age in years), which the framework binds to
+    this formatter by name (column_mapping in country.py).  That path
+    passes a *scalar*, not the roster's DOB Series; pass scalars
+    through unchanged so assets extraction does not crash on
+    ``list(<float>)`` (closes #321).
     '''
+    if not isinstance(value, pd.Series):
+        return value
     month_map = {'Janvier': 1, 'Février': 2, 'Mars': 3, 'Avril': 4, 'Mai': 5,
                  'Juin': 6, 'Juillet': 7, 'Août': 8, 'Septembre': 9,
                  'Octobre': 10, 'Novembre': 11, 'Décembre': 12}

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/mapping.py
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/mapping.py
@@ -43,7 +43,16 @@ def Age(value):
     Formatting age from date components.
     s01q03b (month) uses French month names in this file.
     Mask 9999 sentinels on day and month before passing to age_handler.
+
+    The function name ``Age`` collides with the ``assets`` myvar
+    ``Age: s12q07`` (item age in years), which the framework binds to
+    this formatter by name (column_mapping in country.py).  That path
+    passes a *scalar*, not the roster's DOB Series; pass scalars
+    through unchanged so assets extraction does not crash on
+    ``list(<float>)`` (closes #321).
     '''
+    if not isinstance(value, pd.Series):
+        return value
     month_map = {'Janvier': 1, 'Février': 2, 'Mars': 3, 'Avril': 4, 'Mai': 5,
                  'Juin': 6, 'Juillet': 7, 'Août': 8, 'Septembre': 9,
                  'Octobre': 10, 'Novembre': 11, 'Décembre': 12}

--- a/lsms_library/countries/Burkina_Faso/2021-22/_/mapping.py
+++ b/lsms_library/countries/Burkina_Faso/2021-22/_/mapping.py
@@ -70,7 +70,16 @@ def Age(value):
     'Ne sait pas' ('don't know') is the sentinel for unknown month; it maps to
     None so age_handler falls back to year-only age computation.
     Returns a list [s01q04a, s01q03a(day), s01q03b(month int), s01q03c(year)].
+
+    The function name ``Age`` collides with the ``assets`` myvar
+    ``Age: s12q07`` (item age in years), which the framework binds to
+    this formatter by name (column_mapping in country.py).  That path
+    passes a *scalar*, not the roster's DOB Series; pass scalars
+    through unchanged so assets extraction does not crash on
+    ``list(<float>)`` (closes #321).
     '''
+    if not isinstance(value, pd.Series):
+        return value
     month_map = {'Janvier': 1, 'Février': 2, 'Mars': 3, 'Avril': 4, 'Mai': 5,
                  'Juin': 6, 'Juillet': 7, 'Août': 8, 'Septembre': 9,
                  'Octobre': 10, 'Novembre': 11, 'Décembre': 12}

--- a/lsms_library/countries/CotedIvoire/2018-19/_/mapping.py
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/mapping.py
@@ -134,7 +134,16 @@ def Age(value):
     CotedIvoire s01q03b (month) is already an integer (1-12); no
     month_map conversion needed.  The list is returned unchanged so
     household_roster() can unpack [age_raw, day, month, year].
+
+    The function name ``Age`` collides with the ``assets`` myvar
+    ``Age: s12q07`` (item age in years), which the framework binds to
+    this formatter by name (column_mapping in country.py).  That path
+    passes a *scalar*, not the roster's DOB Series; pass scalars
+    through unchanged so assets extraction does not crash on
+    ``list(<float>)`` (closes #321).
     '''
+    if not isinstance(value, pd.Series):
+        return value
     return list(value)
 
 

--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/mapping.py
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/mapping.py
@@ -134,7 +134,16 @@ def Age(value):
     s01q03b Stata labels are Portuguese month names (Janeiro…Dezembro).
     get_dataframe() returns the label strings as categoricals.
     The sentinel 9999 is left as-is; household_roster() handles it.
+
+    The function name ``Age`` collides with the ``assets`` myvar
+    ``Age: s12q07`` (item age in years), which the framework binds to
+    this formatter by name (column_mapping in country.py).  That path
+    passes a *scalar*, not the roster's DOB Series; pass scalars
+    through unchanged so assets extraction does not crash on
+    ``list(<float>)`` (closes #321).
     '''
+    if not isinstance(value, pd.Series):
+        return value
     result = list(value)
     raw_month = value.iloc[2]
     if isinstance(raw_month, str):

--- a/lsms_library/countries/Mali/2018-19/_/mapping.py
+++ b/lsms_library/countries/Mali/2018-19/_/mapping.py
@@ -49,7 +49,16 @@ def Age(value):
     Pass Age list [s01q04a, s01q03a, s01q03b, s01q03c] through unchanged.
     s01q03b is integer month (1-12); 9999 sentinels handled by age_handler.
     Override country-level mali.py Age() which expects a scalar.
+
+    The function name ``Age`` also collides with the ``assets`` myvar
+    ``Age: s12q07`` (item age in years), which the framework binds to
+    this formatter by name (column_mapping in country.py).  That path
+    passes a *scalar*, not the roster's DOB Series; pass scalars
+    through unchanged so assets extraction does not crash on
+    ``list(<float>)`` (closes #321).
     '''
+    if not isinstance(value, pd.Series):
+        return value
     return list(value)
 
 

--- a/lsms_library/countries/Mali/2021-22/_/mapping.py
+++ b/lsms_library/countries/Mali/2021-22/_/mapping.py
@@ -73,7 +73,16 @@ def Age(value):
     Convert 4-element Age list [s01q04a, s01q03a, s01q03b, s01q03c].
     s01q03b is a French month string (or 'Ne sait pas'); convert to integer.
     Numeric sentinel masking (9999) and age_handler call happen in household_roster(df).
+
+    The function name ``Age`` collides with the ``assets`` myvar
+    ``Age: s12q07`` (item age in years), which the framework binds to
+    this formatter by name (column_mapping in country.py).  That path
+    passes a *scalar*, not the roster's DOB Series; pass scalars
+    through unchanged so assets extraction does not crash on
+    ``list(<float>)`` (closes #321).
     '''
+    if not isinstance(value, pd.Series):
+        return value
     result = list(value)
     m_raw = value.iloc[2]
     if pd.isna(m_raw):

--- a/lsms_library/countries/Niger/2018-19/_/mapping.py
+++ b/lsms_library/countries/Niger/2018-19/_/mapping.py
@@ -242,7 +242,16 @@ def Age(value):
     Pre-process Age list: convert French month name (s01q03b) to integer.
     Sentinel 9999 for any component is left as-is; age_handler's is_valid()
     rejects values >= 2100 (covers 9999).
+
+    The function name ``Age`` collides with the ``assets`` myvar
+    ``Age: s12q07`` (item age in years), which the framework binds to
+    this formatter by name (column_mapping in country.py).  That path
+    passes a *scalar*, not the roster's DOB Series; pass scalars
+    through unchanged so assets extraction does not crash on
+    ``list(<float>)`` (closes #321).
     '''
+    if not isinstance(value, pd.Series):
+        return value
     month_map = {
         'Janvier': 1, 'Fevrier': 2, 'Février': 2, 'Mars': 3, 'Avril': 4,
         'Mai': 5, 'Juin': 6, 'Juillet': 7, 'Aout': 8, 'Août': 8,

--- a/lsms_library/countries/Niger/2021-22/_/mapping.py
+++ b/lsms_library/countries/Niger/2021-22/_/mapping.py
@@ -69,7 +69,16 @@ def Age(value):
     '''
     Pass through Age list; numeric coercion of "." sentinels is done in
     household_roster() before age_handler is called.
+
+    The function name ``Age`` collides with the ``assets`` myvar
+    ``Age: s12q07`` (item age in years), which the framework binds to
+    this formatter by name (column_mapping in country.py).  That path
+    passes a *scalar*, not the roster's DOB Series; pass scalars
+    through unchanged so assets extraction does not crash on
+    ``list(<float>)`` (closes #321).
     '''
+    if not isinstance(value, pd.Series):
+        return value
     return list(value)
 
 

--- a/lsms_library/countries/Togo/2018/_/mapping.py
+++ b/lsms_library/countries/Togo/2018/_/mapping.py
@@ -45,7 +45,16 @@ def Age(value):
 
     The list [s01q04a, s01q03a(day), s01q03b(month), s01q03c(year)] is
     passed to household_roster() via tools.age_handler().
+
+    The function name ``Age`` collides with the ``assets`` myvar
+    ``Age: s12q07`` (item age in years), which the framework binds to
+    this formatter by name (column_mapping in country.py).  That path
+    passes a *scalar*, not the roster's DOB Series; pass scalars
+    through unchanged so assets extraction does not crash on
+    ``list(<float>)`` (closes #321).
     '''
+    if not isinstance(value, pd.Series):
+        return value
     month_map = {'Janvier': 1, 'Février': 2, 'Mars': 3, 'Avril': 4, 'Mai': 5,
                  'Juin': 6, 'Juillet': 7, 'Août': 8, 'Septembre': 9,
                  'Octobre': 10, 'Novembre': 11, 'Décembre': 12}


### PR DESCRIPTION
EHCVM mapping.py defines Age() to preprocess the roster DOB *list* (→Series), but the assets block also declares Age as a *scalar* (s12q07 item-age); the framework binds the same function → assets' float fed into list(value) → crash. Fix: `if not isinstance(value, pd.Series): return value` guard (10 files; also affects 2021-22). Build-verified: Benin/Mali/Niger/Togo assets build + sane ok; roster Age unchanged (Float64). Worktree-delegated; coordinator build-verified.