### PR TITLE
feat(parity): GAP 1 — item-level crop_production (t,i,plot,crop) across 7 LSMS-ISA countries

### DIFF
--- a/lsms_library/countries/Ethiopia/2011-12/_/crop_production.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/crop_production.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""Build crop_production for Ethiopia ESS 2011-12 (Wave 1; GAP 1).
+
+Item-level harvest at (t, i, plot_id, j, u) from §9 post-harvest
+(sect9_ph_w1), with planting month from §4 (sect4_pp_w1), the plot-level
+mixed-stand flag from §3 (sect3_pp_w1), and reported sale qty/value from
+§11 (sect11_ph_w1).
+
+W1 specifics: the §9 harvest quantity is reported directly in KILOS
+(ph_s9q12_a; grams residual ph_s9q12_b is dropped — median 0), so u='Kg'
+and no unit code exists.  §9 has no pure/mixed-stand item variable, so
+intercropped comes from the §3 plot roster (pp_s3q03: 1=No, 2=Yes).
+i = household_id (matches sample().i for W1).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import crop_production_for_wave
+
+
+harvest  = get_dataframe('../Data/sect9_ph_w1.dta',  convert_categoricals=False)
+planting = get_dataframe('../Data/sect4_pp_w1.dta',  convert_categoricals=False)
+intercrop = get_dataframe('../Data/sect3_pp_w1.dta', convert_categoricals=False)
+sale     = get_dataframe('../Data/sect11_ph_w1.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+    crop_code='crop_code',
+    quantity='ph_s9q12_a',         # reported harvest, KILOS (u = 'Kg')
+    harvest_month='ph_s9q13_b',    # harvest-end month
+    # intercrop: §9 has none in W1 -> plot-roster fallback
+    ic_holder_id='holder_id', ic_parcel_id='parcel_id',
+    ic_field_id='field_id', ic_flag='pp_s3q03',
+    pl_crop_code='crop_code', pl_month='pp_s4q12_a',
+    s_crop_code='crop_code', s_sold_flag='ph_s11q01',
+    s_qty='ph_s11q03_a', s_value='ph_s11q04_a',   # sale qty kilos, value Birr
+)
+
+df = crop_production_for_wave('2011-12', harvest, planting, sale, colmap,
+                              intercrop=intercrop)
+
+assert len(df) > 0, "crop_production 2011-12 produced no rows"
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Ethiopia/2013-14/_/crop_production.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/crop_production.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Build crop_production for Ethiopia ESS 2013-14 (Wave 2; GAP 1).
+
+Item-level harvest at (t, i, plot_id, j, u) from §9 (sect9_ph_w2), with
+planting month from §4 (sect4_pp_w2) and reported sale qty/value from §11
+(sect11_ph_w2).
+
+W2 specifics: §9 harvest qty ph_s9q04_a is in a NATIVE unit (code
+ph_s9q04_b) — we carry the reported quantity and the native unit label
+(no kg conversion).  intercropped from §9 ph_s9q01 (1=Pure->False,
+2=Mixed->True).  §11 sale qty ph_s11q03_a is in KILOS (ph_s11q03_b is the
+grams residual), so the sale unit is 'Kg'; sale value is ph_s11q04.
+i = household_id2 (matches sample().i / plot_features for W2).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import crop_production_for_wave
+
+
+harvest  = get_dataframe('../Data/sect9_ph_w2.dta',  convert_categoricals=False)
+hunit    = get_dataframe('../Data/sect9_ph_w2.dta',  convert_categoricals=True)['ph_s9q04_b']
+planting = get_dataframe('../Data/sect4_pp_w2.dta',  convert_categoricals=False)
+sale     = get_dataframe('../Data/sect11_ph_w2.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id2', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+    crop_code='crop_code',
+    quantity='ph_s9q04_a', unit='ph_s9q04_b',
+    harvest_month='ph_s9q07_b',
+    intercrop='ph_s9q01',
+    pl_crop_code='crop_code', pl_month='pp_s4q12_a',
+    s_crop_code='crop_code', s_sold_flag='ph_s11q01',
+    s_qty='ph_s11q03_a', s_value='ph_s11q04',     # sale qty kilos, value Birr
+)
+
+df = crop_production_for_wave('2013-14', harvest, planting, sale, colmap,
+                              unit_labels=hunit)
+
+assert len(df) > 0, "crop_production 2013-14 produced no rows"
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Ethiopia/2015-16/_/crop_production.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/crop_production.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Build crop_production for Ethiopia ESS 2015-16 (Wave 3; GAP 1).
+
+Item-level harvest at (t, i, plot_id, j, u) from §9 (sect9_ph_w3), with
+planting month from §4 (sect4_pp_w3) and reported sale qty/value from §11
+(sect11_ph_w3).
+
+W3 specifics: §9 harvest qty ph_s9q04_a is in a NATIVE unit (code
+ph_s9q04_b).  intercropped from §9 ph_s9q01.  §11 sale qty ph_s11q03_a is
+in a NATIVE unit (code ph_s11q03_b) — Quantity_sold attaches only where
+the sale unit equals the harvest u; value is ph_s11q04 (Birr).
+i = household_id2 (matches sample().i / plot_features for W3).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import crop_production_for_wave
+
+
+harvest  = get_dataframe('../Data/sect9_ph_w3.dta',  convert_categoricals=False)
+hunit    = get_dataframe('../Data/sect9_ph_w3.dta',  convert_categoricals=True)['ph_s9q04_b']
+planting = get_dataframe('../Data/sect4_pp_w3.dta',  convert_categoricals=False)
+sale     = get_dataframe('../Data/sect11_ph_w3.dta', convert_categoricals=False)
+sunit    = get_dataframe('../Data/sect11_ph_w3.dta', convert_categoricals=True)['ph_s11q03_b']
+
+colmap = dict(
+    hhid='household_id2', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+    crop_code='crop_code',
+    quantity='ph_s9q04_a', unit='ph_s9q04_b',
+    harvest_month='ph_s9q07_b',
+    intercrop='ph_s9q01',
+    pl_crop_code='crop_code', pl_month='pp_s4q12_a',
+    s_crop_code='crop_code', s_sold_flag='ph_s11q01',
+    s_qty='ph_s11q03_a', s_value='ph_s11q04',
+)
+
+df = crop_production_for_wave('2015-16', harvest, planting, sale, colmap,
+                              unit_labels=hunit, sale_unit_labels=sunit)
+
+assert len(df) > 0, "crop_production 2015-16 produced no rows"
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Ethiopia/2018-19/_/crop_production.py
+++ b/lsms_library/countries/Ethiopia/2018-19/_/crop_production.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Build crop_production for Ethiopia ESS 2018-19 (Wave 4; GAP 1).
+
+Item-level harvest at (t, i, plot_id, j, u) from §9 (sect9_ph_w4), with
+planting month from §4 (sect4_pp_w4) and reported sale qty/value from §11
+(sect11_ph_w4).
+
+W4 specifics: the crop code lives in s9q00b (§9), s4q01b (§4), s11q01
+(§11) — NOT a column literally named crop_code.  Harvest qty s9q05a in a
+NATIVE unit (code s9q05b).  intercropped from §9 s9q02.  §11 sale qty
+s11q11a (native unit s11q11b), value s11q12, sold-flag s11q07.
+i = household_id (W4 is an entirely new sample).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import crop_production_for_wave
+
+
+harvest  = get_dataframe('../Data/sect9_ph_w4.dta',  convert_categoricals=False)
+hunit    = get_dataframe('../Data/sect9_ph_w4.dta',  convert_categoricals=True)['s9q05b']
+planting = get_dataframe('../Data/sect4_pp_w4.dta',  convert_categoricals=False)
+sale     = get_dataframe('../Data/sect11_ph_w4.dta', convert_categoricals=False)
+sunit    = get_dataframe('../Data/sect11_ph_w4.dta', convert_categoricals=True)['s11q11b']
+
+colmap = dict(
+    hhid='household_id', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+    crop_code='s9q00b',
+    quantity='s9q05a', unit='s9q05b',
+    harvest_month='s9q08b',
+    intercrop='s9q02',
+    pl_crop_code='s4q01b', pl_month='s4q13a',
+    s_crop_code='s11q01', s_sold_flag='s11q07',
+    s_qty='s11q11a', s_value='s11q12',
+)
+
+df = crop_production_for_wave('2018-19', harvest, planting, sale, colmap,
+                              unit_labels=hunit, sale_unit_labels=sunit)
+
+assert len(df) > 0, "crop_production 2018-19 produced no rows"
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Ethiopia/2021-22/_/crop_production.py
+++ b/lsms_library/countries/Ethiopia/2021-22/_/crop_production.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""Build crop_production for Ethiopia ESS 2021-22 (Wave 5; GAP 1).
+
+Item-level harvest at (t, i, plot_id, j, u) from §9 (sect9_ph_w5), with
+planting month from §4 (sect4_pp_w5) and reported sale qty/value from §11
+(sect11_ph_w5).
+
+W5 specifics: crop code in s9q00b (§9), s4q01b (§4), s11q01 (§11).
+Harvest qty s9q05a (native unit s9q05b).  intercropped from §9 s9q02.
+§11 sale qty s11q11a (native unit s11q11b), value s11q12, sold-flag
+s11q07.  i = household_id.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import crop_production_for_wave
+
+
+harvest  = get_dataframe('../Data/sect9_ph_w5.dta',  convert_categoricals=False)
+hunit    = get_dataframe('../Data/sect9_ph_w5.dta',  convert_categoricals=True)['s9q05b']
+planting = get_dataframe('../Data/sect4_pp_w5.dta',  convert_categoricals=False)
+sale     = get_dataframe('../Data/sect11_ph_w5.dta', convert_categoricals=False)
+sunit    = get_dataframe('../Data/sect11_ph_w5.dta', convert_categoricals=True)['s11q11b']
+
+colmap = dict(
+    hhid='household_id', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+    crop_code='s9q00b',
+    quantity='s9q05a', unit='s9q05b',
+    harvest_month='s9q08b',
+    intercrop='s9q02',
+    pl_crop_code='s4q01b', pl_month='s4q13a',
+    s_crop_code='s11q01b', s_sold_flag='s11q07',
+    s_qty='s11q11a', s_value='s11q12',
+)
+
+df = crop_production_for_wave('2021-22', harvest, planting, sale, colmap,
+                              unit_labels=hunit, sale_unit_labels=sunit)
+
+assert len(df) > 0, "crop_production 2021-22 produced no rows"
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Ethiopia/_/Makefile
+++ b/lsms_library/countries/Ethiopia/_/Makefile
@@ -17,7 +17,7 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 # household_characteristics is auto-derived too (_ROSTER_DERIVED, GH #260).
 var = \
       $(VAR_DIR)/shocks.parquet $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet \
-      $(VAR_DIR)/food_coping.parquet
+      $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/crop_production.parquet
 
 all: panel_ids.json updated_ids.json $(parquet) $(var)
 
@@ -60,6 +60,19 @@ plot_features_parquet := $(plot_features:.py=.parquet)
 
 $(VAR_DIR)/plot_features.parquet: plot_features.py $(plot_features_parquet)
 	python plot_features.py
+
+# crop_production (GAP 1; ESS §9 post-harvest item-level crop harvest).
+# Mirrors the plot_features convention: the framework's grab_data calls
+# `make ../<wave>/_/crop_production.parquet`, whose pattern rule runs the
+# wave script; the VAR_DIR rule concatenates them via the country script.
+crop_production = $(shell find $(rounds) -name crop_production.py)
+crop_production_parquet := $(crop_production:.py=.parquet)
+
+../%/_/crop_production.parquet: ../%/_/crop_production.py
+	(cd $(@D) && python crop_production.py)
+
+$(VAR_DIR)/crop_production.parquet: crop_production.py $(crop_production_parquet)
+	python crop_production.py
 
 # food_coping (GH #332, Family B; ESS §7 CSI/rCSI day-count battery).
 # Mirrors the plot_features convention: the framework's grab_data calls

--- a/lsms_library/countries/Ethiopia/_/categorical_mapping.org
+++ b/lsms_library/countries/Ethiopia/_/categorical_mapping.org
@@ -348,8 +348,15 @@ gaps (crop/harvest units, community-price units) extend these rows.
 #+name: u
 | Original Label                     | Preferred Label                    |
 |------------------------------------+------------------------------------|
+| Akumada/Dawla/Lekota Large         | Akumada/Dawla/Lekota Large         |
 | Akumada/Dawla/Lekota Small         | Akumada/Dawla/Lekota Small         |
 | Araba                              | Araba                              |
+| Centilitres                        | Centilitres                        |
+| Chinet                             | Chinet                             |
+| Chinet Large                       | Chinet Large                       |
+| Dawla                              | Dawla                              |
+| Ensira                             | Ensira                             |
+| Esir                               | Esir                               |
 | Birchiko Large                     | Birchiko Large                     |
 | Birchiko Medium                    | Birchiko Medium                    |
 | Birchiko Small                     | Birchiko Small                     |
@@ -372,7 +379,10 @@ gaps (crop/harvest units, community-price units) extend these rows.
 | Gram                               | Gram                               |
 | Jenbe                              | Jenbe                              |
 | Jog                                | Jog                                |
+| Joniya/Kasha Large                 | Joniya/Kasha Large                 |
+| Joniya/Kasha Medium                | Joniya/Kasha Medium                |
 | Joniya/Kasha Small                 | Joniya/Kasha Small                 |
+| Kerchat/Kemba                      | Kerchat/Kemba                      |
 | Kerchat/Kemba Large                | Kerchat/Kemba Large                |
 | Kerchat/Kemba Medium               | Kerchat/Kemba Medium               |
 | Kerchat/Kemba Small                | Kerchat/Kemba Small                |
@@ -381,6 +391,8 @@ gaps (crop/harvest units, community-price units) extend these rows.
 | Kubaya/Cup Large                   | Kubaya/Cup Large                   |
 | Kubaya/Cup Medium                  | Kubaya/Cup Medium                  |
 | Kubaya/Cup Small                   | Kubaya/Cup Small                   |
+| Kunna                              | Kunna                              |
+| Kunna/Mishe/Kefer/Enkib            | Kunna/Mishe/Kefer/Enkib            |
 | Kunna/Mishe/Kefer/Enkib Large      | Kunna/Mishe/Kefer/Enkib Large      |
 | Kunna/Mishe/Kefer/Enkib Medium     | Kunna/Mishe/Kefer/Enkib Medium     |
 | Kunna/Mishe/Kefer/Enkib Small      | Kunna/Mishe/Kefer/Enkib Small      |
@@ -389,6 +401,7 @@ gaps (crop/harvest units, community-price units) extend these rows.
 | Madaberia/Nuse/Shera/Cheret Large  | Madaberia/Nuse/Shera/Cheret Large  |
 | Madaberia/Nuse/Shera/Cheret Medium | Madaberia/Nuse/Shera/Cheret Medium |
 | Madaberia/Nuse/Shera/Cheret Small  | Madaberia/Nuse/Shera/Cheret Small  |
+| Medeb                              | Medeb                              |
 | Medeb Large                        | Medeb Large                        |
 | Medeb Medium                       | Medeb Medium                       |
 | Medeb Small                        | Medeb Small                        |
@@ -396,6 +409,8 @@ gaps (crop/harvest units, community-price units) extend these rows.
 | Melekiya                           | Melekiya                           |
 | Mili Liter                         | Mili Liter                         |
 | Number                             | Number                             |
+| Packets                            | Packets                            |
+| Pieces                             | Pieces                             |
 | Other (Specify)                    | Other (Specify)                    |
 | Other(Specify)                     | Other(Specify)                     |
 | Pack                               | Pack                               |
@@ -420,6 +435,133 @@ gaps (crop/harvest units, community-price units) extend these rows.
 | Tuba                               | Tuba                               |
 | Whole Animal (Poultary)            | Whole Animal (Poultary)            |
 | Whole Animal (Sheep)               | Whole Animal (Sheep)               |
+| Zelela                             | Zelela                             |
+| Zelela Large                       | Zelela Large                       |
+| Zelela Medium                      | Zelela Medium                      |
+| Zelela Small                       | Zelela Small                       |
 | Zorba/Akara Large                  | Zorba/Akara Large                  |
 | Zorba/Akara Medium                 | Zorba/Akara Medium                 |
 | Zorba/Akara Small                  | Zorba/Akara Small                  |
+
+* harmonize_crop (the crop j axis -- GAP 1, crop_production)
+
+Code-keyed crop dictionary for the ESS post-harvest/post-planting crop
+modules (sect9_ph / sect4_pp / sect11_ph).  Maps the stable ESS
+``crop_code`` integer (1-123, consistent across W1-W5; W4/W5 carry it as
+``s9q00b`` / ``s11q01`` / ``s4q01b``) to a Preferred Label.
+
+The Preferred Labels deliberately REUSE the food labels already in the
+``harmonize_food`` table wherever a grown crop is also a consumed food
+(Maize, Sorghum, Teff, Wheat, Barley, Rice, Millet, Oats, the pulses,
+the oilseeds, the vegetables/fruits, Coffee, Onion, Potato, ...), so
+``crop_production.j`` JOINS ``food_acquired.j`` on the shared label.
+NEW Preferred Labels are added only for genuinely non-food / non-
+consumption crops with no food analogue: Cotton, Cotton Seed, Tobacco,
+Enset, Gesho, Chat, Sugar Cane, Cactus, and the residual land-use /
+"Other" categories (Grazing Land, Fallow Land, Forest Land, Other Land
+Use).  Where a crop has no exact food label but is close to one we use
+the food label (e.g. Red Pepper -> Berbere, Green Pepper -> Kariya,
+Kale/Cabbage -> Leafy Greens) so the join still lands.
+
+#+name: harmonize_crop
+| Code | Preferred Label     |
+|------+---------------------|
+|    1 | Barley              |
+|    2 | Maize               |
+|    3 | Millet              |
+|    4 | Oats                |
+|    5 | Rice                |
+|    6 | Sorghum             |
+|    7 | Teff                |
+|    8 | Wheat               |
+|    9 | Mung bean           |
+|   10 | Cassava             |
+|   11 | Chick Pea           |
+|   12 | Haricot Beans       |
+|   13 | Horsebeans          |
+|   14 | Lentils             |
+|   15 | Field Pea           |
+|   16 | Vetch               |
+|   17 | Gibto               |
+|   18 | Soya Beans          |
+|   19 | Red Kidney Beans    |
+|   20 | Fennel              |
+|   22 | Cotton Seed         |
+|   23 | Linseed             |
+|   24 | Ground nuts         |
+|   25 | Niger Seed          |
+|   26 | Rape Seed           |
+|   27 | Sesame              |
+|   28 | Sun Flower          |
+|   29 | Mego                |
+|   31 | Black Cumin         |
+|   32 | Black Pepper        |
+|   33 | Cardamon            |
+|   34 | Chilies             |
+|   35 | Cinnamon            |
+|   36 | Fenugreek           |
+|   37 | Ginger              |
+|   38 | Berbere             |
+|   39 | Turmeric            |
+|   40 | White Cumin         |
+|   41 | Apple               |
+|   42 | Banana              |
+|   43 | Grape               |
+|   44 | Lemon               |
+|   45 | Mandarin            |
+|   46 | Mango               |
+|   47 | Orange              |
+|   48 | Papaya              |
+|   49 | Pineapple           |
+|   50 | Citron              |
+|   51 | Beetroot            |
+|   52 | Leafy Greens        |
+|   53 | Carrot              |
+|   54 | Cauliflower         |
+|   55 | Garlic              |
+|   56 | Leafy Greens        |
+|   57 | Lettuce             |
+|   58 | Onion               |
+|   59 | Kariya              |
+|   60 | Potato              |
+|   61 | Pumpkin             |
+|   62 | Sweet potato        |
+|   63 | Tomato              |
+|   64 | Godere              |
+|   65 | Guava               |
+|   66 | Peach               |
+|   69 | Leafy Greens        |
+|   71 | Chat/Kat            |
+|   72 | Coffee              |
+|   73 | Cotton              |
+|   74 | Enset               |
+|   75 | Hops (gesho)        |
+|   76 | Sugar Cane          |
+|   78 | Tobacco             |
+|   79 | Coriander           |
+|   80 | Sacred Basil        |
+|   81 | Rue                 |
+|   82 | Gishita             |
+|   83 | Watermelon          |
+|   84 | Avocado             |
+|   85 | Grazing Land        |
+|   86 | Fallow Land         |
+|   89 | Forest Land         |
+|   90 | Other Land Use      |
+|   95 | Boye/Yam            |
+|   98 | Other tuber or stem |
+|   99 | Other Land Use      |
+|  108 | Amboshika           |
+|  110 | Giramta             |
+|  111 | Comtatie            |
+|  112 | Kazmir              |
+|  113 | Strawberry          |
+|  114 | Moringa/Shiferaw/Halloka |
+|  115 | Other fruit         |
+|  116 | Timiz Kimem         |
+|  117 | Other condiments    |
+|  118 | Other pulse or nut  |
+|  119 | Other seed          |
+|  120 | Other cereal        |
+|  121 | Other Cash Crop     |
+|  123 | Other vegetable     |

--- a/lsms_library/countries/Ethiopia/_/crop_production.py
+++ b/lsms_library/countries/Ethiopia/_/crop_production.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Concatenate wave-level crop_production data for Ethiopia (GAP 1).
+
+Each wave's ``Ethiopia/<wave>/_/crop_production.py`` produces a parquet
+with index ``(t, i, plot_id, j, u)`` and the canonical crop_production
+columns (Quantity, Quantity_sold, Value_sold, planting_month,
+harvest_month, intercropped, perennial).  This script concatenates them
+across the five ESS waves and applies the cross-wave ``id_walk`` so the
+household index uses the panel canonical id scheme (the same conversion
+``sample()`` receives at API time, keeping the ``_join_v_from_sample``
+join aligned).
+
+``id_walk`` is idempotent (it sets ``attrs['id_converted']``), so the
+framework's ``_finalize_result`` will skip re-applying it.  The wave
+parquets emit the wave-native household id that matches ``sample().i``
+(``household_id2`` for W2/W3, ``household_id`` elsewhere) — see the
+per-wave scripts and the plot_features CONTENTS.org section.
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, id_walk, to_parquet
+from ethiopia import Waves
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/crop_production.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet built / parquet absent (DVC raises PathMissingError).
+        continue
+    pieces.append(df)
+
+assert pieces, "crop_production: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/crop_production.parquet')

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -91,6 +91,29 @@ Data Scheme:
     Irrigated: bool
     materialize: make
 
+  crop_production:
+    # GAP 1 — item-level crop harvest at (t, i, plot_id, j, u).  One row
+    # per (plot, crop) from ESS §9 post-harvest (sect9_ph), carrying only
+    # REPORTED fields: harvest Quantity in its native unit u, Quantity_sold
+    # / Value_sold from §11 (attached at the unambiguous holder-crop join,
+    # see ethiopia.crop_production_for_wave SALES GRAIN CAVEAT),
+    # planting_month (§4) / harvest_month (§9), and the intercropped /
+    # perennial flags.  NO unit->kg conversion, NO yield / main-crop /
+    # value-share rollups (those are transformations).  plot_id and i match
+    # plot_features exactly, so the two features join on (t, i, plot_id).
+    # crop labels reuse the food Preferred Labels (harmonize_crop table) so
+    # crop_production.j joins food_acquired.j.  Multi-file joins (§9+§4+§11,
+    # + §3 for W1 intercrop) + code->label harmonization => script.
+    index: (t, i, plot_id, j, u)
+    Quantity: float
+    Quantity_sold: float
+    Value_sold: float
+    planting_month: int
+    harvest_month: int
+    intercropped: bool
+    perennial: bool
+    materialize: make
+
   food_security:
     # FAO FIES 8-item experience scale (GH #332).  Confirmed ONLY in
     # W5 (2021-22): ESS §8 file sect8_hh_w5.dta carries the FAO battery

--- a/lsms_library/countries/Ethiopia/_/ethiopia.py
+++ b/lsms_library/countries/Ethiopia/_/ethiopia.py
@@ -766,3 +766,311 @@ def food_coping_for_wave(t, df, hhid):
 
     long = long.set_index(['t', 'i', 'Strategy']).sort_index()
     return long
