### PR TITLE
fix(GhanaLSS): region code→name mapping for 1991-92 Birthplace/Region (closes #377)

### DIFF
--- a/lsms_library/countries/GhanaLSS/1991-92/_/categorical_mapping.org
+++ b/lsms_library/countries/GhanaLSS/1991-92/_/categorical_mapping.org
@@ -1,5 +1,32 @@
 The following tables are mapping of numerical codes to categorical labels for 1991--92
 
+* S1 / POV_GH region codes
+
+GLSS3 (1991-92) region code -> name, transcribed from the GLSS3 household
+questionnaire Part A, Section 1, q10 ("In what region/country was [NAME]
+born", value list Western..1 ... Foreign Country..11).  Source PDF:
+Documentation/pdf/G3QPartA.pdf.  This wave-specific table is REQUIRED because
+GLSS3 orders the two northern regions 9=Upper West, 10=Upper East -- the
+reverse of the later-wave GSS coding (e.g. the GLSS5 .dta value labels and the
+country-level GhanaLSS/_/categorical_mapping.org both use 9=Upper East,
+10=Upper West).  s1q10 (Birthplace, codes 1-11) and POV_GH.region / sample
+strata (codes 1-10) both use this list.
+
+#+name: region
+| Code | Label           |
+|------+-----------------|
+|    1 | Western         |
+|    2 | Central         |
+|    3 | Greater Accra   |
+|    4 | Eastern         |
+|    5 | Volta           |
+|    6 | Ashanti         |
+|    7 | Brong Ahafo     |
+|    8 | Northern        |
+|    9 | Upper West      |
+|   10 | Upper East      |
+|   11 | Foreign Country |
+
 * POV_GH
 
 #+name: rural

--- a/lsms_library/countries/GhanaLSS/1991-92/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1991-92/_/mapping.py
@@ -6,8 +6,52 @@ from collections import defaultdict
 from importlib.resources import files
 
 path = files('lsms_library')/'countries'/'GhanaLSS'/'1991-92'
-region_dict = tools.get_categorical_mapping(tablename = 'region', dirs=[f'{path}/_', f'{path}/../_/', f'{path}/../../_/'])
-rural_dict = tools.get_categorical_mapping(tablename = 'rural', dirs=[f'{path}/_', f'{path}/../_/', f'{path}/../../_/'])
+
+def _code_label_map(tablename, dirs):
+    '''Read a Code -> Label org table into a {int code: label} dict.
+
+    ``tools.get_categorical_mapping`` builds its result from ``idxvars='Code'``
+    with no myvars, so the framework's ``df_data_grabber`` drops every value
+    column and the squeeze returns an EMPTY dict (the GH #377 / #372 root
+    cause: region_dict resolved to {} and every Region/Birthplace came out
+    NA).  Here we pass ``Label`` as a myvar so the value column survives, then
+    return a code->label mapping keyed on the integer Code.
+    '''
+    def _as_int(k):
+        # df_data_grabber stringifies the Code index via format_id; coerce back
+        # to int so lookups can use int(value).  Non-numeric codes (e.g. the
+        # country table's '.' None row) are skipped rather than aborting.
+        try:
+            return int(k)
+        except (ValueError, TypeError):
+            return None
+
+    for d in dirs:
+        if d[-1] != '/':
+            d += '/'
+        try:
+            df = tools.df_data_grabber(d + 'categorical_mapping.org', 'Code',
+                                       orgtbl=tablename, Label='Label')
+            s = df['Label']
+            out = {}
+            for k, v in s.to_dict().items():
+                code = _as_int(k)
+                if code is not None and pd.notna(v):
+                    out[code] = v
+            return out
+        except (FileNotFoundError, KeyError, ValueError):
+            continue
+    return {}
+
+# GLSS3 (1991-92) region codes live in the *wave-level* categorical_mapping.org
+# (1991-92/_/), because GLSS3 orders the two northern regions 9=Upper West,
+# 10=Upper East -- the reverse of the country-level table.  Searching the wave
+# dir first picks up the GLSS3-correct list; rural/relationship fall through to
+# whichever file defines them.
+_dirs = [f'{path}/_', f'{path}/../_/', f'{path}/../../_/']
+region_dict = _code_label_map('region', _dirs)
+rural_dict = _code_label_map('rural', _dirs)
+relationship_dict = _code_label_map('relationship', _dirs)
 
 def i(value):
     '''
@@ -29,26 +73,28 @@ def Age(value):
 
 def Birthplace(value):
     '''
-    Formatting birthplace variable
+    Formatting birthplace variable (s1q10, region codes 1-11).
     '''
-    if value > 1e99:
+    if pd.isna(value) or value > 1e99:
         return pd.NA
-    return region_dict.get(f"{value:3.0f}".strip(), pd.NA)
+    return region_dict.get(int(value), pd.NA)
 
 def Relationship(value):
     '''
     Formatting relationship variable
     '''
-    relationship_dict = tools.get_categorical_mapping(tablename = 'relationship', dirs=[f'{path}/_', f'{path}/../../_/', f'{path}/../_/'])
-    return relationship_dict.get(value, pd.NA)
+    if pd.isna(value) or value > 1e99:
+        return pd.NA
+    return relationship_dict.get(int(value), pd.NA)
 
 def Region(value):
     '''
-    Formatting region variable
+    Formatting region variable (POV_GH.region, codes 1-10).
     '''
+    if pd.isna(value) or value > 1e99:
+        return pd.NA
+    return region_dict.get(int(value), pd.NA)
 
-    return region_dict.get(f"{value:3.0f}".strip(), pd.NA)
-    
 
 def v(value):
     '''
@@ -60,14 +106,17 @@ def strata(value):
     '''
     Formatting strata variable (region code to label)
     '''
-    return region_dict.get(f"{value:3.0f}".strip(), pd.NA)
+    if pd.isna(value) or value > 1e99:
+        return pd.NA
+    return region_dict.get(int(value), pd.NA)
 
 def Rural(value):
     '''
     Formatting rural variable
     '''
-
-    return rural_dict.get(value, pd.NA)
+    if pd.isna(value) or value > 1e99:
+        return pd.NA
+    return rural_dict.get(int(value), pd.NA)
 
 def Int_t(value):
     '''


### PR DESCRIPTION
GLSS3 1991-92 Birthplace/Region/Rural/Relationship came out all-NA (the region mapping was empty). Added a wave-local region table (GLSS3 coding: 9=Upper West, 10=Upper East — reversed vs later GSS, so wave-specific) + a _code_label_map helper. Build-verified: 1991-92 Birthplace & Region 100% non-null (Western/Volta/Greater Accra/…), roster ok. NOTE: the agent traced the deeper root cause to a FRAMEWORK bug — local_tools.get_categorical_mapping returns {} when myvars is empty (df_data_grabber drops the value column); worked around in-country here. Worth a follow-up framework fix.