### PR TITLE
feat(parity): GAP 2 — item-level plot_inputs (t,i,plot,input) across 7 LSMS-ISA countries

### DIFF
--- a/lsms_library/countries/Ethiopia/2011-12/_/plot_inputs.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/plot_inputs.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+"""Build plot_inputs for Ethiopia ESS 2011-12 (Wave 1; GAP 2).
+
+Item-level ag inputs at (t, i, plot_id, input, j).  One row per input
+applied to a plot, carrying only REPORTED fields.
+
+W1 sources / specifics:
+  - Seed (§5 sect5_pp_w1): per (field, crop); the seed quantity is
+    reported in kg (pp_s5q19_a) + grams residual (pp_s5q19_b).  §5 ALSO
+    carries field_id, so purchased detail (pp_s5q03 flag, pp_s5q05_a/b
+    kg+gram) attaches directly at plot-crop grain.  The improved-seed
+    flag is NOT in §5 -> joined from §4 (pp_s4q11: 1/3=No, 2=Yes).
+  - Fertilizer / organic (§3 sect3_pp_w1): Urea kg = pp_s3q16_c, DAP kg
+    = pp_s3q19_c (the .do reads the _c kg-form directly), used flags
+    pp_s3q15 / pp_s3q18; organic dummies pp_s3q21 (manure) / pp_s3q23
+    (compost) / pp_s3q25 (other).  No NPS in W1.
+  - Pesticide (§4 sect4_pp_w1): pp_s4q05 used, gated by pp_s4q04==2.
+i = household_id (matches sample().i for W1).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_inputs_for_wave
+
+
+plot_roster = get_dataframe('../Data/sect3_pp_w1.dta', convert_categoricals=False)
+planting    = get_dataframe('../Data/sect4_pp_w1.dta', convert_categoricals=False)
+seeds       = get_dataframe('../Data/sect5_pp_w1.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+
+    # seed quantity from §5 (field-crop grain), kg + grams residual
+    seed_src='seeds', seed_crop_code='crop_code',
+    seed_qty_a='pp_s5q19_a', seed_qty_b='pp_s5q19_b',
+    # improved flag lives in §4; 1/3 = No, 2 = Yes
+    improved_join=True, improved_code='pp_s4q11', pl_crop_code='crop_code',
+    improved_yes=(2,),
+
+    # seed purchase from §5 (field-crop grain): flag + kg + grams
+    p_holder_id='holder_id', p_crop_code='crop_code',
+    p_field_id='field_id', p_parcel_id='parcel_id',
+    p_purch_flag='pp_s5q03', p_purch_a='pp_s5q05_a', p_purch_b='pp_s5q05_b',
+
+    # inorganic fertilizer (§3): used flag + kg-form (_c)
+    urea_used='pp_s3q15', urea_kg='pp_s3q16_c',
+    dap_used='pp_s3q18', dap_kg='pp_s3q19_c',
+    # no NPS in W1
+    # organic (§3): use dummies
+    manure_used='pp_s3q21', compost_used='pp_s3q23', other_organic_used='pp_s3q25',
+
+    # pesticide (§4): used + gate
+    pest_crop_code='crop_code', pest_used='pp_s4q05', pest_gate='pp_s4q04',
+)
+
+df = plot_inputs_for_wave('2011-12', plot_roster, planting, seeds, colmap)
+
+assert len(df) > 0, "plot_inputs 2011-12 produced no rows"
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Ethiopia/2013-14/_/plot_inputs.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/plot_inputs.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+"""Build plot_inputs for Ethiopia ESS 2013-14 (Wave 2; GAP 2).
+
+Item-level ag inputs at (t, i, plot_id, input, j).
+
+W2 sources / specifics:
+  - Seed quantity (§4 sect4_pp_w2): pp_s4q11b (kg), per (field, crop);
+    improved flag pp_s4q11 (1/3=No, 2=Yes).  §4 carries the plot id.
+  - Seed purchase (§5 sect5_pp_w2): pp_s5q03 flag + pp_s5q05_a/b kg+gram
+    at (HOLDER, crop) grain (no field_id) -> attached to the §4 plot-crop
+    seed rows ONLY where (holder, crop) maps to exactly one plot.
+  - Fertilizer (§3 sect3_pp_w2): UREA used pp_s3q15, kg pp_s3q16_a,
+    purchased kg pp_s3q16c; DAP used pp_s3q18, kg pp_s3q19_a, purchased
+    pp_s3q19c.  No NPS in W2.
+  - Organic (§3): manure pp_s3q21 / compost pp_s3q23 / other pp_s3q25.
+  - Pesticide (§4): pp_s4q05 used, gated by pp_s4q04==2.
+i = household_id2 (matches sample().i for W2).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_inputs_for_wave
+
+
+plot_roster = get_dataframe('../Data/sect3_pp_w2.dta', convert_categoricals=False)
+planting    = get_dataframe('../Data/sect4_pp_w2.dta', convert_categoricals=False)
+seeds       = get_dataframe('../Data/sect5_pp_w2.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id2', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+
+    # seed quantity from §4 (field-crop grain); improved also from §4
+    seed_src='planting', seed_crop_code='crop_code',
+    seed_qty='pp_s4q11b',
+    improved_code='pp_s4q11', improved_yes=(2,),
+
+    # seed purchase from §5 (holder-crop grain): flag + kg + grams
+    p_holder_id='holder_id', p_crop_code='crop_code',
+    p_purch_flag='pp_s5q03', p_purch_a='pp_s5q05_a', p_purch_b='pp_s5q05_b',
+
+    # inorganic fertilizer (§3): used + total kg + purchased kg
+    urea_used='pp_s3q15', urea_kg='pp_s3q16_a', urea_purch_kg='pp_s3q16c',
+    dap_used='pp_s3q18', dap_kg='pp_s3q19_a', dap_purch_kg='pp_s3q19c',
+    # organic (§3)
+    manure_used='pp_s3q21', compost_used='pp_s3q23', other_organic_used='pp_s3q25',
+
+    # pesticide (§4)
+    pest_crop_code='crop_code', pest_used='pp_s4q05', pest_gate='pp_s4q04',
+)
+
+df = plot_inputs_for_wave('2013-14', plot_roster, planting, seeds, colmap)
+
+assert len(df) > 0, "plot_inputs 2013-14 produced no rows"
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Ethiopia/2015-16/_/plot_inputs.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/plot_inputs.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""Build plot_inputs for Ethiopia ESS 2015-16 (Wave 3; GAP 2).
+
+Item-level ag inputs at (t, i, plot_id, input, j).
+
+W3 sources / specifics:
+  - Seed quantity (§4 sect4_pp_w3): kg = pp_s4q11b_a + pp_s4q11b_b*0.001
+    (grams), per (field, crop); improved pp_s4q11 (1=No, 2=Yes).
+  - Seed purchase (§5 sect5_pp_w3): pp_s5q03 flag + pp_s5q05_a/b kg+gram
+    at (HOLDER, crop) grain -> attached unambiguously (one plot only).
+  - Fertilizer (§3 sect3_pp_w3): UREA used pp_s3q15, kg pp_s3q16,
+    purchased pp_s3q16c; DAP used pp_s3q18, kg pp_s3q19, purchased
+    pp_s3q19c; NPS used pp_s3q20a_1, kg pp_s3q20a_2, purchased
+    pp_s3q20a_4 (NPS introduced this wave).
+  - Organic (§3): manure pp_s3q21 / compost pp_s3q23 / other pp_s3q25.
+  - Pesticide (§4): pp_s4q05 used, gated by pp_s4q04==2.
+i = household_id2 (matches sample().i for W3).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_inputs_for_wave
+
+
+plot_roster = get_dataframe('../Data/sect3_pp_w3.dta', convert_categoricals=False)
+planting    = get_dataframe('../Data/sect4_pp_w3.dta', convert_categoricals=False)
+seeds       = get_dataframe('../Data/sect5_pp_w3.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id2', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+
+    # seed quantity from §4 (kg + grams); improved from §4
+    seed_src='planting', seed_crop_code='crop_code',
+    seed_qty_a='pp_s4q11b_a', seed_qty_b='pp_s4q11b_b',
+    improved_code='pp_s4q11', improved_yes=(2,),
+
+    # seed purchase from §5 (holder-crop grain)
+    p_holder_id='holder_id', p_crop_code='crop_code',
+    p_purch_flag='pp_s5q03', p_purch_a='pp_s5q05_a', p_purch_b='pp_s5q05_b',
+
+    # inorganic fertilizer (§3): Urea / DAP / NPS
+    urea_used='pp_s3q15', urea_kg='pp_s3q16', urea_purch_kg='pp_s3q16c',
+    dap_used='pp_s3q18', dap_kg='pp_s3q19', dap_purch_kg='pp_s3q19c',
+    nps_used='pp_s3q20a_1', nps_kg='pp_s3q20a_2', nps_purch_kg='pp_s3q20a_4',
+    # organic (§3)
+    manure_used='pp_s3q21', compost_used='pp_s3q23', other_organic_used='pp_s3q25',
+
+    # pesticide (§4)
+    pest_crop_code='crop_code', pest_used='pp_s4q05', pest_gate='pp_s4q04',
+)
+
+df = plot_inputs_for_wave('2015-16', plot_roster, planting, seeds, colmap)
+
+assert len(df) > 0, "plot_inputs 2015-16 produced no rows"
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Ethiopia/2018-19/_/plot_inputs.py
+++ b/lsms_library/countries/Ethiopia/2018-19/_/plot_inputs.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""Build plot_inputs for Ethiopia ESS 2018-19 (Wave 4; GAP 2).
+
+Item-level ag inputs at (t, i, plot_id, input, j).
+
+W4 renamed the pp variables (dropped the ``pp_`` prefix) and restructured
+§3 fertilizer.  Sources / specifics:
+  - Seed quantity (§4 sect4_pp_w4): kg = s4q11a, crop code s4q01b,
+    improved s4q11 (1=No, 2/4=Yes); the .do drops s4q15==1 (immature /
+    cut-green rows) from the seed block.
+  - Seed purchase (§5 sect5_pp_w4): s5q02 flag + s5q04 kg, crop s5q0B,
+    at (HOLDER, crop) grain -> attached unambiguously (one plot only).
+  - Fertilizer (§3 sect3_pp_w4): UREA used s3q21, kg s3q21a, purchased
+    s3q21c; DAP used s3q22, kg s3q22a, purchased s3q22c; NPS used s3q23,
+    kg s3q23a, purchased s3q23c.
+  - Organic (§3): manure s3q25 / compost s3q26 / other s3q27.
+  - Pesticide (§4): s4q05 used, gated by s4q04==2.
+i = household_id (matches sample().i for W4 -- entirely new sample).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_inputs_for_wave
+
+
+plot_roster = get_dataframe('../Data/sect3_pp_w4.dta', convert_categoricals=False)
+planting    = get_dataframe('../Data/sect4_pp_w4.dta', convert_categoricals=False)
+seeds       = get_dataframe('../Data/sect5_pp_w4.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+
+    # seed quantity from §4 (kg); improved from §4; drop s4q15==1
+    seed_src='planting', seed_crop_code='s4q01b',
+    seed_qty='s4q11a', seed_drop_col='s4q15', seed_drop_val=1,
+    improved_code='s4q11', improved_yes=(2, 3, 4),
+
+    # seed purchase from §5 (holder-crop grain)
+    p_holder_id='holder_id', p_crop_code='s5q0B',
+    p_purch_flag='s5q02', p_purch_qty='s5q04',
+
+    # inorganic fertilizer (§3): Urea / DAP / NPS, total + purchased kg
+    urea_used='s3q21', urea_kg='s3q21a', urea_purch_kg='s3q21c',
+    dap_used='s3q22', dap_kg='s3q22a', dap_purch_kg='s3q22c',
+    nps_used='s3q23', nps_kg='s3q23a', nps_purch_kg='s3q23c',
+    # organic (§3)
+    manure_used='s3q25', compost_used='s3q26', other_organic_used='s3q27',
+
+    # pesticide (§4)
+    pest_crop_code='s4q01b', pest_used='s4q05', pest_gate='s4q04',
+)
+
+df = plot_inputs_for_wave('2018-19', plot_roster, planting, seeds, colmap)
+
+assert len(df) > 0, "plot_inputs 2018-19 produced no rows"
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Ethiopia/2021-22/_/plot_inputs.py
+++ b/lsms_library/countries/Ethiopia/2021-22/_/plot_inputs.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""Build plot_inputs for Ethiopia ESS 2021-22 (Wave 5; GAP 2).
+
+Item-level ag inputs at (t, i, plot_id, input, j).  W5 shares W4's
+restructured §3 fertilizer and renamed (no ``pp_`` prefix) pp variables.
+
+Sources / specifics:
+  - Seed quantity (§4 sect4_pp_w5): kg = s4q11a, crop code s4q01b,
+    improved s4q11 (1=No, 2/4=Yes); drop s4q15==1 (immature / cut-green).
+  - Seed purchase (§5 sect5_pp_w5): s5q02 flag + s5q04 kg, crop s5q0B,
+    at (HOLDER, crop) grain -> attached unambiguously (one plot only).
+  - Fertilizer (§3 sect3_pp_w5): UREA used s3q21, kg s3q21a, purchased
+    s3q21c; DAP used s3q22, kg s3q22a, purchased s3q22c; NPS used s3q23,
+    kg s3q23a, purchased s3q23c.
+  - Organic (§3): manure s3q25 / compost s3q26 / other s3q27.
+  - Pesticide (§4): s4q05 used, gated by s4q04==2.
+i = household_id (matches sample().i for W5).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_inputs_for_wave
+
+
+plot_roster = get_dataframe('../Data/sect3_pp_w5.dta', convert_categoricals=False)
+planting    = get_dataframe('../Data/sect4_pp_w5.dta', convert_categoricals=False)
+seeds       = get_dataframe('../Data/sect5_pp_w5.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+
+    # seed quantity from §4 (kg); improved from §4; drop s4q15==1
+    seed_src='planting', seed_crop_code='s4q01b',
+    seed_qty='s4q11a', seed_drop_col='s4q15', seed_drop_val=1,
+    improved_code='s4q11', improved_yes=(2, 3, 4),
+
+    # seed purchase from §5 (holder-crop grain)
+    p_holder_id='holder_id', p_crop_code='s5q0B',
+    p_purch_flag='s5q02', p_purch_qty='s5q04',
+
+    # inorganic fertilizer (§3): Urea / DAP / NPS, total + purchased kg
+    urea_used='s3q21', urea_kg='s3q21a', urea_purch_kg='s3q21c',
+    dap_used='s3q22', dap_kg='s3q22a', dap_purch_kg='s3q22c',
+    nps_used='s3q23', nps_kg='s3q23a', nps_purch_kg='s3q23c',
+    # organic (§3)
+    manure_used='s3q25', compost_used='s3q26', other_organic_used='s3q27',
+
+    # pesticide (§4)
+    pest_crop_code='s4q01b', pest_used='s4q05', pest_gate='s4q04',
+)
+
+df = plot_inputs_for_wave('2021-22', plot_roster, planting, seeds, colmap)
+
+assert len(df) > 0, "plot_inputs 2021-22 produced no rows"
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Ethiopia/_/CONTENTS.org
+++ b/lsms_library/countries/Ethiopia/_/CONTENTS.org
@@ -491,6 +491,66 @@ cross-country alignment.
   - =Ethiopia/_/categorical_mapping.org= -- =harmonize_acquire=,
     =harmonize_soil=, =harmonize_area_unit=.
 
+* plot_inputs (GAP 2)
+
+Item-level ag inputs at =(t, i, plot_id, input, j)= -- one row per input
+APPLIED to a plot (or plot-crop), from the ESS post-planting input modules.
+Joins =plot_features= / =crop_production= on =(t, i, plot_id)= (identical
+=plot_id= and =i= construction), and =plot_inputs.j= joins
+=crop_production.j= / =food_acquired.j= for the crop-specific (Seed /
+Pesticide) rows via the shared =harmonize_crop= labels.
+
+** Source grains (three sections, three grains)
+
+  - §3 plot roster (=sect3_pp=) -- ONE ROW PER FIELD.  Inorganic-fertilizer
+    use + reported kg per type (Urea / DAP / NPS) and organic-fertilizer use
+    dummies (Manure / Compost / Other Organic).  PLOT-LEVEL (no crop) -> these
+    rows carry =j = 'Whole Plot'= (the reserved non-crop sentinel, since =j=
+    is an index level and cannot be null -- mirrors how =crop_production=
+    fills its =u= level).
+  - §4 planting (=sect4_pp=) -- ONE ROW PER (FIELD, CROP).  Seed quantity (kg;
+    W2-W5; W1's seed qty is in §5), the improved-seed flag, and the
+    pesticide-use dummy.  CROP-specific -> =j = crop Preferred Label=.
+  - §5 seed (=sect5_pp=) -- seed PURCHASE detail (purchased y/n, purchased
+    kg).  W1's §5 is (field, crop) grain (direct plot-crop join); W2-W5's §5
+    is (HOLDER, crop) grain (no field_id), so its purchased columns attach to
+    the §4 plot-crop seed rows ONLY where the (holder, crop) maps to exactly
+    ONE plot (the SALES GRAIN CAVEAT =crop_production= uses for §11 sales).
+
+** Per-wave variable drift
+
+  - W1 (2011-12): seed qty in §5 (=pp_s5q19_a= kg + =pp_s5q19_b= g); UREA/DAP
+    kg read from the =_c= kg-form (=pp_s3q16_c= / =pp_s3q19_c=); NO NPS.
+  - W2 (2013-14): seed qty moves to §4 (=pp_s4q11b=); UREA kg =pp_s3q16_a= +
+    purchased =pp_s3q16c=; DAP =pp_s3q19_a= / =pp_s3q19c=; NO NPS.
+  - W3 (2015-16): seed qty =pp_s4q11b_a= + =pp_s4q11b_b= g; NPS INTRODUCED
+    (used =pp_s3q20a_1=, kg =pp_s3q20a_2=, purchased =pp_s3q20a_4=).
+  - W4 (2018-19) / W5 (2021-22): the =pp_= prefix is dropped and §3
+    restructured -- UREA =s3q21=/=s3q21a=/=s3q21c=, DAP =s3q22*=, NPS
+    =s3q23*=, organic =s3q25/26/27=; seed qty =s4q11a= (crop =s4q01b=,
+    improved =s4q11= with 2/4=Yes), §5 purchase =s5q02=/=s5q04= (crop
+    =s5q0B=); the seed block drops =s4q15==1= (immature / cut-green rows).
+    DAP nearly disappears by W5 (3 rows) as NPS displaces it.
+
+** Columns (all REPORTED, item-level)
+
+=Quantity= + =u= (applied kg; =u='Kg'= for every ESS input quantity),
+=Purchased= (seed purchased y/n), =Quantity_purchased= (seed + fertilizer
+purchased kg where recorded), =Improved= (improved-seed flag, seed rows),
+=Applied= (the reported applied/used dummy -- the sole datum for organic /
+pesticide rows, which carry NO quantity in ESS; also set for fertilizer rows
+that report use without a kg; NaN for seed rows).  NO =nitrogen_kg= /
+=seed_kg= sums, NO any-use roll-up flags, NO fertilizer totals -- those are
+=transformations= over these item rows (GAP 2 / GAP 7).
+
+** Files
+
+  - =Ethiopia/_/ethiopia.py:plot_inputs_for_wave= -- shared helper.
+  - =Ethiopia/<wave>/_/plot_inputs.py= -- per-wave drivers (colmaps).
+  - =Ethiopia/_/plot_inputs.py= -- country concatenator (+ id_walk).
+  - =Ethiopia/_/categorical_mapping.org= -- =harmonize_input= (input
+    taxonomy), =harmonize_crop= (crop =j= for seed/pesticide rows).
+
 * Files in Ethiopia/<SOMEYEAR>/_/
 ** DONE household_characteristics.py
 CLOSED: [2023-03-03 Fri 11:26]

--- a/lsms_library/countries/Ethiopia/_/Makefile
+++ b/lsms_library/countries/Ethiopia/_/Makefile
@@ -17,7 +17,8 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 # household_characteristics is auto-derived too (_ROSTER_DERIVED, GH #260).
 var = \
       $(VAR_DIR)/shocks.parquet $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet \
-      $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/crop_production.parquet
+      $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/crop_production.parquet \
+      $(VAR_DIR)/plot_inputs.parquet
 
 all: panel_ids.json updated_ids.json $(parquet) $(var)
 
@@ -73,6 +74,19 @@ crop_production_parquet := $(crop_production:.py=.parquet)
 
 $(VAR_DIR)/crop_production.parquet: crop_production.py $(crop_production_parquet)
 	python crop_production.py
+
+# plot_inputs (GAP 2; ESS §3/§4/§5 post-planting item-level ag inputs).
+# Mirrors the crop_production convention: the framework's grab_data calls
+# `make ../<wave>/_/plot_inputs.parquet`, whose pattern rule runs the wave
+# script; the VAR_DIR rule concatenates them via the country script.
+plot_inputs = $(shell find $(rounds) -name plot_inputs.py)
+plot_inputs_parquet := $(plot_inputs:.py=.parquet)
+
+../%/_/plot_inputs.parquet: ../%/_/plot_inputs.py
+	(cd $(@D) && python plot_inputs.py)
+
+$(VAR_DIR)/plot_inputs.parquet: plot_inputs.py $(plot_inputs_parquet)
+	python plot_inputs.py
 
 # food_coping (GH #332, Family B; ESS §7 CSI/rCSI day-count battery).
 # Mirrors the plot_features convention: the framework's grab_data calls

--- a/lsms_library/countries/Ethiopia/_/categorical_mapping.org
+++ b/lsms_library/countries/Ethiopia/_/categorical_mapping.org
@@ -565,3 +565,39 @@ Kale/Cabbage -> Leafy Greens) so the join still lands.
 |  120 | Other cereal        |
 |  121 | Other Cash Crop     |
 |  123 | Other vegetable     |
+
+* harmonize_input (the input axis -- GAP 2, plot_inputs)
+
+Code-keyed input-type taxonomy for the ESS post-planting input modules
+(sect3_pp fertilizer/organic, sect4_pp seed/pesticide, sect5_pp seed
+purchase).  Maps a small stable internal code to a Preferred Label.
+
+The taxonomy is the shared ag-input set the parity loop standardises on
+across countries (Seed / inorganic-fertilizer types / organic-fertilizer
+types / pesticide), so plot_inputs.input aligns cross-country.  ESS does
+NOT report a numeric input code in the raw data -- the input identity is
+implicit in WHICH question/section is being read -- so ``ethiopia.
+plot_inputs_for_wave`` emits these Preferred Labels DIRECTLY (the same
+in-script labelling crop_production uses for crops); this table is the
+authoritative label source + a cross-country reference, not a runtime
+auto-mapping target (the index level is named ``input``, this table
+``harmonize_input``, so the name-match auto-mapper deliberately does not
+fire on it).
+
+ESS fertilizer coverage by wave: Urea + DAP every wave; NPS added in W3
+(2015-16) and carried in W4/W5; Manure/Compost/Other Organic every wave;
+Pesticide every wave.  Reported quantities (Urea/DAP/NPS kg, seed kg,
+seed purchased kg) are all in kilograms (u = 'Kg'); organic and pesticide
+rows carry an applied-y/n flag only (no quantity in the survey).
+
+#+name: harmonize_input
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Seed            |
+|    2 | Urea            |
+|    3 | DAP             |
+|    4 | NPS             |
+|    5 | Manure          |
+|    6 | Compost         |
+|    7 | Other Organic   |
+|    8 | Pesticide       |

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -114,6 +114,60 @@ Data Scheme:
     perennial: bool
     materialize: make
 
+  plot_inputs:
+    # GAP 2 -- item-level ag inputs at (t, i, plot_id, input, j).  One row
+    # per input APPLIED to a plot (or plot-crop), from the ESS post-planting
+    # input modules: §3 (sect3_pp) fertilizer/organic, §4 (sect4_pp) seed +
+    # pesticide, §5 (sect5_pp) seed purchase.  Carries only REPORTED,
+    # item-level fields:
+    #   input               input identity (Seed / Urea / DAP / NPS / Manure /
+    #                       Compost / Other Organic / Pesticide; Preferred
+    #                       Labels emitted in-script from harmonize_input).
+    #   Quantity + u        reported applied quantity in its native unit
+    #                       ('Kg' for every ESS input quantity).
+    #   Purchased           was the seed PURCHASED (nullable bool; seed rows,
+    #                       from the §5 purchased-flag, attached where the
+    #                       (holder, crop) maps to a single plot).
+    #   Quantity_purchased  reported purchased kg (seed rows; fertilizer
+    #                       purchased kg where the §3 module records it, W2+).
+    #   Improved            improved-seed flag (nullable bool; seed rows only).
+    #   Applied             reported applied/used dummy (nullable bool).  ESS
+    #                       records organic fertilizer (Manure/Compost/Other
+    #                       Organic) and Pesticide as a yes/no USE flag with NO
+    #                       quantity, so for those input types the reported
+    #                       datum is this flag (one row per applied input);
+    #                       also set for inorganic-fertilizer rows that report
+    #                       use without a kg.  NaN for seed rows (their use is
+    #                       implied by Quantity / Improved / Purchased).
+    #
+    # j (crop axis): the crop Preferred Label (harmonize_crop == food labels,
+    # so seed/pesticide rows join crop_production.j / food_acquired.j) for the
+    # crop-specific inputs (Seed, Pesticide); the 'Whole Plot' sentinel for
+    # plot-level fertilizer/organic inputs (which carry no crop -- j cannot be
+    # null as an index level, mirroring how crop_production fills its u level).
+    # plot_id and i match plot_features / crop_production exactly.
+    #
+    # NO nitrogen_kg / seed_kg sums, NO any-use roll-up flags, NO fertilizer
+    # totals (those are transformations over these item rows -- GAP 2/7).
+    # Multi-file joins (§3+§4+§5) + per-section grain + code->label
+    # harmonization => script (materialize: make).  Seed-purchase detail
+    # attaches from the (holder, crop)-grain §5 ONLY where the (holder, crop)
+    # maps to a single plot (the SALES GRAIN CAVEAT crop_production uses).
+    index: (t, i, plot_id, input, j)
+    Quantity: float
+    u: str
+    Purchased:
+      type: bool
+      optional: true
+    Quantity_purchased: float
+    Improved:
+      type: bool
+      optional: true
+    Applied:
+      type: bool
+      optional: true
+    materialize: make
+
   food_security:
     # FAO FIES 8-item experience scale (GH #332).  Confirmed ONLY in
     # W5 (2021-22): ESS §8 file sect8_hh_w5.dta carries the FAO battery