+
+
+# crop_production (GAP 1 — item-level harvest at (t, i, plot, crop))
+# ---------------------------------------------------------------------
+#
+# ESS post-harvest §9 (sect9_ph) records ONE ROW PER (plot, crop): the
+# crop the farmer grew on a field, the REPORTED harvest quantity, and the
+# native reporting unit.  This is the clean item-level source.  We emit
+# exactly those reported fields — NO unit->kg conversion, NO yield, NO
+# main-crop / value-share rollups (those are transformations, per the
+# parity-loop hard rule).
+#
+# Grain / IDs: plot_id == format_id(holder_id)_format_id(parcel_id)_
+# format_id(field_id) and i == format_id(household_id[2]), IDENTICAL to
+# plot_features (so crop_production joins plot_features on (t, i, plot)).
+#
+# Columns (all REPORTED, item-level):
+#   Quantity        reported harvest quantity (native unit)
+#   u               native harvest unit (Preferred Label via the `u` table)
+#   Quantity_sold   reported quantity sold (sect11/§11 sale module)
+#   Value_sold      reported sale value (Birr)
+#   planting_month  Gregorian planting month 1-12 (sect4_pp / §4)
+#   harvest_month   Gregorian harvest-END month 1-12 (§9)
+#   intercropped    field was a mixed stand (bool)
+#   perennial       crop is a perennial/tree crop (bool, crop-code property)
+#
+# crop labels: code-keyed `harmonize_crop` table whose Preferred Labels
+# REUSE the food labels (Maize, Sorghum, Teff, Wheat, Barley, Rice, ...)
+# so crop_production.j joins food_acquired.j; non-food crops (Cotton,
+# Enset, Gesho, Chat, Coffee, ...) get their own Preferred Labels.
+#
+# SALES GRAIN CAVEAT: the §11 sale module is keyed (household, holder,
+# crop) — NOT (plot, crop).  A holder who grows one crop on several plots
+# reports a single sale figure that cannot be split across plots without
+# fabricating an allocation.  We therefore attach Quantity_sold /
+# Value_sold ONLY where the (holder, crop) maps to exactly ONE plot-crop
+# harvest row (unambiguous).  Where the crop is grown on multiple plots
+# the sale columns stay NaN — we never duplicate or arbitrarily split a
+# reported value.  (Cross-wave aggregate harvest_sold lives in
+# transformations, not here.)
+
+# WB perennial/tree crop-code list (ETH_ESS1.do:415 PERENNIAL/FRUIT set).
+PERENNIAL_CROP_CODES = frozenset({
+    19, 20, 22, 34, 35, 37, 38, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+    55, 65, 66, 71, 72, 74, 75, 76, 81, 82, 84, 85, 86, 98, 99, 108, 111,
+    112, 113, 114, 115, 116, 117, 122,
+})
+
+
+def _eth_crop_label_map():
+    """Load the code-keyed harmonize_crop table -> {crop_code: Preferred Label}."""
+    return _harmonize_code_label('harmonize_crop')
+
+
+def _clean_unit_label(series):
+    """Normalize a §9/§11 harvest unit label to a canonical `u` value.
+
+    Strips the survey 'NNN. ' code prefix, title-cases, and canonicalizes
+    the harvest module's parenthesized size suffix ``(Small)/(Medium)/
+    (Large)`` to the `` Small/ Medium/ Large`` form the `u` table (and the
+    food_acquired units) already use -- so harvest units resolve through
+    the SAME `u` table the food units use rather than fragmenting the unit
+    axis with a parallel parenthesized scheme.  Also folds a handful of
+    known synonyms / Stata truncations onto their `u`-table label."""
+    s = series.astype('string')
+    s = s.str.replace(r'^\s*\d+\.\s*', '', regex=True).str.strip()
+    # Drop the U+FFFD replacement-char mojibake ESS W5 embeds in a few
+    # labels (e.g. "Zorba/Akara � Large").
+    s = s.str.replace('�', '', regex=False)
+    s = s.str.title()
+    s = s.str.replace(r'\s+', ' ', regex=True)
+    # Normalize the recurring "Meduim" misspelling BEFORE size matching.
+    s = s.str.replace('Meduim', 'Medium', regex=False)
+    # Parenthesized size suffix "(Small)" -> " Small" (tolerating the
+    # Stata-truncated "(Smal"/"(Medi"/"(Larg" and bare "(Mediu" forms).
+    s = s.str.replace(r'\s*\(\s*Smal[l]?\s*\)?\s*$', ' Small', regex=True)
+    s = s.str.replace(r'\s*\(\s*Med(?:i|iu|ium)?\s*\)?\s*$', ' Medium', regex=True)
+    s = s.str.replace(r'\s*\(\s*Larg[e]?\s*\)?\s*$', ' Large', regex=True)
+    s = s.str.replace(r'\s+', ' ', regex=True).str.strip()
+    s = s.str.replace('Joniya Kysha', 'Joniya/Kasha', regex=False)
+    syn = {
+        'Kilogram': 'Kg', 'Kuintal': 'Quintal', 'Quntal': 'Quintal',
+        'Kurbet': 'Quintal',  # ESS W2 alias of Kuintal/Quintal
+        'Meduim': 'Medium',
+        'Kubaya Small': 'Kubaya/Cup Small',
+        'Kubaya Medium': 'Kubaya/Cup Medium',
+        'Kubaya Large': 'Kubaya/Cup Large',
+        'Akumada(Dawela) Lekota Small': 'Akumada/Dawla/Lekota Small',
+        'Akumada(Dawela) Lekota Large': 'Akumada/Dawla/Lekota Large',
+        'Madaberiya/Nuse/Shera/Chiret Small': 'Madaberia/Nuse/Shera/Cheret Small',
+        'Madaberiya/Nuse/Shera/Chiret Medium': 'Madaberia/Nuse/Shera/Cheret Medium',
+        'Madaberiya/Nuse/Shera/Chiret Large': 'Madaberia/Nuse/Shera/Cheret Large',
+        'Others(Specify)': 'Other (Specify)',
+        'Other(Specify)': 'Other (Specify)',
+    }
+    s = s.replace(syn)
+    return s.replace({'': pd.NA, '0': pd.NA})
+
+
+# Ethiopian-calendar month code -> Gregorian month number (1-12).  ESS
+# records the local-calendar month; this deterministic relabel (the same
+# recode the WB do-files apply) is a label normalization, not an
+# aggregate.  Codes 1/13 -> September (9), 2 -> October, ... 12 -> August.
+_ETH_MONTH_TO_GREG = {1: 9, 13: 9, 2: 10, 3: 11, 4: 12, 5: 1, 6: 2,
+                      7: 3, 8: 4, 9: 5, 10: 6, 11: 7, 12: 8}
+
+
+def _greg_month(series):
+    """Recode the ESS local-calendar month code -> Gregorian month (1-12)."""
+    n = pd.to_numeric(series, errors='coerce').astype('Int64')
+    return n.map(_ETH_MONTH_TO_GREG).astype('Int64')
+
+
+def crop_production_for_wave(t, harvest, planting, sale, colmap,
+                             intercrop=None, unit_labels=None,
+                             sale_unit_labels=None):
+    """Build canonical ``crop_production`` for one Ethiopia ESS wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2011-12"``), the ``t`` index value.
+    harvest : pd.DataFrame
+        Raw §9 post-harvest crop file (sect9_ph_w{N}.dta), loaded with
+        ``convert_categoricals=False`` (codes; unit/crop label decode is
+        done in-script against the harmonize tables).
+    planting : pd.DataFrame or None
+        Raw §4 post-planting crop file (sect4_pp_w{N}.dta) for the
+        planting-month join, or None if unavailable.
+    sale : pd.DataFrame or None
+        Raw §11 post-harvest sale file (sect11_ph_w{N}.dta) for the
+        sold-quantity / sold-value join, or None.
+    colmap : dict
+        Per-wave column map.  Required keys:
+            hhid, holder_id, parcel_id, field_id  — id / plot_id columns
+            crop_code                              — §9 crop code column
+            quantity                               — §9 reported harvest qty
+        Optional keys (NaN where omitted):
+            unit            — §9 native harvest-unit code col (None => Kg,
+                              W1 reports kilos directly)
+            harvest_month   — §9 harvest-END month code col
+            intercrop       — §9 pure/mixed-stand col (1=pure, 2=mixed)
+            pl_crop_code, pl_month  — §4 crop-code + planting-month cols
+            s_crop_code, s_sold_flag, s_qty, s_value, s_unit  — §11 cols
+                              (s_unit None => Kg, W1 sales report kilos)
+    intercrop : pd.DataFrame or None
+        Optional plot-roster (sect3_pp) carrying a plot-level mixed-stand
+        flag, used for W1 (which has no §9 stand variable).  When given,
+        colmap must carry 'ic_holder_id'/'ic_parcel_id'/'ic_field_id'/
+        'ic_flag' (flag: 1=No, 2=Yes per the WB recode).
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id, j, u)`` with columns
+        Quantity (float), Quantity_sold (float), Value_sold (float),
+        planting_month (Int64), harvest_month (Int64),
+        intercropped (boolean), perennial (boolean).
+    """
+    c = colmap
+    crop_map = _eth_crop_label_map()
+
+    h = harvest.copy()
+    # plot_id identical to plot_features.
+    plot_id = (h[c['holder_id']].apply(format_id).astype(str) + '_'
+               + h[c['parcel_id']].apply(format_id).astype(str) + '_'
+               + h[c['field_id']].apply(format_id).astype(str))
+    code = pd.to_numeric(h[c['crop_code']], errors='coerce').astype('Int64')
+
+    out = pd.DataFrame({
+        't':       t,
+        'i':       h[c['hhid']].apply(format_id).values,
+        'plot_id': plot_id.values,
+        '_holder': h[c['holder_id']].apply(format_id).values,
+        '_code':   code.values,
+        'j':       code.map(crop_map).astype('string').values,
+        'Quantity': pd.to_numeric(h[c['quantity']], errors='coerce').astype('Float64').values,
+    })
+
+    # Native harvest unit (Preferred Label).  W1 reports kilos directly.
+    if unit_labels is not None:
+        # ``unit_labels`` is the §9 unit column DECODED to its survey label
+        # (caller loads that one column with convert_categoricals=True),
+        # aligned row-for-row with ``harvest``.  Normalize through the same
+        # pipeline food_acquired uses so it resolves via the shared `u`
+        # table.
+        out['u'] = _clean_unit_label(
+            pd.Series(unit_labels.values, index=h.index)).values
+    else:
+        # W1 reports kilograms directly (no unit code).
+        out['u'] = 'Kg'
+
+    out['harvest_month'] = (_greg_month(h[c['harvest_month']]).values
+                            if c.get('harvest_month') and c['harvest_month'] in h.columns
+                            else pd.NA)
+
+    # intercropped: §9 mixed-stand (1=pure -> False, 2=mixed -> True), or
+    # plot-roster fallback for W1.
+    if c.get('intercrop') and c['intercrop'] in h.columns:
+        ic = pd.to_numeric(h[c['intercrop']], errors='coerce').astype('Int64')
+        icbool = pd.Series(pd.NA, index=h.index, dtype='boolean')
+        icbool = icbool.mask(ic == 1, False).mask(ic == 2, True)
+        out['intercropped'] = icbool.values
+    elif intercrop is not None and c.get('ic_flag'):
+        ic_pid = (intercrop[c['ic_holder_id']].apply(format_id).astype(str) + '_'
+                  + intercrop[c['ic_parcel_id']].apply(format_id).astype(str) + '_'
+                  + intercrop[c['ic_field_id']].apply(format_id).astype(str))
+        flag = pd.to_numeric(intercrop[c['ic_flag']], errors='coerce').astype('Int64')
+        icb = pd.Series(pd.NA, index=intercrop.index, dtype='boolean')
+        icb = icb.mask(flag == 1, False).mask(flag == 2, True)
+        ic_df = pd.DataFrame({'plot_id': ic_pid.values, 'intercropped': icb.values}) \
+            .dropna(subset=['plot_id']).drop_duplicates('plot_id')
+        out = out.merge(ic_df, on='plot_id', how='left')
+    else:
+        out['intercropped'] = pd.Series(pd.NA, index=out.index, dtype='boolean')
+
+    # perennial: crop-code property.
+    out['perennial'] = out['_code'].map(
+        lambda x: (int(x) in PERENNIAL_CROP_CODES) if pd.notna(x) else pd.NA
+    ).astype('boolean')
+
+    # planting_month from §4, joined on (plot_id, crop_code).
+    if planting is not None and c.get('pl_month'):
+        p_pid = (planting[c['holder_id']].apply(format_id).astype(str) + '_'
+                 + planting[c['parcel_id']].apply(format_id).astype(str) + '_'
+                 + planting[c['field_id']].apply(format_id).astype(str))
+        p_code = pd.to_numeric(planting[c['pl_crop_code']], errors='coerce').astype('Int64')
+        pm = pd.DataFrame({
+            'plot_id': p_pid.values,
+            '_code':   p_code.values,
+            'planting_month': _greg_month(planting[c['pl_month']]).values,
+        }).dropna(subset=['plot_id', '_code']).drop_duplicates(['plot_id', '_code'])
+        out = out.merge(pm, on=['plot_id', '_code'], how='left')
+    else:
+        out['planting_month'] = pd.Series(pd.NA, index=out.index, dtype='Int64')
+
+    # Sales: §11 is (household, holder, crop) grain.  Attach reported
+    # sold-qty / sold-value ONLY where (holder, crop) maps to exactly one
+    # plot-crop harvest row (see SALES GRAIN CAVEAT above).
+    #
+    # Value_sold (Birr) is unit-free and always attachable.  Quantity_sold
+    # carries the SALE unit, which need not equal the harvest `u`; since we
+    # never convert units, Quantity_sold is attached only on rows whose
+    # harvest `u` equals the (single) sale unit reported for that
+    # (holder, crop).  Where they differ it stays NaN (no cross-unit fib).
+    out['Quantity_sold'] = pd.Series(pd.NA, index=out.index, dtype='Float64')
+    out['Value_sold'] = pd.Series(pd.NA, index=out.index, dtype='Float64')
+    if sale is not None and c.get('s_qty'):
+        s = sale.copy()
+        s_code = pd.to_numeric(s[c['s_crop_code']], errors='coerce').astype('Int64')
+        s_holder = s[c['holder_id']].apply(format_id)
+        sold_flag = (pd.to_numeric(s[c['s_sold_flag']], errors='coerce').astype('Int64')
+                     if c.get('s_sold_flag') and c['s_sold_flag'] in s.columns else None)
+        qty = pd.to_numeric(s[c['s_qty']], errors='coerce')
+        val = (pd.to_numeric(s[c['s_value']], errors='coerce')
+               if c.get('s_value') and c['s_value'] in s.columns else pd.NA)
+        # sale unit label: pre-decoded labels (s_unit_labels) where the
+        # sale unit is a coded column, else 'Kg' (W1/W2 sale qty is kilos).
+        if sale_unit_labels is not None:
+            s_unit = _clean_unit_label(
+                pd.Series(sale_unit_labels.values, index=s.index)).fillna('Kg')
+        else:
+            s_unit = pd.Series('Kg', index=s.index)
+        sdf = pd.DataFrame({
+            '_holder': s_holder.values,
+            '_code':   s_code.values,
+            '_sunit':  s_unit.values,
+            'Quantity_sold': qty.values,
+            'Value_sold': val if np.isscalar(val) else val.values,
+        })
+        if sold_flag is not None:
+            # sold flag 2 == No -> zero the reported sale.
+            no = (sold_flag == 2).values
+            sdf.loc[no, ['Quantity_sold', 'Value_sold']] = 0.0
+        sdf = sdf.dropna(subset=['_holder', '_code'])
+        # Aggregate to (holder, crop): sum Value_sold (unit-free); for
+        # Quantity_sold sum WITHIN each sale unit and keep the per-unit
+        # breakdown so we can match it against the harvest `u`.
+        vagg = sdf.groupby(['_holder', '_code'], as_index=False)['Value_sold'].sum()
+        qagg = sdf.groupby(['_holder', '_code', '_sunit'], as_index=False)['Quantity_sold'].sum()
+        # Count plot-crop harvest rows per (holder, crop); attach only when 1.
+        nplots = (out.dropna(subset=['_code'])
+                     .groupby(['_holder', '_code'])['plot_id'].nunique()
+                     .rename('_nplots').reset_index())
+        keep = nplots[nplots['_nplots'] == 1][['_holder', '_code']]
+        vagg = vagg.merge(keep, on=['_holder', '_code'], how='inner')
+        qagg = qagg.merge(keep, on=['_holder', '_code'], how='inner')
+        out = out.drop(columns=['Quantity_sold', 'Value_sold'])
+        out = out.merge(vagg, on=['_holder', '_code'], how='left')
+        # Quantity_sold joins additionally on the unit (harvest u == sale unit).
+        out = out.merge(
+            qagg.rename(columns={'_sunit': 'u'}),
+            on=['_holder', '_code', 'u'], how='left')
+
+    out = out.drop(columns=['_holder', '_code'])
+    out = out.dropna(subset=['i', 'plot_id', 'j'])
+    # `u` is an index level (cannot be null).  A row may legitimately
+    # report a quantity with an unrecorded unit -> tag it 'Other (Specify)'
+    # (a value already in the `u` table); rows with neither a quantity nor
+    # a recorded unit are empty placeholders -> drop.
+    empty_u = out['u'].isna()
+    out = out[~(empty_u & out['Quantity'].isna()
+                & out['Quantity_sold'].isna())]
+    out['u'] = out['u'].fillna('Other (Specify)')
+    out = out.set_index(['t', 'i', 'plot_id', 'j', 'u'])
+    # Stable column order.
+    out = out[['Quantity', 'Quantity_sold', 'Value_sold',
+               'planting_month', 'harvest_month', 'intercropped', 'perennial']]
+    return out

--- a/lsms_library/countries/Malawi/2010-11/_/crop_production.py
+++ b/lsms_library/countries/Malawi/2010-11/_/crop_production.py
@@ -1,0 +1,56 @@
+"""Build crop_production for Malawi IHS3/IHPS 2010-11 (GAP 1).
+
+Item-level (t, i, plot, crop) harvest feature.  Sources (Full_Sample/
+Agriculture):
+  * ag_mod_g — seasonal harvest, plot=ag_g0b, crop=ag_g0d (codes 1-48).
+  * ag_mod_p — perennial harvest, plot=ag_p0b, crop=ag_p0d (codes->+1000).
+  * ag_mod_i — seasonal SALE (hh, crop): crop=ag_i0b, sold=ag_i01,
+    qty=ag_i02a, value=ag_i03.  No plot id.
+  * ag_mod_q — perennial SALE (hh, crop): crop=ag_q0b, qty=ag_q02a,
+    value=ag_q03.
+
+i = format_id(case_id), aligning with plot_features 2010-11.  Sale is
+attached only to single-plot (i, crop) rows (see malawi.assemble_
+crop_production).  See lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import (_harvest_block, _sale_block, assemble_crop_production)
+
+
+WAVE = '2010-11'
+BASE = '../Data/Full_Sample/Agriculture/'
+
+g = get_dataframe(BASE + 'ag_mod_g.dta', convert_categoricals=False)
+p = get_dataframe(BASE + 'ag_mod_p.dta', convert_categoricals=False)
+i_mod = get_dataframe(BASE + 'ag_mod_i.dta', convert_categoricals=False)
+q = get_dataframe(BASE + 'ag_mod_q.dta', convert_categoricals=False)
+
+for df in (g, p, i_mod, q):
+    df['hhid'] = df['case_id'].apply(format_id)
+
+harvest = [
+    _harvest_block(g, hhid='hhid', plotkey='ag_g0b', cropcode='ag_g0d',
+                   qty='ag_g13a', unit='ag_g13b', condition='ag_g13c',
+                   plant_m='ag_g05a', plant_y='ag_g05b', harv_m='ag_g12b',
+                   intercrop='ag_g01', perennial=False, t=WAVE),
+    _harvest_block(p, hhid='hhid', plotkey='ag_p0b', cropcode='ag_p0d',
+                   qty='ag_p09a', unit='ag_p09b', plant_y='ag_p04',
+                   harv_m='ag_p06c', perennial=True, t=WAVE),
+]
+
+sale = [
+    _sale_block(i_mod, hhid='hhid', cropcode='ag_i0b', sold_flag='ag_i01',
+                qty_sold='ag_i02a', value_sold='ag_i03', perennial=False),
+    _sale_block(q, hhid='hhid', cropcode='ag_q0b', sold_flag='ag_q01',
+                qty_sold='ag_q02a', value_sold='ag_q03', perennial=True),
+]
+
+df = assemble_crop_production(WAVE, harvest, sale)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot,crop) in crop_production {WAVE}"
+assert len(df) > 0, f"crop_production {WAVE} produced no rows"
+
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Malawi/2013-14/_/crop_production.py
+++ b/lsms_library/countries/Malawi/2013-14/_/crop_production.py
@@ -1,0 +1,56 @@
+"""Build crop_production for Malawi IHPS 2013-14 (GAP 1).
+
+Item-level (t, i, plot, crop) harvest feature.  Variable names shifted
+from 2010-11: in 2013-14 the seasonal Module G plot key is ag_g00 and
+the crop code is ag_g0b (NOT ag_g0d); perennial Module P plot key is
+ag_p00, crop ag_p0c.  Sources (flat Data/):
+  * AG_MOD_G_13 — seasonal harvest, plot=ag_g00, crop=ag_g0b (1-48).
+  * AG_MOD_P_13 — perennial harvest, plot=ag_p00, crop=ag_p0c (->+1000).
+  * AG_MOD_I_13 — seasonal SALE (hh, crop): crop=ag_i0b, sold=ag_i01,
+    qty=ag_i02a, value=ag_i03.
+  * AG_MOD_Q_13 — perennial SALE (hh, crop): crop=ag_q0b, qty=ag_q02a,
+    value=ag_q03.
+
+i = format_id(y2_hhid), aligning with plot_features 2013-14.  See
+lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import (_harvest_block, _sale_block, assemble_crop_production)
+
+
+WAVE = '2013-14'
+
+g = get_dataframe('../Data/AG_MOD_G_13.dta', convert_categoricals=False)
+p = get_dataframe('../Data/AG_MOD_P_13.dta', convert_categoricals=False)
+i_mod = get_dataframe('../Data/AG_MOD_I_13.dta', convert_categoricals=False)
+q = get_dataframe('../Data/AG_MOD_Q_13.dta', convert_categoricals=False)
+
+for df in (g, p, i_mod, q):
+    df['hhid'] = df['y2_hhid'].apply(format_id)
+
+harvest = [
+    _harvest_block(g, hhid='hhid', plotkey='ag_g00', cropcode='ag_g0b',
+                   qty='ag_g13a', unit='ag_g13b', condition='ag_g13c',
+                   plant_m='ag_g05a', plant_y='ag_g05b', harv_m='ag_g12b',
+                   intercrop='ag_g01', perennial=False, t=WAVE),
+    _harvest_block(p, hhid='hhid', plotkey='ag_p00', cropcode='ag_p0c',
+                   qty='ag_p09a', unit='ag_p09b', plant_y='ag_p04',
+                   harv_m='ag_p06c', perennial=True, t=WAVE),
+]
+
+sale = [
+    _sale_block(i_mod, hhid='hhid', cropcode='ag_i0b', sold_flag='ag_i01',
+                qty_sold='ag_i02a', value_sold='ag_i03', perennial=False),
+    _sale_block(q, hhid='hhid', cropcode='ag_q0b', sold_flag='ag_q01',
+                qty_sold='ag_q02a', value_sold='ag_q03', perennial=True),
+]
+
+df = assemble_crop_production(WAVE, harvest, sale)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot,crop) in crop_production {WAVE}"
+assert len(df) > 0, f"crop_production {WAVE} produced no rows"
+
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Malawi/2016-17/_/crop_production.py
+++ b/lsms_library/countries/Malawi/2016-17/_/crop_production.py
@@ -1,0 +1,89 @@
+"""Build crop_production for Malawi IHS4 2016-17 (GAP 1).
+
+IHS4 ships a Cross_Sectional half (cs-17-prefixed case_id) and a Panel
+half (bare y3_hhid), concatenated into the single 2016-17 wave -- exactly
+like plot_features.  Plot key is gardenid_plotid in both halves.
+
+Module naming in IHS4: the seasonal modules (G, I) carry a harmonized
+`crop_code` (codes 1-48); the perennial modules (P, Q) carry their own
+crop code -- P uses ag_p0c, Q uses crop_code -- in the perennial
+namespace (offset +1000 in harmonize_crop).  Sale (I, Q) is at the
+household-crop grain (no plot id); attached to single-plot (i, crop)
+rows only.  See lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import (_harvest_block, _sale_block, assemble_crop_production)
+
+
+WAVE = '2016-17'
+
+
+def _plotkey(df):
+    return (df['gardenid'].apply(format_id) + '_'
+            + df['plotid'].apply(format_id))
+
+
+def _half(g, p, i_mod, q, hh_of):
+    """Build harvest + sale pieces for one XS/Panel half.
+
+    ``hh_of`` maps each raw module DataFrame's hhid column to the
+    canonical wave id string (cs-17 prefix for XS, bare y3_hhid for
+    Panel)."""
+    for df in (g, p, i_mod, q):
+        df['hhid'] = hh_of(df)
+    g['plotkey'] = _plotkey(g)
+    p['plotkey'] = _plotkey(p)
+    # Perennial crop code lives in ag_p0c (Cross_Sectional) or crop_code
+    # (Panel) -- both in the 1-18 perennial namespace.
+    p_crop = 'ag_p0c' if 'ag_p0c' in p.columns else 'crop_code'
+    harvest = [
+        _harvest_block(g, hhid='hhid', plotkey='plotkey', cropcode='crop_code',
+                       qty='ag_g13a', unit='ag_g13b', condition='ag_g13c',
+                       plant_m='ag_g05a', plant_y='ag_g05b', harv_m='ag_g12b',
+                       intercrop='ag_g01', perennial=False, t=WAVE),
+        _harvest_block(p, hhid='hhid', plotkey='plotkey', cropcode=p_crop,
+                       qty='ag_p09a', unit='ag_p09b', plant_y='ag_p04',
+                       harv_m='ag_p06c', perennial=True, t=WAVE),
+    ]
+    sale = [
+        _sale_block(i_mod, hhid='hhid', cropcode='crop_code', sold_flag='ag_i01',
+                    qty_sold='ag_i02a', value_sold='ag_i03', perennial=False),
+        _sale_block(q, hhid='hhid', cropcode='crop_code', sold_flag='ag_q01',
+                    qty_sold='ag_q02a', value_sold='ag_q03', perennial=True),
+    ]
+    return harvest, sale
+
+
+harvest_all, sale_all = [], []
+
+# --- Cross-sectional half (cs-17 prefix) ---
+g_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_g.dta', convert_categoricals=False)
+p_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_p.dta', convert_categoricals=False)
+i_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_i.dta', convert_categoricals=False)
+q_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_q.dta', convert_categoricals=False)
+h, s = _half(g_xs, p_xs, i_xs, q_xs,
+             lambda df: 'cs-17-' + df['case_id'].apply(format_id))
+harvest_all += h
+sale_all += s
+
+# --- Panel half (bare y3_hhid) ---
+g_pn = get_dataframe('../Data/Panel/ag_mod_g_16.dta', convert_categoricals=False)
+p_pn = get_dataframe('../Data/Panel/ag_mod_p_16.dta', convert_categoricals=False)
+i_pn = get_dataframe('../Data/Panel/ag_mod_i_16.dta', convert_categoricals=False)
+q_pn = get_dataframe('../Data/Panel/ag_mod_q_16.dta', convert_categoricals=False)
+h, s = _half(g_pn, p_pn, i_pn, q_pn,
+             lambda df: df['y3_hhid'].apply(format_id))
+harvest_all += h
+sale_all += s
+
+df = assemble_crop_production(WAVE, harvest_all, sale_all)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot,crop) in crop_production {WAVE}"
+assert len(df) > 0, f"crop_production {WAVE} produced no rows"
+
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Malawi/2019-20/_/crop_production.py
+++ b/lsms_library/countries/Malawi/2019-20/_/crop_production.py
@@ -1,0 +1,84 @@
+"""Build crop_production for Malawi IHS5 2019-20 (GAP 1).
+
+IHS5 ships a Cross_Sectional half (bare case_id) and a Panel half
+(y4_hhid), concatenated into the single 2019-20 wave -- exactly like
+plot_features (sample().i for 2019-20 is the bare cross-sectional
+case_id, NOT cs-prefixed).  Plot key is gardenid_plotid in both halves.
+
+Seasonal modules (G, I) carry a harmonized `crop_code` (1-48); perennial
+modules (P, Q) carry the perennial crop code -- P uses ag_p0c, Q uses
+crop_code -- offset +1000 in harmonize_crop.  Sale (I, Q) is at the
+household-crop grain (no plot id); attached to single-plot (i, crop)
+rows only.  See lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import (_harvest_block, _sale_block, assemble_crop_production)
+
+
+WAVE = '2019-20'
+
+
+def _plotkey(df):
+    return (df['gardenid'].apply(format_id) + '_'
+            + df['plotid'].apply(format_id))
+
+
+def _half(g, p, i_mod, q, hh_of):
+    for df in (g, p, i_mod, q):
+        df['hhid'] = hh_of(df)
+    g['plotkey'] = _plotkey(g)
+    p['plotkey'] = _plotkey(p)
+    # Perennial crop code lives in ag_p0c (Cross_Sectional) or crop_code
+    # (Panel) -- both in the 1-18 perennial namespace.
+    p_crop = 'ag_p0c' if 'ag_p0c' in p.columns else 'crop_code'
+    harvest = [
+        _harvest_block(g, hhid='hhid', plotkey='plotkey', cropcode='crop_code',
+                       qty='ag_g13a', unit='ag_g13b', condition='ag_g13c',
+                       plant_m='ag_g05a', plant_y='ag_g05b', harv_m='ag_g12b',
+                       intercrop='ag_g01', perennial=False, t=WAVE),
+        _harvest_block(p, hhid='hhid', plotkey='plotkey', cropcode=p_crop,
+                       qty='ag_p09a', unit='ag_p09b', plant_y='ag_p04',
+                       harv_m='ag_p06c', perennial=True, t=WAVE),
+    ]
+    sale = [
+        _sale_block(i_mod, hhid='hhid', cropcode='crop_code', sold_flag='ag_i01',
+                    qty_sold='ag_i02a', value_sold='ag_i03', perennial=False),
+        _sale_block(q, hhid='hhid', cropcode='crop_code', sold_flag='ag_q01',
+                    qty_sold='ag_q02a', value_sold='ag_q03', perennial=True),
+    ]
+    return harvest, sale
+
+
+harvest_all, sale_all = [], []
+
+# --- Cross-sectional half (bare case_id) ---
+g_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_g.dta', convert_categoricals=False)
+p_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_p.dta', convert_categoricals=False)
+i_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_i.dta', convert_categoricals=False)
+q_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_q.dta', convert_categoricals=False)
+h, s = _half(g_xs, p_xs, i_xs, q_xs,
+             lambda df: df['case_id'].apply(format_id))
+harvest_all += h
+sale_all += s
+
+# --- Panel half (y4_hhid) ---
+g_pn = get_dataframe('../Data/Panel/ag_mod_g_19.dta', convert_categoricals=False)
+p_pn = get_dataframe('../Data/Panel/ag_mod_p_19.dta', convert_categoricals=False)
+i_pn = get_dataframe('../Data/Panel/ag_mod_i_19.dta', convert_categoricals=False)
+q_pn = get_dataframe('../Data/Panel/ag_mod_q_19.dta', convert_categoricals=False)
+h, s = _half(g_pn, p_pn, i_pn, q_pn,
+             lambda df: df['y4_hhid'].apply(format_id))
+harvest_all += h
+sale_all += s
+
+df = assemble_crop_production(WAVE, harvest_all, sale_all)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot,crop) in crop_production {WAVE}"
+assert len(df) > 0, f"crop_production {WAVE} produced no rows"
+
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Malawi/_/Makefile
+++ b/lsms_library/countries/Malawi/_/Makefile
@@ -12,7 +12,7 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 # _ROSTER_DERIVED — no country-level parquet is built or consulted.
 # See GH #218.
 
-all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet
+all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet $(VAR_DIR)/crop_production.parquet
 
 food_acquired = $(shell find $(rounds) -name food_acquired.py)
 # Wave-level parquets live in data_root, not in-tree
@@ -46,6 +46,19 @@ $(VAR_DIR)/food_coping.parquet: food_coping.py $(food_coping_parquet)
 
 $(VAR_DIR)/months_food_inadequate.parquet: months_food_inadequate.py $(months_food_inadequate_parquet)
 	python months_food_inadequate.py
