### PR TITLE
fix(India,Albania): align roster i to sample().i so v-join works (closes #324)

### DIFF
--- a/lsms_library/countries/Albania/2008/_/data_info.yml
+++ b/lsms_library/countries/Albania/2008/_/data_info.yml
@@ -12,12 +12,18 @@ individual_education:
         Educational Attainment: m2b_q04
 
 household_roster:
+    # i=[psu,hh] -> composite via mapping.py:i() ('psu-hh') to match sample()'s
+    # household identity (format_id(psu)+'-'+format_id(hh)), so
+    # _join_v_from_sample resolves v.  Bare i=hh keyed on the within-PSU
+    # household number, which did not match sample()'s composite i and broke the
+    # v-join (the within-PSU number is unique only inside a PSU).  v is NOT
+    # declared here -- the framework joins it from sample() (the 2005 idiom; only
+    # cluster_features owns v).  See GH #324, #340, CONTENTS.org.
     file:
         - ../Data/Modul_1A_household_roster.sav
 
     idxvars:
-        v: psu
-        i: hh
+        i: [psu, hh]
         pid: id
 
     myvars:

--- a/lsms_library/countries/India/1997-98/_/data_info.yml
+++ b/lsms_library/countries/India/1997-98/_/data_info.yml
@@ -35,11 +35,16 @@ cluster_features:
       District: district
 
 household_roster:
+  # i=hhcode matches sample().i (and interview_date/individual_education/housing,
+  # which read this same SECT01A.DTA with i:hhcode), so _join_v_from_sample
+  # resolves v.  The roster's old i:hh was the within-village household number,
+  # which did not match sample()'s i:hhcode and broke the v-join (GH #324).  v is
+  # NOT declared here -- the framework joins it from sample() (only
+  # cluster_features owns v; see CLAUDE.md).
   file:
       - ../Data/SECT01A.DTA
   idxvars:
-      v: village
-      i: hh
+      i: hhcode
       pid: idcode
   myvars:
       Sex: v01a02


### PR DESCRIPTION
India 1997-98 roster i: village+hh → hhcode (matches sample i:hhcode; sibling interview_date/individual_education/housing already use hhcode). Albania 2008 roster v:psu,i:hh → i:[psu,hh] (mirrors #340's 2005 fix). Build-verified: India roster v 100% non-null, i='hhcode', sane ok (resolves India null-index too); Albania 2008 v joins, sane ok. (Albania 2005 already fixed by #340, untouched. India 'employment' shares the same latent i:hh defect — flagged for follow-up.) Worktree-delegated; coordinator build-verified.