--- a/lsms_library/countries/Ethiopia/_/ethiopia.py
+++ b/lsms_library/countries/Ethiopia/_/ethiopia.py
@@ -1074,3 +1074,391 @@ def crop_production_for_wave(t, harvest, planting, sale, colmap,
     out = out[['Quantity', 'Quantity_sold', 'Value_sold',
                'planting_month', 'harvest_month', 'intercropped', 'perennial']]
     return out
+
+
+# plot_inputs (GAP 2 — item-level ag inputs at (t, i, plot, input, j))
+# ---------------------------------------------------------------------
+#
+# ESS records the inputs applied to a plot in the post-planting (pp) round
+# across three sections, at THREE DIFFERENT GRAINS:
+#
+#   §3 plot roster (sect3_pp)  : ONE ROW PER FIELD.  Inorganic-fertilizer
+#       use + reported kg per type (Urea / DAP / NPS), and organic-fertilizer
+#       use dummies (Manure / Compost / Other Organic).  Fertilizer is a
+#       PLOT-LEVEL input (no crop) -> these rows carry j = WHOLE_PLOT_SENTINEL.
+#   §4 planting (sect4_pp)     : ONE ROW PER (FIELD, CROP).  Seed quantity
+#       (kg) + the improved-seed flag (W2-W5; for W1 the seed quantity lives
+#       in §5).  Pesticide use (a plot-crop dummy).  These are CROP-specific
+#       -> j = the crop Preferred Label.
+#   §5 seed (sect5_pp)         : seed PURCHASE detail (purchased y/n, purchased
+#       qty kg, and, for W1, the seed quantity itself).  W1's §5 is at
+#       (field, crop) grain; W2-W5's §5 is at (HOLDER, crop) grain (no
+#       field_id), so its purchased columns attach to the §4 plot-crop seed
+#       rows ONLY where the (holder, crop) maps to exactly ONE plot
+#       (the same SALES GRAIN CAVEAT crop_production uses for §11 sales).
+#
+# We emit ONE ROW PER (plot, input[, crop]) carrying only REPORTED,
+# item-level fields:
+#   input               input identity (Preferred Label via harmonize_input)
+#   Quantity            reported applied quantity (native unit u; kg here)
+#   u                   native unit ('Kg' for every ESS input quantity)
+#   Purchased           was the input purchased (nullable bool; seed rows)
+#   Quantity_purchased  reported purchased quantity (kg; seed rows)
+#   Improved            improved-seed flag (nullable bool; seed rows only)
+#
+# NO unit->kg re-conversion (the source already reports kg), NO nitrogen_kg
+# / seed_kg sums, NO any-use roll-up flags, NO fertilizer totals -- those are
+# transformations over these item rows (GAP 2 / GAP 7), not stored columns.
+#
+# Grain / IDs: plot_id == format_id(holder_id)_format_id(parcel_id)_
+# format_id(field_id) and i == format_id(household_id[2]), IDENTICAL to
+# plot_features / crop_production (so plot_inputs joins them on (t, i, plot)).
+# crop labels reuse harmonize_crop (== the food Preferred Labels) so seed/
+# pesticide rows' j joins crop_production.j and food_acquired.j.
+#
+# WHOLE_PLOT_SENTINEL: a plot-level (non-crop) input cannot carry a real
+# crop label, but `j` is an index level (no nulls allowed; crop_production
+# fills its `u` level the same way).  We tag those rows with a reserved,
+# clearly-non-crop label so the index stays clean and the crop axis is never
+# silently corrupted; downstream code selects crop-specific inputs with
+# `j != 'Whole Plot'`.
+WHOLE_PLOT_SENTINEL = 'Whole Plot'
+
+# Reported nitrogen-fertilizer types whose kg is recorded per plot in §3.
+# (N-content factors live in transformations, NEVER here.)
+PLOT_INPUT_FERTILIZERS = ('Urea', 'DAP', 'NPS')
+PLOT_INPUT_ORGANICS = ('Manure', 'Compost', 'Other Organic')
+
+
+def _eth_input_label_map():
+    """Load the code-keyed harmonize_input table -> {code: Preferred Label}.
+
+    The table documents the shared ESS input taxonomy (Seed / Urea / DAP /
+    NPS / Manure / Compost / Other Organic / Pesticide).  Labels are emitted
+    directly in-script (as crop_production does for crops), so the table is
+    the authoritative label source and a cross-country reference -- not a
+    runtime auto-mapping (the index level is named ``input``, the table
+    ``harmonize_input``, so the name-match auto-mapper does not fire)."""
+    return _harmonize_code_label('harmonize_input')
+
+
+def _yesno_bool(series, yes=1, no=2):
+    """Recode an ESS 1=Yes / 2=No code Series to nullable boolean."""
+    n = pd.to_numeric(series, errors='coerce').astype('Int64')
+    out = pd.Series(pd.NA, index=n.index, dtype='boolean')
+    return out.mask(n == yes, True).mask(n == no, False)
+
+
+def _plot_id_from(df, c, holder='holder_id', parcel='parcel_id', field='field_id'):
+    """holder_parcel_field plot_id, identical to plot_features/crop_production."""
+    return (df[c[holder]].apply(format_id).astype(str) + '_'
+            + df[c[parcel]].apply(format_id).astype(str) + '_'
+            + df[c[field]].apply(format_id).astype(str))
+
+
+def plot_inputs_for_wave(t, plot_roster, planting, seeds, colmap, labels=None):
+    """Build canonical ``plot_inputs`` for one Ethiopia ESS wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2011-12"``), the ``t`` index value.
+    plot_roster : pd.DataFrame or None
+        Raw §3 plot roster (sect3_pp_w{N}.dta), loaded with
+        ``convert_categoricals=False``.  Source of the per-plot
+        fertilizer (Urea/DAP/NPS kg) and organic-fertilizer dummies.
+    planting : pd.DataFrame or None
+        Raw §4 planting crop file (sect4_pp_w{N}.dta), source of the
+        plot-crop seed quantity (W2-W5), the improved-seed flag, and the
+        pesticide-use dummy.
+    seeds : pd.DataFrame or None
+        Raw §5 seed file (sect5_pp_w{N}.dta), source of seed PURCHASE
+        detail (and, for W1, the seed quantity itself).
+    colmap : dict
+        Per-wave column map.  Recognised keys (all optional; a section is
+        skipped when its keys are absent / the frame is None):
+            hhid, holder_id, parcel_id, field_id   — id / plot_id columns
+
+          § seed (the file carrying the plot-crop seed quantity):
+            seed_src ∈ {'seeds', 'planting'}        — which frame holds qty
+            seed_crop_code                          — crop code in seed_src
+            seed_qty / seed_qty_a / seed_qty_b      — qty col, or kg+gram cols
+            improved_code / improved_yes            — improved flag + yes-codes
+
+          § seed purchase (always from §5):
+            p_holder_id, p_crop_code                — §5 grain keys
+            p_field_id, p_parcel_id                 — present only for W1 §5
+            p_purch_flag                            — purchased y/n (2=No)
+            p_purch_a / p_purch_b / p_purch_qty     — purchased kg (+gram)
+
+          § fertilizer (§3 plot roster):
+            urea_used, urea_kg, dap_used, dap_kg,
+            nps_used, nps_kg                         — per-type use + kg
+            urea_purch_kg, dap_purch_kg, nps_purch_kg — purchased kg (W2+)
+
+          § organic (§3 plot roster):
+            manure_used, compost_used, other_organic_used
+
+          § pesticide (§4 planting):
+            pest_crop_code, pest_used, pest_gate     — used + gate (2 zeros it)
+    labels : dict or None
+        Optional {input_code: Preferred Label} override; defaults to the
+        harmonize_input table.
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id, input, j)`` with columns
+        Quantity (float), u (str), Purchased (boolean),
+        Quantity_purchased (float), Improved (boolean).
+    """
+    c = colmap
+    crop_map = _eth_crop_label_map()
+    pieces = []
+
+    # ---- SEED (plot-crop) -------------------------------------------
+    seed_src = c.get('seed_src')
+    src = {'seeds': seeds, 'planting': planting}.get(seed_src)
+    if src is not None and c.get('seed_crop_code'):
+        s = src.copy()
+        # Optional seed-block gate (W4/W5 drop s4q15==1 immature/cut rows).
+        if c.get('seed_drop_col') and c['seed_drop_col'] in s.columns:
+            gate = pd.to_numeric(s[c['seed_drop_col']], errors='coerce')
+            s = s[gate != c.get('seed_drop_val', 1)].copy()
+        pid = _plot_id_from(s, c)
+        code = pd.to_numeric(s[c['seed_crop_code']], errors='coerce').astype('Int64')
+        # seed quantity (kg): either a single col or kg + gram pair.
+        if c.get('seed_qty') and c['seed_qty'] in s.columns:
+            qty = pd.to_numeric(s[c['seed_qty']], errors='coerce').astype('Float64')
+        elif c.get('seed_qty_a') and c['seed_qty_a'] in s.columns:
+            a = pd.to_numeric(s[c['seed_qty_a']], errors='coerce')
+            g = (pd.to_numeric(s[c['seed_qty_b']], errors='coerce') * 0.001
+                 if c.get('seed_qty_b') and c['seed_qty_b'] in s.columns
+                 else pd.Series(0.0, index=s.index))
+            qty = a.add(g, fill_value=0).astype('Float64').where(
+                a.notna() | (g != 0), pd.NA)
+        else:
+            qty = pd.Series(pd.NA, index=s.index, dtype='Float64')
+        qty = qty.mask(qty < 0, pd.NA)
+        # improved flag.
+        if c.get('improved_code') and c['improved_code'] in s.columns:
+            ic = pd.to_numeric(s[c['improved_code']], errors='coerce').astype('Int64')
+            yes = set(c.get('improved_yes', (2,)))
+            improved = pd.Series(pd.NA, index=s.index, dtype='boolean')
+            improved = improved.mask(ic.isin(list(yes)), True)
+            improved = improved.mask(ic.notna() & ~ic.isin(list(yes)), False)
+        else:
+            improved = pd.Series(pd.NA, index=s.index, dtype='boolean')
+
+        seed_df = pd.DataFrame({
+            'i':        s[c['hhid']].apply(format_id).values,
+            'plot_id':  pid.values,
+            '_holder':  s[c['holder_id']].apply(format_id).values,
+            '_code':    code.values,
+            'j':        code.map(crop_map).astype('string').values,
+            'input':    'Seed',
+            'Quantity': qty.values,
+            'u':        'Kg',
+            'Improved': improved.values,
+            'Applied':  pd.Series(pd.NA, index=s.index, dtype='boolean').values,
+        })
+
+        # Improved flag may instead live in the §4 planting file (W1: §5 has
+        # no improved column).  Join it on (plot_id, crop) where requested.
+        if (c.get('improved_join') and planting is not None
+                and c.get('improved_code') and c['improved_code'] in planting.columns):
+            ipl_pid = _plot_id_from(planting, c)
+            ipl_code = pd.to_numeric(planting[c['pl_crop_code']], errors='coerce').astype('Int64') \
+                if c.get('pl_crop_code') and c['pl_crop_code'] in planting.columns \
+                else pd.to_numeric(planting.get(c['seed_crop_code']), errors='coerce').astype('Int64')
+            iic = pd.to_numeric(planting[c['improved_code']], errors='coerce').astype('Int64')
+            yes = set(c.get('improved_yes', (2,)))
+            ibool = pd.Series(pd.NA, index=planting.index, dtype='boolean')
+            ibool = ibool.mask(iic.isin(list(yes)), True)
+            ibool = ibool.mask(iic.notna() & ~iic.isin(list(yes)), False)
+            idf = pd.DataFrame({'plot_id': ipl_pid.values, '_code': ipl_code.values,
+                                '_imp': ibool.values}) \
+                .dropna(subset=['plot_id', '_code']).drop_duplicates(['plot_id', '_code'])
+            seed_df = seed_df.merge(idf, on=['plot_id', '_code'], how='left')
+            seed_df['Improved'] = seed_df.pop('_imp').astype('boolean')
+
+        # Seed PURCHASE detail from §5 (purchased y/n, purchased kg).
+        seed_df['Purchased'] = pd.Series(pd.NA, index=seed_df.index, dtype='boolean')
+        seed_df['Quantity_purchased'] = pd.Series(pd.NA, index=seed_df.index, dtype='Float64')
+        if seeds is not None and c.get('p_purch_flag'):
+            ps = seeds.copy()
+            p_holder = ps[c['p_holder_id']].apply(format_id)
+            p_code = pd.to_numeric(ps[c['p_crop_code']], errors='coerce').astype('Int64')
+            purch = _yesno_bool(ps[c['p_purch_flag']])
+            if c.get('p_purch_qty') and c['p_purch_qty'] in ps.columns:
+                pqty = pd.to_numeric(ps[c['p_purch_qty']], errors='coerce').astype('Float64')
+            elif c.get('p_purch_a') and c['p_purch_a'] in ps.columns:
+                pa = pd.to_numeric(ps[c['p_purch_a']], errors='coerce')
+                pg = (pd.to_numeric(ps[c['p_purch_b']], errors='coerce') * 0.001
+                      if c.get('p_purch_b') and c['p_purch_b'] in ps.columns
+                      else pd.Series(0.0, index=ps.index))
+                pqty = pa.add(pg, fill_value=0).astype('Float64').where(
+                    pa.notna() | (pg != 0), pd.NA)
+            else:
+                pqty = pd.Series(pd.NA, index=ps.index, dtype='Float64')
+            # purchased flag No -> 0 purchased quantity (mirrors the .do).
+            pqty = pqty.mask(purch == False, 0.0)
+
+            if c.get('p_field_id') and c['p_field_id'] in ps.columns:
+                # W1: §5 carries field_id -> direct plot-crop join.
+                p_pid = _plot_id_from(ps, c, parcel=c.get('p_parcel_id', 'parcel_id'),
+                                      field=c['p_field_id'])
+                pdf = pd.DataFrame({
+                    'plot_id': p_pid.values, '_code': p_code.values,
+                    'Purchased': purch.values, 'Quantity_purchased': pqty.values,
+                }).dropna(subset=['plot_id', '_code']).drop_duplicates(['plot_id', '_code'])
+                seed_df = seed_df.drop(columns=['Purchased', 'Quantity_purchased'])
+                seed_df = seed_df.merge(pdf, on=['plot_id', '_code'], how='left')
+            else:
+                # W2-W5: §5 is (holder, crop) grain -> attach only where the
+                # (holder, crop) maps to exactly ONE plot (the SALES GRAIN
+                # CAVEAT; never split a holder figure across plots).
+                pagg = pd.DataFrame({
+                    '_holder': p_holder.values, '_code': p_code.values,
+                    '_purch_any': (purch == True).values,
+                    'Quantity_purchased': pqty.values,
+                })
+                pagg = pagg.dropna(subset=['_holder', '_code'])
+                pa2 = pagg.groupby(['_holder', '_code'], as_index=False).agg(
+                    _purch_any=('_purch_any', 'max'),
+                    Quantity_purchased=('Quantity_purchased', 'sum'),
+                )
+                nplots = (seed_df.dropna(subset=['_code'])
+                          .groupby(['_holder', '_code'])['plot_id'].nunique()
+                          .rename('_n').reset_index())
+                keep = nplots[nplots['_n'] == 1][['_holder', '_code']]
+                pa2 = pa2.merge(keep, on=['_holder', '_code'], how='inner')
+                seed_df = seed_df.drop(columns=['Purchased', 'Quantity_purchased'])
+                seed_df = seed_df.merge(pa2, on=['_holder', '_code'], how='left')
+                seed_df['Purchased'] = seed_df.pop('_purch_any').astype('boolean')
+
+        seed_df = seed_df.drop(columns=['_holder', '_code'])
+        # Keep a seed row only if it carries a crop and SOME reported value.
+        seed_df = seed_df.dropna(subset=['j'])
+        has_val = (seed_df['Quantity'].notna() | seed_df['Improved'].notna()
+                   | seed_df['Purchased'].notna() | seed_df['Quantity_purchased'].notna())
+        seed_df = seed_df[has_val]
+        pieces.append(seed_df)
+
+    # ---- FERTILIZER + ORGANIC (plot-level, §3) ----------------------
+    if plot_roster is not None:
+        pr = plot_roster.copy()
+        pid = _plot_id_from(pr, c)
+        hh = pr[c['hhid']].apply(format_id)
+        fert_specs = [
+            ('Urea',          c.get('urea_used'), c.get('urea_kg'), c.get('urea_purch_kg')),
+            ('DAP',           c.get('dap_used'),  c.get('dap_kg'),  c.get('dap_purch_kg')),
+            ('NPS',           c.get('nps_used'),  c.get('nps_kg'),  c.get('nps_purch_kg')),
+        ]
+        for name, used_col, kg_col, purch_col in fert_specs:
+            if not (kg_col and kg_col in pr.columns):
+                continue
+            used = _yesno_bool(pr[used_col]) if (used_col and used_col in pr.columns) else None
+            kg = pd.to_numeric(pr[kg_col], errors='coerce').astype('Float64')
+            pqty = (pd.to_numeric(pr[purch_col], errors='coerce').astype('Float64')
+                    if purch_col and purch_col in pr.columns
+                    else pd.Series(pd.NA, index=pr.index, dtype='Float64'))
+            fert = pd.DataFrame({
+                'i': hh.values, 'plot_id': pid.values,
+                'j': WHOLE_PLOT_SENTINEL, 'input': name,
+                'Quantity': kg.values, 'u': 'Kg',
+                'Purchased': pd.Series(pd.NA, index=pr.index, dtype='boolean').values,
+                'Quantity_purchased': pqty.values,
+                'Improved': pd.Series(pd.NA, index=pr.index, dtype='boolean').values,
+                'Applied': (used.values if used is not None
+                            else pd.Series(pd.NA, index=pr.index, dtype='boolean').values),
+                '_used': (used.values if used is not None
+                          else pd.Series(pd.NA, index=pr.index, dtype='boolean').values),
+            })
+            # ONE ROW PER FERTILIZER ACTUALLY APPLIED to a plot.  Keep a row
+            # only where the type was used (used == True) OR a kg / purchased
+            # quantity is reported; a plot that answered "did not use" is NOT
+            # an applied-input row (no zero-quantity placeholder rows -- the
+            # any-use roll-up is a transformation, not stored here).
+            keep = ((fert['_used'] == True) | fert['Quantity'].notna()
+                    | fert['Quantity_purchased'].notna())
+            fert = fert[keep].drop(columns='_used')
+            # Drop a reported 0 kg that is really "not applied".
+            fert['Quantity'] = fert['Quantity'].mask(fert['Quantity'] == 0, pd.NA)
+            pieces.append(fert)
+
+        org_specs = [('Manure', c.get('manure_used')),
+                     ('Compost', c.get('compost_used')),
+                     ('Other Organic', c.get('other_organic_used'))]
+        for name, used_col in org_specs:
+            if not (used_col and used_col in pr.columns):
+                continue
+            used = _yesno_bool(pr[used_col])
+            org = pd.DataFrame({
+                'i': hh.values, 'plot_id': pid.values,
+                'j': WHOLE_PLOT_SENTINEL, 'input': name,
+                'Quantity': pd.Series(pd.NA, index=pr.index, dtype='Float64').values,
+                'u': pd.Series(pd.NA, index=pr.index, dtype='string').values,
+                'Purchased': pd.Series(pd.NA, index=pr.index, dtype='boolean').values,
+                'Quantity_purchased': pd.Series(pd.NA, index=pr.index, dtype='Float64').values,
+                'Improved': pd.Series(pd.NA, index=pr.index, dtype='boolean').values,
+                'Applied': used.values,
+            })
+            # Organic fertilizer carries no reported quantity in ESS -- the
+            # reported datum is the applied dummy, stored in ``Applied``.  Keep
+            # only the plots where it was applied (Applied == True); the
+            # Quantity / Purchased / Quantity_purchased / Improved fields stay
+            # NaN (they are seed-only / fertilizer-purchase fields).
+            org = org[org['Applied'] == True]
+            org['u'] = pd.NA
+            pieces.append(org)
+
+    # ---- PESTICIDE (plot-crop, §4) ----------------------------------
+    if planting is not None and c.get('pest_used') and c['pest_used'] in planting.columns:
+        pl = planting.copy()
+        pid = _plot_id_from(pl, c)
+        code = pd.to_numeric(pl[c['pest_crop_code']], errors='coerce').astype('Int64')
+        used = _yesno_bool(pl[c['pest_used']])
+        if c.get('pest_gate') and c['pest_gate'] in pl.columns:
+            gate = pd.to_numeric(pl[c['pest_gate']], errors='coerce').astype('Int64')
+            used = used.mask(gate == 2, False)
+        pest = pd.DataFrame({
+            'i': pl[c['hhid']].apply(format_id).values,
+            'plot_id': pid.values,
+            'j': code.map(crop_map).astype('string').values,
+            'input': 'Pesticide',
+            'Quantity': pd.Series(pd.NA, index=pl.index, dtype='Float64').values,
+            'u': pd.Series(pd.NA, index=pl.index, dtype='string').values,
+            'Purchased': pd.Series(pd.NA, index=pl.index, dtype='boolean').values,
+            'Quantity_purchased': pd.Series(pd.NA, index=pl.index, dtype='Float64').values,
+            'Improved': pd.Series(pd.NA, index=pl.index, dtype='boolean').values,
+            'Applied': used.values,
+        })
+        pest['u'] = pd.NA
+        pest = pest.dropna(subset=['j'])
+        # Pesticide carries no reported quantity in ESS -- the reported datum
+        # is the applied dummy, stored in ``Applied``.  Keep only the applied
+        # plot-crops; collapse duplicate (plot, crop) rows to plot-crop.
+        pest = pest[pest['Applied'] == True]
+        pest = (pest.groupby(['i', 'plot_id', 'j', 'input'], as_index=False)
+                .agg({'Quantity': 'first', 'u': 'first', 'Purchased': 'first',
+                      'Quantity_purchased': 'first', 'Improved': 'first',
+                      'Applied': 'max'}))
+        pieces.append(pest)
+
+    assert pieces, f"plot_inputs {t}: no input sections produced rows"
+    out = pd.concat(pieces, ignore_index=True)
+    out['t'] = t
+    out = out.dropna(subset=['i', 'plot_id', 'input', 'j'])
+    out['Quantity'] = out['Quantity'].astype('Float64')
+    out['Quantity_purchased'] = out['Quantity_purchased'].astype('Float64')
+    out['Purchased'] = out['Purchased'].astype('boolean')
+    out['Improved'] = out['Improved'].astype('boolean')
+    out['Applied'] = out['Applied'].astype('boolean')
+    out['u'] = out['u'].astype('string')
+    out = out.set_index(['t', 'i', 'plot_id', 'input', 'j'])
+    out = out[['Quantity', 'u', 'Purchased', 'Quantity_purchased',
+               'Improved', 'Applied']]
+    # Collapse any exact-duplicate index rows (defensive; e.g. a plot that
+    # reports the same fertilizer type twice) by taking the first.
+    out = out[~out.index.duplicated(keep='first')]
+    return out.sort_index()

--- a/lsms_library/countries/Ethiopia/_/plot_inputs.py
+++ b/lsms_library/countries/Ethiopia/_/plot_inputs.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""Concatenate wave-level plot_inputs data for Ethiopia (GAP 2).
+
+Each wave's ``Ethiopia/<wave>/_/plot_inputs.py`` produces a parquet with
+index ``(t, i, plot_id, input, j)`` and the canonical plot_inputs columns
+(Quantity, u, Purchased, Quantity_purchased, Improved).  This script
+concatenates them across the five ESS waves and applies the cross-wave
+``id_walk`` so the household index uses the panel canonical id scheme (the
+same conversion ``sample()`` receives at API time, keeping the
+``_join_v_from_sample`` join aligned).
+
+``id_walk`` is idempotent (it sets ``attrs['id_converted']``), so the
+framework's ``_finalize_result`` will skip re-applying it.  The wave
+parquets emit the wave-native household id that matches ``sample().i``
+(``household_id2`` for W2/W3, ``household_id`` elsewhere) -- identical to
+plot_features / crop_production, so the three features join on
+``(t, i, plot_id)`` (and plot_inputs.j joins crop_production.j on the
+shared harmonize_crop labels for crop-specific seed / pesticide rows).
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, id_walk, to_parquet
+from ethiopia import Waves
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/plot_inputs.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet built / parquet absent (DVC raises PathMissingError).
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_inputs: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/plot_inputs.parquet')

--- a/lsms_library/countries/Malawi/2010-11/_/plot_inputs.py
+++ b/lsms_library/countries/Malawi/2010-11/_/plot_inputs.py
@@ -1,0 +1,66 @@
+"""Build plot_inputs for Malawi IHS3 2010-11 (GAP 2).
+
+Item-level (t, i, plot, input, crop, u) feature -- one row per input
+applied to a plot.  Sources (Full_Sample/Agriculture):
+  * ag_mod_d -- plot-level input module.  Inorganic fertilizer in two
+    slots (ag_d39a type / ag_d39d applied-qty / ag_d39e unit; ag_d39f
+    type / ag_d39i applied-qty / ag_d39j unit), organic-fertilizer flag
+    ag_d36, agrochemical types ag_d41a/d gated by ag_d40.  Plot key
+    ag_d00 (the same R{n} key as plot_features' ag_c00 and
+    crop_production's ag_g0b).
+  * ag_mod_g -- seasonal plot-crop roster: seed planted ag_g04a/ag_g04b
+    per (plot=ag_g0b, crop=ag_g0d).  No improved-seed flag in IHS3.
+  * ag_mod_h -- purchased seed (hh, crop): ag_h16a/b + ag_h19 (source 1),
+    ag_h26a/b + ag_h29 (source 2); crop=ag_h0b.  Attached to single-plot
+    seed rows only (no plot in the module).
+
+i = format_id(case_id), aligning with plot_features / crop_production.
+See lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import (_fertilizer_block, _organic_block, _pesticide_block,
+                    _seed_block, _seed_purchase_block, assemble_plot_inputs)
+
+
+WAVE = '2010-11'
+BASE = '../Data/Full_Sample/Agriculture/'
+
+d = get_dataframe(BASE + 'ag_mod_d.dta', convert_categoricals=False)
+g = get_dataframe(BASE + 'ag_mod_g.dta', convert_categoricals=False)
+h = get_dataframe(BASE + 'ag_mod_h.dta', convert_categoricals=False)
+
+d['hhid'] = d['case_id'].apply(format_id)
+d['plotkey'] = d['ag_d00'].apply(format_id)
+g['hhid'] = g['case_id'].apply(format_id)
+g['plotkey'] = g['ag_g0b'].apply(format_id)
+h['hhid'] = h['case_id'].apply(format_id)
+
+pieces = [
+    _fertilizer_block(d, hhid='hhid', plotkey='plotkey',
+                      type1='ag_d39a', qty1='ag_d39d', unit1='ag_d39e',
+                      type2='ag_d39f', qty2='ag_d39i', unit2='ag_d39j',
+                      t=WAVE),
+    _organic_block(d, hhid='hhid', plotkey='plotkey', flag='ag_d36', t=WAVE),
+    _pesticide_block(d, hhid='hhid', plotkey='plotkey', gate='ag_d40',
+                     slots=[('ag_d41a', 'ag_d41b', 'ag_d41c'),
+                            ('ag_d41d', 'ag_d41e', 'ag_d41f')], t=WAVE),
+    _seed_block(g, hhid='hhid', plotkey='plotkey', cropcode='ag_g0d',
+                qty='ag_g04a', unit='ag_g04b', improved=None, t=WAVE),
+]
+
+seed_purchase = [
+    _seed_purchase_block(h, hhid='hhid', cropcode='ag_h0b',
+                         qty_cols=['ag_h16a', 'ag_h26a'],
+                         unit_cols=['ag_h16b', 'ag_h26b'],
+                         value_cols=['ag_h19', 'ag_h29']),
+]
+
+df = assemble_plot_inputs(WAVE, pieces, seed_purchase)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot,input,crop,u) in plot_inputs {WAVE}"
+assert len(df) > 0, f"plot_inputs {WAVE} produced no rows"
+
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Malawi/2013-14/_/plot_inputs.py
+++ b/lsms_library/countries/Malawi/2013-14/_/plot_inputs.py
@@ -1,0 +1,62 @@
+"""Build plot_inputs for Malawi IHPS 2013-14 (GAP 2).
+
+Item-level (t, i, plot, input, crop, u) feature.  Variable names track
+2010-11 except the household id (y2_hhid) and Module G/H crop-code columns
+(seasonal crop is ag_g0b; Module H crop is ag_h0c).  Module D layout is
+the IHS3/IHPS2 generation: slot-2 fertilizer type ag_d39f, applied-qty
+ag_d39i.  No improved-seed flag in this wave.  Sources (flat Data/):
+  * AG_MOD_D_13 -- plot inputs; plot key ag_d00.
+  * AG_MOD_G_13 -- seasonal plot-crop roster; plot ag_g00, crop ag_g0b,
+    seed ag_g04a/ag_g04b.
+  * AG_MOD_H_13 -- purchased seed (hh, crop): ag_h16a/b + ag_h19,
+    ag_h26a/b + ag_h29; crop ag_h0c.
+
+i = format_id(y2_hhid), aligning with plot_features / crop_production.
+See lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import (_fertilizer_block, _organic_block, _pesticide_block,
+                    _seed_block, _seed_purchase_block, assemble_plot_inputs)
+
+
+WAVE = '2013-14'
+
+d = get_dataframe('../Data/AG_MOD_D_13.dta', convert_categoricals=False)
+g = get_dataframe('../Data/AG_MOD_G_13.dta', convert_categoricals=False)
+h = get_dataframe('../Data/AG_MOD_H_13.dta', convert_categoricals=False)
+
+d['hhid'] = d['y2_hhid'].apply(format_id)
+d['plotkey'] = d['ag_d00'].apply(format_id)
+g['hhid'] = g['y2_hhid'].apply(format_id)
+g['plotkey'] = g['ag_g00'].apply(format_id)
+h['hhid'] = h['y2_hhid'].apply(format_id)
+
+pieces = [
+    _fertilizer_block(d, hhid='hhid', plotkey='plotkey',
+                      type1='ag_d39a', qty1='ag_d39d', unit1='ag_d39e',
+                      type2='ag_d39f', qty2='ag_d39i', unit2='ag_d39j',
+                      t=WAVE),
+    _organic_block(d, hhid='hhid', plotkey='plotkey', flag='ag_d36', t=WAVE),
+    _pesticide_block(d, hhid='hhid', plotkey='plotkey', gate='ag_d40',
+                     slots=[('ag_d41a', 'ag_d41b', 'ag_d41c'),
+                            ('ag_d41d', 'ag_d41e', 'ag_d41f')], t=WAVE),
+    _seed_block(g, hhid='hhid', plotkey='plotkey', cropcode='ag_g0b',
+                qty='ag_g04a', unit='ag_g04b', improved=None, t=WAVE),
+]
+
+seed_purchase = [
+    _seed_purchase_block(h, hhid='hhid', cropcode='ag_h0c',
+                         qty_cols=['ag_h16a', 'ag_h26a'],
+                         unit_cols=['ag_h16b', 'ag_h26b'],
+                         value_cols=['ag_h19', 'ag_h29']),
+]
+
+df = assemble_plot_inputs(WAVE, pieces, seed_purchase)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot,input,crop,u) in plot_inputs {WAVE}"
+assert len(df) > 0, f"plot_inputs {WAVE} produced no rows"
+
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Malawi/2016-17/_/plot_inputs.py
+++ b/lsms_library/countries/Malawi/2016-17/_/plot_inputs.py
@@ -1,0 +1,136 @@
+"""Build plot_inputs for Malawi IHS4 2016-17 (GAP 2).
+
+IHS4 ships a Cross_Sectional half (cs-17-prefixed case_id) and a Panel
+half (bare y3_hhid), concatenated into the single 2016-17 wave -- exactly
+like plot_features / crop_production.  Plot key is gardenid_plotid in both
+halves (Module D and Module G agree).
+
+Module D layout is the IHS4/IHS5 generation: slot-1 fertilizer type
+ag_d39a / applied-qty ag_d39d / unit ag_d39e; slot-2 type ag_d39g /
+applied-qty ag_d39j (no distinct slot-2 applied-unit column -> u NaN for
+slot 2).  Module G carries a harmonized `crop_code`, the seed columns
+ag_g04a/ag_g04b, and the improved-seed flag ag_g0f (2 = improved).
+Module H purchased seed: ag_h16a/b + ag_h19, ag_h26a/b + ag_h29;
+crop_code.
+
+The Cross_Sectional ag_mod_d.dta has a latin-1 bad byte in an unused
+free-text column that breaks a full read; we read only the columns we
+need via the _read_usecols helper (same recipe as plot_features 2016-17).
+See lsms_library/countries/Malawi/_/malawi.py.
+"""
+import os
+import sys
+import tempfile
+
+sys.path.append('../../_/')
+import pandas as pd
+import pyreadstat
+
+from lsms_library.local_tools import (get_dataframe, to_parquet, format_id,
+                                       DVCFS, _ensure_dvc_pulled,
+                                       _dvc_working_directory, _COUNTRIES_DIR)
+from malawi import (_fertilizer_block, _organic_block, _pesticide_block,
+                    _seed_block, _seed_purchase_block, assemble_plot_inputs)
+
+
+WAVE = '2016-17'
+
+# Module D columns needed for the input blocks (avoid the latin-1 free-text
+# column by restricting the read).
+_D_USECOLS = ['case_id', 'y3_hhid', 'gardenid', 'plotid',
+              'ag_d36', 'ag_d38', 'ag_d39a', 'ag_d39d', 'ag_d39e',
+              'ag_d39g', 'ag_d39j', 'ag_d40',
+              'ag_d41a', 'ag_d41b', 'ag_d41c',
+              'ag_d41d', 'ag_d41e', 'ag_d41f']
+
+
+def _read_usecols(countries_rel, usecols):
+    """Read only ``usecols`` from a DVC-tracked .dta that a full read
+    cannot decode (latin-1 bad byte in an unused column)."""
+    _ensure_dvc_pulled(countries_rel)
+    with _dvc_working_directory(_COUNTRIES_DIR):
+        with DVCFS.open(countries_rel) as f:
+            data = f.read()
+    with tempfile.NamedTemporaryFile(suffix='.dta', delete=False) as tmp:
+        tmp.write(data)
+        tmp_path = tmp.name
+    try:
+        df, _ = pyreadstat.read_dta(tmp_path, usecols=usecols,
+                                    apply_value_formats=False)
+        return df
+    finally:
+        os.unlink(tmp_path)
+
+
+def _plotkey(df):
+    return (df['gardenid'].apply(format_id) + '_'
+            + df['plotid'].apply(format_id))
+
+
+def _fert_args(d):
+    return dict(type1='ag_d39a', qty1='ag_d39d', unit1='ag_d39e',
+                type2='ag_d39g', qty2='ag_d39j', unit2=None)
+
+
+def _half(d, g, h, hh_of, seed_qty, seed_unit, seed_value):
+    for df in (d, g, h):
+        df['hhid'] = hh_of(df)
+    d['plotkey'] = _plotkey(d)
+    g['plotkey'] = _plotkey(g)
+    pieces = [
+        _fertilizer_block(d, hhid='hhid', plotkey='plotkey', t=WAVE,
+                          **_fert_args(d)),
+        _organic_block(d, hhid='hhid', plotkey='plotkey', flag='ag_d36',
+                       t=WAVE),
+        _pesticide_block(d, hhid='hhid', plotkey='plotkey', gate='ag_d40',
+                         slots=[('ag_d41a', 'ag_d41b', 'ag_d41c'),
+                                ('ag_d41d', 'ag_d41e', 'ag_d41f')], t=WAVE),
+        _seed_block(g, hhid='hhid', plotkey='plotkey', cropcode='crop_code',
+                    qty='ag_g04a', unit='ag_g04b', improved='ag_g0f', t=WAVE),
+    ]
+    # Seed purchase column naming differs by half: the Cross_Sectional file
+    # keeps the original IHS4 names (ag_h07*/ag_h09 source 1, ag_h38*/ag_h40
+    # source 2); the Panel file uses the harmonized ag_h16*/ag_h19,
+    # ag_h26*/ag_h29 that the WB code reads.
+    seed_purchase = [
+        _seed_purchase_block(h, hhid='hhid', cropcode='crop_code',
+                             qty_cols=seed_qty, unit_cols=seed_unit,
+                             value_cols=seed_value),
+    ]
+    return pieces, seed_purchase
+
+
+all_pieces, all_seed_purchase = [], []
+
+# --- Cross-sectional half (cs-17 prefix) ---
+d_xs = _read_usecols('Malawi/2016-17/Data/Cross_Sectional/ag_mod_d.dta',
+                     _D_USECOLS)
+g_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_g.dta',
+                     convert_categoricals=False)
+h_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_h.dta',
+                     convert_categoricals=False)
+p, s = _half(d_xs, g_xs, h_xs,
+             lambda df: 'cs-17-' + df['case_id'].apply(format_id),
+             seed_qty=['ag_h07a', 'ag_h38a'],
+             seed_unit=['ag_h07b', 'ag_h38b'],
+             seed_value=['ag_h09', 'ag_h40'])
+all_pieces += p
+all_seed_purchase += s
+
+# --- Panel half (bare y3_hhid) ---
+d_pn = get_dataframe('../Data/Panel/ag_mod_d_16.dta', convert_categoricals=False)
+g_pn = get_dataframe('../Data/Panel/ag_mod_g_16.dta', convert_categoricals=False)
+h_pn = get_dataframe('../Data/Panel/ag_mod_h_16.dta', convert_categoricals=False)
+p, s = _half(d_pn, g_pn, h_pn, lambda df: df['y3_hhid'].apply(format_id),
+             seed_qty=['ag_h16a', 'ag_h26a'],
+             seed_unit=['ag_h16b', 'ag_h26b'],
+             seed_value=['ag_h19', 'ag_h29'])
+all_pieces += p
+all_seed_purchase += s
+
+df = assemble_plot_inputs(WAVE, all_pieces, all_seed_purchase)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot,input,crop,u) in plot_inputs {WAVE}"
+assert len(df) > 0, f"plot_inputs {WAVE} produced no rows"
+
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Malawi/2019-20/_/plot_inputs.py
+++ b/lsms_library/countries/Malawi/2019-20/_/plot_inputs.py
@@ -1,0 +1,97 @@
+"""Build plot_inputs for Malawi IHS5 2019-20 (GAP 2).
+
+IHS5 ships a Cross_Sectional half (bare case_id) and a Panel half
+(y4_hhid), concatenated into the single 2019-20 wave -- exactly like
+plot_features / crop_production (sample().i for 2019-20 is the bare
+cross-sectional case_id, NOT cs-prefixed).  Plot key is gardenid_plotid
+in both halves.
+
+Module D layout is the IHS4/IHS5 generation: slot-1 fertilizer type
+ag_d39a / applied-qty ag_d39d / unit ag_d39e; slot-2 type ag_d39g /
+applied-qty ag_d39j (no distinct slot-2 applied-unit -> u NaN slot 2).
+Module G: harmonized crop_code, seed ag_g04a/ag_g04b, improved flag
+ag_g0f (2 = improved).  Module H purchased seed naming differs by half:
+Cross_Sectional uses ag_h07*/ag_h09 + ag_h38*/ag_h40; Panel uses the
+harmonized ag_h16*/ag_h19 + ag_h26*/ag_h29.
+
+Neither IHS5 ag_mod_d ships with the latin-1 bad byte that the IHS4
+cross-section had, so a plain get_dataframe read suffices.
+See lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import (_fertilizer_block, _organic_block, _pesticide_block,
+                    _seed_block, _seed_purchase_block, assemble_plot_inputs)
+
+
+WAVE = '2019-20'
+
+
+def _plotkey(df):
+    return (df['gardenid'].apply(format_id) + '_'
+            + df['plotid'].apply(format_id))
+
+
+def _half(d, g, h, hh_of, seed_qty, seed_unit, seed_value):
+    for df in (d, g, h):
+        df['hhid'] = hh_of(df)
+    d['plotkey'] = _plotkey(d)
+    g['plotkey'] = _plotkey(g)
+    pieces = [
+        _fertilizer_block(d, hhid='hhid', plotkey='plotkey',
+                          type1='ag_d39a', qty1='ag_d39d', unit1='ag_d39e',
+                          type2='ag_d39g', qty2='ag_d39j', unit2=None,
+                          t=WAVE),
+        _organic_block(d, hhid='hhid', plotkey='plotkey', flag='ag_d36',
+                       t=WAVE),
+        # IHS5 pesticide layout shifted vs IHS3/IHS4: ag_d41d is now a
+        # Yes/No "applied a second agrochemical?" gate, so slot 2 is
+        # (ag_d41e type, ag_d41f qty, ag_d41g unit).
+        _pesticide_block(d, hhid='hhid', plotkey='plotkey', gate='ag_d40',
+                         slots=[('ag_d41a', 'ag_d41b', 'ag_d41c'),
+                                ('ag_d41e', 'ag_d41f', 'ag_d41g')], t=WAVE),
+        _seed_block(g, hhid='hhid', plotkey='plotkey', cropcode='crop_code',
+                    qty='ag_g04a', unit='ag_g04b', improved='ag_g0f', t=WAVE),
+    ]
+    seed_purchase = [
+        _seed_purchase_block(h, hhid='hhid', cropcode='crop_code',
+                             qty_cols=seed_qty, unit_cols=seed_unit,
+                             value_cols=seed_value),
+    ]
+    return pieces, seed_purchase
+
+
+all_pieces, all_seed_purchase = [], []
+
+# --- Cross-sectional half (bare case_id) ---
+d_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_d.dta', convert_categoricals=False)
+g_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_g.dta', convert_categoricals=False)
+h_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_h.dta', convert_categoricals=False)
+p, s = _half(d_xs, g_xs, h_xs, lambda df: df['case_id'].apply(format_id),
+             seed_qty=['ag_h07a', 'ag_h38a'],
+             seed_unit=['ag_h07b', 'ag_h38b'],
+             seed_value=['ag_h09', 'ag_h40'])
+all_pieces += p
+all_seed_purchase += s
+
+# --- Panel half (y4_hhid) ---
+d_pn = get_dataframe('../Data/Panel/ag_mod_d_19.dta', convert_categoricals=False)
+g_pn = get_dataframe('../Data/Panel/ag_mod_g_19.dta', convert_categoricals=False)
+h_pn = get_dataframe('../Data/Panel/ag_mod_h_19.dta', convert_categoricals=False)
+p, s = _half(d_pn, g_pn, h_pn, lambda df: df['y4_hhid'].apply(format_id),
+             seed_qty=['ag_h16a', 'ag_h26a'],
+             seed_unit=['ag_h16b', 'ag_h26b'],
+             seed_value=['ag_h19', 'ag_h29'])
+all_pieces += p
+all_seed_purchase += s
+
+df = assemble_plot_inputs(WAVE, all_pieces, all_seed_purchase)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot,input,crop,u) in plot_inputs {WAVE}"
+assert len(df) > 0, f"plot_inputs {WAVE} produced no rows"
+
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Malawi/_/Makefile
+++ b/lsms_library/countries/Malawi/_/Makefile
@@ -12,7 +12,7 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 # _ROSTER_DERIVED — no country-level parquet is built or consulted.
 # See GH #218.
 
-all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet $(VAR_DIR)/crop_production.parquet
+all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet $(VAR_DIR)/crop_production.parquet $(VAR_DIR)/plot_inputs.parquet
 
 food_acquired = $(shell find $(rounds) -name food_acquired.py)
 # Wave-level parquets live in data_root, not in-tree
@@ -59,6 +59,20 @@ $(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/crop_production.parquet: malawi.py
 
 $(VAR_DIR)/crop_production.parquet: crop_production.py $(crop_production_parquet)
 	python crop_production.py
+
+# --- plot_inputs / agricultural inputs (GAP 2) ----------------------------
+# Item-level (t, i, plot, input, crop, u) inputs for the four IHS3+/IHPS
+# waves.  Each wave script writes its parquet into data_root; the country
+# script concatenates.  2004-05 is ABSENT (household-level aggregated ag
+# file, no plot-input roster).
+input_waves := 2010-11 2013-14 2016-17 2019-20
+plot_inputs_parquet := $(foreach r,$(input_waves),$(LSMS_DATA_ROOT)/$(COUNTRY)/$(r)/_/plot_inputs.parquet)
+
+$(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/plot_inputs.parquet: malawi.py
+	(cd ../$(*)/_/ && python plot_inputs.py)
+
+$(VAR_DIR)/plot_inputs.parquet: plot_inputs.py $(plot_inputs_parquet)
+	python plot_inputs.py
 
 %.parquet: %.py malawi.py
 	(cd $(@D) && python ./$(<F))

--- a/lsms_library/countries/Malawi/_/categorical_mapping.org
+++ b/lsms_library/countries/Malawi/_/categorical_mapping.org
@@ -636,3 +636,29 @@
 |   11 | Basket (Dengu)  |
 |   12 | Ox-Cart         |
 |   13 | Other (Specify) |
+
+# harmonize_input: agricultural-input identity for the plot_inputs feature
+# (GAP 2).  Codes 1-6 are the Module D inorganic-fertilizer type codes
+# (ag_d39a / slot-2 type); codes 7-11 are the Module D agrochemical type
+# codes (ag_d41a / ag_d41d) -- the source already numbers fertilizers 1-6
+# and pesticides 7-11 in one disjoint namespace within Module D.  Codes
+# 20 / 30 are synthetic for the two inputs the survey records without a
+# type code: organic fertilizer (ag_d36 Yes/No) and seed planted (Module
+# G ag_g04a).  Stable across the four IHS3+/IHPS waves (2010-11, 2013-14,
+# 2016-17, 2019-20), so no per-wave column is needed.
+#+name: harmonize_input
+| Code | Preferred Label       |
+|------+-----------------------|
+|    1 | NPK Fertilizer        |
+|    2 | DAP Fertilizer        |
+|    3 | CAN Fertilizer        |
+|    4 | Urea Fertilizer       |
+|    5 | D Compound Fertilizer |
+|    6 | Other Fertilizer      |
+|    7 | Insecticide           |
+|    8 | Herbicide             |
+|    9 | Fungicide             |
+|   10 | Fumigant              |
+|   11 | Other Pesticide       |
+|   20 | Organic Fertilizer    |
+|   30 | Seed                  |

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -159,5 +159,36 @@ Data Scheme:
     intercropped: bool
     perennial: bool
     materialize: make
+  plot_inputs:
+    # Item-level (t, i, plot, input, crop, u) agricultural-input feature
+    # for the four IHS3+/IHPS waves (2010-11, 2013-14, 2016-17, 2019-20);
+    # GAP 2.  One reported row per input applied to a plot.  Sources:
+    # Module D (ag_mod_d) -- inorganic fertilizer in two slots (type +
+    # applied quantity + unit), an organic-fertilizer used? flag (ag_d36),
+    # and pesticide/herbicide/fungicide/fumigant types + qty + unit gated
+    # by ag_d40; Module G (ag_mod_g) -- seed planted per plot-crop
+    # (ag_g04a/b) with the improved-seed flag ag_g0f in IHS4/IHS5; Module H
+    # (ag_mod_h) -- purchased seed (household-crop grain) attached to the
+    # single-plot seed row of that (i, crop), like crop_production's sale.
+    # `input` is the shared harmonize_input Preferred Label
+    # (NPK/DAP/CAN/Urea/D-Compound/Other fertilizer, Organic Fertilizer,
+    # Insecticide/Herbicide/Fungicide/Fumigant/Other Pesticide, Seed).
+    # `crop` is the harmonize_crop->harmonize_food label for seed rows
+    # (NaN for fertilizer/pesticide).  `u` is the reported native unit
+    # label (NaN where the survey records no quantity basis, e.g. organic
+    # fertilizer).  crop / u are in the index because a plot may carry
+    # several seed crops or a fertilizer in several units.  Reported item
+    # columns only: Quantity, native u, Purchased (bool, True where a
+    # purchased seed quantity is attached), Quantity_purchased, Improved
+    # (bool, seed rows).  Aggregates (seed_kg, nitrogen_kg,
+    # inorganic/organic/pesticide any-flags) are transformations, NOT
+    # stored columns.  2004-05 (IHS2) deferred: household-level aggregated
+    # ag file, no plot-input roster.  See _/malawi.py:assemble_plot_inputs.
+    index: (t, i, plot, input, crop, u)
+    Quantity: float
+    Purchased: bool
+    Quantity_purchased: float
+    Improved: bool
+    materialize: make
   food_expenditures:
   food_prices:

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -1093,3 +1093,382 @@ def months_food_inadequate_for_wave(t, df, idcol, i_prefix=''):
     out = out.groupby(['t', 'i'], as_index=False).first()
     out = out.set_index(['t', 'i'])
     return out
+
+
+# --- plot_inputs (GAP 2) ------------------------------------------------
+# Item-level (t, i, plot, input) feature -- one row per agricultural input
+# applied to a plot.  Sources (the four IHS3+/IHPS waves):
+#   * Module D (ag_mod_d) -- the plot-level input module.  Per plot it
+#     records, in up to two slots, an INORGANIC FERTILIZER type + applied
+#     quantity (ag_d39a/ag_d39d/ag_d39e slot 1; ag_d39f|ag_d39g type +
+#     ag_d39i|ag_d39j applied-qty slot 2 -- the slot-2 column letters
+#     shifted between the IHS3/IHPS2 layout and the IHS4/IHS5 layout),
+#     an ORGANIC FERTILIZER used? flag (ag_d36), and up to two
+#     PESTICIDE/HERBICIDE types + qty + unit (ag_d41a/b/c slot 1;
+#     ag_d41d/e/f slot 2), gated by the any-agrochemical flag ag_d40.
+#   * Module G (ag_mod_g) -- the seasonal plot-crop roster.  Per (plot,
+#     crop) it records the SEED quantity planted + unit (ag_g04a/ag_g04b)
+#     and, in IHS4/IHS5 only, an improved-seed flag (ag_g0f: 2=improved).
+#
+# The grain is (t, i, plot, input).  Fertilizer / pesticide rows have NO
+# crop attached (the questionnaire records them at the plot, not the
+# plot-crop, level); seed rows DO carry the crop (shared harmonize_food
+# label axis) because Module G is a plot-crop roster.  `input` is mapped
+# to the shared harmonize_input Preferred Label.  Reported item columns
+# only: Quantity + native unit `u`, Purchased (bool) + Quantity_purchased
+# for fertilizer/seed acquired through purchase (Module F ferts / Module H
+# seeds, household-crop grain -- attached only when single-plot, like the
+# crop_production sale), and Improved (bool) for seed rows.  Everything
+# aggregate (seed_kg, nitrogen_kg, inorganic/organic/pesticide any-flags)
+# is a transformations.py concern, NOT a stored column.
+
+# Module D inorganic-fertilizer TYPE codes (ag_d39a / slot-2 type) ->
+# harmonize_input codes 1-6 (identity: the source codes ARE the
+# harmonize_input codes for fertilizer).
+_MWI_FERT_TYPE_CODES = [1, 2, 3, 4, 5, 6]
+
+# Module D agrochemical TYPE codes (ag_d41a / ag_d41d) -> harmonize_input
+# codes 7-11 (identity: the source codes ARE the harmonize_input codes for
+# pesticides; the source already numbers them 7..11 disjoint from fert 1-6).
+_MWI_PEST_TYPE_CODES = [7, 8, 9, 10, 11]
+
+# Synthetic harmonize_input codes for the two non-coded inputs.
+_MWI_INPUT_ORGANIC = 20   # ag_d36 == Yes (organic fertilizer used on plot)
+_MWI_INPUT_SEED = 30      # Module G seed planted (per plot-crop)
+
+# Module D APPLIED-amount unit codes -> readable label.  The applied-amount
+# unit value-label set (ag_d39e / ag_d39j) is the SAME bag-size coding as
+# the acquired-amount unit (ag_d39c): 1=gram, 2=kilogram, 3..7 = bag sizes,
+# 13=Other.  Codes 11/12 appear on the applied unit but are not in the
+# acquired value-label set (free-text "tin"/"ox-cart"-style residuals);
+# they map to NaN so we never fabricate a quantity basis.  We carry the
+# REPORTED applied quantity with this declared unit -- the kg conversion
+# (which the WB code performs, treating the applied amount as already-kg)
+# is a transformation, NOT stored here.
+_MWI_FERT_UNIT_LABELS = {
+    1: 'Gram',
+    2: 'Kilogram',
+    3: '2 kg Bag',
+    4: '3 kg Bag',
+    5: '5 kg Bag',
+    6: '10 kg Bag',
+    7: '50 kg Bag',
+    13: 'Other (Specify)',
+}
+
+# Module G SEED unit codes (ag_g04b) -> readable label.  Distinct bag-size
+# coding from the fertilizer unit (note 5 = 3.7 kg bag here, vs 5 kg bag in
+# the fertilizer set), so it gets its own map.
+_MWI_SEED_UNIT_LABELS = {
+    1: 'Gram',
+    2: 'Kilogram',
+    3: '2 kg Bag',
+    4: '3 kg Bag',
+    5: '3.7 kg Bag',
+    6: '5 kg Bag',
+    7: '10 kg Bag',
+    8: '50 kg Bag',
+    9: 'Other (Specify)',
+}
+
+# Module H / Module F PURCHASE unit codes (ag_h{n}6b / ag_f{n}6b) -> label.
+# Same coding as the seed unit set for Module H; carried with the reported
+# purchased quantity.
+_MWI_PURCH_UNIT_LABELS = dict(_MWI_SEED_UNIT_LABELS)
+
+
+def _int_codes(series):
+    """Coerce a raw column to a nullable-Int64 code Series, rounding any
+    stray fractional values (a unit/type code is conceptually an integer;
+    a fractional entry is a data-entry residual).  Plain ``.astype('Int64')``
+    raises on non-equivalent floats (e.g. the 0.5 that turns up in some
+    IHS5 pesticide unit columns), so round first."""
+    s = pd.to_numeric(series, errors='coerce')
+    return s.round().astype('Int64')
+
+
+def _input_labels(code_series):
+    """Map a numeric harmonize_input code Series -> Preferred Label
+    (nullable string), via the harmonize_input categorical table.  NaN
+    where the code is absent / has no Preferred Label."""
+    cmap = _malawi_code_map('harmonize_input')
+    codes = _int_codes(code_series)
+    out = codes.map(cmap)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def _fertilizer_block(df, *, hhid, plotkey, type1, qty1, unit1,
+                      type2, qty2, unit2, t):
+    """Reshape Module D's two inorganic-fertilizer slots to canonical
+    long rows -- one per (plot, fertilizer-type) applied.
+
+    All keyword args are RAW column names in ``df`` (or None when a slot
+    is absent for that wave).  ``df`` must already carry an ``hhid`` string
+    column and a ``plotkey`` string column.  Returns a long DataFrame with
+    (i, plot, _input_code, Quantity, u) and the perennial/seed columns set
+    to NA.  NO aggregation, NO kg conversion.
+    """
+    pieces = []
+    for tcol, qcol, ucol in ((type1, qty1, unit1), (type2, qty2, unit2)):
+        if tcol is None or tcol not in df.columns:
+            continue
+        code = _int_codes(df[tcol])
+        keep = code.isin(_MWI_FERT_TYPE_CODES)
+        q = (pd.to_numeric(df[qcol], errors='coerce').astype('Float64')
+             if qcol and qcol in df.columns
+             else pd.Series(pd.NA, index=df.index, dtype='Float64'))
+        if ucol and ucol in df.columns:
+            ucode = _int_codes(df[ucol])
+            u = ucode.map(_MWI_FERT_UNIT_LABELS).astype('string')
+            u = u.where(u.notna(), pd.NA)
+        else:
+            u = pd.Series(pd.NA, index=df.index, dtype='string')
+        piece = pd.DataFrame({
+            'i':           df['hhid'].astype('string').values,
+            'plot':        df['plotkey'].astype('string').values,
+            '_input_code': code.values,
+            'crop':        pd.array([pd.NA] * len(df), dtype='string'),
+            'Quantity':    q.values,
+            'u':           u.values,
+            'Improved':    pd.array([pd.NA] * len(df), dtype='boolean'),
+        })
+        pieces.append(piece[keep.values])
+    if not pieces:
+        return pd.DataFrame(columns=['i', 'plot', '_input_code', 'crop',
+                                     'Quantity', 'u', 'Improved'])
+    return pd.concat(pieces, ignore_index=True)
+
+
+def _organic_block(df, *, hhid, plotkey, flag, t):
+    """One row per plot where organic fertilizer was reported applied
+    (ag_d36 == 1/Yes).  Presence is the reported item; Quantity / u are NA
+    (Module D records no organic-fertilizer quantity)."""
+    if flag is None or flag not in df.columns:
+        return pd.DataFrame(columns=['i', 'plot', '_input_code', 'crop',
+                                     'Quantity', 'u', 'Improved'])
+    used = _int_codes(df[flag]) == 1
+    out = pd.DataFrame({
+        'i':           df['hhid'].astype('string').values,
+        'plot':        df['plotkey'].astype('string').values,
+        '_input_code': _MWI_INPUT_ORGANIC,
+        'crop':        pd.array([pd.NA] * len(df), dtype='string'),
+        'Quantity':    pd.array([pd.NA] * len(df), dtype='Float64'),
+        'u':           pd.array([pd.NA] * len(df), dtype='string'),
+        'Improved':    pd.array([pd.NA] * len(df), dtype='boolean'),
+    })
+    return out[used.values]
+
+
+def _pesticide_block(df, *, hhid, plotkey, gate, slots, t):
+    """Reshape Module D's agrochemical slots to canonical long rows -- one
+    per (plot, pesticide-type).  ``slots`` is a list of (type, qty, unit)
+    raw-column-name triples (qty/unit may be None).  ``gate`` is ag_d40
+    (any agrochemical used? 1/2); rows are dropped where gate != Yes."""
+    if gate is not None and gate in df.columns:
+        gated = _int_codes(df[gate]) == 1
+    else:
+        gated = pd.Series(True, index=df.index)
+    pieces = []
+    for tcol, qcol, ucol in slots:
+        if tcol is None or tcol not in df.columns:
+            continue
+        code = _int_codes(df[tcol])
+        keep = code.isin(_MWI_PEST_TYPE_CODES) & gated
+        q = (pd.to_numeric(df[qcol], errors='coerce').astype('Float64')
+             if qcol and qcol in df.columns
+             else pd.Series(pd.NA, index=df.index, dtype='Float64'))
+        if ucol and ucol in df.columns:
+            ucode = _int_codes(df[ucol])
+            # Pesticide unit value-label set: 1=gram, 2=kilogram, 8=liter,
+            # 9=milliliter (ag_d41c).  Reuse the fert label map for the
+            # mass codes; add the volume codes.
+            umap = dict(_MWI_FERT_UNIT_LABELS)
+            umap.update({8: 'Liter', 9: 'Milliliter'})
+            u = ucode.map(umap).astype('string')
+            u = u.where(u.notna(), pd.NA)
+        else:
+            u = pd.Series(pd.NA, index=df.index, dtype='string')
+        piece = pd.DataFrame({
+            'i':           df['hhid'].astype('string').values,
+            'plot':        df['plotkey'].astype('string').values,
+            '_input_code': code.values,
+            'crop':        pd.array([pd.NA] * len(df), dtype='string'),
+            'Quantity':    q.values,
+            'u':           u.values,
+            'Improved':    pd.array([pd.NA] * len(df), dtype='boolean'),
+        })
+        pieces.append(piece[keep.values])
+    if not pieces:
+        return pd.DataFrame(columns=['i', 'plot', '_input_code', 'crop',
+                                     'Quantity', 'u', 'Improved'])
+    return pd.concat(pieces, ignore_index=True)
+
+
+def _seed_block(df, *, hhid, plotkey, cropcode, qty, unit, improved=None,
+                t=None):
+    """Reshape Module G's seed-planted columns to canonical long rows --
+    one per (plot, crop) seed.  ``cropcode`` is the harmonize_crop code
+    column (mapped to the shared crop/food label).  Returns (i, plot,
+    _input_code=SEED, crop, Quantity, u, Improved)."""
+    crop_label, _crop_code = _crop_codes(df[cropcode], perennial=False)
+    q = (pd.to_numeric(df[qty], errors='coerce').astype('Float64')
+         if qty and qty in df.columns
+         else pd.Series(pd.NA, index=df.index, dtype='Float64'))
+    if unit and unit in df.columns:
+        ucode = _int_codes(df[unit])
+        u = ucode.map(_MWI_SEED_UNIT_LABELS).astype('string')
+        u = u.where(u.notna(), pd.NA)
+    else:
+        u = pd.Series(pd.NA, index=df.index, dtype='string')
+    if improved is not None and improved in df.columns:
+        icode = _int_codes(df[improved])
+        # ag_g0f: 2 = improved/hybrid, 1 = local/unimproved (WB recode).
+        imp = (icode == 2).astype('boolean')
+        imp = imp.where(icode.notna(), pd.NA)
+    else:
+        imp = pd.Series(pd.NA, index=df.index, dtype='boolean')
+    out = pd.DataFrame({
+        'i':           df['hhid'].astype('string').values,
+        'plot':        df['plotkey'].astype('string').values,
+        '_input_code': _MWI_INPUT_SEED,
+        'crop':        crop_label.values,
+        'Quantity':    q.values,
+        'u':           u.values,
+        'Improved':    imp.values,
+    })
+    # Keep a seed row only where a crop identity is present (the seed item
+    # is meaningless without the crop it seeds).
+    out = out[crop_label.notna().values]
+    return out
+
+
+def _seed_purchase_block(df, *, hhid, cropcode, qty_cols, unit_cols,
+                         value_cols):
+    """Reshape Module H purchased-seed columns to (i, crop) reported
+    purchase totals.  ``qty_cols``/``unit_cols``/``value_cols`` are lists
+    of the per-source raw column names (two purchase sources: ag_h16*,
+    ag_h26*).  A purchased amount is counted only where the corresponding
+    value column is non-zero (WB rule).  Returns (i, _crop_code,
+    Quantity_purchased) -- household-crop grain, no plot."""
+    crop_label, crop_code_int = _crop_codes(df[cropcode], perennial=False)
+    cols = []
+    for qcol, vcol in zip(qty_cols, value_cols):
+        if qcol not in df.columns:
+            continue
+        q = pd.to_numeric(df[qcol], errors='coerce').astype('Float64')
+        if vcol and vcol in df.columns:
+            v = pd.to_numeric(df[vcol], errors='coerce').astype('Float64')
+            q = q.where(v.notna() & (v != 0), pd.NA)
+        cols.append(q)
+    if cols:
+        # Sum the per-source purchased amounts; the row total stays NA when
+        # NO source recorded a (value-backed) purchase -- so a household
+        # that did not buy seed of that crop gets NA, never a spurious 0.
+        total = pd.concat(cols, axis=1).sum(axis=1, min_count=1).astype('Float64')
+    else:
+        total = pd.Series(pd.NA, index=df.index, dtype='Float64')
+    out = pd.DataFrame({
+        'i':            df['hhid'].astype('string').values,
+        '_crop_code':   crop_code_int.values,
+        'Quantity_purchased': total.values,
+    })
+    out = out[out['_crop_code'].notna()]
+    grp = out.groupby(['i', '_crop_code'], as_index=False).agg(
+        {'Quantity_purchased': lambda s: s.sum(min_count=1)})
+    # Drop the (i, crop) rows where no purchase was recorded.
+    grp = grp[grp['Quantity_purchased'].notna()]
+    return grp
+
+
+def assemble_plot_inputs(t, input_pieces, seed_purchase_pieces=None):
+    """Combine reshaped input pieces into the canonical plot_inputs
+    DataFrame for wave ``t``.
+
+    Parameters
+    ----------
+    t : str -- wave id, used as the ``t`` index value.
+    input_pieces : list[pd.DataFrame] -- outputs of the per-module blocks
+        (_fertilizer_block, _organic_block, _pesticide_block, _seed_block),
+        each carrying (i, plot, _input_code, crop, Quantity, u, Improved).
+    seed_purchase_pieces : list[pd.DataFrame] | None -- outputs of
+        _seed_purchase_block (i, _crop_code, Quantity_purchased) at the
+        household-crop grain; attached to the single-plot seed row of that
+        (i, crop), like crop_production's sale (no plot fabrication).
+
+    Returns
+    -------
+    pd.DataFrame indexed (t, i, plot, input) with columns Quantity, u,
+    Purchased, Quantity_purchased, Improved, crop.  Item-level reported
+    values only.
+    """
+    df = pd.concat([p for p in input_pieces if p is not None and len(p)],
+                   ignore_index=True)
+
+    df['input'] = _input_labels(df['_input_code'])
+    # An input row needs a resolved input label to land on the index.
+    df = df[df['input'].notna()]
+
+    # Seed-purchase merge (household-crop grain -> single-plot seed rows).
+    df['Quantity_purchased'] = pd.array([pd.NA] * len(df), dtype='Float64')
+    if seed_purchase_pieces:
+        sp = pd.concat([p for p in seed_purchase_pieces if p is not None
+                        and len(p)], ignore_index=True)
+        if len(sp):
+            sp = sp.groupby(['i', '_crop_code'], as_index=False).agg(
+                {'Quantity_purchased': 'sum'})
+            # Re-derive the crop label so we can join on (i, crop) without
+            # carrying _crop_code on the seed rows.
+            sp_label, _ = _crop_codes(sp['_crop_code'], perennial=False)
+            sp = sp.assign(crop=sp_label.values)
+            sp = sp[sp['crop'].notna()]
+            seed = df['input'] == 'Seed'
+            # Count plots per (i, crop) among seed rows; attach only when a
+            # crop's seed is on exactly one plot (unambiguous).
+            seed_rows = df[seed]
+            nplots = (seed_rows.groupby(['i', 'crop'])['plot']
+                      .nunique().rename('_nplots').reset_index())
+            attach = sp.merge(nplots, on=['i', 'crop'], how='inner')
+            attach = attach[attach['_nplots'] == 1][
+                ['i', 'crop', 'Quantity_purchased']]
+            attach = attach.rename(
+                columns={'Quantity_purchased': '_qp'})
+            df = df.merge(attach, on=['i', 'crop'], how='left')
+            take = seed & df['_qp'].notna()
+            df['Quantity_purchased'] = df['Quantity_purchased'].where(
+                ~take, df['_qp'])
+            df = df.drop(columns=['_qp'])
+
+    # Purchased flag: True where a purchased quantity is attached (seed),
+    # else NA (Module D fertilizer/pesticide applied-on-plot rows do not
+    # record a purchase split at the plot grain).
+    df['Purchased'] = pd.array([pd.NA] * len(df), dtype='boolean')
+    df.loc[df['Quantity_purchased'].notna(), 'Purchased'] = True
+
+    df = df.drop(columns=['_input_code'])
+    df['t'] = t
+
+    # Consolidate exact-duplicate reported lines: same (i, plot, input,
+    # crop, u) summed on Quantity (a plot may record the same fertilizer
+    # in two slots with the same unit); first-wins on the flag columns.
+    # Rows in different units `u` stay distinct.  NaN crop / u participate
+    # in the grouping (dropna=False) so fertilizer/pesticide rows (crop
+    # NaN) are not silently dropped.
+    df['crop'] = df['crop'].astype('string')
+    df['u'] = df['u'].astype('string')
+    grp = df.groupby(['t', 'i', 'plot', 'input', 'crop', 'u'],
+                     as_index=False, dropna=False).agg({
+        'Quantity':           'sum',
+        'Quantity_purchased': 'first',
+        'Purchased':          'first',
+        'Improved':           'first',
+    })
+
+    # The natural per-input-line grain is (t, i, plot, input, crop, u): a
+    # plot may carry several seed crops (same input='Seed', distinct crop)
+    # and a fertilizer may be reported in two slots in different units
+    # (same input, crop NaN, distinct u).  crop / u therefore belong in the
+    # index to keep it unique; both are NaN for the inputs that don't carry
+    # them (fertilizer/pesticide have NaN crop; organic-fertilizer rows have
+    # NaN u as well).  dropna=False above keeps those NaN-keyed rows.
+    grp = grp.set_index(['t', 'i', 'plot', 'input', 'crop', 'u'])
+    return grp

--- a/lsms_library/countries/Malawi/_/plot_inputs.py
+++ b/lsms_library/countries/Malawi/_/plot_inputs.py
@@ -1,0 +1,37 @@
+"""Concatenate wave-level plot_inputs parquets for Malawi (GAP 2).
+
+Each buildable wave's ``Malawi/<wave>/_/plot_inputs.py`` produces a parquet
+indexed (t, i, plot, input, crop, u) with the canonical item-level columns
+(Quantity, Quantity_purchased, Purchased, Improved).  This script
+concatenates them.  Cross-wave id_walk (panel-id chaining) and the join of
+the cluster id ``v`` are applied by the framework at API time in
+_finalize_result.
+
+Only the four IHS3+ IHPS waves are buildable (2010-11, 2013-14, 2016-17,
+2019-20) -- the same waves as crop_production / plot_features.  2004-05
+(IHS2) is DEFERRED: its agricultural file is household-level aggregated,
+with no plot-level input roster.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2010-11', '2013-14', '2016-17', '2019-20']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_inputs.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built (DVC raises
+        # PathMissingError here, not FileNotFoundError).
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_inputs: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/plot_inputs.parquet')

