### PR TITLE
feat(EthiopiaRHS): bespoke livestock + income (1999 R5) (#277)

### DIFF
--- a/lsms_library/countries/EthiopiaRHS/1999/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/.gitignore
@@ -1,1 +1,12 @@
 /roster.tab
+/arslvs5.tab
+/deblvs5.tab
+/dinklvs5.tab
+/gamlvs5.tab
+/harlvs5.tab
+/sidlvs5.tab
+/wollvs5.tab
+/arsinc5.tab
+/debinc5.tab
+/dininc5.tab
+/sidinc5.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/arsinc5.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/arsinc5.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: a00c95a87b2276f0fc52dfef892296f2
+  size: 156711
+  hash: md5
+  path: arsinc5.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/arslvs5.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/arslvs5.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 57f965bb7359d26aca01844407dfe1d7
+  size: 122336
+  hash: md5
+  path: arslvs5.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/debinc5.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/debinc5.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 6ec54ddad706965e055a80d480123044
+  size: 111098
+  hash: md5
+  path: debinc5.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/deblvs5.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/deblvs5.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 29d950282d107aedc970ff8fb8d190e5
+  size: 193560
+  hash: md5
+  path: deblvs5.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/dininc5.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/dininc5.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 3f1fee5c68111c1dc94bfc0207df5884
+  size: 109050
+  hash: md5
+  path: dininc5.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/dinklvs5.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/dinklvs5.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: dafd782670e9906144ee4e787596d765
+  size: 239498
+  hash: md5
+  path: dinklvs5.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/gamlvs5.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/gamlvs5.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 66d692db17602f95197161e9641f84b8
+  size: 126998
+  hash: md5
+  path: gamlvs5.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/harlvs5.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/harlvs5.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 0be02a895dc210aef2f135db0fea2638
+  size: 105584
+  hash: md5
+  path: harlvs5.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/sidinc5.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/sidinc5.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 4ceb332624b3fa98418dfe1e8cb89c68
+  size: 31835
+  hash: md5
+  path: sidinc5.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/sidlvs5.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/sidlvs5.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: c07722edf6c1307e991f29ec44cf496a
+  size: 120103
+  hash: md5
+  path: sidlvs5.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/Data/wollvs5.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1999/Data/wollvs5.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: f87a4caf2793d46a94e44a9cd5e7c250
+  size: 49992
+  hash: md5
+  path: wollvs5.tab

--- a/lsms_library/countries/EthiopiaRHS/1999/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1999/_/data_info.yml
@@ -27,3 +27,64 @@ household_roster:
         Sex: sex                 # already 'Male'/'Female' -> M/F via canonical spellings
         Age: age4                # round-5 age in years
         Relationship: reltn3     # already a label; decomposed by kinship.yml
+
+# livestock + income (#277): HH-level VALUE aggregates from the R5
+# livestock ({village}lvs5.tab) and income ({village}inc5.tab) modules,
+# one .tab per ORIGINAL-7-village peasant association.  These are
+# pre-aggregated household TOTALS (herd value, TLU, income subtotals),
+# NOT the canonical item-level (t,i,j) Quantity/Value -- so EthiopiaRHS
+# `livestock`/`income` are documented HH-level (t,i) variants (see
+# data_scheme.yml + the 1989 `assets` precedent + Liberia's reduced
+# `assets`).
+#
+# i-KEY (CRITICAL).  The R5 lvs5/inc5 files key on the *packed 5-digit*
+# `hhid` (region+PA+HH, e.g. 10101) -- the SAME pre-expansion scalar
+# scheme as the 1989 roster/assets, NOT the 1999 roster's named
+# composite [q1c, hh] (= 'Haresaw_1.2.').  Measured overlap of the
+# packed `hhid` against the 1999-roster composite i is ZERO (different
+# keyspaces); against the 338-HH 1989 packed-hhid roster it is
+# 322/541 (livestock) and 150/252 (income).  So i = the single packed
+# `hhid` (shared `i` formatter's scalar path), reconciling with the
+# 1989 roster (and, transitively, the 1994+ panel via the `q2`/panel_ids
+# linkage) -- exactly as the 1989 `assets` block does.  lvs5/inc5 HH
+# absent from the 1999 person roster keep v=NA, mirroring the documented
+# 1989 roster<asset gap.  The 7 village files share an identical schema,
+# so listing them together row-concatenates (missing_ok column union).
+#
+# Calendar note: the `*80` suffix is the Ethiopian-calendar reference
+# year of the R5 current-stock columns (lvsval80 = total livestock value
+# in Birr; lsu80 = Livestock Standard Units = TLU).  All chosen myvars
+# are present and populated in every listed file (statically verified).
+livestock:
+    file:
+        - arslvs5.tab
+        - deblvs5.tab
+        - dinklvs5.tab      # din's livestock file is dinklvs5.tab
+        - gamlvs5.tab
+        - harlvs5.tab
+        - sidlvs5.tab
+        - wollvs5.tab
+    idxvars:
+        i: hhid             # packed 5-digit region+PA+HH, unique per HH
+    myvars:
+        LivestockValue: lvsval80  # total value of livestock herd (Birr), current year
+        TLU: lsu80                # Livestock Standard Units (tropical livestock units)
+
+# income: only 4 of the 7 villages have an R5 inc5 file in the IFPRI
+# Dataverse deposit (ars/deb/din/sid); gam/har/wol have no inc5 (gam has
+# only gaminc6 = R6/2004, OUT OF SCOPE).  `din`'s income file is
+# `dininc5.tab` (note: NOT `dinkinc5`).
+income:
+    file:
+        - arsinc5.tab
+        - debinc5.tab
+        - dininc5.tab       # din's income file is dininc5.tab
+        - sidinc5.tab
+    idxvars:
+        i: hhid             # packed 5-digit region+PA+HH, unique per HH
+    myvars:
+        TotalIncome: totinc       # total household income (Birr)
+        CropIncome: cropinc       # income from crop production/sales
+        LivestockIncome: lvsincom # income from livestock products/sales
+        OffFarmIncome: nonfarmy   # non-farm income
+        WageIncome: wageinc       # wage/labour income

--- a/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
+++ b/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
@@ -33,6 +33,31 @@ Data Scheme:
     TotalValue: float
     NumberOfAssets: float
 
+  # livestock (#277): HH-level livestock-VALUE aggregates from the R5
+  # (1999) livestock module (one {village}lvs5.tab per original-7-village
+  # peasant association).  Pre-aggregated household TOTALS (herd value +
+  # TLU), NOT canonical item-level (t,i,j) -- so this is a documented
+  # HH-level (t,i) variant, like `assets`.  i = the packed 5-digit hhid
+  # (same scalar scheme as the 1989 roster; ZERO overlap with the 1999
+  # roster's named [q1c,hh] composite, 322/541 vs the 1989 packed roster).
+  livestock:
+    index: (t, i)
+    LivestockValue: float   # total value of livestock herd (Birr)
+    TLU: float              # Livestock Standard Units (tropical livestock units)
+
+  # income (#277): HH-level income-VALUE aggregates from the R5 (1999)
+  # income module ({village}inc5.tab; only 4 of 7 villages have an inc5
+  # file -- ars/deb/din/sid).  Pre-aggregated household income TOTALS +
+  # major source subtotals, NOT item-level -- a documented HH-level (t,i)
+  # variant.  i = the same packed 5-digit hhid as `livestock`.
+  income:
+    index: (t, i)
+    TotalIncome: float      # total household income (Birr)
+    CropIncome: float       # income from crop production/sales
+    LivestockIncome: float  # income from livestock products/sales
+    OffFarmIncome: float    # non-farm income
+    WageIncome: float       # wage/labour income
+
   # Mali-style clean YAML: extract wide per-source columns; the
   # `food_acquired` df_edit hook in _/ethiopiarhs.py melts them to
   # canonical long form on s. Price is API-derived (food_prices).

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -1832,7 +1832,7 @@ class Country:
             # v; joining v from sample() would produce a non-canonical shape.
             # See SkunkWorks/audits/framework_diagnosis.md for the schema survey.
             _no_v_join = {'sample', 'cluster_features', 'panel_ids', 'updated_ids',
-                          'shocks', 'assets'}
+                          'shocks', 'assets', 'livestock', 'income'}
             if (not v_already_present
                     and 'i' in current_names
                     and 't' in current_names


### PR DESCRIPTION
Two bespoke HH-level value tables for the 1999 (R5) wave, keyed on the packed ERHS panel hhid: **livestock** (541 HH; LivestockValue=lvsval80, TLU=lsu80) and **income** (252 HH; TotalIncome/CropIncome/LivestockIncome/OffFarmIncome/WageIncome). 11 source .tab files (7 villages livestock, 4 income) row-concatenate via multi-file data_info lists. Adds livestock/income to the framework `_no_v_join` set (alongside assets/shocks) — the 1999 wave has no packed-keyed sample, so the v-join would inject an all-null v and fail sane. Build-verified: both (t,i)/t=1999, fully populated, is_this_feature_sane ok; 269 passed/4 skipped. Config by a worktree agent; data-placement + DVC + framework fix + build-verify by coordinator. The roster keeps [q1c,hh] (packed q2 is panel-only, 462/1475 HH); packed↔named panel reconciliation is a panel_ids follow-up.