### PR TITLE
fix(GhanaLSS): decode 1991-92 food_acquired unit codes (closes #348)

### DIFF
--- a/lsms_library/countries/GhanaLSS/1991-92/_/food_acquired.py
+++ b/lsms_library/countries/GhanaLSS/1991-92/_/food_acquired.py
@@ -38,13 +38,21 @@ x = x.reset_index().set_index(['h','w','j','u','visit'])
 ####################
 
 labelsd = get_categorical_mapping(tablename='harmonize_food',idxvars={'Code':('Code_8h',format_id)},**{'Label':'Preferred Label'})
-unitsd = get_categorical_mapping(tablename='units')
+# GH #348: pass the value column ('Label') so the Code->Label dict is built.
+# A bare get_categorical_mapping(tablename='units') yields an EMPTY dict (no
+# value column requested -> df_data_grabber returns a column-less frame), so
+# the wave-level unit decode was silently dead and raw s8hq13 codes
+# (1/7/8/9/12/14/16/17/18/19/22/23/25) leaked into food_acquired's u.
+unitsd = get_categorical_mapping(tablename='units', Label='Label')
 
-# food quantities
+# food quantities.  s8hq13 reads as float (1.0); the units table is keyed on
+# string codes ('1'), so normalize via format_id before lookup (same pattern
+# as j above) -- otherwise every code misses the dict.  Unknown / missing
+# sentinel codes (Stata's large-number NA) map to <NA>.
 idxvars = dict(h=(['clust','nh'],lambda x: format_id(x.clust)+format_id(x.nh)),
                w=('nh',lambda x: w),
                j=('homagrcd',lambda x: labelsd[format_id(x)]),
-               u=('s8hq13',unitsd))
+               u=('s8hq13',lambda x: unitsd.get(format_id(x), pd.NA)))
 
 # Keep visits separate
 myvars = {'Price':('s8hq14',_to_numeric)}

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -159,6 +159,24 @@ time, and no =u= table needs to be wired into
 =_/categorical_mapping.org=.  The framework's auto-discovery on
 =u= would be a no-op.
 
+**GH #348 fix (2026-06-07).** The country-level =unit_labels.org=
+=.replace()= only catches the *purchase* rows and the production rows
+whose wave already decoded =s8hq13= to a text label.  The *1991--92*
+wave decodes =s8hq13= itself via the wave-level =units= table
+(=1991-92/_/categorical_mapping.org=, =Code | Label=), but that decode
+was silently dead: =get_categorical_mapping(tablename='units')= was
+called with no value column, so =df_data_grabber= returned a
+column-less frame and the dict came back *empty* -- every code passed
+through, and the country-level =.replace()= only mopped up a subset,
+leaving 13 raw codes (1/7/8/9/12/14/16/17/18/19/22/23/25) in =u=.  Two
+one-line fixes in =1991-92/_/food_acquired.py=: (1) request the value
+column -- =get_categorical_mapping(tablename='units', Label='Label')=;
+(2) =s8hq13= reads as float (=1.0=) while the table keys are string
+codes (='1'=), so normalize via =format_id= before lookup
+(=unitsd.get(format_id(x), pd.NA)=), the same pattern used for =j=.
+Result: GhanaLSS =food_acquired= code leaks 13 -> 0; 1991--92 =u= now
+reads Pounds / Basket / Bowl / American tin / Tubers / ... .
+
 There is no =_/conversion_to_kgs.json= for GhanaLSS; the
 food_quantities pipeline for this country is currently a
 work-in-progress (see =food_prices_quantities_and_expenditures.py=

--- a/tests/test_u_code_leak.py
+++ b/tests/test_u_code_leak.py
@@ -77,11 +77,13 @@ _KNOWN_CLEAN = ["Mali", "Niger", "CotedIvoire", "Guinea-Bissau"]
 #   Nigeria   32 -> 3  (WB .dta labels; residual 131/151/152 ACCEPTED*)
 #   Senegal    1 -> 0  (code '1' data-entry anomaly, 2 rows -> u='NA')
 #   Malawi   217 -> 19 (#382/#391/#399/#383; 19 residual ACCEPTED*)
+#   GhanaLSS  13 -> 0  (#348; 1991-92 units dict was empty -- fixed value-col
+#                       + float->str code lookup; all codes now decode)
 # *ACCEPTED = item-specific / data-entry codes with no label in ANY source
 #  (questionnaire scheme differs from the data coding); documented per-country
 #  and left as codes -- they still yield valid food_expenditures + unitvalue,
-#  only the kg aggregate excludes them.  Still genuinely dirty: GhanaLSS
-#  (#348/#384 -- raw codes, Tier-4 unit_label lift not yet done).
+#  only the kg aggregate excludes them.  No food_acquired country now leaks
+#  non-accepted unit codes (Layer-2 u-harmonization complete).
 
 
 def test_clean_countries_have_no_u_code_leaks():


### PR DESCRIPTION
## Summary

Retires the **last dirty-`u` `food_acquired` country**. GhanaLSS's 1991-92 wave decodes its production unit `s8hq13` via the wave-level `units` table (`Code | Label`), but the decode was **silently dead**: `get_categorical_mapping(tablename='units')` was called with **no value column**, so `df_data_grabber` returned a column-less frame and the dict came back **empty**. Every code passed through; the country-level `unit_labels.org` `.replace()` only caught a subset, leaving **13 raw codes** (`1/7/8/9/12/14/16/17/18/19/22/23/25`) in `food_acquired`'s `u`.

## Fix (two one-liners in `1991-92/_/food_acquired.py`)
- Request the value column: `get_categorical_mapping(tablename='units', Label='Label')`.
- `s8hq13` reads as float (`1.0`) but the table is keyed on string codes (`'1'`), so normalize via `format_id` before lookup — `unitsd.get(format_id(x), pd.NA)` — the same pattern already used for the `j` (item) mapping. Missing/sentinel codes (Stata large-number NA) → `<NA>`.

## Effect (NO_CACHE rebuild)
- GhanaLSS `food_acquired` code leaks **13 → 0**; 1991-92 `u` now reads Pounds/Basket/Bowl/American tin/Tubers/…
- With this, **no `food_acquired` country leaks non-accepted unit codes** — the #223 Layer-2 `u`-harmonization is **complete** (all remaining residuals are documented, accepted item-specific/data-entry codes).

## Tests / docs
`tests/test_u_code_leak.py` progress tracking updated (GhanaLSS → 0; 7 passed). GhanaLSS CONTENTS unit-handling section documents the root cause + fix.

Closes #348. (Note: #384 — GhanaLSS 2016-17 building empty + expenditures coverage — is a separate data/build issue, not this `u`-decode fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)