--- a/lsms_library/countries/Mali/2014-15/_/plot_inputs.py
+++ b/lsms_library/countries/Mali/2014-15/_/plot_inputs.py
@@ -1,0 +1,190 @@
+"""Build plot_inputs (item-level ag inputs) for Mali EACI 2014-15.
+
+GAP 2 (parity loop).  One row per (t, i, plot, input[, crop]).
+
+Sources (post-harvest passage 2; cultivation passage 1):
+  - EACIS1E_p2.dta   seed roster, keyed (grappe, menage, field, parcel, crop)
+  - EACIS2C_p2.dta   plot-fertilizer / pesticide roster (one row per plot,
+                     with separate Urea/DAP/NPK/other-inorganic and
+                     manure/compost/other-organic and pesticide/fungicide/
+                     herbicide/other-phytosanitary slots)
+
+plot = "{field}_{parcel}" (s1eq01_s1eq02 for seed; s2cq01_s2cq02 for
+fertilizer) — the SAME plot id as crop_production / plot_features.
+
+REPORTED item-level columns only — Quantity / u / Purchased /
+Quantity_purchased / Improved / crop.  NO seed_kg / nitrogen_kg / any-use
+flags / fertilizer totals (those are transformations over these rows).
+
+Variable map traced from MLI_EACI1.do (WB harmonised input section):
+  seed: crop=s1eq03b improved=s1eq04 qty=s1eq05a unit=s1eq05b
+        purchased-mode is not asked here; the WB code assumes seeds were
+        bought (seeds_amount_purchased_kg = seed_kg), so Purchased is left
+        NA at item grain (honest missing) rather than force-true.
+  inorganic fert: flag=s2cq21; Urea qty/unit=s2cq25a/b, DAP=s2cq25c/d,
+        NPK=s2cq25e/f, other=s2cq25g/h
+  organic fert: manure flag=s2cq04 acq=s2cq07 qty/unit=s2cq08a/b;
+        compost flag=s2cq09 acq=s2cq13 qty/unit=s2cq14a/b;
+        other-org flag=s2cq15 acq=s2cq19 qty/unit=s2cq20a/b
+  pesticide: flag=s2cq26; pesticide qty/unit=s2cq29a/b, fungicide=s2cq29c/d,
+        herbicide=s2cq29e/f, other=s2cq29g/h
+  Purchased (organic): acquisition mode == 'Achat'.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import i as mali_i, plot_inputs_finalize
+
+WAVE = '2014-15'
+
+
+def _hhid(df):
+    return df.apply(lambda r: mali_i(pd.Series([r['grappe'], r['menage']])), axis=1)
+
+
+def _plot(df, fcol, pcol):
+    f = df[fcol].astype('Int64').astype('string')
+    p = df[pcol].astype('Int64').astype('string')
+    return (f + '_' + p).where(f.notna() & p.notna(), pd.NA)
+
+
+def _yes(series):
+    """'Oui'/'Non' (or NA) -> nullable bool."""
+    s = series.astype('string').str.strip()
+    out = s.map({'Oui': True, 'Non': False})
+    return out.astype('boolean')
+
+
+pieces = []
+
+# --- seeds (s1e): per plot-crop ---
+s1e = get_dataframe('../Data/EACIS1E_p2.dta').copy()
+s1e['i'] = _hhid(s1e)
+# improved: WB recode s1eq04 (2/5 -> improved, 1=Locales -> not improved).
+improved_raw = s1e['s1eq04'].astype('string').str.strip()
+improved = pd.Series(pd.NA, index=s1e.index, dtype='boolean')
+improved = improved.mask(improved_raw.eq('Locales'), False)
+improved = improved.mask(improved_raw.str.startswith('Améliorées').fillna(False), True)
+seed = pd.DataFrame({
+    't': WAVE,
+    'i': s1e['i'],
+    'plot': _plot(s1e, 's1eq01', 's1eq02'),
+    'input': 'seed',
+    'crop': s1e['s1eq03b'],
+    'u': s1e['s1eq05b'],
+    'Quantity': pd.to_numeric(s1e['s1eq05a'], errors='coerce'),
+    'Purchased': pd.NA,            # not asked at item grain in 2014-15 s1e
+    'Quantity_purchased': pd.NA,
+    'Improved': improved,
+})
+pieces.append(seed)
+
+# --- plot fertilizer / pesticide (s2c): one row per used input slot ---
+s2c = get_dataframe('../Data/EACIS2C_p2.dta').copy()
+s2c['i'] = _hhid(s2c)
+s2c['plot'] = _plot(s2c, 's2cq01', 's2cq02')
+
+
+def _fert_slot(code, qty_col, unit_col, purchased=None):
+    """Build a (plot, input) fertilizer/pesticide slot frame."""
+    return pd.DataFrame({
+        't': WAVE,
+        'i': s2c['i'],
+        'plot': s2c['plot'],
+        'input': code,
+        'crop': pd.NA,             # fertilizer/pesticide applied at plot grain
+        'u': s2c[unit_col] if unit_col else pd.NA,
+        'Quantity': pd.to_numeric(s2c[qty_col], errors='coerce'),
+        'Purchased': purchased if purchased is not None
+                     else pd.Series(pd.NA, index=s2c.index, dtype='boolean'),
+        'Quantity_purchased': pd.NA,
+        'Improved': pd.NA,
+    })
+
+
+# inorganic: Urea / DAP / NPK / other-inorganic (purchase signal -> s2d below)
+pieces.append(_fert_slot('urea', 's2cq25a', 's2cq25b'))
+pieces.append(_fert_slot('dap', 's2cq25c', 's2cq25d'))
+pieces.append(_fert_slot('npk', 's2cq25e', 's2cq25f'))
+pieces.append(_fert_slot('other_inorganic', 's2cq25g', 's2cq25h'))
+
+# organic: manure / compost / other-organic, with Purchased from acq mode.
+_achat = lambda c: s2c[c].astype('string').str.strip().eq('Achat')
+manure_p = pd.Series(pd.NA, index=s2c.index, dtype='boolean').mask(
+    s2c['s2cq07'].notna(), _achat('s2cq07'))
+compost_p = pd.Series(pd.NA, index=s2c.index, dtype='boolean').mask(
+    s2c['s2cq13'].notna(), _achat('s2cq13'))
+otherorg_p = pd.Series(pd.NA, index=s2c.index, dtype='boolean').mask(
+    s2c['s2cq19'].notna(), _achat('s2cq19'))
+pieces.append(_fert_slot('manure', 's2cq08a', 's2cq08b', purchased=manure_p))
+pieces.append(_fert_slot('compost', 's2cq14a', 's2cq14b', purchased=compost_p))
+pieces.append(_fert_slot('other_organic', 's2cq20a', 's2cq20b', purchased=otherorg_p))
+
+# phytosanitary: pesticide / fungicide / herbicide / other
+pieces.append(_fert_slot('pesticide', 's2cq29a', 's2cq29b'))
+pieces.append(_fert_slot('fungicide', 's2cq29c', 's2cq29d'))
+pieces.append(_fert_slot('herbicide', 's2cq29e', 's2cq29f'))
+pieces.append(_fert_slot('other_phytosanitary', 's2cq29g', 's2cq29h'))
+
+# --- household inorganic-fertilizer purchases (s2d): qty/value per type ---
+# s2d records purchases at the HOUSEHOLD grain (no plot/parcel).  We use it
+# only to set Purchased=True and Quantity_purchased on the matching inorganic
+# input rows for households that report a purchase of that type — joined at
+# (i, input).  We do NOT fabricate a plot allocation: the purchased quantity
+# is broadcast as a household-level signal onto every plot row of that input
+# type (a transformations.py rollup can recover the exact HH total).
+s2d = get_dataframe('../Data/EACIS2D_p2.dta').copy()
+s2d['i'] = _hhid(s2d)
+# Map the (truncated) s2dq01 fertilizer-type label -> harmonize_input Code.
+_S2D_TYPE = {
+    'Engrais inorganiques - Ur': 'urea',
+    'Engrais inorganiques - DA': 'dap',
+    'Engrais inorganiques - NP': 'npk',
+    'Engrais inorganiques - Co': 'other_inorganic',
+    'Engrais inorganiques - PN': 'other_inorganic',
+    'Engrais inorganiques - KC': 'other_inorganic',
+    'Engrais inorganiques - Ni': 'other_inorganic',
+    'Autres engrais inorganiqu': 'other_inorganic',
+    'Engrais organiques - Fumu': 'manure',
+    'Engrais organiques - Comp': 'compost',
+    'Engrais organiques - Sabu': 'other_organic',
+}
+s2d['input'] = s2d['s2dq01'].astype('string').str.strip().map(_S2D_TYPE)
+bought = _yes(s2d['s2dq02'])
+purch = s2d[s2d['input'].notna()].copy()
+purch['bought'] = bought.loc[purch.index]
+purch['qty'] = pd.to_numeric(purch['s2dq09a'], errors='coerce')
+# collapse to (i, input): any purchase -> True; sum reported purchased qty.
+hh_purch = purch.groupby(['i', 'input'], as_index=False).agg(
+    Purchased=('bought', 'max'),
+    Quantity_purchased=('qty', lambda s: s.sum(min_count=1)),
+)
+
+df = pd.concat(pieces, ignore_index=True)
+
+# Join the household-grain purchase signal (s2d) onto input rows by
+# (i, input).  The HH purchase ANNOTATES a plot APPLICATION row — it does not
+# create one: gate the merged Purchased / Quantity_purchased on the row having
+# a reported plot-level application Quantity (so a fertilizer a household
+# bought but whose plot-level application went unrecorded does not manufacture
+# a content-free row on every plot).  Organic Purchased already set from the
+# plot acquisition mode is kept where present.
+df = df.merge(hh_purch, on=['i', 'input'], how='left', suffixes=('', '_hh'))
+applied = df['Quantity'].notna()
+df['Purchased'] = df['Purchased'].astype('boolean').where(
+    df['Purchased'].notna(),
+    df['Purchased_hh'].astype('boolean').where(applied, pd.NA))
+df['Quantity_purchased'] = df['Quantity_purchased'].where(
+    df['Quantity_purchased'].notna(),
+    df['Quantity_purchased_hh'].where(applied))
+df = df.drop(columns=['Purchased_hh', 'Quantity_purchased_hh'])
+
+df = plot_inputs_finalize(df)
+
+assert len(df) > 0, "plot_inputs 2014-15 produced no rows"
+assert df.index.is_unique, "Non-unique (t,i,plot,input,crop) in plot_inputs 2014-15"
+
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Mali/2017-18/_/plot_inputs.py
+++ b/lsms_library/countries/Mali/2017-18/_/plot_inputs.py
@@ -1,0 +1,192 @@
+"""Build plot_inputs (item-level ag inputs) for Mali EACI 2017-18.
+
+GAP 2 (parity loop).  One row per (t, i, plot, input[, crop]).
+
+Sources (cultivation passage 1; post-harvest passage 2):
+  - eaci17_s11cp1.dta  seed/cultivation roster, keyed
+                       (grappe, exploitation, field, parcel, crop)
+  - eaci17_s07dp2.dta  plot-fertilizer / pesticide roster (one row per plot,
+                       Urea/DAP/NPK/other-inorganic + manure/compost/other-
+                       organic + pesticide/fungicide/herbicide/other slots)
+  - eaci17_s07bp2.dta  household input-purchase roster (type, qty, value;
+                       NO plot grain) -> Purchased / Quantity_purchased
+
+i = (grappe, exploitation) — the 2017-18 household key.
+plot = "{field}_{parcel}" (s11cq01_s11cq02 for seed; s7dq01_s7dq02 for
+fertilizer) — the SAME plot id as crop_production / plot_features.
+
+REPORTED item-level columns only — Quantity / u / Purchased /
+Quantity_purchased / Improved / crop.  NO seed_kg / nitrogen_kg / any-use
+flags / fertilizer totals.
+
+Variable map traced from MLI_EACI2.do (WB harmonised input section):
+  seed: crop=s11cq03 improved=s11cq10 qty=s11cq11a unit=s11cq11b
+        paid?=s11cq12 amount=s11cq13  (purchase IS asked here)
+  inorganic fert: flag=s7dq22; Urea qty/unit=s7dq26a1/a2, DAP=s7dq26b1/b2,
+        NPK=s7dq26c1/c2, other=s7dq26d1/d2
+  organic fert: manure flag=s7dq05 acq=s7dq08 qty/unit=s7dq09a/b;
+        compost flag=s7dq10 acq=s7dq14 qty/unit=s7dq15a/b;
+        other-org flag=s7dq16 acq=s7dq20 qty/unit=s7dq21a/b
+  pesticide: flag=s7dq27; pesticide qty/unit=s7dq30a1/a2, fungicide=
+        s7dq30b1/b2, herbicide=s7dq30c1/c2, other=s7dq30d1/d2
+  purchases (s7b): type=s7bq01 bought?=s7bq02 qty=s7bq09a value=s7bq09c
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import i as mali_i, plot_inputs_finalize
+
+WAVE = '2017-18'
+
+
+def _hhid(df):
+    return df.apply(lambda r: mali_i(pd.Series([r['grappe'], r['exploitation']])),
+                    axis=1)
+
+
+def _plot(df, fcol, pcol):
+    f = df[fcol].astype('Int64').astype('string')
+    p = df[pcol].astype('Int64').astype('string')
+    return (f + '_' + p).where(f.notna() & p.notna(), pd.NA)
+
+
+def _yes(series):
+    s = series.astype('string').str.strip()
+    return s.map({'Oui': True, 'Non': False}).astype('boolean')
+
+
+pieces = []
+
+# --- seeds (s11c): per plot-crop; purchase IS asked (s11cq12/s11cq13) ---
+s11c = get_dataframe('../Data/eaci17_s11cp1.dta').copy()
+s11c['i'] = _hhid(s11c)
+improved_raw = s11c['s11cq10'].astype('string').str.strip()
+improved = pd.Series(pd.NA, index=s11c.index, dtype='boolean')
+improved = improved.mask(improved_raw.eq('Locales'), False)
+improved = improved.mask(improved_raw.str.startswith('Améliorées').fillna(False), True)
+paid = _yes(s11c['s11cq12'])
+seed = pd.DataFrame({
+    't': WAVE,
+    'i': s11c['i'],
+    'plot': _plot(s11c, 's11cq01', 's11cq02'),
+    'input': 'seed',
+    'crop': s11c['s11cq03'],
+    'u': s11c['s11cq11b'],
+    'Quantity': pd.to_numeric(s11c['s11cq11a'], errors='coerce'),
+    'Purchased': paid,
+    # s11cq13 is the AMOUNT PAID (value, CFA), not a quantity — do not put it
+    # in Quantity_purchased (which is a kg/native-unit quantity).  Left NA;
+    # seed purchase value is recoverable from the raw module if needed.
+    'Quantity_purchased': pd.NA,
+    'Improved': improved,
+})
+pieces.append(seed)
+
+# --- plot fertilizer / pesticide (s7d): one row per used input slot ---
+s7d = get_dataframe('../Data/eaci17_s07dp2.dta').copy()
+s7d['i'] = _hhid(s7d)
+s7d['plot'] = _plot(s7d, 's7dq01', 's7dq02')
+
+
+def _fert_slot(code, qty_col, unit_col, purchased=None):
+    return pd.DataFrame({
+        't': WAVE,
+        'i': s7d['i'],
+        'plot': s7d['plot'],
+        'input': code,
+        'crop': pd.NA,
+        'u': s7d[unit_col] if unit_col else pd.NA,
+        'Quantity': pd.to_numeric(s7d[qty_col], errors='coerce'),
+        'Purchased': purchased if purchased is not None
+                     else pd.Series(pd.NA, index=s7d.index, dtype='boolean'),
+        'Quantity_purchased': pd.NA,
+        'Improved': pd.NA,
+    })
+
+
+pieces.append(_fert_slot('urea', 's7dq26a1', 's7dq26a2'))
+pieces.append(_fert_slot('dap', 's7dq26b1', 's7dq26b2'))
+pieces.append(_fert_slot('npk', 's7dq26c1', 's7dq26c2'))
+pieces.append(_fert_slot('other_inorganic', 's7dq26d1', 's7dq26d2'))
+
+_achat = lambda c: s7d[c].astype('string').str.strip().eq('Achat')
+manure_p = pd.Series(pd.NA, index=s7d.index, dtype='boolean').mask(
+    s7d['s7dq08'].notna(), _achat('s7dq08'))
+compost_p = pd.Series(pd.NA, index=s7d.index, dtype='boolean').mask(
+    s7d['s7dq14'].notna(), _achat('s7dq14'))
+otherorg_p = pd.Series(pd.NA, index=s7d.index, dtype='boolean').mask(
+    s7d['s7dq20'].notna(), _achat('s7dq20'))
+pieces.append(_fert_slot('manure', 's7dq09a', 's7dq09b', purchased=manure_p))
+pieces.append(_fert_slot('compost', 's7dq15a', 's7dq15b', purchased=compost_p))
+pieces.append(_fert_slot('other_organic', 's7dq21a', 's7dq21b', purchased=otherorg_p))
+
+pieces.append(_fert_slot('pesticide', 's7dq30a1', 's7dq30a2'))
+pieces.append(_fert_slot('fungicide', 's7dq30b1', 's7dq30b2'))
+pieces.append(_fert_slot('herbicide', 's7dq30c1', 's7dq30c2'))
+pieces.append(_fert_slot('other_phytosanitary', 's7dq30d1', 's7dq30d2'))
+
+# --- household input purchases (s7b): qty per type; HOUSEHOLD grain ---
+s7b = get_dataframe('../Data/eaci17_s07bp2.dta').copy()
+s7b['i'] = _hhid(s7b)
+
+
+def _s7b_type(label):
+    s = str(label)
+    if 'Urée' in s:
+        return 'urea'
+    if 'DAP' in s:
+        return 'dap'
+    if 'NPK' in s:
+        return 'npk'
+    if s.startswith('Engrais inorganiques') or s.startswith('Autres engrais inorganiques'):
+        return 'other_inorganic'
+    if 'Fumure' in s:
+        return 'manure'
+    if 'Compost' in s:
+        return 'compost'
+    if s.startswith('Engrais organiques'):
+        return 'other_organic'
+    if 'Pesticides' in s:
+        return 'pesticide'
+    if 'Fongicides' in s:
+        return 'fungicide'
+    if 'Herbicides' in s:
+        return 'herbicide'
+    if 'phytosanitaires' in s:
+        return 'other_phytosanitary'
+    return pd.NA
+
+
+s7b['input'] = s7b['s7bq01'].astype('string').map(_s7b_type)
+purch = s7b[s7b['input'].notna()].copy()
+purch['bought'] = _yes(purch['s7bq02']).loc[purch.index]
+purch['qty'] = pd.to_numeric(purch['s7bq09a'], errors='coerce')
+hh_purch = purch.groupby(['i', 'input'], as_index=False).agg(
+    Purchased=('bought', 'max'),
+    Quantity_purchased=('qty', lambda s: s.sum(min_count=1)),
+)
+
+df = pd.concat(pieces, ignore_index=True)
+# The HH-grain purchase (s7b) ANNOTATES a plot APPLICATION row — gate on a
+# reported plot-level application Quantity so a purchased-but-unapplied
+# fertilizer does not manufacture a content-free row on every plot.  The seed
+# rows already carry their own paid-for question (s11cq12), kept where present.
+df = df.merge(hh_purch, on=['i', 'input'], how='left', suffixes=('', '_hh'))
+applied = df['Quantity'].notna()
+df['Purchased'] = df['Purchased'].astype('boolean').where(
+    df['Purchased'].notna(),
+    df['Purchased_hh'].astype('boolean').where(applied, pd.NA))
+df['Quantity_purchased'] = df['Quantity_purchased'].where(
+    df['Quantity_purchased'].notna(),
+    df['Quantity_purchased_hh'].where(applied))
+df = df.drop(columns=['Purchased_hh', 'Quantity_purchased_hh'])
+
+df = plot_inputs_finalize(df)
+
+assert len(df) > 0, "plot_inputs 2017-18 produced no rows"
+assert df.index.is_unique, "Non-unique (t,i,plot,input,crop) in plot_inputs 2017-18"
+
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Mali/_/Makefile
+++ b/lsms_library/countries/Mali/_/Makefile
@@ -38,6 +38,16 @@ $(VAR_DIR)/food_coping.parquet: food_coping.py ../2014-15/_/food_coping.parquet
 $(VAR_DIR)/crop_production.parquet: crop_production.py ../2014-15/_/crop_production.parquet ../2017-18/_/crop_production.parquet
 	python crop_production.py
 
