### PR TITLE
feat(EthiopiaRHS): plot_features (1994a/R1) (#278)

### DIFF
--- a/lsms_library/countries/EthiopiaRHS/1994a/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1994a/Data/.gitignore
@@ -1,1 +1,2 @@
 /*.dta
+/land1all.tab

--- a/lsms_library/countries/EthiopiaRHS/1994a/Data/land1all.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1994a/Data/land1all.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 327f4e8332bbe25c080271c11a4fa908
+  size: 3189057
+  hash: md5
+  path: land1all.tab

--- a/lsms_library/countries/EthiopiaRHS/1994a/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1994a/_/data_info.yml
@@ -86,3 +86,113 @@ cluster_features:
         Woreda:
             - q1c
             - mappings: ['erhs_village_woreda', 'Code', 'Woreda']
+
+# plot_features (#278, under #167).  LASTING plot/parcel characteristics
+# of the household's farmland, from the R1 (early 1994) land section
+# (questionnaire Q21).  ONE ROW PER PLOT -- multiple plots per household
+# (mean ~3.9, max 29 over 1,477 HH; 5,811 source rows).
+#
+# SOURCE FILE.  land1all.tab is the conversion-applied version of the
+# raw R1 land section r1p2s1.tab (Landconversion.SPS sets
+# area1 = q21_1b and merges the land-unit -> hectare factors): it ships
+# the pre-computed per-plot HECTARE column q21_1aha, so Area needs no
+# in-library unit conversion (cf. the R4 plotha "oracle" in the design
+# doc, slurm_logs/DESIGN_erhs_plot_features_2026-05-20.org).  land1all
+# is also markedly cleaner than r1p2s1 (19 vs 215 duplicate (i, plot_id)
+# pairs), so it is the chosen R1 source.
+#
+# CODE-BASED extraction (converted_categoricals: False), consistent with
+# the 1994a roster/food: q1c and q5 are read as the STABLE NUMERIC CODES
+# the shared `i` formatter title-cases and joins as <village>_<hh_no>.
+#
+# i-KEY (statically verified).  i = [q1c, q5] -- peasant-association code
+# + HH-no-within-village -- the SAME composite the 1994a `food_acquired`
+# block uses (food1.dta q1c+q5).  Measured overlap of the plot file's
+# packed [q1c, q5] against the 1994a roster's [q1c, hhid] composite is
+# 1477/1477 (perfect): the roster's `hhid` == the land/food file's `q5`
+# (both = HH number within village).  v (peasant association) is
+# auto-joined from sample() at API time (NOT in the index).
+#
+# plot_id = q21_1, the plot's sequence number within the household
+# (1..29).  507 of the 5,811 rows (8.7%) are per-HH land TOTAL rows that
+# carry q21_1a/q21_1aha but NO q21_1 / area1 / q21_3 -- they get a null
+# plot_id and surface as the documented residual (is_this_feature_sane
+# warns, not fails, below the 10% null-index threshold), mirroring the
+# ERHS food harmonization residual posture.  A handful of duplicate
+# (i, plot_id) pairs (~19) are genuine source data-entry artifacts.
+#
+# COLUMNS (= source var):
+#  - Area     = q21_1aha  (plot area in HECTARES, the canonical unit;
+#               already converted in-file -- 5,808 non-null, 0-7.5 ha).
+#  - AreaUnit = area1 (== raw q21_1b) -- the NATIVE local area unit, mapped
+#               to its harmonized label (Timad/Gemed/Kert/Hectare/...);
+#               preserves provenance behind the hectare conversion.
+#  - Tenure   = q21_3, the form under which the plot is HELD, mapped to the
+#               canonical plot_features Tenure spellings.  ERHS code 5
+#               conflates "sharecropped, rented" -> sharecropped_in (the
+#               dominant arrangement); code 6 (fixed rent) -> rented_in;
+#               redistribution / land-reform / pre-reform purchase -> owned;
+#               pre-reform inheritance + gift from parents -> inherited;
+#               cleared forest -> squatted; trustship -> communal; the rest
+#               -> other_tenure.  (Per-season contract detail -- crop-share
+#               %, partner identity -- is plot_cultivation territory, out
+#               of scope per the design doc's D2.)
+#  - SoilType = q21_5, the local soil-FERTILITY class (Lem = fertile,
+#               Lem-teuf = medium, Teuf = poor); carried as its label.
+#  - Irrigated= q21_7 (Yes/No -> True/False), the plot's irrigation
+#               status; treated as a lasting plot attribute.
+plot_features:
+    file: land1all.tab
+    converted_categoricals: False
+    idxvars:
+        i:
+            - q1c
+            - q5
+        plot_id: q21_1
+    myvars:
+        Area: q21_1aha
+        AreaUnit:
+            - area1
+            - mapping:
+                2: Hectare
+                3: Gemed
+                4: Timad
+                5: Kert
+                6: Massa
+                8: Kufaro
+                9: Other
+                10: Kend (arms-length)
+                11: Square meters
+                12: Farrow (Boy)
+                13: Tinto
+                14: Ermija
+                15: Dearo
+                16: Gezem
+                17: Debe Zhir
+                20: Wodero
+                21: Gura Zhir
+        Tenure:
+            - q21_3
+            - mapping:
+                1: inherited        # Own land, pre-reform inheritance
+                2: owned            # Own land, pre-reform purchase
+                3: owned            # Own land, obtained at land reform
+                4: owned            # Own land, obtained during redistribution
+                5: sharecropped_in  # "Sharecropped, rented land" (conflated)
+                6: rented_in        # Rented land with fixed rent
+                7: other_tenure     # Other
+                10: other_tenure    # after demise of prod coop / state farm
+                11: squatted        # by clearing forest
+                12: inherited       # gift from parents
+                13: communal        # trustship land
+        SoilType:
+            - q21_5
+            - mapping:
+                1: Lem        # fertile
+                2: Lem-teuf   # medium
+                3: Teuf       # poor
+        Irrigated:
+            - q21_7
+            - mapping:
+                1: True       # Yes
+                2: False      # No

--- a/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
+++ b/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
@@ -66,6 +66,31 @@ Data Scheme:
     Quantity: float
     Expenditure: float
 
+  # plot_features (#278, under #167): LASTING plot/parcel characteristics
+  # of the household's farmland.  One row per plot -- MULTIPLE PLOTS PER
+  # HOUSEHOLD (mean ~3.9, max 29).  WIRED for 1994a (R1) only, from the
+  # conversion-applied R1 land section land1all.tab (clean YAML, code-
+  # based, i=[q1c,q5], plot_id=q21_1; see 1994a/_/data_info.yml).  Area
+  # is in HECTARES (pre-computed in-file); AreaUnit carries the native
+  # local unit label; Tenure is mapped to the canonical plot_features
+  # spellings.  v (peasant association) is auto-joined by
+  # _join_v_from_sample() at API time, so it is NOT in the index --
+  # canonical (t, v, i, plot_id) less the framework-joined v.
+  #
+  # DEFERRED (no plot_features yet): 1989 (no plot roster in the IFPRI
+  # Dataverse archive -- HH x crop only), 1994b/1995/1997 (R2-R4 raw
+  # plot sections present but unwired -- R2/R4 are multi-file/script-path,
+  # R3 needs a composite plot_id formatter), and 1999/2004/2009 (R5-R7,
+  # only pre-aggregated HH x crop area_output_* -- no raw plot rows).
+  # See slurm_logs/DESIGN_erhs_plot_features_2026-05-20.org.
+  plot_features:
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    Tenure: str
+    SoilType: str
+    Irrigated: bool
+
   # Sampling design.  ERHS is a PURPOSIVE 15-village longitudinal
   # panel, not a weighted national sample -- there are no design
   # weights, so weight/panel_weight are NaN (sourcing any constructed


### PR DESCRIPTION
Plot-level agricultural outcomes for R1 (1994a) from land1all.tab: (t,i,v,plot_id), 5,284 rows, ~3.8 plots/HH, Area(ha)/AreaUnit/Tenure/SoilType/Irrigated. i=[q1c,q5] (1477/1477 roster overlap). Build-verified, is_this_feature_sane ok. R2-R7 deferred (documented). Config worktree-delegated; data+DVC+verify by coordinator.