### PR TITLE
feat(EthiopiaRHS): wire 1999 (R5) household_roster (#277)

### DIFF
--- a/lsms_library/categorical_mapping/kinship.yml
+++ b/lsms_library/categorical_mapping/kinship.yml
@@ -78,6 +78,11 @@ Visitor:             [0, 0, guest]
 Non-Relative:        [0, 0, unrelated]
 Other Non-Relative:  [0, 0, unrelated]
 Other Relative:      [0, 0, consanguineal]
+# EthiopiaRHS 1999 (R5) source-label spellings (sic) -> same tuples as the
+# canonical forms above; kept verbatim so the value-label decode matches.
+Other reative:       [0, 0, consanguineal]   # "Other relative" (source typo)
+Other unrelated:     [0, 0, unrelated]
+Tenant/Broader:      [0, 0, guest]           # "Tenant/Boarder" (source typo)
 Other Family:        [0, 0, consanguineal]
 Adopted Child:       [-1, 0, consanguineal]
 

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/.gitignore
@@ -1,0 +1,1 @@
+/roster.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/roster.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/roster.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: d122dd568c62bd4e4e17f2e56e365f94
+  size: 23680046
+  hash: md5
+  path: roster.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1999/_/data_info.yml
@@ -1,0 +1,29 @@
+# EthiopiaRHS 1999 (Round 5).  Source: IFPRI ERHS 1989-2009 Dataverse
+# deposit (doi:10.7910/DVN/T8G8IV), file "11 3.3.99 roster.tab" -> Data/roster.tab.
+#
+# Unlike the raw-code rosters of 1994a/b/1995/1997 (which set
+# converted_categoricals: False and decode q11_5/q11_1b via erhs_sex/
+# erhs_relation), this R5 file carries embedded VALUE LABELS, so we leave
+# converted_categoricals unset (-> convert_categoricals=True, country.py:700):
+# get_dataframe then decodes `sex` to Male/Female and `reltn3` to the
+# relationship label (Head, Son/Daughter, Wife/Husband/Partner, ...) on read,
+# and the canonical Sex spellings + kinship.yml handle those labels directly --
+# no per-country code mapping needed.  (Setting converted_categoricals: False
+# here would surface raw codes 1.0/2.0 and break kinship decomposition.)
+#
+# Household keys q1c (peasant association) + hh (HH no. within village) are the
+# SAME stable codes used by the other waves' roster i:[q1c, hhid].
+#
+# R5 (1999) has a person roster; R6 (2004) / R7 (2009) do NOT (only HH-size
+# summaries), and item-level food is absent for R5-R7 -- see CONTENTS.org.
+household_roster:
+    file: roster.tab
+    idxvars:
+        i:
+            - q1c        # peasant association (stable code)
+            - hh         # HH no. within village
+        pid: pid         # roster-card id
+    myvars:
+        Sex: sex                 # already 'Male'/'Female' -> M/F via canonical spellings
+        Age: age4                # round-5 age in years
+        Relationship: reltn3     # already a label; decomposed by kinship.yml

--- a/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
+++ b/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
@@ -12,15 +12,17 @@ import pandas as pd
 import lsms_library.local_tools as tools
 
 
-# Explicit `waves` list (consumed by Country.waves, country.py:1054-1073):
-# only the FIVE wired rounds are declared.  Rounds 1999/2004/2009
-# (R5/R6/R7) are deliberately excluded -- the IFPRI Dataverse archive has
-# no person roster and no item-level food for them (only pre-aggregated
-# consumption scalars), so they are NOT WIREABLE for the canonical tables
-# and must not appear in sample() / derived-table wave coverage.  Their
-# ``Documentation/`` dirs are retained on disk for provenance.
-# See _/CONTENTS.org (decision 2026-06-05) and GH #271 / #277.
-waves = ['1989', '1994a', '1994b', '1995', '1997']
+# Explicit `waves` list (consumed by Country.waves, country.py:1054-1073).
+# 1989/1994a/1994b/1995/1997 are the original wired rounds.  1999 (R5) was
+# previously excluded as "no person roster", but the IFPRI Dataverse archive
+# DOES contain an R5 person roster ("11 3.3.99 roster.tab" -> 1999/Data/
+# roster.tab, 10,788 person-rows, already label-decoded), so it is now wired
+# for household_roster (GH #277; data-availability sleuth 2026-06-07).
+# 2004/2009 (R6/R7) remain excluded -- they carry only HH-size summaries, no
+# person roster.  Item-level food is absent for R5/R6/R7 (only pre-aggregated
+# consumption scalars), so food_acquired stays 1994-1997 only.
+# See _/CONTENTS.org and GH #271 / #277.
+waves = ['1989', '1994a', '1994b', '1995', '1997', '1999']
 
 
 # Unit handling (GH #347).  ``u`` carries the harmonized unit label


### PR DESCRIPTION
Sleuthing found the IFPRI Dataverse deposit DOES contain an R5 person roster (`11 3.3.99 roster.tab`, 10,788 rows), contradicting the prior 'not-wireable' note. Wired as a YAML household_roster (label-decoded sex/age4/reltn3; `converted_categoricals` left unset so embedded value labels decode); added 1999 to ethiopiarhs.py `waves`; 3 ERHS source-spelling relations added to kinship.yml. Build-verified: 10,788 rows (Sex M/F, 9,562 kinship-decomposed), household_characteristics regains 1999, is_this_feature_sane ok. Used the add-feature/add-wave skills. Part of #277 (assets/livestock/income to follow as bespoke HH-level tables; 2004/2009 rosterless, item-level food absent R5-R7).