+# plot_inputs (item-level ag inputs, GAP 2 / parity loop).  The input
+# module lives in the EACI waves only (2014-15, 2017-18).  The wave pattern
+# rule materializes each wave parquet; the country-level concatenator
+# (plot_inputs.py) aggregates into var/plot_inputs.parquet.
+../%/_/plot_inputs.parquet: ../%/_/plot_inputs.py
+	(cd $(@D) && python plot_inputs.py)
+
+$(VAR_DIR)/plot_inputs.parquet: plot_inputs.py ../2014-15/_/plot_inputs.parquet ../2017-18/_/plot_inputs.parquet
+	python plot_inputs.py
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Mali/_/categorical_mapping.org
+++ b/lsms_library/countries/Mali/_/categorical_mapping.org
@@ -90,6 +90,13 @@
 | Casier                       | Casier          | x       | ---     | ---     |
 | Chargement camion            | Chargement camion | x       | ---     | ---     |
 | Tonne                        | Tonne           | x       | ---     | ---     |
+|------------------------------+-----------------+---------+---------+---------|
+| # plot_inputs units (EACI 2014-15 s1c/s1e/s2c & 2017-18 s11c/s7d) — fertilizer/seed/pesticide units not already present above |                 |         |         |         |
+| Charrette asine              | Cart (donkey)   | x       | ---     | ---     |
+| Charette asine               | Cart (donkey)   | x       | ---     | ---     |
+| Charrette bovine             | Cart (ox)       | x       | ---     | ---     |
+| Charette bovine              | Cart (ox)       | x       | ---     | ---     |
+| Litres                       | Litre           | x       | ---     | ---     |
 
 #+name: harmonize_food
 | Code                                                                                                 | Preferred Label                              | 2014-15 | 2018-19 | 2021-22 |
@@ -493,3 +500,29 @@
 |    1 | freehold                   |
 |    2 | granted_right_of_occupancy |
 |    4 | leasehold                  |
+
+# harmonize_input — the input-identity (`input` index level) taxonomy for
+# plot_inputs (GAP 2, parity loop).  Unlike the other harmonize_* tables,
+# the inputs are NOT a decoded label column in the source: each input type
+# is a FIXED questionnaire slot in the EACI ag instrument (seed module
+# s1e/s11c; plot-fertilizer/pesticide module s2c/s7d, with separate
+# Urea/DAP/NPK/other and manure/compost/other-organic and pesticide/
+# fungicide/herbicide/other-phytosanitary columns).  The wave scripts emit
+# a synthetic `Code` per slot (identical across waves, hence one shared
+# column), and this table maps it to the canonical Preferred Label.  The
+# Code IS the cross-wave join key; both EACI waves emit every slot.
+#+name: harmonize_input
+| Code                | Preferred Label     | 2014-15 | 2017-18 |
+|---------------------+---------------------+---------+---------|
+| seed                | Seed                | x       | x       |
+| urea                | Urea                | x       | x       |
+| dap                 | DAP                 | x       | x       |
+| npk                 | NPK                 | x       | x       |
+| other_inorganic     | Other inorganic     | x       | x       |
+| manure              | Manure              | x       | x       |
+| compost             | Compost             | x       | x       |
+| other_organic       | Other organic       | x       | x       |
+| pesticide           | Pesticide           | x       | x       |
+| fungicide           | Fungicide           | x       | x       |
+| herbicide           | Herbicide           | x       | x       |
+| other_phytosanitary | Other phytosanitary | x       | x       |

--- a/lsms_library/countries/Mali/_/data_scheme.yml
+++ b/lsms_library/countries/Mali/_/data_scheme.yml
@@ -155,3 +155,37 @@ Data Scheme:
     intercropped: bool
     perennial: bool
     materialize: make
+  plot_inputs:
+    # Item-level agricultural inputs, GAP 2 (parity loop).  One row per
+    # (t, i, plot, input, crop): the REPORTED inputs the survey records, NOT
+    # aggregates.  The input module lives in the EACI waves only (2014-15
+    # EACI14 s1e/s2c, 2017-18 EACI17 s11c/s7d).  The EHCVM waves (2018-19,
+    # 2021-22) have no agriculture-input block — deferred (same split as
+    # crop_production).
+    #
+    # plot  = "{field}_{parcel}" — the SAME plot id as crop_production /
+    #         plot_features.  crop is set on SEED rows only (the seed's crop,
+    #         harmonize_food Preferred Label); NaN for fertilizer/pesticide
+    #         rows (applied at the plot grain, not per-crop).
+    # input = harmonize_input Preferred Label (Seed / Urea / DAP / NPK /
+    #         Other inorganic / Manure / Compost / Other organic / Pesticide /
+    #         Fungicide / Herbicide / Other phytosanitary).  These are FIXED
+    #         questionnaire slots, not a decoded label column.
+    # u     = harmonize unit label (`u` categorical table).
+    #
+    # Purchased / Quantity_purchased come from the household input-purchase
+    # roster (s2d / s7b, HH grain) for fertilizers, and from the seed module's
+    # paid-for question (s11cq12) in 2017-18; organic-fertilizer Purchased is
+    # also derivable from the plot-level acquisition mode ('Achat').  Improved
+    # is set on seed rows (s1eq04 / s11cq10).
+    #
+    # NO seed_kg / nitrogen_kg / any-use flags / fertilizer totals — those are
+    # transformations.py rollups over these item rows.  Built by per-wave
+    # scripts + a country-level concatenator.
+    index: (t, i, plot, input, crop)
+    Quantity: float
+    u: str
+    Purchased: bool
+    Quantity_purchased: float
+    Improved: bool
+    materialize: make

--- a/lsms_library/countries/Mali/_/mali.py
+++ b/lsms_library/countries/Mali/_/mali.py
@@ -336,3 +336,102 @@ def crop_production_finalize(df):
     out = out[['Quantity', 'u', 'Quantity_sold', 'Value_sold',
                'planting_month', 'harvest_month', 'intercropped', 'perennial']]
     return out.sort_index()
+
+
+# ---------------------------------------------------------------------------
+# plot_inputs (GAP 2; parity loop) — item-level (t, i, plot, input)
+# ---------------------------------------------------------------------------
+#
+# One row per input APPLIED to a plot.  The crop/input modules live in the
+# EACI waves only (2014-15 EACI14, 2017-18 EACI17); the EHCVM waves
+# (2018-19, 2021-22) carry no agriculture-input block (the same wave split as
+# crop_production), so plot_inputs is wired for the two EACI waves only.
+#
+# Grain: one row per (t, i, plot, input), where
+#   - i     = Mali composite household id (grappe, menage/exploitation),
+#   - plot  = "{field}_{parcel}" — the SAME plot id as crop_production /
+#             plot_features (s2cq01_s2cq02 etc.); seed rows additionally key
+#             on a crop column where the source records it,
+#   - input = harmonize_input Preferred Label (Seed / Urea / DAP / NPK /
+#             Other inorganic / Manure / Compost / Other organic / Pesticide /
+#             Fungicide / Herbicide / Other phytosanitary).
+#
+# REPORTED item-level columns only (NO seed_kg / nitrogen_kg / any-use flags /
+# fertilizer totals — those are transformations.py rollups over these rows):
+#   Quantity, u, Purchased, Quantity_purchased, Improved, crop.
+#
+# The input types are FIXED questionnaire slots (not a decoded label column),
+# so the wave scripts assign the harmonize_input Code directly; this module's
+# _input_labels maps that Code -> Preferred Label.  Units arrive as decoded
+# Stata labels (the `u` categorical table); the seed's crop is the
+# harmonize_food Preferred Label so it joins crop_production / food_acquired.
+
+
+def _input_labels(series):
+    """Map a Series of harmonize_input Codes -> Preferred Label."""
+    m = tools.get_categorical_mapping(tablename='harmonize_input', idxvars='Code',
+                                      **{'Preferred Label': 'Preferred Label'})
+    out = series.astype('string').str.strip().map(m)
+    return out.astype('string')
+
+
+def plot_inputs_finalize(df):
+    """Common post-processing for a plot_inputs wave DataFrame.
+
+    Expects raw columns already assembled:
+        t, i, plot, input (harmonize_input Code), crop (decoded crop name or
+        NA), u (decoded unit label or NA), Quantity, Purchased (nullable
+        bool), Quantity_purchased, Improved (nullable bool).
+    Maps input/unit/crop labels, coerces dtypes, drops content-free rows
+    (an input slot the household did not use -> no quantity, no purchase,
+    no improved flag), sets the (t, i, plot, input, crop) index, and
+    collapses exact-duplicate index rows by summing the reported quantities
+    and taking the first/any of the flags.
+    """
+    df = df.copy()
+    df['input'] = _input_labels(df['input'])
+    df['u'] = _unit_labels(df['u'])
+    df['crop'] = _crop_labels(df['crop'])
+    df = df.dropna(subset=['input'])  # drop unmapped input slots
+
+    for c in ('Quantity', 'Quantity_purchased'):
+        df[c] = pd.to_numeric(df[c], errors='coerce')
+    # 9999 / 999 / 99 are the EACI "Manquant" sentinels on the reported
+    # quantity columns (cf. the WB seed_kg block `replace seed_kg=. if
+    # s1eq05a>=9999`); coerce to NA so they do not contaminate a downstream
+    # kg-conversion sum.
+    for c in ('Quantity', 'Quantity_purchased'):
+        df.loc[df[c].isin([99, 999, 9999, 99999]), c] = pd.NA
+    df['Purchased'] = df['Purchased'].astype('boolean')
+    df['Improved'] = df['Improved'].astype('boolean')
+
+    # Drop content-free rows: an input slot for which the household reported
+    # nothing positive.  A reported Quantity, a reported purchased quantity,
+    # a positive Purchased flag, or a non-NA Improved flag all count as
+    # content.  Purchased == False does NOT count (it is the ABSENCE of a
+    # purchase — keeping it would emit a content-free row on every plot for a
+    # fertilizer type the household neither applied here nor bought).
+    has_content = (df['Quantity'].notna() | df['Quantity_purchased'].notna()
+                   | df['Purchased'].fillna(False).astype('boolean')
+                   | df['Improved'].notna())
+    df = df[has_content]
+
+    # plot / crop may be NA; carry as NA-able strings so the index level is
+    # not silently dropped.
+    df['plot'] = df['plot'].astype('string')
+    df['crop'] = df['crop'].astype('string')
+
+    keys = ['t', 'i', 'plot', 'input', 'crop']
+    # Collapse any exact (t,i,plot,input,crop) duplicates: sum reported
+    # amounts (min_count=1 keeps an all-NA group NA, not a spurious 0),
+    # first/any for flags.  dropna=False so plot/crop NA rows survive.
+    g = df.groupby(keys, dropna=False, as_index=True)
+    out = pd.DataFrame({
+        'Quantity':           g['Quantity'].sum(min_count=1),
+        'Quantity_purchased': g['Quantity_purchased'].sum(min_count=1),
+        'u':                  g['u'].first(),
+        'Purchased':          g['Purchased'].max(),
+        'Improved':           g['Improved'].max(),
+    })
+    out = out[['Quantity', 'u', 'Purchased', 'Quantity_purchased', 'Improved']]
+    return out.sort_index()

