### PR TITLE
feat(EthiopiaRHS): bespoke HH-level assets (1989 module) (#277)

### DIFF
--- a/lsms_library/countries/EthiopiaRHS/1989/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1989/Data/.gitignore
@@ -1,1 +1,8 @@
 /*.dta
+/assetars.tab
+/assetdeb.tab
+/assetdin.tab
+/assetgam.tab
+/assethar.tab
+/assetsid.tab
+/assetwol.tab

--- a/lsms_library/countries/EthiopiaRHS/1989/Data/assetars.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1989/Data/assetars.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: e0967284fe14afb7000a2d1e66c5c64e
+  size: 9496
+  hash: md5
+  path: assetars.tab

--- a/lsms_library/countries/EthiopiaRHS/1989/Data/assetdeb.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1989/Data/assetdeb.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: dc73552a05aed0f64d9ae0212f72f5fe
+  size: 6936
+  hash: md5
+  path: assetdeb.tab

--- a/lsms_library/countries/EthiopiaRHS/1989/Data/assetdin.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1989/Data/assetdin.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: c863b5d7c95f92d4a618b503fb70a54c
+  size: 6136
+  hash: md5
+  path: assetdin.tab

--- a/lsms_library/countries/EthiopiaRHS/1989/Data/assetgam.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1989/Data/assetgam.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: a4a48e4c25b5c181ce9f1831317c7154
+  size: 9656
+  hash: md5
+  path: assetgam.tab

--- a/lsms_library/countries/EthiopiaRHS/1989/Data/assethar.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1989/Data/assethar.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 14948dd164f9251d4c68981fe2433cac
+  size: 7496
+  hash: md5
+  path: assethar.tab

--- a/lsms_library/countries/EthiopiaRHS/1989/Data/assetsid.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1989/Data/assetsid.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: c9620d423bae3f01ee9a8d054a3b51ea
+  size: 5336
+  hash: md5
+  path: assetsid.tab

--- a/lsms_library/countries/EthiopiaRHS/1989/Data/assetwol.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1989/Data/assetwol.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 0a8aef26e7b4e1a0e132bdb9323984d5
+  size: 6136
+  hash: md5
+  path: assetwol.tab

--- a/lsms_library/countries/EthiopiaRHS/1989/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1989/_/data_info.yml
@@ -77,3 +77,30 @@ sample:
 # reconciliation is a documented follow-up).  1989 keeps `sample`
 # (cluster v = site) for the v-join; market='Region'/'Woreda' rows
 # for 1989 are NaN and drop, as documented in CONTENTS.
+
+# assets (#277): HH-level asset-VALUE aggregates from the 1989/R1 asset
+# module (fieldwork 1989-1990), one .tab per peasant association.  This
+# instrument records household TOTALS (farm/non-farm asset value +
+# count), NOT the canonical item-level (t,i,j) Quantity/Value -- so
+# EthiopiaRHS `assets` is a documented HH-level (t,i) variant (see
+# data_scheme.yml + Liberia's documented-variant precedent).  i = the
+# same packed 5-digit hhid as the roster (276/488 overlap with the 338-HH
+# 1989 roster; asset-only HH keep v=NA, mirroring the roster<food gap).
+# The 7 village files share an identical schema, so listing them together
+# row-concatenates them (missing_ok column union).
+assets:
+    file:
+        - assetars.tab
+        - assetdeb.tab
+        - assetdin.tab
+        - assetgam.tab
+        - assethar.tab
+        - assetsid.tab
+        - assetwol.tab
+    idxvars:
+        i: hhid
+    myvars:
+        FarmValue: frmval         # value of farm assets (land, oxen, ...)
+        NonFarmValue: nfrmval     # value of non-farm assets
+        TotalValue: assettot      # total asset value
+        NumberOfAssets: noassets  # count of distinct assets held

--- a/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
+++ b/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
@@ -21,6 +21,18 @@ Data Scheme:
     Distance: int
     Affinity: str
 
+  # assets (#277): HH-level asset-VALUE aggregates from the 1989/R1
+  # asset module (one .tab per peasant association).  The ERHS
+  # instrument records household TOTALS (farm/non-farm value + count),
+  # NOT the canonical item-level (t,i,j) Quantity/Value -- so this is a
+  # documented HH-level (t,i) variant (cf. Liberia's reduced `assets`).
+  assets:
+    index: (t, i)
+    FarmValue: float
+    NonFarmValue: float
+    TotalValue: float
+    NumberOfAssets: float
+
   # Mali-style clean YAML: extract wide per-source columns; the
   # `food_acquired` df_edit hook in _/ethiopiarhs.py melts them to
   # canonical long form on s. Price is API-derived (food_prices).


### PR DESCRIPTION
The 1989/R1 asset module records household TOTALS (farm/non-farm asset value + count), one .tab per peasant association — NOT canonical item-level (t,i,j). Modeled as a documented HH-level (t,i) variant (cf. Liberia's reduced assets): FarmValue/NonFarmValue/TotalValue/NumberOfAssets, i=packed hhid (matches 1989 roster). 7 village files row-concatenate via a multi-file data_info list (no script). Build-verified: 488 rows, t=1989, is_this_feature_sane ok; Feature('assets') cross-country still builds. Part of #277.