### PR TITLE
cleanup(pandas-3): replace groupby(axis=1) in tangled .org files (closes #262)

### DIFF
--- a/lsms_library/countries/GhanaSPS/_/notes.org
+++ b/lsms_library/countries/GhanaSPS/_/notes.org
@@ -323,7 +323,7 @@ z=[]
 for t in rounds:
     x = pd.concat([pd.read_parquet('../%s/_/food_expenditures.parquet' % t).rename(columns=labels),
                    pd.read_parquet('../%s/_/other_expenditures.parquet' % t).rename(columns=labels)],axis=1)
-    x = x.groupby('i',axis=1).sum()
+    x = x.T.groupby('i').sum().T
     x = x.replace(0,np.nan)
     x = x[x.columns.intersection(items)] # Drop anything not an item with expenditures
 

--- a/lsms_library/countries/Tanzania/_/demands.org
+++ b/lsms_library/countries/Tanzania/_/demands.org
@@ -529,7 +529,7 @@ if 'm' not in x.index.names:
     x = x.reset_index().set_index(['j','t','m'])
 
 # Change to new expenditure labels
-x = x.groupby('i',axis=1).sum()
+x = x.T.groupby('i').sum().T
 
 # Replace zeros with NaNs
 x = x.replace(0,np.nan)
@@ -829,7 +829,7 @@ if 'm' not in q.index.names:
 
 # Change to new expenditure labels
 q = q.rename(columns=i_labels)
-q = q.groupby('i',axis=1).sum()
+q = q.T.groupby('i').sum().T
 
 # Replace zeros with NaNs
 q = q.replace(0,np.nan)

--- a/lsms_library/countries/Uganda/_/nutrition.org
+++ b/lsms_library/countries/Uganda/_/nutrition.org
@@ -2372,7 +2372,7 @@ if 'm' not in x.index.names:
 
 # Change to new expenditure labels
 x = x.rename(columns=i_labels)
-x = x.groupby('i',axis=1).sum()
+x = x.T.groupby('i').sum().T
 
 # Replace zeros with NaNs
 x = x.replace(0,np.nan)
@@ -2664,7 +2664,7 @@ if 'm' not in q.index.names:
 
 # Change to new expenditure labels
 q = q.rename(columns=i_labels)
-q = q.groupby('i',axis=1).sum()
+q = q.T.groupby('i').sum().T
 
 # Replace zeros with NaNs
 q = q.replace(0,np.nan)
@@ -2702,7 +2702,7 @@ if 'm' not in p.index.names:
 
 # Change to new expenditure labels
 p = p.rename(columns=i_labels)
-p = p.groupby('i',axis=1).mean()
+p = p.T.groupby('i').mean().T
 
 # Replace zeros with NaNs
 p = p.replace(0,np.nan)


### PR DESCRIPTION
6 sites across Uganda/nutrition.org, Tanzania/demands.org, GhanaSPS/notes.org: `groupby('i',axis=1).agg()` → `.T.groupby('i').agg().T` (semantically equivalent; .idxmax(axis=1) left alone). Verified: no `groupby(axis=1)` remains. Worktree-delegated.