--- a/lsms_library/countries/Mali/_/plot_inputs.py
+++ b/lsms_library/countries/Mali/_/plot_inputs.py
@@ -1,0 +1,38 @@
+"""Concatenate wave-level plot_inputs for Mali (GAP 2; parity loop).
+
+Each EACI wave's ``Mali/<wave>/_/plot_inputs.py`` writes a parquet indexed
+by ``(t, i, plot, input, crop)`` with the reported item-level input columns
+(Quantity, u, Purchased, Quantity_purchased, Improved).  The crop/input
+module lives in the EACI waves only (2014-15 EACI14, 2017-18 EACI17); the
+EHCVM waves (2018-19, 2021-22) carry no agriculture-input block, so they
+contribute nothing — the same wave split as crop_production.
+
+``v`` is NOT baked in — the framework joins it from ``sample()`` at API
+time.  ``id_walk`` is left to ``_finalize_result`` (cached parquets store
+pre-transformation data), matching the crop_production / plot_features /
+food_coping pattern.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+WAVES = ['2014-15', '2017-18', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_inputs.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired (no .py script / no parquet); DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_inputs: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, plot, input, crop) after concat"
+
+to_parquet(p, '../var/plot_inputs.parquet')

--- a/lsms_library/countries/Niger/2011-12/_/plot_inputs.py
+++ b/lsms_library/countries/Niger/2011-12/_/plot_inputs.py
@@ -1,0 +1,66 @@
+"""Build plot_inputs for Niger ECVMA 2011-12 (GAP 2, item-level).
+
+Single source file: ecvmaas2c_p1.dta — the household agricultural-input
+roster, one row per (crop, input-type) the household was ASKED about.
+Columns:
+  as02cq02  input type (organic / inorganic fert / phyto / 7 seed slots)
+  as02cq03  USED this input? (1=Oui / 2=Non) — the application gate
+  as02cq04  crop (same crop codes as the harvest module)
+  as02cq05a / as02cq05b   quantity used + native unit
+  as02cq07  purchased? (1=Oui / 2=Non)
+  as02cq08a quantity purchased (native purchased-unit)
+
+Only the rows the household actually applied are reported inputs, so we
+keep as02cq03==1 (the .do code does the same: `replace seed_kg=0 if
+as02cq03==2`, `keep if ... & as02cq03==1`).  i = str(int(hid)); hid
+already equals grappe*100+menage (the canonical 2011-12 household id),
+matching crop_production / sample.  No plot column in this roster (Niger
+inputs are reported at the household level), so the grain is
+(t, i, input, crop, u); see niger.py:_finish_plot_inputs.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import (i as niger_i, _input_maps, _input_labels,
+                   _unit_labels, _finish_plot_inputs)
+
+
+src = get_dataframe(
+    '../Data/NER_2011_ECVMA_v01_M_Stata8/ecvmaas2c_p1.dta',
+    convert_categoricals=True)
+srcn = get_dataframe(
+    '../Data/NER_2011_ECVMA_v01_M_Stata8/ecvmaas2c_p1.dta',
+    convert_categoricals=False)
+
+input_map, unit_map, _ = _input_maps()
+# ECVMA reuses the harvest crop labels for its input-roster crop column.
+from niger import _crop_maps, _crop_labels
+crop_map, _ = _crop_maps()
+
+# Keep only inputs the household actually applied (as02cq03 == 1 = Oui).
+applied = srcn['as02cq03'] == 1
+src = src[applied.values]
+srcn = srcn[applied.values]
+
+hh = srcn['hid'].apply(lambda x: niger_i(x) if pd.notna(x) else pd.NA)
+
+# purchased: as02cq07 1 = Oui -> True, 2 = Non -> False (9 Manquant -> NA)
+purchased = srcn['as02cq07'].map({1: True, 2: False})
+
+df = pd.DataFrame({
+    'i':                  hh.values,
+    'input':              _input_labels(src['as02cq02'], input_map).values,
+    'crop':               _crop_labels(srcn['as02cq04'], src['as02cq04'], crop_map).values,
+    'u':                  _unit_labels(src['as02cq05b'], unit_map).values,
+    'Quantity':           pd.to_numeric(srcn['as02cq05a'], errors='coerce').values,
+    'Purchased':          purchased.values,
+    'Quantity_purchased': pd.to_numeric(srcn['as02cq08a'], errors='coerce').values,
+})
+
+df = _finish_plot_inputs(df, '2011-12')
+
+assert len(df) > 0, 'plot_inputs 2011-12 produced no rows'
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Niger/2014-15/_/plot_inputs.py
+++ b/lsms_library/countries/Niger/2014-15/_/plot_inputs.py
@@ -1,0 +1,59 @@
+"""Build plot_inputs for Niger ECVMA 2014-15 (GAP 2, item-level).
+
+Single source file: ECVMA2_AS02CP1.dta — the household agricultural-input
+roster, one row per (crop, input-type) the household was asked about.  Same
+layout as 2011-12 but UPPERCASE columns:
+  AS02CQ02  input type (organic / inorganic fert / phyto / 7 seed slots)
+  AS02CQ03  USED this input? (1=Oui / 2=Non) — the application gate
+  AS02CQ04  crop (same crop codes as the harvest module)
+  AS02CQ05A / AS02CQ05B   quantity used + native unit
+  AS02CQ07  purchased? (1=Oui / 2=Non)
+  AS02CQ08A quantity purchased (native purchased-unit, AS02CQ08B)
+
+Only the rows the household actually applied are reported inputs, so we
+keep AS02CQ03==1.  i is built from (GRAPPE, MENAGE) via niger.i (matching
+this wave's sample / roster / crop_production idxvars, which omit
+EXTENSION).  No plot column; grain is (t, i, input, crop, u).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import (i as niger_i, _input_maps, _input_labels,
+                   _unit_labels, _finish_plot_inputs, _crop_maps, _crop_labels)
+
+
+base = '../Data/NER_2014_ECVMA-II_v02_M_STATA8/'
+src = get_dataframe(base + 'ECVMA2_AS02CP1.dta', convert_categoricals=True)
+srcn = get_dataframe(base + 'ECVMA2_AS02CP1.dta', convert_categoricals=False)
+
+input_map, unit_map, _ = _input_maps()
+crop_map, _ = _crop_maps()
+
+# Keep only inputs the household actually applied (AS02CQ03 == 1 = Oui).
+applied = srcn['AS02CQ03'] == 1
+src = src[applied.values]
+srcn = srcn[applied.values]
+
+hh = src.apply(lambda r: niger_i(pd.Series([r['GRAPPE'], r['MENAGE']],
+                                           index=['GRAPPE', 'MENAGE'])), axis=1)
+
+# purchased: AS02CQ07 1 = Oui -> True, 2 = Non -> False (9 Manquant -> NA)
+purchased = srcn['AS02CQ07'].map({1: True, 2: False})
+
+df = pd.DataFrame({
+    'i':                  hh.values,
+    'input':              _input_labels(src['AS02CQ02'], input_map).values,
+    'crop':               _crop_labels(srcn['AS02CQ04'], src['AS02CQ04'], crop_map).values,
+    'u':                  _unit_labels(src['AS02CQ05B'], unit_map).values,
+    'Quantity':           pd.to_numeric(srcn['AS02CQ05A'], errors='coerce').values,
+    'Purchased':          purchased.values,
+    'Quantity_purchased': pd.to_numeric(srcn['AS02CQ08A'], errors='coerce').values,
+})
+
+df = _finish_plot_inputs(df, '2014-15')
+
+assert len(df) > 0, 'plot_inputs 2014-15 produced no rows'
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Niger/2018-19/_/plot_inputs.py
+++ b/lsms_library/countries/Niger/2018-19/_/plot_inputs.py
@@ -1,0 +1,59 @@
+"""Build plot_inputs for Niger EHCVM 2018-19 (GAP 2, item-level).
+
+Single source file: s16b_me_ner2018.dta — the household agricultural-input
+roster, one row per input-type the household was asked about.  Columns:
+  s16bq01   input type (organic / inorganic fert / phyto / seeds-by-crop)
+  s16bq02   USED this input? (Oui / Non) — application gate (all Oui in 2018)
+  s16bq03a / s16bq03b   quantity used + native unit
+  s16bq05   purchased? (Oui / Non)
+  s16bq07a  quantity purchased (native unit)
+
+We keep s16bq02==1 (applied) rows — in 2018 every row is already an applied
+input, but the gate is kept for parity with 2021 (where most rows are
+not-used / not-asked).  The EHCVM roster has NO crop column — the seed's
+crop is embedded in the input-type label ('Semences de petit mil'),
+resolved to the harmonize_food crop label via harmonize_seed_crop.
+Non-seed input rows carry crop NaN.  i is the EHCVM composite id ('E_' +
+grappe + '0' + zero-padded menage) via niger.i.  No plot column; grain is
+(t, i, input, crop, u).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import (i as niger_i, _input_maps, _input_labels,
+                   _seed_crop_labels, _unit_labels, _finish_plot_inputs)
+
+
+src = get_dataframe('../Data/s16b_me_ner2018.dta', convert_categoricals=True)
+srcn = get_dataframe('../Data/s16b_me_ner2018.dta', convert_categoricals=False)
+
+input_map, unit_map, seed_crop_map = _input_maps()
+
+# Keep only inputs the household actually applied (s16bq02 == 1 = Oui).
+applied = srcn['s16bq02'] == 1
+src = src[applied.values]
+srcn = srcn[applied.values]
+
+hh = src.apply(lambda r: niger_i(pd.Series([r['grappe'], r['menage']],
+                                           index=['grappe', 'menage'])), axis=1)
+
+# purchased: s16bq05 Oui/Non (loaded as labels with convert_categoricals)
+purchased = src['s16bq05'].map({'Oui': True, 'Non': False})
+
+df = pd.DataFrame({
+    'i':                  hh.values,
+    'input':              _input_labels(src['s16bq01'], input_map).values,
+    'crop':               _seed_crop_labels(src['s16bq01'], seed_crop_map).values,
+    'u':                  _unit_labels(src['s16bq03b'], unit_map).values,
+    'Quantity':           pd.to_numeric(srcn['s16bq03a'], errors='coerce').values,
+    'Purchased':          purchased.values,
+    'Quantity_purchased': pd.to_numeric(srcn['s16bq07a'], errors='coerce').values,
+})
+
+df = _finish_plot_inputs(df, '2018-19')
+
+assert len(df) > 0, 'plot_inputs 2018-19 produced no rows'
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Niger/2021-22/_/plot_inputs.py
+++ b/lsms_library/countries/Niger/2021-22/_/plot_inputs.py
@@ -1,0 +1,57 @@
+"""Build plot_inputs for Niger EHCVM 2021-22 (GAP 2, item-level).
+
+Single source file: s16b_me_ner2021.dta — the household agricultural-input
+roster, one row per input-type the household was asked about.  Same layout
+as 2018-19:
+  s16bq01   input type (organic / inorganic fert / phyto / seeds-by-crop)
+  s16bq02   USED this input? (Oui / Non) — application gate
+  s16bq03a / s16bq03b   quantity used + native unit
+  s16bq05   purchased? (Oui / Non)
+  s16bq07a  quantity purchased (native unit)
+
+The 2021-22 roster lists EVERY input-type per household (most not used), so
+the s16bq02==1 gate is essential: of 73006 raw rows only ~12439 are applied
+inputs.  As in 2018-19 the seed's crop is embedded in the input-type label
+and resolved via harmonize_seed_crop (2021-22 adds 'Semences de coton',
+'Plants/boutures de tubercules' etc.).  Non-seed rows carry crop NaN.
+i is the EHCVM composite id via niger.i.  Grain (t, i, input, crop, u).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import (i as niger_i, _input_maps, _input_labels,
+                   _seed_crop_labels, _unit_labels, _finish_plot_inputs)
+
+
+src = get_dataframe('../Data/s16b_me_ner2021.dta', convert_categoricals=True)
+srcn = get_dataframe('../Data/s16b_me_ner2021.dta', convert_categoricals=False)
+
+input_map, unit_map, seed_crop_map = _input_maps()
+
+# Keep only inputs the household actually applied (s16bq02 == 1 = Oui).
+applied = srcn['s16bq02'] == 1
+src = src[applied.values]
+srcn = srcn[applied.values]
+
+hh = src.apply(lambda r: niger_i(pd.Series([r['grappe'], r['menage']],
+                                           index=['grappe', 'menage'])), axis=1)
+
+purchased = src['s16bq05'].map({'Oui': True, 'Non': False})
+
+df = pd.DataFrame({
+    'i':                  hh.values,
+    'input':              _input_labels(src['s16bq01'], input_map).values,
+    'crop':               _seed_crop_labels(src['s16bq01'], seed_crop_map).values,
+    'u':                  _unit_labels(src['s16bq03b'], unit_map).values,
+    'Quantity':           pd.to_numeric(srcn['s16bq03a'], errors='coerce').values,
+    'Purchased':          purchased.values,
+    'Quantity_purchased': pd.to_numeric(srcn['s16bq07a'], errors='coerce').values,
+})
+
+df = _finish_plot_inputs(df, '2021-22')
+
+assert len(df) > 0, 'plot_inputs 2021-22 produced no rows'
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Niger/_/Makefile
+++ b/lsms_library/countries/Niger/_/Makefile
@@ -33,6 +33,20 @@ $(VAR_DIR)/crop_production.parquet: crop_production.py niger.py categorical_mapp
 ../%/_/crop_production.parquet: ../%/_/crop_production.py niger.py categorical_mapping.org
 	(cd $(@D) && python crop_production.py)
 
+# plot_inputs (GAP 2, item-level).  Same shape as crop_production: the
+# country-level var/ parquet is built by the concatenator, which reads each
+# wave's parquet; the country script is run unconditionally to (re)build the
+# wave parquets it reads, then concatenates.
+INPUT_WAVES := 2011-12 2014-15 2018-19 2021-22
+
+$(VAR_DIR)/plot_inputs.parquet: plot_inputs.py niger.py categorical_mapping.org \
+		$(foreach w,$(INPUT_WAVES),../$(w)/_/plot_inputs.py)
+	$(foreach w,$(INPUT_WAVES),(cd ../$(w)/_ && python plot_inputs.py);)
+	python plot_inputs.py
+
+../%/_/plot_inputs.parquet: ../%/_/plot_inputs.py niger.py categorical_mapping.org
+	(cd $(@D) && python plot_inputs.py)
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Niger/_/categorical_mapping.org
+++ b/lsms_library/countries/Niger/_/categorical_mapping.org
@@ -157,6 +157,26 @@
 | botte                 | Botte            |      |                  |                       |
 | Manquant              | Manquant         |      |                  |                       |
 | manquant              | Manquant         |      |                  |                       |
+| sac de 5 kg           | Sac de 5 kg      |      |                  |                       |
+| sac de 10 kg          | Sac de 10 kg     |      |                  |                       |
+| sac de 25 kg          | Sac (25 Kg)      |      |                  |                       |
+| tas                   | Tas              |      |                  |                       |
+| litres                | Litre            |      |                  |                       |
+| Litres                | Litre            |      |                  |                       |
+| sachet                | Sachet           |      |                  |                       |
+| Sac                   | Sac              |      |                  |                       |
+| Tonne                 | Tonne            |      |                  |                       |
+| Charrette             | Charrette        |      |                  |                       |
+| charette asine        | Charrette asine  |      |                  |                       |
+| Charette asine        | Charrette asine  |      |                  |                       |
+| Charrette asine       | Charrette asine  |      |                  |                       |
+| charette bovine       | Charrette bovine |      |                  |                       |
+| Charette bovine       | Charrette bovine |      |                  |                       |
+| Charrette bovine      | Charrette bovine |      |                  |                       |
+| Sac (50kg)            | Sac de 50 kg     |      |                  |                       |
+| Sac(50kg)             | Sac de 50 kg     |      |                  |                       |
+| Sac (100kg)           | Sac de 100 kg    |      |                  |                       |
+| Sac(100kg)            | Sac de 100 kg    |      |                  |                       |
 
 #+NAME: Region
 | Original Label                 | Preferred Label                |
@@ -783,3 +803,124 @@
 | Autre                                                                                     | Autre crop                                                                           |
 | autre                                                                                     | Autre crop                                                                           |
 | Autre (à préciser)                                                                        | Autre crop                                                                           |
+| jaxatu                                                                                    | Jaxatu                                                                               |
+| Jaxatu                                                                                    | Jaxatu                                                                               |
+| epinard                                                                                   | Épinard                                                                              |
+| Epinard                                                                                   | Épinard                                                                              |
+| Épinard                                                                                   | Épinard                                                                              |
+| petits pois                                                                               | Petits pois                                                                          |
+| Céléri                                                                                    | Céleri                                                                               |
+| Celeri                                                                                    | Céleri                                                                               |
+
+* Agricultural Inputs (plot_inputs — the input axis)
+
+# harmonize_input (GAP 2 plot_inputs, parity loop 2026-06-14).  Maps each
+# wave's agricultural-input *type* label onto a shared input taxonomy
+# `Preferred Label`.  The reported item-level input feature `plot_inputs`
+# (grain (t, i, input, crop, u)) puts this Preferred Label on its `input`
+# index level.
+#
+# WHY STRING-KEYED (Original Label), like harmonize_food / u: the integer
+# input-type code is NOT a stable cross-wave key.  In the ECVMA waves
+# (2011-12 ecvmaas2c_p1 / 2014-15 ECVMA2_AS02CP1, column as02cq02) DAP=4,
+# NPK=5, fungicide=8, herbicide=9.  In the EHCVM waves (2018-19 / 2021-22
+# s16b, column s16bq01) phosphate=4, NPK=5, DAP=6, herbicide=8,
+# fungicide=9 — the codes for DAP / herbicide / fungicide all shifted.
+# So the wave scripts load with convert_categoricals=True and key on the
+# raw French label string, exactly as crop_production keys on the crop
+# label.  Both ECVMA case variants (2011-12 lowercase, 2014-15 Title-case)
+# are listed.
+#
+# TAXONOMY (the Preferred Labels, a sensible shared input vocabulary):
+#   Organic manure / Organic compost   (organic fertilizers)
+#   Urea / DAP / NPK / Phosphate / Mixed fertilizer  (inorganic fertilizers)
+#   Pesticide / Herbicide / Fungicide / Other phytosanitary  (phytosanitary)
+#   Seed                                 (all seed slots collapse to Seed;
+#                                         the seed's crop is carried in the
+#                                         separate `crop` column, NOT here)
+# The ECVMA input roster carries the seed's crop in its own crop column
+# (as02cq04), so all seven ECVMA seed slots ('Semences') map to Seed.
+# The EHCVM s16b roster instead embeds the crop IN the seed-type label
+# ('Semences de petit mil', ...), so every EHCVM seed label ALSO maps to
+# Seed here and its crop is resolved by the companion harmonize_seed_crop
+# table below.  ECVMA code 6 'Mélange' (an unspecified inorganic blend)
+# -> Mixed fertilizer; EHCVM has no such code (it splits DAP/phosphate).
+#
+# Referenced from the wave-level _/plot_inputs.py via
+#   tools.get_categorical_mapping('harmonize_input','Original Label','Preferred Label').
+
+#+NAME: harmonize_input
+| Original Label                            | Preferred Label     |
+|-------------------------------------------+---------------------|
+| engrais organiques-fumure                 | Organic manure      |
+| Engrais organiques-Fumure                 | Organic manure      |
+| Engrais organiques - déchets d'animaux    | Organic manure      |
+| engrais organiques-compost                | Organic compost     |
+| Engrais organiques-Compost                | Organic compost     |
+| Engrais organiques - Ordures ménagères    | Organic compost     |
+| engrais inorganiques - urée               | Urea                |
+| Engrais inorganiques - Urée               | Urea                |
+| engrais inorganiques - dap                | DAP                 |
+| Engrais inorganiques - DAP                | DAP                 |
+| DAP et autres engrais inorganiques        | DAP                 |
+| engrais inorganiques - npk 15/15          | NPK                 |
+| Engrais inorganiques - NPK 15/15          | NPK                 |
+| Engrais inorganiques - NPK/Formule unique | NPK                 |
+| Engrais inorganiques - Phosphates         | Phosphate           |
+| engrais inorganiques - mélange            | Mixed fertilizer    |
+| Engrais inorganiques - Mélange            | Mixed fertilizer    |
+| produits phytosanitaires - pesticides     | Pesticide           |
+| Produits phytosanitaires - Pesticides     | Pesticide           |
+| produits phytosanitaires - herbicides     | Herbicide           |
+| Produits phytosanitaires - Herbicides     | Herbicide           |
+| produits phytosanitaires - fongicides     | Fungicide           |
+| Produits phytosanitaires - Fongicides     | Fungicide           |
+| Produits phytosanitaires-Fongicides       | Fungicide           |
+| Produits phytosanitaires -Fongicides      | Fungicide           |
+| autres produits phytosanitaires           | Other phytosanitary |
+| Autres produits phytosanitaires           | Other phytosanitary |
+| semences                                  | Seed                |
+| Semences                                  | Seed                |
+| Semences de petit mil                     | Seed                |
+| Semences de sorgho                        | Seed                |
+| Semences de maïs                          | Seed                |
+| Semences de riz                           | Seed                |
+| Semences d'autres céréales                | Seed                |
+| Semences de coton                         | Seed                |
+| Semences de sésame                        | Seed                |
+| Semences de césame                        | Seed                |
+| Semences de haricots/niébé                | Seed                |
+| Plants/boutures de tubercules             | Seed                |
+| Autres semences                           | Seed                |
+| 20                                        | Seed                |
+
+# harmonize_seed_crop (GAP 2 plot_inputs, 2026-06-14).  EHCVM-only helper.
+# The EHCVM s16b input roster (2018-19 / 2021-22) has NO crop column — the
+# crop is encoded in the seed-type label ('Semences de petit mil').  This
+# table resolves each EHCVM seed-type label to the crop's harmonize_food
+# `Preferred Label`, so seed rows carry the SAME `crop` value a consumed
+# food / grown crop would (the shared j axis).  The catch-all seed slots
+# ('Semences d'autres céréales', 'Autres semences', 'Plants/boutures de
+# tubercules') resolve to 'Autre crop' (no single crop named).  The bare
+# label '20' is the 2018-19 trailing seed slot whose value-label text was
+# not stored (it is 'Autres semences' = code 20 in the sibling 2021-22
+# wave), so it also maps to 'Autre crop'.  Non-seed input labels are absent
+# here (the wave script only consults this table for rows whose input
+# resolved to 'Seed').  The ECVMA waves do NOT use this table — they read
+# the crop from the roster's own crop column.
+
+#+NAME: harmonize_seed_crop
+| Original Label                | Preferred Label     |
+|-------------------------------+---------------------|
+| Semences de petit mil         | Mil                 |
+| Semences de sorgho            | Sorgho              |
+| Semences de maïs              | Maïs en grain       |
+| Semences de riz               | Riz Paddy           |
+| Semences de coton             | Coton               |
+| Semences de sésame            | Sésame              |
+| Semences de césame            | Sésame              |
+| Semences de haricots/niébé    | Niébé/Haricots secs |
+| Semences d'autres céréales    | Autre crop          |
+| Plants/boutures de tubercules | Autre crop          |
+| Autres semences               | Autre crop          |
+| 20                            | Autre crop          |

--- a/lsms_library/countries/Niger/_/data_scheme.yml
+++ b/lsms_library/countries/Niger/_/data_scheme.yml
@@ -164,3 +164,43 @@ Data Scheme:
     harvest_month: float
     intercropped: bool
     materialize: make
+
+  plot_inputs:
+    # Item-level agricultural inputs (GAP 2, parity loop 2026-06-14).  One
+    # row per REPORTED input applied by a household in a wave: input
+    # identity (Seed / Urea / DAP / NPK / Phosphate / Mixed fertilizer /
+    # Organic manure / Organic compost / Pesticide / Herbicide / Fungicide
+    # / Other phytosanitary), reported quantity used + native unit,
+    # purchased flag + reported purchased quantity, and (seed rows) the
+    # seed's crop on the shared harmonize_food labels.  REPORTED values
+    # only: seed_kg / nitrogen_kg / inorganic_fertilizer any-use flags /
+    # fertilizer totals are TRANSFORMATIONS over these rows, never columns.
+    #
+    # GRAIN NOTE: Niger records inputs at the HOUSEHOLD x input grain
+    # (ECVMA additionally x crop), NOT plot x input — no wave reports
+    # inputs at the parcel level.  The WB .do code that emits plot-level
+    # seed_kg / nitrogen_kg fabricates a plot split (plot_area /
+    # total_land_area); the reported-only rule forbids that, so `plot` is
+    # NOT in the index.  The feature keeps the GAP-2 name `plot_inputs`.
+    #
+    # All four waves have a household input roster (script-path):
+    #   2011-12 ecvmaas2c_p1   (hid, crop, input)  qty/unit + purchased
+    #   2014-15 ECVMA2_AS02CP1 (hh, crop, input)   same, UPPERCASE cols
+    #   2018-19 s16b_me_ner2018 (hh, input)        crop in seed label
+    #   2021-22 s16b_me_ner2021 (hh, input)        crop in seed label
+    # input -> harmonize_input; u -> the u table; crop -> harmonize_food
+    # (ECVMA crop column directly; EHCVM via harmonize_seed_crop on the
+    # seed label).  `crop` is in the index because one (input, u) spans
+    # several seed crops in ECVMA.  Non-crop-specific rows (every fertilizer
+    # / pesticide; unresolved seed crops) carry the sentinel
+    # '(not crop-specific)' rather than NaN — a NaN index level would be
+    # silently dropped by the framework's canonical NaN-key de-dup collapse
+    # (_finalize_result groupby().first()), losing every non-seed row.  `u`
+    # is in the index because one (input, crop) can be reported in several
+    # units; a missing unit is filled with the 'Manquant' u label for the
+    # same non-null reason.
+    index: (t, i, input, crop, u)
+    Quantity: float
+    Purchased: bool
+    Quantity_purchased: float
+    materialize: make

--- a/lsms_library/countries/Niger/_/niger.py
+++ b/lsms_library/countries/Niger/_/niger.py
@@ -431,3 +431,124 @@ def _finish_crop_production(df, t):
     df = df[[c for c in keep if c in df.columns]]
     df = df.set_index(['t', 'i', 'plot', 'crop', 'u'])
     return df
+
+
+# ---------------------------------------------------------------------------
+# plot_inputs (GAP 2 — item-level agricultural inputs)
+# ---------------------------------------------------------------------------
+#
+# One row per REPORTED agricultural input applied by a household in a wave:
+# its harmonized input identity (Seed / Urea / DAP / NPK / Phosphate / Mixed
+# fertilizer / Organic manure / Organic compost / Pesticide / Herbicide /
+# Fungicide / Other phytosanitary), reported quantity used + native unit, the
+# purchased flag + reported purchased quantity, and — for seed rows — the
+# seed's crop (on the shared harmonize_food labels).  No aggregation: every
+# reported input line is kept.  seed_kg, nitrogen_kg, inorganic_fertilizer
+# any-use flags and fertilizer totals are TRANSFORMATIONS over these rows,
+# never columns here (GAP-2 / item-level discipline).
+#
+# GRAIN = (t, i, input, crop, u).  NOTE: Niger's input modules are at the
+# HOUSEHOLD x input grain (ECVMA additionally x crop), NOT plot x input —
+# no Niger wave records inputs at the parcel level (the WB .do code that
+# emits plot-level seed_kg / nitrogen_kg fabricates a plot allocation via
+# indicator = plot_area / total_land_area, which the reported-only rule
+# forbids).  So `plot` is NOT in the index; the feature name `plot_inputs`
+# follows the GAP-2 ranking name, but the data is the reported HH-level
+# input roster.  `crop` is in the index because the ECVMA input roster is
+# per-(crop) for every input type, and several seed slots / crops can share
+# the same (input, u); it is NaN for non-seed EHCVM rows (those modules
+# carry no crop), accepted as a partly-null index level.
+#
+# Input instrument by wave (all four waves have one; all are item-level
+# household input rosters, loaded convert_categoricals=True so the input /
+# crop / unit labels arrive as the strings the harmonize_* tables key on):
+#   2011-12  ecvmaas2c_p1  : (hid, crop, input-type) — as02cq02 input,
+#                            as02cq04 crop, as02cq05a/b qty+unit,
+#                            as02cq03 purchased(1/2), as02cq08a purchased qty.
+#   2014-15  ECVMA2_AS02CP1: same layout, UPPERCASE columns (AS02CQ*),
+#                            i from (GRAPPE, MENAGE).
+#   2018-19  s16b_me_ner2018: (grappe, menage, input-type) — s16bq01 input
+#                            (crop embedded in seed label -> harmonize_seed_crop),
+#                            s16bq03a/b qty+unit, s16bq05 purchased(Oui/Non),
+#                            s16bq07a purchased qty.  NO crop column.
+#   2021-22  s16b_me_ner2021: same as 2018-19.
+
+
+def _input_maps():
+    """Load the harmonize_input (input-type) and u (unit) string->label
+    maps, plus the harmonize_seed_crop map (EHCVM seed-label -> crop).
+    Keyed on Original Label, like crop_production's _crop_maps."""
+    input_map = tools.get_categorical_mapping(
+        tablename='harmonize_input', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    unit_map = tools.get_categorical_mapping(
+        tablename='u', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    seed_crop_map = tools.get_categorical_mapping(
+        tablename='harmonize_seed_crop', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    return input_map, unit_map, seed_crop_map
+
+
+def _input_labels(source_labels, input_map):
+    """Map an input-type column (string labels from convert_categoricals=True)
+    through harmonize_input.  Unmapped labels pass through unchanged (kept
+    visible, flagged by the sanity checker)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: input_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _seed_crop_labels(source_labels, seed_crop_map):
+    """For EHCVM waves: resolve the crop embedded in a seed-type label
+    ('Semences de petit mil' -> 'Mil') via harmonize_seed_crop.  Returns NA
+    for any label not in the seed-crop table (i.e. non-seed input rows)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: seed_crop_map.get(x, pd.NA) if pd.notna(x) else pd.NA).astype('string')
+
+
+# Sentinel for the `crop` index level on input rows that are NOT
+# crop-specific (every fertilizer / pesticide row, and any seed row whose
+# crop could not be resolved).  WHY A SENTINEL, NOT NaN: the framework's
+# canonical-index de-duplication (_finalize_result, country.py ~L3457) does
+# groupby(level=...).first(), and pandas groupby drops rows whose grouping
+# KEY is NaN — so a partly-null `crop` index level silently discards every
+# non-seed input row.  A non-null token keeps all reported rows and makes
+# "no crop dimension" explicit; '(not crop-specific)' is deliberately not a
+# food/crop label so it never collides with the harmonize_food `crop`
+# values that the seed rows carry.
+CROP_NA = '(not crop-specific)'
+
+
+def _finish_plot_inputs(df, t):
+    """Common tail for the wave-level plot_inputs scripts: coerce numeric
+    columns, guarantee the full schema column set, build the
+    (t, i, input, crop, u) index.  Mirrors _finish_crop_production.
+
+    Drops rows with no input identity (input NA) — a roster placeholder
+    line, not a reported input.  The `crop` index level is filled with the
+    CROP_NA sentinel wherever no crop applies (non-seed inputs, unresolved
+    seed crops) so the index is fully non-null and no row is lost to the
+    framework's NaN-key duplicate collapse.  The native unit `u` is filled
+    likewise (a reported input may lack a unit), keeping `u` non-null."""
+    for col in ['Quantity', 'Quantity_purchased']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Purchased' not in df.columns:
+        df['Purchased'] = pd.NA
+    df['Purchased'] = df['Purchased'].astype('boolean')
+    df['t'] = t
+    df['input'] = df['input'].astype('string')
+    if 'crop' not in df.columns:
+        df['crop'] = pd.NA
+    df['crop'] = df['crop'].astype('string').fillna(CROP_NA)
+    # A reported input may lack a recorded unit (e.g. a count of bags); fill
+    # with the existing 'Manquant' (=missing) `u` Preferred Label so the `u`
+    # index level is non-null and survives the canonical de-dup collapse.
+    df['u'] = df['u'].astype('string').fillna('Manquant')
+    df = df[df['input'].notna()]
+    keep = ['t', 'i', 'input', 'crop', 'u',
+            'Quantity', 'Purchased', 'Quantity_purchased']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'input', 'crop', 'u'])
+    return df