+
+# --- crop_production / harvest (GAP 1) ------------------------------------
+# Item-level (t, i, plot, crop) harvest for the four IHS3+/IHPS waves.
+# Each wave script writes its parquet into data_root; the country script
+# concatenates.  2004-05 is ABSENT (household-level aggregated ag file).
+crop_waves := 2010-11 2013-14 2016-17 2019-20
+crop_production_parquet := $(foreach r,$(crop_waves),$(LSMS_DATA_ROOT)/$(COUNTRY)/$(r)/_/crop_production.parquet)
+
+$(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/crop_production.parquet: malawi.py
+	(cd ../$(*)/_/ && python crop_production.py)
+
+$(VAR_DIR)/crop_production.parquet: crop_production.py $(crop_production_parquet)
+	python crop_production.py
 
 %.parquet: %.py malawi.py
 	(cd $(@D) && python ./$(<F))

--- a/lsms_library/countries/Malawi/_/categorical_mapping.org
+++ b/lsms_library/countries/Malawi/_/categorical_mapping.org
@@ -379,6 +379,10 @@
 | 72 | Tin 250G | TIN 250G |
 | 73 | Tin 500G | TIN 500G |
 | 74 | Tin 1Kg | TIN 1KG |
+| C02 | 50 kg Bag |  |
+| C03 | 90 kg Bag |  |
+| C11 | Basket (Dengu) |  |
+| C12 | Ox-Cart |  |
 | 00 | Other (Specify) |  |
 | 03 | Other (Specify) |  |
 | 12 | Other (Specify) |  |
@@ -516,3 +520,119 @@
 |    7 | Rainfed/No irrigation |
 |    8 | Other                 |
 |    9 | Other                 |
+
+# crop_production (GAP 1).  Code-keyed crop map for the IHS/IHPS
+# agricultural harvest modules.  Codes 1-48 are the SEASONAL (rainy-
+# season, Module G) crop codes; the perennial (Module P / tree-crop)
+# codes are offset by +1000 (codes 1001-1018) to keep the two namespaces
+# disjoint, exactly as the World Bank cleaning code does
+# (MWI_IHPS1.do:59 "replace crop_code = crop_code + 1000").  The same
+# numeric codes are stable across all four buildable waves (2010-11,
+# 2013-14, 2016-17, 2019-20); only the decoded label spelling drifts, so
+# we key on the integer code (convert_categoricals=False) rather than the
+# label string.  Preferred Labels REUSE the consumed-food labels from the
+# harmonize_food table above wherever the crop is also a food (Rice,
+# Sorghum, Pigeon Pea (Nandolo), Ground Bean, Groundnut, Tomato, Onion,
+# Cabbage, Sugar Cane, Banana, Mango, Papaya, Pineapple, Avocado, Guava,
+# Nkwani, Tanaposi Rape, Okra/Therere, Irish Potato, ...) so that
+# crop_production.j JOINS food_acquired.j on the shared Preferred Label.
+# New Preferred Labels are added ONLY for crops with no food analogue
+# (Maize as a grain crop, Wheat, Cassava, Sweet Potato, Beans, Soyabean,
+# Cotton, Sunflower, Paprika, Pea, Tobacco varieties, Tea, Coffee,
+# Macadamia, the citrus/stone-tree perennials).
+#+name: harmonize_crop
+| Code | Preferred Label      |
+|------+----------------------|
+|    1 | Maize                |
+|    2 | Maize                |
+|    3 | Maize                |
+|    4 | Maize                |
+|    5 | Tobacco              |
+|    6 | Tobacco              |
+|    7 | Tobacco              |
+|    8 | Tobacco              |
+|    9 | Tobacco              |
+|   10 | Tobacco              |
+|   11 | Groundnut            |
+|   12 | Groundnut            |
+|   13 | Groundnut            |
+|   14 | Groundnut            |
+|   15 | Groundnut            |
+|   16 | Groundnut            |
+|   17 | Rice                 |
+|   18 | Rice                 |
+|   19 | Rice                 |
+|   20 | Rice                 |
+|   21 | Rice                 |
+|   22 | Rice                 |
+|   23 | Rice                 |
+|   24 | Rice                 |
+|   25 | Rice                 |
+|   26 | Rice                 |
+|   27 | Ground Bean          |
+|   28 | Sweet Potato         |
+|   29 | Irish Potato         |
+|   30 | Wheat                |
+|   31 | Finger Millet        |
+|   32 | Sorghum              |
+|   33 | Pearl Millet         |
+|   34 | Beans                |
+|   35 | Soyabean             |
+|   36 | Pigeon Pea (Nandolo) |
+|   37 | Cotton               |
+|   38 | Sunflower            |
+|   39 | Sugar Cane           |
+|   40 | Cabbage              |
+|   41 | Tanaposi Rape        |
+|   42 | Nkwani               |
+|   43 | Okra/Therere         |
+|   44 | Tomato               |
+|   45 | Onion                |
+|   46 | Pea                  |
+|   47 | Paprika              |
+|   48 | Other                |
+| 1001 | Cassava              |
+| 1002 | Tea                  |
+| 1003 | Coffee               |
+| 1004 | Mango                |
+| 1005 | Citrus               |
+| 1006 | Papaya               |
+| 1007 | Banana               |
+| 1008 | Avocado              |
+| 1009 | Guava                |
+| 1010 | Citrus               |
+| 1011 | Citrus               |
+| 1012 | Peach                |
+| 1013 | Custard Apple        |
+| 1014 | Masuku               |
+| 1015 | Masau                |
+| 1016 | Pineapple            |
+| 1017 | Macadamia            |
+| 1018 | Other                |
+
+# crop_production harvest/sale UNIT codes (Module G/I/P/Q non-standard
+# unit list, codes 1-13).  This is a DIFFERENT code space from the
+# food-consumption `u` table above (whose codes are zero-padded strings),
+# so it gets its own Code-keyed table -- but the Preferred Labels REUSE
+# the same `u` Preferred Label strings ('Kilogramme', '50 kg Bag',
+# 'Pail', 'Bunch', 'Piece', 'Bale', ...) so crop_production.u joins
+# food_acquired.u on the shared physical-unit label.  '90 kg Bag',
+# 'Basket (Dengu)' and 'Ox-Cart' are crop-harvest-only physical units
+# also added to the `u` table.  kg-conversion factors are NOT stored
+# here (that is a transformations concern); this is the label axis only.
+#+name: harmonize_crop_unit
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Kilogramme      |
+|    2 | 50 kg Bag       |
+|    3 | 90 kg Bag       |
+|    4 | Pail (Small)    |
+|    5 | Pail (Large)    |
+|    6 | No 10 Plate     |
+|    7 | No 12 Plate     |
+|    8 | Bunch           |
+|    9 | Piece           |
+|   10 | Bale            |
+|   11 | Basket (Dengu)  |
+|   12 | Ox-Cart         |
+|   13 | Other (Specify) |

--- a/lsms_library/countries/Malawi/_/crop_production.py
+++ b/lsms_library/countries/Malawi/_/crop_production.py
@@ -1,0 +1,37 @@
+"""Concatenate wave-level crop_production parquets for Malawi (GAP 1).
+
+Each buildable wave's ``Malawi/<wave>/_/crop_production.py`` produces a
+parquet indexed (t, i, plot, crop) with the canonical item-level columns
+(Quantity, u, Quantity_sold, Value_sold, planting_month, harvest_month,
+intercropped, perennial).  This script concatenates them.  Cross-wave
+id_walk (panel-id chaining) and the join of the cluster id ``v`` are
+applied by the framework at API time in _finalize_result.
+
+Only the four IHS3+ IHPS waves are buildable (2010-11, 2013-14, 2016-17,
+2019-20) -- these are the World Bank Plotcrop panel's waves 1-4.  2004-05
+(IHS2) is DEFERRED: its agricultural file is household-level aggregated
+(wide crop columns), with no plot-crop roster.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2010-11', '2013-14', '2016-17', '2019-20']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/crop_production.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built (DVC raises
+        # PathMissingError here, not FileNotFoundError).
+        continue
+    pieces.append(df)
+
+assert pieces, "crop_production: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/crop_production.parquet')

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -133,5 +133,31 @@ Data Scheme:
     MonthsInadequate: int
     AnyInadequate: bool
     materialize: make
+  crop_production:
+    # Item-level (t, i, plot, crop) harvest feature for the four IHS3+
+    # IHPS waves (2010-11, 2013-14, 2016-17, 2019-20); GAP 1.  Reported
+    # values only -- harvest Quantity + native unit, household-crop sale
+    # (Quantity_sold / Value_sold, attached to single-plot crops only),
+    # item planting / harvest-end months, and intercropped / perennial
+    # flags.  Sources: seasonal Module G + perennial Module P (plot-crop
+    # harvest), seasonal Module I + perennial Module Q (household-crop
+    # sale).  crop on the shared harmonize_crop -> harmonize_food
+    # Preferred Label axis so a crop that is also a consumed food (Rice,
+    # Sorghum, Groundnut, Tomato, ...) JOINS food_acquired.j; u on the
+    # shared `u` Preferred Label axis.  Plot grain aligns with
+    # plot_features.  Aggregates (harvest_kg / yield / share_kg_sold /
+    # main_crop / value-shares) are transformations, NOT stored columns.
+    # 2004-05 (IHS2) deferred: household-level aggregated ag file, no
+    # plot-crop roster.  See _/malawi.py:assemble_crop_production.
+    index: (t, i, plot, crop)
+    Quantity: float
+    u: str
+    Quantity_sold: float
+    Value_sold: float
+    planting_month: int
+    harvest_month: int
+    intercropped: bool
+    perennial: bool
+    materialize: make
   food_expenditures:
   food_prices:

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -731,6 +731,218 @@ def plot_features_for_wave(t, df_c, df_d, colmap):
     return out
 
 
+# --- crop_production / harvest (GAP 1) ----------------------------------
+# Item-level (t, i, plot, crop) harvest feature.  Two source modules feed
+# the plot-crop grain:
+#   * Module G  — seasonal (rainy-season) crop harvest, one row per
+#     (plot, crop).  Crop codes 1-48 (harmonize_crop).
+#   * Module P  — perennial / tree-crop harvest, one row per (plot, crop).
+#     Crop codes offset +1000 (1001-1018) to disambiguate the namespace,
+#     exactly as the World Bank cleaning code does (MWI_IHPS1.do:59).
+# Two further modules carry the SALE, but only at the household-crop grain
+# (NO plot id in the questionnaire):
+#   * Module I  — seasonal harvest sale, one row per (hh, crop).
+#   * Module Q  — perennial harvest sale, one row per (hh, crop).
+# We therefore attach the REPORTED Quantity_sold / Value_sold to a
+# plot-crop row ONLY when that (i, crop) is grown on exactly one plot, so
+# the reported value unambiguously belongs to that single plot-crop.
+# Where a crop spans several plots, the sale is not plot-resolvable and
+# those columns stay NaN -- we never fabricate a per-plot split of a
+# household-level reported figure.  Everything aggregate (harvest_kg,
+# yield, share_kg_sold, main_crop, value-shares) is a transformations.py
+# concern, NOT a stored column.
+
+# Module G/I/P/Q "non-standard unit" codes -> months map is for dates;
+# the 1-12 month codes are the standard Stata month value labels.
+_MONTH_CODES = {i: i for i in range(1, 13)}  # months stored as 1-12 ints
+
+
+def _crop_codes(series, perennial=False):
+    """Map a numeric crop-code Series through harmonize_crop, applying
+    the +1000 perennial offset first when ``perennial`` is True.  Source
+    must be loaded convert_categoricals=False (numeric codes)."""
+    codes = pd.to_numeric(series, errors='coerce').astype('Int64')
+    if perennial:
+        codes = codes + 1000
+    cmap = _malawi_code_map('harmonize_crop')
+    out = codes.map(cmap)
+    return out.astype('string').where(out.notna(), pd.NA), codes
+
+
+def _harvest_block(df, *, hhid, plotkey, cropcode, qty, unit, condition=None,
+                   plant_m=None, plant_y=None, harv_m=None, intercrop=None,
+                   perennial=False, t=None):
+    """Reshape one harvest module (G or P) to canonical long rows.
+
+    All keyword args are RAW column names in ``df`` (or None when the
+    wave/module lacks that field).  ``df`` must already carry an ``hhid``
+    string column.  Returns a long DataFrame with the canonical columns
+    (i, plot, crop, crop_code, Quantity, u, planting_month, harvest_month,
+    intercropped, perennial) -- NO aggregation.
+    """
+    unit_map = _malawi_code_map('harmonize_crop_unit')
+
+    crop_label, crop_code_int = _crop_codes(df[cropcode], perennial=perennial)
+    plot = df[plotkey].apply(format_id).astype('string')
+
+    u = (pd.to_numeric(df[unit], errors='coerce').astype('Int64').map(unit_map)
+         if unit is not None and unit in df.columns
+         else pd.Series(pd.NA, index=df.index, dtype='string'))
+    u = u.astype('string').where(u.notna(), pd.NA)
+
+    quantity = (pd.to_numeric(df[qty], errors='coerce').astype('Float64')
+                if qty is not None and qty in df.columns
+                else pd.Series(pd.NA, index=df.index, dtype='Float64'))
+
+    def _month(col):
+        if col is None or col not in df.columns:
+            return pd.Series(pd.NA, index=df.index, dtype='Int64')
+        m = pd.to_numeric(df[col], errors='coerce').astype('Int64')
+        # Calendar months are 1-12; 0 / out-of-range codes are "not
+        # recorded" sentinels -> NaN.
+        return m.where((m >= 1) & (m <= 12), pd.NA)
+
+    planting_month = _month(plant_m)
+    harvest_month = _month(harv_m)
+
+    # intercropped flag: Module G ag_g01 crop-stand code (1 = pure/sole;
+    # >=2 = some form of intercrop/mixed stand).  Perennial rows: NaN.
+    if intercrop is not None and intercrop in df.columns:
+        stand = pd.to_numeric(df[intercrop], errors='coerce').astype('Int64')
+        intercropped = (stand >= 2).astype('boolean')
+        intercropped = intercropped.where(stand.notna(), pd.NA)
+    else:
+        intercropped = pd.Series(pd.NA, index=df.index, dtype='boolean')
+
+    out = pd.DataFrame({
+        't':              t,
+        'i':              df['hhid'].astype('string').values,
+        'plot':           plot.values,
+        'crop':           crop_label.values,
+        '_crop_code':     crop_code_int.values,
+        'Quantity':       quantity.values,
+        'u':              u.values,
+        'planting_month': planting_month.values,
+        'harvest_month':  harvest_month.values,
+        'intercropped':   intercropped.values,
+        'perennial':      pd.array([perennial] * len(df), dtype='boolean'),
+    })
+    # Drop rows with no crop identity (crop code missing) — not a planted
+    # item.  Keep rows with a crop even if Quantity is NaN (reported "no
+    # harvest yet"/refused are legitimately item rows).
+    out = out[out['crop'].notna() | out['_crop_code'].notna()]
+    return out
+
+
+def _sale_block(df, *, hhid, cropcode, sold_flag, qty_sold, value_sold,
+                perennial=False):
+    """Reshape one sale module (I or Q) to (i, _crop_code) reported sale.
+
+    Returns a DataFrame with columns [i, _crop_code, Quantity_sold,
+    Value_sold] at the household-crop grain (no plot).  Summed within
+    (i, _crop_code) because a household may report several sale rows for
+    the same crop -- this is the REPORTED total the household sold of that
+    crop, not a derived aggregate over plots.
+    """
+    crop_label, crop_code_int = _crop_codes(df[cropcode], perennial=perennial)
+
+    qs = (pd.to_numeric(df[qty_sold], errors='coerce').astype('Float64')
+          if qty_sold is not None and qty_sold in df.columns
+          else pd.Series(pd.NA, index=df.index, dtype='Float64'))
+    vs = (pd.to_numeric(df[value_sold], errors='coerce').astype('Float64')
+          if value_sold is not None and value_sold in df.columns
+          else pd.Series(pd.NA, index=df.index, dtype='Float64'))
+
+    out = pd.DataFrame({
+        'i':            df['hhid'].astype('string').values,
+        '_crop_code':   crop_code_int.values,
+        'Quantity_sold': qs.values,
+        'Value_sold':   vs.values,
+    })
+    out = out[out['_crop_code'].notna()]
+    grp = out.groupby(['i', '_crop_code'], as_index=False).agg(
+        {'Quantity_sold': 'sum', 'Value_sold': 'sum'})
+    return grp
+
+
+def assemble_crop_production(t, harvest_pieces, sale_pieces):
+    """Combine reshaped harvest (_harvest_block) and sale (_sale_block)
+    pieces into the canonical crop_production DataFrame for wave ``t``.
+
+    Parameters
+    ----------
+    t : str — wave id, used as the ``t`` index value.
+    harvest_pieces : list[pd.DataFrame] — outputs of _harvest_block.
+    sale_pieces : list[pd.DataFrame] — outputs of _sale_block (may be []).
+
+    Returns
+    -------
+    pd.DataFrame indexed (t, i, plot, crop) with columns Quantity, u,
+    Quantity_sold, Value_sold, planting_month, harvest_month,
+    intercropped, perennial.  Item-level reported values only.
+    """
+    harv = pd.concat(harvest_pieces, ignore_index=True)
+
+    # Collapse exact duplicate (i, plot, crop, u) harvest rows by summing
+    # reported quantity (a plot-crop may be split across several recorded
+    # lines in the same unit); keep the first non-null date/flag.  This is
+    # a reported-line consolidation, NOT a cross-unit aggregation: rows in
+    # different units `u` stay distinct.
+    harv['u'] = harv['u'].astype('string')
+    harv = harv.groupby(['i', 'plot', 'crop', 'u', '_crop_code'],
+                        as_index=False, dropna=False).agg({
+        'Quantity':       'sum',
+        'planting_month': 'first',
+        'harvest_month':  'first',
+        'intercropped':   'first',
+        'perennial':      'first',
+    })
+
+    if sale_pieces:
+        sale = pd.concat(sale_pieces, ignore_index=True)
+        sale = sale.groupby(['i', '_crop_code'], as_index=False).agg(
+            {'Quantity_sold': 'sum', 'Value_sold': 'sum'})
+        # Attach sale ONLY where the (i, crop) is grown on exactly one
+        # plot, so the household-crop reported figure unambiguously
+        # belongs to that single plot-crop.  Multi-plot crops keep NaN.
+        nplots = (harv.groupby(['i', '_crop_code'])['plot']
+                  .nunique().rename('_nplots').reset_index())
+        harv = harv.merge(nplots, on=['i', '_crop_code'], how='left')
+        harv = harv.merge(sale, on=['i', '_crop_code'], how='left')
+        single = harv['_nplots'] == 1
+        harv['Quantity_sold'] = harv['Quantity_sold'].where(single, pd.NA)
+        harv['Value_sold'] = harv['Value_sold'].where(single, pd.NA)
+        harv = harv.drop(columns=['_nplots'])
+    else:
+        harv['Quantity_sold'] = pd.array([pd.NA] * len(harv), dtype='Float64')
+        harv['Value_sold'] = pd.array([pd.NA] * len(harv), dtype='Float64')
+
+    harv = harv.drop(columns=['_crop_code'])
+    harv['t'] = t
+
+    # crop must be non-null for the index; rows where the code did not map
+    # to a Preferred Label (only code 48/1018 "Other (Specify)" and any
+    # unmapped) are dropped from the index axis but logged by row count.
+    harv = harv[harv['crop'].notna()]
+
+    out = harv.set_index(['t', 'i', 'plot', 'crop'])
+    # Defensive: collapse any residual duplicate index tuples (same
+    # plot-crop reported in two units would survive above; sum Quantity).
+    if not out.index.is_unique:
+        num = out.groupby(level=['t', 'i', 'plot', 'crop']).agg({
+            'Quantity':       'sum',
+            'u':              'first',
+            'Quantity_sold':  'first',
+            'Value_sold':     'first',
+            'planting_month': 'first',
+            'harvest_month':  'first',
+            'intercropped':   'first',
+            'perennial':      'first',
+        })
+        out = num
+    return out
+
+
 # --- non-FIES food security (GH #332) -----------------------------------
 # Module H "Food Security" of the IHS3/IHS4/IHS5 household questionnaire and
 # the IHPS 2013 carries two non-FIES batteries shared verbatim across all

--- a/lsms_library/countries/Mali/2014-15/_/crop_production.py
+++ b/lsms_library/countries/Mali/2014-15/_/crop_production.py
@@ -1,0 +1,111 @@
+"""Build crop_production (item-level harvest) for Mali EACI 2014-15.
+
+Sources (post-harvest, passage 2 / cultivation, passage 1):
+  - EACIS3A_p2.dta   seasonal-crop harvest roster (one row per plot-crop)
+  - EACIS3B_p2.dta   perennial-tree roster (one row per HH-tree; no field grid)
+  - EACICULTURE_p1.dta (s1c) cultivation roster -> planting month + intercrop
+
+Grain: (t, i, plot, crop).  plot = "{field}_{parcel}" (s3aq01_s3aq02) for
+seasonal crops; <NA> for perennial trees.  Reported, item-level columns
+only — Quantity / u / Quantity_sold / Value_sold / planting_month /
+harvest_month / intercropped / perennial.  No harvest_kg / yield / share /
+main_crop (those are transformations over these rows).
+
+Variable map traced from MLI_EACI1.do (WB LSMS-ISA harmonised crop section):
+  field=s3aq01 parcel=s3aq02 crop=s3aq03b harvest_qty=s3aq08a unit=s3aq08b
+  sold_y/n=s3aq22 sold_qty=s3aq23a sold_value=s3aq24 harvest_month=s3aq07b
+  perennial: crop=s3bq01 still_prod=s3bq03 qty=s3bq09 unit=s3bq10b
+             sold_qty=s3bq13a sold_value=s3bq14
+  cultivation: field=s1cq01 parcel=s1cq02 crop=s1cq03 plant_month=s1cq11b
+             intercrop=s1cq05 (Pure / Association de cultures)
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import i as mali_i, crop_production_finalize
+
+WAVE = '2014-15'
+
+
+def _hhid(df):
+    return df.apply(lambda r: mali_i(pd.Series([r['grappe'], r['menage']])), axis=1)
+
+
+def _plot(df, fcol, pcol):
+    f = df[fcol].astype('Int64').astype('string')
+    p = df[pcol].astype('Int64').astype('string')
+    return (f + '_' + p).where(f.notna() & p.notna(), pd.NA)
+
+
+# --- seasonal harvest (s3a) ---
+s3a = get_dataframe('../Data/EACIS3A_p2.dta').copy()
+s3a['i'] = _hhid(s3a)
+seasonal = pd.DataFrame({
+    't': WAVE,
+    'i': s3a['i'],
+    'plot': _plot(s3a, 's3aq01', 's3aq02'),
+    'crop': s3a['s3aq03b'],
+    'u': s3a['s3aq08b'],
+    'Quantity': s3a['s3aq08a'],
+    'Quantity_sold': s3a['s3aq23a'],
+    'Value_sold': s3a['s3aq24'],
+    'harvest_month': s3a['s3aq07b'],
+    'planting_month': pd.NA,
+    'intercropped': pd.NA,
+    'perennial': False,
+})
+# s3aq22 == 'Non' -> household reports not having sold this crop: 0 sold.
+not_sold = s3a['s3aq22'].astype('string').str.strip().eq('Non')
+seasonal.loc[not_sold, ['Quantity_sold', 'Value_sold']] = 0
+
+# --- planting month + intercrop from cultivation roster (s1c) ---
+s1c = get_dataframe('../Data/EACICULTURE_p1.dta').copy()
+s1c['i'] = _hhid(s1c)
+cult = pd.DataFrame({
+    'i': s1c['i'],
+    'plot': _plot(s1c, 's1cq01', 's1cq02'),
+    'crop': s1c['s1cq03'],
+    'planting_month': s1c['s1cq11b'],
+    'intercropped': s1c['s1cq05'].astype('string').str.strip()
+                       .map({'Pure': False, 'Association de cultures': True}),
+})
+cult = cult.dropna(subset=['plot', 'crop'])
+cult = cult.drop_duplicates(subset=['i', 'plot', 'crop'], keep='first')
+
+seasonal = seasonal.drop(columns=['planting_month', 'intercropped']).merge(
+    cult, on=['i', 'plot', 'crop'], how='left')
+
+# --- perennial trees (s3b): no field grid -> plot = <NA>, perennial=True ---
+# s3b is a FIXED tree roster: every HH gets a row per possible species, with
+# s3bq03 == 'Non' for trees it does not have/produce (3416 placeholder rows
+# with no harvest).  Keep only s3bq03 == 'Oui' (currently producing) — the
+# 358 rows that carry an actual harvest, matching WB `drop if s3bq03==2`.
+s3b = get_dataframe('../Data/EACIS3B_p2.dta').copy()
+s3b = s3b[s3b['s3bq01'].notna()]  # rows that actually name a tree
+s3b = s3b[s3b['s3bq03'].astype('string').str.strip().eq('Oui')]
+s3b['i'] = _hhid(s3b)
+perennial = pd.DataFrame({
+    't': WAVE,
+    'i': s3b['i'],
+    'plot': pd.NA,
+    'crop': s3b['s3bq01'],
+    'u': s3b['s3bq10b'],
+    'Quantity': pd.to_numeric(s3b['s3bq09'], errors='coerce'),
+    'Quantity_sold': s3b['s3bq13a'],
+    'Value_sold': s3b['s3bq14'],
+    'harvest_month': pd.NA,
+    'planting_month': pd.NA,
+    'intercropped': pd.NA,
+    'perennial': True,
+})
+
+df = pd.concat([seasonal, perennial], ignore_index=True)
+df = crop_production_finalize(df)
+
+assert len(df) > 0, "crop_production 2014-15 produced no rows"
+assert df.index.is_unique, "Non-unique (t, i, plot, crop) in crop_production 2014-15"
+
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Mali/2017-18/_/crop_production.py
+++ b/lsms_library/countries/Mali/2017-18/_/crop_production.py
@@ -1,0 +1,148 @@
+"""Build crop_production (item-level harvest) for Mali EACI 2017-18.
+
+Sources (post-harvest passage 2; cultivation passage 1):
+  - eaci17_s7fp2.dta   seasonal-crop harvest roster (one row per plot-crop)
+  - eaci17_s7gp2.dta   crop-sales roster, keyed (grappe, exploitation, crop)
+                       — HOUSEHOLD-crop grain, NOT plot-crop
+  - eaci17_s11fp1.dta  perennial-tree roster (one row per HH-tree; no field grid)
+  - eaci17_s11cp1.dta  cultivation roster -> planting month
+
+Grain: (t, i, plot, crop).  plot = "{field}_{parcel}" (s7fq01_s7fq02) for
+seasonal crops; <NA> for perennial trees.  i = (grappe, exploitation) —
+the 2017-18 household key (cf. sample/cluster_features data_info.yml).
+
+Reported, item-level columns only.  IMPORTANT: the 2017-18 sales module
+(s7g) records sold quantity / value at the (household, crop) grain, NOT
+plot-crop.  To avoid fabricating a plot allocation, Quantity_sold /
+Value_sold are joined onto the plot-crop row ONLY when the (i, crop) maps
+to a single plot (68% of crop-hh combos); where a crop spans >1 plot
+(32%), sold stays NaN at the plot grain — the survey simply did not record
+sales at plot granularity.  (The household-crop sold totals remain
+recoverable from the raw module; a transformations.py rollup can sum
+harvest to (i, crop) and join the full sold series there.)
+
+Variable map traced from MLI_EACI2.do (WB harmonised crop section):
+  field=s7fq01 parcel=s7fq02 crop=s7fq03 harvest_qty=s7fq13a unit=s7fq13c
+  fully_harvested=s7fq06 harvest_month=s7fq12b
+  sold: crop=s7gq01 sold_y/n=s7gq20 sold_qty=s7gq21a sold_value=s7gq22
+  perennial: crop=s11fq01 still_prod=s11fq03 qty=s11fq10 unit=s11fq11c-?
+             sold_qty=s11fq14a sold_value=s11fq15
+  cultivation: field=s11cq01 parcel=s11cq02 crop=s11cq03 plant_month=s11cq14b
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import i as mali_i, crop_production_finalize
+
+WAVE = '2017-18'
+
+
+def _hhid(df):
+    return df.apply(lambda r: mali_i(pd.Series([r['grappe'], r['exploitation']])),
+                    axis=1)
+
+
+def _plot(df, fcol, pcol):
+    f = df[fcol].astype('Int64').astype('string')
+    p = df[pcol].astype('Int64').astype('string')
+    return (f + '_' + p).where(f.notna() & p.notna(), pd.NA)
+
+
+# --- seasonal harvest (s7f) ---
+s7f = get_dataframe('../Data/eaci17_s7fp2.dta').copy()
+s7f['i'] = _hhid(s7f)
+seasonal = pd.DataFrame({
+    't': WAVE,
+    'i': s7f['i'],
+    'plot': _plot(s7f, 's7fq01', 's7fq02'),
+    'crop': s7f['s7fq03'],
+    'u': s7f['s7fq13c'],
+    'Quantity': s7f['s7fq13a'],
+    'Quantity_sold': pd.NA,
+    'Value_sold': pd.NA,
+    'harvest_month': s7f['s7fq12b'],
+    'planting_month': pd.NA,
+    'intercropped': pd.NA,   # 2017-18 s11cq05 has no documented monoculture/
+                             # intercrop binary; left NaN (honest missing).
+    'perennial': False,
+})
+
+# --- sold (s7g): household-crop grain; attach only to single-plot crops ---
+s7g = get_dataframe('../Data/eaci17_s7gp2.dta').copy()
+s7g['i'] = _hhid(s7g)
+sold = pd.DataFrame({
+    'i': s7g['i'],
+    'crop': s7g['s7gq01'],
+    'Quantity_sold': pd.to_numeric(s7g['s7gq21a'], errors='coerce'),
+    'Value_sold': pd.to_numeric(s7g['s7gq22'], errors='coerce'),
+})
+not_sold = s7g['s7gq20'].astype('string').str.strip().eq('Non')
+sold.loc[not_sold, ['Quantity_sold', 'Value_sold']] = 0
+sold = sold.groupby(['i', 'crop'], as_index=False).agg(
+    {'Quantity_sold': 'sum', 'Value_sold': 'sum'})
+
+# (i, crop) -> number of distinct plots in the harvest roster
+nplots = (seasonal.dropna(subset=['plot'])
+          .groupby(['i', 'crop'])['plot'].nunique().rename('nplots'))
+seasonal = seasonal.merge(nplots, on=['i', 'crop'], how='left')
+seasonal = seasonal.drop(columns=['Quantity_sold', 'Value_sold']).merge(
+    sold, on=['i', 'crop'], how='left')
+# blank out sold where the crop spans >1 plot (cannot place at plot grain)
+multi = seasonal['nplots'].fillna(0) > 1
+seasonal.loc[multi, ['Quantity_sold', 'Value_sold']] = pd.NA
+seasonal = seasonal.drop(columns=['nplots'])
+
+# --- planting month from cultivation roster (s11c) ---
+s11c = get_dataframe('../Data/eaci17_s11cp1.dta').copy()
+s11c['i'] = _hhid(s11c)
+cult = pd.DataFrame({
+    'i': s11c['i'],
+    'plot': _plot(s11c, 's11cq01', 's11cq02'),
+    'crop': s11c['s11cq03'],
+    'planting_month': s11c['s11cq14b'],
+}).dropna(subset=['plot', 'crop']).drop_duplicates(
+    subset=['i', 'plot', 'crop'], keep='first')
+seasonal = seasonal.drop(columns=['planting_month']).merge(
+    cult, on=['i', 'plot', 'crop'], how='left')
+
+# --- perennial trees (s11f): no field grid -> plot = <NA>, perennial=True ---
+# Like 2014-15, s11f is a FIXED tree roster (every HH gets a row per species,
+# s11fq03 == 'Non' for trees it does not have).  Keep only s11fq03 == 'Oui'
+# (currently producing) — the ~270 rows with an actual harvest; matching WB
+# `drop if s11fq03==2`.
+s11f = get_dataframe('../Data/eaci17_s11fp1.dta').copy()
+s11f = s11f[s11f['s11fq01'].notna()]
+s11f = s11f[s11f['s11fq03'].astype('string').str.strip().eq('Oui')]
+# perennial roster uses 'ménage' as the within-cluster household key
+key2 = 'exploitation' if 'exploitation' in s11f.columns else 'ménage'
+s11f['exploitation'] = s11f[key2]
+s11f['i'] = _hhid(s11f)
+perennial = pd.DataFrame({
+    't': WAVE,
+    'i': s11f['i'],
+    'plot': pd.NA,
+    'crop': s11f['s11fq01'],
+    # s11fq11a = harvested quantity (numeric); s11fq11b = its unit.
+    # (s11fq10 is a free-text "months producing" field, NOT a quantity.)
+    'u': s11f['s11fq11b'] if 's11fq11b' in s11f.columns else pd.NA,
+    'Quantity': pd.to_numeric(s11f['s11fq11a'], errors='coerce'),
+    'Quantity_sold': pd.to_numeric(s11f['s11fq14a'], errors='coerce')
+                       if 's11fq14a' in s11f.columns else pd.NA,
+    'Value_sold': pd.to_numeric(s11f['s11fq15'], errors='coerce')
+                       if 's11fq15' in s11f.columns else pd.NA,
+    'harvest_month': pd.NA,
+    'planting_month': pd.NA,
+    'intercropped': pd.NA,
+    'perennial': True,
+})
+
+df = pd.concat([seasonal, perennial], ignore_index=True)
+df = crop_production_finalize(df)
+
+assert len(df) > 0, "crop_production 2017-18 produced no rows"
+assert df.index.is_unique, "Non-unique (t, i, plot, crop) in crop_production 2017-18"
+
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Mali/_/Makefile
+++ b/lsms_library/countries/Mali/_/Makefile
@@ -28,6 +28,16 @@ panel_ids.json updated_ids.json: panel_ids.py mali.py
 $(VAR_DIR)/food_coping.parquet: food_coping.py ../2014-15/_/food_coping.parquet
 	python food_coping.py
 
+# crop_production (item-level harvest, GAP 1 / parity loop).  The crop
+# module lives in the EACI waves only (2014-15, 2017-18).  The wave
+# pattern rule materializes each wave parquet; the country-level
+# concatenator (crop_production.py) aggregates into var/crop_production.parquet.
+../%/_/crop_production.parquet: ../%/_/crop_production.py
+	(cd $(@D) && python crop_production.py)
+
+$(VAR_DIR)/crop_production.parquet: crop_production.py ../2014-15/_/crop_production.parquet ../2017-18/_/crop_production.parquet
+	python crop_production.py
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Mali/_/categorical_mapping.org
+++ b/lsms_library/countries/Mali/_/categorical_mapping.org
@@ -77,10 +77,23 @@
 | Sachet                       | Sachet          | x       | ---     | ---     |
 | Unité                        | Unité           | x       | ---     | ---     |
 | Verre                        | Verre           | x       | ---     | ---     |
+|------------------------------+-----------------+---------+---------+---------|
+| # crop_production harvest units (EACI 2014-15 & 2017-18 s3a/s7f/s3b) |                 |         |         |         |
+| Sac                          | Sac             | x       | ---     | ---     |
+| Charretée                    | Charretée       | x       | ---     | ---     |
+| Moude                        | Moude           | x       | ---     | ---     |
+| Kilogramme                   | Kg              | x       | ---     | ---     |
+| Gerbe                        | Gerbe           | x       | ---     | ---     |
+| Grenier                      | Grenier         | x       | ---     | ---     |
+| Bassine                      | Bassine         | x       | ---     | ---     |
+| Calebasse                    | Calebasse       | x       | ---     | ---     |
+| Casier                       | Casier          | x       | ---     | ---     |
+| Chargement camion            | Chargement camion | x       | ---     | ---     |
+| Tonne                        | Tonne           | x       | ---     | ---     |
 
 #+name: harmonize_food
 | Code                                                                                                 | Preferred Label                              | 2014-15 | 2018-19 | 2021-22 |
-|------------------------------------------------------------------------------------------------------+----------------------------------------------+---------+---------+---------|
+|------------------------------------------------------------------------------------------------------+----------------------------------------------+---------+---------+---------+---------|
 | ?ufs                                                                                                 | Oeufs                                        | x       | ---     | ---     |
 | Abats et tripes (foie, rognon, etc.)                                                                 | Abats et tripes                              | x       | x       | x       |
 | Ail                                                                                                  | Ail                                          | ---     | x       | x       |
@@ -334,6 +347,75 @@
 | Zaban                                                                                                | Zaban                                        | x       | ---     | ---     |
 | ufs                                                                                                 | Œufs                                         | ---     | x       | ---     |
 | Œufs                                                                                                 | Œufs                                         | ---     | ---     | x       |
+|------------------------------------------------------------------------------------------------------+----------------------------------------------+---------+---------+---------|
+| # crop_production (GAP 1) crops — EACI 2014-15 & 2017-18 harvest/perennial; food crops REUSE the consumed-food |                                              |         |         |         |
+| Mil                                                                                                  | Mil                                          | x       | ---     | ---     |
+| Sorgho                                                                                               | Sorgho                                       | x       | ---     | ---     |
+| Maïs                                                                                                 | Maïs                                         | x       | ---     | ---     |
+| Riz                                                                                                  | Riz                                          | x       | ---     | ---     |
+| Fonio                                                                                                | Fonio                                        | x       | ---     | ---     |
+| Blé                                                                                                  | Blé                                          | x       | ---     | ---     |
+| Orge                                                                                                 | Orge                                         | x       | ---     | ---     |
+| Arachide                                                                                             | Arachide                                     | x       | ---     | ---     |
+| Niébé                                                                                                | Haricots secs                                | x       | ---     | ---     |
+| Niébé Fourrager                                                                                      | Niébé fourrager                              | x       | ---     | ---     |
+| Voandzou                                                                                             | Voandzou                                     | x       | ---     | ---     |
+| Soja                                                                                                 | Soja                                         | x       | ---     | ---     |
+| Petits Pois                                                                                          | Petit pois                                   | x       | ---     | ---     |
+| Pois sucré                                                                                           | Pois sucrés                                  | x       | ---     | ---     |
+| Sésame                                                                                               | Sésame                                       | x       | ---     | ---     |
+| Coton                                                                                                | Coton                                        | x       | ---     | ---     |
+| Dah/Fibre                                                                                            | Dah/Fibre                                    | x       | ---     | ---     |
+| Igname                                                                                               | Igname                                       | x       | ---     | ---     |
+| Manioc                                                                                               | Manioc                                       | x       | ---     | ---     |
+| Patate Douce                                                                                         | Patate douce                                 | x       | ---     | ---     |
+| Taro                                                                                                 | Taro, macabo                                 | x       | ---     | ---     |
+| Pomme de terre                                                                                       | Pomme de terre                               | x       | ---     | ---     |
+| Tomate                                                                                               | Tomate fraîche                               | x       | ---     | ---     |
+| Oignon                                                                                               | Oignon                                       | x       | ---     | ---     |
+| Aïl                                                                                                  | Ail                                          | x       | ---     | ---     |
+| Gombo                                                                                                | Gombo                                        | x       | ---     | ---     |
+| Piment                                                                                               | Piment                                       | x       | ---     | ---     |
+| Poivron                                                                                              | Poivron frais                                | x       | ---     | ---     |
+| Aubergine                                                                                            | Aubergine                                    | x       | ---     | ---     |
+| Jaxatu                                                                                               | Jaxatu                                       | x       | ---     | ---     |
+| Concombre                                                                                            | Concombre                                    | x       | ---     | ---     |
+| Choux                                                                                                | Chou                                         | x       | ---     | ---     |
+| Carotte                                                                                              | Carotte                                      | x       | ---     | ---     |
+| Betterave                                                                                            | Betterave                                    | x       | ---     | ---     |
+| Laitue                                                                                               | Salade                                       | x       | ---     | ---     |
+| Gingembre                                                                                            | Gingembre                                    | x       | ---     | ---     |
+| Calebasse                                                                                            | Calebasse                                    | x       | ---     | ---     |
+| Courge                                                                                               | Courge, Courgette                            | x       | ---     | ---     |
+| Haricot vert                                                                                         | Haricot vert                                 | x       | ---     | ---     |
+| Melon                                                                                                | Melon                                        | x       | ---     | ---     |
+| Pastèque                                                                                             | Pastèque                                     | x       | ---     | ---     |
+| Oseille verte                                                                                        | Oseille verte                                | x       | ---     | ---     |
+| Oseille rouge de Guinée                                                                              | Oseille rouge de Guinée                      | x       | ---     | ---     |
+| Anacarde                                                                                             | Noix de cajou                                | x       | ---     | ---     |
+| Anacardier                                                                                           | Noix de cajou                                | x       | ---     | ---     |
+| Manguier                                                                                             | Mangue                                       | x       | ---     | ---     |
+| Oranger                                                                                              | Orange                                       | x       | ---     | ---     |
+| Citronnier                                                                                           | Citron                                       | x       | ---     | ---     |
+| Lime Mexicaine                                                                                       | Lime mexicaine                               | x       | ---     | ---     |
+| Lime mexicaine                                                                                       | Lime mexicaine                               | x       | ---     | ---     |
+| Mandarinier                                                                                          | Mandarine                                    | x       | ---     | ---     |
+| Tangerine                                                                                            | Mandarine                                    | x       | ---     | ---     |
+| Tangérine                                                                                            | Mandarine                                    | x       | ---     | ---     |
+| Pamplemoussier                                                                                       | Pamplemousse                                 | x       | ---     | ---     |
+| Plamplemoussier                                                                                      | Pamplemousse                                 | x       | ---     | ---     |
+| Goyavier                                                                                             | Goyave                                       | x       | ---     | ---     |
+| Papayer                                                                                              | Papaye                                       | x       | ---     | ---     |
+| Bananier                                                                                             | Banane douce                                 | x       | ---     | ---     |
+| Bananier (banane douce)                                                                              | Banane douce                                 | x       | ---     | ---     |
+| Bananier (plantain)                                                                                  | Plantain                                     | x       | ---     | ---     |
+| Bananier (banane plantin)                                                                            | Plantain                                     | x       | ---     | ---     |
+| Jujubier Greffé                                                                                      | Jujube                                       | x       | ---     | ---     |
+| Jujubier greffé                                                                                      | Jujube                                       | x       | ---     | ---     |
+| Palmier dattier                                                                                      | Dattes                                       | x       | ---     | ---     |
+| Palmier à huile                                                                                      | Palmier à huile                              | x       | ---     | ---     |
+| Pomme canelle                                                                                        | Pomme cannelle                               | x       | ---     | ---     |
+| Autres                                                                                               | Autres cultures                              | x       | ---     | ---     |
 
 #+name: Roof
 | Alternate Spelling | Preferred Label |

--- a/lsms_library/countries/Mali/_/crop_production.py
+++ b/lsms_library/countries/Mali/_/crop_production.py
@@ -1,0 +1,37 @@
+"""Concatenate wave-level crop_production for Mali (GAP 1; parity loop).
+
+Each EACI wave's ``Mali/<wave>/_/crop_production.py`` writes a parquet
+indexed by ``(t, i, plot, crop)`` with the reported item-level harvest
+columns (Quantity, u, Quantity_sold, Value_sold, planting_month,
+harvest_month, intercropped, perennial).  The crop/harvest module lives in
+the EACI waves only (2014-15 EACI14, 2017-18 EACI17); the EHCVM waves
+(2018-19, 2021-22) carry no harvest block, so they contribute nothing.
+
+``v`` is NOT baked in — the framework joins it from ``sample()`` at API
+time.  ``id_walk`` is left to ``_finalize_result`` (cached parquets store
+pre-transformation data), matching the plot_features / food_coping pattern.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+WAVES = ['2014-15', '2017-18', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/crop_production.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired (no .py script / no parquet); DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "crop_production: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, plot, crop) after concat"
+
+to_parquet(p, '../var/crop_production.parquet')

--- a/lsms_library/countries/Mali/_/data_scheme.yml
+++ b/lsms_library/countries/Mali/_/data_scheme.yml
@@ -123,3 +123,35 @@ Data Scheme:
     SoilType: str
     Irrigated: bool
     materialize: make
+  crop_production:
+    # Item-level harvest, GAP 1 (parity loop).  One row per (t, i, plot,
+    # crop): the REPORTED quantities the survey records, NOT aggregates.
+    # The crop/harvest module lives in the EACI waves only (2014-15 EACI14
+    # s3a/s3b/s1c; 2017-18 EACI17 s7f/s7g/s11f/s11c).  The EHCVM waves
+    # (2018-19, 2021-22) have no harvest block — deferred (the same split
+    # as plot_features, but the opposite two waves).
+    #
+    # plot = "{field}_{parcel}" for seasonal crops; <NA> for perennial
+    # trees (the perennial roster is not on the seasonal field grid).
+    # crop = harmonize_food Preferred Label (food crops REUSE the consumed-
+    # food label so crop_production.j joins food_acquired.j; non-food crops
+    # — Coton, Soja, Voandzou, Dah/Fibre, tree species — get new labels).
+    # u   = harmonize unit label (`u` categorical table).
+    #
+    # NO harvest_kg / yield / main_crop / value-share columns — those are
+    # transformations.py rollups over these item rows.  2017-18 sold qty/
+    # value is recorded at (household, crop) grain (module s7g), so it is
+    # attached at the plot level only for single-plot crops; multi-plot
+    # crops carry NaN sold (see the wave script).  intercropped is recorded
+    # in 2014-15 (s1cq05 Pure/Association) only; NaN in 2017-18.
+    # Built by per-wave scripts + a country-level concatenator.
+    index: (t, i, plot, crop)
+    Quantity: float
+    u: str
+    Quantity_sold: float
+    Value_sold: float
+    planting_month: int
+    harvest_month: int
+    intercropped: bool
+    perennial: bool
+    materialize: make

--- a/lsms_library/countries/Mali/_/mali.py
+++ b/lsms_library/countries/Mali/_/mali.py
@@ -219,3 +219,120 @@ def plot_features_for_wave(t, source, colmap):
     })
     df = df.set_index(['t', 'i', 'plot_id'])
     return df
