### PR TITLE
feat(Cambodia,Serbia): food_items.org harmonization + Makefile fixes (#108, #111 partial)

### DIFF
--- a/lsms_library/countries/Cambodia/2019-20/_/food_acquired.py
+++ b/lsms_library/countries/Cambodia/2019-20/_/food_acquired.py
@@ -5,14 +5,24 @@ sys.path.append('../../../_/')
 import pandas as pd
 import numpy as np
 import json
-from lsms_library.local_tools import to_parquet, get_dataframe
-
-foods = get_dataframe('../Data/hh_sec_5.dta', convert_categoricals=True)
+from lsms_library.local_tools import to_parquet, get_dataframe, df_from_orgfile
 
 df = get_dataframe('../Data/hh_sec_5.dta', convert_categoricals=False)
 
 df = df.rename({'HHID': 'j', 'food_consumption_roster_1__id' : 'i', 's05q03' : 'units','s05q04' : 'quantity', 's05q05' : 'total spent', 's05q06': 'value obtained'}, axis=1)
-df['i'] = foods['food_consumption_roster_1__id']
+
+# Harmonize raw item codes to Preferred Labels via food_items.org,
+# keyed on the numeric item code 1-64 (food_consumption_roster_1__id).
+# We key on the code rather than the categorical text because some raw
+# Stata value labels carry mojibake (e.g. a zero-width space in item 41)
+# that does not round-trip reliably as a join key.
+df['i'] = pd.to_numeric(df['i'], errors='coerce').astype('Int64').astype(str)
+food_items = df_from_orgfile('../../_/food_items.org', name='food_label', to_numeric=False)
+food_items = food_items.loc[:, ['Preferred Label', 'Code']]
+food_items['Code'] = food_items['Code'].str.strip()
+food_items = food_items.replace(['', '---'], pd.NA).dropna()
+food_items = food_items.set_index('Code')['Preferred Label'].str.strip().to_dict()
+df['i'] = df['i'].replace(food_items)
 
 cols = df.loc[:, ['quantity', 'total spent', 'value obtained']].columns
 df[cols] = df[cols].apply(pd.to_numeric, errors='coerce')

--- a/lsms_library/countries/Cambodia/_/CONTENTS.org
+++ b/lsms_library/countries/Cambodia/_/CONTENTS.org
@@ -20,10 +20,10 @@ and no =data_info.yml= at the country level, so Cambodia is not yet
 accessible via the =Country()= API.
 
 * Known issues
-- Makefile :: The generic =%.parquet= rule references =food_items.org=
-  and =malawi.py= (copy-paste error from Malawi).  Neither file exists
-  in this country.  The rule will fail for any target that falls through
-  to it.
+- Makefile :: FIXED (2026-06-08).  The generic =%.parquet= rule
+  previously referenced =malawi.py= (copy-paste error from Malawi); it
+  now references =cambodia.py=.  =food_items.org= now exists (see below),
+  so that prerequisite resolves too.
 - =cambodia.py= :: Uses deprecated =from ligonlibrary.dataframes import from_dta=
   and =dvc.api.open()= anti-patterns instead of =get_dataframe()=.
 - No =data_scheme.yml= :: Cambodia cannot be loaded via
@@ -64,12 +64,16 @@ parquets from =var/food_acquired.parquet=.
 Note: writes CSV files to =~/Downloads/=, which is a side effect that
 should be removed.
 
-** TODO food_items.org
-No food item label mapping exists.  A =food_items.org= table is needed
-to harmonize the food codes from =hh_sec_5.dta= (variable
-=food_consumption_roster_1__id=) into preferred labels.  Since there is
-only one wave, the table would be simple (one column plus preferred
-label).
+** DONE food_items.org (2026-06-08; FCT column scaffolded)
+Harmonizes the 64 food codes from =hh_sec_5.dta= (variable
+=food_consumption_roster_1__id=) into preferred labels.  Columns:
+=Preferred Label | 2019-20 | Code | FCT ID=.  =2019-20/_/food_acquired.py=
+keys on the numeric =Code= (1--64) to map =i= to Preferred Labels
+(verified 64/64 coverage).  The =FCT ID= column is a *scaffold* (blank):
+no freely-downloadable, machine-readable Cambodia FCT was obtained.
+Candidate FCT = SMILING-project Cambodia table (ASEANFOODS-based); see
+the org file's "Food Conversion Table" section for the source URL and
+remaining steps.
 
 ** TODO nutrition.py
 Not yet implemented.  Requires:

--- a/lsms_library/countries/Cambodia/_/Makefile
+++ b/lsms_library/countries/Cambodia/_/Makefile
@@ -33,7 +33,7 @@ interview_date_parquet := $(interview_date:.py=.parquet)
 $(VAR_DIR)/interview_date.parquet: interview_date.py $(interview_date_parquet)
 	python interview_date.py
 
-%.parquet: %.py malawi.py
+%.parquet: %.py cambodia.py
 	(cd $(@D) && python ./$(<F))
 
 clean:

--- a/lsms_library/countries/Cambodia/_/food_items.org
+++ b/lsms_library/countries/Cambodia/_/food_items.org
@@ -1,0 +1,117 @@
+#+title: Cambodia food items
+#+author: LSMS Library
+
+Harmonization table mapping the raw food-item labels of the Cambodia
+LSMS+ 2019-20 food-consumption module (=hh_sec_5.dta=, variable
+=food_consumption_roster_1__id=, codes 1--64) to preferred English
+labels.
+
+* Columns
+- =Preferred Label= :: canonical cross-survey label.
+- =2019-20= :: the raw categorical label as decoded from
+  =hh_sec_5.dta='s =food_consumption_roster_1__id=.  These strings are
+  the join key used by =2019-20/_/food_acquired.py= (which sets =i= from
+  the categorical of that variable).  Encoding artifacts in the raw
+  Stata value labels are reproduced verbatim so the string match
+  succeeds (e.g. =sugarâ​ cane/ palm sugar=, =cafÃ©=).
+- =Code= :: the integer item code (1--64) from the source roster.
+- =FCT ID= :: *SCAFFOLD -- not yet populated.*  Intended to key into a
+  Cambodia Food Composition Table (see "Food Conversion Table" below).
+  Left blank pending a machine-readable FCT.
+
+The Code column lets =harmonized_food_labels()= (key=Code) build a
+numeric-code -> Preferred Label map; the =2019-20= column lets
+=df_from_orgfile()= consumers build a raw-label -> Preferred Label map.
+
+#+name: food_label
+| Preferred Label                 | 2019-20                                          | Code | FCT ID |
+|---------------------------------+--------------------------------------------------+------+--------|
+| Rice (quality 1)                | rice, quality 1                                  |    1 |        |
+| Rice (quality 2)                | rice, quality 2                                  |    2 |        |
+| Rice Noodles                    | rice noodles/ fried noodle                       |    3 |        |
+| Chinese/Khmer Noodles           | chinese noodle/ Khmer noodles                    |    4 |        |
+| Other Cereals/Flour/Bakery      | other cereals or flour and other bakery products |    5 |        |
+| Bread                           | bread                                            |    6 |        |
+| Mudfish                         | Mudfish                                          |    7 |        |
+| Catfish                         | Catfish                                          |    8 |        |
+| Other Inland Fish               | Other inland fish                                |    9 |        |
+| Shrimp/Lobster                  | shrimp/lobster                                   |   10 |        |
+| Crab                            | Crabs                                            |   11 |        |
+| Other Seafood                   | Other seafood                                    |   12 |        |
+| Fish/Seafood (preserved)        | preserved or processed fish/seafood              |   13 |        |
+| Pork                            | Pork                                             |   14 |        |
+| Beef                            | Beef                                             |   15 |        |
+| Duck                            | Duck                                             |   16 |        |
+| Chicken                         | Chicken                                          |   17 |        |
+| Other Meat Products             | Other meat products                              |   18 |        |
+| Eggs                            | eggs and egg-based products                      |   19 |        |
+| Milk/Yoghurt                    | milk or yoghurt                                  |   20 |        |
+| Oils/Fats                       | oils or fats                                     |   21 |        |
+| Banana                          | Banana                                           |   22 |        |
+| Mango                           | mangoes                                          |   23 |        |
+| Longan                          | longan (mien)                                    |   24 |        |
+| Papaya                          | papaya                                           |   25 |        |
+| Tamarind                        | tamarind                                         |   26 |        |
+| Coconut                         | coconut                                          |   27 |        |
+| Nuts/Edible Seeds               | nuts and edible seeds                            |   28 |        |
+| Maize                           | maize and corn crop                              |   29 |        |
+| Other Fresh Fruits              | other fresh fruits                               |   30 |        |
+| Dried/Preserved Fruits          | dried and preserved fruits                       |   31 |        |
+| Watercress (trakun)             | trakun (watercress marsh cabbage)                |   32 |        |
+| Spring Onion/Garlic/Leeks       | spring onion/ garlic/ leeks leaves               |   33 |        |
+| Cabbage/Leaves                  | cabbage/ leaves                                  |   34 |        |
+| Gourd/Cucumber/Pumpkin/Eggplant | gourd, cucumber, pumpkin,  eggplant              |   35 |        |
+| Other Fresh Vegetables          | other fresh vegetables                           |   36 |        |
+| Prepared/Preserved Vegetables   | prepared and preserved vegetables                |   37 |        |
+| Tubers                          | tubers (potato, sweet potato, carrot, radish..)  |   38 |        |
+| Mushrooms                       | mushrooms/ dried mushrooms                       |   39 |        |
+| Pea/Bean/Soybean/Bean Sprout    | pea, bean/ soybean/ bean sprout                  |   40 |        |
+| Sugarcane/Palm Sugar            | sugarâ​ cane/ palm sugar                         |   41 |        |
+| Sweets                          | sweets                                           |   42 |        |
+| Salt                            | salt                                             |   43 |        |
+| Pepper                          | pepper                                           |   44 |        |
+| Monosodium Glutamate            | monosodium glutamte                              |   45 |        |
+| Fish/Soy/Chilli Sauces          | fish sources/ soy sources/ chilly sources        |   46 |        |
+| Other Ingredients               | Other ingrediences                               |   47 |        |
+| Nutritive Tablets               | nutritive tablets                                |   48 |        |
+| Coffee/Tea/Chocolate            | coffee, tea, and chocolate                       |   49 |        |
+| Bottled/Mineral Water           | bottled/mineral water                            |   50 |        |
+| Soft Drinks/Juices              | soft drinks, orange juices, friut juices         |   51 |        |
+| Ice Cream                       | ice cream                                        |   52 |        |
+| Beer (at home)                  | beer at home                                     |   53 |        |
+| Wine (at home)                  | wine at home                                     |   54 |        |
+| Other Alcohol (at home)         | other alcohol not in bar or restaurant           |   55 |        |
+| Cigarettes/Tobacco              | cigarettes and other tobacco                     |   56 |        |
+| Food (at school)                | food at school                                   |   57 |        |
+| Drinks (at school)              | drinks at school                                 |   58 |        |
+| Food (at work)                  | food at work                                     |   59 |        |
+| Drinks (at work)                | drinks at work                                   |   60 |        |
+| Food/Snacks (restaurant)        | food/snacks at restaurant pub or cafÃ©           |   61 |        |
+| Drinks (restaurant)             | drinks at restaurant pub or cafÃ©                |   62 |        |
+| Prepared Meals (takeaway)       | Prepared meals bought outside and eaten at home  |   63 |        |
+| Other Food Expenses             | other food expenses                              |   64 |        |
+
+* Food Conversion Table (FCT) -- TODO
+
+The =FCT ID= column above is a scaffold.  No freely-downloadable,
+machine-readable Cambodia FCT was obtained for this commit.
+
+Candidate source: the *SMILING project* Cambodia FCT (ASEANFOODS-based,
+~140--175 selected foods with energy, protein, fat, carbohydrate, iron,
+zinc, vitamin A, folate, calcium, vitamin D, B-vitamins, vitamin C).
+See Berger et al. (2019), "Food Composition Tables in Southeast Asia:
+The Contribution of the SMILING Project", /Matern Child Health J/ 23
+(Suppl 1):S46--S54, https://doi.org/10.1007/s10995-018-2528-8 (open
+access: https://pmc.ncbi.nlm.nih.gov/articles/PMC6373311/).  The
+underlying Cambodia FCT is an unpublished Excel held by the SMILING/IRD
+consortium (http://www.nutrition-smiling.eu/) and is not posted for
+direct download; obtain it by request, or fall back to ASEANFOODS /
+FAO/INFOODS regional tables.
+
+Remaining steps to wire nutrition:
+1. Obtain the Cambodia FCT (above) as CSV.
+2. Map each of the 64 items here to an FCT food code; fill the =FCT ID=
+   column.
+3. Add a country-level =fct.py= / =nutrition.py= (cf. Panama,
+   Guatemala) that joins =food_acquired= quantities to per-100g nutrient
+   values via =FCT ID=.

--- a/lsms_library/countries/Serbia/2007/_/food_acquired.py
+++ b/lsms_library/countries/Serbia/2007/_/food_acquired.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-from lsms_library.local_tools import to_parquet, get_dataframe
+from lsms_library.local_tools import to_parquet, get_dataframe, df_from_orgfile
 
 import sys
 sys.path.append('../../_/')
 import pandas as pd
-import pyreadstat
 import numpy as np
 import json
 
@@ -22,8 +21,22 @@ dailyprice = pd.concat([df[s]/df[q] for q,s in zip(quant, spent)], axis=1)
 median = dailyprice.median(axis=1)
 df['Price'] = median
 
-dict = {'nsifra': 'i', 'mera': 'units'}
+# Use the numeric product code 'proizvod' as the harmonization key.
+# (The text 'nsifra' field carries the legacy YUSCII transliteration in
+# which '|' stands for "đ", which cannot survive an org-mode table; see
+# ../../_/food_items.org for the rationale.)
+dict = {'proizvod': 'i', 'mera': 'units'}
 df = df.rename(dict, axis = 1).reset_index()
+
+# Harmonize raw item codes to Preferred Labels via food_items.org,
+# keyed on the numeric 'proizvod' code.
+food_items = df_from_orgfile('../../_/food_items.org', name='food_label', to_numeric=False)
+food_items = food_items.loc[:, ['Preferred Label', 'proizvod']]
+food_items['proizvod'] = food_items['proizvod'].str.strip()
+food_items = food_items.replace(['', '---'], pd.NA).dropna()
+food_items = food_items.set_index('proizvod')['Preferred Label'].str.strip().to_dict()
+df['i'] = df['i'].astype(str).str.strip().replace(food_items)
+
 final = df.loc[:, ['j', 'i', 'Quantity', 'units', 'Total Expenditure', 'Price']]
 
 final = final.set_index(['j','i'])

--- a/lsms_library/countries/Serbia/_/CONTENTS.org
+++ b/lsms_library/countries/Serbia/_/CONTENTS.org
@@ -41,18 +41,19 @@ independently since it uses the CLI materializer, but the legacy
 Makefile pipeline for food and other features is non-functional.
 
 * Known issues
-- Makefile :: Generic rule references =food_items.org= and =panama.py=
-  (copy-paste error from Panama).  Should reference =serbia.py= and
-  a to-be-created =food_items.org=.
+- Makefile :: FIXED (2026-06-08).  The generic rule's =panama.py=
+  prerequisite (copy-paste error from Panama) now reads =serbia.py=, and
+  =food_items.org= now exists.
 - =serbia.py= :: Nearly empty---imports deprecated =ligonlibrary= and
   =lsms.tools= but defines no functions.  Contrast with =cambodia.py=
   which at least defines =age_sex_composition()=.
 - No =categorical_mapping.org= :: No label harmonization for any
   variables.
-- Anti-pattern usage :: All wave-level scripts use =dvc.api.open()= and
-  =from ligonlibrary.dataframes import from_dta= instead of
-  =get_dataframe()=.  The =food_acquired.py= script additionally
-  imports =pyreadstat= directly.
+- Anti-pattern usage :: =other_features.py= / =household_characteristics.py=
+  still use =dvc.api.open()= and =from ligonlibrary.dataframes import
+  from_dta=.  =food_acquired.py= already uses =get_dataframe()=; its
+  stray =import pyreadstat= was removed (2026-06-08) when wiring
+  =food_items.org=.
 
 * Files in Serbia/_/
 ** DONE data_scheme.yml
@@ -60,31 +61,37 @@ Declares =household_roster= with index =(t, v, i, pid)= and columns
 =Sex=, =Age=, =Generation=, =Distance=, =Affinity=.  Does not declare
 =food_acquired=, =household_characteristics=, or =other_features=.
 
-** TODO food_items.org
-Not yet created.  This is the primary blocker for the food pipeline.
-The 2007 survey uses numeric food codes (=nsifra= in =m5_1_diary.dta=)
-that need mapping to human-readable labels.  With only one wave, the
-table would be simple.
+** DONE food_items.org (2026-06-08; FCT column scaffolded)
+Harmonizes the 100 food items of the 2007 diary (=m5_1_diary.dta=) into
+preferred labels.  Columns: =Preferred Label | proizvod | Serbian Label
+| FCT ID=.  =2007/_/food_acquired.py= keys on the numeric =proizvod=
+code (verified 100/100 coverage) rather than on =nsifra=: =nsifra= is
+the product *text*, stored in a legacy YUSCII transliteration in which
+='|'= encodes "đ" and cannot survive an org-mode pipe-delimited table.
+The =Serbian Label= column is the decoded =nsifra= (documentation only).
+The =FCT ID= column is a *scaffold* (blank) -- see "Food Conversion
+Table" below.
 
-The existing CONTENTS.org had a contradictory status (both DONE and
-TODO) for this item.  It is definitively missing from the directory.
-
-** TODO Food Conversion Table
-Not yet created.  Needed to convert food quantities into nutritional
-content.  The FAO Food Composition Tables for Eastern Europe may be a
-useful starting point.
+** TODO Food Conversion Table (FCT)
+Not yet wired.  No freely-downloadable, machine-readable Serbian FCT was
+obtained.  Candidate = Serbian Food and Nutrition Database (IMR
+Belgrade, EuroFIR-harmonized); access requires EuroFIR registration, no
+bulk download.  Fallback = EuroFIR Balkan regional FCT.  See the
+=food_items.org= "Food Conversion Table" section for source URLs and the
+remaining steps (obtain FCT CSV -> fill =FCT ID= column -> add
+=nutrition.py= cf. Panama/Guatemala).
 
 ** TODO nutrition.py
-Not yet implemented.  Blocked by missing =food_items.org= and Food
-Conversion Table.
+Not yet implemented.  Blocked by the missing FCT (above);
+=food_items.org= is now present.
 
-** TODO Makefile
-Currently broken.  The generic rule references =food_items.org= and
-=panama.py= (copy-paste from Panama).  Needs:
-1. Replace =panama.py= with =serbia.py= in the generic rule.
-2. Create =food_items.org= (or remove the dependency if not needed).
-3. Populate =serbia.py= with any country-specific helper functions, or
-   remove the dependency from the Makefile.
+** DONE Makefile (2026-06-08)
+The generic =%.parquet= rule's =panama.py= prerequisite (copy-paste from
+Panama) was replaced with =serbia.py= (which exists).  =food_items.org=
+now exists too, so that prerequisite resolves.  =serbia.py= remains a
+near-empty placeholder (no helper functions defined); the wave scripts
+do not import it, so the Makefile prerequisite is satisfied by file
+presence alone.
 
 ** DONE other_features.py
 CLOSED: [2023-07-24 Mon]

--- a/lsms_library/countries/Serbia/_/Makefile
+++ b/lsms_library/countries/Serbia/_/Makefile
@@ -23,7 +23,7 @@ food_acquired_parquet := $(food_acquired:.py=.parquet)
 $(VAR_DIR)/food_acquired.parquet: food_acquired.py $(food_acquired_parquet)
 	python food_acquired.py
 
-%.parquet: %.py panama.py
+%.parquet: %.py serbia.py
 	(cd $(@D) && python ./$(<F))
 
 clean:

--- a/lsms_library/countries/Serbia/_/food_items.org
+++ b/lsms_library/countries/Serbia/_/food_items.org
@@ -1,0 +1,160 @@
+#+title: Serbia food items
+#+author: LSMS Library
+
+Harmonization table mapping the food-item codes of the Serbia LSMS 2007
+food-consumption diary (=m5_1_diary.dta=) to preferred English labels.
+
+* Why the join key is =proizvod=, not =nsifra=
+
+In =m5_1_diary.dta= the =nsifra= field holds the *Serbian product name*
+as text and =proizvod= holds the numeric product code.  The raw Serbian
+text is stored in a legacy single-byte (YUSCII-style) transliteration in
+which the pipe character ='|'= is used for the letter "đ" (e.g.
+=Gove|e meso= = "Goveđe meso", beef).  A literal ='|'= inside a cell
+cannot survive an org-mode pipe-delimited table, so this table keys on
+the clean numeric =proizvod= code instead.  =2007/_/food_acquired.py= was
+updated to look up =proizvod= -> Preferred Label.
+
+* Columns
+- =Preferred Label= :: canonical cross-survey English label.
+- =proizvod= :: the numeric product code (e.g. =0101=) from the source;
+  the join key.  Grouped by leading digits: 01 cereals/bread, 02
+  vegetables, 03 fruit/nuts, 04 meat, 05 fish, 06 fats/oils, 07
+  dairy/eggs, 08 sugar/spices/misc, 09 beverages, 10 tobacco, 11 meals
+  away.
+- =Serbian Label= :: the =nsifra= product name decoded from the source
+  YUSCII transliteration into readable Serbian Latin (documentation
+  only; not a join key).
+- =FCT ID= :: *SCAFFOLD -- not yet populated.*  Intended to key into the
+  Serbian Food and Nutrition Database (see "Food Conversion Table"
+  below).  Left blank pending a machine-readable FCT.
+
+#+name: food_label
+| Preferred Label                     | proizvod | Serbian Label                                                  | FCT ID |
+|-------------------------------------+----------+----------------------------------------------------------------+--------|
+| White Bread                         |     0101 | Beli hleb                                                      |        |
+| Semi-White Bread                    |     0102 | Polubeli hleb                                                  |        |
+| Black/Rye/Wholegrain Bread          |     0103 | Crni, ražani, integralni hleb                                 |        |
+| Pastries                            |     0104 | Peciva                                                         |        |
+| Other Bread                         |     0105 | Druge vrste hleba                                             |        |
+| Wheat/Rye Flour and Semolina        |     0106 | Pšenično, ražano brašno i griz                               |        |
+| Maize Flour and Maize               |     0107 | Kukuruzno brašno i kukuruz                                    |        |
+| Flour Products and Pasta            |     0108 | Proizvodi od brašna i testenine                              |        |
+| Other Cereals                       |     0109 | Druge vrste žita                                             |        |
+| Rice                                |     0110 | Pirinač                                                       |        |
+| Frozen Dough                        |     0111 | Smrznuto testo                                                |        |
+| Yeast                               |     0112 | Kvasac                                                        |        |
+| Potato                              |     0201 | Krompir                                                       |        |
+| Beans                               |     0202 | Pasulj                                                        |        |
+| Onion/Garlic/Leek                   |     0203 | Crni i beli luk i praziluk                                    |        |
+| Carrot/Greens/Celery/Beetroot       |     0204 | Šargarepa, zelen, celer, cvekla,                             |        |
+| Cabbage/Kale/Brussels/Broccoli      |     0205 | Kupus, kelj, prokelj, brokule                                |        |
+| Spinach/Chard (fresh, frozen)       |     0206 | Spanać, blitva svež i zamrznuti                              |        |
+| Cucumber                            |     0207 | Krastavac                                                     |        |
+| Tomato (fresh)                      |     0208 | Paradajz (svež)                                              |        |
+| Pepper (fresh, frozen, dried)       |     0209 | Paprika (sveža i zamrznuta i suva)                           |        |
+| Lettuce                             |     0210 | Zelena salata                                                 |        |
+| Peas/Green Beans (fresh, frozen)    |     0211 | Grašak,boranija, svež i zamrznut                            |        |
+| Mushrooms                           |     0212 | Pečurke, gljive                                              |        |
+| Other Fresh Vegetables              |     0213 | Ostalo sveže povrće                                          |        |
+| Pickled Vegetables                  |     0214 | Ukiseljeno povrće                                            |        |
+| Processed/Canned Vegetables         |     0215 | Prerađeno i konzerv. povrće, paradajz sok                   |        |
+| Apple                               |     0301 | Jabuke                                                        |        |
+| Pear                                |     0302 | Kruške                                                       |        |
+| Cherries (fresh, frozen)            |     0303 | Trešnje i višnje sveže, zamrznuto                           |        |
+| Apricots/Peaches (fresh, frozen)    |     0304 | Kajsije i breskve sveže, zamrznuto                           |        |
+| Plum                                |     0305 | Šljive                                                       |        |
+| Grape                               |     0306 | Grožđe                                                       |        |
+| Other Fresh Fruit                   |     0307 | Ostalo sveže  voće                                           |        |
+| Citrus (orange/lemon/mandarin)      |     0308 | Pomorandže, limun, mandarine, grejp                         |        |
+| Other Tropical Fruit                |     0309 | Ostalo južno voće, banane, ananas, kivi …                   |        |
+| Walnut/Hazelnut/Almond              |     0310 | Orah, lešnik, badem                                          |        |
+| Dried Fruit (plum/fig/grape)        |     0311 | Suvo voće, šljive, smokve, grožđe                           |        |
+| Jam/Compote/Preserves/Marmalade     |     0312 | Džem, kompot, slatko, marmelada                             |        |
+| Beef                                |     0401 | Goveđe meso                                                  |        |
+| Young Beef                          |     0402 | Juneće meso                                                  |        |
+| Veal                                |     0403 | Teleće meso                                                  |        |
+| Pork                                |     0404 | Svinjsko meso                                                 |        |
+| Suckling Pig                        |     0405 | Praseće meso                                                 |        |
+| Mutton/Goat                         |     0406 | Ovčije i kozije                                              |        |
+| Lamb/Kid                            |     0407 | Jagnjeće i jareće                                            |        |
+| Poultry                             |     0408 | Živinsko meso                                                 |        |
+| Other Fresh Meat and Offal          |     0409 | Ostalo sveže meso i iznutrice                               |        |
+| Dried/Cooked Bacon                  |     0410 | Suva i barena slanina                                        |        |
+| Dried Meat (boneless)               |     0411 | Suvo meso bez kostiju                                         |        |
+| Dried Meat (with bone)              |     0412 | Suvo meso sa kostima                                         |        |
+| Salami and Sausages                 |     0413 | Salame i kobasice svih vrsta                                 |        |
+| Frankfurters/Debreziner             |     0414 | Viršle, debreciner, safalade                                |        |
+| Other Sausage Products              |     0415 | Ostali kobasičarski proizvodi                               |        |
+| Canned/Processed Meat               |     0416 | Konzervirano i prerađeno meso                               |        |
+| Freshwater Fish (fresh, frozen)     |     0501 | Sveža/zamrz. rečna i jezer.riba                             |        |
+| Sea Fish (fresh, frozen)            |     0502 | Sveža i zamrznuta morska riba                               |        |
+| Fish Products                       |     0503 | Proizvodi i prerađev.od ribe                                |        |
+| Lard/Suet/Tallow                    |     0601 | Svinjska mast, salo, loj                                     |        |
+| Edible Oil                          |     0602 | Jestivo ulje                                                  |        |
+| Other Vegetable Fats                |     0603 | Ostale biljne masnoće                                        |        |
+| Margarine                           |     0604 | Margarin                                                      |        |
+| Milk                                |     0701 | Mleko                                                         |        |
+| Sour Milk/Yoghurt/Kefir             |     0702 | Kiselo mleko,  jogurt, kefir                                 |        |
+| White Cheese (all kinds)            |     0703 | Domaći, beli  sir (sve vrste)                                |        |
+| Other Cheese (yellow/hard/cream)    |     0704 | Ostale vrste sira (žuti, tvrdi, krem)                        |        |
+| Butter                              |     0705 | Maslac                                                        |        |
+| Kajmak/Cream/Mileram                |     0706 | Kajmak, pavlaka, mileram, vurda                             |        |
+| Ice Cream                           |     0707 | Sladoled                                                      |        |
+| Other Dairy Products                |     0708 | Ostali mlečni proizvodi                                      |        |
+| Eggs (chicken and other)            |     0709 | Jaja (kokošija i druga)                                      |        |
+| Sugar (crystal/cube/powder)         |     0801 | Šećer (kristal, kocke, prah)                                 |        |
+| Salt                                |     0802 | So                                                           |        |
+| Honey                               |     0803 | Med                                                          |        |
+| Chocolate and Chocolate Spread      |     0804 | Čokolade i čokoladni krem                                    |        |
+| Sweets/Biscuits/Candy               |     0805 | Slatkiši, keks, biskviti, bombone                           |        |
+| Salted Snacks (peanuts/chips)       |     0806 | Slani kikiriki, smoki, grisine, čips i sl.                  |        |
+| Cocoa                               |     0807 | Kakao                                                        |        |
+| Coffee (raw/roasted/ground)         |     0808 | Kafa (sirova, pržena, mlevena)                              |        |
+| Baby Food                           |     0809 | Hrana za odojčad                                            |        |
+| Spices                              |     0810 | Začini                                                      |        |
+| Tea                                 |     0811 | Čajevi                                                      |        |
+| Mayonnaise/Mustard/Ketchup          |     0812 | Majonez, senf, kečap                                        |        |
+| Instant Soup                        |     0813 | Instant supe                                                 |        |
+| Ready Meals                         |     0814 | Gotova jela                                                  |        |
+| Whipped Cream/Pudding               |     0815 | Šlag, puding, i sl.                                         |        |
+| Other Unspecified Products          |     0816 | Ostali nepomenuti proizvodi                                 |        |
+| Wine                                |     0901 | Vino                                                         |        |
+| Beer                                |     0902 | Pivo                                                         |        |
+| Rakija (spirits)                    |     0903 | Rakija                                                       |        |
+| Other Alcoholic Drinks              |     0904 | Ostala alkoholna pića                                       |        |
+| Mineral Water                       |     0905 | Mineralna (gazirana/negazirana) voda                       |        |
+| Soft Drinks (carbonated/still)      |     0906 | Gazirani i negazirani sokovi                                |        |
+| Natural Fruit Juices                |     0907 | Prirodni voćni sokovi                                       |        |
+| Cigarettes                          |     1001 | Cigarete                                                     |        |
+| Tobacco                             |     1002 | Duvan                                                        |        |
+| Food Away (work/school)             |     1101 | Hrana na poslu, u školi                                     |        |
+| Food in Restaurant (incl. delivery) |     1102 | Hrana u restoranu (i poručena hrana koja se dostavlja na kuću) |     |
+| Drinks Away (work/school)           |     1103 | Pice na poslu, u skoli                                      |        |
+| Drinks in Restaurant                |     1104 | Pice u restoranima                                          |        |
+
+* Food Conversion Table (FCT) -- TODO
+
+The =FCT ID= column above is a scaffold.  No freely-downloadable,
+machine-readable Serbian FCT was obtained for this commit.
+
+Candidate source: the *Serbian Food and Nutrition Database* developed by
+the Institute for Medical Research (IMR), University of Belgrade -- the
+first national FCDB built to EuroFIR criteria (LanguaL + EFSA FoodEx2
+coding; ~1046 foods + ~129 composite dishes).  See Gurinovic et al.
+(2016), "Establishment and advances in the online Serbian food and
+recipe data base harmonized with EuroFIR standards", /Food Chemistry/
+193:190--196, https://doi.org/10.1016/j.foodchem.2015.01.124; online
+entry via the EuroFIR FoodEXplorer network
+(https://www.eurofir.org/food-information/food-composition-databases/)
+and the IMR Serbian nutrition DB.  Access requires EuroFIR
+registration; there is no bulk public download.  A EuroFIR regional
+(Balkan Food Platform) FCT is the fallback.
+
+Remaining steps to wire nutrition:
+1. Obtain the Serbian FCDB (or a EuroFIR Balkan regional FCT) as CSV.
+2. Map each of the ~100 items here to an FCT food code; fill the
+   =FCT ID= column.
+3. Add a country-level =fct.py= / =nutrition.py= (cf. Panama,
+   Guatemala) joining =food_acquired= quantities to per-100g nutrient
+   values via =FCT ID=.


### PR DESCRIPTION
Builds food_items.org for Cambodia (64 items from hh_sec_5) and Serbia (100 from m5_1_diary), 0 unmapped against live data; fixes stray Makefile module refs (Cambodia malawi.py→cambodia.py, Serbia panama.py→serbia.py). food_acquired.py is scaffolded but NOT yet canonical (not declared in data_scheme; needs the (t,i,j,u,s) shape + Quantity/Expenditure, and Cambodia has an i/j fix pending) — left as inert scaffolding. FCT scaffolded (FCT ID blank): no free machine-readable Cambodia/Serbia FCT — download URLs documented in each food_items.org. Regression-checked: existing roster builds unaffected.