--- a/lsms_library/countries/Niger/_/plot_inputs.py
+++ b/lsms_library/countries/Niger/_/plot_inputs.py
@@ -1,0 +1,38 @@
+"""Concatenate wave-level plot_inputs for Niger (GAP 2, item-level).
+
+Each wave's ``Niger/<wave>/_/plot_inputs.py`` writes a parquet indexed by
+``(t, i, input, crop, u)`` with the reported per-input columns.  This
+script concatenates the four waves (2011-12, 2014-15, 2018-19, 2021-22),
+each of which has a household agricultural-input roster.  ``v`` is NOT
+baked in — the framework joins it from ``sample()`` at API time.
+
+As in the crop_production / plot_features siblings, this does NOT apply
+``id_walk`` here; the framework runs it in ``_finalize_result`` on every
+read.  The ``(t, i, input, crop, u)`` index is intentionally NON-unique
+(a household can report the same input on several lines / crops) and the
+``crop`` level is partly NaN (the EHCVM waves carry no crop for non-seed
+inputs) — both are expected and stay within the diagnostics tolerance.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2011-12', '2014-15', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_inputs.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for plot_inputs (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, 'plot_inputs: no wave-level parquets found'
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/plot_inputs.parquet')

--- a/lsms_library/countries/Nigeria/_/categorical_mapping.org
+++ b/lsms_library/countries/Nigeria/_/categorical_mapping.org
@@ -394,6 +394,7 @@
 | 1016 | Piece | --- | --- | --- | --- |
 | 1017 | Stalk | --- | --- | --- | --- |
 | 1018 | Tiya | --- | --- | --- | --- |
+| 1019 | days | --- | --- | --- | --- |
 
 * Geopolitical Zones
 
@@ -684,3 +685,39 @@
 |    5 | loamy           |
 |    6 | other           |
 |   96 | other           |
+
+* Agricultural inputs (plot_inputs, GAP 2)
+
+** harmonize_input -- input-type identity (the plot_inputs `input` axis)
+
+  The plot_inputs feature's ``input`` index level carries one of these
+  Preferred Labels.  The country-level ``_/plot_inputs.py`` script
+  resolves each module's native input identity to the Preferred Label
+  directly (mirroring how crop_production resolves crops via
+  harmonize_food), so this table is the canonical REGISTRY for the
+  cross-wave input taxonomy.  The per-wave columns record the native
+  source label / questionnaire concept each Preferred Label is built
+  from; ``---`` means the wave does not record that input separately.
+
+  Fertilizer types: W1/W2/W3 record a single fertilizer-type code per
+  acquisition channel (1=NPK, 2=UREA, 3=COMPOSITE MANURE -> Organic
+  Fertilizer, 4=OTHER); W4/W5 give NPK / Urea / other-inorganic /
+  organic each its own quantity column.  Pesticide / herbicide carry the
+  reported quantity used (+unit).  Animal Traction carries reported own +
+  rented animal-days (u = days).  Seeds are the per-plot-crop seed-use
+  rows (crop carried on the harmonize_food ``crop`` index level).  The
+  plain "did you use a tractor/machine?" question records no per-input
+  quantity at this grain, so it is NOT stored as a flag-only row (it is a
+  ``used_machinery`` transformation, not a data-layer item).
+
+#+NAME: harmonize_input
+| Code | Preferred Label            | 2010Q3            | 2012Q3            | 2015Q3              | 2018Q3             | 2023Q3             |
+|------+----------------------------+-------------------+-------------------+---------------------+--------------------+--------------------|
+|    1 | Seed                       | seed (sect11e)    | seed (sect11e)    | seed (sect11e)      | seed (sect11f)     | seed (sect11f)     |
+|    2 | NPK                        | npk               | NPK               | 1. NPK              | NPK                | NPK                |
+|    3 | Urea                       | urea              | UREA              | 2. UREA             | UREA               | UREA               |
+|    4 | Organic Fertilizer         | composite manure  | Composite Manure  | 3. COMPOSITE MANURE | organic fertilizer | organic fertilizer |
+|    5 | Other Inorganic Fertilizer | other (specify)   | Other (specify)   | 4. OTHER (SPECIFY)  | other inorganic    | other inorganic    |
+|    6 | Pesticide                  | pesticide         | pesticide         | pesticide           | pesticide          | pesticide          |
+|    7 | Herbicide                  | herbicide         | herbicide         | herbicide           | herbicide          | herbicide          |
+|    8 | Animal Traction            | animal traction   | animal traction   | animal traction     | animal traction    | animal traction    |

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -133,6 +133,50 @@ Data Scheme:
     perennial: bool
     materialize: make
 
+  plot_inputs:
+    # Item-level reported agricultural inputs (GAP 2) at natural grain
+    # (t, i, plot, input, crop).  Source: the post-planting / post-harvest
+    # input modules (seeds sect11e/sect11f, fertilizer sect11d/secta11c2,
+    # pesticide sect11c/secta11c2).  Each wave maps to a single t = PP
+    # quarter (2010Q3 / 2012Q3 / 2015Q3 / 2018Q3 / 2023Q3), matching
+    # plot_features; plot_id aligns with crop_production via format_id.
+    # Country-level script (_/plot_inputs.py) reshapes the per-acquisition-
+    # channel modules into one row per input applied to a plot ->
+    # materialize: make.  Stores REPORTED item-level fields ONLY -- no
+    # seed_kg / nitrogen_kg conversion, no inorganic/organic any-use flags,
+    # no fertilizer totals (those are transformations over these rows).
+    #
+    # `input` (index) carries a harmonized input-type Preferred Label
+    # (Seed / NPK / Urea / Other Inorganic Fertilizer / Organic Fertilizer
+    # / Pesticide / Herbicide / Animal Traction), resolved in-script and
+    # registered in harmonize_input (the canonical registry, mirroring how
+    # crop_production resolves crops via harmonize_food).  `crop` (index)
+    # is the seed's crop on the shared harmonize_food Preferred Label (so
+    # seed rows join food_acquired.j / crop_production.crop); non-seed
+    # crop-agnostic inputs carry crop = 'n/a'.  u is normalized to the
+    # shared `u` table base labels (chemicals: Kg/g/l/cl; animal traction:
+    # days).
+    #
+    # Every row carries a REPORTED quantity (an item), never a bare any-use
+    # flag.  Quantity / u: reported native quantity + unit, summed across
+    # same-unit acquisition channels (mixed-unit channels keep the largest
+    # reported channel -- no kg conversion, which is a transformation).
+    # Animal Traction carries reported own+rented animal-days (u=days).
+    # The plain "used a tractor/machine?" yes/no records no per-input
+    # quantity -> left to a used_machinery transformation, not stored.
+    # Purchased / Quantity_purchased: from the commercial acquisition
+    # channels (W1-W3 only; W4/W5 seed/fert modules do not split purchase
+    # at this grain -> NaN).  Improved: seed rows only -- W3 s11eq3b
+    # (hybrid/improved), W4/W5 s11fq3b/s11fq7 + certified flag; W1/W2 seed
+    # modules have no improved-variety question -> NaN.
+    index: (t, i, plot, input, crop)
+    Quantity: float
+    u: str
+    Purchased: bool
+    Quantity_purchased: float
+    Improved: bool
+    materialize: make
+
   food_coping:
     # Family B (coping-strategies / rCSI), #332.  GHS section 9 ("Food
     # Security") is a coping day-count battery (items s9q1a..s9q1i: "how

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -302,6 +302,383 @@ def crop_production_for_wave(t, frames, crop_labels):
 
 
 # ---------------------------------------------------------------------
+# plot_inputs (GAP 2) -- item-level reported agricultural inputs
+# ---------------------------------------------------------------------
+#
+# Natural grain (t, i, plot, input[, crop]): one row per input applied to
+# a plot in the post-planting / post-harvest input modules.  `input` is a
+# harmonized input-type label (Seed / NPK / Urea / Organic Fertilizer /
+# Other Inorganic Fertilizer / Pesticide / Herbicide / Animal Traction /
+# Tractor-Machinery) carried on the harmonize_input categorical table.
+# A `crop` index level (harmonize_food labels) disambiguates the multiple
+# seed rows a plot can carry (one per crop); non-seed inputs are not
+# crop-specific and carry crop = 'n/a' (a non-null sentinel so the index
+# stays unique and free of null index levels).
+#
+# Stores REPORTED item-level fields ONLY:
+#   input               harmonized input-type label (index)
+#   crop                seed's crop (index; 'n/a' for non-seed inputs)
+#   Quantity, u         reported quantity + native unit
+#   Purchased           bool: any of this input acquired by purchase
+#   Quantity_purchased  reported purchased quantity (where recorded)
+#   Improved            bool (seed rows): improved / certified seed variety
+# NO kg conversion, NO seed_kg / nitrogen_kg / any-use flags, NO fertilizer
+# totals -- those are transformations.
+#
+# The Nigeria GHS input modules organise each input by ACQUISITION CHANNEL
+# (left-over / free / commercial-1 / commercial-2), each channel its own
+# quantity+unit triplet.  We keep ONE row per (plot[,crop], input) and sum
+# the reported native-unit quantities across channels ONLY when they share
+# a unit; otherwise we keep the channel with the largest reported quantity
+# and carry its unit (mixed-unit channels can't be summed without a kg
+# conversion, which is a transformation).  Purchased quantity is the sum of
+# the commercial channels.  This keeps the row item-level and reported.
+
+# Harmonized input-type labels (the `input` index axis).  Codes are an
+# arbitrary stable enumeration registered in harmonize_input.
+INPUT_SEED = 'Seed'
+INPUT_NPK = 'NPK'
+INPUT_UREA = 'Urea'
+INPUT_FERT_OTHER = 'Other Inorganic Fertilizer'
+INPUT_ORGANIC = 'Organic Fertilizer'
+INPUT_PESTICIDE = 'Pesticide'
+INPUT_HERBICIDE = 'Herbicide'
+INPUT_ANIMAL = 'Animal Traction'
+INPUT_TRACTOR = 'Tractor/Machinery'
+
+NO_CROP = 'n/a'      # crop-level sentinel for non-seed (crop-agnostic) rows
+
+
+def _seed_unit_label(unit_series, unit_dec):
+    """Canonical unit label for a seed-quantity unit column.  `unit_dec`
+    is the decoded-label Series (convert_categoricals=True); fall back to
+    pd.NA where the unit is blank/junk."""
+    if unit_dec is not None:
+        return unit_dec.map(_canon_unit).astype('string')
+    return pd.Series(pd.NA, index=unit_series.index, dtype='string')
+
+
+def _pick_channel(channels):
+    """Collapse a list of (qty Series, unit Series) acquisition channels
+    into ONE (Quantity, u) pair per row, reported-only:
+
+    - If every non-null channel for a row shares the same unit label, sum
+      the quantities (legitimate -- same native unit).
+    - Otherwise keep the channel with the largest reported quantity and
+      its unit (cannot sum across units without a kg conversion factor,
+      which is a transformation).
+
+    `channels` is a list of dicts {qty: Series(float), u: Series(string)},
+    all aligned to a common index.  Returns (qty Series, u Series)."""
+    if not channels:
+        return None, None
+    idx = channels[0]['qty'].index
+    qty_out = pd.Series(pd.NA, index=idx, dtype='Float64')
+    u_out = pd.Series(pd.NA, index=idx, dtype='string')
+
+    qmat = pd.concat([c['qty'] for c in channels], axis=1)
+    umat = pd.concat([c['u'] for c in channels], axis=1)
+    qmat.columns = range(len(channels))
+    umat.columns = range(len(channels))
+
+    for ix in idx:
+        qrow = qmat.loc[ix]
+        urow = umat.loc[ix]
+        mask = qrow.notna() & (qrow > 0)
+        if not mask.any():
+            # No positive quantity; keep first reported unit (if any) so a
+            # recorded-but-zero / recorded-without-qty input still surfaces.
+            present = urow[urow.notna()]
+            if len(present):
+                u_out.loc[ix] = present.iloc[0]
+            # leave a single reported qty (possibly NaN) so the row exists
+            present_q = qrow[qrow.notna()]
+            if len(present_q):
+                qty_out.loc[ix] = present_q.iloc[0]
+            continue
+        units = urow[mask].dropna().unique()
+        if len(units) == 1:
+            qty_out.loc[ix] = qrow[mask].sum()
+            u_out.loc[ix] = units[0]
+        else:
+            # mixed units -> keep the single largest reported channel
+            j = qrow[mask].astype(float).idxmax()
+            qty_out.loc[ix] = qrow[j]
+            u_out.loc[ix] = urow[j]
+    return qty_out, u_out
+
+
+def seed_rows_for_wave(df, dec, hhid, plot, crop, channels, crop_labels,
+                       purchased_idx=None, improved=None):
+    """Build item-level seed rows (input='Seed') for one wave.
+
+    Parameters
+    ----------
+    df, dec : raw / decoded seed-module DataFrames (same row order).
+    hhid, plot, crop : column names for household, plot, cropcode.
+    channels : list of dicts describing each acquisition channel:
+        {qty: 'col', unit: 'col', purchased: bool}
+        `unit` is decoded via `dec` -> _canon_unit.
+    crop_labels : {int cropcode: Preferred Label}.
+    purchased_idx : list[int] | None
+        Indices into `channels` that are purchase (commercial) channels;
+        their summed quantity is Quantity_purchased and Purchased=True when
+        positive.  None -> infer from channel['purchased'].
+    improved : Series aligned to df (nullable boolean) | None.
+
+    Returns a DataFrame with columns
+        [i, plot, input, crop, Quantity, u, Purchased, Quantity_purchased,
+         Improved].
+    """
+    i = df[hhid].apply(format_id)
+    plot_id = df[plot].apply(format_id)
+    crop_code = pd.to_numeric(df[crop], errors='coerce').astype('Int64')
+    crop_lab = crop_code.map(crop_labels).astype('string')
+
+    chan_pairs = []
+    purch_qtys = []
+    for k, ch in enumerate(channels):
+        q = (pd.to_numeric(df[ch['qty']], errors='coerce').astype('Float64')
+             if ch['qty'] in df.columns
+             else pd.Series(pd.NA, index=df.index, dtype='Float64'))
+        u = (_seed_unit_label(df[ch['unit']],
+                              dec[ch['unit']] if ch['unit'] in dec.columns else None)
+             if ch.get('unit') else pd.Series(pd.NA, index=df.index, dtype='string'))
+        q.index = df.index
+        u.index = df.index
+        chan_pairs.append({'qty': q, 'u': u})
+        is_purch = ch.get('purchased', False) if purchased_idx is None else (k in purchased_idx)
+        if is_purch:
+            purch_qtys.append(q)
+
+    qty, u = _pick_channel(chan_pairs)
+
+    if purch_qtys:
+        pq = pd.concat(purch_qtys, axis=1).sum(axis=1, min_count=1)
+        pq = pd.Series(pq.values, index=df.index, dtype='Float64')
+    else:
+        pq = pd.Series(pd.NA, index=df.index, dtype='Float64')
+    purchased = pd.Series(pd.NA, index=df.index, dtype='boolean')
+    purchased = purchased.where(~(pq > 0), True)
+    purchased = purchased.where(~(pq == 0), False)
+
+    out = pd.DataFrame({
+        'i': i.values,
+        'plot': plot_id.values,
+        'input': INPUT_SEED,
+        'crop': crop_lab.values,
+        'Quantity': pd.Series(qty.values, dtype='Float64'),
+        'u': pd.Series(u.values, dtype='string'),
+        'Purchased': pd.Series(purchased.values, dtype='boolean'),
+        'Quantity_purchased': pd.Series(pq.values, dtype='Float64'),
+    })
+    if improved is not None:
+        out['Improved'] = pd.Series(improved.reindex(df.index).values,
+                                    dtype='boolean')
+    else:
+        out['Improved'] = pd.Series(pd.NA, index=out.index, dtype='boolean')
+    # Keep only rows with a household, a plot, and a resolved crop.
+    out = out[out['i'].notna() & out['plot'].notna() & out['crop'].notna()]
+    return out
+
+
+def fert_rows_long_typed(df, dec, hhid, plot, channels, type_map):
+    """Build fertilizer rows for waves where each acquisition channel
+    records a fertilizer TYPE code + a single quantity/unit (W1/W2/W3).
+
+    For each channel (left-over/free/commercial), the row's type comes
+    from the channel's 'type' column mapped through `type_map`
+    ({code:label}); rows are grouped to ONE row per (plot, type),
+    summing same-unit quantities across the channels that resolved to
+    that type.
+
+    df  : raw frame (convert_categoricals=False; numeric type/qty codes).
+    dec : decoded frame (convert_categoricals=True; unit LABELS).
+    channels : list of dicts {qty, unit, type, purchased}.
+    Returns DataFrame [i, plot, input, crop, Quantity, u, Purchased,
+    Quantity_purchased, Improved].
+    """
+    i = df[hhid].apply(format_id)
+    plot_id = df[plot].apply(format_id)
+    base = pd.DataFrame({'i': i.values, 'plot': plot_id.values},
+                        index=df.index)
+
+    # Build a per-channel long frame, then split by resolved type label.
+    chan_frames = []
+    for ch in channels:
+        if ch['qty'] not in df.columns or ch['type'] not in df.columns:
+            continue
+        typ = (pd.to_numeric(df[ch['type']], errors='coerce').astype('Int64')
+               .map(type_map).astype('string'))
+        q = pd.to_numeric(df[ch['qty']], errors='coerce').astype('Float64')
+        u = (dec[ch['unit']].map(_canon_unit).astype('string')
+             if ch.get('unit') and ch['unit'] in dec.columns
+             else pd.Series('Kg', index=df.index, dtype='string'))
+        chan_frames.append(pd.DataFrame({
+            'i': base['i'].values, 'plot': base['plot'].values,
+            'type': typ.values, 'qty': q.values, 'u': u.values,
+            'purchased': bool(ch.get('purchased', False)),
+        }, index=df.index))
+    if not chan_frames:
+        return pd.DataFrame(columns=['i', 'plot', 'input', 'crop', 'Quantity',
+                                     'u', 'Purchased', 'Quantity_purchased',
+                                     'Improved'])
+    long = pd.concat(chan_frames, ignore_index=True)
+    long = long[long['type'].notna() & long['i'].notna() & long['plot'].notna()]
+
+    # One row per (i, plot, type): sum same-unit quantities, purchased = any
+    # positive purchased-channel quantity.
+    recs = []
+    for (i_, p_, typ), g in long.groupby(['i', 'plot', 'type']):
+        gg = g[g['qty'].notna() & (g['qty'] > 0)]
+        if len(gg):
+            units = gg['u'].dropna().unique()
+            if len(units) == 1:
+                qty = gg['qty'].sum(); uu = units[0]
+            else:
+                row = gg.loc[gg['qty'].astype(float).idxmax()]
+                qty = row['qty']; uu = row['u']
+        else:
+            qty = pd.NA
+            uu = g['u'].dropna().iloc[0] if g['u'].notna().any() else pd.NA
+        pq = g.loc[g['purchased'] & g['qty'].notna(), 'qty']
+        pqsum = pq.sum() if len(pq) else pd.NA
+        purchased = (pd.NA if (pqsum is pd.NA or pd.isna(pqsum))
+                     else (True if pqsum > 0 else False))
+        recs.append({'i': i_, 'plot': p_, 'input': typ, 'crop': NO_CROP,
+                     'Quantity': qty, 'u': uu, 'Purchased': purchased,
+                     'Quantity_purchased': pqsum, 'Improved': pd.NA})
+    out = pd.DataFrame.from_records(recs)
+    if len(out):
+        out['Quantity'] = out['Quantity'].astype('Float64')
+        out['Quantity_purchased'] = out['Quantity_purchased'].astype('Float64')
+        out['u'] = out['u'].astype('string')
+        out['Purchased'] = out['Purchased'].astype('boolean')
+        out['Improved'] = out['Improved'].astype('boolean')
+    return out
+
+
+def fert_rows_wide_typed(df, dec, hhid, plot, specs):
+    """Build fertilizer rows for waves where each TYPE has its own
+    quantity/unit columns (W4/W5: NPK / Urea / other / organic).
+
+    df  : raw frame (numeric quantity codes).
+    dec : decoded frame (unit LABELS).
+    specs : list of dicts {input, qty, unit}.  One output row per (plot,
+    input) where the type's quantity is recorded.
+    """
+    i = df[hhid].apply(format_id)
+    plot_id = df[plot].apply(format_id)
+    pieces = []
+    for sp in specs:
+        if sp['qty'] not in df.columns:
+            continue
+        q = pd.to_numeric(df[sp['qty']], errors='coerce').astype('Float64')
+        u = (dec[sp['unit']].map(_canon_unit).astype('string')
+             if sp.get('unit') and sp['unit'] in dec.columns
+             else pd.Series('Kg', index=df.index, dtype='string'))
+        piece = pd.DataFrame({
+            'i': i.values, 'plot': plot_id.values, 'input': sp['input'],
+            'crop': NO_CROP, 'Quantity': q.values, 'u': u.values,
+            'Purchased': pd.Series(pd.NA, index=df.index, dtype='boolean').values,
+            'Quantity_purchased': pd.Series(pd.NA, index=df.index, dtype='Float64').values,
+            'Improved': pd.Series(pd.NA, index=df.index, dtype='boolean').values,
+        }, index=df.index)
+        # keep rows where the type's quantity was recorded (>0 or non-null)
+        piece = piece[piece['Quantity'].notna()]
+        pieces.append(piece)
+    if not pieces:
+        return pd.DataFrame(columns=['i', 'plot', 'input', 'crop', 'Quantity',
+                                     'u', 'Purchased', 'Quantity_purchased',
+                                     'Improved'])
+    out = pd.concat(pieces, ignore_index=True)
+    out = out[out['i'].notna() & out['plot'].notna()]
+    return out
+
+
+def chem_rows(df, dec, hhid, plot, specs):
+    """Build pesticide / herbicide / animal-traction rows carrying the
+    REPORTED quantity (chemical quantity+unit, or animal-traction days).
+
+    df  : raw frame (numeric used/qty codes).
+    dec : decoded frame (unit LABELS).
+    specs : list of dicts; each must record a reported quantity so the row
+    is an item, NOT a bare any-use flag:
+        {input, qty, unit}            -> chemical quantity + decoded unit
+        {input, qty_cols, u_label}    -> sum of numeric day/count columns
+                                         carried with a fixed unit label
+    A row is emitted only where a positive reported quantity exists
+    (so rows are genuine reported items, never collapse-max use flags).
+    """
+    i = df[hhid].apply(format_id)
+    plot_id = df[plot].apply(format_id)
+    pieces = []
+    for sp in specs:
+        if sp.get('qty_cols'):
+            cols = [c for c in sp['qty_cols'] if c in df.columns]
+            if cols:
+                q = (pd.concat([pd.to_numeric(df[c], errors='coerce')
+                                for c in cols], axis=1)
+                     .sum(axis=1, min_count=1).astype('Float64'))
+            else:
+                q = pd.Series(pd.NA, index=df.index, dtype='Float64')
+            u = pd.Series(sp.get('u_label'), index=df.index, dtype='string')
+        else:
+            q = (pd.to_numeric(df[sp['qty']], errors='coerce').astype('Float64')
+                 if sp.get('qty') in df.columns
+                 else pd.Series(pd.NA, index=df.index, dtype='Float64'))
+            if sp.get('unit') and sp['unit'] in dec.columns:
+                u = dec[sp['unit']].map(_canon_unit).astype('string')
+            else:
+                u = pd.Series(pd.NA, index=df.index, dtype='string')
+        q.index = df.index
+        u.index = df.index
+        # Emit ONLY where a positive reported quantity exists.
+        emit = (q.fillna(0) > 0)
+        piece = pd.DataFrame({
+            'i': i.values, 'plot': plot_id.values, 'input': sp['input'],
+            'crop': NO_CROP, 'Quantity': q.values, 'u': u.values,
+            'Purchased': pd.Series(pd.NA, index=df.index, dtype='boolean').values,
+            'Quantity_purchased': pd.Series(pd.NA, index=df.index, dtype='Float64').values,
+            'Improved': pd.Series(pd.NA, index=df.index, dtype='boolean').values,
+        }, index=df.index)
+        piece = piece[emit.values]
+        pieces.append(piece)
+    if not pieces:
+        return pd.DataFrame(columns=['i', 'plot', 'input', 'crop', 'Quantity',
+                                     'u', 'Purchased', 'Quantity_purchased',
+                                     'Improved'])
+    out = pd.concat(pieces, ignore_index=True)
+    out = out[out['i'].notna() & out['plot'].notna()]
+    return out
+
+
+def assemble_plot_inputs(t, parts):
+    """Concatenate the per-module row frames for one wave, attach `t`,
+    drop empties, set the (t, i, plot, input, crop) index and dedup."""
+    parts = [p for p in parts if p is not None and len(p)]
+    cols = ['i', 'plot', 'input', 'crop', 'Quantity', 'u', 'Purchased',
+            'Quantity_purchased', 'Improved']
+    if not parts:
+        return pd.DataFrame(columns=cols).set_index(
+            ['i', 'plot', 'input', 'crop'])
+    out = pd.concat(parts, ignore_index=True)
+    for c in cols:
+        if c not in out.columns:
+            out[c] = pd.NA
+    out['t'] = t
+    out['crop'] = out['crop'].fillna(NO_CROP).astype('string')
+    out['input'] = out['input'].astype('string')
+    # Dedup on the index grain (defensive: a handful of duplicate
+    # (i, plot, input, crop) rows can survive the per-module collapse).
+    out = out.sort_values(['i', 'plot', 'input', 'crop'])
+    out = out.drop_duplicates(subset=['t', 'i', 'plot', 'input', 'crop'],
+                              keep='first')
+    out = out.set_index(['t', 'i', 'plot', 'input', 'crop']).sort_index()
+    return out[['Quantity', 'u', 'Purchased', 'Quantity_purchased', 'Improved']]
+
+
+# ---------------------------------------------------------------------
 # food_coping (#332, Family B: coping-strategies / rCSI)
 # ---------------------------------------------------------------------
 #

--- a/lsms_library/countries/Nigeria/_/plot_inputs.py
+++ b/lsms_library/countries/Nigeria/_/plot_inputs.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+"""Build item-level plot_inputs for Nigeria GHS-Panel (GAP 2).
+
+Natural grain (t, i, plot, input, crop): one row per agricultural input
+applied to a plot in the post-planting / post-harvest input modules.
+Stores REPORTED item-level fields ONLY -- no seed_kg / nitrogen_kg
+conversion, no inorganic/organic any-use flags, no fertilizer totals
+(those are transformations over these rows).
+
+`input` (index) is a harmonized input-type label registered in the
+harmonize_input categorical table:
+  Seed / NPK / Urea / Other Inorganic Fertilizer / Organic Fertilizer /
+  Pesticide / Herbicide / Animal Traction
+`crop` (index) is the seed's crop (harmonize_food labels) for seed rows;
+non-seed (crop-agnostic) inputs carry crop = 'n/a'.
+
+Every emitted row carries a REPORTED quantity (a recorded item), never a
+bare any-use flag: chemicals carry the reported quantity+unit; animal
+traction carries reported person/animal-days (own + rented).  The plain
+"did you use a tractor/machine?" question (W1-W5) records no per-input
+quantity at this grain and is left to a transformation (used_machinery),
+not stored as a flag-only row.
+
+Columns (reported): Quantity + u (native unit), Purchased (bool) +
+Quantity_purchased, Improved (bool, seed rows).
+
+Per-wave source structure
+-------------------------
+The Nigeria GHS input modules organise each input by ACQUISITION CHANNEL
+(left-over / free / commercial-1 / commercial-2).  Fertilizer / pesticide
+move from the post-planting round (W1/W2: sect11d/sect11c2) to the
+post-harvest round (W3-W5: secta11d / secta11c2), and the fertilizer
+recording switches from one-type-code-per-channel (W1-W3) to
+one-column-per-type (W4/W5: NPK / Urea / other / organic).  Seeds stay in
+post-planting throughout (W1-W3 sect11e per-channel; W4/W5 sect11f
+plot-crop planting roster with a single quantity + improved/certified
+flags).  Each wave maps to a single t = PP_QUARTER[wave] (matching
+plot_features; plot_id aligns via format_id with crop_production too).
+
+  W1 2010-11  seeds  sect11e_plantingw1   ferts sect11d  pest sect11c
+  W2 2012-13  seeds  sect11e_plantingw2   ferts sect11d  pest sect11c2
+  W3 2015-16  seeds  sect11e_plantingw3   ferts secta11d_harvest pest secta11c2_harvest
+  W4 2018-19  seeds  sect11f_plantingw4   ferts secta11c2_harvest (wide-typed)
+  W5 2023-24  seeds  sect11f_plantingw5   ferts secta11c2_harvest (wide-typed)
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import (PP_QUARTER, _crop_labels, seed_rows_for_wave,
+                     fert_rows_long_typed, fert_rows_wide_typed, chem_rows,
+                     assemble_plot_inputs, INPUT_NPK, INPUT_UREA,
+                     INPUT_FERT_OTHER, INPUT_ORGANIC, INPUT_PESTICIDE,
+                     INPUT_HERBICIDE, INPUT_ANIMAL)
+
+crop_labels = _crop_labels()
+
+# Fertilizer TYPE-code -> harmonized input label (W1-W3 one-type-per-channel).
+# Source value labels: 1=NPK, 2=UREA, 3=Composite Manure (organic),
+# 4=Other.  Composite manure is an organic fertilizer.
+FERT_TYPE_MAP = {1: INPUT_NPK, 2: INPUT_UREA, 3: INPUT_ORGANIC,
+                 4: INPUT_FERT_OTHER}
+
+
+def _read(f):
+    raw = get_dataframe(f, convert_categoricals=False)
+    dec = get_dataframe(f, convert_categoricals=True)
+    return raw, dec
+
+
+pieces = []
+
+# ============================ W1 2010-11 =============================
+t = PP_QUARTER['2010-11']
+parts = []
+
+# -- seeds (sect11e): leftover/free/commercial-1/commercial-2 channels.
+sraw, sdec = _read('../2010-11/Data/Post Planting Wave 1/Agriculture/'
+                   'sect11e_plantingw1.dta')
+parts.append(seed_rows_for_wave(
+    sraw, sdec, 'hhid', 'plotid', 's11eq2',
+    channels=[
+        dict(qty='s11eq6a', unit='s11eq6b', purchased=False),    # leftover
+        dict(qty='s11eq10a', unit='s11eq10b', purchased=False),  # free
+        dict(qty='s11eq17a', unit='s11eq17b', purchased=True),   # commercial 1
+        dict(qty='s11eq28a', unit='s11eq28b', purchased=True),   # commercial 2
+    ], crop_labels=crop_labels, improved=None))
+
+# -- fertilizer (sect11d): leftover/free/comm-1/comm-2, type-per-channel.
+fraw, fdec = _read('../2010-11/Data/Post Planting Wave 1/Agriculture/'
+                   'sect11d_plantingw1.dta')
+parts.append(fert_rows_long_typed(
+    fraw, fdec, 'hhid', 'plotid',
+    channels=[
+        dict(type='s11dq3', qty='s11dq4', unit=None, purchased=False),
+        dict(type='s11dq7', qty='s11dq8', unit=None, purchased=False),
+        dict(type='s11dq14', qty='s11dq15', unit=None, purchased=True),
+        dict(type='s11dq25', qty='s11dq26', unit=None, purchased=True),
+    ], type_map=FERT_TYPE_MAP))
+
+# -- pesticide / herbicide / traction (sect11c).
+praw, pdec = _read('../2010-11/Data/Post Planting Wave 1/Agriculture/'
+                   'sect11c_plantingw1.dta')
+parts.append(chem_rows(praw, pdec, 'hhid', 'plotid', specs=[
+    dict(input=INPUT_PESTICIDE, qty='s11cq2a', unit='s11cq2b'),
+    dict(input=INPUT_HERBICIDE, qty='s11cq11a', unit='s11cq11b'),
+    dict(input=INPUT_ANIMAL, qty_cols=['s11cq20', 's11cq21'], u_label='days'),
+]))
+pieces.append(assemble_plot_inputs(t, parts))
+
+# ============================ W2 2012-13 =============================
+t = PP_QUARTER['2012-13']
+parts = []
+sraw, sdec = _read('../2012-13/Data/Post Planting Wave 2/Agriculture/'
+                   'sect11e_plantingw2.dta')
+parts.append(seed_rows_for_wave(
+    sraw, sdec, 'hhid', 'plotid', 'cropcode',
+    channels=[
+        dict(qty='s11eq6a', unit='s11eq6b', purchased=False),
+        dict(qty='s11eq10a', unit='s11eq10b', purchased=False),
+        dict(qty='s11eq18a', unit='s11eq18b', purchased=True),
+        dict(qty='s11eq30a', unit='s11eq30b', purchased=True),
+    ], crop_labels=crop_labels, improved=None))
+
+fraw, fdec = _read('../2012-13/Data/Post Planting Wave 2/Agriculture/'
+                   'sect11d_plantingw2.dta')
+parts.append(fert_rows_long_typed(
+    fraw, fdec, 'hhid', 'plotid',
+    channels=[
+        dict(type='s11dq3', qty='s11dq4', unit=None, purchased=False),
+        dict(type='s11dq7', qty='s11dq8', unit=None, purchased=False),
+        dict(type='s11dq14', qty='s11dq15', unit=None, purchased=True),
+        dict(type='s11dq25a', qty='s11dq26', unit=None, purchased=True),
+    ], type_map=FERT_TYPE_MAP))
+
+praw, pdec = _read('../2012-13/Data/Post Planting Wave 2/Agriculture/'
+                   'sect11c2_plantingw2.dta')
+parts.append(chem_rows(praw, pdec, 'hhid', 'plotid', specs=[
+    dict(input=INPUT_PESTICIDE, qty='s11c2q2a', unit='s11c2q2b'),
+    dict(input=INPUT_HERBICIDE, qty='s11c2q11a', unit='s11c2q11b'),
+    dict(input=INPUT_ANIMAL, qty_cols=['s11c2q20', 's11c2q21'], u_label='days'),
+]))
+pieces.append(assemble_plot_inputs(t, parts))
+
+# ============================ W3 2015-16 =============================
+t = PP_QUARTER['2015-16']
+parts = []
+# Seeds: PP round.  Improved from s11eq3b (1 HYBRID/2 IMPROVED -> True;
+# 3 TRADITIONAL/4 LOCAL -> False).
+sraw, sdec = _read('../2015-16/Data/sect11e_plantingw3.dta')
+imp = pd.to_numeric(sraw['s11eq3b'], errors='coerce')
+improved = pd.Series(pd.NA, index=sraw.index, dtype='boolean')
+improved = improved.where(~imp.isin([1, 2]), True)
+improved = improved.where(~imp.isin([3, 4]), False)
+parts.append(seed_rows_for_wave(
+    sraw, sdec, 'hhid', 'plotid', 'cropcode',
+    channels=[
+        dict(qty='s11eq6a', unit='s11eq6b', purchased=False),
+        dict(qty='s11eq10a', unit='s11eq10b', purchased=False),
+        dict(qty='s11eq18a', unit='s11eq18b', purchased=True),
+        dict(qty='s11eq30a', unit='s11eq30b', purchased=True),
+    ], crop_labels=crop_labels, improved=improved))
+
+# Fertilizer: post-harvest secta11d.  leftover/free/purch-1/purch-2 +
+# organic.  Organic recorded with its own qty/unit (s11dq37a/b).
+fraw, fdec = _read('../2015-16/Data/secta11d_harvestw3.dta')
+parts.append(fert_rows_long_typed(
+    fraw, fdec, 'hhid', 'plotid',
+    channels=[
+        dict(type='s11dq3', qty='s11dq4a', unit='s11dq4b', purchased=False),
+        dict(type='sect11dq7', qty='sect11dq8a', unit='sect11dq8b', purchased=False),
+        dict(type='s11dq15', qty='s11dq16a', unit='s11dq16b', purchased=True),
+        dict(type='s11dq27', qty='s11dq28a', unit='s11dq28b', purchased=True),
+    ], type_map=FERT_TYPE_MAP))
+# Organic fertilizer (separate qty/unit block, no type code).
+parts.append(fert_rows_wide_typed(
+    fraw, fdec, 'hhid', 'plotid',
+    specs=[dict(input=INPUT_ORGANIC, qty='s11dq37a', unit='s11dq37b')]))
+
+# Pesticide / herbicide / traction: post-harvest secta11c2.
+praw, pdec = _read('../2015-16/Data/secta11c2_harvestw3.dta')
+parts.append(chem_rows(praw, pdec, 'hhid', 'plotid', specs=[
+    dict(input=INPUT_PESTICIDE, qty='s11c2q2a', unit='s11c2q2b'),
+    dict(input=INPUT_HERBICIDE, qty='s11c2q11a', unit='s11c2q11b'),
+    dict(input=INPUT_ANIMAL, qty_cols=['s11c2q20', 's11c2q21'], u_label='days'),
+]))
+pieces.append(assemble_plot_inputs(t, parts))
+
+# ============================ W4 2018-19 =============================
+t = PP_QUARTER['2018-19']
+parts = []
+# Seeds: sect11f planting roster (one row per plot-crop).  Quantity
+# planted s11fq3d_1/_2; improved s11fq3b (1 Improved -> True, 2 Local ->
+# False); certified s11fq3aa.  No purchase channel here (the W4/W5 seed
+# acquisition/cost detail lives in sect11e1/e2 at a different grain).
+sraw, sdec = _read('../2018-19/Data/sect11f_plantingw4.dta')
+imp = pd.to_numeric(sraw['s11fq3b'], errors='coerce')
+improved = pd.Series(pd.NA, index=sraw.index, dtype='boolean')
+improved = improved.where(~(imp == 1), True)
+improved = improved.where(~(imp == 2), False)
+# certified strengthens improved=True (a certified seed is improved).
+cert = pd.to_numeric(sraw['s11fq3aa'], errors='coerce')
+improved = improved.where(~(cert == 1), True)
+parts.append(seed_rows_for_wave(
+    sraw, sdec, 'hhid', 'plotid', 'cropcode',
+    channels=[dict(qty='s11fq3d_1', unit='s11fq3d_2', purchased=False)],
+    crop_labels=crop_labels, improved=improved))
+
+# Fertilizer: secta11c2 wide-typed (NPK / Urea / other inorganic /
+# organic each its own qty+unit).
+fraw, fdec = _read('../2018-19/Data/secta11c2_harvestw4.dta')
+parts.append(fert_rows_wide_typed(fraw, fdec, 'hhid', 'plotid', specs=[
+    dict(input=INPUT_NPK, qty='s11c2q37a', unit='s11c2q37b'),
+    dict(input=INPUT_UREA, qty='s11c2q38a', unit='s11c2q38b'),
+    dict(input=INPUT_FERT_OTHER, qty='s11c2q39a', unit='s11c2q39b'),
+    dict(input=INPUT_ORGANIC, qty='s11dq37a', unit='s11dq37b'),
+]))
+# Pesticide / herbicide / traction in the same secta11c2 file.
+parts.append(chem_rows(fraw, fdec, 'hhid', 'plotid', specs=[
+    dict(input=INPUT_PESTICIDE, qty='s11c2q2a', unit='s11c2q2b'),
+    dict(input=INPUT_HERBICIDE, qty='s11c2q11a', unit='s11c2q11b'),
+    dict(input=INPUT_ANIMAL, qty_cols=['s11c2q20', 's11c2q21'], u_label='days'),
+]))
+pieces.append(assemble_plot_inputs(t, parts))
+
+# ============================ W5 2023-24 =============================
+t = PP_QUARTER['2023-24']
+parts = []
+sraw, sdec = _read('../2023-24/Data/Post Planting Wave 5/Agriculture/'
+                   'sect11f_plantingw5.dta')
+imp = pd.to_numeric(sraw['s11fq7'], errors='coerce')
+improved = pd.Series(pd.NA, index=sraw.index, dtype='boolean')
+improved = improved.where(~(imp == 1), True)
+improved = improved.where(~(imp == 2), False)
+cert = pd.to_numeric(sraw['s11fq6'], errors='coerce')
+improved = improved.where(~(cert == 1), True)
+parts.append(seed_rows_for_wave(
+    sraw, sdec, 'hhid', 'plotid', 'cropcode',
+    channels=[dict(qty='s11fq5a', unit='s11fq5b', purchased=False)],
+    crop_labels=crop_labels, improved=improved))
+
+# Fertilizer: secta11c2 wide-typed (NPK s11c2q7a/b, Urea s11c2q11a/b,
+# other s11c2q9a/b, organic s11c2q16a/b).
+fraw, fdec = _read('../2023-24/Data/Post Harvest Wave 5/Agriculture/'
+                   'secta11c2_harvestw5.dta')
+parts.append(fert_rows_wide_typed(fraw, fdec, 'hhid', 'plotid', specs=[
+    dict(input=INPUT_NPK, qty='s11c2q7a', unit='s11c2q7b'),
+    dict(input=INPUT_UREA, qty='s11c2q11a', unit='s11c2q11b'),
+    dict(input=INPUT_FERT_OTHER, qty='s11c2q9a', unit='s11c2q9b'),
+    dict(input=INPUT_ORGANIC, qty='s11c2q16a', unit='s11c2q16b'),
+]))
+# Pesticide / herbicide / traction.  W5 swapped the question order:
+# herbicide s11c2q1/2a/2b, pesticide s11c2q3/4a/4b.
+parts.append(chem_rows(fraw, fdec, 'hhid', 'plotid', specs=[
+    dict(input=INPUT_HERBICIDE, qty='s11c2q2a', unit='s11c2q2b'),
+    dict(input=INPUT_PESTICIDE, qty='s11c2q4a', unit='s11c2q4b'),
+    dict(input=INPUT_ANIMAL, qty_cols=['s11c2q15', 's11c2q16'], u_label='days'),
+]))
+pieces.append(assemble_plot_inputs(t, parts))
+
+# ============================== combine =============================
+df = pd.concat(pieces, axis=0)
+df = df.sort_index()
+
+to_parquet(df, '../var/plot_inputs.parquet')