+
+# ---------------------------------------------------------------------------
+# crop_production (GAP 1; parity loop) — item-level (t, i, plot, crop)
+# ---------------------------------------------------------------------------
+#
+# The crop/harvest module lives in the EACI waves only (2014-15 EACI14,
+# 2017-18 EACI17).  The EHCVM waves (2018-19, 2021-22) carry no crop-harvest
+# block, so crop_production is wired for the two EACI waves only — exactly
+# the two waves the WB MLI_EACI*.do crop sections cover.
+#
+# Grain: one row per (t, i, plot, crop), where
+#   - i     = Mali composite household id (grappe, menage/exploitation),
+#   - plot  = "{field_no}_{parcel_no}" for seasonal crops; NaN for perennial
+#             trees (the perennial roster s3b/s11f is not on the field grid),
+#   - crop  = harmonize_food Preferred Label (food crops REUSE the consumed-
+#             food label so crop_production.j joins food_acquired.j).
+#
+# REPORTED item-level columns only (no harvest_kg / yield / main_crop /
+# value-share — those are transformations.py work over these rows):
+#   Quantity, u, Quantity_sold, Value_sold,
+#   planting_month, harvest_month, intercropped, perennial.
+#
+# Crop names and harvest units arrive as DECODED Stata labels (strings), so
+# the harmonize_food / u tables key on the decoded label (Code column).
+
+# French month name -> month number (2017-18 records month as a label).
+_FR_MONTHS = {
+    'janvier': 1, 'février': 2, 'fevrier': 2, 'mars': 3, 'avril': 4, 'mai': 5,
+    'juin': 6, 'juillet': 7, 'août': 8, 'aout': 8, 'septembre': 9,
+    'octobre': 10, 'novembre': 11, 'décembre': 12, 'decembre': 12,
+}
+
+
+def _crop_labels(series):
+    """Map a Series of decoded crop names -> harmonize_food Preferred Label."""
+    m = tools.get_categorical_mapping(tablename='harmonize_food', idxvars='Code',
+                                      **{'Preferred Label': 'Preferred Label'})
+    out = series.astype('string').str.strip().map(m)
+    return out.astype('string')
+
+
+def _unit_labels(series):
+    """Map a Series of decoded harvest-unit names -> u Preferred Label."""
+    m = tools.get_categorical_mapping(tablename='u', idxvars='Code',
+                                      **{'Preferred Label': 'Preferred Label'})
+    out = series.astype('string').str.strip().map(m)
+    return out.astype('string')
+
+
+def _month_num(series):
+    """Coerce a month column (numeric code or French label) to 1-12 / NA."""
+    def conv(v):
+        if pd.isna(v):
+            return pd.NA
+        s = str(v).strip()
+        if s in ('Manquant', 'Manqant', 'NSP', '99', '99.0', ''):
+            return pd.NA
+        try:
+            n = int(float(s))
+            return n if 1 <= n <= 12 else pd.NA
+        except (TypeError, ValueError):
+            return _FR_MONTHS.get(s.lower(), pd.NA)
+    return series.map(conv).astype('Int64')
+
+
+def crop_production_finalize(df):
+    """Common post-processing for a crop_production wave DataFrame.
+
+    Expects raw columns already assembled:
+        t, i, plot, crop (decoded), u (decoded), Quantity, Quantity_sold,
+        Value_sold, planting_month, harvest_month, intercropped, perennial.
+    Maps crop/unit labels, coerces dtypes, sets the (t, i, plot, crop) index,
+    and collapses exact-duplicate index rows (a crop reported on the same
+    plot more than once in a single questionnaire row-set) by summing the
+    reported quantities / values and taking the first of the flags/dates.
+    """
+    df = df.copy()
+    df['crop'] = _crop_labels(df['crop'])
+    df['u'] = _unit_labels(df['u'])
+    df = df.dropna(subset=['crop'])  # drop "Non exploitée" / unmapped residual
+
+    for c in ('Quantity', 'Quantity_sold', 'Value_sold'):
+        df[c] = pd.to_numeric(df[c], errors='coerce')
+    # 9999 / 99 are the EACI "Manquant" sentinels on the reported quantity
+    # columns (cf. WB `harvest_kg=. if s3aq08a==9999`); coerce to NA so they
+    # do not contaminate a downstream kg-conversion sum.
+    for c in ('Quantity', 'Quantity_sold'):
+        df.loc[df[c].isin([99, 9999]), c] = pd.NA
+    df['planting_month'] = _month_num(df['planting_month'])
+    df['harvest_month'] = _month_num(df['harvest_month'])
+    df['intercropped'] = df['intercropped'].astype('boolean')
+    df['perennial'] = df['perennial'].astype('boolean')
+
+    # plot may be NA (perennial); fill index with <NA> string so the level is
+    # not silently dropped, but keep it as a real pandas NA-able string.
+    df['plot'] = df['plot'].astype('string')
+
+    keys = ['t', 'i', 'plot', 'crop']
+    # Aggregate any exact (t,i,plot,crop) duplicates: sum reported amounts,
+    # first non-null for flags/dates/unit.  Use dropna=False so perennial
+    # rows with plot=<NA> are not discarded by groupby.  min_count=1 on the
+    # sums keeps an all-NA group as NA (not a spurious 0) — important for the
+    # 2017-18 multi-plot crops whose sold qty/value is deliberately NaN.
+    g = df.groupby(keys, dropna=False, as_index=True)
+    out = pd.DataFrame({
+        'Quantity':       g['Quantity'].sum(min_count=1),
+        'Quantity_sold':  g['Quantity_sold'].sum(min_count=1),
+        'Value_sold':     g['Value_sold'].sum(min_count=1),
+        'u':              g['u'].first(),
+        'planting_month': g['planting_month'].first(),
+        'harvest_month':  g['harvest_month'].first(),
+        'intercropped':   g['intercropped'].max(),
+        'perennial':      g['perennial'].max(),
+    })
+    out = out[['Quantity', 'u', 'Quantity_sold', 'Value_sold',
+               'planting_month', 'harvest_month', 'intercropped', 'perennial']]
+    return out.sort_index()

--- a/lsms_library/countries/Niger/2011-12/_/crop_production.py
+++ b/lsms_library/countries/Niger/2011-12/_/crop_production.py
@@ -1,0 +1,53 @@
+"""Build crop_production for Niger ECVMA 2011-12 (GAP 1, item-level).
+
+Single source file: ecvmaas2e_p2.dta (rainy-season harvest module).  One
+row per reported (field, parcel, crop) harvest line; harvest qty + unit
+(as02eq07a / as02eq07b), sold qty + unit (as02eq12a / as02eq12b) and sale
+value (as02eq13) are all at this plot-crop grain.  ``hid`` already equals
+grappe*100+menage (the canonical 2011-12 household id), so i() just
+str()s it.  No intercrop / perennial / date variables in this module
+(left NaN).
+
+plot = "{as02eq01}_{as02eq03}".  The pre-EHCVM waves have no plot_features
+recipe yet, so this plot id is internal to crop_production (it still
+aligns by construction with any future ECVMA plot_features build).
+Index = (t, i, plot, crop, u).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from niger import (i as niger_i, _crop_maps, _crop_labels, _unit_labels,
+                   _finish_crop_production)
+
+
+src = get_dataframe(
+    '../Data/NER_2011_ECVMA_v01_M_Stata8/ecvmaas2e_p2.dta',
+    convert_categoricals=True)
+srcn = get_dataframe(
+    '../Data/NER_2011_ECVMA_v01_M_Stata8/ecvmaas2e_p2.dta',
+    convert_categoricals=False)
+
+crop_map, unit_map = _crop_maps()
+
+hh = srcn['hid'].apply(lambda x: niger_i(x) if pd.notna(x) else pd.NA)
+field = srcn['as02eq01'].apply(format_id)
+parcel = srcn['as02eq03'].apply(format_id)
+plot = field.astype(str) + '_' + parcel.astype(str)
+
+df = pd.DataFrame({
+    'i':             hh.values,
+    'plot':          plot.values,
+    'crop':          _crop_labels(srcn['as02eq06'], src['as02eq06'], crop_map).values,
+    'u':             _unit_labels(src['as02eq07b'], unit_map).values,
+    'Quantity':      pd.to_numeric(srcn['as02eq07a'], errors='coerce').values,
+    'Quantity_sold': pd.to_numeric(srcn['as02eq12a'], errors='coerce').values,
+    'Value_sold':    pd.to_numeric(srcn['as02eq13'], errors='coerce').values,
+})
+
+df = _finish_crop_production(df, '2011-12')
+
+assert len(df) > 0, 'crop_production 2011-12 produced no rows'
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Niger/2014-15/_/crop_production.py
+++ b/lsms_library/countries/Niger/2014-15/_/crop_production.py
@@ -1,0 +1,77 @@
+"""Build crop_production for Niger ECVMA 2014-15 (GAP 1, item-level).
+
+Two source files, as the instrument splits harvest from sale:
+  - ECVMA2_AS2E1P2.dta : plot-crop harvest — qty + unit (AS02EQ07A /
+    AS02EQ07B) plus the harvest start/end month (AS02EQ06A / AS02EQ06B).
+    One row per reported (field, parcel, crop) line.
+  - ECVMA2_AS2E2P2.dta : CROP level (no plot) — sold qty + unit
+    (AS02EQ12A / AS02EQ12B) and sale value (AS02EQ13).
+
+i is built from (GRAPPE, MENAGE) via niger.i (matching this wave's
+sample / roster idxvars, which omit EXTENSION).  As in 2021-22 the
+crop-level sale is attributed only to (i, crop) pairs grown on a single
+plot; multi-plot crops keep Quantity_sold / Value_sold NaN (no fabricated
+split).  ``harvest_month`` = AS02EQ06A (month-of-harvest-start, 1-12);
+``planting_month`` is not in this module (NaN).
+
+plot = "{AS02EQ01}_{AS02EQ03}".  Index = (t, i, plot, crop, u).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from niger import (i as niger_i, _crop_maps, _crop_labels, _unit_labels,
+                   _finish_crop_production)
+
+
+crop_map, unit_map = _crop_maps()
+
+base = '../Data/NER_2014_ECVMA-II_v02_M_STATA8/'
+src = get_dataframe(base + 'ECVMA2_AS2E1P2.dta', convert_categoricals=True)
+srcn = get_dataframe(base + 'ECVMA2_AS2E1P2.dta', convert_categoricals=False)
+
+hh = src.apply(lambda r: niger_i(pd.Series([r['GRAPPE'], r['MENAGE']],
+                                           index=['GRAPPE', 'MENAGE'])), axis=1)
+field = srcn['AS02EQ01'].apply(format_id)
+parcel = srcn['AS02EQ03'].apply(format_id)
+plot = field.astype(str) + '_' + parcel.astype(str)
+
+# harvest start month: integer 1-12; 0 / >12 -> NaN
+hmonth = pd.to_numeric(srcn['AS02EQ06A'], errors='coerce')
+hmonth = hmonth.where((hmonth >= 1) & (hmonth <= 12))
+
+df = pd.DataFrame({
+    'i':             hh.values,
+    'plot':          plot.values,
+    'crop':          _crop_labels(srcn['CULTURE'], src['CULTURE'], crop_map).values,
+    'u':             _unit_labels(src['AS02EQ07B'], unit_map).values,
+    'Quantity':      pd.to_numeric(srcn['AS02EQ07A'], errors='coerce').values,
+    'harvest_month': hmonth.values,
+})
+
+# --- crop-level sale block (AS2E2), single-plot attribution --------------
+sold = get_dataframe(base + 'ECVMA2_AS2E2P2.dta', convert_categoricals=True)
+soldn = get_dataframe(base + 'ECVMA2_AS2E2P2.dta', convert_categoricals=False)
+sold_i = sold.apply(lambda r: niger_i(pd.Series([r['GRAPPE'], r['MENAGE']],
+                                                index=['GRAPPE', 'MENAGE'])), axis=1)
+sold_crop = _crop_labels(soldn['AS02EQ110B'], sold['AS02EQ110B'], crop_map)
+sold_df = pd.DataFrame({
+    'i':             sold_i.values,
+    'crop':          sold_crop.values,
+    'Quantity_sold': pd.to_numeric(sold['AS02EQ12A'], errors='coerce').values,
+    'Value_sold':    pd.to_numeric(sold['AS02EQ13'], errors='coerce').values,
+}).dropna(subset=['i', 'crop'])
+sold_one = sold_df.groupby(['i', 'crop'], as_index=False)[['Quantity_sold', 'Value_sold']].sum(min_count=1)
+
+plots_per = df.dropna(subset=['i', 'crop']).groupby(['i', 'crop'])['plot'].nunique()
+single = plots_per[plots_per == 1].index
+sold_one = sold_one[sold_one.set_index(['i', 'crop']).index.isin(single)]
+
+df = df.merge(sold_one, on=['i', 'crop'], how='left')
+
+df = _finish_crop_production(df, '2014-15')
+
+assert len(df) > 0, 'crop_production 2014-15 produced no rows'
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Niger/2018-19/_/crop_production.py
+++ b/lsms_library/countries/Niger/2018-19/_/crop_production.py
@@ -1,0 +1,53 @@
+"""Build crop_production for Niger EHCVM 2018-19 (GAP 1, item-level).
+
+Single source file: s16c_me_ner2018.dta (agriculture crop/harvest module).
+One row per reported (field, parcel, crop) harvest record.  Harvest qty +
+unit (s16cq12a / s16cq12b), sold qty + unit (s16cq16a / s16cq16b), sale
+value (s16cq17), and the intercrop flag (s16cq07) are ALL recorded at this
+plot-crop grain in 2018-19, so no cross-file join is needed.
+
+Index = (t, i, plot, crop, u); plot = "{s16cq02}_{s16cq03}" aligns with
+plot_features' plot_id.  See niger.py:_finish_crop_production for the shared
+schema tail and the GAP-1 design note.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from niger import (i as niger_i, _crop_maps, _crop_labels, _unit_labels,
+                   _finish_crop_production)
+
+
+# convert_categoricals=True so crop / unit value labels arrive as the
+# strings that harmonize_food / the u table key on.
+src = get_dataframe('../Data/s16c_me_ner2018.dta', convert_categoricals=True)
+src_codes = get_dataframe('../Data/s16c_me_ner2018.dta', convert_categoricals=False)
+
+crop_map, unit_map = _crop_maps()
+
+hh = src.apply(lambda r: niger_i(pd.Series([r['grappe'], r['menage']],
+                                           index=['grappe', 'menage'])), axis=1)
+field = src_codes['s16cq02'].apply(format_id)
+parcel = src_codes['s16cq03'].apply(format_id)
+plot = field.astype(str) + '_' + parcel.astype(str)
+
+# intercrop: s16cq07 == 'Association de cultures' (code 2) -> True, 'Pure' -> False
+intercropped = src['s16cq07'].map({'Association de cultures': True, 'Pure': False})
+
+df = pd.DataFrame({
+    'i':             hh.values,
+    'plot':          plot.values,
+    'crop':          _crop_labels(src_codes['s16cq04'], src['s16cq04'], crop_map).values,
+    'u':             _unit_labels(src['s16cq12b'], unit_map).values,
+    'Quantity':      src['s16cq12a'].values,
+    'Quantity_sold': src['s16cq16a'].values,
+    'Value_sold':    src['s16cq17'].values,
+    'intercropped':  intercropped.values,
+})
+
+df = _finish_crop_production(df, '2018-19')
+
+assert len(df) > 0, 'crop_production 2018-19 produced no rows'
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Niger/2021-22/_/crop_production.py
+++ b/lsms_library/countries/Niger/2021-22/_/crop_production.py
@@ -1,0 +1,79 @@
+"""Build crop_production for Niger EHCVM 2021-22 (GAP 1, item-level).
+
+The 2021-22 instrument SPLITS the crop module that 2018-19 kept together:
+  - s16c_me_ner2021.dta : plot-crop level — harvest qty + unit (s16cq16a /
+    s16cq16b) and the intercrop flag (s16cq07).  One row per reported
+    (field, parcel, crop) harvest line.
+  - s16d_me_ner2021.dta : CROP level (no plot) — sold qty + unit (s16dq05a /
+    s16dq05b) and sale value (s16dq06).
+
+Because the sale block has no plot dimension, its qty/value can only be
+attributed to a plot-crop row when the household grows that crop on a
+SINGLE plot (a 1:1 (i, crop) -> plot).  Where the crop spans several plots
+the sale cannot be split without inventing an allocation, so Quantity_sold
+/ Value_sold are left NaN for those rows (reported-only discipline — no
+fabricated split).
+
+Index = (t, i, plot, crop, u); plot = "{s16cq02}_{s16cq03}".
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from niger import (i as niger_i, _crop_maps, _crop_labels, _unit_labels,
+                   _finish_crop_production)
+
+
+crop_map, unit_map = _crop_maps()
+
+# --- plot-crop harvest (s16c) -------------------------------------------
+src = get_dataframe('../Data/s16c_me_ner2021.dta', convert_categoricals=True)
+srcn = get_dataframe('../Data/s16c_me_ner2021.dta', convert_categoricals=False)
+
+hh = src.apply(lambda r: niger_i(pd.Series([r['grappe'], r['menage']],
+                                           index=['grappe', 'menage'])), axis=1)
+field = srcn['s16cq02'].apply(format_id)
+parcel = srcn['s16cq03'].apply(format_id)
+plot = field.astype(str) + '_' + parcel.astype(str)
+intercropped = src['s16cq07'].map({'Association de cultures': True, 'Pure': False})
+
+df = pd.DataFrame({
+    'i':            hh.values,
+    'plot':         plot.values,
+    'crop':         _crop_labels(srcn['s16cq04'], src['s16cq04'], crop_map).values,
+    'u':            _unit_labels(src['s16cq16b'], unit_map).values,
+    'Quantity':     src['s16cq16a'].values,
+    'intercropped': intercropped.values,
+})
+
+# --- crop-level sale block (s16d), attributed only when crop is on one plot
+sold = get_dataframe('../Data/s16d_me_ner2021.dta', convert_categoricals=True)
+soldn = get_dataframe('../Data/s16d_me_ner2021.dta', convert_categoricals=False)
+sold_i = sold.apply(lambda r: niger_i(pd.Series([r['grappe'], r['menage']],
+                                                index=['grappe', 'menage'])), axis=1)
+sold_crop = _crop_labels(soldn['s16dq01'], sold['s16dq01'], crop_map)
+sold_df = pd.DataFrame({
+    'i':             sold_i.values,
+    'crop':          sold_crop.values,
+    'Quantity_sold': pd.to_numeric(sold['s16dq05a'], errors='coerce').values,
+    'Value_sold':    pd.to_numeric(sold['s16dq06'], errors='coerce').values,
+})
+# Collapse the sale block to one (i, crop) row by summing the reported
+# sale across the (rare) duplicate crop lines, then attribute ONLY to
+# (i, crop) pairs that map to a single plot in the harvest block.
+sold_df = sold_df.dropna(subset=['i', 'crop'])
+sold_one = sold_df.groupby(['i', 'crop'], as_index=False)[['Quantity_sold', 'Value_sold']].sum(min_count=1)
+
+# (i, crop) grown on exactly one plot in the harvest block
+plots_per = df.dropna(subset=['i', 'crop']).groupby(['i', 'crop'])['plot'].nunique()
+single = plots_per[plots_per == 1].index
+sold_one = sold_one[sold_one.set_index(['i', 'crop']).index.isin(single)]
+
+df = df.merge(sold_one, on=['i', 'crop'], how='left')
+
+df = _finish_crop_production(df, '2021-22')
+
+assert len(df) > 0, 'crop_production 2021-22 produced no rows'
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Niger/_/Makefile
+++ b/lsms_library/countries/Niger/_/Makefile
@@ -17,6 +17,22 @@ panel_ids.json updated_ids.json: panel_ids.py niger.py
 ../%/_/plot_features.parquet: ../%/_/plot_features.py
 	(cd $(@D) && python plot_features.py)
 
+# crop_production (GAP 1, item-level).  Country-level var/ parquet built by
+# the concatenator, which depends on each wave's parquet; the pattern rule
+# below runs each wave script.  Wave parquets land under data_root() (via
+# to_parquet); the in-tree paths here are only the make prerequisites'
+# script files, so we run the country script unconditionally to (re)build
+# the wave parquets it reads, then concatenate.
+CROP_WAVES := 2011-12 2014-15 2018-19 2021-22
+
+$(VAR_DIR)/crop_production.parquet: crop_production.py niger.py categorical_mapping.org \
+		$(foreach w,$(CROP_WAVES),../$(w)/_/crop_production.py)
+	$(foreach w,$(CROP_WAVES),(cd ../$(w)/_ && python crop_production.py);)
+	python crop_production.py
+
+../%/_/crop_production.parquet: ../%/_/crop_production.py niger.py categorical_mapping.org
+	(cd $(@D) && python crop_production.py)
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Niger/_/categorical_mapping.org
+++ b/lsms_library/countries/Niger/_/categorical_mapping.org
@@ -25,6 +25,23 @@
 # Preferred Label keeps native French / local names.
 # SCOPE = food_acquired's existing units only (Unit #0 foundation); crop /
 # community-price units extend this table later.
+#
+# CROP-HARVEST EXTENSION (GAP 1 crop_production, 2026-06-14).  The
+# agriculture harvest/sold modules report quantities in their own local
+# unit lists, distinct from the food-consumption units above and varying
+# in spelling/case across waves: 2011-12 lowercase ('kilogramme', 'sac de
+# 50 kg', 'panier'), 2014-15 Title-case ('Kilogramme', 'Sac de 50 Kg'),
+# EHCVM 2018-19 ('Gros sac', 'Sac Moyen', 'Plat Yoruba', 'Tine', 'Tia',
+# 'Botte', 'Unité'), EHCVM 2021-22 ('Sac de 50kg', 'tiya', 'tongolo',
+# 'panier').  Each raw spelling is added as an Original Label keying onto
+# one clean Preferred Label; 'Kilogramme'/'kilogramme' collapse onto the
+# existing food 'Kg' so crop and food quantities share that unit, and the
+# sack/local units ('Sac de 50 kg', 'Sac de 100 kg', 'Gros sac', 'Sac
+# Moyen', 'Plat Yoruba', 'Tine', 'Tia', 'Cope', 'Planche', 'Gramme') get
+# their own Preferred Labels (kg-conversion factors are NOT stored here —
+# the u table is the label axis only, per the GAP_RANKING steer).  Used by
+# the script-path crop_production via tools.get_categorical_mapping('u',
+# 'Original Label', 'Preferred Label').
 
 
 #+name: u
@@ -109,6 +126,37 @@
 | 147. Unité            | Unité            | 147  | Unité            | 147. Unité            |
 | Unité                 | Unité            | 147  | Unité            | 147. Unité            |
 | Waygouizé             | Waygouizé        | 513  | Waygouizé        |                       |
