### PR TITLE
fix(framework): warn on silent dup-index drop (#323); name Feature() index levels (#326)

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -3431,10 +3431,23 @@ def _normalize_dataframe_index(
     # Aggregate duplicates if any remain
     if not df.index.is_unique:
         present_levels = [lvl for lvl in declared if lvl in df.index.names]
+        n_dropped = int(df.index.duplicated().sum())
         # Convert unordered categoricals to strings so groupby.first() works
         for col in df.columns:
             if hasattr(df[col], 'cat') and not df[col].cat.ordered:
                 df[col] = df[col].astype(str).replace({'nan': pd.NA, 'None': pd.NA, '<NA>': pd.NA})
         df = df.groupby(level=present_levels, observed=True).first()
+        if n_dropped:
+            # GH #323: collapsing a non-unique canonical index with .first()
+            # silently DISCARDS the dropped rows.  Surface it loudly rather
+            # than lose data quietly; a feature whose source legitimately has
+            # multiple rows per index tuple needs an explicit duplicate-
+            # aggregation policy (e.g. sum quantities) instead of .first().
+            warnings.warn(
+                f"Canonical index over {present_levels} had {n_dropped} "
+                f"duplicate tuple(s); collapsed via groupby().first(), dropping "
+                f"those rows (possible silent data loss — GH #323).",
+                RuntimeWarning,
+            )
 
     return df

--- a/lsms_library/feature.py
+++ b/lsms_library/feature.py
@@ -228,6 +228,18 @@ class Feature:
 
         result = pd.concat(frames)
 
+        # GH #326: pd.concat can leave the (structurally-consistent) index
+        # levels UNNAMED, forcing callers to index positionally instead of
+        # `groupby('country')`.  When the level count matches the canonical
+        # shape (country + declared levels), restore the names — the per-country
+        # frames were already coerced to canonical order by
+        # _harmonize_country_frame above.  The nlevels-mismatch (genuinely
+        # heterogeneous) case is left to the warning below.
+        expected_names = ["country"] + canonical_levels
+        if (result.index.nlevels == len(expected_names)
+                and list(result.index.names) != expected_names):
+            result.index = result.index.set_names(expected_names)
+
         # Surface (rather than silently return) the pathological case where
         # heterogeneous per-country indices made pandas fall back to an
         # unnamed object index of stringified tuples (GH #325).


### PR DESCRIPTION
**#323** — `_normalize_dataframe_index` collapsed a non-unique canonical index with `groupby().first()`, **silently dropping rows** (assets lost thousands while passing sane-check). Now emits a RuntimeWarning with the dropped count — surfaces the loss without changing behavior (a real fix per feature needs an explicit dup-aggregation policy). **#326** — `Feature()` left index levels unnamed (`[None]`) for some tables; restore `['country']+canonical` names when the level count matches (heterogeneous case still warned). Verified: synthetic dup warns+drops; Feature indices now named; **285 passed, 4 skipped** (test_feature/dtype/schema).