### PR TITLE
fix(Burkina_Faso,Mali): individual_education build failures (closes #322)

### DIFF
--- a/lsms_library/countries/Burkina_Faso/2014/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2014/_/data_info.yml
@@ -35,6 +35,21 @@ household_roster:
         Relationship: B5
         MonthsSpent: B3A
 
+individual_education:
+    # 2014 EMC: highest formal-education level attained is B14 ("Quel est le
+    # degré de l'enseignement formel le plus élevé que [NOM] a suivi"), the
+    # EMC analog of the EHCVM waves' educ_hi.  Read from the same person-level
+    # file as the roster, so (i, pid) align with household_roster by
+    # construction: i = country i([zd, menage]), pid = numind (scalar).
+    file: emc2014_p1_individu_27022015.dta
+    idxvars:
+        i:
+            - zd
+            - menage
+        pid: numind
+    myvars:
+        Educational Attainment: B14
+
 cluster_features:
     dfs:
         - df_main

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/data_info.yml
@@ -80,6 +80,25 @@ household_roster:
         - i
         - pid
 
+individual_education:
+    # EHCVM 2018-19: highest education attained = educ_hi (same convention as
+    # Mali / CotedIvoire EHCVM reference).  pid = [grappe, menage, numind]
+    # built with this wave's pid() override, matching household_roster's
+    # [grappe, menage, s01q00a] composite (numind == s01q00a in the individu
+    # file; verified 45,612/45,612 key overlap after format_id).
+    file: ehcvm_individu_bfa2018.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+        pid:
+            - grappe
+            - menage
+            - numind
+    myvars:
+        Educational Attainment: educ_hi
+
 cluster_features:
     dfs:
         - df_main

--- a/lsms_library/countries/Burkina_Faso/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2021-22/_/data_info.yml
@@ -77,6 +77,22 @@ household_roster:
         - i
         - pid
 
+individual_education:
+    # EHCVM 2021-22: highest education attained = educ_hi.  This wave's
+    # household_roster keys pid off a SCALAR `pid` column, and the individu
+    # file carries the same scalar `pid`, so individual_education uses
+    # `pid: pid` (scalar) to align (verified 22,362/22,362 individu keys
+    # overlap the roster after format_id).  i = country i([grappe, menage]).
+    file: ehcvm_individu_bfa2021.dta
+    idxvars:
+        v: grappe
+        i:
+            - grappe
+            - menage
+        pid: pid
+    myvars:
+        Educational Attainment: educ_hi
+
 cluster_features:
     file: s00_me_bfa2021.dta
     idxvars:

--- a/lsms_library/countries/Mali/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Mali/2021-22/_/data_info.yml
@@ -193,13 +193,18 @@ individual_education:
     file: ehcvm_individu_mli2021.dta
     idxvars:
         v: grappe
-        i: 
+        i:
             - grappe
             - menage
-        pid:
-            - grappe
-            - menage 
-            - numind
+        # 2021-22 uses a SCALAR within-household member number for pid, to
+        # match this wave's household_roster (which keys pid off the scalar
+        # membres__id; numind == membres__id here -- verified 43,472/43,472
+        # key overlap).  The wave-level pid() override in mapping.py also
+        # expects a scalar (format_id(value)); passing the 3-column composite
+        # list [grappe, menage, numind] made df_data_grabber apply pid()
+        # row-wise to a Series and raise "The truth value of a Series is
+        # ambiguous" (GH #322).
+        pid: numind
     myvars:
         Educational Attainment: 'educ_hi'
 


### PR DESCRIPTION
Mali: 2021-22 mapping.py pid() is a scalar override but individual_education declared pid:[grappe,menage,numind] (list→Series) → format_id raised; fix to scalar pid:numind. Burkina_Faso: country declared individual_education but no wave data_info defined it → load_from_waves empty; added wave blocks (2014 B14, 2018-19/2021-22 educ_hi). Independently build-verified: Burkina 132,451 (3 waves), Mali 132,483 (4 waves), is_this_feature_sane ok. Worktree-delegated; coordinator build-verified. (Agent flagged a separate latent bug: Mali 2018-19 individual_education pid 0% roster overlap — left untouched.)