### PR TITLE
feat(GhanaLSS): wire 2005-06 individual_education (#109 partial)

### DIFF
--- a/lsms_library/countries/GhanaLSS/2005-06/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2005-06/_/data_info.yml
@@ -43,6 +43,20 @@ household_roster:
         Relationship: s1q3
         MonthsAway: s1q22
 
+individual_education:
+    # GLSS5 Section 2A (Education).  s2aq2 = "highest grade completed"; the
+    # .dta carries embedded value labels (none, preschool, p1..p6, jss1..jss3,
+    # m1..m4, sss1..sss3, voc, teacher training, nursing, polytechnic,
+    # university, ...), decoded automatically by get_dataframe().  i = hhid and
+    # pid = pid to match this wave's household_roster index.
+    file: parta/sec2a.dta
+    idxvars:
+        v: clust
+        i: hhid
+        pid: pid
+    myvars:
+        Educational Attainment: s2aq2
+
 housing:
     # GLSS5 Section 7 dwelling characteristics (parta/sec7.dta).  Wall/Floor/
     # Roof = Part F (s7fq1/2/3); Water = Part D q1a; Toilet = Part D q16;

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -252,3 +252,33 @@ Contrary to an earlier triage (GH #350), GLSS DOES field a dwelling module:
 (earlier waves), plus =04_GHA_EXPHOUS= (housing expenditure).  The data is
 present in-repo but no =housing= feature is wired.  A future =housing=
 extractor is feasible — this is a feature gap, not an absence.
+
+* individual_education — wave coverage (2026-06-08, GH #109)
+
+=individual_education= (Educational Attainment from each round's Section 2A)
+is now wired for *5* of the 7 waves: 1998-99, *2005-06* (newly added),
+2012-13, 2016-17 — and was already absent-by-design only for the two GLSS1/2
+rounds.  Source files and label handling:
+
+| Wave    | File              | Var   | Labels                                    |
+|---------+-------------------+-------+-------------------------------------------|
+| 1998-99 | =SEC2A.DTA=       | s2aq2 | hand-decoded (no embedded value labels)   |
+| 2005-06 | =parta/sec2a.dta= | s2aq2 | embedded value labels (grade-level scheme)|
+| 2012-13 | =PARTA/SEC2a.dta= | s2aq2 | embedded value labels                     |
+| 2016-17 | =g7sec2.dta=      | s2aq2 | embedded value labels                     |
+
+Still NOT wired (genuine blockers, not feature gaps to close cheaply):
+
+- *1987-88 / 1988-89* (GLSS1/GLSS2): the education module lives in
+  =Y02A.DAT=/=Y02B.DAT= fixed-format =.DAT= files (parsed via =.DCT=
+  dictionaries), which are not in the local DVC blob cache and carry no
+  embedded value labels.  Wiring would require materializing those blobs and
+  hand-building a GLSS1/2 grade→label map from the questionnaire — but the
+  GLSS1/2 questionnaires are scanned-image PDFs with no text layer (same
+  blocker noted for =housing= above), so the codes cannot be reliably decoded.
+- *1991-92* (GLSS3): the cached =S2.DTA= blob is a cover/control file
+  (interviewer codes + interview dates), NOT the Section-2 education roster.
+  The GLSS3 person-level education module is among the ~140 un-cached blobs,
+  GLSS3 =.dta= files carry NO embedded value labels, and the correct file is
+  not identifiable from the cached set, so it is left unwired rather than
+  guessed.


### PR DESCRIPTION
Wires GhanaLSS 2005-06 individual_education (parta/sec2a.dta, s2aq2; coverage 5/7 waves), mirroring 2012-13/2016-17. Build-verified: 23,380 rows, is_this_feature_sane ok. Remaining under #109: 1987-88/1988-89/1991-92 ie are blocked (uncached source blobs + scanned-PDF codebooks); FIES food_security confirmed GLSS7-only (not a gap).