### PR TITLE
docs(EHCVM): characterize + accept residual food_acquired unit codes (#223)

### DIFF
--- a/lsms_library/countries/Burkina_Faso/_/CONTENTS.org
+++ b/lsms_library/countries/Burkina_Faso/_/CONTENTS.org
@@ -27,7 +27,12 @@ Standard EHCVM format, nearly identical to Mali.  Variable names: =s07bq01= (foo
 *** Categorical mapping
 ISSUE: No harmonised =categorical_mapping.org= file yet.  Food labels and units come through as raw categoricals from the =.dta= files.  Many 2014 units remain as French text without standardisation.  The 2018-19/2021-22 unit codes are numeric without categorical labels in some entries.
 
-UPDATE (GH #223 Layer 2): the 2018-19/2021-22 =s07bq03b= numeric unit codes are now decoded via the shared EHCVM codebook (=lsms_library/categorical_mapping/ehcvm_units.org=, unioned from the sibling countries' =.dta= value labels) applied through =mappings: ['ehcvm_units','Code','Preferred Label']= in =data_info.yml=.  The dead identity rows (=101.0->101.0=, ...) were removed from =categorical_mapping.org=.  Code leaks 22 -> 2; residual codes =254, 255= have no label in any EHCVM source.
+UPDATE (GH #223 Layer 2): the 2018-19/2021-22 =s07bq03b= numeric unit codes are now decoded via the shared EHCVM codebook (=lsms_library/categorical_mapping/ehcvm_units.org=, unioned from the sibling countries' =.dta= value labels) applied through =mappings: ['ehcvm_units','Code','Preferred Label']= in =data_info.yml=.  The dead identity rows (=101.0->101.0=, ...) were removed from =categorical_mapping.org=.  Code leaks 22 -> 2.  Residual codes =254, 255= are item-specific local units
+for meats/poultry (size =s07bq03c= = 'Taille unique'); they have no label in
+any EHCVM source =.dta= and are not in the questionnaire's generic 1--57
+=Unites= sheet, so they are accepted as undecodable and left as codes
+(consistent with Malawi #383).  They still yield valid food_expenditures and
+per-native-unit unitvalue; only the kg aggregate excludes them.
 
 ** DONE sample
 Sampling design table: cluster, weights, strata, and Rural classification.

--- a/lsms_library/countries/Togo/_/CONTENTS.org
+++ b/lsms_library/countries/Togo/_/CONTENTS.org
@@ -28,9 +28,16 @@ see =slurm_logs/ehcvm_unit_codebook_2026-06-07.org=) is applied to =u= via
 =mappings: ['ehcvm_units','Code','Preferred Label']= in
 =2018/_/data_info.yml=.  Result: code leaks 25 -> 4.
 
-Residual undecoded codes (=114, 659, 660, 662=) have no label in *any*
-EHCVM source =.dta= and are left as codes pending the questionnaire unit
-nomenclature.
+Residual codes (=114, 659, 660, 662=) are *item-specific local units* --
+659 banana/plantain, 660 meat, 662 yam/cassava/plantain portions, 114
+tomato -- with the size in =s07bq03c= (Petit/Moyen/Grand).  They have no
+label in *any* EHCVM source =.dta=, and the household-questionnaire =Unites=
+sheet is the generic 1--57 scheme, NOT the data's 100--700 coding (whose
+neighbours -- 663=Agoua, 664=Kpogban -- are specific local names).  No
+available source decodes them, so they are *accepted as undecodable* and
+left as codes (consistent with Malawi's residuals, #383).  They still
+contribute valid food_expenditures and per-native-unit =unitvalue= prices;
+only the kg aggregate excludes them.
 
 * Household Presence / MonthsSpent
 

--- a/tests/test_u_code_leak.py
+++ b/tests/test_u_code_leak.py
@@ -71,13 +71,17 @@ def test_leak_detector_no_u_level():
 # Clean per the 2026-06-07 audit; must stay clean.
 _KNOWN_CLEAN = ["Mali", "Niger", "CotedIvoire", "Guinea-Bissau"]
 # Tracked dirty (driven down by Layer 2 / #347 / #348). Progress:
-#   Ethiopia  45 -> 0 (prefix strip, #370)
-#   Togo      25 -> 4 (EHCVM codebook decode; residual 114/659/660/662)
-#   Burkina   22 -> 2 (EHCVM codebook decode; residual 254/255)
-#   Nigeria   32 -> 3 (codes decoded from WB .dta labels; residual 131/151/152)
-#   Senegal    1 -> 0 (code '1' data-entry anomaly, 2 rows -> u='NA')
-# Residual codes have no label in any source .dta. Still dirty:
-# Malawi, GhanaLSS, EthiopiaRHS.
+#   Ethiopia  45 -> 0  (prefix strip, #370)
+#   Togo      25 -> 4  (EHCVM codebook; residual 114/659/660/662 ACCEPTED*)
+#   Burkina   22 -> 2  (EHCVM codebook; residual 254/255 ACCEPTED*)
+#   Nigeria   32 -> 3  (WB .dta labels; residual 131/151/152 ACCEPTED*)
+#   Senegal    1 -> 0  (code '1' data-entry anomaly, 2 rows -> u='NA')
+#   Malawi   217 -> 19 (#382/#391/#399/#383; 19 residual ACCEPTED*)
+# *ACCEPTED = item-specific / data-entry codes with no label in ANY source
+#  (questionnaire scheme differs from the data coding); documented per-country
+#  and left as codes -- they still yield valid food_expenditures + unitvalue,
+#  only the kg aggregate excludes them.  Still genuinely dirty: GhanaLSS
+#  (#348/#384 -- raw codes, Tier-4 unit_label lift not yet done).
 
 
 def test_clean_countries_have_no_u_code_leaks():


### PR DESCRIPTION
## Summary

Closes out the EHCVM residual-code investigation (the last item of the wrap-up sequence). The codes that survive the shared-codebook decode — **Togo `114/659/660/662`, Burkina `254/255`** — are **item-specific local units**:

| code | item | size (`s07bq03c`) |
|---|---|---|
| Togo 659 (514 rows) | banana/plantain | Petit/Moyen/Grand |
| Togo 660 (24) | meat | Petit/Moyen/Grand |
| Togo 662 (1486) | yam/cassava/plantain | Petit/Moyen/Grand |
| Togo 114 (1) | tomato | Petit |
| Burkina 254/255 (6/123) | meats/poultry | Taille unique |

They have **no label in any EHCVM source `.dta`**, and the household-questionnaire `Unites` sheet is the **generic 1–57 scheme**, not the data's 100–700 coding (whose neighbours — `663=Agoua`, `664=Kpogban` — are specific local names). No available source decodes them, so per your call they're **accepted as undecodable and left as codes**, consistent with Malawi's residuals (#383). They still contribute valid `food_expenditures` and per-native-unit `unitvalue`; only the kg aggregate excludes them.

## Changes (docs/tests only)
- Enhanced residual notes in `Togo/_/CONTENTS.org` and `Burkina_Faso/_/CONTENTS.org`.
- Updated the `food_acquired` `u`-leak progress tracking in `tests/test_u_code_leak.py` (marks ACCEPTED residuals; flags **GhanaLSS #348/#384** as the one remaining genuinely-dirty `u` country).

Senegal's lone code-`'1'` anomaly was already resolved (→ `u='NA'`, #379).

🤖 Generated with [Claude Code](https://claude.com/claude-code)