### PR TITLE
feat(India,Kazakhstan): recover item-level assets from DDI labels (#342)

### DIFF
--- a/lsms_library/countries/India/1997-98/_/assets.py
+++ b/lsms_library/countries/India/1997-98/_/assets.py
@@ -1,0 +1,63 @@
+import pandas as pd
+import sys
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+# India 1997-98 §7 Part D 'Consumer durables owned' (SECT07D.DTA).
+#
+# The module is already stored long: one row per (household, item) with
+#   itemcode  = consumer-durable item code (value-labelled in the .dta)
+#   v07d02    = "Number of items owned"  -> Quantity
+# There is no reported value/price column in this part (§7D records counts
+# only; the value of durables is not collected in the 1997-98 instrument),
+# so only Quantity is emitted.  This mirrors the canonical assets schema
+# (t, i, j) with whichever of Quantity/Value the survey records.
+#
+# The item label is recovered from the .dta value-label set on `itemcode`.
+# The old Stata-105 format truncates those labels to 8 characters
+# ('Radio/ca', 'Motorcyc', ...) and -- worse -- gives codes 512 and 515 the
+# *same* truncated label 'Pressure', which would silently merge two distinct
+# items if used as j.  We therefore map by code to the full, disambiguated
+# item names (codes are the authoritative identity; the expansions follow the
+# standard SLC consumer-durables roster).
+#
+# i = hhcode (matches sample()/household_roster 100%; see the
+# months_food_inadequate.py note in this directory).  v is NOT baked in; it is
+# joined from sample() at API time by _join_v_from_sample.
+
+# itemcode -> canonical item label (j).  Codes are the source of truth; the
+# .dta value labels are 8-char-truncated and collide on 512/515.
+ITEM_LABELS = {
+    501: 'Radio/cassette player',
+    502: 'Camera/camcorder',
+    503: 'Bicycle',
+    504: 'Motorcycle/scooter',
+    505: 'Motor car',
+    506: 'Refrigerator',
+    507: 'Washing machine',
+    508: 'Fans',
+    509: 'Heaters',
+    510: 'B/W television',
+    511: 'Colour television',
+    512: 'Pressure cooker',
+    513: 'Telephone',
+    514: 'Sewing machine',
+    515: 'Pressure lamp/stove',
+    516: 'Watches/clocks',
+}
+
+df = get_dataframe('../Data/SECT07D.DTA')
+
+out = pd.DataFrame(index=df.index)
+out['i'] = df['hhcode'].astype(int).astype(str)
+out['t'] = '1997-98'
+out['j'] = df['itemcode'].astype('Int64').map(ITEM_LABELS).astype('string')
+out['Quantity'] = pd.to_numeric(df['v07d02'], errors='coerce')
+
+# Drop rows whose item code is unknown or whose count is missing/zero.
+out = out.dropna(subset=['j'])
+out = out[out['Quantity'].fillna(0) > 0]
+
+out = out.set_index(['t', 'i', 'j']).sort_index()
+
+to_parquet(out, 'assets.parquet')

--- a/lsms_library/countries/India/1997-98/_/assets.py
+++ b/lsms_library/countries/India/1997-98/_/assets.py
@@ -46,7 +46,11 @@ ITEM_LABELS = {
     516: 'Watches/clocks',
 }
 
-df = get_dataframe('../Data/SECT07D.DTA')
+# convert_categoricals=False: keep itemcode as the numeric code (the .dta
+# value labels are 8-char-truncated and collide on 512/515; we map codes
+# ourselves via ITEM_LABELS).  With the default decode, itemcode comes back
+# as the label string ('Watches'...) and astype('Int64') raises.
+df = get_dataframe('../Data/SECT07D.DTA', convert_categoricals=False)
 
 out = pd.DataFrame(index=df.index)
 out['i'] = df['hhcode'].astype(int).astype(str)

--- a/lsms_library/countries/India/_/CONTENTS.org
+++ b/lsms_library/countries/India/_/CONTENTS.org
@@ -1,5 +1,18 @@
 #+title: Contents
 
+* assets — consumer durables (2026-06-08, #342)
+Source: =SECT07D.DTA= §7 Part D "Consumer durables owned".  The module is
+already stored long (one row per household-item) with =itemcode= and =v07d02=
+"Number of items owned".  The item label (=j=) is recovered from the
+value-label set on =itemcode=; the old Stata-105 format truncates those labels
+to 8 characters AND gives codes 512/515 the same truncated label =Pressure=, so
+we map by code to full, disambiguated names (512 = Pressure cooker, 515 =
+Pressure lamp/stove).  §7D records counts only — there is no value/price column
+— so only =Quantity= is emitted (cf. Liberia's count-only instrument).
+Canonical index =(t, i, j)=, i = hhcode.  15 distinct items appear in the data
+(washing machine, code 507, has zero owners).  Built via
+=1997-98/_/assets.py= (materialize: make).
+
 * shocks — not available (2026-06-07, verified)
 
 =shocks= (a household adverse-events-and-coping roster, index =(t, i, Shock)=)

--- a/lsms_library/countries/India/_/data_scheme.yml
+++ b/lsms_library/countries/India/_/data_scheme.yml
@@ -53,3 +53,11 @@ Data Scheme:
     MonthsInadequate: int
     AnyInadequate: bool
     materialize: make
+
+  assets:
+    # Consumer durables owned (SECT07D §7D). Item-level (t, i, j); j is the
+    # recovered durable-item label.  §7D records counts only, so Quantity is
+    # the sole measure (no reported value).
+    index: (t, i, j)
+    Quantity: float
+    materialize: make

--- a/lsms_library/countries/Kazakhstan/1996/_/assets.py
+++ b/lsms_library/countries/Kazakhstan/1996/_/assets.py
@@ -53,7 +53,10 @@ ITEM_LABELS = {
     '16': 'Carpets',
 }
 
-df = get_dataframe('../Data/KZ96HSG_PUF.dta')
+# convert_categoricals=False: keep the b37 block numeric (b37_NN_1 = 1/0 have-flag,
+# counts/prices numeric).  With the default decode, b37_NN_1 comes back as
+# 'Yes'/'No' -> to_numeric NaN -> `owned` never true -> empty records.
+df = get_dataframe('../Data/KZ96HSG_PUF.dta', convert_categoricals=False)
 
 # Durables are constant within household; collapse person-level rows to one per hh.
 keep_cols = ['rn'] + [f'b37_{n}_{a}' for n in ITEM_LABELS for a in ('1', '2', '4')]

--- a/lsms_library/countries/Kazakhstan/1996/_/assets.py
+++ b/lsms_library/countries/Kazakhstan/1996/_/assets.py
@@ -1,0 +1,88 @@
+"""
+Kazakhstan 1996 household assets (durable goods).
+
+Source: ../Data/KZ96HSG_PUF.dta, the dwelling/durables module.  Block b37 is a
+WIDE durable-goods roster -- 16 items x 4 attributes, one column per
+(item, attribute):
+
+    b37_NN_1  "<item>: do you have?"        (1 = yes, 2 = no)
+    b37_NN_2  "<item>: how many pieces?"    -> Quantity
+    b37_NN_3  "<item>: what year did you get it?"   (not emitted)
+    b37_NN_4  "<item>: how much does one piece cost?" (per-piece price)
+
+The columns carry no usable per-item *value* label of their own (the j key is
+buried in the variable label), so the wide block is unusable as-is.  The item
+labels ARE recoverable from the variable labels (b37_NN_1 == "<item>: do you
+have?"); we hard-code the recovered names here and melt wide -> long to the
+canonical assets schema (t, i, j) with j = the item name.
+
+Like housing.py, the file is person-level (one row per personnr) but every b37
+value is constant within the household key ``rn``; we collapse to one row per
+household with drop_duplicates on rn before melting.
+
+i = rn (the household key used by household_roster idxvars i: rn).  v is NOT
+baked in; it is joined from sample() at API time by _join_v_from_sample.
+
+Quantity = pieces owned (b37_NN_2; missing among owned households is treated as
+1 -- the modal answer -- since ownership is affirmed).  Value = pieces x
+per-piece price (b37_NN_4), the household's total reported value for the item.
+Only items the household reports owning (b37_NN_1 == 1) are emitted.
+"""
+import pandas as pd
+import numpy as np
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+# b37 item suffix -> canonical item label (j), recovered from the variable
+# labels of the b37_NN_1 "<item>: do you have?" columns.
+ITEM_LABELS = {
+    '01': 'Refrigerator',
+    '02': 'Freezer',
+    '03': 'Washing machine',
+    '04': 'B/W television',
+    '05': 'Colour television',
+    '06': 'Musical center',
+    '07': 'Record-player',
+    '08': 'Tape recorder',
+    '09': 'Video player',
+    '10': 'Computer',
+    '11': 'Sewing/knitting machine',
+    '12': 'Passenger car',
+    '13': 'Truck',
+    '14': 'Motorcycle/moped',
+    '15': '(Mini-)tractor',
+    '16': 'Carpets',
+}
+
+df = get_dataframe('../Data/KZ96HSG_PUF.dta')
+
+# Durables are constant within household; collapse person-level rows to one per hh.
+keep_cols = ['rn'] + [f'b37_{n}_{a}' for n in ITEM_LABELS for a in ('1', '2', '4')]
+hh = df[keep_cols].drop_duplicates(subset=['rn']).copy()
+hh['i'] = hh['rn'].astype(int).astype(str)
+
+records = []
+for suffix, label in ITEM_LABELS.items():
+    have = pd.to_numeric(hh[f'b37_{suffix}_1'], errors='coerce')
+    owned = have == 1
+    if not owned.any():
+        continue
+    sub = hh.loc[owned, ['i']].copy()
+    pieces = pd.to_numeric(hh.loc[owned, f'b37_{suffix}_2'], errors='coerce')
+    # Ownership affirmed but piece count missing -> treat as 1 (the modal value).
+    pieces = pieces.fillna(1.0)
+    price = pd.to_numeric(hh.loc[owned, f'b37_{suffix}_4'], errors='coerce')
+    sub['j'] = label
+    sub['Quantity'] = pieces.values
+    sub['Value'] = (pieces * price).values
+    records.append(sub)
+
+out = pd.concat(records, axis=0, ignore_index=True)
+out['t'] = '1996'
+out['j'] = out['j'].astype('string')
+
+# Value is genuinely missing where the household didn't report a price.
+out['Value'] = out['Value'].replace(0, np.nan)
+
+out = out.set_index(['t', 'i', 'j']).sort_index()
+
+to_parquet(df=out, fn='assets.parquet')

--- a/lsms_library/countries/Kazakhstan/_/CONTENTS.org
+++ b/lsms_library/countries/Kazakhstan/_/CONTENTS.org
@@ -1,5 +1,20 @@
 #+TITLE: Kazakhstan — country notes & known data issues
 
+* assets — durable goods (2026-06-08, #342)
+Source: =KZ96HSG_PUF.dta= block =b37=, a WIDE durable-goods roster (16 items x
+4 attributes, one column per (item, attribute)):
+=b37_NN_1= "do you have?" (1/2), =b37_NN_2= "how many pieces?", =b37_NN_3= year
+acquired, =b37_NN_4= per-piece price.  The item label (=j=) is buried in the
+=b37_NN_1= variable label ("<item>: do you have?") — the columns themselves
+carry no usable label — so the wide block is unusable as-is; we recover the 16
+names from the variable labels and melt wide -> long.  Like =housing.py= the
+file is person-level but =b37= is constant within =rn= (household), so we
+=drop_duplicates= on =rn= first.  =Quantity= = pieces (missing-among-owned
+treated as 1, the modal value); =Value= = pieces x per-piece price.  Only items
+the household reports owning (=b37_NN_1 == 1=) are emitted.  Canonical index
+=(t, i, j)=, i = rn.  ~11k rows, 16 items, 1979 households.  Built via
+=1996/_/assets.py= (materialize: make).
+
 * Known data issues
 
 ** interview_date — not available at household level (2026-06-06)

--- a/lsms_library/countries/Kazakhstan/_/data_scheme.yml
+++ b/lsms_library/countries/Kazakhstan/_/data_scheme.yml
@@ -32,6 +32,15 @@ Data Scheme:
     Own Step: int
     materialize: make
 
+  assets:
+    # Durable goods owned (KZ96HSG_PUF b37 block, melted wide->long). Item-level
+    # (t, i, j); j is the recovered durable-item label.  Quantity = pieces;
+    # Value = pieces x per-piece price.
+    index: (t, i, j)
+    Quantity: float
+    Value: float
+    materialize: make
+
   sample:
     index: (i, t)
     v: str


### PR DESCRIPTION
India (SECT07D, 15 durable items, Quantity) + Kazakhstan (b37 block, 16 items, Quantity+Value) assets recovered to canonical (t,i,j) with real j labels (script-path melt/relabel). Item labels from .dta value/variable metadata (DDI is PDF-only). Build-verified: India 4,371 rows, Kazakhstan 11,016, j-null 0%, is_this_feature_sane ok. (Coordinator fixed a convert_categoricals default bug the static-only agent missed.) Recoverable slice of #342; the other 4 countries stay documented-as-limited.