--- a/lsms_library/countries/Tanzania/2019-20/_/plot_inputs.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/plot_inputs.py
@@ -1,0 +1,29 @@
+"""plot_inputs for Tanzania NPS 2019-20 (NPS-SDD, Extended Panel;
+parity-loop GAP 2).
+
+Item-level inputs at grain (t, i, plot_id, input, crop) from two modules:
+  AG_SEC_3A  plot detail: organic fertilizer (ag3a_41..45), inorganic
+             fertilizer type 1 (ag3a_47..51) and type 2 (ag3a_54..58),
+             herbicide (ag3a_60..63), pesticide (ag3a_65a..65c).
+  AG_SEC_4A  seasonal-crop seed: ag4a_08 improved flag, ag4a_10_1/2 total
+             seed qty+unit, ag4a_10c_1/2 purchased seed qty+unit, ag4a_12
+             amount paid; cropid -> the seed's crop (crop index level).
+Emits raw sdd_hhid as ``i``; the country-level concatenator applies id_walk
+and the framework joins ``v`` from sample().
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import plot_inputs_for_wave
+
+
+sec3a = get_dataframe('../Data/AG_SEC_3A.dta', convert_categoricals=False)
+sec4a = get_dataframe('../Data/AG_SEC_4A.dta', convert_categoricals=False)
+
+colmap = dict(hhid='sdd_hhid', plot='plotnum', crop='cropid')
+
+df = plot_inputs_for_wave('2019-20', sec3a, sec4a, colmap)
+assert df.index.is_unique, "plot_inputs 2019-20: (t,i,plot_id,input,crop) not unique"
+assert len(df) > 0
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Tanzania/2020-21/_/plot_inputs.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/plot_inputs.py
@@ -1,0 +1,25 @@
+"""plot_inputs for Tanzania NPS 2020-21 (NPS Y5 Refresh Panel;
+parity-loop GAP 2).
+
+Same two modules and variable names as 2019-20 (identical NPS questionnaire);
+only the file names (lowercase) and the household / plot id columns differ
+(y5_hhid / plot_id).  See ``tanzania.plot_inputs_for_wave`` for the schema.
+Emits raw y5_hhid as ``i``; the country-level concatenator applies id_walk
+and the framework joins ``v`` from sample().
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import plot_inputs_for_wave
+
+
+sec3a = get_dataframe('../Data/ag_sec_3a.dta', convert_categoricals=False)
+sec4a = get_dataframe('../Data/ag_sec_4a.dta', convert_categoricals=False)
+
+colmap = dict(hhid='y5_hhid', plot='plot_id', crop='cropid')
+
+df = plot_inputs_for_wave('2020-21', sec3a, sec4a, colmap)
+assert df.index.is_unique, "plot_inputs 2020-21: (t,i,plot_id,input,crop) not unique"
+assert len(df) > 0
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Tanzania/_/Makefile
+++ b/lsms_library/countries/Tanzania/_/Makefile
@@ -75,6 +75,15 @@ $(VAR_DIR)/crop_production.parquet: crop_production.py $(crop_production_parquet
 ../%/_/crop_production.parquet:
 	(cd $(@D) && python crop_production.py)
 
+plot_inputs = $(shell find $(rounds) -name plot_inputs.py)
+plot_inputs_parquet := $(plot_inputs:.py=.parquet)
+
+$(VAR_DIR)/plot_inputs.parquet: plot_inputs.py $(plot_inputs_parquet)
+	python plot_inputs.py
+
+../%/_/plot_inputs.parquet:
+	(cd $(@D) && python plot_inputs.py)
+
 %.parquet: %.py CONTENTS.org tanzania.py
 	(cd $(@D) && python ./$(<F))
 

--- a/lsms_library/countries/Tanzania/_/categorical_mapping.org
+++ b/lsms_library/countries/Tanzania/_/categorical_mapping.org
@@ -611,6 +611,10 @@
 | mililitre      | Millilitre      |            |            | mililitre |
 | PIECES         | Piece           | PIECES     | PIECES     |           |
 | kilogram       | Kg              |            |            | kilogram  |
+| 20 liter bucket | 20l Bucket     |            |            |           |
+| small cup      | Small Cup       |            |            |           |
+| large cup      | Large Cup       |            |            |           |
+| millilitre     | Millilitre      |            |            |           |
 
 # harmonize_crop is the (j) axis for crop_production (parity-loop GAP 1).
 # Keyed on the NPS crop CODE ("cropid" / "zaocode") from the agriculture
@@ -734,3 +738,34 @@
 | 851  | Citrus Fruits            | Lime            | 851     | 851     |
 | 852  | Citrus Fruits            | Lemon           | 852     | 852     |
 | 998  | Other Crop               | Other           | 998     | 998     |
+
+# harmonize_input is the (input) axis for plot_inputs (parity-loop GAP 2).
+# Two kinds of rows:
+#   * INORGANIC-FERTILIZER TYPE codes (1-8) -- the ag3a_48 / ag3a_55 value
+#     labels ("What type of INORGANIC FERTILIZER you used?") map to a canonical
+#     fertilizer-product Preferred Label (urea / DAP / NPK / ...).  The 2019-20
+#     and 2020-21 columns carry the same raw integer code; plot_inputs.py
+#     resolves code -> Preferred Label in-script via
+#     _plot_harmonized_codes('harmonize_input').
+#   * The five NON-coded input categories the questionnaire records as their
+#     OWN modules (seed, organic fertilizer, herbicide, pesticide) -- plot_inputs.py
+#     emits these canonical Preferred Labels DIRECTLY as the (input) value, so
+#     they need no code; they are listed here (Code blank) only to document the
+#     full shared input taxonomy.  Fertilizer-product / category names are the
+#     parity input taxonomy reused across waves (and intended to be reused
+#     across countries for GAP 2).
+#+name: harmonize_input
+| Code | Preferred Label | 2019-20 | 2020-21 |
+|------+-----------------+---------+---------|
+| 1    | DAP             | 1       | 1       |
+| 2    | Urea            | 2       | 2       |
+| 3    | TSP             | 3       | 3       |
+| 4    | CAN             | 4       | 4       |
+| 5    | SA              | 5       | 5       |
+| 6    | NPK             | 6       | 6       |
+| 7    | MRP             | 7       | 7       |
+| 8    | Other Fertilizer | 8      | 8       |
+|      | Seed            |         |         |
+|      | Organic Fertilizer |      |         |
+|      | Herbicide       |         |         |
+|      | Pesticide       |         |         |

--- a/lsms_library/countries/Tanzania/_/data_scheme.yml
+++ b/lsms_library/countries/Tanzania/_/data_scheme.yml
@@ -144,3 +144,42 @@ Data Scheme:
     intercropped: bool
     perennial: bool
     materialize: make
+
+  plot_inputs:
+    # Item-level plot inputs (parity-loop GAP 2) at the natural grain
+    # (t, i, plot_id, input, crop) -- one row per input applied to a plot.
+    # Stacks the AG_SEC_3A plot-detail input modules (organic fertilizer
+    # ag3a_41..45; inorganic fertilizer type 1 ag3a_47..51 and type 2
+    # ag3a_54..58; herbicide ag3a_60..63; pesticide ag3a_65a..65c) and the
+    # AG_SEC_4A seasonal-crop seed module (ag4a_08 improved; ag4a_10_1/2 qty+unit;
+    # ag4a_10c_1/2 purchased qty+unit; ag4a_12 amount paid).
+    #   input : the input identity on the shared harmonize_input labels -- Seed /
+    #           Organic Fertilizer / a named inorganic-fertilizer product (Urea,
+    #           DAP, NPK, CAN, SA, TSP, MRP, Other Fertilizer from ag3a_48/55) /
+    #           Herbicide / Pesticide.
+    #   crop  : seed rows ONLY -- the canonical harmonize_food/harmonize_crop
+    #           Preferred Label of the crop the seed was sown for (NPS seed is
+    #           reported per plot-crop), so plot_inputs.crop joins crop_production.j
+    #           and food_acquired.j.  pd.NA for plot-level inputs (fertilizer /
+    #           herbicide / pesticide).  ~23% of rows are non-seed -> the crop
+    #           index level is partially null by construction.
+    #   u     : native unit -- 'kg' for fertilizer (the questionnaire records
+    #           fertilizer in KG); native litre/millilitre/bucket/cup for
+    #           seed / herbicide / pesticide, harmonized by the country u table.
+    # Only 2019-20 and 2020-21 are buildable; 2008-15 has no agriculture source
+    # on disk (same as plot_features / crop_production, GH #167).
+    # SEASON SCOPE: long-rainy-season modules (AG_SEC_3A / AG_SEC_4A) only,
+    # matching crop_production's long-rainy + perennial scope; the short-rainy
+    # AG_SEC_3B / AG_SEC_4B inputs are not stacked (few short-season plots use
+    # inputs -- e.g. 2 inorganic-fertilizer plots in 2019-20 3B).  This is why
+    # per-plot input coverage is ~half the WB Plot_dataset, which counts both
+    # seasons as separate plot-season rows.
+    # STORES REPORTED VALUES ONLY -- seed_kg / nitrogen_kg / any-use flags /
+    # fertilizer totals are transformations over these rows, NOT columns here.
+    index: (t, i, plot_id, input, crop)
+    Quantity: float
+    u: str
+    Purchased: bool
+    Quantity_purchased: float
+    Improved: bool
+    materialize: make

--- a/lsms_library/countries/Tanzania/_/plot_inputs.py
+++ b/lsms_library/countries/Tanzania/_/plot_inputs.py
@@ -1,0 +1,45 @@
+"""Concatenate wave-level plot_inputs data for Tanzania NPS
+(parity-loop GAP 2).
+
+Each buildable wave's ``Tanzania/<wave>/_/plot_inputs.py`` produces a
+parquet with index ``(t, i, plot_id, input, crop)`` and the canonical
+reported columns from data_scheme.yml (Quantity, u, Purchased,
+Quantity_purchased, Improved).  This script concatenates the per-wave
+parquets and applies cross-wave id_walk so the household index uses the
+panel canonical id scheme.
+
+Only 2019-20 (NPS-SDD Extended Panel) and 2020-21 (NPS Y5 Refresh Panel)
+are buildable: the 2008-15 multi-round folder has no agriculture source
+file on disk (only the household upd4_hh_* modules), so those four NPS
+rounds are deferred -- exactly as for plot_features / crop_production
+(GH #167).
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import id_walk
+
+
+WAVES = ['2019-20', '2020-21']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_inputs.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built.  DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_inputs: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids, hh_index='i')
+
+to_parquet(p, '../var/plot_inputs.parquet')

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -999,3 +999,217 @@ def crop_production_for_wave(t, seas, fruit, peren, sales, colmaps):
         })
     df = df[CROP_PRODUCTION_COLUMNS]
     return df
+
+
+# Plot-inputs feature (parity-loop GAP 2).  Item-level inputs applied to a
+# plot at the natural grain (t, i, plot_id, input, crop) -- one row per input
+# applied to a plot -- carrying ONLY reported survey fields.  No seed_kg sum,
+# no nitrogen_kg, no any-use flags, no fertilizer totals: those are
+# transformations over these rows.
+#   * input  : the input identity, on the shared harmonize_input labels --
+#              seed / organic fertilizer / a named inorganic-fertilizer product
+#              (Urea / DAP / NPK / CAN / SA / TSP / MRP / Other Fertilizer,
+#              from ag3a_48 / ag3a_55 codes) / herbicide / pesticide.
+#   * crop   : ONLY for seed rows -- the canonical harmonize_food/harmonize_crop
+#              Preferred Label of the crop the seed was sown for (NPS seed is
+#              reported per plot-crop in AG_SEC_4A).  pd.NA for plot-level
+#              inputs (fertilizer / herbicide / pesticide), which are recorded
+#              once per plot with no crop split.
+#   * Quantity + u : reported native quantity and its native unit.  Fertilizer
+#              quantities are in KG; seed/herbicide/pesticide units are the
+#              reported native unit code resolved to a tidy label (kg / litre /
+#              millilitre / 20 liter bucket / small/large cup), harmonized at
+#              API time by the country u table.
+#   * Purchased (bool) + Quantity_purchased : whether any of the input was
+#              purchased and (where the survey records it as a SEPARATE
+#              quantity) how much.  Organic fertilizer and seed record a
+#              purchased quantity (ag3a_44 / ag4a_10c_1); inorganic fert /
+#              herbicide / pesticide record only a purchased VALUE, so Purchased
+#              there is value>0 and Quantity_purchased is NaN (not fabricated).
+#   * Improved (bool) : seed rows only -- ag4a_08 improved/recycled-improved.
+PLOT_INPUTS_COLUMNS = ['Quantity', 'u', 'Purchased', 'Quantity_purchased',
+                       'Improved']
+
+# Native seed-unit code (ag4a_10_2 / ag4a_10c_2) -> tidy label.  kg/litre/etc.
+# are harmonized to the canonical u Preferred Label at API time by the country
+# u table; the bucket/cup rows were added to that table by this feature.
+_SEED_UNIT_LABELS = {
+    1: 'kg', 2: '20 liter bucket', 3: 'small cup', 4: 'large cup',
+    5: pd.NA,  # OTHER (SPECIFY) -- unit unknown
+}
+# Native herbicide/pesticide-unit code (ag3a_62_2 / ag3a_65b_2) -> tidy label.
+_LIQUID_UNIT_LABELS = {1: 'kg', 2: 'litre', 3: 'millilitre', 4: pd.NA}
+
+
+def _yn_true(series):
+    """Coerce a Stata 1=YES/2=NO column to a nullable boolean (1->True,
+    2->False, else NaN)."""
+    v = pd.to_numeric(series, errors='coerce').astype('Int64')
+    return v.map({1: True, 2: False}).astype('boolean')
+
+
+def plot_inputs_for_wave(t, sec3a, sec4a, colmap):
+    """Build canonical ``plot_inputs`` for one Tanzania NPS wave.
+
+    Item-level inputs at grain (t, i, plot_id, input, crop) from two modules:
+      sec3a -- AG_SEC_3A plot detail: organic fertilizer (ag3a_41/42/43/44),
+               inorganic fertilizer type 1 (ag3a_47/48/49/51) and type 2
+               (ag3a_54/55/56/58), herbicide (ag3a_60/62_1/62_2/63), pesticide
+               (ag3a_65a/65b_1/65b_2/65c).  One row per (plot, input).
+      sec4a -- AG_SEC_4A seasonal-crop seed: ag4a_08 improved flag, ag4a_10_1/2
+               total seed qty+unit, ag4a_10c_1/2 purchased seed qty+unit,
+               ag4a_12 amount paid.  One SEED row per (plot, crop).
+
+    STORES REPORTED VALUES ONLY.  seed_kg / nitrogen_kg / inorganic_fertilizer
+    any-use flags are transformations over these rows, NOT columns here.
+
+    Parameters
+    ----------
+    t : str            wave id ('2019-20' or '2020-21'); the ``t`` value.
+    sec3a, sec4a : pd.DataFrame
+        raw AG_SEC_3A / AG_SEC_4A frames (convert_categoricals=False).
+    colmap : dict with keys hhid, plot, crop (the id columns, which differ
+        across waves: sdd_hhid/plotnum/cropid vs y5_hhid/plot_id/cropid).
+
+    Returns
+    -------
+    pd.DataFrame indexed by (t, i, plot_id, input, crop) with columns
+    PLOT_INPUTS_COLUMNS.
+    """
+    c = colmap
+    fert_type_map = _plot_harmonized_codes('harmonize_input')
+    crop_map = _crop_labels()
+
+    def _ids(df):
+        return (df[c['hhid']].apply(format_id), df[c['plot']].apply(format_id))
+
+    rows = []
+
+    # --- AG_SEC_4A: SEED (one row per plot-crop) ------------------------
+    if sec4a is not None and len(sec4a):
+        hh, plot = _ids(sec4a)
+        code = pd.to_numeric(sec4a[c['crop']], errors='coerce').astype('Int64')
+        qty = pd.to_numeric(sec4a['ag4a_10_1'], errors='coerce').astype('Float64')
+        unit = pd.to_numeric(sec4a['ag4a_10_2'], errors='coerce').astype('Int64')
+        pqty = pd.to_numeric(sec4a['ag4a_10c_1'], errors='coerce').astype('Float64')
+        paid = pd.to_numeric(sec4a['ag4a_12'], errors='coerce').astype('Float64')
+        seedtype = pd.to_numeric(sec4a['ag4a_08'], errors='coerce').astype('Int64')
+        seed = pd.DataFrame({
+            'i': hh.values, 'plot_id': plot.values,
+            'input': 'Seed',
+            'crop': code.map(crop_map).astype('string').values,
+            'Quantity': qty.values,
+            'u': unit.map(_SEED_UNIT_LABELS).astype('string').values,
+            # Purchased if a purchased quantity OR an amount paid is recorded.
+            'Purchased': ((pqty.fillna(0) > 0) | (paid.fillna(0) > 0)).values,
+            'Quantity_purchased': pqty.values,
+            'Improved': seedtype.map({1: True, 2: False, 3: True})
+                        .astype('boolean').values,
+        })
+        # A seed row is real only if a quantity OR a crop label is present.
+        seed = seed[seed['Quantity'].notna() | seed['crop'].notna()]
+        # crop unresolved -> keep raw code as crop_<code> (do not drop).
+        seed['crop'] = seed['crop'].where(
+            seed['crop'].notna(),
+            code.map(lambda x: f'crop_{int(x)}' if pd.notna(x) else pd.NA)
+                .astype('string').reindex(seed.index).values)
+        rows.append(seed)
+
+    # --- AG_SEC_3A: plot-level inputs (crop = NA) -----------------------
+    hh3, plot3 = _ids(sec3a)
+
+    def _liquid_unit(col):
+        return (pd.to_numeric(sec3a[col], errors='coerce').astype('Int64')
+                .map(_LIQUID_UNIT_LABELS).astype('string'))
+
+    # organic fertilizer
+    used = _yn_true(sec3a['ag3a_41'])
+    org = pd.DataFrame({
+        'i': hh3.values, 'plot_id': plot3.values, 'input': 'Organic Fertilizer',
+        'crop': pd.array([pd.NA] * len(sec3a), dtype='string'),
+        'Quantity': pd.to_numeric(sec3a['ag3a_42'], errors='coerce').astype('Float64').values,
+        'u': 'kg',
+        'Purchased': _yn_true(sec3a['ag3a_43']).values,
+        'Quantity_purchased': pd.to_numeric(sec3a['ag3a_44'], errors='coerce').astype('Float64').values,
+        'Improved': pd.array([pd.NA] * len(sec3a), dtype='boolean'),
+    })
+    org = org[used.fillna(False).values]
+
+    # inorganic fertilizer, first and second type
+    def _inorg(used_col, type_col, qty_col, val_col):
+        u = _yn_true(sec3a[used_col])
+        typ = pd.to_numeric(sec3a[type_col], errors='coerce').astype('Int64')
+        label = typ.map(fert_type_map).astype('string')
+        val = pd.to_numeric(sec3a[val_col], errors='coerce').astype('Float64')
+        d = pd.DataFrame({
+            'i': hh3.values, 'plot_id': plot3.values,
+            'input': label.where(label.notna(), 'Other Fertilizer').values,
+            'crop': pd.array([pd.NA] * len(sec3a), dtype='string'),
+            'Quantity': pd.to_numeric(sec3a[qty_col], errors='coerce').astype('Float64').values,
+            'u': 'kg',
+            # Inorganic fert records a purchased VALUE (TSH), not a separate
+            # purchased qty -> Purchased = value>0; Quantity_purchased NaN.
+            'Purchased': (val.fillna(0) > 0).astype('boolean').values,
+            'Quantity_purchased': pd.array([pd.NA] * len(sec3a), dtype='Float64'),
+            'Improved': pd.array([pd.NA] * len(sec3a), dtype='boolean'),
+        })
+        return d[u.fillna(False).values]
+
+    inorg1 = _inorg('ag3a_47', 'ag3a_48', 'ag3a_49', 'ag3a_51')
+    inorg2 = _inorg('ag3a_54', 'ag3a_55', 'ag3a_56', 'ag3a_58')
+
+    # herbicide
+    uh = _yn_true(sec3a['ag3a_60'])
+    valh = pd.to_numeric(sec3a['ag3a_63'], errors='coerce').astype('Float64')
+    herb = pd.DataFrame({
+        'i': hh3.values, 'plot_id': plot3.values, 'input': 'Herbicide',
+        'crop': pd.array([pd.NA] * len(sec3a), dtype='string'),
+        'Quantity': pd.to_numeric(sec3a['ag3a_62_1'], errors='coerce').astype('Float64').values,
+        'u': _liquid_unit('ag3a_62_2').values,
+        'Purchased': (valh.fillna(0) > 0).astype('boolean').values,
+        'Quantity_purchased': pd.array([pd.NA] * len(sec3a), dtype='Float64'),
+        'Improved': pd.array([pd.NA] * len(sec3a), dtype='boolean'),
+    })
+    herb = herb[uh.fillna(False).values]
+
+    # pesticide
+    up = _yn_true(sec3a['ag3a_65a'])
+    valp = pd.to_numeric(sec3a['ag3a_65c'], errors='coerce').astype('Float64')
+    pest = pd.DataFrame({
+        'i': hh3.values, 'plot_id': plot3.values, 'input': 'Pesticide',
+        'crop': pd.array([pd.NA] * len(sec3a), dtype='string'),
+        'Quantity': pd.to_numeric(sec3a['ag3a_65b_1'], errors='coerce').astype('Float64').values,
+        'u': _liquid_unit('ag3a_65b_2').values,
+        'Purchased': (valp.fillna(0) > 0).astype('boolean').values,
+        'Quantity_purchased': pd.array([pd.NA] * len(sec3a), dtype='Float64'),
+        'Improved': pd.array([pd.NA] * len(sec3a), dtype='boolean'),
+    })
+    pest = pest[up.fillna(False).values]
+
+    rows += [org, inorg1, inorg2, herb, pest]
+    df = pd.concat([r for r in rows if r is not None and len(r)], ignore_index=True)
+
+    # u is meaningless where there is no quantity.
+    df['u'] = df['u'].where(df['Quantity'].notna(), pd.NA)
+
+    df['t'] = t
+    df = df.set_index(['t', 'i', 'plot_id', 'input', 'crop'])
+    # Collapse the rare exact-duplicate (t,i,plot,input,crop) -- a plot listing
+    # the same inorganic-fertilizer product as both type 1 and type 2, or two
+    # raw crop codes that share a canonical Seed crop label (e.g. Beans +
+    # Cowpeas -> Pulses): sum the reported quantities, OR the purchased flag,
+    # keep the first unit.  ``min_count=1`` so an all-NA group stays NA (a plain
+    # ``sum`` would zero the all-NA Quantity_purchased of fertilizer rows, which
+    # record only a purchased VALUE, not a purchased quantity).  ``dropna=False``
+    # keeps the NA-crop (plot-level input) rows.
+    if not df.index.is_unique:
+        def _sum1(s):
+            return s.sum(min_count=1)
+        df = df.groupby(level=['t', 'i', 'plot_id', 'input', 'crop'],
+                        dropna=False).agg({
+            'Quantity': _sum1, 'u': 'first',
+            'Purchased': 'max', 'Quantity_purchased': _sum1,
+            'Improved': 'max',
+        })
+    df = df[PLOT_INPUTS_COLUMNS]
+    return df

--- a/lsms_library/countries/Uganda/2009-10/_/plot_inputs.py
+++ b/lsms_library/countries/Uganda/2009-10/_/plot_inputs.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""plot_inputs for Uganda UNPS 2009-10 (GAP 2 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules (organic /
+inorganic fertilizer + pesticide blocks) and AGSEC4A (plot-crop roster, seed
+block) via get_dataframe, and emits a canonical (t,i,plot,input,j) parquet of
+REPORTED input values.  See uganda.INPUT_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_inputs_for_wave, INPUT_COLMAPS
+
+t = '2009-10'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/AGSEC3A.dta')
+df3b = _try('../Data/AGSEC3B.dta')
+df4a = _try('../Data/AGSEC4A.dta')
+
+df = plot_inputs_for_wave(t, df3a, df3b, df4a, INPUT_COLMAPS[t])
+assert len(df) > 0, f"plot_inputs produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_inputs index for {t}"
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Uganda/2010-11/_/plot_inputs.py
+++ b/lsms_library/countries/Uganda/2010-11/_/plot_inputs.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""plot_inputs for Uganda UNPS 2010-11 (GAP 2 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules (organic /
+inorganic fertilizer + pesticide blocks) and AGSEC4A (plot-crop roster, seed
+block) via get_dataframe, and emits a canonical (t,i,plot,input,j) parquet of
+REPORTED input values.  See uganda.INPUT_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_inputs_for_wave, INPUT_COLMAPS
+
+t = '2010-11'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/AGSEC3A.dta')
+df3b = _try('../Data/AGSEC3B.dta')
+df4a = _try('../Data/AGSEC4A.dta')
+
+df = plot_inputs_for_wave(t, df3a, df3b, df4a, INPUT_COLMAPS[t])
+assert len(df) > 0, f"plot_inputs produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_inputs index for {t}"
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Uganda/2011-12/_/plot_inputs.py
+++ b/lsms_library/countries/Uganda/2011-12/_/plot_inputs.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""plot_inputs for Uganda UNPS 2011-12 (GAP 2 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules (organic /
+inorganic fertilizer + pesticide blocks) and AGSEC4A (plot-crop roster, seed
+block) via get_dataframe, and emits a canonical (t,i,plot,input,j) parquet of
+REPORTED input values.  See uganda.INPUT_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_inputs_for_wave, INPUT_COLMAPS
+
+t = '2011-12'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/AGSEC3A.dta')
+df3b = _try('../Data/AGSEC3B.dta')
+df4a = _try('../Data/AGSEC4A.dta')
+
+df = plot_inputs_for_wave(t, df3a, df3b, df4a, INPUT_COLMAPS[t])
+assert len(df) > 0, f"plot_inputs produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_inputs index for {t}"
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Uganda/2013-14/_/plot_inputs.py
+++ b/lsms_library/countries/Uganda/2013-14/_/plot_inputs.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""plot_inputs for Uganda UNPS 2013-14 (GAP 2 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules (organic /
+inorganic fertilizer + pesticide blocks) and AGSEC4A (plot-crop roster, seed
+block) via get_dataframe, and emits a canonical (t,i,plot,input,j) parquet of
+REPORTED input values.  See uganda.INPUT_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_inputs_for_wave, INPUT_COLMAPS
+
+t = '2013-14'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/AGSEC3A.dta')
+df3b = _try('../Data/AGSEC3B.dta')
+df4a = _try('../Data/AGSEC4A.dta')
+
+df = plot_inputs_for_wave(t, df3a, df3b, df4a, INPUT_COLMAPS[t])
+assert len(df) > 0, f"plot_inputs produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_inputs index for {t}"
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Uganda/2015-16/_/plot_inputs.py
+++ b/lsms_library/countries/Uganda/2015-16/_/plot_inputs.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""plot_inputs for Uganda UNPS 2015-16 (GAP 2 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules (organic /
+inorganic fertilizer + pesticide blocks) and AGSEC4A (plot-crop roster, seed
+block) via get_dataframe, and emits a canonical (t,i,plot,input,j) parquet of
+REPORTED input values.  See uganda.INPUT_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_inputs_for_wave, INPUT_COLMAPS
+
+t = '2015-16'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/AGSEC3A.dta')
+df3b = _try('../Data/AGSEC3B.dta')
+df4a = _try('../Data/AGSEC4A.dta')
+
+df = plot_inputs_for_wave(t, df3a, df3b, df4a, INPUT_COLMAPS[t])
+assert len(df) > 0, f"plot_inputs produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_inputs index for {t}"
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Uganda/2018-19/_/plot_inputs.py
+++ b/lsms_library/countries/Uganda/2018-19/_/plot_inputs.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""plot_inputs for Uganda UNPS 2018-19 (GAP 2 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules (organic /
+inorganic fertilizer + pesticide blocks) and AGSEC4A (plot-crop roster, seed
+block) via get_dataframe, and emits a canonical (t,i,plot,input,j) parquet of
+REPORTED input values.  See uganda.INPUT_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_inputs_for_wave, INPUT_COLMAPS
+
+t = '2018-19'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/AGSEC3A.dta')
+df3b = _try('../Data/AGSEC3B.dta')
+df4a = _try('../Data/AGSEC4A.dta')
+
+df = plot_inputs_for_wave(t, df3a, df3b, df4a, INPUT_COLMAPS[t])
+assert len(df) > 0, f"plot_inputs produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_inputs index for {t}"
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Uganda/2019-20/_/plot_inputs.py
+++ b/lsms_library/countries/Uganda/2019-20/_/plot_inputs.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""plot_inputs for Uganda UNPS 2019-20 (GAP 2 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules (organic /
+inorganic fertilizer + pesticide blocks) and AGSEC4A (plot-crop roster, seed
+block) via get_dataframe, and emits a canonical (t,i,plot,input,j) parquet of
+REPORTED input values.  See uganda.INPUT_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_inputs_for_wave, INPUT_COLMAPS
+
+t = '2019-20'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/Agric/agsec3a.dta')
+df3b = _try('../Data/Agric/agsec3b.dta')
+df4a = _try('../Data/Agric/agsec4a.dta')
+
+df = plot_inputs_for_wave(t, df3a, df3b, df4a, INPUT_COLMAPS[t])
+assert len(df) > 0, f"plot_inputs produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_inputs index for {t}"
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Uganda/_/Makefile
+++ b/lsms_library/countries/Uganda/_/Makefile
@@ -24,6 +24,7 @@ var = $(VAR_DIR)/shocks.parquet $(VAR_DIR)/nonfood_expenditures.parquet $(VAR_DI
 	  $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet \
 	  $(VAR_DIR)/plot_features.parquet \
 	  $(VAR_DIR)/crop_production.parquet \
+	  $(VAR_DIR)/plot_inputs.parquet \
 	  $(VAR_DIR)/months_food_inadequate.parquet
 
 all: $(parquet) $(var)
@@ -87,6 +88,12 @@ crop_production_parquet := $(crop_production:.py=.parquet)
 
 $(VAR_DIR)/crop_production.parquet: crop_production.py $(crop_production_parquet)
 	python crop_production.py
+
+plot_inputs = $(shell find $(rounds) -name plot_inputs.py)
+plot_inputs_parquet := $(plot_inputs:.py=.parquet)
+
+$(VAR_DIR)/plot_inputs.parquet: plot_inputs.py $(plot_inputs_parquet)
+	python plot_inputs.py
 
 months_food_inadequate = $(shell find $(rounds) -name months_food_inadequate.py)
 months_food_inadequate_parquet := $(months_food_inadequate:.py=.parquet)

--- a/lsms_library/countries/Uganda/_/categorical_mapping.org
+++ b/lsms_library/countries/Uganda/_/categorical_mapping.org
@@ -825,3 +825,56 @@
 |  108 | Nice cup (60g) - Medium           |
 |  119 | Nomi Tin (1kg)                    |
 |  120 | Nomi Tin (500g)                   |
+
+# harmonize_input: agricultural-input identity Code -> Preferred Label for
+# the plot_inputs feature (GAP 2).  One row per REPORTED input applied to a
+# plot, ``input`` axis.  The UNPS plot-input module (AGSEC3A/3B) records four
+# input BLOCKS per plot; the seed block lives in AGSEC4A.  Codes carry the
+# finest identity the source records, in distinct ranges per block so a
+# single table disambiguates:
+#   10        Seed                  (AGSEC4A seed block; Improved flag is a
+#             column, not a separate identity)
+#   20        Organic Fertilizer    (folds the UNPS single organic item;
+#             manure/compost not separately coded by UNPS)
+#   30        Inorganic Fertilizer  (type unreported)
+#   31..34    Inorganic by type     (a3aq14/15 1=Nitrate 2=Phosphate
+#             3=Potash 4=Mixed) -> Nitrate/Phosphate/Potash/Mixed Fertilizer
+#   40        Pesticide             (type unreported)
+#   41..46,49 Pesticide by type     (a3aq22/23 1=Insecticide 2=Miticide/
+#             Acaricide 3=Fungicide 4=Growth Regulator 5=Rodenticide
+#             6=Nematicide/Molluscicide 96->9=Other Pesticide)
+# UNPS records these identities directly (no urea/DAP/NPK product names): the
+# Nitrate/Phosphate/Potash/Mixed nutrient classes are what the questionnaire
+# asks.  This is a country-level shared input taxonomy across waves; the per-
+# wave source columns are documented in uganda.INPUT_COLMAPS, so no per-wave
+# code columns are needed (the wave scripts resolve labels before writing).
+#+name: harmonize_input
+| Code | Preferred Label              |
+|------+------------------------------|
+|   10 | Seed                         |
+|   20 | Organic Fertilizer           |
+|   30 | Inorganic Fertilizer         |
+|   31 | Nitrate Fertilizer           |
+|   32 | Phosphate Fertilizer         |
+|   33 | Potash Fertilizer            |
+|   34 | Mixed Fertilizer             |
+|   40 | Pesticide                    |
+|   41 | Insecticide                  |
+|   42 | Miticide/Acaricide           |
+|   43 | Fungicide                    |
+|   44 | Growth Regulator             |
+|   45 | Rodenticide                  |
+|   46 | Nematicide/Molluscicide      |
+|   49 | Other Pesticide              |
+
+# harmonize_pesticide_unit: pesticide quantity-unit Code -> Preferred Label
+# for the plot_inputs pesticide block (AGSEC3A a3aq24a / a3aq28a, AGSEC3B
+# a3bq24a / a3bq28a).  This is a tiny 2-code scheme (1=Kg, 2=Litres) distinct
+# from the UNPS harvest/seed unit scheme (which seed rows reuse via
+# harvest_units).  Organic/inorganic fertilizer quantities are implicitly Kg
+# (no unit column) -> u='Kg'.
+#+name: harmonize_pesticide_unit
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Kg              |
+|    2 | Litre           |

--- a/lsms_library/countries/Uganda/_/data_scheme.yml
+++ b/lsms_library/countries/Uganda/_/data_scheme.yml
@@ -137,4 +137,39 @@ Data Scheme:
     harvest_month: int
     intercropped: bool
     materialize: make
+  plot_inputs:
+    # Item-level agricultural-input module (GAP 2 parity build).  One row
+    # per REPORTED input applied to a plot.  Source: AGSEC3A (season 1) +
+    # AGSEC3B (season 2) plot-input modules for the fertilizer / pesticide
+    # blocks, and AGSEC4A (plot-crop roster) for the seed block.
+    #
+    # Grain (t, i, plot, input, j):
+    #   plot   — hhid-parcel-plot, mirroring the WB harmonised plot_id and
+    #            the crop_production plot key (join on (t, i, plot)); its
+    #            parcel component is the parcel plot_features keys on.
+    #   input  — the input identity on the shared 'harmonize_input'
+    #            Preferred Labels: Seed; Organic Fertilizer; Inorganic
+    #            Fertilizer refined by nutrient class (Nitrate / Phosphate /
+    #            Potash / Mixed Fertilizer); Pesticide refined by type
+    #            (Insecticide / Fungicide / Growth Regulator / ...).  These
+    #            are the finest identities the UNPS questionnaire records
+    #            (it asks nutrient class, not urea/DAP/NPK product names).
+    #   j      — the seed's crop, on harmonize_crop labels, for seed rows;
+    #            the sentinel 'n/a' for fertilizer/pesticide rows (no crop
+    #            linkage).  In the index so per-crop seed rows on a
+    #            multi-crop plot stay distinct (plot-crop seed grain) — ~38%
+    #            of seeded plots carry >1 crop.
+    #
+    # Columns are REPORTED values only — NO seed_kg / nitrogen_kg / any-use
+    # flags / fertilizer totals (those are transformations).  Missing in a
+    # wave -> NaN.  Improved is non-null only on seed rows (1=Improved seed
+    # type, 0=Traditional).  Quantity is NaN on 2009-10/2010-11 seed rows
+    # (those waves record no seed quantity, only purchased y/n + seed type).
+    index: (t, i, plot, input, j)
+    Quantity: float
+    u: str
+    Purchased: bool
+    Quantity_purchased: float
+    Improved: bool
+    materialize: make
   nonfood_expenditures: !make

--- a/lsms_library/countries/Uganda/_/plot_inputs.py
+++ b/lsms_library/countries/Uganda/_/plot_inputs.py
@@ -1,0 +1,39 @@
+"""Concatenate wave-level plot_inputs data for Uganda (GAP 2).
+
+Each wave's ``Uganda/<wave>/_/plot_inputs.py`` produces a parquet indexed
+``(t, i, plot, input, j)`` with the REPORTED input columns (Quantity, u,
+Purchased, Quantity_purchased, Improved).  This script concatenates them
+across waves and applies cross-wave id_walk so the household index uses the
+panel canonical id scheme.
+
+Source: AGSEC3A/3B (fertilizer / pesticide) + AGSEC4A (seed).  2005-06 is
+intentionally absent: it has no plot-input module (the UNPS agriculture
+panel starts at wave 1 = 2009-10).
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import Waves, id_walk
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/plot_inputs.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for plot_inputs (no .py / parquet, e.g. 2005-06).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_inputs: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/plot_inputs.parquet')

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -1028,3 +1028,429 @@ CROP_COLMAPS = {
                       'flag': 's4aq16', 'crop': 'cropID'},
     },
 }
