### PR TITLE
fix(India,Mali): employment i-key + Mali 2018-19 individual_education pid (session follow-ups)

### DIFF
--- a/lsms_library/countries/India/1997-98/_/data_info.yml
+++ b/lsms_library/countries/India/1997-98/_/data_info.yml
@@ -75,10 +75,15 @@ housing:
       Toilet: v03b09
 
 employment:
+  # i=hhcode matches sample().i (HHLIST.DTA uses i:hhcode), so
+  # _join_v_from_sample resolves v.  The old i:hh was the within-village
+  # household number, which did not match sample()'s i:hhcode and broke the
+  # v-join (sibling of the household_roster defect fixed in GH #324).  v is
+  # NOT declared here -- the framework joins it from sample().
   file:
       - ../Data/SECT02AD.DTA
   idxvars:
-      i: hh
+      i: hhcode
       pid: idcode
   myvars:
       Cash_per_day: v02b02

--- a/lsms_library/countries/Mali/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Mali/2018-19/_/data_info.yml
@@ -204,13 +204,17 @@ individual_education:
     file: ehcvm_individu_mli2018.dta
     idxvars:
         v: grappe
-        i: 
+        i:
             - grappe
             - menage
-        pid:
-            - grappe
-            - menage 
-            - numind
+        # 2018-19 uses a SCALAR within-household member number for pid, to
+        # match this wave's household_roster (which keys pid off the scalar
+        # s01q00a; numind == s01q00a here -- verified 46,014/46,014 key
+        # overlap).  The 3-column composite list [grappe, menage, numind]
+        # made Mali's pid() formatter build a "grappe0menage0numind"
+        # composite that the roster's scalar pid never matched (0% overlap;
+        # sibling of the Mali 2021-22 defect fixed in GH #322).
+        pid: numind
     myvars:
         Educational Attainment: 'educ_hi'
 


### PR DESCRIPTION
Two latent bugs surfaced this session. India 1997-98 'employment' used i:hh (0% sample overlap) → i:hhcode (100%, 1429/1430), the #324 sibling. Mali 2018-19 individual_education used pid:[grappe,menage,numind] (composite, 0% roster overlap) → pid:numind (100%, 46014/46014), the #322 sibling. Build-verified: both is_this_feature_sane ok, v resolves. Worktree-delegated; coordinator build-verified.