+| Kilogramme            | Kg               |      |                  |                       |
+| kilogramme            | Kg               |      |                  |                       |
+| Gramme                | Gramme           |      |                  |                       |
+| gramme                | Gramme           |      |                  |                       |
+| Cope                  | Cope             |      |                  |                       |
+| cope                  | Cope             |      |                  |                       |
+| tiya                  | Tiya             |      |                  |                       |
+| tongolo               | Tongolo          |      |                  |                       |
+| panier                | Panier           |      |                  |                       |
+| unité                 | Unité            |      |                  |                       |
+| Planche               | Planche          |      |                  |                       |
+| planche               | Planche          |      |                  |                       |
+| Plat Yoruba           | Plat Yoruba      |      |                  |                       |
+| Sac Moyen             | Sac Moyen        |      |                  |                       |
+| Gros sac              | Gros sac         |      |                  |                       |
+| Tia                   | Tia              |      |                  |                       |
+| Tine                  | Tine             |      |                  |                       |
+| Sac de 50 Kg          | Sac de 50 kg     |      |                  |                       |
+| Sac de 50 kg          | Sac de 50 kg     |      |                  |                       |
+| sac de 50 kg          | Sac de 50 kg     |      |                  |                       |
+| Sac de 50kg           | Sac de 50 kg     |      |                  |                       |
+| Sac de 100 Kg         | Sac de 100 kg    |      |                  |                       |
+| sac de 100 kg         | Sac de 100 kg    |      |                  |                       |
+| Sac de 100kg          | Sac de 100 kg    |      |                  |                       |
+| Autre                 | Autre            |      |                  |                       |
+| autre                 | Autre            |      |                  |                       |
+| Autre (préciser)      | Autre            |      |                  |                       |
+| Autres                | Autre            |      |                  |                       |
+| botte                 | Botte            |      |                  |                       |
+| Manquant              | Manquant         |      |                  |                       |
+| manquant              | Manquant         |      |                  |                       |
 
 #+NAME: Region
 | Original Label                 | Preferred Label                |
@@ -326,6 +374,27 @@
 #   mappings: ['harmonize_food', 'Original Label', 'Preferred Label'].
 # SCOPE = food_acquired's existing items only (Unit #0 foundation); crop /
 # community-price items extend this table later.
+#
+# CROP EXTENSION (GAP 1 crop_production, 2026-06-14).  The agriculture
+# harvest modules (ecvmaas2e / ECVMA2_AS2E1 / s16c) carry a crop code
+# whose value labels are short crop names ('Mil', 'Sorgho', 'Maïs', ...);
+# 2011-12 emits them lowercase, the other three waves Title-case, so BOTH
+# case variants are added as Original Label keys.  Per the maintainer
+# steer, every crop that is also a consumed food REUSES the existing food
+# Preferred Label so crop_production.j joins food_acquired.j (e.g. crop
+# 'Maïs' -> 'Maïs en grain'; 'Niébé' -> 'Niébé/Haricots secs'; 'Tomate'
+# -> 'Tomate fraîche'; 'Oignon' -> 'Oignon frais'; 'Laitue' ->
+# 'Salade (laitue)'; staples 'Mil'/'Sorgho'/'Blé'/'Fonio'/'Sésame'/
+# 'Manioc'/etc. match an existing label exactly).  NEW Preferred Labels
+# are added ONLY for crops with no consumed-food counterpart: the raw
+# crop 'Riz Paddy' (unhusked, distinct from the milled-rice foods),
+# 'Souchet' (tigernut), 'Voandzou' (bambara groundnut), the unprocessed
+# 'Arachide'/'Oseille' crops, 'Menthe', 'Persil', 'Amarante',
+# 'Calebassier'/'Calebasse' (gourd), 'Betterave', the cash crop 'Coton',
+# and the catch-all 'Autre crop'.  crop_production is a script-path
+# feature; it looks this table up via
+# tools.get_categorical_mapping('harmonize_food', 'Original Label',
+# 'Preferred Label') in the wave-level _/crop_production.py.
 
 #+NAME: harmonize_food
 | Original Label                                                                            | Preferred Label                                                                      |
@@ -630,3 +699,87 @@
 | 148. Vinaigre de citron                                                                   | Vinaigre de citron                                                                   |
 | 60. Œufs                                                                                  | Œufs                                                                                 |
 | Å__ufs                                                                                    | Œufs                                                                                 |
+| Mil                                                                                       | Mil                                                                                  |
+| mil                                                                                       | Mil                                                                                  |
+| Sorgho                                                                                    | Sorgho                                                                               |
+| sorgho                                                                                    | Sorgho                                                                               |
+| Riz Paddy                                                                                 | Riz Paddy                                                                            |
+| riz paddy                                                                                 | Riz Paddy                                                                            |
+| Maïs                                                                                      | Maïs en grain                                                                        |
+| maïs                                                                                      | Maïs en grain                                                                        |
+| Souchet                                                                                   | Souchet                                                                              |
+| souchet                                                                                   | Souchet                                                                              |
+| Blé                                                                                       | Blé                                                                                  |
+| blé                                                                                       | Blé                                                                                  |
+| Fonio                                                                                     | Fonio                                                                                |
+| fonio                                                                                     | Fonio                                                                                |
+| Niébé                                                                                     | Niébé/Haricots secs                                                                  |
+| niébé                                                                                     | Niébé/Haricots secs                                                                  |
+| Voandzou                                                                                  | Voandzou                                                                             |
+| voandzou                                                                                  | Voandzou                                                                             |
+| Arachide                                                                                  | Arachide                                                                             |
+| arachide                                                                                  | Arachide                                                                             |
+| Gombo                                                                                     | Gombo frais                                                                          |
+| gombo                                                                                     | Gombo frais                                                                          |
+| Oseille                                                                                   | Oseille                                                                              |
+| oseille                                                                                   | Oseille                                                                              |
+| Sésame                                                                                    | Sésame                                                                               |
+| sésame                                                                                    | Sésame                                                                               |
+| Manioc                                                                                    | Manioc                                                                               |
+| manioc                                                                                    | Manioc                                                                               |
+| Patate douce                                                                              | Patate douce                                                                         |
+| patate douce                                                                              | Patate douce                                                                         |
+| Pomme de terre                                                                            | Pomme de terre                                                                       |
+| pomme de terre                                                                            | Pomme de terre                                                                       |
+| Poivron                                                                                   | Poivron frais                                                                        |
+| poivron                                                                                   | Poivron frais                                                                        |
+| Menthe                                                                                    | Menthe                                                                               |
+| menthe                                                                                    | Menthe                                                                               |
+| Persil                                                                                    | Persil                                                                               |
+| persil                                                                                    | Persil                                                                               |
+| Piment                                                                                    | Piment frais                                                                         |
+| piment                                                                                    | Piment frais                                                                         |
+| Melon                                                                                     | Melon                                                                                |
+| melon                                                                                     | Melon                                                                                |
+| Pastèque                                                                                  | Pastèque                                                                             |
+| pastèque                                                                                  | Pastèque                                                                             |
+| Laitue                                                                                    | Salade (laitue)                                                                      |
+| laitue                                                                                    | Salade (laitue)                                                                      |
+| Chou                                                                                      | Chou                                                                                 |
+| chou                                                                                      | Chou                                                                                 |
+| Tomate                                                                                    | Tomate fraîche                                                                       |
+| tomate                                                                                    | Tomate fraîche                                                                       |
+| Oignon                                                                                    | Oignon frais                                                                         |
+| oignon                                                                                    | Oignon frais                                                                         |
+| Courge                                                                                    | Courge/Courgette                                                                     |
+| courge                                                                                    | Courge/Courgette                                                                     |
+| Haricot vert                                                                              | Haricot vert                                                                         |
+| haricot vert                                                                              | Haricot vert                                                                         |
+| Calebassier                                                                               | Calebassier                                                                          |
+| calebassier                                                                               | Calebassier                                                                          |
+| Betterave                                                                                 | Betterave                                                                            |
+| betterave                                                                                 | Betterave                                                                            |
+| Aubergine                                                                                 | Aubergine,                                                                           |
+| aubergine                                                                                 | Aubergine,                                                                           |
+| Concombre                                                                                 | Concombre                                                                            |
+| concombre                                                                                 | Concombre                                                                            |
+| Ail                                                                                       | Ail                                                                                  |
+| ail                                                                                       | Ail                                                                                  |
+| Amarante                                                                                  | Amarante                                                                             |
+| amarante                                                                                  | Amarante                                                                             |
+| Coton                                                                                     | Coton                                                                                |
+| coton                                                                                     | Coton                                                                                |
+| Calebasse                                                                                 | Calebassier                                                                          |
+| Menthe Fraiche                                                                            | Menthe                                                                               |
+| Manguier                                                                                  | Mangue                                                                               |
+| manguier                                                                                  | Mangue                                                                               |
+| Agrume                                                                                    | Agrume                                                                               |
+| agrume                                                                                    | Agrume                                                                               |
+| Navet                                                                                     | Navet                                                                               |
+| navet                                                                                     | Navet                                                                               |
+| Poireaux                                                                                  | Poireaux                                                                            |
+| Poireau                                                                                   | Poireaux                                                                            |
+| poireau                                                                                   | Poireaux                                                                            |
+| Autre                                                                                     | Autre crop                                                                           |
+| autre                                                                                     | Autre crop                                                                           |
+| Autre (à préciser)                                                                        | Autre crop                                                                           |