+
+
+# ---------------------------------------------------------------------------
+# plot_inputs  (GAP 2 — item-level agricultural inputs)
+# ---------------------------------------------------------------------------
+#
+# One row per REPORTED input applied to a plot, grain (t, i, plot, input).
+# Source: AGSEC3A (season-1 plot-input module) + AGSEC3B (season-2) for the
+# fertilizer / pesticide blocks, and AGSEC4A (plot-crop roster) for the seed
+# block.  ``plot`` mirrors the crop_production / WB harmonised plot_id =
+# hhid-parcel-plot, so a plot_inputs row joins crop_production on
+# (t, i, plot) and plot_features on the parcel component.
+#
+# The UNPS plot-input module records four input *blocks* per plot, each a
+# fixed column group:
+#   organic fertilizer   used / qty / purchased? / purchased-qty / purch-value
+#   inorganic fertilizer used / type / qty / purchased? / purch-qty / value
+#   pesticide/herbicide  used / type / unit / qty / purchased? / purch-qty / value
+# and the seed block (AGSEC4A, plot-crop grain):
+#   seed                 qty / unit / seed-type(Trad/Improved) / improved-type
+#                        / purchase-value [/ purchased? in 2009-10/2010-11]
+#
+# ``input`` carries the FINEST identity the source records, via the
+# harmonize_input table (Code | Preferred Label).  Fertilizer/pesticide
+# sub-types live in distinct Code ranges so one table disambiguates:
+#   10           Seed
+#   20           Organic Fertilizer
+#   30 / 31..34  Inorganic Fertilizer  (Nitrate/Phosphate/Potash/Mixed)
+#   40 / 41..49  Pesticide             (Insecticide/Fungicide/...)
+# Reported attribute columns: Quantity + native unit ``u``, Purchased (bool),
+# Quantity_purchased, Improved (bool, seed rows only), crop (j, seed rows
+# where the source records the seed's crop, on harmonize_crop labels).
+# NO seed_kg / nitrogen_kg / any-use flags — those are transformations.
+
+_INPUT_TABLE = 'harmonize_input'
+# pesticide unit scheme is a tiny 1=Kg / 2=Litres code (a3aq24a / a3aq28a),
+# distinct from the UNPS harvest/seed unit scheme reused for seed via
+# harvest_units.  Stored in its own harmonize_pesticide_unit table.
+_PEST_UNIT_TABLE = 'harmonize_pesticide_unit'
+
+# input-block -> harmonize_input base Code.  Inorganic/pesticide refine by
+# adding the source type code (1..4 / 1..6,96 -> 96 folds to 9) so e.g.
+# Nitrate inorganic = 31, Fungicide pesticide = 43.
+_INPUT_BASE = {'seed': 10, 'organic': 20, 'inorganic': 30, 'pesticide': 40}
+
+
+def _input_label_map():
+    return _harmonized_codes(_INPUT_TABLE)
+
+
+def _pest_unit_map():
+    return _harmonized_codes(_PEST_UNIT_TABLE)
+
+
+def _input_code(block, type_code):
+    """Resolve the harmonize_input Code for a block + native type code.
+
+    ``type_code`` may be NaN (block used but type unreported -> base code).
+    Pesticide ``96`` ("Other") folds to base+9 so the table stays compact.
+    """
+    base = _INPUT_BASE[block]
+    if block in ('inorganic', 'pesticide') and pd.notna(type_code):
+        tc = int(type_code)
+        if tc == 96:
+            tc = 9
+        if 1 <= tc <= 9:
+            return base + tc
+    return base
+
+
+def _recode_yes(series):
+    """Map a 1/2 (Yes/No) coded column to a nullable boolean (1->True,
+    2->False; everything else -> NA).  UNPS uses 1=Yes, 2=No."""
+    code = _to_int_code(series)
+    out = pd.Series(pd.NA, index=series.index, dtype='boolean')
+    out[code == 1] = True
+    out[code == 2] = False
+    return out
+
+
+def plot_inputs_for_wave(t, df3a, df3b, df4a, colmap):
+    """Build canonical ``plot_inputs`` for one Uganda UNPS wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2011-12"``).
+    df3a, df3b : pd.DataFrame | None
+        Raw AGSEC3A (season 1) / AGSEC3B (season 2) plot-input modules,
+        loaded with ``convert_categoricals=False`` so code columns carry
+        integer codes.  ``None`` permitted (season absent).
+    df4a : pd.DataFrame | None
+        Raw AGSEC4A plot-crop roster, for the seed block.  ``None``
+        permitted; when absent no seed rows are emitted.
+    colmap : dict
+        Per-wave column map; see ``INPUT_COLMAPS``.
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot, input)`` with columns
+    ``Quantity`` (Float64), ``u`` (object, native unit label), ``Purchased``
+    (boolean), ``Quantity_purchased`` (Float64), ``Improved`` (boolean,
+    seed rows), and ``j`` (object crop label, seed rows where recorded).
+    Reported values only; missing-in-wave columns are NaN.
+    """
+    input_map = _input_label_map()
+    unit_map = _harvest_unit_map()        # seed unit reuses harvest scheme
+    pest_unit_map = _pest_unit_map()
+    crop_map = _crop_label_map()
+
+    pieces = []
+
+    # ---- fertilizer / pesticide blocks from AGSEC3A / AGSEC3B ----
+    for season, df3 in (('A', df3a), ('B', df3b)):
+        if df3 is None or len(df3) == 0:
+            continue
+        cm = (colmap.get(season) or {}).get('inputs')
+        if not cm:
+            continue
+        hh = df3[cm['hhid']].apply(format_id)
+        parcel = df3[cm['parcel']].apply(format_id)
+        plot = (df3[cm['plot']].apply(format_id)
+                if cm.get('plot') and cm['plot'] in df3.columns
+                else pd.Series([''] * len(df3), index=df3.index))
+        plot_id = hh.astype(str) + '-' + parcel.astype(str) + '-' + plot.astype(str)
+
+        for block in ('organic', 'inorganic', 'pesticide'):
+            b = cm.get(block)
+            if not b:
+                continue
+            # A block "applies" to a plot when its used-flag is Yes, OR
+            # (no used-flag column, e.g. inorganic in 2011+) when a type
+            # or quantity is reported.
+            type_code = (_to_int_code(df3[b['type']])
+                         if b.get('type') and b['type'] in df3.columns
+                         else pd.Series([pd.NA] * len(df3), index=df3.index, dtype='Int64'))
+            qty = (pd.to_numeric(df3[b['qty']], errors='coerce')
+                   if b.get('qty') and b['qty'] in df3.columns
+                   else pd.Series([np.nan] * len(df3), index=df3.index))
+
+            if b.get('used') and b['used'] in df3.columns:
+                used = _recode_yes(df3[b['used']])
+                applied = (used == True)
+            else:
+                applied = type_code.notna() | qty.notna()
+
+            if not applied.any():
+                continue
+
+            # native unit: pesticide carries a 1=Kg/2=Litre unit column;
+            # organic/inorganic are implicitly kg (no unit column).
+            if b.get('unit') and b['unit'] in df3.columns:
+                ucode = _to_int_code(df3[b['unit']])
+                u = ucode.map(lambda c: pest_unit_map.get(int(c), pd.NA)
+                              if pd.notna(c) else pd.NA)
+            elif block in ('organic', 'inorganic'):
+                u = pd.Series(['Kg'] * len(df3), index=df3.index, dtype='object')
+            else:
+                u = pd.Series([pd.NA] * len(df3), index=df3.index, dtype='object')
+
+            purchased = (_recode_yes(df3[b['purchased']])
+                         if b.get('purchased') and b['purchased'] in df3.columns
+                         else pd.Series([pd.NA] * len(df3), index=df3.index, dtype='boolean'))
+            qpur = (pd.to_numeric(df3[b['purchased_qty']], errors='coerce')
+                    if b.get('purchased_qty') and b['purchased_qty'] in df3.columns
+                    else pd.Series([np.nan] * len(df3), index=df3.index))
+
+            input_code = type_code.map(lambda c: _input_code(block, c))
+            input_label = input_code.map(lambda c: input_map.get(int(c), pd.NA)
+                                         if pd.notna(c) else pd.NA)
+
+            piece = pd.DataFrame({
+                't': t,
+                'i': hh.values,
+                'plot': plot_id.values,
+                'input': input_label.values,
+                'Quantity': qty.values,
+                'u': u.values,
+                'Purchased': purchased.values,
+                'Quantity_purchased': qpur.values,
+                'Improved': pd.Series([pd.NA] * len(df3), dtype='boolean').values,
+                'j': pd.Series([pd.NA] * len(df3), dtype='object').values,
+            })
+            piece = piece[applied.values]
+            pieces.append(piece)
+
+    # ---- seed block from AGSEC4A (plot-crop grain) ----
+    sc = colmap.get('seed')
+    if df4a is not None and len(df4a) and sc:
+        hh = df4a[sc['hhid']].apply(format_id)
+        parcel = df4a[sc['parcel']].apply(format_id)
+        plot = (df4a[sc['plot']].apply(format_id)
+                if sc.get('plot') and sc['plot'] in df4a.columns
+                else pd.Series([''] * len(df4a), index=df4a.index))
+        plot_id = hh.astype(str) + '-' + parcel.astype(str) + '-' + plot.astype(str)
+
+        crop_code = (_to_int_code(df4a[sc['crop']])
+                     if sc.get('crop') and sc['crop'] in df4a.columns
+                     else pd.Series([pd.NA] * len(df4a), index=df4a.index, dtype='Int64'))
+        j = crop_code.map(lambda c: crop_map.get(int(c), pd.NA)
+                          if pd.notna(c) else pd.NA)
+
+        qty = (pd.to_numeric(df4a[sc['qty']], errors='coerce')
+               if sc.get('qty') and sc['qty'] in df4a.columns
+               else pd.Series([np.nan] * len(df4a), index=df4a.index))
+        if sc.get('unit') and sc['unit'] in df4a.columns:
+            ucode = _to_int_code(df4a[sc['unit']])
+            u = ucode.map(lambda c: unit_map.get(int(c), pd.NA)
+                          if pd.notna(c) else pd.NA)
+        else:
+            u = pd.Series([pd.NA] * len(df4a), index=df4a.index, dtype='object')
+
+        # Improved: seed-type 1=Traditional, 2=Improved.
+        stype = (_to_int_code(df4a[sc['seed_type']])
+                 if sc.get('seed_type') and sc['seed_type'] in df4a.columns
+                 else pd.Series([pd.NA] * len(df4a), index=df4a.index, dtype='Int64'))
+        improved = pd.Series(pd.NA, index=df4a.index, dtype='boolean')
+        improved[stype == 2] = True
+        improved[stype == 1] = False
+
+        purchased = (_recode_yes(df4a[sc['purchased']])
+                     if sc.get('purchased') and sc['purchased'] in df4a.columns
+                     else pd.Series([pd.NA] * len(df4a), index=df4a.index, dtype='boolean'))
+        qpur = (pd.to_numeric(df4a[sc['purchased_qty']], errors='coerce')
+                if sc.get('purchased_qty') and sc['purchased_qty'] in df4a.columns
+                else pd.Series([np.nan] * len(df4a), index=df4a.index))
+
+        seed_label = input_map.get(_INPUT_BASE['seed'], 'Seed')
+        piece = pd.DataFrame({
+            't': t,
+            'i': hh.values,
+            'plot': plot_id.values,
+            'input': seed_label,
+            'Quantity': qty.values,
+            'u': u.values,
+            'Purchased': purchased.values,
+            'Quantity_purchased': qpur.values,
+            'Improved': improved.values,
+            'j': j.values,
+        })
+        # Keep a seed row when any seed measure is reported (qty, improved,
+        # purchased, or a crop label) — a plot-crop with a recorded seed.
+        keep = (piece['Quantity'].notna() | piece['Improved'].notna()
+                | piece['Purchased'].notna() | piece['j'].notna())
+        pieces.append(piece[keep.values])
+
+    cols = ['Quantity', 'u', 'Purchased', 'Quantity_purchased', 'Improved']
+    if not pieces:
+        return pd.DataFrame(columns=cols)
+
+    df = pd.concat(pieces, ignore_index=True)
+    df = df[df['input'].notna()]
+
+    df['Quantity'] = pd.to_numeric(df['Quantity'], errors='coerce').astype('Float64')
+    df['Quantity_purchased'] = pd.to_numeric(df['Quantity_purchased'], errors='coerce').astype('Float64')
+    df['Purchased'] = df['Purchased'].astype('boolean')
+    df['Improved'] = df['Improved'].astype('boolean')
+    # u may be NaN (a reported pesticide with no unit label); sentinel so it
+    # is not an issue for downstream code that strings the column.
+    df['u'] = df['u'].astype('object').where(df['u'].notna(), 'Unknown')
+    # j is the seed's crop (on harmonize_crop labels) for seed rows, and a
+    # 'n/a' sentinel for fertilizer/pesticide rows (no crop linkage).  It is
+    # an INDEX level so per-crop seed rows on a multi-crop plot stay distinct
+    # (the maintainer's "plot-crop seed grain") rather than collapsing —
+    # 37.9% of seeded plots in 2011-12 carry >1 crop.  The sentinel keeps the
+    # level non-null so it is a valid index level.
+    df['j'] = df['j'].astype('object').where(df['j'].notna(), 'n/a')
+
+    df = df.set_index(['t', 'i', 'plot', 'input', 'j'])
+    # Collapse only EXACT-duplicate (t,i,plot,input,j) tuples — the same input
+    # identity reported twice for the same plot-crop (e.g. a fertilizer block
+    # appearing in both AGSEC3A passes, or a seed row repeated).  This is
+    # de-duplication of the index grain, NOT cross-item aggregation: Quantity
+    # / purchased quantity sum, flags/unit take first.
+    if not df.index.is_unique:
+        num = df[['Quantity', 'Quantity_purchased']].groupby(level=df.index.names).sum(min_count=1)
+        flags = df[['Purchased', 'Improved']].groupby(level=df.index.names).max()
+        us = df[['u']].groupby(level=df.index.names).first()
+        df = num.join(flags).join(us)
+        df = df[cols]
+    return df
+
+
+# Per-wave column maps for plot_inputs_for_wave.
+#
+# Two questionnaire vintages:
+#   2009-10 / 2010-11 (older numbering):
+#     organic   used a3aq4  qty a3aq5  purch a3aq6  pqty a3aq7
+#     inorganic used a3aq14 type a3aq15 qty a3aq16 purch a3aq17 pqty a3aq18
+#     pesticide used a3aq26 type a3aq27 unit a3aq28a qty a3aq28b purch a3aq29 pqty a3aq30
+#     seed (AGSEC4A): NO qty/unit; purch a4aq10, seed_type a4aq13  (qty absent)
+#   2011-12 / 2013-14 / 2015-16 / 2018-19 / 2019-20 (newer numbering, s-prefix
+#   for 2018+):
+#     organic   used .4  qty .5  purch .6  pqty .7
+#     inorganic used .13 type .14 qty .15 purch .16 pqty .17
+#     pesticide used .22 type .23 unit .24a qty .24b purch .25 pqty .26
+#     seed (AGSEC4A): qty .11a unit .11b seed_type .13  (purch via value .15;
+#                     no explicit purchased y/n -> Purchased NA)
+INPUT_COLMAPS = {
+    '2009-10': {
+        'A': {'hhid': 'HHID', 'parcel': 'a3aq1', 'plot': 'a3aq3',
+              'inputs': {
+                  'hhid': 'HHID', 'parcel': 'a3aq1', 'plot': 'a3aq3',
+                  'organic':   {'used': 'a3aq4', 'qty': 'a3aq5', 'purchased': 'a3aq6', 'purchased_qty': 'a3aq7'},
+                  'inorganic': {'used': 'a3aq14', 'type': 'a3aq15', 'qty': 'a3aq16', 'purchased': 'a3aq17', 'purchased_qty': 'a3aq18'},
+                  'pesticide': {'used': 'a3aq26', 'type': 'a3aq27', 'unit': 'a3aq28a', 'qty': 'a3aq28b', 'purchased': 'a3aq29', 'purchased_qty': 'a3aq30'},
+              }},
+        'B': {'hhid': 'HHID', 'parcel': 'a3bq1', 'plot': 'a3bq3',
+              'inputs': {
+                  'hhid': 'HHID', 'parcel': 'a3bq1', 'plot': 'a3bq3',
+                  'organic':   {'used': 'a3bq4', 'qty': 'a3bq5', 'purchased': 'a3bq6', 'purchased_qty': 'a3bq7'},
+                  'inorganic': {'used': 'a3bq14', 'type': 'a3bq15', 'qty': 'a3bq16', 'purchased': 'a3bq17', 'purchased_qty': 'a3bq18'},
+                  'pesticide': {'used': 'a3bq26', 'type': 'a3bq27', 'unit': 'a3bq28a', 'qty': 'a3bq28b', 'purchased': 'a3bq29', 'purchased_qty': 'a3bq30'},
+              }},
+        'seed': {'hhid': 'HHID', 'parcel': 'a4aq2', 'plot': 'a4aq4', 'crop': 'a4aq6',
+                 'purchased': 'a4aq10', 'seed_type': 'a4aq13'},
+    },
+    '2010-11': {
+        'A': {'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid',
+              'inputs': {
+                  'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid',
+                  'organic':   {'used': 'a3aq4', 'qty': 'a3aq5', 'purchased': 'a3aq6', 'purchased_qty': 'a3aq7'},
+                  'inorganic': {'used': 'a3aq14', 'type': 'a3aq15', 'qty': 'a3aq16', 'purchased': 'a3aq17', 'purchased_qty': 'a3aq18'},
+                  'pesticide': {'used': 'a3aq26', 'type': 'a3aq27', 'unit': 'a3aq28a', 'qty': 'a3aq28b', 'purchased': 'a3aq29', 'purchased_qty': 'a3aq30'},
+              }},
+        'B': {'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid',
+              'inputs': {
+                  'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid',
+                  'organic':   {'used': 'a3bq4', 'qty': 'a3bq5', 'purchased': 'a3bq6', 'purchased_qty': 'a3bq7'},
+                  'inorganic': {'used': 'a3bq14', 'type': 'a3bq15', 'qty': 'a3bq16', 'purchased': 'a3bq17', 'purchased_qty': 'a3bq18'},
+                  'pesticide': {'used': 'a3bq26', 'type': 'a3bq27', 'unit': 'a3bq28a', 'qty': 'a3bq28b', 'purchased': 'a3bq29', 'purchased_qty': 'a3bq30'},
+              }},
+        'seed': {'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid', 'crop': 'cropID',
+                 'purchased': 'a4aq10', 'seed_type': 'a4aq13'},
+    },
+    '2011-12': {
+        'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+              'inputs': {
+                  'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+                  'organic':   {'used': 'a3aq4', 'qty': 'a3aq5', 'purchased': 'a3aq6', 'purchased_qty': 'a3aq7'},
+                  'inorganic': {'used': 'a3aq13', 'type': 'a3aq14', 'qty': 'a3aq15', 'purchased': 'a3aq16', 'purchased_qty': 'a3aq17'},
+                  'pesticide': {'used': 'a3aq22', 'type': 'a3aq23', 'unit': 'a3aq24a', 'qty': 'a3aq24b', 'purchased': 'a3aq25', 'purchased_qty': 'a3aq26'},
+              }},
+        'B': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+              'inputs': {
+                  'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+                  'organic':   {'used': 'a3bq4', 'qty': 'a3bq5', 'purchased': 'a3bq6', 'purchased_qty': 'a3bq7'},
+                  'inorganic': {'used': 'a3bq13', 'type': 'a3bq14', 'qty': 'a3bq15', 'purchased': 'a3bq16', 'purchased_qty': 'a3bq17'},
+                  'pesticide': {'used': 'a3bq22', 'type': 'a3bq23', 'unit': 'a3bq24a', 'qty': 'a3bq24b', 'purchased': 'a3bq25', 'purchased_qty': 'a3bq26'},
+              }},
+        'seed': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
+                 'qty': 'a4aq11a', 'unit': 'a4aq11b', 'seed_type': 'a4aq13'},
+    },
+    '2013-14': {
+        'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+              'inputs': {
+                  'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+                  'organic':   {'used': 'a3aq4', 'qty': 'a3aq5', 'purchased': 'a3aq6', 'purchased_qty': 'a3aq7'},
+                  'inorganic': {'used': 'a3aq13', 'type': 'a3aq14', 'qty': 'a3aq15', 'purchased': 'a3aq16', 'purchased_qty': 'a3aq17'},
+                  'pesticide': {'used': 'a3aq22', 'type': 'a3aq23', 'unit': 'a3aq24a', 'qty': 'a3aq24b', 'purchased': 'a3aq25', 'purchased_qty': 'a3aq26'},
+              }},
+        'B': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+              'inputs': {
+                  'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+                  'organic':   {'used': 'a3bq4', 'qty': 'a3bq5', 'purchased': 'a3bq6', 'purchased_qty': 'a3bq7'},
+                  'inorganic': {'used': 'a3bq13', 'type': 'a3bq14', 'qty': 'a3bq15', 'purchased': 'a3bq16', 'purchased_qty': 'a3bq17'},
+                  'pesticide': {'used': 'a3bq22', 'type': 'a3bq23', 'unit': 'a3bq24a', 'qty': 'a3bq24b', 'purchased': 'a3bq25', 'purchased_qty': 'a3bq26'},
+              }},
+        'seed': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
+                 'qty': 'a4aq11a', 'unit': 'a4aq11b', 'seed_type': 'a4aq13'},
+    },
+    '2015-16': {
+        'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+              'inputs': {
+                  'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+                  'organic':   {'used': 'a3aq4', 'qty': 'a3aq5', 'purchased': 'a3aq6', 'purchased_qty': 'a3aq7'},
+                  'inorganic': {'used': 'a3aq13', 'type': 'a3aq14', 'qty': 'a3aq15', 'purchased': 'a3aq16', 'purchased_qty': 'a3aq17'},
+                  'pesticide': {'used': 'a3aq22', 'type': 'a3aq23', 'unit': 'a3aq24a', 'qty': 'a3aq24b', 'purchased': 'a3aq25', 'purchased_qty': 'a3aq26'},
+              }},
+        'B': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+              'inputs': {
+                  'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+                  'organic':   {'used': 'a3bq4', 'qty': 'a3bq5', 'purchased': 'a3bq6', 'purchased_qty': 'a3bq7'},
+                  'inorganic': {'used': 'a3bq13', 'type': 'a3bq14', 'qty': 'a3bq15', 'purchased': 'a3bq16', 'purchased_qty': 'a3bq17'},
+                  'pesticide': {'used': 'a3bq22', 'type': 'a3bq23', 'unit': 'a3bq24a', 'qty': 'a3bq24b', 'purchased': 'a3bq25', 'purchased_qty': 'a3bq26'},
+              }},
+        'seed': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
+                 'qty': 'a4aq11a', 'unit': 'a4aq11b', 'seed_type': 'a4aq13'},
+    },
+    '2018-19': {
+        'A': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+              'inputs': {
+                  'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+                  'organic':   {'used': 's3aq04', 'qty': 's3aq05', 'purchased': 's3aq06', 'purchased_qty': 's3aq07'},
+                  'inorganic': {'used': 's3aq13', 'type': 's3aq14', 'qty': 's3aq15', 'purchased': 's3aq16', 'purchased_qty': 's3aq17'},
+                  'pesticide': {'used': 's3aq22', 'type': 's3aq23', 'unit': 's3aq24a', 'qty': 's3aq24b', 'purchased': 's3aq25', 'purchased_qty': 's3aq26'},
+              }},
+        'B': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+              'inputs': {
+                  'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+                  'organic':   {'used': 's3bq04', 'qty': 's3bq05', 'purchased': 's3bq06', 'purchased_qty': 's3bq07'},
+                  'inorganic': {'used': 's3bq13', 'type': 's3bq14', 'qty': 's3bq15', 'purchased': 's3bq16', 'purchased_qty': 's3bq17'},
+                  'pesticide': {'used': 's3bq22', 'type': 's3bq23', 'unit': 's3bq24a', 'qty': 's3bq24b', 'purchased': 's3bq25', 'purchased_qty': 's3bq26'},
+              }},
+        'seed': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid', 'crop': 'cropID',
+                 'qty': 's4aq11a', 'unit': 's4aq11b', 'seed_type': 's4aq13'},
+    },
+    '2019-20': {
+        'A': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+              'inputs': {
+                  'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+                  'organic':   {'used': 's3aq04', 'qty': 's3aq05', 'purchased': 's3aq06', 'purchased_qty': 's3aq07'},
+                  'inorganic': {'used': 's3aq13', 'type': 's3aq14', 'qty': 's3aq15', 'purchased': 's3aq16', 'purchased_qty': 's3aq17'},
+                  'pesticide': {'used': 's3aq22', 'type': 's3aq23', 'unit': 's3aq24a', 'qty': 's3aq24b', 'purchased': 's3aq25', 'purchased_qty': 's3aq26'},
+              }},
+        'B': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+              'inputs': {
+                  'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+                  'organic':   {'used': 's3bq04', 'qty': 's3bq05', 'purchased': 's3bq06', 'purchased_qty': 's3bq07'},
+                  'inorganic': {'used': 's3bq13', 'type': 's3bq14', 'qty': 's3bq15', 'purchased': 's3bq16', 'purchased_qty': 's3bq17'},
+                  'pesticide': {'used': 's3bq22', 'type': 's3bq23', 'unit': 's3bq24a', 'qty': 's3bq24b', 'purchased': 's3bq25', 'purchased_qty': 's3bq26'},
+              }},
+        'seed': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid', 'crop': 'cropID',
+                 'qty': 's4aq11a', 'unit': 's4aq11b', 'seed_type': 's4aq13'},
+    },
+}


### PR DESCRIPTION
GAP 2 of the WB-parity loop. Item-level `plot_inputs` at `(t, i, plot, input)` from the seed/fertilizer/pesticide modules — **reported** input type, qty/native-unit, purchased flag+qty, improved-seed flag. NO aggregates (nitrogen_kg, seed_kg, any-use flags, fertilizer totals are `transformations`).

- Input-type labels in a new `harmonize_input` table; units in `u`; seed-crop in `harmonize_food` (joins crop_production/food_acquired).
- `v` auto-joins from `sample()` (plot_features pattern); **no framework edits** (GAP-1 lesson held — adversary confirmed `country.py` untouched).
- Plot-IDs align with merged crop_production (~99% join).
- Documented grain/coverage choices (consistent with crop_production): Niger = HH×input (source has no parcel-level inputs; WB fabricates an area-split which the reported-only rule forbids); Tanzania long-rainy season; EHCVM/early waves with no input module deferred.
- Adversary PASS (cold-rebuilt all 7, exact row match): no aggregates, no framework edits, no scope/regression, all `is_this_feature_sane.ok`.

232 table-structure/schema tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>