--- a/lsms_library/countries/Niger/_/crop_production.py
+++ b/lsms_library/countries/Niger/_/crop_production.py
@@ -1,0 +1,39 @@
+"""Concatenate wave-level crop_production for Niger (GAP 1, item-level).
+
+Each wave's ``Niger/<wave>/_/crop_production.py`` writes a parquet indexed
+by ``(t, i, plot, crop, u)`` with the reported harvest columns.  This
+script concatenates the four waves (2011-12, 2014-15, 2018-19, 2021-22),
+each of which has a crop/harvest module.  ``v`` is NOT baked in — the
+framework joins it from ``sample()`` at API time.
+
+As in the plot_features sibling, this does NOT apply ``id_walk`` here;
+the framework runs it in ``_finalize_result`` on every read.  The
+``(t, i, plot, crop, u)`` index is intentionally NON-unique: a single
+(plot, crop) may carry several reported harvest lines (different units /
+records), and collapsing them would be a sum — forbidden by the
+item-level / reported-values discipline.  Duplicate rate stays well under
+the diagnostics tolerance.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2011-12', '2014-15', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/crop_production.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for crop_production (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, 'crop_production: no wave-level parquets found'
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/crop_production.parquet')

--- a/lsms_library/countries/Niger/_/data_scheme.yml
+++ b/lsms_library/countries/Niger/_/data_scheme.yml
@@ -129,3 +129,38 @@ Data Scheme:
     SoilType: str
     Irrigated: bool
     materialize: make
+
+  crop_production:
+    # Item-level crop harvest (GAP 1, parity loop 2026-06-14).  One row
+    # per REPORTED (field, parcel, crop) harvest line — REPORTED values
+    # only; harvest_kg / yield / main_crop / value-shares are
+    # transformations, never columns here.  All four waves have an
+    # agriculture harvest module (script-path):
+    #   2011-12 ecvmaas2e_p2          (plot-crop harvest + sold + value)
+    #   2014-15 ECVMA2_AS2E1 (+AS2E2)  (harvest + months; sold crop-level)
+    #   2018-19 s16c                   (harvest + sold + value + intercrop)
+    #   2021-22 s16c (+s16d)           (harvest + intercrop; sold crop-level)
+    # crop joins food via harmonize_food Preferred Labels (so a crop that
+    # is also a consumed food shares food_acquired's Preferred Label); u
+    # via the u table.  ``u`` is in the index (as in food_acquired) because one
+    # (plot, crop) can be reported in several units — collapsing would
+    # sum.  plot = "{field_no}_{parcel_no}" aligns with plot_features'
+    # plot_id (verified 100% join on the EHCVM waves).  Quantity_sold /
+    # Value_sold are at plot-crop grain only where the survey records them
+    # there (2011-12, 2018-19); in 2014-15 / 2021-22 the sale block is
+    # crop-level and is attributed only to single-plot crops, else NaN.
+    # Columns intentionally OMITTED (no Niger wave records them, so an
+    # all-NaN column would just trip the sanity checker — GAP rule "only
+    # include columns the source actually records"): planting_month (no
+    # planting-date question in any harvest module) and a perennial flag
+    # (the perennial-crop roster is a separate, un-wired instrument).
+    # harvest_month is recorded only in 2014-15 (AS02EQ06A); intercropped
+    # only in the EHCVM waves (s16cq07).  Both are present in >=1 wave so
+    # they are carried (NaN in the waves that lack them).
+    index: (t, i, plot, crop, u)
+    Quantity: float
+    Quantity_sold: float
+    Value_sold: float
+    harvest_month: float
+    intercropped: bool
+    materialize: make

--- a/lsms_library/countries/Niger/_/niger.py
+++ b/lsms_library/countries/Niger/_/niger.py
@@ -346,3 +346,88 @@ def plot_features_for_wave(t, source, colmap):
     })
     df = df.set_index(['t', 'i', 'plot_id'])
     return df
+
+
+# ---------------------------------------------------------------------------
+# crop_production (GAP 1 — item-level crop harvest at (t, i, plot, crop, u))
+# ---------------------------------------------------------------------------
+#
+# One row per REPORTED harvest record: a crop grown on a plot, with the
+# reported harvest quantity in its native unit, plus reported sale
+# quantity / sale value and the intercropped / perennial flags WHERE the
+# instrument records them.  No aggregation — every reported line is kept;
+# harvest_kg, yield, value-shares and main_crop are transformations, not
+# columns here.
+#
+# Index = (t, i, plot, crop, u).  ``u`` is carried in the index (as in
+# food_acquired) because a single (plot, crop) can be reported in more
+# than one unit / harvest line, and collapsing those would be a sum.
+# ``plot`` = "{field_no}_{parcel_no}" aligns with plot_features' plot_id.
+#
+# Crop instrument by wave:
+#   2011-12  ecvmaas2e_p2  : plot-crop harvest + sold (qty/value) in one file.
+#   2014-15  ECVMA2_AS2E1  : plot-crop harvest + harvest months; sold lives
+#                            in ECVMA2_AS2E2 at CROP level (no plot) — joined
+#                            to the plot-crop rows by (i, crop) where a
+#                            household grows the crop on a single plot,
+#                            else left NaN (cannot attribute to one plot).
+#   2018-19  s16c          : plot-crop harvest + sold (qty/value) + intercrop.
+#   2021-22  s16c (+s16d)  : plot-crop harvest + intercrop in s16c; sold
+#                            (qty/value) in s16d at CROP level — joined the
+#                            same single-plot way as 2014-15.
+# perennial is NOT a separate flag in any Niger harvest module (the
+# perennial-crop roster is a distinct instrument not wired here), so the
+# ``perennial`` column is emitted all-NaN for parity with the schema.
+
+
+def _crop_labels(source_codes, source_labels, crop_map):
+    """Map a crop column (string labels from convert_categoricals=True)
+    through ``harmonize_food`` (keyed on Original Label).  Unmapped labels
+    pass through unchanged (kept visible, flagged by the sanity checker)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: crop_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _unit_labels(unit_series, unit_map):
+    """Map a harvest-unit column (string labels) through the ``u`` table.
+    Unmapped labels pass through unchanged."""
+    u = unit_series.astype('string')
+    return u.map(lambda x: unit_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _crop_maps():
+    crop_map = tools.get_categorical_mapping(
+        tablename='harmonize_food', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    unit_map = tools.get_categorical_mapping(
+        tablename='u', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    return crop_map, unit_map
+
+
+def _finish_crop_production(df, t):
+    """Common tail: tag t, build the (t, i, plot, crop, u) index, coerce
+    numeric columns, and guarantee the full schema column set."""
+    for col in ['Quantity', 'Quantity_sold', 'Value_sold']:
+        df[col] = pd.to_numeric(df.get(col), errors='coerce').astype('Float64')
+    # harvest_month: only 2014-15 records it; NaN elsewhere (still carried
+    # because >=1 wave has it).  planting_month / perennial are omitted from
+    # the schema entirely — no Niger wave records them.
+    if 'harvest_month' not in df.columns:
+        df['harvest_month'] = pd.NA
+    df['harvest_month'] = pd.to_numeric(df['harvest_month'], errors='coerce').astype('Float64')
+    if 'intercropped' not in df.columns:
+        df['intercropped'] = pd.NA
+    df['intercropped'] = df['intercropped'].astype('boolean')
+    df['t'] = t
+    df['crop'] = df['crop'].astype('string')
+    df['u'] = df['u'].astype('string')
+    # Drop placeholder rows with no crop recorded (a parcel listed but no
+    # crop grown / reported on the line).  These carry no harvest data
+    # (crop, Quantity, unit all NA) and are not item-level harvest records.
+    df = df[df['crop'].notna()]
+    keep = ['t', 'i', 'plot', 'crop', 'u', 'Quantity',
+            'Quantity_sold', 'Value_sold', 'harvest_month', 'intercropped']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'plot', 'crop', 'u'])
+    return df

--- a/lsms_library/countries/Nigeria/_/categorical_mapping.org
+++ b/lsms_library/countries/Nigeria/_/categorical_mapping.org
@@ -8,6 +8,19 @@
   sub-varieties (e.g. "Maize (shelled)" and "Maize (unshelled)" both
   aggregate to "Maize").
 
+  Crop-production item codes (GAP 1 / crop_production feature) are appended
+  to the same table.  The post-harvest crop module (secta3*) uses its own
+  cropcode scheme (1010-9999), DISJOINT from the food-consumption codes
+  above (1-601), so they coexist in one Code column with no collision.  The
+  Preferred Label REUSES the consumed-food label where the crop is itself a
+  consumed food (e.g. cropcode 1080 MAIZE -> "Maize", 1110 RICE ->
+  "Rice--local"), so crop_production.j joins food_acquired.j on Preferred
+  Label.  New Preferred Labels are added only for non-food / newly-introduced
+  crops (Cotton, Tobacco, Gum arabic, Rubber, Jute, Cocoa, Cowpea, Wheat,
+  Ginger, ...).  The per-wave columns for crop rows carry the native crop
+  label in the PH harvest quarters (2011Q1/2013Q1/2016Q1/2019Q1); 2023-24
+  (PH quarter 2024Q1) has no column but resolves via Code.
+
 #+NAME: harmonize_food
 | Code | Preferred Label                         | Aggregate Label              | 2010Q3                                        | 2011Q1                                        | 2012Q3                                        | 2013Q1                                        | 2015Q3                                        | 2016Q1                                        | 2018Q3                                        | 2019Q1                                        |
 |------+-----------------------------------------+------------------------------|-----------------------------------------------|-----------------------------------------------|-----------------------------------------------|-----------------------------------------------|-----------------------------------------------|-----------------------------------------------|-----------------------------------------------|-----------------------------------------------|
@@ -139,6 +152,120 @@
 |  163 | Gin                                     | Gin                          | Gin                                           | Gin                                           | Gin                                           | Gin                                           | Gin                                           | Gin                                           | Gin                                           | Gin                                           |
 |  164 | Other alcoholic beverages               | Other alcoholic beverages    | Other alcoholic beverages                     | Other alcoholic beverages                     | Other alcoholic beverages                     | Other alcoholic beverages                     | Other alcoholic beverages                     | Other alcoholic beverages                     | Other alcoholic beverages                     | Other alcoholic beverages                     |
 |  601 | Guava                                   | Guava                        | ---                                           | ---                                           | ---                                           | ---                                           | Guava                                         | Guava                                         | Guava                                         | Guava                                         |
+| 1010 | Cowpea | Cowpea | --- | Beans/Cowpea | --- | Beans/Cowpea | --- | Beans/Cowpea | --- | Beans/Cowpea |
+| 1020 | Cassava--roots | Cassava | --- | Cassava Old | --- | Cassava Old | --- | Cassava Old | --- | Cassava Old |
+| 1040 | Cocoyam | Cocoyam | --- | Cocoyam | --- | Cocoyam | --- | Cocoyam | --- | Cocoyam |
+| 1050 | Cotton | Cotton | --- | Cotton | --- | Cotton | --- | Cotton | --- | Cotton |
+| 1051 | Cotton | Cotton | --- | Seed Cotton | --- | Seed Cotton | --- | Seed Cotton | --- | Seed Cotton |
+| 1052 | Cotton | Cotton | --- | Cotton Lint | --- | Cotton Lint | --- | Cotton Lint | --- | Cotton Lint |
+| 1053 | Cotton | Cotton | --- | Cotton Seed | --- | Cotton Seed | --- | Cotton Seed | --- | Cotton Seed |
+| 1060 | Groundnuts (unshelled) | Groundnuts | --- | Ground Nut/Peanuts | --- | Ground Nut/Peanuts | --- | Ground Nut/Peanuts | --- | Ground Nut/Peanuts |
+| 1061 | Groundnuts (unshelled) | Groundnuts | --- | Unshelled Ground Nuts | --- | Unshelled Ground Nuts | --- | Unshelled Ground Nuts | --- | Unshelled Ground Nuts |
+| 1062 | Groundnuts (shelled) | Groundnuts | --- | Shelled Ground Nuts | --- | Shelled Ground Nuts | --- | Shelled Ground Nuts | --- | Shelled Ground Nuts |
+| 1070 | Guinea corn/sorghum | Guinea corn/sorghum | --- | Guinea Courn/Sorghum | --- | Guinea Courn/Sorghum | --- | Guinea Courn/Sorghum | --- | Guinea Courn/Sorghum |
+| 1080 | Maize | Maize | --- | Maize | --- | Maize | --- | Maize | --- | Maize |
+| 1081 | Maize (unshelled, on the cob) | Maize | --- | Unshelled Maize(Cob) | --- | Unshelled Maize(Cob) | --- | Unshelled Maize(Cob) | --- | Unshelled Maize(Cob) |
+| 1082 | Maize (shelled, off the cob) | Maize | --- | Shelled Maize(Grain) | --- | Shelled Maize(Grain) | --- | Shelled Maize(Grain) | --- | Shelled Maize(Grain) |
+| 1083 | Maize | Maize | --- | Pop Corn Maize | --- | Pop Corn Maize | --- | Pop Corn Maize | --- | Pop Corn Maize |
+| 1090 | Melon (unshelled) | Melon | --- | Melon | --- | Melon | --- | Melon | --- | Melon |
+| 1091 | Melon (unshelled) | Melon | --- | Unshelled Melon | --- | Unshelled Melon | --- | Unshelled Melon | --- | Unshelled Melon |
+| 1092 | Melon (shelled) | Melon | --- | Shelled Melon | --- | Shelled Melon | --- | Shelled Melon | --- | Shelled Melon |
+| 1093 | Watermelon | Watermelon | --- | Water Melon | --- | Water Melon | --- | Water Melon | --- | Water Melon |
+| 1100 | Millet | Millet | --- | Millet/Maiwa | --- | Millet/Maiwa | --- | Millet/Maiwa | --- | Millet/Maiwa |
+| 1110 | Rice--local | Rice | --- | Rice | --- | Rice | --- | Rice | --- | Rice |
+| 1111 | Rice--local | Rice | --- | Unshelled Rice(Paddy) | --- | Unshelled Rice(Paddy) | --- | Unshelled Rice(Paddy) | --- | Unshelled Rice(Paddy) |
+| 1112 | Rice--local | Rice | --- | Shelled Rice(Milled) | --- | Shelled Rice(Milled) | --- | Shelled Rice(Milled) | --- | Shelled Rice(Milled) |
+| 1120 | Yam--roots | Yam | --- | Yam | --- | Yam | --- | Yam | --- | Yam |
+| 1121 | Yam--roots | Yam | --- | White Yam | --- | White Yam | --- | White Yam | --- | White Yam |
+| 1122 | Yam--roots | Yam | --- | Yellow Yam | --- | Yellow Yam | --- | Yellow Yam | --- | Yellow Yam |
+| 1123 | Yam--roots | Yam | --- | Water Yam | --- | Water Yam | --- | Water Yam | --- | Water Yam |
+| 1124 | Yam--roots | Yam | --- | Three Leave Yam | --- | Three Leave Yam | --- | Three Leave Yam | --- | Three Leave Yam |
+| 2010 | Acha | Acha | --- | Acha | --- | Acha | --- | Acha | --- | Acha |
+| 2020 | Bambara nut | Bambara nut | --- | Bambara Nut | --- | Bambara Nut | --- | Bambara Nut | --- | Bambara Nut |
+| 2030 | Bananas | Bananas | --- | Banana | --- | Banana | --- | Banana | --- | Banana |
+| 2040 | Sesame | Sesame | --- | Beeni-Seed/Sesame | --- | Beeni-Seed/Sesame | --- | Beeni-Seed/Sesame | --- | Beeni-Seed/Sesame |
+| 2050 | Carrot | Carrot | --- | Carrot | --- | Carrot | --- | Carrot | --- | Carrot |
+| 2060 | Cucumber | Cucumber | --- | Cucumber | --- | Cucumber | --- | Cucumber | --- | Cucumber |
+| 2070 | Cabbage | Cabbage | --- | Cabbage | --- | Cabbage | --- | Cabbage | --- | Cabbage |
+| 2071 | Lettuce | Lettuce | --- | Letus | --- | Letus | --- | Letus | --- | Letus |
+| 2080 | Garden eggs/egg plant | Garden eggs/egg plant | --- | Garden Egg | --- | Garden Egg | --- | Garden Egg | --- | Garden Egg |
+| 2090 | Garlic | Garlic | --- | Garlic | --- | Garlic | --- | Garlic | --- | Garlic |
+| 2100 | Ginger | Ginger | --- | Ginger | --- | Ginger | --- | Ginger | --- | Ginger |
+| 2101 | Ginger | Ginger | --- | Ginger Peeled | --- | Ginger Peeled | --- | Ginger Peeled | --- | Ginger Peeled |
+| 2102 | Ginger | Ginger | --- | Ginger Split | --- | Ginger Split | --- | Ginger Split | --- | Ginger Split |
+| 2103 | Other Spices | Other Spices | --- | Other Spices/Vanila | --- | Other Spices/Vanila | --- | Other Spices/Vanila | --- | Other Spices/Vanila |
+| 2110 | Gum arabic | Gum arabic | --- | Gum Arabic | --- | Gum Arabic | --- | Gum Arabic | --- | Gum Arabic |
+| 2120 | Okra--fresh | Okra | --- | Okro | --- | Okro | --- | Okro | --- | Okro |
+| 2130 | Onions | Onions | --- | Onion | --- | Onion | --- | Onion | --- | Onion |
+| 2140 | Fresh Pepper | Fresh Pepper | --- | Pepper | --- | Pepper | --- | Pepper | --- | Pepper |
+| 2141 | Fresh Pepper | Fresh Pepper | --- | Sweet Pepper | --- | Sweet Pepper | --- | Sweet Pepper | --- | Sweet Pepper |
+| 2142 | Fresh Pepper | Fresh Pepper | --- | Small Pepper | --- | Small Pepper | --- | Small Pepper | --- | Small Pepper |
+| 2143 | Other Spices | Other Spices | --- | Atare | --- | Atare | --- | Atare | --- | Atare |
+| 2150 | Pigeon pea | Pigeon pea | --- | Pigeon Pea | --- | Pigeon Pea | --- | Pigeon Pea | --- | Pigeon Pea |
+| 2160 | Pineapples | Pineapples | --- | Pineapple | --- | Pineapple | --- | Pineapple | --- | Pineapple |
+| 2170 | Plantains | Plantains | --- | Plantain | --- | Plantain | --- | Plantain | --- | Plantain |
+| 2180 | Potatoes | Potatoes | --- | Potato | --- | Potato | --- | Potato | --- | Potato |
+| 2181 | Sweet potatoes | Sweet potatoes | --- | Sweet Potato | --- | Sweet Potato | --- | Sweet Potato | --- | Sweet Potato |
+| 2190 | Pumpkin | Pumpkin | --- | Pumpkin | --- | Pumpkin | --- | Pumpkin | --- | Pumpkin |
+| 2191 | Pumpkin | Pumpkin | --- | Pumpkin Leave | --- | Pumpkin Leave | --- | Pumpkin Leave | --- | Pumpkin Leave |
+| 2192 | Pumpkin | Pumpkin | --- | Pumpkin Fruit | --- | Pumpkin Fruit | --- | Pumpkin Fruit | --- | Pumpkin Fruit |
+| 2193 | Pumpkin | Pumpkin | --- | Pumpkin Seed | --- | Pumpkin Seed | --- | Pumpkin Seed | --- | Pumpkin Seed |
+| 2194 | Leaves (Cocoyam, Spinach, etc.) | Leaves | --- | Green Vegetable | --- | Green Vegetable | --- | Green Vegetable | --- | Green Vegetable |
+| 2195 | Leaves (Cocoyam, Spinach, etc.) | Leaves | --- | Dry Leaves(Kuka) | --- | Dry Leaves(Kuka) | --- | Dry Leaves(Kuka) | --- | Dry Leaves(Kuka) |
+| 2200 | Rizga | Rizga | --- | Rizga | --- | Rizga | --- | Rizga | --- | Rizga |
+| 2210 | Shea nuts | Shea nuts | --- | Shea Nuts | --- | Shea Nuts | --- | Shea Nuts | --- | Shea Nuts |
+| 2220 | Soya beans | Soya beans | --- | Soya Beans | --- | Soya Beans | --- | Soya Beans | --- | Soya Beans |
+| 2230 | Sugar cane | Sugar cane | --- | Sugar Cane | --- | Sugar Cane | --- | Sugar Cane | --- | Sugar Cane |
+| 2240 | Tea | Tea | --- | Tea | --- | Tea | --- | Tea | --- | Tea |
+| 2250 | Tobacco | Tobacco | --- | Tobacco | --- | Tobacco | --- | Tobacco | --- | Tobacco |
+| 2260 | Tomatoes | Tomatoes | --- | Tomato | --- | Tomato | --- | Tomato | --- | Tomato |
+| 2270 | Walnut | Walnut | --- | Walnut | --- | Walnut | --- | Walnut | --- | Walnut |
+| 2280 | Wheat | Wheat | --- | Wheat | --- | Wheat | --- | Wheat | --- | Wheat |
+| 2290 | Zobo | Zobo | --- | Zobo | --- | Zobo | --- | Zobo | --- | Zobo |
+| 2291 | Zobo | Zobo | --- | Zobo Seed | --- | Zobo Seed | --- | Zobo Seed | --- | Zobo Seed |
+| 3010 | Apples | Apples | --- | Apple | --- | Apple | --- | Apple | --- | Apple |
+| 3020 | Cashew nut | Cashew nut | --- | Cashew | --- | Cashew | --- | Cashew | --- | Cashew |
+| 3021 | Cashew nut | Cashew nut | --- | Cashew Fruit | --- | Cashew Fruit | --- | Cashew Fruit | --- | Cashew Fruit |
+| 3022 | Cashew nut | Cashew nut | --- | Cashew Nut | --- | Cashew Nut | --- | Cashew Nut | --- | Cashew Nut |
+| 3030 | Dry Pepper | Dry Pepper | --- | Chilli | --- | Chilli | --- | Chilli | --- | Chilli |
+| 3040 | Cocoa | Cocoa | --- | Cocoa | --- | Cocoa | --- | Cocoa | --- | Cocoa |
+| 3041 | Cocoa | Cocoa | --- | Cocoa Pod | --- | Cocoa Pod | --- | Cocoa Pod | --- | Cocoa Pod |
+| 3042 | Cocoa | Cocoa | --- | Cocoa Beans | --- | Cocoa Beans | --- | Cocoa Beans | --- | Cocoa Beans |
+| 3050 | Coconut | Coconut | --- | Coconut | --- | Coconut | --- | Coconut | --- | Coconut |
+| 3060 | Coffee | Coffee | --- | Coffe | --- | Coffe | --- | Coffe | --- | Coffe |
+| 3061 | Coffee | Coffee | --- | Coffe Arabica | --- | Coffe Arabica | --- | Coffe Arabica | --- | Coffe Arabica |
+| 3062 | Coffee | Coffee | --- | Coffee Robuster | --- | Coffee Robuster | --- | Coffee Robuster | --- | Coffee Robuster |
+| 3070 | Date palm | Date palm | --- | Date Palm | --- | Date Palm | --- | Date Palm | --- | Date Palm |
+| 3080 | Grapefruit | Grapefruit | --- | Grape Fruit | --- | Grape Fruit | --- | Grape Fruit | --- | Grape Fruit |
+| 3090 | Guava | Guava | --- | Guava | --- | Guava | --- | Guava | --- | Guava |
+| 3100 | Jute | Jute | --- | Jute | --- | Jute | --- | Jute | --- | Jute |
+| 3110 | Kola nut | Kola nut | --- | Kolanut | --- | Kolanut | --- | Kolanut | --- | Kolanut |
+| 3111 | Kola nut | Kola nut | --- | Kolanut Unshelled | --- | Kolanut Unshelled | --- | Kolanut Unshelled | --- | Kolanut Unshelled |
+| 3112 | Kola nut | Kola nut | --- | Kolanut Shelled | --- | Kolanut Shelled | --- | Kolanut Shelled | --- | Kolanut Shelled |
+| 3113 | Kola nut | Kola nut | --- | Bitter Kola | --- | Bitter Kola | --- | Bitter Kola | --- | Bitter Kola |
+| 3120 | Lemon | Lemon | --- | Lemon | --- | Lemon | --- | Lemon | --- | Lemon |
+| 3130 | Lime | Lime | --- | Lime | --- | Lime | --- | Lime | --- | Lime |
+| 3140 | Locust bean | Locust bean | --- | Locust Bean | --- | Locust Bean | --- | Locust Bean | --- | Locust Bean |
+| 3150 | Orange/tangerine | Orange/tangerine | --- | Mandarin/Tangerine | --- | Mandarin/Tangerine | --- | Mandarin/Tangerine | --- | Mandarin/Tangerine |
+| 3160 | Mangoes | Mangoes | --- | Mango | --- | Mango | --- | Mango | --- | Mango |
+| 3170 | Orange/tangerine | Orange/tangerine | --- | Orange | --- | Orange | --- | Orange | --- | Orange |
+| 3180 | Palm oil | Palm oil | --- | Oil Palm Tree | --- | Oil Palm Tree | --- | Oil Palm Tree | --- | Oil Palm Tree |
+| 3181 | Palm oil | Palm oil | --- | Fresh Fruit Bunch | --- | Fresh Fruit Bunch | --- | Fresh Fruit Bunch | --- | Fresh Fruit Bunch |
+| 3182 | Palm oil | Palm oil | --- | Fresh Nut | --- | Fresh Nut | --- | Fresh Nut | --- | Fresh Nut |
+| 3183 | Palm oil | Palm oil | --- | Palm Oil | --- | Palm Oil | --- | Palm Oil | --- | Palm Oil |
+| 3184 | Palm kernel | Palm kernel | --- | Palm Kernel | --- | Palm Kernel | --- | Palm Kernel | --- | Palm Kernel |
+| 3190 | Unground Ogbono | Ogbono | --- | Agbono(Oro Seed) | --- | Agbono(Oro Seed) | --- | Agbono(Oro Seed) | --- | Agbono(Oro Seed) |
+| 3200 | Oil bean | Oil bean | --- | Oil Bean | --- | Oil Bean | --- | Oil Bean | --- | Oil Bean |
+| 3210 | Pawpaw | Pawpaw | --- | Pawpaw | --- | Pawpaw | --- | Pawpaw | --- | Pawpaw |
+| 3220 | Avocado pear | Avocado pear | --- | Pear | --- | Pear | --- | Pear | --- | Pear |
+| 3221 | Avocado pear | Avocado pear | --- | Avocado Pear | --- | Avocado Pear | --- | Avocado Pear | --- | Avocado Pear |
+| 3230 | Rubber | Rubber | --- | Rubber | --- | Rubber | --- | Rubber | --- | Rubber |
+| 3231 | Rubber | Rubber | --- | Rubber Lump | --- | Rubber Lump | --- | Rubber Lump | --- | Rubber Lump |
+| 3232 | Rubber | Rubber | --- | Rubber Sheet | --- | Rubber Sheet | --- | Rubber Sheet | --- | Rubber Sheet |
+| 3240 | Cherry (Agbalumo) | Cherry (Agbalumo) | --- | Cherry(Agbalumo) | --- | Cherry(Agbalumo) | --- | Cherry(Agbalumo) | --- | Cherry(Agbalumo) |
+| 3250 | Eru | Eru | --- | Eru | --- | Eru | --- | Eru | --- | Eru |
+| 3260 | Iyere | Iyere | --- | Iyere | --- | Iyere | --- | Iyere | --- | Iyere |
+| 9999 | Other crop | Other crop | --- | Other (Specify) | --- | Other (Specify) | --- | Other (Specify) | --- | Other (Specify) |
 
 * Units
 
@@ -151,6 +278,19 @@
   Note: the same code number can mean different things across waves
   (e.g., code 10 = "medium derica" in wave 2 but "bin/basket" in
   waves 3-4).  The per-wave columns record the wave-specific meaning.
+
+  Harvest production units (GAP 1 / crop_production): the post-harvest
+  crop module (secta3*) reports harvest quantity in its own per-wave
+  production-unit-code scheme (which collides on Code with the food
+  scheme, so it is NOT given per-wave Code columns here).  crop_production.py
+  decodes the native unit label and normalizes it to a size-agnostic base
+  Preferred Label (Sack/Bag, Basket, Basin, Bowl, Bunch, Bundle, Tuber,
+  Heap, Stalk, Wheelbarrow, Piece, Pick-up, Jerry Can, Mudu, Congo, Derica,
+  Tiya, Kobiowu, Paint rubber, ...).  Codes 1001-1018 below register the
+  base harvest units that the food module's size-prefixed rows did not
+  already cover; the rest reuse existing food-unit Preferred Labels (Kg, g,
+  l, cl, Sack/Bag, Basket, Basin, Tuber, Wheelbarrow, ...).  kg-conversion
+  factors are NOT stored here (that is a transformation).
 
 #+NAME: u
 | Code | Preferred Label              | 2010-11                      | 2012-13                      | 2015-16                      | 2018-19                      |
@@ -236,6 +376,24 @@
 | 131 | other specify (131) | --- | --- | other specify (131) | --- |
 | 151 | other specify (151) | --- | --- | other specify (151) | --- |
 | 152 | other specify (152) | --- | --- | other specify (152) | --- |
+| 1001 | Bowl | --- | --- | --- | --- |
+| 1002 | Bunch | --- | --- | --- | --- |
+| 1003 | Bundle | --- | --- | --- | --- |
+| 1004 | Cigarette cup | --- | --- | --- | --- |
+| 1005 | Congo | --- | --- | --- | --- |
+| 1006 | Derica | --- | --- | --- | --- |
+| 1007 | Heap | --- | --- | --- | --- |
+| 1008 | Jerry Can | --- | --- | --- | --- |
+| 1009 | Kobiowu | --- | --- | --- | --- |
+| 1010 | Milk cup | --- | --- | --- | --- |
+| 1011 | Mudu | --- | --- | --- | --- |
+| 1012 | Olodo | --- | --- | --- | --- |
+| 1013 | Packet/Sachet | --- | --- | --- | --- |
+| 1014 | Paint rubber | --- | --- | --- | --- |
+| 1015 | Pick-up | --- | --- | --- | --- |
+| 1016 | Piece | --- | --- | --- | --- |
+| 1017 | Stalk | --- | --- | --- | --- |
+| 1018 | Tiya | --- | --- | --- | --- |
 
 * Geopolitical Zones
 

--- a/lsms_library/countries/Nigeria/_/crop_production.py
+++ b/lsms_library/countries/Nigeria/_/crop_production.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+"""Build item-level crop_production for Nigeria GHS-Panel (GAP 1).
+
+Natural grain (t, i, plot, crop): one row per crop grown on a plot in the
+post-harvest crop module (secta3*).  Stores REPORTED item-level fields
+only -- no kg conversion, no yield, no main_crop, no value shares (those
+are transformations).
+
+Per-wave source structure (post-harvest round):
+
+  W1 2010-11  secta3_harvestw1.dta      single plot-crop file; sold +
+              (Post Harvest Wave 1/Agriculture)   value at plot-crop grain.
+  W2 2012-13  secta3_harvestw2.dta      single plot-crop file; sold +
+              (Post Harvest Wave 2/Agriculture)   value at plot-crop grain.
+  W3 2015-16  secta3i_harvestw3.dta     annual plot-crop harvest qty/unit.
+              (sold/value live in secta3ii at hh-crop grain -- no plot
+               linkage, so NOT attributed to a plot here.)
+  W4 2018-19  secta3i_harvestw4.dta     annual plot-crop harvest qty/unit;
+              secta3iii_harvestw4.dta   perennial/tree plot-crop harvest.
+  W5 2023-24  secta3i_harvestw5.dta     annual plot-crop harvest qty/unit;
+              secta3iii_harvestw5.dta   perennial/tree plot-crop harvest.
+              (Post Harvest Wave 5/Agriculture)
+
+crop labels (j): cropcode -> Preferred Label via harmonize_food (shared
+with food_acquired; reused food labels where the crop is a consumed food).
+units (u): native production-unit label normalized to a base Preferred
+Label registered in the `u` table.  `v` is added at API time by
+_join_v_from_sample.  plot_id aligns with plot_features (format_id).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import (PH_QUARTER, crop_production_for_wave, _crop_labels,
+                     format_id)
+
+crop_labels = _crop_labels()
+
+
+def _intercropped_from_planting(planting_fn):
+    """Derive a per-(i, plot, cropcode) intercropped flag from the
+    post-planting crop roster (sect11f): cropping-type (s11fq2) mono ->
+    False, mixed/inter/alley/relay/strip -> True.  Returns a Series keyed
+    by (i, plot, cropcode) or None if unavailable."""
+    try:
+        df = get_dataframe(planting_fn, convert_categoricals=False)
+    except Exception:
+        return None
+    cols = {c.lower(): c for c in df.columns}
+    cc = cols.get('cropcode')
+    plot = cols.get('plotid')
+    hh = cols.get('hhid')
+    q2 = cols.get('s11fq2')
+    if not all([cc, plot, hh, q2]):
+        return None
+    code = pd.to_numeric(df[q2], errors='coerce')
+    # 1 = mono-cropping -> not intercropped; 2..7 mixed/inter/etc -> True.
+    inter = pd.Series(pd.NA, index=df.index, dtype='boolean')
+    inter = inter.where(~(code == 1), False)
+    inter = inter.where(~(code.between(2, 7)), True)
+    key = pd.DataFrame({
+        'i': df[hh].apply(format_id).values,
+        'plot': df[plot].apply(format_id).values,
+        'crop_code': pd.to_numeric(df[cc], errors='coerce').astype('Int64').values,
+        'intercropped': inter.values,
+    })
+    key = key.dropna(subset=['intercropped']).drop_duplicates(['i', 'plot', 'crop_code'])
+    return key
+
+
+def _align_intercropped(raw, hhid, plot, cropcol, planting_fn):
+    """Build an intercropped Series aligned to `raw` rows by joining the
+    planting-roster flag on (i, plot, cropcode)."""
+    key = _intercropped_from_planting(planting_fn)
+    if key is None:
+        return None
+    j = pd.DataFrame({
+        'i': raw[hhid].apply(format_id).values,
+        'plot': raw[plot].apply(format_id).values,
+        'crop_code': pd.to_numeric(raw[cropcol], errors='coerce').astype('Int64').values,
+    }, index=raw.index)
+    merged = j.merge(key, on=['i', 'plot', 'crop_code'], how='left')
+    return pd.Series(merged['intercropped'].values, index=raw.index, dtype='boolean')
+
+
+pieces = []
+
+# ----------------------------- W1 2010-11 -----------------------------
+t = PH_QUARTER['2010-11']
+f = '../2010-11/Data/Post Harvest Wave 1/Agriculture/secta3_harvestw1.dta'
+raw = get_dataframe(f, convert_categoricals=False)
+dec = get_dataframe(f, convert_categoricals=True)
+inter = _align_intercropped(
+    raw, 'hhid', 'plotid', 'sa3q2',
+    '../2010-11/Data/Post Planting Wave 1/Agriculture/sect11f_plantingw1.dta')
+pieces.append(crop_production_for_wave(t, [dict(
+    df=raw, dec=dec, hhid='hhid', plot='plotid', crop='sa3q2',
+    qty='sa3q6a', unit='sa3q6b',
+    qty_sold='sa3q11a', value_sold='sa3q12', sold_on='plot',
+    intercropped=inter, perennial=False)], crop_labels))
+
+# ----------------------------- W2 2012-13 -----------------------------
+t = PH_QUARTER['2012-13']
+f = '../2012-13/Data/Post Harvest Wave 2/Agriculture/secta3_harvestw2.dta'
+raw = get_dataframe(f, convert_categoricals=False)
+dec = get_dataframe(f, convert_categoricals=True)
+inter = _align_intercropped(
+    raw, 'hhid', 'plotid', 'cropcode',
+    '../2012-13/Data/Post Planting Wave 2/Agriculture/sect11f_plantingw2.dta')
+pieces.append(crop_production_for_wave(t, [dict(
+    df=raw, dec=dec, hhid='hhid', plot='plotid', crop='cropcode',
+    qty='sa3q6a1', unit='sa3q6a2',
+    qty_sold='sa3q11a', value_sold='sa3q12', sold_on='plot',
+    intercropped=inter, perennial=False)], crop_labels))
+
+# ----------------------------- W3 2015-16 -----------------------------
+# secta3i: annual plot-crop harvest.  Sold/value are hh-crop grain
+# (secta3ii) -> not attributable to a plot, left NaN.
+t = PH_QUARTER['2015-16']
+f = '../2015-16/Data/secta3i_harvestw3.dta'
+raw = get_dataframe(f, convert_categoricals=False)
+dec = get_dataframe(f, convert_categoricals=True)
+inter = _align_intercropped(
+    raw, 'hhid', 'plotid', 'cropcode',
+    '../2015-16/Data/sect11f_plantingw3.dta')
+pieces.append(crop_production_for_wave(t, [dict(
+    df=raw, dec=dec, hhid='hhid', plot='plotid', crop='cropcode',
+    qty='sa3iq6i', unit='sa3iq6ii',
+    harv_m='sa3iq6c1', harv_y='sa3iq6c2',
+    intercropped=inter, perennial=False)], crop_labels))
+
+# ----------------------------- W4 2018-19 -----------------------------
+# secta3i annual + secta3iii perennial, both plot-crop.
+t = PH_QUARTER['2018-19']
+frames = []
+fa = '../2018-19/Data/secta3i_harvestw4.dta'
+raw_a = get_dataframe(fa, convert_categoricals=False)
+dec_a = get_dataframe(fa, convert_categoricals=True)
+inter_a = _align_intercropped(
+    raw_a, 'hhid', 'plotid', 'cropcode',
+    '../2018-19/Data/sect11f_plantingw4.dta')
+frames.append(dict(
+    df=raw_a, dec=dec_a, hhid='hhid', plot='plotid', crop='cropcode',
+    qty='sa3iq6i', unit='sa3iq6ii',
+    plant_m='sa3iq4a1', plant_y='sa3iq4a2',
+    harv_m='sa3iq6c1', harv_y='sa3iq6c2',
+    intercropped=inter_a, perennial=False))
+fp = '../2018-19/Data/secta3iii_harvestw4.dta'
+raw_p = get_dataframe(fp, convert_categoricals=False)
+dec_p = get_dataframe(fp, convert_categoricals=True)
+frames.append(dict(
+    df=raw_p, dec=dec_p, hhid='hhid', plot='plotid', crop='cropcode',
+    qty='sa3iiiq13a', unit='sa3iiiq13c',
+    plant_m='sa3iiiq8a', plant_y='sa3iiiq8b',
+    harv_m='sa3iiiq12a', harv_y='sa3iiiq12b',
+    perennial=True))
+pieces.append(crop_production_for_wave(t, frames, crop_labels))
+
+# ----------------------------- W5 2023-24 -----------------------------
+t = PH_QUARTER['2023-24']
+frames = []
+fa = '../2023-24/Data/Post Harvest Wave 5/Agriculture/secta3i_harvestw5.dta'
+raw_a = get_dataframe(fa, convert_categoricals=False)
+dec_a = get_dataframe(fa, convert_categoricals=True)
+frames.append(dict(
+    df=raw_a, dec=dec_a, hhid='hhid', plot='plotid', crop='cropcode',
+    qty='sa3iq9a', unit='sa3iq9b',
+    plant_m='sa3iq5a', plant_y='sa3iq5b',
+    harv_m='sa3iq14a', harv_y='sa3iq14b',
+    perennial=False))
+fp = '../2023-24/Data/Post Harvest Wave 5/Agriculture/secta3iii_harvestw5.dta'
+raw_p = get_dataframe(fp, convert_categoricals=False)
+dec_p = get_dataframe(fp, convert_categoricals=True)
+frames.append(dict(
+    df=raw_p, dec=dec_p, hhid='hhid', plot='plotid', crop='cropcode',
+    qty='sa3iiiq23a', unit='sa3iiiq23b',
+    plant_m='sa3iiiq18a', plant_y='sa3iiiq18b',
+    harv_m='sa3iiiq22a', harv_y='sa3iiiq22b',
+    perennial=True))
+pieces.append(crop_production_for_wave(t, frames, crop_labels))
+
+# ----------------------------- combine -------------------------------
+df = pd.concat(pieces, axis=0)
+df = df.sort_index()
+
+to_parquet(df, '../var/crop_production.parquet')

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -104,6 +104,35 @@ Data Scheme:
     Irrigated: bool
     materialize: make
 
+  crop_production:
+    # Item-level reported crop harvest (GAP 1) at natural grain
+    # (t, i, plot, crop).  Source: post-harvest crop module secta3*.
+    # Crop-level harvest is recorded only in the post-harvest round, so
+    # each wave maps to a single t = PH quarter (2011Q1 / 2013Q1 /
+    # 2016Q1 / 2019Q1 / 2024Q1), distinct from plot_features' PP quarter
+    # (same wave, different round; plot_id aligns via format_id).
+    # Country-level script (_/crop_production.py) joins/reshapes per wave
+    # (W3-W5 split the module across secta3i / secta3ii / secta3iii) ->
+    # materialize: make.  Stores REPORTED fields only -- no kg
+    # conversion, yield, main_crop, or value shares (transformations).
+    # crop (j) on the shared harmonize_food Preferred Label so it joins
+    # food_acquired.j; u normalized to the shared `u` table base labels.
+    # Quantity_sold / Value_sold populated only where the survey records
+    # sales at the plot-crop grain (W1/W2); W3-W5 record sales at
+    # hh-crop grain (no plot linkage) -> NaN.  intercropped derived from
+    # the PP planting roster (sect11f s11fq2) where present (W1-W3);
+    # perennial = True for tree/permanent-crop rows (W4/W5 secta3iii).
+    index: (t, i, plot, crop)
+    Quantity: float
+    u: str
+    Quantity_sold: float
+    Value_sold: float
+    planting_month: str
+    harvest_month: str
+    intercropped: bool
+    perennial: bool
+    materialize: make
+
   food_coping:
     # Family B (coping-strategies / rCSI), #332.  GHS section 9 ("Food
     # Security") is a coping day-count battery (items s9q1a..s9q1i: "how

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -50,6 +50,257 @@ PP_QUARTER = {
     '2023-24': '2023Q3',
 }
 
+# Post-harvest quarter assigned as the single `t` for each wave's
+# crop_production.  Crop-level harvest is recorded only in the
+# post-harvest round (the secta3* files), so each wave contributes
+# exactly one t value -- the PH quarter -- distinct from the PP quarter
+# used by plot_features (same survey wave, different round).  plot_id
+# values still align across the two rounds (both format_id(plotid)).
+PH_QUARTER = {
+    '2010-11': '2011Q1',
+    '2012-13': '2013Q1',
+    '2015-16': '2016Q1',
+    '2018-19': '2019Q1',
+    '2023-24': '2024Q1',
+}
+
+
+# ---------------------------------------------------------------------
+# crop_production (GAP 1) -- item-level reported crop harvest
+# ---------------------------------------------------------------------
+#
+# Natural grain (t, i, plot, crop): one row per crop grown on a plot in
+# the post-harvest crop module (secta3*).  Stores REPORTED item-level
+# fields only -- Quantity (native harvest qty) + u (native unit),
+# Quantity_sold + Value_sold (reported), planting_month + harvest_month
+# (item dates), intercropped + perennial flags.  No kg conversion, no
+# yield, no main_crop, no shares -- those are transformations.
+#
+# crop labels (j): cropcode -> Preferred Label via harmonize_food
+# (extended with the crop codes; reused food labels where a crop is a
+# consumed food so crop_production.j joins food_acquired.j).
+# units (u): native production-unit label normalized to a base
+# Preferred Label registered in the `u` table.
+
+
+def _crop_labels():
+    """{int cropcode: Preferred Label} from harmonize_food (shared with
+    food_acquired)."""
+    from lsms_library.local_tools import get_categorical_mapping
+    raw = get_categorical_mapping(tablename='harmonize_food', idxvars='Code',
+                                  **{'Preferred Label': 'Preferred Label'})
+    out = {}
+    for k, v in raw.items():
+        try:
+            ik = int(k)
+        except (TypeError, ValueError):
+            continue
+        if pd.isna(v) or str(v).strip() in ('', '---'):
+            continue
+        out[ik] = str(v).strip()
+    return out
+
+
+def _strip_code_prefix(s):
+    """'1080. MAIZE' -> 'MAIZE'; '130. SACK/BAG' -> 'SACK/BAG'."""
+    import re
+    s = str(s).strip()
+    m = re.match(r'^\s*\d+\.\s*(.*)$', s)
+    return (m.group(1) if m else s).strip()
+
+
+def _canon_unit(s):
+    """Normalize a native harvest production-unit label to a size-agnostic
+    base Preferred Label registered in the `u` table.  Returns pd.NA for
+    blanks / pure-numeric junk."""
+    import re
+    if s is None or (isinstance(s, float) and pd.isna(s)):
+        return pd.NA
+    t = _strip_code_prefix(s)
+    if t == '' or re.fullmatch(r'[\d.]+', t):
+        return pd.NA
+    tl = t.lower()
+    if 'kilogram' in tl or tl == 'kg' or tl == 'kilograms':
+        return 'Kg'
+    if 'gram' in tl or tl == 'grams':
+        return 'g'
+    if 'centilitre' in tl or tl == 'cl':
+        return 'cl'
+    if 'litre' in tl or tl == 'litres' or tl == 'l':
+        return 'l'
+    if 'bag' in tl or 'sack' in tl:
+        return 'Sack/Bag'
+    if 'basket' in tl or 'bin/basket' in tl:
+        return 'Basket'
+    if 'basin' in tl:
+        return 'Basin'
+    if 'bowl' in tl:
+        return 'Bowl'
+    if 'bunch' in tl:
+        return 'Bunch'
+    if 'bundle' in tl:
+        return 'Bundle'
+    if 'tuber' in tl:
+        return 'Tuber'
+    if 'heap' in tl:
+        return 'Heap'
+    if 'stalk' in tl:
+        return 'Stalk'
+    if 'wheel' in tl:
+        return 'Wheelbarrow'
+    if 'pick' in tl:
+        return 'Pick-up'
+    if 'jerry' in tl or 'keg' in tl:
+        return 'Jerry Can'
+    if 'derica' in tl or tl == 'tin':
+        return 'Derica'
+    if 'tiya' in tl:
+        return 'Tiya'
+    if 'kobiowu' in tl:
+        return 'Kobiowu'
+    if 'congo' in tl:
+        return 'Congo'
+    if 'mudu' in tl:
+        return 'Mudu'
+    if 'packet' in tl or 'sachet' in tl:
+        return 'Packet/Sachet'
+    if 'piece' in tl:
+        return 'Piece'
+    if 'paint rubber' in tl:
+        return 'Paint rubber'
+    if 'milk cup' in tl:
+        return 'Milk cup'
+    if 'cigarette' in tl:
+        return 'Cigarette cup'
+    if 'olodo' in tl:
+        return 'Olodo'
+    if 'other' in tl or 'specify' in tl:
+        return 'other specify'
+    return pd.NA
+
+
+def _month_str(month_series, year_series):
+    """Build a 'YYYY-MM' month string from numeric month + year columns;
+    pd.NA where month is missing/invalid."""
+    m = pd.to_numeric(month_series, errors='coerce')
+    y = pd.to_numeric(year_series, errors='coerce') if year_series is not None else None
+    out = pd.Series(pd.NA, index=m.index, dtype='string')
+    valid = m.between(1, 12)
+    if y is not None:
+        valid = valid & y.notna()
+        out.loc[valid] = (y[valid].astype('Int64').astype(str) + '-'
+                          + m[valid].astype('Int64').astype(str).str.zfill(2))
+    else:
+        out.loc[valid] = m[valid].astype('Int64').astype(str).str.zfill(2)
+    return out
+
+
+def crop_production_for_wave(t, frames, crop_labels):
+    """Assemble item-level crop_production for one Nigeria GHS-Panel wave.
+
+    Parameters
+    ----------
+    t : str
+        PH-quarter wave id (e.g. '2011Q1'), used as the `t` index.
+    frames : list of dict
+        Each dict describes one source frame (annual harvest, perennial,
+        and/or an hh-crop sold frame) with keys:
+            df        : raw DataFrame (convert_categoricals as noted below)
+            dec       : decoded-label DataFrame (for crop/unit label decode)
+            hhid, plot, crop                 column names (plot may be None)
+            qty, unit                        harvest qty / unit columns
+            qty_sold, unit_sold, value_sold  reported sale columns (optional)
+            plant_m, plant_y                 planting/harvest-start month/yr
+            harv_m, harv_y                   harvest-end month/yr (optional)
+            intercropped                     bool Series aligned to df (opt)
+            perennial                        bool flag for the whole frame
+            sold_on                          'plot' | 'hh' join grain for sale
+    crop_labels : dict
+        {int cropcode: Preferred Label}.
+
+    Returns
+    -------
+    DataFrame indexed by (t, i, plot, crop) with reported columns.
+    Sale columns are populated only for frames where they sit at the
+    plot-crop grain; hh-crop sale frames are merged on (i, crop) where
+    that is the survey's grain (W3-W5 record sales at hh-crop level, so
+    the same sale value applies to every plot row of that hh-crop --
+    a reported attribute, not a per-plot allocation).
+    """
+    pieces = []
+    for fr in frames:
+        df = fr['df']
+        dec = fr['dec']
+        n = len(df)
+        i = df[fr['hhid']].apply(format_id)
+        crop_code = pd.to_numeric(df[fr['crop']], errors='coerce').astype('Int64')
+        crop = crop_code.map(crop_labels).astype('string')
+        if fr.get('plot') is not None:
+            plot = df[fr['plot']].apply(format_id)
+        else:
+            plot = pd.Series(pd.NA, index=df.index, dtype='string')
+
+        piece = pd.DataFrame({
+            'i': i.values,
+            'plot': plot.values,
+            'crop': crop.values,
+        }, index=df.index)
+
+        piece['Quantity'] = (pd.to_numeric(df[fr['qty']], errors='coerce')
+                             if fr.get('qty') in df.columns else pd.NA)
+        if fr.get('unit') in dec.columns:
+            piece['u'] = dec[fr['unit']].map(_canon_unit).astype('string').values
+        else:
+            piece['u'] = pd.Series(pd.NA, index=df.index, dtype='string').values
+
+        # Reported sale at plot-crop grain (W1/W2); hh-crop sales merged
+        # separately below.
+        if fr.get('sold_on') == 'plot':
+            piece['Quantity_sold'] = (pd.to_numeric(df[fr['qty_sold']], errors='coerce')
+                                      if fr.get('qty_sold') in df.columns else pd.NA)
+            piece['Value_sold'] = (pd.to_numeric(df[fr['value_sold']], errors='coerce')
+                                   if fr.get('value_sold') in df.columns else pd.NA)
+
+        piece['planting_month'] = (
+            _month_str(df[fr['plant_m']], df.get(fr.get('plant_y'))).values
+            if fr.get('plant_m') in df.columns
+            else pd.Series(pd.NA, index=df.index, dtype='string').values)
+        piece['harvest_month'] = (
+            _month_str(df[fr['harv_m']], df.get(fr.get('harv_y'))).values
+            if fr.get('harv_m') in df.columns
+            else pd.Series(pd.NA, index=df.index, dtype='string').values)
+
+        if fr.get('intercropped') is not None:
+            piece['intercropped'] = fr['intercropped'].reindex(df.index).values
+        piece['perennial'] = bool(fr.get('perennial', False))
+
+        pieces.append(piece)
+
+    out = pd.concat(pieces, ignore_index=True)
+    out['t'] = t
+
+    # Ensure all canonical columns exist.
+    for col in ['Quantity', 'u', 'Quantity_sold', 'Value_sold',
+                'planting_month', 'harvest_month', 'intercropped', 'perennial']:
+        if col not in out.columns:
+            out[col] = pd.NA
+
+    # Drop rows with no crop label resolved (free-text junk codes) and no
+    # household.  Keep rows with a crop even if Quantity is NaN (the
+    # survey recorded the crop on the plot but no harvest qty).
+    out = out[out['i'].notna() & out['crop'].notna()]
+
+    # Dedup on the index grain (a handful of duplicate (i,plot,crop) rows
+    # exist in W1); keep the first non-null record.
+    out = out.sort_values(['i', 'plot', 'crop'])
+    out = out.drop_duplicates(subset=['t', 'i', 'plot', 'crop'], keep='first')
+
+    out = out.set_index(['t', 'i', 'plot', 'crop']).sort_index()
+    out = out[['Quantity', 'u', 'Quantity_sold', 'Value_sold',
+               'planting_month', 'harvest_month', 'intercropped', 'perennial']]
+    return out
+
+
 # ---------------------------------------------------------------------
 # food_coping (#332, Family B: coping-strategies / rCSI)
 # ---------------------------------------------------------------------

--- a/lsms_library/countries/Tanzania/2019-20/_/crop_production.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/crop_production.py
@@ -1,0 +1,52 @@
+"""crop_production for Tanzania NPS 2019-20 (NPS-SDD, Extended Panel;
+parity-loop GAP 1).
+
+Item-level harvest at grain (t, i, plot_id, j) from three modules:
+  AG_SEC_4A  seasonal/annual crops  (ag4a_27 kg; ag4a_19 harvested y/n;
+             ag4a_04 intercrop; ag4a_24_2 harvest-end month)
+  AG_SEC_6A  perennial FRUIT trees  (ag6a_09 kg; ag6a_05; ag6a_07_4)
+  AG_SEC_6B  perennial non-fruit    (ag6b_09 kg; ag6b_05; ag6b_07_4)
+Reported sales (qty kg + value TSH) at (hhid, crop) grain are attached only
+to single-plot (hhid, crop) rows: AG_SEC_5A seasonal, 7A fruit, 7B non-fruit.
+Emits raw sdd_hhid as ``i``; the country-level concatenator applies id_walk
+and the framework joins ``v`` from sample().
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import crop_production_for_wave
+
+
+seas = get_dataframe('../Data/AG_SEC_4A.dta', convert_categoricals=False)
+fruit = get_dataframe('../Data/AG_SEC_6A.dta', convert_categoricals=False)
+peren = get_dataframe('../Data/AG_SEC_6B.dta', convert_categoricals=False)
+s5 = get_dataframe('../Data/AG_SEC_5A.dta', convert_categoricals=False)
+s7a = get_dataframe('../Data/AG_SEC_7A.dta', convert_categoricals=False)
+s7b = get_dataframe('../Data/AG_SEC_7B.dta', convert_categoricals=False)
+
+colmaps = dict(
+    seasonal=dict(hhid='sdd_hhid', plot='plotnum', crop='cropid',
+                  qty='ag4a_27', harvested='ag4a_19',
+                  harvest_month='ag4a_24_2', intercrop='ag4a_04'),
+    fruit=dict(hhid='sdd_hhid', plot='plotnum', crop='cropid',
+               qty='ag6a_09', harvested=None,
+               harvest_month='ag6a_07_4', intercrop='ag6a_05'),
+    perennial=dict(hhid='sdd_hhid', plot='plotnum', crop='cropid',
+                   qty='ag6b_09', harvested=None,
+                   harvest_month='ag6b_07_4', intercrop='ag6b_05'),
+    sales_seasonal=dict(hhid='sdd_hhid', crop='cropid',
+                        qty='ag5a_02', value='ag5a_03'),
+    sales_fruit=dict(hhid='sdd_hhid', crop='cropid',
+                     qty='ag7a_03', value='ag7a_04'),
+    sales_perennial=dict(hhid='sdd_hhid', crop='cropid',
+                         qty='ag7b_03', value='ag7b_04'),
+)
+
+df = crop_production_for_wave(
+    '2019-20', seas, fruit, peren,
+    sales=dict(seasonal=s5, fruit=s7a, perennial=s7b),
+    colmaps=colmaps)
+assert df.index.is_unique, "crop_production 2019-20: (t,i,plot_id,j) not unique"
+assert len(df) > 0
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Tanzania/2020-21/_/crop_production.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/crop_production.py
@@ -1,0 +1,48 @@
+"""crop_production for Tanzania NPS 2020-21 (NPS Y5, Refresh Panel;
+parity-loop GAP 1).
+
+Same three-module harvest stack as 2019-20, but this wave keys on
+``y5_hhid`` and ``plot_id`` (there is no ``plotnum`` column), matching the
+plot_features grain.  Variable names (ag4a_27 / ag4a_19 / ag4a_24_2 /
+ag4a_04 / ag6a_09 / ag6a_07_4 / ag6a_05 / ag5a_02 / ag5a_03 / ag7a_03 ...)
+are identical to 2019-20.  See ``crop_production_for_wave`` in tanzania.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import crop_production_for_wave
+
+
+seas = get_dataframe('../Data/ag_sec_4a.dta', convert_categoricals=False)
+fruit = get_dataframe('../Data/ag_sec_6a.dta', convert_categoricals=False)
+peren = get_dataframe('../Data/ag_sec_6b.dta', convert_categoricals=False)
+s5 = get_dataframe('../Data/ag_sec_5a.dta', convert_categoricals=False)
+s7a = get_dataframe('../Data/ag_sec_7a.dta', convert_categoricals=False)
+s7b = get_dataframe('../Data/ag_sec_7b.dta', convert_categoricals=False)
+
+colmaps = dict(
+    seasonal=dict(hhid='y5_hhid', plot='plot_id', crop='cropid',
+                  qty='ag4a_27', harvested='ag4a_19',
+                  harvest_month='ag4a_24_2', intercrop='ag4a_04'),
+    fruit=dict(hhid='y5_hhid', plot='plot_id', crop='cropid',
+               qty='ag6a_09', harvested=None,
+               harvest_month='ag6a_07_4', intercrop='ag6a_05'),
+    perennial=dict(hhid='y5_hhid', plot='plot_id', crop='cropid',
+                   qty='ag6b_09', harvested=None,
+                   harvest_month='ag6b_07_4', intercrop='ag6b_05'),
+    sales_seasonal=dict(hhid='y5_hhid', crop='cropid',
+                        qty='ag5a_02', value='ag5a_03'),
+    sales_fruit=dict(hhid='y5_hhid', crop='cropid',
+                     qty='ag7a_03', value='ag7a_04'),
+    sales_perennial=dict(hhid='y5_hhid', crop='cropid',
+                         qty='ag7b_03', value='ag7b_04'),
+)
+
+df = crop_production_for_wave(
+    '2020-21', seas, fruit, peren,
+    sales=dict(seasonal=s5, fruit=s7a, perennial=s7b),
+    colmaps=colmaps)
+assert df.index.is_unique, "crop_production 2020-21: (t,i,plot_id,j) not unique"
+assert len(df) > 0
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Tanzania/_/Makefile
+++ b/lsms_library/countries/Tanzania/_/Makefile
@@ -66,6 +66,15 @@ $(VAR_DIR)/plot_features.parquet: plot_features.py $(plot_features_parquet)
 ../%/_/plot_features.parquet:
 	(cd $(@D) && python plot_features.py)
 
+crop_production = $(shell find $(rounds) -name crop_production.py)
+crop_production_parquet := $(crop_production:.py=.parquet)
+
+$(VAR_DIR)/crop_production.parquet: crop_production.py $(crop_production_parquet)
+	python crop_production.py
+
+../%/_/crop_production.parquet:
+	(cd $(@D) && python crop_production.py)
+
 %.parquet: %.py CONTENTS.org tanzania.py
 	(cd $(@D) && python ./$(<F))
 

--- a/lsms_library/countries/Tanzania/_/categorical_mapping.org
+++ b/lsms_library/countries/Tanzania/_/categorical_mapping.org
@@ -611,3 +611,126 @@
 | mililitre      | Millilitre      |            |            | mililitre |
 | PIECES         | Piece           | PIECES     | PIECES     |           |
 | kilogram       | Kg              |            |            | kilogram  |
+
+# harmonize_crop is the (j) axis for crop_production (parity-loop GAP 1).
+# Keyed on the NPS crop CODE ("cropid" / "zaocode") from the agriculture
+# questionnaire crop-code flap (extracted from
+# 2019-20/Documentation/nps_sdd_agriculture_qx_final_english_.pdf).  The
+# Preferred Label REUSES the harmonize_food Preferred Labels wherever a crop
+# is a consumed food, so crop_production.j shares the (j) axis with
+# food_acquired and community_prices -- e.g. Maize -> "Maize (grain)",
+# Paddy -> "Rice (paddy)", Beans/Cowpeas/Pigeon Pea -> "Pulses",
+# Sugar Cane -> "Sugarcane", Coffee/Cocoa -> "Coffee & Cocoa".  NEW Preferred
+# Labels are added ONLY for non-food crops (Cotton, Tobacco, Sisal, Rubber,
+# Sunflower, Pyrethrum, Jute, Kapok, Wattle, Palm Oil, Seaweed, Spices (crop),
+# Bamboo, Timber, Firewood/Fodder, Medicinal Plant, Fence Tree, Other Crop).
+# The 2019-20 / 2020-21 columns carry the same raw integer code; the
+# crop_production.py scripts resolve code -> Preferred Label in-script via
+# _plot_harmonized_codes('harmonize_crop') (Code -> Preferred Label), so the
+# emitted (j) is already canonical (mostly non-numeric).
+#+name: harmonize_crop
+| Code | Preferred Label          | Crop            | 2019-20 | 2020-21 |
+|------+--------------------------+-----------------+---------+---------|
+| 11   | Maize (grain)            | Maize           | 11      | 11      |
+| 12   | Rice (paddy)             | Paddy           | 12      | 12      |
+| 13   | Millet & Sorghum (grain) | Sorghum         | 13      | 13      |
+| 14   | Millet & Sorghum (grain) | Bulrush Millet  | 14      | 14      |
+| 15   | Millet & Sorghum (grain) | Finger Millet   | 15      | 15      |
+| 16   | Other Cereals            | Wheat           | 16      | 16      |
+| 17   | Other Cereals            | Barley          | 17      | 17      |
+| 18   | Spices (crop)            | Black Pepper    | 18      | 18      |
+| 19   | Seaweed                  | Seaweed         | 19      | 19      |
+| 21   | Cassava Fresh            | Cassava         | 21      | 21      |
+| 22   | Sweet Potatoes           | Sweet Potatoes  | 22      | 22      |
+| 23   | Irish Potatoes           | Irish Potatoes  | 23      | 23      |
+| 24   | Yams/Cocoyams            | Yams            | 24      | 24      |
+| 25   | Yams/Cocoyams            | Cocoyams        | 25      | 25      |
+| 26   | Vegetables (fresh)       | Onions          | 26      | 26      |
+| 27   | Spices (crop)            | Ginger          | 27      | 27      |
+| 31   | Pulses                   | Beans           | 31      | 31      |
+| 32   | Pulses                   | Cowpeas         | 32      | 32      |
+| 33   | Pulses                   | Green Gram      | 33      | 33      |
+| 34   | Pulses                   | Pigeon Pea      | 34      | 34      |
+| 35   | Pulses                   | Chick Peas      | 35      | 35      |
+| 36   | Pulses                   | Bambara Nuts    | 36      | 36      |
+| 37   | Pulses                   | Field Peas      | 37      | 37      |
+| 38   | Other Fruits             | Malay Apple     | 38      | 38      |
+| 39   | Other Fruits             | Star Fruit      | 39      | 39      |
+| 41   | Sunflower                | Sunflower       | 41      | 41      |
+| 42   | Seeds                    | Sesame          | 42      | 42      |
+| 43   | Groundnuts               | Groundnut       | 43      | 43      |
+| 44   | Palm Oil                 | Palm Oil        | 44      | 44      |
+| 45   | Coconuts                 | Coconut         | 45      | 45      |
+| 46   | Nuts                     | Cashew Nut      | 46      | 46      |
+| 47   | Pulses                   | Soyabeans       | 47      | 47      |
+| 48   | Seeds                    | Caster Seed     | 48      | 48      |
+| 50   | Cotton                   | Cotton          | 50      | 50      |
+| 51   | Tobacco                  | Tobacco         | 51      | 51      |
+| 52   | Pyrethrum                | Pyrethrum       | 52      | 52      |
+| 53   | Sisal                    | Sisal           | 53      | 53      |
+| 54   | Coffee & Cocoa           | Coffee          | 54      | 54      |
+| 55   | Tea (dry)                | Tea             | 55      | 55      |
+| 56   | Coffee & Cocoa           | Cocoa           | 56      | 56      |
+| 57   | Rubber                   | Rubber          | 57      | 57      |
+| 58   | Wattle                   | Wattle          | 58      | 58      |
+| 59   | Kapok                    | Kapok           | 59      | 59      |
+| 60   | Sugarcane                | Sugar Cane      | 60      | 60      |
+| 61   | Spices (crop)            | Cardamom        | 61      | 61      |
+| 62   | Jute                     | Jute            | 62      | 62      |
+| 63   | Other Fruits             | Tamarind        | 63      | 63      |
+| 64   | Spices (crop)            | Cinnamon        | 64      | 64      |
+| 65   | Spices (crop)            | Nutmeg          | 65      | 65      |
+| 66   | Spices (crop)            | Clove           | 66      | 66      |
+| 67   | Other Fruits             | Bread Fruit     | 67      | 67      |
+| 68   | Citrus Fruits            | Pomelo          | 68      | 68      |
+| 69   | Other Fruits             | Jack Fruit      | 69      | 69      |
+| 70   | Other Fruits             | Passion Fruit   | 70      | 70      |
+| 71   | Ripe Bananas             | Banana          | 71      | 71      |
+| 72   | Other Fruits             | Avocado         | 72      | 72      |
+| 73   | Other Fruits             | Mango           | 73      | 73      |
+| 74   | Other Fruits             | Papaw           | 74      | 74      |
+| 75   | Other Fruits             | Pineapple       | 75      | 75      |
+| 76   | Citrus Fruits            | Orange          | 76      | 76      |
+| 77   | Citrus Fruits            | Grapefruit      | 77      | 77      |
+| 78   | Other Fruits             | Grapes          | 78      | 78      |
+| 79   | Citrus Fruits            | Mandarin        | 79      | 79      |
+| 80   | Other Fruits             | Guava           | 80      | 80      |
+| 81   | Other Fruits             | Plums           | 81      | 81      |
+| 82   | Other Fruits             | Apples          | 82      | 82      |
+| 83   | Other Fruits             | Pears           | 83      | 83      |
+| 84   | Other Fruits             | Peaches         | 84      | 84      |
+| 86   | Leafy Greens             | Cabbage         | 86      | 86      |
+| 87   | Vegetables (fresh)       | Tomatoes        | 87      | 87      |
+| 88   | Leafy Greens             | Spinach         | 88      | 88      |
+| 89   | Vegetables (fresh)       | Carrot          | 89      | 89      |
+| 90   | Vegetables (fresh)       | Chilies         | 90      | 90      |
+| 91   | Leafy Greens             | Amaranths       | 91      | 91      |
+| 92   | Vegetables (fresh)       | Pumpkins        | 92      | 92      |
+| 93   | Vegetables (fresh)       | Cucumber        | 93      | 93      |
+| 94   | Vegetables (fresh)       | Egg Plant       | 94      | 94      |
+| 95   | Other Fruits             | Water Mellon    | 95      | 95      |
+| 96   | Leafy Greens             | Cauliflower     | 96      | 96      |
+| 97   | Other Fruits             | Durian          | 97      | 97      |
+| 98   | Other Fruits             | Bilimbi         | 98      | 98      |
+| 99   | Other Fruits             | Rambutan        | 99      | 99      |
+| 100  | Vegetables (fresh)       | Okra            | 100     | 100     |
+| 101  | Pulses                   | Fiwi            | 101     | 101     |
+| 200  | Other Fruits             | Custard Apple   | 200     | 200     |
+| 201  | Other Fruits             | God Fruit       | 201     | 201     |
+| 202  | Other Fruits             | Mitobo          | 202     | 202     |
+| 203  | Other Fruits             | Plum            | 203     | 203     |
+| 204  | Other Fruits             | Peaches         | 204     | 204     |
+| 205  | Other Fruits             | Pomegranate     | 205     | 205     |
+| 210  | Other Fruits             | Date            | 210     | 210     |
+| 211  | Other Fruits             | Tungamaa        | 211     | 211     |
+| 212  | Other Fruits             | Other Fruit     | 212     | 212     |
+| 300  | Vegetables (fresh)       | Green Tomato    | 300     | 300     |
+| 301  | Other Fruits             | Monkeybread     | 301     | 301     |
+| 302  | Bamboo                   | Bamboo          | 302     | 302     |
+| 303  | Firewood/Fodder          | Firewood/Fodder | 303     | 303     |
+| 304  | Timber                   | Timber          | 304     | 304     |
+| 305  | Medicinal Plant          | Medicinal Plant | 305     | 305     |
+| 306  | Fence Tree               | Fence Tree      | 306     | 306     |
+| 851  | Citrus Fruits            | Lime            | 851     | 851     |
+| 852  | Citrus Fruits            | Lemon           | 852     | 852     |
+| 998  | Other Crop               | Other           | 998     | 998     |

--- a/lsms_library/countries/Tanzania/_/crop_production.py
+++ b/lsms_library/countries/Tanzania/_/crop_production.py
@@ -1,0 +1,44 @@
+"""Concatenate wave-level crop_production data for Tanzania NPS
+(parity-loop GAP 1).
+
+Each buildable wave's ``Tanzania/<wave>/_/crop_production.py`` produces a
+parquet with index ``(t, i, plot_id, j)`` and the canonical reported
+columns from data_scheme.yml (Quantity, u, Quantity_sold, Value_sold,
+planting_month, harvest_month, intercropped, perennial).  This script
+concatenates the per-wave parquets and applies cross-wave id_walk so the
+household index uses the panel canonical id scheme.
+
+Only 2019-20 (NPS-SDD Extended Panel) and 2020-21 (NPS Y5 Refresh Panel)
+are buildable: the 2008-15 multi-round folder has no agriculture source
+file on disk (only the household upd4_hh_* modules), so those four NPS
+rounds are deferred -- exactly as for plot_features (GH #167).
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import id_walk
+
+
+WAVES = ['2019-20', '2020-21']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/crop_production.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built.  DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "crop_production: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids, hh_index='i')
+
+to_parquet(p, '../var/crop_production.parquet')

--- a/lsms_library/countries/Tanzania/_/data_scheme.yml
+++ b/lsms_library/countries/Tanzania/_/data_scheme.yml
@@ -115,3 +115,32 @@ Data Scheme:
     SoilType: str
     Irrigated: bool
     materialize: make
+
+  crop_production:
+    # Item-level crop harvest (parity-loop GAP 1) at the natural grain
+    # (t, i, plot_id, j) -- one row per crop grown on a plot.  Stacks three
+    # harvest modules per wave: AG_SEC_4A (seasonal/annual), AG_SEC_6A
+    # (perennial fruit), AG_SEC_6B (perennial non-fruit/cash trees); reported
+    # sales (5A/7A/7B) attached at the unambiguous single-plot (hhid, crop)
+    # grain.  j is the canonical Preferred Label from harmonize_crop, which
+    # REUSES harmonize_food Preferred Labels where a crop is a consumed food
+    # (Maize (grain), Rice (paddy), Pulses, ...) so crop_production.j joins
+    # food_acquired.j; new labels only for non-food crops (Cotton, Sisal,
+    # Coffee & Cocoa via the food label, Tobacco, ...).  u='kg' (every NPS
+    # harvest variable is recorded in kilograms).  Only 2019-20 and 2020-21
+    # are buildable; 2008-15 has no agriculture source on disk (same as
+    # plot_features).  STORES REPORTED VALUES ONLY -- harvest_kg sums,
+    # yield_kg, main_crop and value-shares are transformations over these
+    # rows, NOT columns here.
+    # planting_month is part of the GAP-1 schema but is NOT recorded by the
+    # NPS instrument (WB cleaning code: "planting month (absent)"), so it is
+    # omitted rather than carried all-null.
+    index: (t, i, plot_id, j)
+    Quantity: float
+    u: str
+    Quantity_sold: float
+    Value_sold: float
+    harvest_month: float
+    intercropped: bool
+    perennial: bool
+    materialize: make

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -829,3 +829,173 @@ def plot_features_for_wave(t, sec02, sec3a, colmap):
     df = df.set_index(['t', 'i', 'plot_id'])
     df = df[['Area', 'AreaUnit', 'Tenure', 'TenureSystem', 'SoilType', 'Irrigated']]
     return df
+
+
+# Crop-production feature (parity-loop GAP 1).  Item-level harvest at the
+# natural grain (t, i, plot_id, j) -- one row per crop grown on a plot --
+# carrying ONLY reported survey fields.  No harvest_kg sum, no yield, no
+# main_crop, no value-share: those are transformations over these rows.
+CROP_PRODUCTION_COLUMNS = [
+    'Quantity', 'u', 'Quantity_sold', 'Value_sold',
+    'harvest_month', 'intercropped', 'perennial',
+]
+# NB: planting_month is part of the GAP-1 schema but is NOT recorded by the
+# Tanzania NPS instrument (the WB cleaning code notes "planting month
+# (absent)").  Both buildable waves lack it, so the column is omitted here
+# rather than carried all-null (which fails the no_all_null_columns sanity
+# check); it would be added back for a wave/country that records it.
+
+
+def _crop_labels(tablename='harmonize_crop'):
+    """{int crop code -> canonical Preferred Label} from
+    Tanzania/_/categorical_mapping.org.  Reuses ``_plot_harmonized_codes``
+    (codes with a blank Preferred Label collapse to pd.NA)."""
+    return _plot_harmonized_codes(tablename)
+
+
+def _months_to_int(series):
+    """Coerce a survey month column to nullable Int64 in 1..12; 0/blank -> NaN."""
+    m = pd.to_numeric(series, errors='coerce').astype('Int64')
+    return m.where((m >= 1) & (m <= 12), pd.NA)
+
+
+def crop_production_for_wave(t, seas, fruit, peren, sales, colmaps):
+    """Build canonical ``crop_production`` for one Tanzania NPS wave.
+
+    Three harvest modules are stacked at grain (hhid, plot, crop):
+      seas  -- AG_SEC_4A  seasonal/annual crops (harvest qty ``ag4a_27``,
+               zeroed where ``ag4a_19`` == 2 "did not harvest"; intercrop
+               ``ag4a_04``; harvest-end month ``ag4a_24_2``).
+      fruit -- AG_SEC_6A  perennial FRUIT trees (``ag6a_09``; intercrop
+               ``ag6a_05``; end month ``ag6a_07_4``).  perennial=True.
+      peren -- AG_SEC_6B  perennial NON-fruit/cash trees (``ag6b_09`` ...).
+               perennial=True.
+
+    Reported harvest quantity is recorded in KILOGRAMS by the questionnaire
+    ((KG) on every harvest variable), so ``u`` = 'kg' and the native
+    ``Quantity`` is the reported kg -- NO unit conversion is performed here.
+
+    Sales are recorded at the (hhid, crop) grain (no plot): seasonal in
+    AG_SEC_5A (``ag5a_02`` qty kg, ``ag5a_03`` value), perennial in 7A/7B.
+    We attach ``Quantity_sold`` / ``Value_sold`` to a harvest row ONLY when
+    the (hhid, crop) maps to exactly ONE plot in that wave -- so a reported
+    household-crop sale is carried without being split or duplicated across
+    plots (splitting would fabricate an allocation, which is a
+    transformation, not a reported value).  Where a crop spans >1 plot the
+    sold columns stay NaN.
+
+    planting_month is ABSENT in NPS (the WB cleaning code notes
+    "planting month (absent)") -> NaN.
+
+    Parameters
+    ----------
+    t : str            wave id ('2019-20' or '2020-21'); the ``t`` value.
+    seas, fruit, peren : pd.DataFrame
+        raw AG_SEC_4A / 6A / 6B frames (convert_categoricals=False).
+    sales : dict with optional keys 'seasonal' (5A), 'fruit' (7A),
+        'perennial' (7B), each a raw DataFrame or None.
+    colmaps : dict 'seasonal'/'fruit'/'perennial'/'sales_*' -> column-name
+        dicts (so 2019-20 'plotnum'/'sdd_hhid' vs 2020-21 'plot_id'/'y5_hhid'
+        differences live in the wave script, not here).
+
+    Returns
+    -------
+    pd.DataFrame indexed by (t, i, plot_id, j) with columns
+    CROP_PRODUCTION_COLUMNS.
+    """
+    crop_map = _crop_labels()
+
+    def _block(df, cm, perennial):
+        """One harvest module -> tidy (i, plot_id, code, fields) frame."""
+        if df is None or len(df) == 0:
+            return None
+        out = pd.DataFrame(index=df.index)
+        out['i'] = df[cm['hhid']].apply(format_id)
+        out['plot_id'] = df[cm['plot']].apply(format_id)
+        code = pd.to_numeric(df[cm['crop']], errors='coerce').astype('Int64')
+        out['_code'] = code
+        out['j'] = code.map(crop_map).astype('string')
+        qty = pd.to_numeric(df[cm['qty']], errors='coerce').astype('Float64')
+        # Seasonal: harvest is 0 where respondent did not harvest (ag4a_19==2).
+        if cm.get('harvested') is not None:
+            harvested = pd.to_numeric(df[cm['harvested']], errors='coerce')
+            qty = qty.where(harvested != 2, 0.0)
+        out['Quantity'] = qty
+        out['u'] = pd.Series(['kg'] * len(df), index=df.index, dtype='string')
+        out['u'] = out['u'].where(qty.notna(), pd.NA)
+        out['harvest_month'] = _months_to_int(df[cm['harvest_month']]).values
+        ic = pd.to_numeric(df[cm['intercrop']], errors='coerce').astype('Int64')
+        out['intercropped'] = ic.map({1: True, 2: False}).astype('boolean').values
+        out['perennial'] = perennial
+        return out
+
+    pieces = [
+        _block(seas, colmaps['seasonal'], False),
+        _block(fruit, colmaps['fruit'], True),
+        _block(peren, colmaps['perennial'], True),
+    ]
+    pieces = [p for p in pieces if p is not None]
+    if not pieces:
+        raise ValueError(f"crop_production {t}: no harvest source rows")
+    df = pd.concat(pieces, ignore_index=True)
+
+    # Drop rows with no resolvable crop label AND no quantity (pure noise).
+    df = df[~(df['j'].isna() & df['Quantity'].isna())].copy()
+
+    # --- reported sales, attached at the unambiguous single-plot grain ----
+    def _sales_block(raw, cm):
+        if raw is None or len(raw) == 0:
+            return None
+        s = pd.DataFrame(index=raw.index)
+        s['i'] = raw[cm['hhid']].apply(format_id)
+        s['_code'] = pd.to_numeric(raw[cm['crop']], errors='coerce').astype('Int64')
+        s['Quantity_sold'] = pd.to_numeric(raw[cm['qty']], errors='coerce').astype('Float64')
+        s['Value_sold'] = pd.to_numeric(raw[cm['value']], errors='coerce').astype('Float64')
+        s = s.dropna(subset=['_code'])
+        # Multiple sale rows per (i, crop) (e.g. fruit + non-fruit listed under
+        # the same code) -> sum reported quantities/values.
+        s = (s.groupby(['i', '_code'], dropna=False)[['Quantity_sold', 'Value_sold']]
+               .sum(min_count=1).reset_index())
+        return s
+
+    sales_pieces = [
+        _sales_block(sales.get('seasonal'), colmaps['sales_seasonal']),
+        _sales_block(sales.get('fruit'), colmaps['sales_fruit']),
+        _sales_block(sales.get('perennial'), colmaps['sales_perennial']),
+    ]
+    sales_pieces = [s for s in sales_pieces if s is not None]
+    if sales_pieces:
+        all_sales = pd.concat(sales_pieces, ignore_index=True)
+        all_sales = (all_sales.groupby(['i', '_code'], dropna=False)
+                     [['Quantity_sold', 'Value_sold']].sum(min_count=1)
+                     .reset_index())
+        # Only attach where (i, crop) lives on exactly one plot (no fabricated
+        # split across plots).
+        plot_count = df.groupby(['i', '_code'])['plot_id'].transform('nunique')
+        single = df[['i', '_code']].copy()
+        single['_single'] = (plot_count == 1).values
+        df = df.merge(all_sales, on=['i', '_code'], how='left')
+        df.loc[~single['_single'].values, ['Quantity_sold', 'Value_sold']] = pd.NA
+    else:
+        df['Quantity_sold'] = pd.Series([pd.NA] * len(df), dtype='Float64')
+        df['Value_sold'] = pd.Series([pd.NA] * len(df), dtype='Float64')
+
+    # j unresolved (rare 'Other' / unmapped) -> keep raw code as a string so
+    # the row is not silently dropped, but flag via the sentinel label.
+    df['j'] = df['j'].where(df['j'].notna(),
+                            df['_code'].astype('string').radd('crop_'))
+
+    df['t'] = t
+    df = df.drop(columns=['_code'])
+    df = df.set_index(['t', 'i', 'plot_id', 'j'])
+    # Collapse exact-duplicate (t,i,plot,j) rows (same crop listed twice on a
+    # plot across the seasonal+perennial stack is not expected, but guard):
+    if not df.index.is_unique:
+        df = df.groupby(level=['t', 'i', 'plot_id', 'j']).agg({
+            'Quantity': 'sum', 'u': 'first',
+            'Quantity_sold': 'first', 'Value_sold': 'first',
+            'harvest_month': 'max',
+            'intercropped': 'max', 'perennial': 'max',
+        })
+    df = df[CROP_PRODUCTION_COLUMNS]
+    return df

--- a/lsms_library/countries/Uganda/2009-10/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2009-10/_/crop_production.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""crop_production for Uganda UNPS 2009-10 (GAP 1 item-level build).
+
+Reads AGSEC5A (season 1), AGSEC5B (season 2) and AGSEC4A (intercrop
+flag) via get_dataframe and emits a canonical (t,i,plot,j,u,season)
+parquet of REPORTED harvest values.  Harvest unit is a5aq6c (the column
+whose labels decode to Kg/Sack/Bunch); a5aq6b is the Fresh/Dry condition.
+See uganda.CROP_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import crop_production_for_wave, CROP_COLMAPS
+
+t = '2009-10'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df5a = _try('../Data/AGSEC5A.dta')
+df5b = _try('../Data/AGSEC5B.dta')
+df4a = _try('../Data/AGSEC4A.dta')
+
+df = crop_production_for_wave(t, df5a, df5b, df4a, CROP_COLMAPS[t])
+assert len(df) > 0, f"crop_production produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique crop_production index for {t}"
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Uganda/2010-11/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2010-11/_/crop_production.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""crop_production for Uganda UNPS 2010-11 (GAP 1 item-level build).
+
+Reads AGSEC5A (season 1), AGSEC5B (season 2) and AGSEC4A (intercrop
+flag) via get_dataframe and emits a canonical (t,i,plot,j,u,season)
+parquet of REPORTED harvest values.  Harvest unit is a5aq6c (the column
+whose labels decode to Kg/Sack/Bunch); a5aq6b is the Fresh/Dry condition.
+See uganda.CROP_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import crop_production_for_wave, CROP_COLMAPS
+
+t = '2010-11'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df5a = _try('../Data/AGSEC5A.dta')
+df5b = _try('../Data/AGSEC5B.dta')
+df4a = _try('../Data/AGSEC4A.dta')
+
+df = crop_production_for_wave(t, df5a, df5b, df4a, CROP_COLMAPS[t])
+assert len(df) > 0, f"crop_production produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique crop_production index for {t}"
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Uganda/2011-12/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2011-12/_/crop_production.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""crop_production for Uganda UNPS 2011-12 (GAP 1 item-level build).
+
+Reads AGSEC5A (season 1), AGSEC5B (season 2) and AGSEC4A (intercrop
+flag) via get_dataframe and emits a canonical (t,i,plot,j,u,season)
+parquet of REPORTED harvest values.  Harvest unit is a5aq6c (the column
+whose labels decode to Kg/Sack/Bunch); a5aq6b is the Fresh/Dry condition.
+See uganda.CROP_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import crop_production_for_wave, CROP_COLMAPS
+
+t = '2011-12'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df5a = _try('../Data/AGSEC5A.dta')
+df5b = _try('../Data/AGSEC5B.dta')
+df4a = _try('../Data/AGSEC4A.dta')
+
+df = crop_production_for_wave(t, df5a, df5b, df4a, CROP_COLMAPS[t])
+assert len(df) > 0, f"crop_production produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique crop_production index for {t}"
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Uganda/2013-14/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2013-14/_/crop_production.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""crop_production for Uganda UNPS 2013-14 (GAP 1 item-level build).
+
+Reads AGSEC5A (season 1), AGSEC5B (season 2) and AGSEC4A (intercrop
+flag) via get_dataframe and emits a canonical (t,i,plot,j,u,season)
+parquet of REPORTED harvest values.  Harvest unit is a5aq6c (the column
+whose labels decode to Kg/Sack/Bunch); a5aq6b is the Fresh/Dry condition.
+See uganda.CROP_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import crop_production_for_wave, CROP_COLMAPS
+
+t = '2013-14'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df5a = _try('../Data/AGSEC5A.dta')
+df5b = _try('../Data/AGSEC5B.dta')
+df4a = _try('../Data/AGSEC4A.dta')
+
+df = crop_production_for_wave(t, df5a, df5b, df4a, CROP_COLMAPS[t])
+assert len(df) > 0, f"crop_production produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique crop_production index for {t}"
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Uganda/2015-16/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2015-16/_/crop_production.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""crop_production for Uganda UNPS 2015-16 (GAP 1 item-level build).
+
+Reads AGSEC5A (season 1), AGSEC5B (season 2) and AGSEC4A (intercrop
+flag) via get_dataframe and emits a canonical (t,i,plot,j,u,season)
+parquet of REPORTED harvest values.  Harvest unit is a5aq6c (the column
+whose labels decode to Kg/Sack/Bunch); a5aq6b is the Fresh/Dry condition.
+See uganda.CROP_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import crop_production_for_wave, CROP_COLMAPS
+
+t = '2015-16'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df5a = _try('../Data/AGSEC5A.dta')
+df5b = _try('../Data/AGSEC5B.dta')
+df4a = _try('../Data/AGSEC4A.dta')
+
+df = crop_production_for_wave(t, df5a, df5b, df4a, CROP_COLMAPS[t])
+assert len(df) > 0, f"crop_production produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique crop_production index for {t}"
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Uganda/2018-19/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2018-19/_/crop_production.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""crop_production for Uganda UNPS 2018-19 (GAP 1 item-level build).
+
+Reads AGSEC5A (season 1), AGSEC5B (season 2) and AGSEC4A (intercrop
+flag) via get_dataframe and emits a canonical (t,i,plot,j,u,season)
+parquet of REPORTED harvest values.  Harvest unit is a5aq6c (the column
+whose labels decode to Kg/Sack/Bunch); a5aq6b is the Fresh/Dry condition.
+See uganda.CROP_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import crop_production_for_wave, CROP_COLMAPS
+
+t = '2018-19'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df5a = _try('../Data/AGSEC5A.dta')
+df5b = _try('../Data/AGSEC5B.dta')
+df4a = _try('../Data/AGSEC4A.dta')
+
+df = crop_production_for_wave(t, df5a, df5b, df4a, CROP_COLMAPS[t])
+assert len(df) > 0, f"crop_production produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique crop_production index for {t}"
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Uganda/2019-20/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2019-20/_/crop_production.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""crop_production for Uganda UNPS 2019-20 (GAP 1 item-level build).
+
+2019-20 keeps the WB column names (s5aq06b_1 = harvest unit, s5aq06c_1 =
+condition) and records two parallel harvest conditions (_1 / _2) per
+(plot, crop); both are emitted as separate reported rows.  Crop module
+lives under Data/Agric/.  See uganda.CROP_COLMAPS['2019-20'].
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import crop_production_for_wave, CROP_COLMAPS
+
+t = '2019-20'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df5a = _try('../Data/Agric/agsec5a.dta')
+df5b = _try('../Data/Agric/agsec5b.dta')
+df4a = _try('../Data/Agric/agsec4a.dta')
+
+df = crop_production_for_wave(t, df5a, df5b, df4a, CROP_COLMAPS[t])
+assert len(df) > 0, "crop_production produced no rows for 2019-20"
+assert df.index.is_unique, "Non-unique crop_production index for 2019-20"
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Uganda/_/Makefile
+++ b/lsms_library/countries/Uganda/_/Makefile
@@ -23,6 +23,7 @@ var = $(VAR_DIR)/shocks.parquet $(VAR_DIR)/nonfood_expenditures.parquet $(VAR_DI
 	  $(VAR_DIR)/assets.parquet $(VAR_DIR)/earnings.parquet $(VAR_DIR)/income.parquet \
 	  $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet \
 	  $(VAR_DIR)/plot_features.parquet \
+	  $(VAR_DIR)/crop_production.parquet \
 	  $(VAR_DIR)/months_food_inadequate.parquet
 
 all: $(parquet) $(var)
@@ -80,6 +81,12 @@ plot_features_parquet := $(plot_features:.py=.parquet)
 
 $(VAR_DIR)/plot_features.parquet: plot_features.py $(plot_features_parquet)
 	python plot_features.py
+
+crop_production = $(shell find $(rounds) -name crop_production.py)
+crop_production_parquet := $(crop_production:.py=.parquet)
+
+$(VAR_DIR)/crop_production.parquet: crop_production.py $(crop_production_parquet)
+	python crop_production.py
 
 months_food_inadequate = $(shell find $(rounds) -name months_food_inadequate.py)
 months_food_inadequate_parquet := $(months_food_inadequate:.py=.parquet)

--- a/lsms_library/countries/Uganda/_/categorical_mapping.org
+++ b/lsms_library/countries/Uganda/_/categorical_mapping.org
@@ -687,3 +687,141 @@
 | 2019-20 | 2B   |    8 | use_right       |
 | 2019-20 | 2B   |    9 | squatted        |
 | 2019-20 | 2B   |   96 | other_tenure    |
+
+# harmonize_crop: crop-item code -> Preferred Label for the post-harvest
+# crop module (AGSEC5A/5B cropID).  The UNPS crop-code scheme is SEPARATE
+# from the food-consumption harmonize_food Code scheme (crop 130 = Maize
+# but food 130 = Passion Fruits), so crop labels live in their own table.
+# Where a crop is also a consumed food the Preferred Label REUSES the
+# harmonize_food *Aggregate Label* string (Maize, Beans, Rice, Sorghum,
+# Cassava, Sweet Potatoes, Ground Nuts, Sim Sim, Coffee, Tea, Onions,
+# Tomatoes, Cabbages, Sugarcane, Mangos, Oranges, Pineapple, Avocado,
+# Pawpaw, Passion Fruits, Soybean, Yam, Jackfruit, Millet) so
+# crop_production.j joins food_acquired(labels='Aggregate').j.  Non-food
+# crops (Cotton, Tobacco, Cocoa, Vanilla, Sunflower, Finger Millet, Field
+# / Cow / Pigeon / Chick Peas, Banana Beer, Cocoyam, Green Gram) get new
+# labels.  Land-status / non-crop codes (Fallow, Bush, Pastures, Forest,
+# Other) keep their literal label.
+#+name: harmonize_crop
+| Code | Preferred Label  |
+|------+------------------|
+|  111 | Wheat            |
+|  112 | Barley           |
+|  120 | Rice             |
+|  130 | Maize            |
+|  141 | Finger Millet    |
+|  150 | Sorghum          |
+|  210 | Beans            |
+|  211 | Beans            |
+|  221 | Field Peas       |
+|  222 | Cow Peas         |
+|  223 | Pigeon Peas      |
+|  224 | Chick Peas       |
+|  310 | Ground Nuts      |
+|  320 | Soybean          |
+|  330 | Sunflower        |
+|  340 | Sim Sim          |
+|  410 | Cabbages         |
+|  420 | Tomatoes         |
+|  430 | Carrots          |
+|  440 | Onions           |
+|  450 | Pumpkins         |
+|  460 | Dodo             |
+|  470 | Eggplant         |
+|  480 | Other Vegetable  |
+|  490 | Other Vegetable  |
+|  510 | Sugarcane        |
+|  520 | Cotton           |
+|  530 | Tobacco          |
+|  610 | Irish Potatoes   |
+|  620 | Sweet Potatoes   |
+|  630 | Cassava          |
+|  640 | Yam              |
+|  650 | Cocoyam          |
+|  700 | Oranges          |
+|  710 | Pawpaw           |
+|  720 | Pineapple        |
+|  741 | Banana Food      |
+|  742 | Banana Beer      |
+|  744 | Sweet Bananas    |
+|  750 | Mangos           |
+|  760 | Jackfruit        |
+|  770 | Avocado          |
+|  780 | Passion Fruits   |
+|  810 | Coffee           |
+|  811 | Coffee           |
+|  812 | Coffee           |
+|  820 | Cocoa            |
+|  830 | Tea              |
+|  840 | Ginger           |
+|  860 | Other Spice      |
+|  870 | Vanilla          |
+|  890 | Other Crop       |
+|  891 | Other Crop       |
+|  910 | Natural Pasture  |
+|  920 | Improved Pasture |
+|  930 | Fallow           |
+|  940 | Bush             |
+|  950 | Natural Forest   |
+|  960 | Plantation Trees |
+|  990 | Other Forest     |
+|  991 | Green Gram       |
+
+# harvest_units: harvest measurement-unit code -> Preferred Label for the
+# post-harvest crop module (AGSEC5A/5B a5aq6c / s5aq06b_1 and sold a5aq7c
+# / s5aq07c_1).  This is the UNPS *harvest* unit scheme (1=Kg, sacks,
+# tins, baskets, bunches, ...), distinct from the food-consumption u
+# scheme.  Preferred Labels reuse the canonical u-table unit strings where
+# they coincide (Kg, Sack/Tin/Basket/Bunch sizes, Number of Units
+# (General)).  kg-conversion factors are NOT stored here (they live in
+# transformations; the survey also carries a per-row conversion factor
+# a5aq6d / s5aq06d_1).
+#+name: harvest_units
+| Code | Preferred Label                   |
+|------+-----------------------------------|
+|    1 | Kg                                |
+|    2 | Gram                              |
+|    9 | Sack (120 kgs)                    |
+|   10 | Sack (100 kgs)                    |
+|   11 | Sack (80 kgs)                     |
+|   12 | Sack (50 kgs)                     |
+|   13 | Sack (unspecified)                |
+|   14 | Jerrican (20 lts)                 |
+|   15 | Jerrican (10 lts)                 |
+|   16 | Jerrican (5 lts)                  |
+|   17 | Jerrican (3 lts)                  |
+|   18 | Jerrican (2 lts)                  |
+|   20 | Tin (Debe) (20 lts)               |
+|   21 | Tin (5 lts)                       |
+|   22 | Plastic Basin (15 lts)            |
+|   29 | Kimbo/Cowboy/Blueband Tin (2kg)   |
+|   30 | Kimbo/Cowboy/Blueband Tin (1kg)   |
+|   31 | Kimbo/Cowboy/Blueband Tin (0.5kg) |
+|   32 | Cup/Mug(0.5lt)                    |
+|   37 | Basket (20 kg)                    |
+|   38 | Basket (10 kg)                    |
+|   39 | Basket (5 kg)                     |
+|   40 | Basket (2 kg)                     |
+|   63 | Crate                             |
+|   64 | Heap (unspecified)                |
+|   66 | Bundle (Unspecified)              |
+|   67 | Bunch (Big)                       |
+|   68 | Bunch (Medium)                    |
+|   69 | Bunch (Small)                     |
+|   70 | Cluster (Unspecified)             |
+|   83 | Tobacco leaf (Number)             |
+|   85 | Number of Units (General)         |
+|   87 | Piece (Big)                       |
+|   88 | Piece (Medium)                    |
+|   89 | Piece (Small)                     |
+|   90 | Heap (Big)                        |
+|   91 | Heap (Medium)                     |
+|   92 | Heap (Small)                      |
+|   93 | Cluster (Big)                     |
+|   94 | Cluster (Medium)                  |
+|   95 | Cluster (Small)                   |
+|   99 | Others specify                    |
+|  107 | Nice cup (100g) - Large           |
+|  108 | Nice cup (60g) - Medium           |
+|  119 | Nomi Tin (1kg)                    |
+|  120 | Nomi Tin (500g)                   |

--- a/lsms_library/countries/Uganda/_/crop_production.py
+++ b/lsms_library/countries/Uganda/_/crop_production.py
@@ -1,0 +1,40 @@
+"""Concatenate wave-level crop_production data for Uganda (GAP 1).
+
+Each wave's ``Uganda/<wave>/_/crop_production.py`` produces a parquet
+indexed ``(t, i, plot, j, u, season)`` with the REPORTED harvest columns
+(Quantity, Quantity_sold, Value_sold, harvest_month, intercropped,
+perennial, planting_month).  This script concatenates them across waves
+and applies cross-wave id_walk so the household index uses the panel
+canonical id scheme.
+
+2005-06 is intentionally absent: its AGSEC5A is a crop-area allocation
+matrix with no crop-level harvest quantities (and the WB LSMS-ISA panel
+starts at wave 1 = 2009-10).
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import Waves, id_walk
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/crop_production.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for crop_production (no .py / parquet, e.g.
+        # 2005-06).  DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "crop_production: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/crop_production.parquet')

--- a/lsms_library/countries/Uganda/_/data_scheme.yml
+++ b/lsms_library/countries/Uganda/_/data_scheme.yml
@@ -107,4 +107,34 @@ Data Scheme:
     SoilType: str
     Irrigated: bool
     materialize: make
+  crop_production:
+    # Item-level post-harvest crop module (GAP 1 parity build).  One row
+    # per REPORTED harvest record for a crop on a plot.  Source: AGSEC5A
+    # (season 1) + AGSEC5B (season 2) of the UNPS post-harvest
+    # questionnaire, joined to AGSEC4A for the intercropped flag.
+    #
+    # Grain (t, i, plot, j, u, season):
+    #   plot   — hhid-parcel-plot, mirroring the WB harmonised plot_id;
+    #            its parcel component is the parcel plot_features keys on.
+    #   j      — crop, on the shared 'harmonize_crop' Preferred Labels,
+    #            which REUSE the harmonize_food Aggregate Label strings
+    #            for food crops (Maize, Beans, Rice, ...) so a crop j
+    #            joins food_acquired(labels='Aggregate').j.
+    #   u      — reported native harvest unit ('harvest_units' table);
+    #            'Unknown' where a wave records no harvest unit label
+    #            (e.g. 2018-19 harvest side).
+    #   season — 'A' (first season) / 'B' (second season).
+    #
+    # Columns are REPORTED values only — no harvest_kg / yield /
+    # main_crop / value-share (those are transformations).  Missing in a
+    # wave -> NaN.  2005-06 is excluded: its AGSEC5A is a crop-area
+    # allocation matrix with no crop-level harvest quantities, and the
+    # WB LSMS-ISA panel itself starts at wave 1 (2009-10).
+    index: (t, i, plot, j, u, season)
+    Quantity: float
+    Quantity_sold: float
+    Value_sold: float
+    harvest_month: int
+    intercropped: bool
+    materialize: make
   nonfood_expenditures: !make

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -708,3 +708,323 @@ def plot_features_for_wave(t, source_2a, source_2b, colmap):
     df = df.set_index(['t', 'i', 'plot_id'])
     return df
 
+
+
+# ----------------------------------------------------------------------
+# crop_production  (GAP 1 — item-level post-harvest crop module)
+# ----------------------------------------------------------------------
+#
+# Grain: (t, i, plot, j, u, season).  One row per *reported* harvest
+# record for a crop on a plot.  Stores REPORTED values only — Quantity
+# (native harvest unit u), Quantity_sold, Value_sold, harvest_month and
+# the intercropped / perennial flags.  No harvest_kg / yield / main_crop /
+# value-share — those are transformations over these item rows.
+#
+# Source: AGSEC5A (season 1) + AGSEC5B (season 2), the UNPS post-harvest
+# crop module.  Column names AND the unit/condition column semantics drift
+# across waves (see slurm notes in the wave scripts), so each wave passes
+# an explicit colmap.  Some newer waves (2018-19, 2019-20) record two
+# harvest "conditions" per (plot, crop) in parallel _1 / _2 column sets;
+# we emit one row per non-empty condition rather than summing them.
+#
+# plot id mirrors the WB harmonised plot_id = hhid-parcel-plot; its parcel
+# component (hhid-parcel) is the same parcel that plot_features keys on
+# (plot_features uses the coarser parcel grain with an _A/_B source tag).
+
+_CROP_TABLE = 'harmonize_crop'
+_HARVEST_UNIT_TABLE = 'harvest_units'
+
+
+def _crop_label_map():
+    return _harmonized_codes(_CROP_TABLE)
+
+
+def _harvest_unit_map():
+    return _harmonized_codes(_HARVEST_UNIT_TABLE)
+
+
+def _to_int_code(series):
+    """Coerce a (possibly categorical/float/str) code column to Int64."""
+    if series is None:
+        return None
+    if pd.api.types.is_categorical_dtype(series):
+        # When convert_categoricals=False the categories ARE the codes;
+        # otherwise fall back to numeric coercion of the string form.
+        try:
+            return series.astype('Int64')
+        except (TypeError, ValueError):
+            return pd.to_numeric(series.astype(str), errors='coerce').astype('Int64')
+    return pd.to_numeric(series, errors='coerce').astype('Int64')
+
+
+def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
+    """Build canonical ``crop_production`` for one Uganda UNPS wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2013-14"``).
+    df5a, df5b : pd.DataFrame | None
+        Raw AGSEC5A (season 1) / AGSEC5B (season 2) post-harvest crop
+        modules, loaded with ``convert_categoricals=False`` so code
+        columns carry integer codes.  ``None`` permitted.
+    df4a : pd.DataFrame | None
+        Raw AGSEC4A plot-crop roster (for the intercropped flag and,
+        where available, the perennial flag).  ``None`` permitted; when
+        absent the flags are NaN.
+    colmap : dict
+        Per-(season) column maps keyed by ``'A'`` / ``'B'``.  Each value
+        is a dict with keys:
+            hhid, parcel, plot, crop       — id columns
+            conditions : list of dicts, one per parallel harvest-record
+                         set, each with keys:
+                qty           — reported harvest quantity column
+                unit          — reported harvest unit code column (or None)
+                qty_sold      — reported quantity sold column (or None)
+                value_sold    — reported sale value column (or None)
+                month         — harvest-end month code column (or None)
+        plus an optional top-level key ``cf`` listing per-condition CF
+        columns (unused for storage; documented for transformations).
+    intercrop_map : (passed via colmap['intercrop']) optional dict
+            file_hhid, file_parcel, file_plot, flag, [perennial]
+        describing how to read the intercropped flag from ``df4a``.
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot, j, u, season)`` with columns
+        ``Quantity`` (Float64), ``Quantity_sold`` (Float64),
+        ``Value_sold`` (Float64), ``harvest_month`` (Int64 1-12) and
+        ``intercropped`` (boolean).  The ``perennial`` / ``planting_month``
+        lookups are wired but not emitted — no current Uganda wave
+        populates them cleanly (they would be all-null).
+    """
+    crop_map = _crop_label_map()
+    unit_map = _harvest_unit_map()
+
+    # --- intercropped / perennial / planting from AGSEC4A (plot-crop) ---
+    inter_lookup = {}      # (hh, parcel, plot) -> bool   (plot-level flag)
+    perennial_lookup = {}  # (hh, parcel, plot, crop) -> bool
+    planting_lookup = {}   # (hh, parcel, plot, crop) -> Int month
+    ic = colmap.get('intercrop')
+    if df4a is not None and ic is not None:
+        hh4 = df4a[ic['hhid']].apply(format_id)
+        pa4 = df4a[ic['parcel']].apply(format_id)
+        pl4 = df4a[ic['plot']].apply(format_id)
+        key3 = list(zip(hh4, pa4, pl4))
+        if ic.get('flag') and ic['flag'] in df4a.columns:
+            flagcode = _to_int_code(df4a[ic['flag']])
+            # 1 = mono/No, 2 = Yes  (recode mirrors WB: 2 -> True)
+            for k, c in zip(key3, flagcode):
+                if pd.notna(c):
+                    inter_lookup[k] = bool(int(c) == 2)
+        if ic.get('crop') and ic['crop'] in df4a.columns:
+            crop4 = _to_int_code(df4a[ic['crop']])
+            key4 = list(zip(hh4, pa4, pl4, crop4))
+            if ic.get('perennial') and ic['perennial'] in df4a.columns:
+                per = _to_int_code(df4a[ic['perennial']])
+                for k, c in zip(key4, per):
+                    if pd.notna(c):
+                        perennial_lookup[k] = bool(int(c) == 2)
+            if ic.get('planting_month') and ic['planting_month'] in df4a.columns:
+                pm = _to_int_code(df4a[ic['planting_month']])
+                for k, m in zip(key4, pm):
+                    if pd.notna(m) and 1 <= int(m) <= 12:
+                        planting_lookup[k] = int(m)
+
+    pieces = []
+    for season, df5 in (('A', df5a), ('B', df5b)):
+        if df5 is None or len(df5) == 0:
+            continue
+        cm = colmap.get(season)
+        if cm is None:
+            continue
+
+        hh = df5[cm['hhid']].apply(format_id)
+        parcel = df5[cm['parcel']].apply(format_id)
+        plot = df5[cm['plot']].apply(format_id) if cm.get('plot') and cm['plot'] in df5.columns else pd.Series(['']*len(df5), index=df5.index)
+        plot_id = hh.astype(str) + '-' + parcel.astype(str) + '-' + plot.astype(str)
+        crop_code = _to_int_code(df5[cm['crop']])
+        j = crop_code.map(lambda c: crop_map.get(int(c), pd.NA) if pd.notna(c) else pd.NA)
+
+        for cond in cm['conditions']:
+            qcol = cond.get('qty')
+            if not qcol or qcol not in df5.columns:
+                continue
+            qty = pd.to_numeric(df5[qcol], errors='coerce')
+
+            # reported native unit
+            if cond.get('unit') and cond['unit'] in df5.columns:
+                ucode = _to_int_code(df5[cond['unit']])
+                u = ucode.map(lambda c: unit_map.get(int(c), pd.NA) if pd.notna(c) else pd.NA)
+            else:
+                u = pd.Series([pd.NA]*len(df5), index=df5.index, dtype='object')
+
+            qsold = pd.to_numeric(df5[cond['qty_sold']], errors='coerce') if cond.get('qty_sold') in df5.columns else pd.Series([pd.NA]*len(df5), index=df5.index)
+            vsold = pd.to_numeric(df5[cond['value_sold']], errors='coerce') if cond.get('value_sold') in df5.columns else pd.Series([pd.NA]*len(df5), index=df5.index)
+
+            if cond.get('month') and cond['month'] in df5.columns:
+                hm = _to_int_code(df5[cond['month']])
+                hm = hm.where((hm >= 1) & (hm <= 12), pd.NA)
+            else:
+                hm = pd.Series([pd.NA]*len(df5), index=df5.index, dtype='Int64')
+
+            piece = pd.DataFrame({
+                't':             t,
+                'i':             hh.values,
+                'plot':          plot_id.values,
+                'j':             j.values,
+                'u':             u.values,
+                'season':        season,
+                'Quantity':      qty.values,
+                'Quantity_sold': qsold.values,
+                'Value_sold':    vsold.values,
+                'harvest_month': hm.values,
+            })
+            # intercropped flag (plot-level) joined from AGSEC4A.  The
+            # perennial_lookup / planting_lookup hooks exist for future
+            # waves but no current Uganda wave populates them cleanly, so
+            # those columns are not emitted (they would be all-null).
+            k3 = list(zip(hh.values, parcel.values, plot.values))
+            piece['intercropped'] = [inter_lookup.get(k, pd.NA) for k in k3]
+            pieces.append(piece)
+
+    cols = ['Quantity', 'Quantity_sold', 'Value_sold', 'harvest_month',
+            'intercropped']
+    if not pieces:
+        return pd.DataFrame(columns=cols)
+
+    df = pd.concat(pieces, ignore_index=True)
+
+    # Drop rows with no crop label and no quantity at all (empty source
+    # rows / land-status placeholders with nothing reported).
+    df = df[df['j'].notna()]
+    # Keep rows even when Quantity is NaN but a sale was reported; drop
+    # only when ALL reported measures are missing.
+    measure_cols = ['Quantity', 'Quantity_sold', 'Value_sold']
+    df = df[df[measure_cols].notna().any(axis=1)]
+
+    df['Quantity'] = pd.to_numeric(df['Quantity'], errors='coerce').astype('Float64')
+    df['Quantity_sold'] = pd.to_numeric(df['Quantity_sold'], errors='coerce').astype('Float64')
+    df['Value_sold'] = pd.to_numeric(df['Value_sold'], errors='coerce').astype('Float64')
+    df['harvest_month'] = pd.to_numeric(df['harvest_month'], errors='coerce').astype('Int64')
+    df['intercropped'] = df['intercropped'].astype('boolean')
+
+    # u may be NaN (e.g. 2018-19 harvest side has no unit label); fill
+    # with a sentinel so it can be an index level without null-index
+    # failures, but ONLY where Quantity is present (a reported quantity
+    # with no unit).  Where there's no quantity at all, leave the unit
+    # sentinel too.
+    df['u'] = df['u'].astype('object').where(df['u'].notna(), 'Unknown')
+
+    df = df.set_index(['t', 'i', 'plot', 'j', 'u', 'season'])
+    # Collapse exact-duplicate index tuples (same plot/crop/unit/season
+    # reported twice) by summing the reported quantities — this is NOT an
+    # aggregation across distinct items, just de-duplication of repeated
+    # identical source rows so the index is unique.
+    if not df.index.is_unique:
+        num = df[['Quantity', 'Quantity_sold', 'Value_sold']].groupby(level=df.index.names).sum(min_count=1)
+        firstcols = df[['harvest_month', 'intercropped']].groupby(level=df.index.names).first()
+        df = num.join(firstcols)
+    return df
+
+
+# Per-wave column maps for crop_production_for_wave.  The harvest UNIT is
+# the column whose value labels decode to Kg/Sack/Bunch (the harvest_units
+# scheme) — empirically a5aq6c for 2009-16 (NOT a5aq6b, which is the
+# Fresh/Dry condition; the WB .do's A5aq6b/A5aq6c unit/condition rename is
+# inverted for these actual UNPS files).  2018-19's harvest side carries
+# no unit label (-> u='Unknown'); 2019-20 keeps WB names s5aq06b_1.
+CROP_COLMAPS = {
+    '2009-10': {
+        'A': {'hhid': 'HHID', 'parcel': 'a5aq1', 'plot': 'a5aq3', 'crop': 'a5aq5',
+              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c',
+                              'qty_sold': 'a5aq7a', 'value_sold': 'a5aq8',
+                              'month': None}]},
+        'B': {'hhid': 'HHID', 'parcel': 'a5bq1', 'plot': 'a5bq3', 'crop': 'a5bq5',
+              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c',
+                              'qty_sold': 'a5bq7a', 'value_sold': 'a5bq8',
+                              'month': None}]},
+        # 2009-10 AGSEC4A uses a non-standard column layout (a4aq1/a4aq2/
+        # a4aq4, no parcel/plot/cropID in the form the join needs), so the
+        # intercrop flag is not cleanly joinable -> intercropped is NaN
+        # this wave.
+        'intercrop': None,
+    },
+    '2010-11': {
+        'A': {'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid', 'crop': 'cropID',
+              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c',
+                              'qty_sold': 'a5aq7a', 'value_sold': 'a5aq8',
+                              'month': None}]},
+        'B': {'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid', 'crop': 'cropID',
+              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c',
+                              'qty_sold': 'a5bq7a', 'value_sold': 'a5bq8',
+                              'month': None}]},
+        'intercrop': {'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid',
+                      'flag': 'a4aq3', 'crop': 'cropID'},
+    },
+    '2011-12': {
+        'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
+              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c',
+                              'qty_sold': 'a5aq7a', 'value_sold': 'a5aq8',
+                              'month': 'a5aq6f'}]},
+        'B': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
+              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c',
+                              'qty_sold': 'a5bq7a', 'value_sold': 'a5bq8',
+                              'month': 'a5bq6f'}]},
+        'intercrop': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+                      'flag': 'a4aq3', 'crop': 'cropID'},
+    },
+    '2013-14': {
+        'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
+              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c',
+                              'qty_sold': 'a5aq7a', 'value_sold': 'a5aq8',
+                              'month': 'a5aq6f'}]},
+        'B': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
+              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c',
+                              'qty_sold': 'a5bq7a', 'value_sold': 'a5bq8',
+                              'month': 'a5bq6f'}]},
+        'intercrop': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+                      'flag': 'a4aq16', 'crop': 'cropID'},
+    },
+    '2015-16': {
+        'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
+              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c',
+                              'qty_sold': 'a5aq7a', 'value_sold': 'a5aq8',
+                              'month': 'a5aq6f'}]},
+        'B': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
+              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c',
+                              'qty_sold': 'a5bq7a', 'value_sold': 'a5bq8',
+                              'month': 'a5bq6f'}]},
+        'intercrop': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+                      'flag': 'a4aq16', 'crop': 'cropID'},
+    },
+    '2018-19': {
+        'A': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid', 'crop': 'cropID',
+              'conditions': [{'qty': 's5aq06a_1', 'unit': None,
+                              'qty_sold': 's5aq07a_1', 'value_sold': 's5aq08_1',
+                              'month': 's5aq06f_1'}]},
+        'B': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid', 'crop': 'cropID',
+              'conditions': [{'qty': 's5bq06a_1', 'unit': None,
+                              'qty_sold': 's5bq07a_1', 'value_sold': 's5bq08_1',
+                              'month': 's5bq06f_1'}]},
+        'intercrop': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+                      'flag': 's4aq16', 'crop': 'cropID'},
+    },
+    '2019-20': {
+        'A': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid', 'crop': 'cropID',
+              'conditions': [
+                  {'qty': 's5aq06a_1', 'unit': 's5aq06b_1',
+                   'qty_sold': 's5aq07a_1', 'value_sold': 's5aq08_1',
+                   'month': 's5aq06f_1'},
+                  {'qty': 's5aq06a_2', 'unit': 's5aq06b_2',
+                   'qty_sold': 's5aq07a_2', 'value_sold': 's5aq08_2',
+                   'month': 's5aq06f_2'},
+              ]},
+        'B': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid', 'crop': 'cropID',
+              'conditions': [{'qty': 's5bq06a_1', 'unit': 's5bq06b_1',
+                              'qty_sold': 's5bq07a_1', 'value_sold': 's5bq08_1',
+                              'month': 's5bq06f_1'}]},
+        'intercrop': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+                      'flag': 's4aq16', 'crop': 'cropID'},
+    },
+}


### PR DESCRIPTION
GAP 1 of the WB-parity loop. Builds item-level `crop_production` at grain `(t, i, plot, crop)` from the post-harvest crop module — **reported** harvest qty/native-unit, sold qty/value, planting/harvest months, intercropped/perennial flags. NO aggregates baked in (harvest_kg, yield, main_crop, value-shares are `transformations`, not columns).

- Crop labels extend `harmonize_food` (reusing food Preferred Labels where crop==food, so crops join consumed foods); units extend the `u` table.
- `v` auto-joins from `sample()` (same pattern as `plot_features`) — the Uganda worker's `_no_v_join` framework edit was reverted as unnecessary (all 7 pass `is_this_feature_sane.ok` with `v` joined).
- Coverage vs WB Plotcrop parquet: Nigeria 99.9%, Mali ~100%, Ethiopia 87%, Uganda ~73% (one-row-per-reported-harvest vs WB wide-merge multiplicity; per-wave HH parity ~1.0). Tanzania **partial** (NPS wave 5 only; panel rounds unbuildable, documented GH #167, same as plot_features).
- Adversary PASS: no aggregates, no food_acquired regression, item-level grain confirmed.

Follow-ups (NOT crop_production defects): (1) Nigeria/Tanzania `food_acquired.j` is raw (numeric/uppercase) — pre-existing j-wiring gap so crop↔food join can't complete there yet; (2) Uganda 13.7% crop rows have no sample `v` (passes sane).

220 table-structure/schema tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>