### PR TITLE
feat(parity): GAP 4 — item-level livestock (t,i,animal) across 7 LSMS-ISA countries

### DIFF
--- a/lsms_library/countries/Ethiopia/2011-12/_/livestock.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/livestock.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""Build livestock for Ethiopia ESS 2011-12 (Wave 1; GAP 4).
+
+Item-level livestock at (t, i, animal).  One row per (household, canonical
+species), carrying only REPORTED §8 roster fields.  This is the pre-collapse
+roster the WB code reads then throws away down to a single engaged-y/n
+binary (recode pp_saq13 ... collapse-max).
+
+W1 source / specifics (sect8a_ls_w1.dta -- the long-format roster, one row
+per holder x animal code):
+  - animal code   ls_s8aq00  (1=Cattle .. 14=Beehives)
+  - head count    ls_s8aq13a (grand total owned by the HH, Total column)
+  - head acquired ls_s8aq44a (amount PURCHASED in last 12 months, Total)
+  - head sold     ls_s8aq46a (amount of SALES in last 12 months, Total)
+  - sale value    ls_s8aq60  (total value of sales in last 12 months, Birr)
+All transaction columns are in the SAME file as the count (txn=None).
+W1 reports NO current herd value -> Value carries the reported sale value,
+which is the only monetary livestock field the §8 roster records this wave.
+i = household_id (matches sample().i for W1).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import livestock_for_wave
+
+
+count = get_dataframe('../Data/sect8a_ls_w1.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', holder_id='holder_id',
+    animal_code='ls_s8aq00',
+    head_count='ls_s8aq13a',
+    head_acquired='ls_s8aq44a',
+    head_sold='ls_s8aq46a',
+    sale_value='ls_s8aq60',
+)
+
+df = livestock_for_wave('2011-12', count, None, colmap)
+
+assert len(df) > 0, "livestock 2011-12 produced no rows"
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Ethiopia/2013-14/_/livestock.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/livestock.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""Build livestock for Ethiopia ESS 2013-14 (Wave 2; GAP 4).
+
+Item-level livestock at (t, i, animal); see the country-level
+Ethiopia/_/livestock.py docstring and the 2011-12 wave script for the
+construct.  W2 §8 roster (sect8a_ls_w2.dta) is structurally identical to
+W1: a single long-format file (one row per holder x animal code) carrying
+the count AND the transactions, with the same ls_s8aq* column names.
+
+  - animal code   ls_s8aq00  (1=Cattle .. 14=Beehives)
+  - head count    ls_s8aq13a (grand total owned, Total column)
+  - head acquired ls_s8aq44a (purchased in last 12 months, Total)
+  - head sold     ls_s8aq46a (sales in last 12 months, Total)
+  - sale value    ls_s8aq60  (total value of sales, Birr)
+i = household_id2 (matches sample().i / plot_features for W2).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import livestock_for_wave
+
+
+count = get_dataframe('../Data/sect8a_ls_w2.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id2', holder_id='holder_id',
+    animal_code='ls_s8aq00',
+    head_count='ls_s8aq13a',
+    head_acquired='ls_s8aq44a',
+    head_sold='ls_s8aq46a',
+    sale_value='ls_s8aq60',
+)
+
+df = livestock_for_wave('2013-14', count, None, colmap)
+
+assert len(df) > 0, "livestock 2013-14 produced no rows"
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Ethiopia/2015-16/_/livestock.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/livestock.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""Build livestock for Ethiopia ESS 2015-16 (Wave 3; GAP 4).
+
+Item-level livestock at (t, i, animal); see Ethiopia/_/livestock.py.
+
+W3 splits the §8 roster across two files joined on (holder_id, ls_code):
+  - sect8_1_ls_w3.dta  current head count:
+      animal code  ls_code           (1=Bulls .. 23=Bee Colony; finer scheme)
+      head count   ls_sec_8_1q01     (currently own and keep)
+  - sect8_2_ls_w3.dta  transactions (per the same ls_code):
+      head acquired ls_sec_8_2aq04   (bought alive in last 12 months)
+      head sold     ls_sec_8_2aq13   (sold alive in last 12 months)
+      sale value    ls_sec_8_2aq14   (total income from sales, Birr)
+The finer ls_code (Bulls/Oxen/Cows/... ; Goats-He/She/Kids; etc.) folds to
+canonical species via the wave-keyed harmonize_species table and is summed
+within household.  No current herd value is asked -> Value = reported sale
+income (the only monetary §8 field).
+i = household_id2 (matches sample().i / plot_features for W3).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import livestock_for_wave
+
+
+count = get_dataframe('../Data/sect8_1_ls_w3.dta', convert_categoricals=False)
+txn   = get_dataframe('../Data/sect8_2_ls_w3.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id2', holder_id='holder_id',
+    animal_code='ls_code',
+    head_count='ls_sec_8_1q01',
+    t_animal_code='ls_code', t_holder_id='holder_id',
+    head_acquired='ls_sec_8_2aq04',
+    head_sold='ls_sec_8_2aq13',
+    sale_value='ls_sec_8_2aq14',
+)
+
+df = livestock_for_wave('2015-16', count, txn, colmap)
+
+assert len(df) > 0, "livestock 2015-16 produced no rows"
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Ethiopia/2018-19/_/livestock.py
+++ b/lsms_library/countries/Ethiopia/2018-19/_/livestock.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""Build livestock for Ethiopia ESS 2018-19 (Wave 4; GAP 4).
+
+Item-level livestock at (t, i, animal); see Ethiopia/_/livestock.py.
+
+W4 splits the §8 roster across two files joined on (holder_id, ls_code):
+  - sect8_1_ls_w4.dta  current head count:
+      animal code  ls_code        (1=Bulls .. 16=Bee Colony)
+      head count   ls_s8_1q01     (currently keep)
+  - sect8_2_ls_w4.dta  transactions (per the same ls_code):
+      head acquired ls_s8_2q04    (purchased alive in last 12 months)
+      head sold     ls_s8_2q13    (sold alive in last 12 months)
+      sale value    ls_s8_2q14    (total income from sales, Birr)
+ls_code (Bulls/Oxen/Cows/Steers/Heifers/Calves -> Cattle; chicken sub-types
+-> Poultry) folds to canonical species via harmonize_species and is summed
+within household.  No current herd value asked -> Value = sale income.
+i = household_id (W4 is an entirely new sample).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import livestock_for_wave
+
+
+count = get_dataframe('../Data/sect8_1_ls_w4.dta', convert_categoricals=False)
+txn   = get_dataframe('../Data/sect8_2_ls_w4.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', holder_id='holder_id',
+    animal_code='ls_code',
+    head_count='ls_s8_1q01',
+    t_animal_code='ls_code', t_holder_id='holder_id',
+    head_acquired='ls_s8_2q04',
+    head_sold='ls_s8_2q13',
+    sale_value='ls_s8_2q14',
+)
+
+df = livestock_for_wave('2018-19', count, txn, colmap)
+
+assert len(df) > 0, "livestock 2018-19 produced no rows"
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Ethiopia/2021-22/_/livestock.py
+++ b/lsms_library/countries/Ethiopia/2021-22/_/livestock.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+"""Build livestock for Ethiopia ESS 2021-22 (Wave 5; GAP 4).
+
+Item-level livestock at (t, i, animal); see Ethiopia/_/livestock.py.
+
+W5 splits the §8 roster across two files joined on (holder_id, ls_code),
+structurally identical to W4:
+  - sect8_1_ls_w5.dta  current head count:
+      animal code  ls_code        (1=Bulls .. 16=Bee Colony)
+      head count   ls_s8_1q01     (currently keep)
+  - sect8_2_ls_w5.dta  transactions (per the same ls_code):
+      head acquired ls_s8_2q04    (purchased alive in last 12 months)
+      head sold     ls_s8_2q13    (sold alive in last 12 months)
+      sale value    ls_s8_2q14    (total income from sales, Birr)
+No current herd value asked -> Value = reported sale income.
+i = household_id.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import livestock_for_wave
+
+
+count = get_dataframe('../Data/sect8_1_ls_w5.dta', convert_categoricals=False)
+txn   = get_dataframe('../Data/sect8_2_ls_w5.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', holder_id='holder_id',
+    animal_code='ls_code',
+    head_count='ls_s8_1q01',
+    t_animal_code='ls_code', t_holder_id='holder_id',
+    head_acquired='ls_s8_2q04',
+    head_sold='ls_s8_2q13',
+    sale_value='ls_s8_2q14',
+)
+
+df = livestock_for_wave('2021-22', count, txn, colmap)
+
+assert len(df) > 0, "livestock 2021-22 produced no rows"
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Ethiopia/_/Makefile
+++ b/lsms_library/countries/Ethiopia/_/Makefile
@@ -18,7 +18,7 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 var = \
       $(VAR_DIR)/shocks.parquet $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet \
       $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/crop_production.parquet \
-      $(VAR_DIR)/plot_inputs.parquet
+      $(VAR_DIR)/plot_inputs.parquet $(VAR_DIR)/livestock.parquet
 
 all: panel_ids.json updated_ids.json $(parquet) $(var)
 
@@ -87,6 +87,19 @@ plot_inputs_parquet := $(plot_inputs:.py=.parquet)
 
 $(VAR_DIR)/plot_inputs.parquet: plot_inputs.py $(plot_inputs_parquet)
 	python plot_inputs.py
+
+# livestock (GAP 4; ESS §8 item-level livestock roster at (t, i, animal)).
+# Mirrors the crop_production convention: the framework's grab_data calls
+# `make ../<wave>/_/livestock.parquet`, whose pattern rule runs the wave
+# script; the VAR_DIR rule concatenates them via the country script.
+livestock = $(shell find $(rounds) -name livestock.py)
+livestock_parquet := $(livestock:.py=.parquet)
+
+../%/_/livestock.parquet: ../%/_/livestock.py
+	(cd $(@D) && python livestock.py)
+
+$(VAR_DIR)/livestock.parquet: livestock.py $(livestock_parquet)
+	python livestock.py
 
 # food_coping (GH #332, Family B; ESS §7 CSI/rCSI day-count battery).
 # Mirrors the plot_features convention: the framework's grab_data calls

--- a/lsms_library/countries/Ethiopia/_/categorical_mapping.org
+++ b/lsms_library/countries/Ethiopia/_/categorical_mapping.org
@@ -601,3 +601,117 @@ rows carry an applied-y/n flag only (no quantity in the survey).
 |    6 | Compost         |
 |    7 | Other Organic   |
 |    8 | Pesticide       |
+
+* harmonize_species (the animal axis -- GAP 4, livestock; WAVE-KEYED)
+
+The §8 livestock-roster animal code (=ls_s8aq00= W1-W2, =ls_code= W4-W5,
+=ls_code= W3) -> canonical species.  WAVE-KEYED because the raw code
+scheme is NOT stable across waves:
+
+- W1-W2 (=ls_s8aq00=, 14 codes) report CATTLE / POULTRY at the *aggregate*
+  species grain (a single CATTLE code; four separate poultry codes for
+  laying/non-laying hens, cocks, cockerels, pullets, chicks).
+- W3 (=ls_code=, 23 codes) and W4-W5 (=ls_code=, 16 codes) split the
+  bovine herd by age/sex (Bulls / Oxen / Cows / Steers / Heifers /
+  Calves) and the small ruminants / camels likewise.
+
+To keep a single cross-wave =animal= axis we fold every bovine sub-type
+(Bulls/Oxen/Cows/Steers/Heifers/Calves) onto *Cattle* and every
+chicken/hen/cock/chick sub-type onto *Poultry* -- W1-W2 cannot
+distinguish Oxen from the rest of the herd, so a finer scheme would not
+be cross-wave comparable.  The wave-level script SUMS the reported head
+counts over the raw codes that share a canonical species within a
+household (e.g. W3 Bulls+Oxen+Cows+... -> one Cattle row per HH), which
+is the within-household roll-up to the (t, i, animal) grain, NOT a
+WB-style collapse-to-binary.
+
+Canonical species: Cattle, Sheep, Goats, Camels, Poultry, Horses,
+Mules, Donkeys, Beehives.  (Beehives are a hive count, not a head
+count, but ride the same roster row; carried for completeness.)
+
+#+name: harmonize_species
+| Wave    | Code | Preferred Label |
+|---------+------+-----------------|
+| 2011-12 |    1 | Cattle          |
+| 2011-12 |    2 | Sheep           |
+| 2011-12 |    3 | Goats           |
+| 2011-12 |    4 | Horses          |
+| 2011-12 |    5 | Donkeys         |
+| 2011-12 |    6 | Mules           |
+| 2011-12 |    7 | Camels          |
+| 2011-12 |    8 | Poultry         |
+| 2011-12 |    9 | Poultry         |
+| 2011-12 |   10 | Poultry         |
+| 2011-12 |   11 | Poultry         |
+| 2011-12 |   12 | Poultry         |
+| 2011-12 |   13 | Poultry         |
+| 2011-12 |   14 | Beehives        |
+| 2013-14 |    1 | Cattle          |
+| 2013-14 |    2 | Sheep           |
+| 2013-14 |    3 | Goats           |
+| 2013-14 |    4 | Horses          |
+| 2013-14 |    5 | Donkeys         |
+| 2013-14 |    6 | Mules           |
+| 2013-14 |    7 | Camels          |
+| 2013-14 |    8 | Poultry         |
+| 2013-14 |    9 | Poultry         |
+| 2013-14 |   10 | Poultry         |
+| 2013-14 |   11 | Poultry         |
+| 2013-14 |   12 | Poultry         |
+| 2013-14 |   13 | Poultry         |
+| 2013-14 |   14 | Beehives        |
+| 2015-16 |    1 | Cattle          |
+| 2015-16 |    2 | Cattle          |
+| 2015-16 |    3 | Cattle          |
+| 2015-16 |    4 | Cattle          |
+| 2015-16 |    5 | Cattle          |
+| 2015-16 |    6 | Cattle          |
+| 2015-16 |    7 | Goats           |
+| 2015-16 |    8 | Goats           |
+| 2015-16 |    9 | Goats           |
+| 2015-16 |   10 | Sheep           |
+| 2015-16 |   11 | Sheep           |
+| 2015-16 |   12 | Sheep           |
+| 2015-16 |   13 | Camels          |
+| 2015-16 |   14 | Camels          |
+| 2015-16 |   15 | Camels          |
+| 2015-16 |   16 | Poultry         |
+| 2015-16 |   17 | Poultry         |
+| 2015-16 |   18 | Poultry         |
+| 2015-16 |   19 | Poultry         |
+| 2015-16 |   20 | Horses          |
+| 2015-16 |   21 | Mules           |
+| 2015-16 |   22 | Donkeys         |
+| 2015-16 |   23 | Beehives        |
+| 2018-19 |    1 | Cattle          |
+| 2018-19 |    2 | Cattle          |
+| 2018-19 |    3 | Cattle          |
+| 2018-19 |    4 | Cattle          |
+| 2018-19 |    5 | Cattle          |
+| 2018-19 |    6 | Cattle          |
+| 2018-19 |    7 | Goats           |
+| 2018-19 |    8 | Sheep           |
+| 2018-19 |    9 | Camels          |
+| 2018-19 |   10 | Poultry         |
+| 2018-19 |   11 | Poultry         |
+| 2018-19 |   12 | Poultry         |
+| 2018-19 |   13 | Horses          |
+| 2018-19 |   14 | Mules           |
+| 2018-19 |   15 | Donkeys         |
+| 2018-19 |   16 | Beehives        |
+| 2021-22 |    1 | Cattle          |
+| 2021-22 |    2 | Cattle          |
+| 2021-22 |    3 | Cattle          |
+| 2021-22 |    4 | Cattle          |
+| 2021-22 |    5 | Cattle          |
+| 2021-22 |    6 | Cattle          |
+| 2021-22 |    7 | Goats           |
+| 2021-22 |    8 | Sheep           |
+| 2021-22 |    9 | Camels          |
+| 2021-22 |   10 | Poultry         |
+| 2021-22 |   11 | Poultry         |
+| 2021-22 |   12 | Poultry         |
+| 2021-22 |   13 | Horses          |
+| 2021-22 |   14 | Mules           |
+| 2021-22 |   15 | Donkeys         |
+| 2021-22 |   16 | Beehives        |

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -168,6 +168,47 @@ Data Scheme:
       optional: true
     materialize: make
 
+  livestock:
+    # GAP 4 -- item-level livestock at (t, i, animal).  One row per
+    # (household, canonical species) from ESS §8 (sect8a_ls W1/W2;
+    # sect8_1_ls + sect8_2_ls W3-W5), carrying only REPORTED roster fields:
+    #   HeadCount     current head owned/kept by the HH.
+    #   HeadAcquired  head PURCHASED alive in the last 12 months.
+    #   HeadSold      head SOLD alive in the last 12 months.
+    #   Value         total income from livestock SALES in the last 12 months
+    #                 (Birr).  The §8 roster records NO current herd-value
+    #                 question in any ESS wave, so Value carries the reported
+    #                 sale income (the only monetary §8 field); it is NOT a
+    #                 herd valuation.
+    # This is the PRE-COLLAPSE §8 roster the WB code reads then throws away
+    # down to a single engaged-in-livestock y/n binary (their recode of the
+    # post-planting cover pp_saq13 + collapse-max).  We keep the head counts
+    # / transactions instead -- strictly richer than their binary, over the
+    # same (broader, since §8 covers livestock-only HHs the PP module omits)
+    # set of households.
+    #
+    # animal axis: the canonical species Preferred Label (Cattle / Sheep /
+    # Goats / Camels / Poultry / Horses / Mules / Donkeys / Beehives) from
+    # the WAVE-KEYED harmonize_species table -- W1/W2 report Cattle/Poultry
+    # at the aggregate grain, W3-W5 split the herd by age/sex; the script
+    # folds the sub-codes (Bulls/Oxen/Cows/... -> Cattle) onto the canonical
+    # species and SUMS the reported head counts within each household (the
+    # within-household roll-up to the grain, NOT a WB collapse-to-binary).
+    #
+    # NO TLU / herd-value total / engaged-y/n binary baked in (those are
+    # transformations -- the binary = groupby(['t','i']).any() over these
+    # rows; tlu = Sum(head x species-TLU-factor)).  Grain is (t, i, animal)
+    # with NO v level: livestock is per-household, and the framework
+    # _no_v_join set already covers 'livestock'.  Multi-file join (count <->
+    # transactions on (holder, code)) + per-wave code->species harmonization
+    # + within-household sum => script (materialize: make).
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    Value: float
+    materialize: make
+
   food_security:
     # FAO FIES 8-item experience scale (GH #332).  Confirmed ONLY in
     # W5 (2021-22): ESS §8 file sect8_hh_w5.dta carries the FAO battery

--- a/lsms_library/countries/Ethiopia/_/ethiopia.py
+++ b/lsms_library/countries/Ethiopia/_/ethiopia.py
@@ -1462,3 +1462,128 @@ def plot_inputs_for_wave(t, plot_roster, planting, seeds, colmap, labels=None):
     # reports the same fertilizer type twice) by taking the first.
     out = out[~out.index.duplicated(keep='first')]
     return out.sort_index()
+
+
+def _eth_species_label_map(t):
+    """Load the wave-keyed harmonize_species -> {code: Preferred Label} for t."""
+    wave_keyed = _harmonize_wave_keyed('harmonize_species')
+    return {code: lab for (wv, code), lab in wave_keyed.items() if wv == t}
+
+
+def livestock_for_wave(t, count, txn, colmap):
+    """Build canonical ``livestock`` for one Ethiopia ESS §8 wave (GAP 4).
+
+    Item-level livestock at ``(t, i, animal)`` -- one row per
+    (household, canonical species).  Carries only the REPORTED fields the
+    §8 roster records; anything a wave does not ask is NaN.  This is the
+    *pre-collapse* roster the WB code throws away down to a single
+    engaged-y/n binary (their =recode pp_saq13 ... collapse(max)=); we keep
+    the head counts / transactions instead.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2011-12"``), the ``t`` index value AND the wave
+        key for the wave-keyed harmonize_species table.
+    count : pd.DataFrame
+        Raw §8 livestock-roster file carrying the current head count
+        (W1/W2 ``sect8a_ls`` -- which also carries the transactions; W3-W5
+        ``sect8_1_ls``), loaded with ``convert_categoricals=False`` so the
+        animal code column carries the integer codes harmonize_species
+        keys on.
+    txn : pd.DataFrame or None
+        Raw §8 transaction file (W3-W5 ``sect8_2_ls``).  None for W1/W2,
+        where the transaction columns live in the ``count`` frame itself.
+    colmap : dict
+        Per-wave column map.  Required keys:
+            hhid        — household id column EMITTED as ``i`` (household_id2
+                          for W2/W3, else household_id -- matches sample().i).
+            holder_id   — holder id (join key for the count<->txn merge).
+            animal_code — animal/species code column in ``count``.
+            head_count  — current-head-count column in ``count``.
+        Optional keys (NaN where the wave does not ask):
+            t_animal_code   — animal code column in ``txn`` (W3-W5; defaults
+                              to animal_code).
+            t_holder_id     — holder id in ``txn`` (defaults to holder_id).
+            head_acquired   — head purchased in last 12 months.
+            head_sold       — head sold alive in last 12 months.
+            sale_value      — total income from livestock sales (Birr).
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, animal)`` with columns
+        HeadCount (float), HeadAcquired (float), HeadSold (float),
+        Value (float).  Summed over the raw animal sub-codes that share a
+        canonical species within a household (e.g. Bulls+Oxen+Cows ->
+        Cattle), which is the within-household roll-up to the (t, i, animal)
+        grain -- NOT a WB-style collapse-to-binary.  Rows where the
+        household reports neither any head nor any transaction for a
+        species are dropped.
+    """
+    c = colmap
+    species_map = _eth_species_label_map(t)
+    assert species_map, f'livestock {t}: harmonize_species has no rows for this wave'
+
+    def _num(df, key):
+        col = c.get(key)
+        if col is None or col not in df.columns:
+            return None
+        return pd.to_numeric(df[col], errors='coerce').astype('Float64')
+
+    # ---- current head count (from `count`) --------------------------
+    cnt = count.copy()
+    code = pd.to_numeric(cnt[c['animal_code']], errors='coerce').astype('Int64')
+    base = pd.DataFrame({
+        'i':        cnt[c['hhid']].apply(format_id).values,
+        '_holder':  cnt[c['holder_id']].apply(format_id).values,
+        '_code':    code.values,
+        'animal':   code.map(species_map).astype('string').values,
+        'HeadCount': (_num(cnt, 'head_count') if c.get('head_count') else
+                      pd.Series(pd.NA, index=cnt.index, dtype='Float64')).values,
+    })
+
+    # ---- transactions (same frame for W1/W2; `txn` for W3-W5) -------
+    src = txn if txn is not None else count
+    tx = src.copy()
+    t_code = pd.to_numeric(tx[c.get('t_animal_code', c['animal_code'])],
+                           errors='coerce').astype('Int64')
+    txdf = pd.DataFrame({
+        '_holder': tx[c.get('t_holder_id', c['holder_id'])].apply(format_id).values,
+        '_code':   t_code.values,
+        'HeadAcquired': (_num(tx, 'head_acquired') if c.get('head_acquired') else
+                         pd.Series(pd.NA, index=tx.index, dtype='Float64')).values,
+        'HeadSold': (_num(tx, 'head_sold') if c.get('head_sold') else
+                     pd.Series(pd.NA, index=tx.index, dtype='Float64')).values,
+        'Value':   (_num(tx, 'sale_value') if c.get('sale_value') else
+                    pd.Series(pd.NA, index=tx.index, dtype='Float64')).values,
+    })
+
+    if txn is None:
+        # W1/W2: count and txn are the same rows -> concatenate columns.
+        merged = pd.concat([base, txdf.drop(columns=['_holder', '_code'])], axis=1)
+    else:
+        # W3-W5: join txn onto the count rows by (holder, raw code).
+        merged = base.merge(txdf, on=['_holder', '_code'], how='left')
+
+    merged = merged[merged['animal'].notna()].copy()
+
+    # Within-household roll-up to the (t, i, animal) grain: sum the head
+    # counts / transactions over the raw codes that share a canonical
+    # species (and over multiple holders in one household).
+    agg = merged.groupby(['i', 'animal'], dropna=True)[
+        ['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']].sum(min_count=1)
+
+    # Drop species the household neither owns nor transacts (all-NaN or
+    # all-zero across every reported column).
+    nonzero = agg.fillna(0).abs().sum(axis=1) > 0
+    agg = agg[nonzero]
+
+    agg = agg.reset_index()
+    agg['t'] = t
+    agg['i'] = agg['i'].astype('string')
+    agg['animal'] = agg['animal'].astype('string')
+    for col in ['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']:
+        agg[col] = agg[col].astype('Float64')
+    agg = agg.set_index(['t', 'i', 'animal'])
+    agg = agg[['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']]
+    return agg.sort_index()

--- a/lsms_library/countries/Ethiopia/_/livestock.py
+++ b/lsms_library/countries/Ethiopia/_/livestock.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""Concatenate wave-level livestock data for Ethiopia (GAP 4).
+
+Each wave's ``Ethiopia/<wave>/_/livestock.py`` produces a parquet with
+index ``(t, i, animal)`` and the canonical livestock columns (HeadCount,
+HeadAcquired, HeadSold, Value).  This script concatenates them across the
+five ESS waves and applies the cross-wave ``id_walk`` so the household
+index uses the panel canonical id scheme (the same conversion ``sample()``
+receives at API time -- though livestock is in the framework ``_no_v_join``
+set, so no ``v`` is joined; ``id_walk`` keeps ``i`` aligned with the panel
+for cross-feature joins / the WB livestock-binary cross-check).
+
+``id_walk`` is idempotent (it sets ``attrs['id_converted']``), so the
+framework's ``_finalize_result`` skips re-applying it.  The wave parquets
+emit the wave-native household id that matches ``sample().i``
+(``household_id2`` for W2/W3, ``household_id`` elsewhere) -- identical to
+plot_features / crop_production / plot_inputs.
+
+Grain is ``(t, i, animal)`` -- NO ``v`` level (livestock is per-household,
+not per-cluster; the framework ``_no_v_join`` set already covers it).
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, id_walk, to_parquet
+from ethiopia import Waves
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/livestock.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet built / parquet absent (DVC raises PathMissingError).
+        continue
+    pieces.append(df)
+
+assert pieces, "livestock: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/livestock.parquet')

--- a/lsms_library/countries/Malawi/2010-11/_/livestock.py
+++ b/lsms_library/countries/Malawi/2010-11/_/livestock.py
@@ -1,0 +1,35 @@
+"""Build livestock for Malawi IHS3 2010-11 (GAP 4).
+
+Item-level (t, i, animal) livestock-roster feature.  Source
+(Full_Sample/Agriculture):
+  * ag_mod_r1 -- Module R livestock roster, one row per (HH, species).
+    animal = ag_r0a (LIVESTOCK CODE, 2010-11 fine 301-318 scheme),
+    HeadCount = ag_r02, HeadAcquired = ag_r10 (bought to raise),
+    HeadSold = ag_r16, Value = ag_r04 (per-head current value).
+
+i = format_id(case_id), aligning with plot_features / crop_production
+2010-11.  This is the SAME roster the World Bank code collapses to a
+single HH "engaged-in-livestock" binary (MWI_IHPS1.do:978-986); we keep
+the pre-collapse rows.  See lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import _livestock_block, assemble_livestock
+
+
+WAVE = '2010-11'
+BASE = '../Data/Full_Sample/Agriculture/'
+
+r = get_dataframe(BASE + 'ag_mod_r1.dta', convert_categoricals=False)
+r['hhid'] = r['case_id'].apply(format_id)
+
+piece = _livestock_block(r, hhid='hhid', animalcode='ag_r0a', t=WAVE)
+
+df = assemble_livestock(WAVE, [piece])
+
+assert df.index.is_unique, f"Non-unique (t,i,animal) in livestock {WAVE}"
+assert len(df) > 0, f"livestock {WAVE} produced no rows"
+
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Malawi/2013-14/_/livestock.py
+++ b/lsms_library/countries/Malawi/2013-14/_/livestock.py
@@ -1,0 +1,33 @@
+"""Build livestock for Malawi IHS3-IHPS 2013-14 (GAP 4).
+
+Item-level (t, i, animal) livestock-roster feature.  Source:
+  * AG_MOD_R1_13 -- Module R livestock roster, one row per (HH, species).
+    animal = ag_r0a (LIVESTOCK CODE, coarse scheme with Ox=3304 etc.),
+    HeadCount = ag_r02, HeadAcquired = ag_r10 (bought to raise),
+    HeadSold = ag_r16, Value = ag_r04 (per-head current value).
+
+i = format_id(y2_hhid), aligning with plot_features / crop_production
+2013-14.  Same roster the World Bank code collapses to a binary
+(MWI_IHPS2.do:1032-1040); we keep the pre-collapse rows.  See
+lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import _livestock_block, assemble_livestock
+
+
+WAVE = '2013-14'
+
+r = get_dataframe('../Data/AG_MOD_R1_13.dta', convert_categoricals=False)
+r['hhid'] = r['y2_hhid'].apply(format_id)
+
+piece = _livestock_block(r, hhid='hhid', animalcode='ag_r0a', t=WAVE)
+
+df = assemble_livestock(WAVE, [piece])
+
+assert df.index.is_unique, f"Non-unique (t,i,animal) in livestock {WAVE}"
+assert len(df) > 0, f"livestock {WAVE} produced no rows"
+
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Malawi/2016-17/_/livestock.py
+++ b/lsms_library/countries/Malawi/2016-17/_/livestock.py
@@ -1,0 +1,42 @@
+"""Build livestock for Malawi IHS4 2016-17 (GAP 4).
+
+Item-level (t, i, animal) livestock-roster feature.  IHS4 ships a
+Cross_Sectional half (cs-17-prefixed case_id) and a Panel half (bare
+y3_hhid), concatenated into the single 2016-17 wave -- exactly like
+crop_production / plot_features.  Source per half: ag_mod_r1 (Module R
+livestock roster), one row per (HH, species).
+    animal = ag_r0a (LIVESTOCK CODE, coarse scheme),
+    HeadCount = ag_r02, HeadAcquired = ag_r10 (bought to raise),
+    HeadSold = ag_r16, Value = ag_r04 (per-head current value).
+
+Same roster the World Bank code collapses to a binary
+(MWI_IHPS3.do:1016-1024); we keep the pre-collapse rows.  See
+lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import _livestock_block, assemble_livestock
+
+
+WAVE = '2016-17'
+
+pieces = []
+
+# --- Cross-sectional half (cs-17 prefix) ---
+r_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_r1.dta', convert_categoricals=False)
+r_xs['hhid'] = 'cs-17-' + r_xs['case_id'].apply(format_id)
+pieces.append(_livestock_block(r_xs, hhid='hhid', animalcode='ag_r0a', t=WAVE))
+
+# --- Panel half (bare y3_hhid) ---
+r_pn = get_dataframe('../Data/Panel/ag_mod_r1_16.dta', convert_categoricals=False)
+r_pn['hhid'] = r_pn['y3_hhid'].apply(format_id)
+pieces.append(_livestock_block(r_pn, hhid='hhid', animalcode='ag_r0a', t=WAVE))
+
+df = assemble_livestock(WAVE, pieces)
+
+assert df.index.is_unique, f"Non-unique (t,i,animal) in livestock {WAVE}"
+assert len(df) > 0, f"livestock {WAVE} produced no rows"
+
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Malawi/2019-20/_/livestock.py
+++ b/lsms_library/countries/Malawi/2019-20/_/livestock.py
@@ -1,0 +1,42 @@
+"""Build livestock for Malawi IHS5 2019-20 (GAP 4).
+
+Item-level (t, i, animal) livestock-roster feature.  IHS5 ships a
+Cross_Sectional half (bare case_id, NOT cs-prefixed) and a Panel half
+(y4_hhid), concatenated into the single 2019-20 wave -- exactly like
+crop_production / plot_features.  Source per half: ag_mod_r1 (Module R
+livestock roster), one row per (HH, species).
+    animal = ag_r0a (LIVESTOCK CODE, coarse scheme),
+    HeadCount = ag_r02, HeadAcquired = ag_r10 (bought to raise),
+    HeadSold = ag_r16, Value = ag_r04 (per-head current value).
+
+Same roster the World Bank code collapses to a binary
+(MWI_IHPS4.do:1043-1051); we keep the pre-collapse rows.  See
+lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import _livestock_block, assemble_livestock
+
+
+WAVE = '2019-20'
+
+pieces = []
+
+# --- Cross-sectional half (bare case_id) ---
+r_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_r1.dta', convert_categoricals=False)
+r_xs['hhid'] = r_xs['case_id'].apply(format_id)
+pieces.append(_livestock_block(r_xs, hhid='hhid', animalcode='ag_r0a', t=WAVE))
+
+# --- Panel half (y4_hhid) ---
+r_pn = get_dataframe('../Data/Panel/ag_mod_r1_19.dta', convert_categoricals=False)
+r_pn['hhid'] = r_pn['y4_hhid'].apply(format_id)
+pieces.append(_livestock_block(r_pn, hhid='hhid', animalcode='ag_r0a', t=WAVE))
+
+df = assemble_livestock(WAVE, pieces)
+
+assert df.index.is_unique, f"Non-unique (t,i,animal) in livestock {WAVE}"
+assert len(df) > 0, f"livestock {WAVE} produced no rows"
+
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Malawi/_/CONTENTS.org
+++ b/lsms_library/countries/Malawi/_/CONTENTS.org
@@ -48,6 +48,66 @@ Wave-specific notes (validated against the recon refuter pass,
   prefix so XS plots are not ~100% orphaned.  All other halves emit the
   raw wave hhid and rely on framework id_walk / =panel_ids= chaining.
 
+* livestock (GAP 4)
+
+Item-level livestock-roster feature.  Schema: =(t, i, animal)= index;
+columns =HeadCount= (head owned now, =ag_r02=), =HeadAcquired= (head
+bought to raise in the last 12 months, =ag_r10=), =HeadSold= (head sold
+alive in the last 12 months, =ag_r16=), =Value= (REPORTED per-head
+current value, =ag_r04= -- "if you sold one today, how much would you
+receive?").  One reported row per (household, species owned).
+
+Source: Module R livestock roster (=ag_mod_r1_{10,13,16,19}.dta=) -- the
+SAME file the World Bank cleaning code reads then *collapses to a single
+HH "engaged-in-livestock" binary* (=MWI_IHPS{1-4}.do=: =recode ag_r00 ...
+gen(livestock)= then =collapse (max) livestock, by(<hhid>)=).  We keep
+the *pre-collapse* roster, which is strictly richer.  Their binary is
+recovered as =livestock().groupby(['t','i']).size() > 0=; a TLU rollup
+=Sigma(head x species-TLU-factor)= is a =transformations= concern, NOT a
+stored column.
+
+Built for the four IHS3+ waves; *2004-05 (IHS2) deferred* -- its ag file
+is household-level aggregated, with no Module R roster.  Each wave's
+=Malawi/<wave>/_/livestock.py= reshapes the roster via the shared
+=malawi._livestock_block= + =malawi.assemble_livestock= helpers; the
+country-level =Malawi/_/livestock.py= concatenates them.  Grain is
+=(t, i, animal)= with *NO v level* -- 'livestock' is in the framework
+=_no_v_join= set (a household holding, not a cluster-keyed roster).
+Registered =materialize: make= in =data_scheme.yml=.
+
+| Wave    | Module R file                                        | hhid                   |
+|---------+------------------------------------------------------+------------------------|
+| 2010-11 | Full_Sample/Agriculture/ag_mod_r1.dta                | case_id                |
+| 2013-14 | AG_MOD_R1_13.dta                                     | y2_hhid                |
+| 2016-17 | Cross_Sectional/ag_mod_r1.dta + Panel/ag_mod_r1_16.dta | case_id (cs-17) / y3_hhid |
+| 2019-20 | Cross_Sectional/ag_mod_r1.dta + Panel/ag_mod_r1_19.dta | case_id / y4_hhid      |
+
+=animal= is the =harmonize_species= Preferred Label (Code-keyed table in
+=categorical_mapping.org=).  Two code namespaces are reconciled: 2010-11
+uses the fine 301-318 scheme (separate Donkey 305 / Mule-horse 306,
+Chicken-layer 310 / -broiler 312, Turkey 314 / Guinea fowl 316, Beehive
+317; Bull/ox shares code 304), while 2013-14 + IHS4/IHS5 use a coarser
+scheme (Bull 304, Ox 3304, Donkey/Horse 3305, Chicken 3310,
+Turkey/Guinea Fowl 3314, Dove/Pigeon 319).  Each code -> one canonical
+species (no within-wave collapse, so =(t, i, animal)= stays unique); code
+318 "Other (Specify)" -> NaN -> dropped from the index, like
+=crop_production='s "Other" crop.
+
+Keep-filter: a roster row is retained when the household genuinely holds
+the species -- per-species ownership flag =ag_r01= == Yes, OR any
+positive reported =HeadCount= / =HeadSold= / =HeadAcquired=.  Rows for
+species the HH was merely asked about and does not own are dropped, so
+the feature is the household's actual herd, not the full species
+checklist.
+
+Coverage cross-check (distinct livestock-owning HH per wave): the feature
+matches the raw Module-R =ag_r00= == Yes universe within ~0.5% every wave
+(2010-11: 5674 vs 5710; 2013-14: 1886 vs 1888; 2016-17: 6178 vs 6210;
+2019-20: 6534 vs 6575).  The WB =Plot_dataset= livestock binary is much
+smaller (1484 / 1835 / 1119 / 1249) because it is joined onto the
+*plot-cultivating subsample* only -- so the item feature both is richer
+AND spans the correct, broader livestock-keeping universe.
+
 * Housing feature (added 2026-04-12)
 
 Schema: =(t, i)= index, =Roof: str=, =Floor: str=.  Categorical material

--- a/lsms_library/countries/Malawi/_/Makefile
+++ b/lsms_library/countries/Malawi/_/Makefile
@@ -12,7 +12,7 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 # _ROSTER_DERIVED — no country-level parquet is built or consulted.
 # See GH #218.
 
-all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet $(VAR_DIR)/crop_production.parquet $(VAR_DIR)/plot_inputs.parquet
+all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet $(VAR_DIR)/crop_production.parquet $(VAR_DIR)/plot_inputs.parquet $(VAR_DIR)/livestock.parquet
 
 food_acquired = $(shell find $(rounds) -name food_acquired.py)
 # Wave-level parquets live in data_root, not in-tree
@@ -73,6 +73,20 @@ $(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/plot_inputs.parquet: malawi.py
 
 $(VAR_DIR)/plot_inputs.parquet: plot_inputs.py $(plot_inputs_parquet)
 	python plot_inputs.py
+
+# --- livestock (GAP 4) ----------------------------------------------------
+# Item-level (t, i, animal) livestock roster for the four IHS3+/IHPS waves.
+# Each wave script writes its parquet into data_root; the country script
+# concatenates.  2004-05 is ABSENT (household-level aggregated ag file, no
+# Module R livestock roster).
+livestock_waves := 2010-11 2013-14 2016-17 2019-20
+livestock_parquet := $(foreach r,$(livestock_waves),$(LSMS_DATA_ROOT)/$(COUNTRY)/$(r)/_/livestock.parquet)
+
+$(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/livestock.parquet: malawi.py
+	(cd ../$(*)/_/ && python livestock.py)
+
+$(VAR_DIR)/livestock.parquet: livestock.py $(livestock_parquet)
+	python livestock.py
 
 %.parquet: %.py malawi.py
 	(cd $(@D) && python ./$(<F))

--- a/lsms_library/countries/Malawi/_/categorical_mapping.org
+++ b/lsms_library/countries/Malawi/_/categorical_mapping.org
@@ -662,3 +662,53 @@
 |   11 | Other Pesticide       |
 |   20 | Organic Fertilizer    |
 |   30 | Seed                  |
+
+# harmonize_species: livestock-species identity for the livestock feature
+# (GAP 4).  Code-keyed map for the Module R livestock-roster animal code
+# (ag_r0a, "LIVESTOCK CODE"; convert_categoricals=False).  Two code
+# namespaces are reconciled here:
+#   * IHS3 2010-11 uses the fine 301-318 scheme (separate Donkey 305 /
+#     Mule-horse 306, Chicken-layer 310 / -broiler 312, Turkey 314 /
+#     Guinea fowl 316, Beehive 317; Bull/ox shares code 304).
+#   * IHS3-IHPS 2013-14 + IHS4/IHS5 (2016-17, 2019-20) use a coarser
+#     scheme: code 304 is just Bull, with Ox split out to 3304,
+#     Donkey/mule/horse merged to 3305, Chicken-layer/broiler merged to
+#     3310, Turkey/guinea-fowl merged to 3314, and Dove/pigeon at 319.
+# Each numeric code maps to exactly ONE canonical Preferred Label (no
+# within-wave collapse, so the (t, i, animal) index stays unique), but a
+# canonical label may be reached from several codes across the two
+# schemes (e.g. 314 Turkey & 316 Guinea fowl from 2010-11 are kept
+# distinct, while the later merged 3314 -> "Turkey/Guinea Fowl").  Code
+# 318 "Other (Specify)" maps to NaN (no canonical species) and so is
+# dropped from the animal index, like crop_production's "Other" crop.
+# The cattle subtypes (Calf, Steer/Heifer, Cow, Bull, Ox) are kept as
+# separate reported species rather than rolled into one "Cattle" label,
+# preserving the survey's item-level distinction; a tropical-livestock-
+# unit (TLU) rollup over species is a transformations concern, not a
+# stored column.
+#+name: harmonize_species
+| Code | Preferred Label   |
+|------+-------------------|
+|  301 | Calf              |
+|  302 | Steer/Heifer      |
+|  303 | Cow               |
+|  304 | Bull              |
+|  305 | Donkey            |
+|  306 | Mule/Horse        |
+|  307 | Goat              |
+|  308 | Sheep             |
+|  309 | Pig               |
+|  310 | Chicken-Layer     |
+|  311 | Local Hen         |
+|  312 | Chicken-Broiler   |
+|  313 | Local Cock        |
+|  314 | Turkey            |
+|  315 | Duck              |
+|  316 | Guinea Fowl       |
+|  317 | Beehive           |
+|  318 | ---               |
+|  319 | Dove/Pigeon       |
+| 3304 | Ox                |
+| 3305 | Donkey/Horse      |
+| 3310 | Chicken           |
+| 3314 | Turkey/Guinea Fowl|

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -190,5 +190,35 @@ Data Scheme:
     Quantity_purchased: float
     Improved: bool
     materialize: make
+  livestock:
+    # Item-level (t, i, animal) livestock-roster feature for the four
+    # IHS3+/IHPS waves (2010-11, 2013-14, 2016-17, 2019-20); GAP 4.  One
+    # reported row per (household, species owned), from Module R
+    # (ag_mod_r1) -- the SAME roster the World Bank cleaning code reads then
+    # collapses to a single HH "engaged-in-livestock" binary (MWI_IHPS{1-4}
+    # .do: recode ag_r00 -> collapse (max) livestock by hhid).  We keep the
+    # PRE-collapse rows, which are strictly richer: their binary =
+    # livestock().groupby(['t','i']).size() > 0.  Reported item columns:
+    #   HeadCount    (ag_r02, head owned now),
+    #   HeadAcquired (ag_r10, head bought to raise in last 12 months),
+    #   HeadSold     (ag_r16, head sold alive in last 12 months),
+    #   Value        (ag_r04, REPORTED per-head current value -- "if you
+    #                 sold one today, how much would you receive?";  a herd
+    #                 value = Value x HeadCount and a TLU rollup are
+    #                 transformations, NOT stored columns).
+    # `animal` is the harmonize_species Preferred Label (the wave scripts
+    # reconcile 2010-11's fine 301-318 code scheme with the later coarse
+    # scheme -- Ox=3304, Donkey/Horse=3305, Chicken=3310,
+    # Turkey/Guinea Fowl=3314 -- and drop code 318 "Other (Specify)").
+    # Grain is (t, i, animal) with NO v level: 'livestock' is in the
+    # framework _no_v_join set (a household holding, not a cluster roster).
+    # 2004-05 (IHS2) deferred: household-level aggregated ag file, no
+    # Module R roster.  See _/malawi.py:assemble_livestock.
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    Value: float
+    materialize: make
   food_expenditures:
   food_prices:

--- a/lsms_library/countries/Malawi/_/livestock.py
+++ b/lsms_library/countries/Malawi/_/livestock.py
@@ -1,0 +1,39 @@
+"""Concatenate wave-level livestock parquets for Malawi (GAP 4).
+
+Each buildable wave's ``Malawi/<wave>/_/livestock.py`` produces a parquet
+indexed (t, i, animal) with the canonical item-level columns (HeadCount,
+HeadAcquired, HeadSold, Value).  This script concatenates them.  Cross-wave
+id_walk (panel-id chaining) is applied by the framework at API time in
+_finalize_result.  ``v`` is NOT joined: 'livestock' is in the framework
+_no_v_join set (a household-level holding, not a cluster-keyed roster), so
+the grain stays (t, i, animal) with no cluster level.
+
+Only the four IHS3+ IHPS waves are buildable (2010-11, 2013-14, 2016-17,
+2019-20) -- the same waves as crop_production / plot_inputs / plot_features,
+and the World Bank Plotcrop panel's waves 1-4.  2004-05 (IHS2) is DEFERRED:
+its agricultural file is household-level aggregated, with no Module R
+livestock roster.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2010-11', '2013-14', '2016-17', '2019-20']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/livestock.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built (DVC raises
+        # PathMissingError here, not FileNotFoundError).
+        continue
+    pieces.append(df)
+
+assert pieces, "livestock: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/livestock.parquet')

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -1472,3 +1472,144 @@ def assemble_plot_inputs(t, input_pieces, seed_purchase_pieces=None):
     # NaN u as well).  dropna=False above keeps those NaN-keyed rows.
     grp = grp.set_index(['t', 'i', 'plot', 'input', 'crop', 'u'])
     return grp
+
+
+# --- livestock (GAP 4) --------------------------------------------------
+# Item-level (t, i, animal) livestock-roster feature -- one reported row per
+# (household, species owned).  Source: Module R livestock roster
+# (ag_mod_r1_{10,13,16,19}.dta), the SAME file the World Bank cleaning code
+# reads then collapses to a single HH "engaged in livestock" binary
+# (MWI_IHPS{1-4}.do: `recode ag_r00 ... gen(livestock)` then
+# `collapse (max) livestock, by(<hhid>)`).  We keep the PRE-collapse roster
+# at its natural grain, which is strictly richer than their binary (their
+# binary = our `livestock().groupby(['t','i']).size() > 0`).
+#
+# One row per (household, species).  Reported item columns (only those the
+# survey records; missing-in-wave -> NaN):
+#   * HeadCount     -- ag_r02: head owned now (present at farm or away).
+#   * HeadAcquired  -- ag_r10: head bought to raise in the last 12 months
+#                      (the survey also records born/ag_r08 and gifts/ag_r09
+#                      separately; HeadAcquired carries the PURCHASED count,
+#                      the closest single reported "acquired" figure -- a
+#                      born+gifts+bought total would be a transformation).
+#   * HeadSold      -- ag_r16: head sold alive in the last 12 months.
+#   * Value         -- ag_r04: REPORTED per-head current value ("if you sold
+#                      one [LIVESTOCK] today, how much would you receive?").
+#                      This is the per-head value the survey records; a herd
+#                      value (Value x HeadCount) and a TLU rollup are
+#                      transformations, NOT stored columns.  Malawi reports
+#                      no herd-total value column, so we carry the honest
+#                      per-head figure rather than fabricating a total.
+#
+# The per-animal ownership gate is ag_r01 (Yes/No, "did you own
+# [LIVESTOCK]?"); ag_r00 is the HH-level any-livestock gate the WB binary
+# comes from.  We keep a roster row when the household reports owning that
+# species (ag_r01 == 1, i.e. "Yes") OR records any positive HeadCount /
+# HeadSold / HeadAcquired -- i.e. the species is genuinely part of the
+# household's livestock holding.  Rows for species the HH was simply asked
+# about and does not own (ag_r01 == No, all counts 0/NaN) are dropped, so
+# the roster is the household's actual herd, not the full species checklist.
+# `animal` is the harmonize_species Preferred Label (code 318 "Other
+# (Specify)" -> NaN -> dropped from the index, like crop_production's
+# "Other" crop).
+
+# Module R columns are stable across all four waves EXCEPT the gifts-received
+# count, which is ag_r09 in 2010-11 and ag_r09_1 from 2013-14 on.  The
+# columns we read (ag_r00/r0a/r01/r02/r04/r10/r16) carry the same name in
+# every wave; ag_r09* is not among them (gifts is not one of our four
+# reported columns), so no per-wave column remap is needed.
+
+def _livestock_block(df, *, hhid, animalcode, owned_flag='ag_r01',
+                     headcount='ag_r02', acquired='ag_r10', sold='ag_r16',
+                     value='ag_r04', t=None):
+    """Reshape one wave's Module R livestock roster to canonical long rows.
+
+    All keyword args are RAW column names in ``df`` (or None when a wave
+    lacks that field).  ``df`` must already carry an ``hhid`` string column.
+    Returns a long DataFrame at grain (t, i, animal) with the reported item
+    columns (HeadCount, HeadAcquired, HeadSold, Value) and an internal
+    ``_animal_code`` used for the keep-filter / dedup.  NO aggregation.
+    """
+    species_map = _malawi_code_map('harmonize_species')
+    code = pd.to_numeric(df[animalcode], errors='coerce').astype('Int64')
+    animal = code.map(species_map)
+    animal = animal.astype('string').where(animal.notna(), pd.NA)
+
+    def _num(col):
+        if col is None or col not in df.columns:
+            return pd.Series(pd.NA, index=df.index, dtype='Float64')
+        return pd.to_numeric(df[col], errors='coerce').astype('Float64')
+
+    head = _num(headcount)
+    acq = _num(acquired)
+    sold_n = _num(sold)
+    val = _num(value)
+
+    # Per-species ownership gate (ag_r01 == 1 "Yes").  NaN where the wave
+    # lacks the column (then the count-based keep below carries the row).
+    if owned_flag is not None and owned_flag in df.columns:
+        owns = pd.to_numeric(df[owned_flag], errors='coerce') == 1
+    else:
+        owns = pd.Series(False, index=df.index)
+
+    out = pd.DataFrame({
+        't':            t,
+        'i':            df['hhid'].astype('string').values,
+        'animal':       animal.values,
+        '_animal_code': code.values,
+        'HeadCount':    head.values,
+        'HeadAcquired': acq.values,
+        'HeadSold':     sold_n.values,
+        'Value':        val.values,
+        '_owns':        owns.values,
+    })
+    # Keep a roster row when the household genuinely holds the species:
+    # owned-flag Yes, or any positive reported head movement / holding.
+    holds = (out['_owns']
+             | (out['HeadCount'].fillna(0) > 0)
+             | (out['HeadSold'].fillna(0) > 0)
+             | (out['HeadAcquired'].fillna(0) > 0))
+    out = out[holds]
+    # Must have a species identity for the index axis.
+    out = out[out['_animal_code'].notna()]
+    out = out.drop(columns=['_owns'])
+    return out
+
+
+def assemble_livestock(t, pieces):
+    """Combine reshaped per-half livestock blocks (_livestock_block) into the
+    canonical livestock DataFrame for wave ``t``.
+
+    Parameters
+    ----------
+    t : str -- wave id, used as the ``t`` index value.
+    pieces : list[pd.DataFrame] -- outputs of _livestock_block.
+
+    Returns
+    -------
+    pd.DataFrame indexed (t, i, animal) with columns HeadCount,
+    HeadAcquired, HeadSold, Value.  Item-level reported values only.
+    """
+    cat = pd.concat(pieces, ignore_index=True)
+
+    # Drop rows whose code did not resolve to a canonical species (code 318
+    # "Other (Specify)" and any unmapped) -- they have no place on the
+    # `animal` index axis, exactly like crop_production's "Other" crop.
+    cat = cat[cat['animal'].notna()]
+
+    # Collapse any duplicate (i, animal) rows.  A canonical species is
+    # reached from a SINGLE code within any wave (the harmonize_species map
+    # is 1:1 per wave), so a duplicate here means the household reported the
+    # same species on two roster lines: sum the head movements (HeadCount /
+    # HeadAcquired / HeadSold are additive counts of the same herd) and take
+    # the first reported per-head Value (a per-head price is not additive).
+    cat['t'] = t
+    grp = cat.groupby(['t', 'i', 'animal'], as_index=False, dropna=False).agg({
+        'HeadCount':    'sum',
+        'HeadAcquired': 'sum',
+        'HeadSold':     'sum',
+        'Value':        'first',
+    })
+    out = grp.set_index(['t', 'i', 'animal'])
+    assert out.index.is_unique, f"Non-unique (t,i,animal) in livestock {t}"
+    return out

--- a/lsms_library/countries/Mali/2014-15/_/livestock.py
+++ b/lsms_library/countries/Mali/2014-15/_/livestock.py
@@ -1,0 +1,66 @@
+"""Build livestock (item-level animal roster) for Mali EACI 2014-15.
+
+GAP 4 (parity loop).  One row per (t, i, animal) — the pre-collapse roster
+the WB MLI_EACI1.do reads, recodes to a single engaged-in-livestock binary
+(``s4aq03``, collapse-max per hhid), then discards.
+
+Source: EACIS4A_p2.dta (passage 2 / post-harvest livestock module s4a).  It
+is a FIXED roster: every household gets one row per possible species
+(s4aq02 / s4aq01), with s4aq03 == 'Oui' for species it keeps.  We keep the
+rows the household actually owns, carrying the reported item-level counts.
+
+Variable map traced from MLI_EACI1.do + the s4a questionnaire labels:
+  species code   = s4aq02   (110..910; harmonize_species Code)
+  owns y/n       = s4aq03   ('Oui' / 'Non')   ["Le menage a eleve ou possede"]
+  HeadCount      = s4aq04   "Nombre actuellement dans le troupeau"
+  HeadAcquired   = s4aq15   "Nombre achete au cours des 12 derniers mois"
+  HeadSold       = s4aq22   "Nombre vendu appartenant au menage"
+  Value (sales)  = s4aq24   "Valeur brute des ventes" (FCFA)
+
+The EACI roster carries NO current herd-value question, so Value is the
+gross SALES value where reported (else NaN), matching the GAP-4 brief
+("value where the source reports it; else NaN").  NO TLU, NO herd-value
+total, NO engaged-in-livestock binary — those are transformations over
+these rows.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import i as mali_i, livestock_finalize
+
+WAVE = '2014-15'
+
+
+def _hhid(df):
+    return df.apply(lambda r: mali_i(pd.Series([r['grappe'], r['menage']])), axis=1)
+
+
+# Load with convert_categoricals=False so the species code arrives as the
+# integer s4aq02 (the harmonize_species join key) and the owns flag as 1/2.
+s4 = get_dataframe('../Data/EACIS4A_p2.dta', convert_categoricals=False).copy()
+s4['i'] = _hhid(s4)
+
+# Keep only rows the household actually keeps this species (s4aq03 == 1
+# "Oui").  This is exactly the WB engaged-in-livestock signal, applied at
+# the species grain instead of collapsed to a household binary.
+owned = s4[s4['s4aq03'] == 1].copy()
+
+df = pd.DataFrame({
+    't': WAVE,
+    'i': owned['i'],
+    'animal': owned['s4aq02'],          # numeric species code -> Preferred Label
+    'HeadCount': owned['s4aq04'],
+    'HeadAcquired': owned['s4aq15'],
+    'HeadSold': owned['s4aq22'],
+    'Value': owned['s4aq24'],
+})
+
+df = livestock_finalize(df)
+
+assert len(df) > 0, "livestock 2014-15 produced no rows"
+assert df.index.is_unique, "Non-unique (t, i, animal) in livestock 2014-15"
+
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Mali/2017-18/_/livestock.py
+++ b/lsms_library/countries/Mali/2017-18/_/livestock.py
@@ -1,0 +1,93 @@
+"""Build livestock (item-level animal roster) for Mali EACI 2017-18.
+
+GAP 4 (parity loop).  One row per (t, i, animal) — the pre-collapse roster
+the WB MLI_EACI2.do reads, recodes to a single engaged-in-livestock binary
+(``s8aq04``, collapse-max per hhid), then discards.
+
+Sources (passage 2 / post-harvest livestock module s8):
+  - eaci17_s8ap2.dta   stock roster: one row per possible species per HH,
+                       with s8aq04 == 'Oui' for species it keeps and
+                       s8aq06 = number currently in the herd.  This file
+                       carries the HEAD COUNT but no transactions.
+  - eaci17_s8b1p2.dta  12-month flow roster (acquisitions / sales), keyed
+                       on the SAME (grappe, exploitation, species) — the
+                       acquired / sold / sale-value the WB code never reads.
+
+i = (grappe, exploitation) — the 2017-18 household key (cf. crop_production
+/ plot_features).  HeadCount from s8a; HeadAcquired / HeadSold / Value
+joined from s8b1 on (grappe, exploitation, species_code).
+
+Variable map traced from the s8a / s8b1 questionnaire labels:
+  species code   = s8aq02 / s8b1q02  (110..910; harmonize_species Code)
+  owns y/n       = s8aq04   ('Oui'/'Non') ["...a-t-il eleve espece... 12 mois?"]
+  HeadCount      = s8aq06   "Nombre d'animaux ... actuellement dans le troupeau"
+  HeadAcquired   = s8b1q10  "Nbre d'animaux ... achetes au cours des 12 ... mois"
+  HeadSold       = s8b1q13  "Nbre ... appartenant au menage vendus ... 12 ... mois"
+  Value (sales)  = s8b1q14  "Valeur brute de la vente de ces animaux ... fcfa"
+
+The EACI roster carries NO current herd-value question, so Value is the
+gross SALES value where reported (else NaN).  NO TLU, NO herd-value total,
+NO engaged-in-livestock binary — those are transformations over these rows.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import i as mali_i, livestock_finalize
+
+WAVE = '2017-18'
+
+
+def _hhid(df):
+    return df.apply(lambda r: mali_i(pd.Series([r['grappe'], r['exploitation']])),
+                    axis=1)
+
+
+# --- stock roster (s8a): head count per (grappe, exploitation, species) ---
+# convert_categoricals=False so the species code arrives as the integer
+# s8aq02 (the harmonize_species join key) and the owns flag as 1/2.
+s8a = get_dataframe('../Data/eaci17_s8ap2.dta', convert_categoricals=False).copy()
+# Keep only species the household actually keeps (s8aq04 == 1 "Oui") — the
+# WB engaged-in-livestock signal, at the species grain.
+s8a = s8a[s8a['s8aq04'] == 1].copy()
+s8a['animal_code'] = pd.to_numeric(s8a['s8aq02'], errors='coerce').astype('Int64')
+
+# --- flow roster (s8b1): 12-month acquisitions / sales / sale value ---
+s8b1 = get_dataframe('../Data/eaci17_s8b1p2.dta', convert_categoricals=False).copy()
+s8b1['animal_code'] = pd.to_numeric(s8b1['s8b1q02'], errors='coerce').astype('Int64')
+flow = s8b1[['grappe', 'exploitation', 'animal_code',
+             's8b1q10', 's8b1q13', 's8b1q14']].rename(columns={
+    's8b1q10': 'HeadAcquired',
+    's8b1q13': 'HeadSold',
+    's8b1q14': 'Value',
+})
+# Collapse the flow file to one row per (grappe, exploitation, species) in
+# case a species appears more than once; sum the reported flows.
+flow = flow.groupby(['grappe', 'exploitation', 'animal_code'],
+                    as_index=False).agg(
+    HeadAcquired=('HeadAcquired', lambda s: pd.to_numeric(s, errors='coerce').sum(min_count=1)),
+    HeadSold=('HeadSold', lambda s: pd.to_numeric(s, errors='coerce').sum(min_count=1)),
+    Value=('Value', lambda s: pd.to_numeric(s, errors='coerce').sum(min_count=1)),
+)
+
+merged = s8a.merge(flow, on=['grappe', 'exploitation', 'animal_code'], how='left')
+merged['i'] = _hhid(merged)
+
+df = pd.DataFrame({
+    't': WAVE,
+    'i': merged['i'],
+    'animal': merged['animal_code'],     # numeric species code -> Preferred Label
+    'HeadCount': merged['s8aq06'],
+    'HeadAcquired': merged['HeadAcquired'],
+    'HeadSold': merged['HeadSold'],
+    'Value': merged['Value'],
+})
+
+df = livestock_finalize(df)
+
+assert len(df) > 0, "livestock 2017-18 produced no rows"
+assert df.index.is_unique, "Non-unique (t, i, animal) in livestock 2017-18"
+
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Mali/_/Makefile
+++ b/lsms_library/countries/Mali/_/Makefile
@@ -48,6 +48,16 @@ $(VAR_DIR)/crop_production.parquet: crop_production.py ../2014-15/_/crop_product
 $(VAR_DIR)/plot_inputs.parquet: plot_inputs.py ../2014-15/_/plot_inputs.parquet ../2017-18/_/plot_inputs.parquet
 	python plot_inputs.py
 
+# livestock (item-level animal roster, GAP 4 / parity loop).  The livestock
+# module lives in the EACI waves only (2014-15, 2017-18).  The wave pattern
+# rule materializes each wave parquet; the country-level concatenator
+# (livestock.py) aggregates into var/livestock.parquet.
+../%/_/livestock.parquet: ../%/_/livestock.py
+	(cd $(@D) && python livestock.py)
+
+$(VAR_DIR)/livestock.parquet: livestock.py ../2014-15/_/livestock.parquet ../2017-18/_/livestock.parquet
+	python livestock.py
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Mali/_/categorical_mapping.org
+++ b/lsms_library/countries/Mali/_/categorical_mapping.org
@@ -526,3 +526,43 @@
 | fungicide           | Fungicide           | x       | x       |
 | herbicide           | Herbicide           | x       | x       |
 | other_phytosanitary | Other phytosanitary | x       | x       |
+
+# harmonize_species — the animal-identity (`animal` index level) taxonomy
+# for livestock (GAP 4, parity loop).  Source: the EACI livestock roster
+# the WB MLI_EACI*.do code collapses to a single engaged-in-livestock
+# binary (s4aq03 / s8aq04) then discards.  The `Code` is the survey's own
+# integer species code (s4aq02 in 2014-15 EACIS4A_p2; s8aq02 in 2017-18
+# eaci17_s8ap2 / eaci17_s8b1p2) — IDENTICAL across both EACI waves, hence
+# one shared Code column.  The wave scripts key on this integer code; this
+# table maps it to a canonical species Preferred Label.
+#
+# Mali's roster carries a FINER grain than the coarse Cattle/Sheep/Goats/
+# Poultry rollup (it separately reports bulls/cows/heifers/calves within
+# cattle, rams/ewes within sheep, bucks/does within goats, and three
+# poultry types).  We keep that finer grain on the `animal` axis — strictly
+# RICHER than the WB single binary AND richer than a coarse species
+# rollup; the coarse Cattle/Smallruminants/Poultry grouping and any TLU
+# weighting are transformations.py rollups over these item rows, never a
+# stored column.  Per-wave decoded-label columns document the (near-
+# identical) source strings; the join key is the numeric Code.
+#+name: harmonize_species
+| Code | Preferred Label    | 2014-15               | 2017-18               |
+|------+--------------------+-----------------------+-----------------------|
+|  110 | Oxen               | Buf                   | Boeufs                |
+|  120 | Bulls              | Taureau               | Taureau               |
+|  130 | Cows               | Vache                 | Vache                 |
+|  140 | Young Cattle       | Taurillon / Bouvillon | Taurillon / Bouvillon |
+|  150 | Heifers            | Génisse               | Génisse               |
+|  160 | Calves             | Veau / Velle          | Veau / Velle          |
+|  210 | Rams               | Mouton / Bélier       | Mouton / Bélier       |
+|  220 | Ewes               | Brebis                | Brebis                |
+|  310 | Bucks              | Bouc                  | Bouc                  |
+|  320 | Goats              | Chèvre                | Chèvre                |
+|  410 | Camels             | Chameaux/Chamelles    | Chameaux/Chamelles    |
+|  510 | Horses             | Cheveau/Jument        | Cheveau/Jument        |
+|  610 | Donkeys            | Anes/Anesse           | Anes/Anesse           |
+|  710 | Chickens           | Poules / poulets      | Coq/Poules            |
+|  720 | Guinea Fowl        | Pintades              | Pintades              |
+|  730 | Other Poultry      | Autres volailles      | Autres volailles      |
+|  810 | Pigs               | Porcs                 | Porcs                 |
+|  910 | Rabbits            | Lapins                | Lapins                |

--- a/lsms_library/countries/Mali/_/data_scheme.yml
+++ b/lsms_library/countries/Mali/_/data_scheme.yml
@@ -189,3 +189,37 @@ Data Scheme:
     Quantity_purchased: float
     Improved: bool
     materialize: make
+  livestock:
+    # Item-level animal roster, GAP 4 (parity loop).  One row per
+    # (t, i, animal): the REPORTED counts the survey records, NOT the WB
+    # single engaged-in-livestock binary (which is groupby(['t','i']).any()
+    # over these rows).  The livestock module lives in the EACI waves only
+    # (2014-15 EACIS4A_p2 / s4a; 2017-18 eaci17_s8ap2 + eaci17_s8b1p2 /
+    # s8a+s8b1).  The EHCVM waves (2018-19, 2021-22) carry no livestock
+    # roster — deferred (the same split as crop_production / plot_inputs).
+    #
+    # animal = harmonize_species Preferred Label, keyed on the survey's own
+    # integer species code (s4aq02 / s8aq02; identical across both EACI
+    # waves).  Mali's roster has a FINER grain than a coarse Cattle/Sheep/
+    # Goats/Poultry rollup (separate bulls/cows/heifers/calves, rams/ewes,
+    # bucks/does, three poultry types) — kept on the `animal` axis so we are
+    # richer than the WB binary AND than a species rollup.  NO v: the
+    # framework's _no_v_join set already excludes 'livestock', so the
+    # canonical grain is (t, i, animal) with no cluster level.
+    #
+    # HeadCount    = number currently in the herd (s4aq04 / s8aq06).
+    # HeadAcquired = number bought in the recall period (s4aq15 / s8b1q10).
+    # HeadSold     = number owned by the HH sold (s4aq22 / s8b1q13).
+    # Value        = gross SALES value (FCFA) where reported (s4aq24 /
+    #                s8b1q14); NaN otherwise — the EACI roster carries NO
+    #                current herd-value question.
+    #
+    # NO TLU / herd-value total / engaged-in-livestock binary — those are
+    # transformations.py rollups over these item rows.  Built by per-wave
+    # scripts + a country-level concatenator.
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    Value: float
+    materialize: make

--- a/lsms_library/countries/Mali/_/livestock.py
+++ b/lsms_library/countries/Mali/_/livestock.py
@@ -1,0 +1,40 @@
+"""Concatenate wave-level livestock for Mali (GAP 4; parity loop).
+
+Each EACI wave's ``Mali/<wave>/_/livestock.py`` writes a parquet indexed by
+``(t, i, animal)`` with the reported item-level columns (HeadCount,
+HeadAcquired, HeadSold, Value).  The livestock module lives in the EACI
+waves only (2014-15 EACIS4A_p2 / s4a, 2017-18 eaci17_s8ap2 + eaci17_s8b1p2 /
+s8a+s8b1).  The EHCVM waves (2018-19, 2021-22) carry no livestock roster, so
+they contribute nothing — the same wave split as crop_production /
+plot_inputs.
+
+``v`` is NOT baked in — and is NOT joined for livestock at all: the
+framework's ``_no_v_join`` set already excludes 'livestock', so the
+canonical grain is (t, i, animal) with no cluster level.  ``id_walk`` is
+left to ``_finalize_result`` (cached parquets store pre-transformation
+data), matching the crop_production / plot_inputs / food_coping pattern.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+WAVES = ['2014-15', '2017-18', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/livestock.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired (no .py script / no parquet); DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "livestock: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, animal) after concat"
+
+to_parquet(p, '../var/livestock.parquet')

--- a/lsms_library/countries/Mali/_/mali.py
+++ b/lsms_library/countries/Mali/_/mali.py
@@ -435,3 +435,97 @@ def plot_inputs_finalize(df):
     })
     out = out[['Quantity', 'u', 'Purchased', 'Quantity_purchased', 'Improved']]
     return out.sort_index()
+
+
+# ---------------------------------------------------------------------------
+# livestock (GAP 4; parity loop) — item-level (t, i, animal)
+# ---------------------------------------------------------------------------
+#
+# One row per (household, species owned).  Source: the EACI livestock roster
+# that the WB MLI_EACI*.do code reads, recodes to a single engaged-in-
+# livestock binary (s4aq03==Oui / s8aq04==Oui, collapse-max per hhid), then
+# THROWS AWAY.  We keep the pre-collapse roster — strictly richer than their
+# one y/n flag.
+#
+# Grain: one row per (t, i, animal), where
+#   - i      = Mali composite household id (grappe, menage/exploitation),
+#   - animal = harmonize_species Preferred Label (the survey's own integer
+#              species code s4aq02/s8aq02 -> canonical species).
+#
+# REPORTED item-level columns only (NO TLU, NO herd-value total, NO
+# engaged-in-livestock binary — those are transformations.py rollups over
+# these rows; their binary is groupby(['t','i']).any() over these rows):
+#   HeadCount        — number currently in the herd (owned + raised),
+#   HeadAcquired     — number bought in the recall period,
+#   HeadSold         — number owned by the HH sold in the recall period,
+#   Value            — gross value of those sales (FCFA) where the source
+#                      records it; NaN otherwise (the EACI roster carries NO
+#                      current herd-value question, only a sales value).
+#
+# `animal` is set by the wave script from the numeric species code, mapped
+# here to the harmonize_species Preferred Label.  No `v`: the framework's
+# _no_v_join set already excludes 'livestock', so the canonical grain is
+# (t, i, animal) with no cluster level.
+
+# EACI "Manquant" / refusal sentinels on the reported count/value columns.
+_LIVESTOCK_SENTINELS = [99, 999, 9999, 99999, 999999, 9999999]
+
+
+def _species_labels(series):
+    """Map a Series of numeric survey species codes (110, 120, ... 910)
+    -> harmonize_species Preferred Label.  The org-table Code column is read
+    back as STRING keys ('110', ...), so coerce the raw code to int->str
+    before the map; unmapped codes (none expected) become NA."""
+    m = tools.get_categorical_mapping(tablename='harmonize_species',
+                                      idxvars='Code',
+                                      **{'Preferred Label': 'Preferred Label'})
+    code = pd.to_numeric(series, errors='coerce').astype('Int64')
+    key = code.astype('string').str.replace(r'\.0$', '', regex=True)
+    out = key.map(m)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def livestock_finalize(df):
+    """Common post-processing for a livestock wave DataFrame.
+
+    Expects raw columns already assembled:
+        t, i, animal (numeric species code), HeadCount, HeadAcquired,
+        HeadSold, Value.
+    Maps the species code -> harmonize_species Preferred Label, coerces the
+    reported count/value columns to numeric (clearing the EACI Manquant
+    sentinels), drops content-free rows (a species the household does not
+    keep — no head count and no transaction), sets the (t, i, animal) index,
+    and collapses any exact-duplicate index rows by summing the reported
+    amounts (min_count=1 so an all-NA group stays NA, not a spurious 0).
+    """
+    df = df.copy()
+    df['animal'] = _species_labels(df['animal'])
+    df = df.dropna(subset=['animal'])  # drop unmapped species codes
+
+    for c in ('HeadCount', 'HeadAcquired', 'HeadSold', 'Value'):
+        if c not in df.columns:
+            df[c] = pd.NA
+        df[c] = pd.to_numeric(df[c], errors='coerce')
+        df.loc[df[c].isin(_LIVESTOCK_SENTINELS), c] = pd.NA
+
+    # Drop content-free rows: a species the household reported nothing
+    # positive for.  A reported head count, an acquisition, a sale, or a
+    # sale value all count as content; an all-zero/all-NA row does not (the
+    # roster has a fixed slot per species, with zeros for animals the HH
+    # does not keep — keeping them would emit 18 rows per household).
+    has_content = (df['HeadCount'].fillna(0).gt(0)
+                   | df['HeadAcquired'].fillna(0).gt(0)
+                   | df['HeadSold'].fillna(0).gt(0)
+                   | df['Value'].fillna(0).gt(0))
+    df = df[has_content]
+
+    keys = ['t', 'i', 'animal']
+    g = df.groupby(keys, dropna=False, as_index=True)
+    out = pd.DataFrame({
+        'HeadCount':    g['HeadCount'].sum(min_count=1),
+        'HeadAcquired': g['HeadAcquired'].sum(min_count=1),
+        'HeadSold':     g['HeadSold'].sum(min_count=1),
+        'Value':        g['Value'].sum(min_count=1),
+    })
+    out = out[['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']]
+    return out.sort_index()

--- a/lsms_library/countries/Niger/2011-12/_/livestock.py
+++ b/lsms_library/countries/Niger/2011-12/_/livestock.py
@@ -1,0 +1,54 @@
+"""Build livestock for Niger ECVMA 2011-12 (GAP 4, item-level).
+
+Single source file: ecvmaas4a_p2.dta — the livestock roster, one row per
+(household, species) the household was ASKED about.  The WB .do code
+(NER_ECVMA1.do:1103-1108) reads this same file, recodes as4aq05 to a y/n
+binary and collapses it to one row per HH; we keep the pre-collapse rows.
+
+Columns:
+  as4aq04  species code (3-digit; harmonize_species_ecvma -> animal)
+  as4aq05  owned/raised this species? (1=Oui / 2=Non) — the ownership gate
+  as4aq11  number belonging to the household (HeadCount owned now)
+  as4aq43  number bought in the last 12 months (HeadAcquired)
+  as4aq51  number sold on the hoof in the last 12 months (HeadSold)
+
+Only rows the household actually owns are reported owned-animal records, so
+we keep as4aq05==1 (the WB binary is exactly max(as4aq05==1) over these).
+``hid`` already equals grappe*100+menage (the canonical 2011-12 household
+id), so i() just str()s it — matching crop_production / sample.  Grain
+(t, i, animal); no v level (livestock is in the framework _no_v_join set).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import i as niger_i, _species_maps, _map_codes, _finish_livestock
+
+
+srcn = get_dataframe(
+    '../Data/NER_2011_ECVMA_v01_M_Stata8/ecvmaas4a_p2.dta',
+    convert_categoricals=False)
+
+ecvma_map, _ = _species_maps()
+
+# Keep only species the household actually owns (as4aq05 == 1 = Oui).  This is
+# the WB ownership gate; the engaged-in-livestock binary = any such row per HH.
+owned = srcn['as4aq05'] == 1
+srcn = srcn[owned.values]
+
+hh = srcn['hid'].apply(lambda x: niger_i(x) if pd.notna(x) else pd.NA)
+
+df = pd.DataFrame({
+    'i':            hh.values,
+    'animal':       _map_codes(srcn['as4aq04'], ecvma_map).values,
+    'HeadCount':    pd.to_numeric(srcn['as4aq11'], errors='coerce').values,
+    'HeadAcquired': pd.to_numeric(srcn['as4aq43'], errors='coerce').values,
+    'HeadSold':     pd.to_numeric(srcn['as4aq51'], errors='coerce').values,
+})
+
+df = _finish_livestock(df, '2011-12')
+
+assert len(df) > 0, 'livestock 2011-12 produced no rows'
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Niger/2014-15/_/livestock.py
+++ b/lsms_library/countries/Niger/2014-15/_/livestock.py
@@ -1,0 +1,55 @@
+"""Build livestock for Niger ECVMA 2014-15 (GAP 4, item-level).
+
+Single source file: ECVMA2_AS4AP2.dta — the livestock roster, same layout
+as 2011-12 with UPPERCASE columns.  The WB .do code (NER_ECVMA2.do:1170-
+1177) reads this same file, recodes AS4AQ05 to a y/n binary and collapses
+it to one row per HH; we keep the pre-collapse rows.
+
+Columns:
+  AS4AQ04  species code (3-digit; harmonize_species_ecvma -> animal)
+  AS4AQ05  owned/raised this species? (1=Oui / 2=Non) — the ownership gate
+  AS4AQ11  number belonging to the household (HeadCount owned now)
+  AS4AQ43  number bought in the last 12 months (HeadAcquired)
+  AS4AQ51  number sold on the hoof in the last 12 months (HeadSold)
+
+i is built from (GRAPPE, MENAGE) via niger.i — matching this wave's
+sample / household_roster idxvars, which omit EXTENSION (the roster file
+HAS an EXTENSION column but the canonical 2014-15 id is grappe0menage).
+Only owned rows (AS4AQ05==1) are kept; the WB binary = any such row per HH.
+Grain (t, i, animal); no v level (livestock is in the framework
+_no_v_join set).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import i as niger_i, _species_maps, _map_codes, _finish_livestock
+
+
+base = '../Data/NER_2014_ECVMA-II_v02_M_STATA8/'
+srcn = get_dataframe(base + 'ECVMA2_AS4AP2.dta', convert_categoricals=False)
+
+ecvma_map, _ = _species_maps()
+
+# Keep only species the household actually owns (AS4AQ05 == 1 = Oui).
+owned = srcn['AS4AQ05'] == 1
+srcn = srcn[owned.values]
+
+# i from (GRAPPE, MENAGE) only (EXTENSION omitted to match sample/roster).
+hh = srcn.apply(lambda r: niger_i(pd.Series([r['GRAPPE'], r['MENAGE']],
+                                            index=['GRAPPE', 'MENAGE'])), axis=1)
+
+df = pd.DataFrame({
+    'i':            hh.values,
+    'animal':       _map_codes(srcn['AS4AQ04'], ecvma_map).values,
+    'HeadCount':    pd.to_numeric(srcn['AS4AQ11'], errors='coerce').values,
+    'HeadAcquired': pd.to_numeric(srcn['AS4AQ43'], errors='coerce').values,
+    'HeadSold':     pd.to_numeric(srcn['AS4AQ51'], errors='coerce').values,
+})
+
+df = _finish_livestock(df, '2014-15')
+
+assert len(df) > 0, 'livestock 2014-15 produced no rows'
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Niger/2018-19/_/livestock.py
+++ b/lsms_library/countries/Niger/2018-19/_/livestock.py
@@ -1,0 +1,52 @@
+"""Build livestock for Niger EHCVM 2018-19 (GAP 4, item-level).
+
+Single source file: s17_me_ner2018.dta — the EHCVM section-17 livestock
+('Élevage') roster, one row per (household, species).  The roster is
+already restricted to owned species (s17q03 == 1 for every row).  This is
+the EHCVM analogue of the ECVMA as4a roster the WB collapses to a binary.
+
+Columns:
+  s17q02  species code (1-11, elevage__id; harmonize_species_ehcvm -> animal)
+  s17q03  owned/raised this species? (1=Oui / 2=Non) — gate (all ==1 here)
+  s17q06  number belonging to the household (HeadCount owned now)
+  s17q08  number bought in the last 12 months (HeadAcquired)
+  s17q10  number sold on the hoof in the last 12 months (HeadSold)
+
+There is NO current herd-value question in EHCVM s17 (s17q05/q06 are head
+counts; s17q09/q13 are purchase/sale FLOW values), so Value is not emitted.
+i is the EHCVM composite id ('E_' + grappe + '0' + zero-padded menage) via
+niger.i, matching sample().  Grain (t, i, animal); no v level (livestock
+is in the framework _no_v_join set).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import i as niger_i, _species_maps, _map_codes, _finish_livestock
+
+
+srcn = get_dataframe('../Data/s17_me_ner2018.dta', convert_categoricals=False)
+
+_, ehcvm_map = _species_maps()
+
+# The roster only carries owned species, but keep the gate for parity / safety.
+owned = srcn['s17q03'] == 1
+srcn = srcn[owned.values]
+
+hh = srcn.apply(lambda r: niger_i(pd.Series([r['grappe'], r['menage']],
+                                            index=['grappe', 'menage'])), axis=1)
+
+df = pd.DataFrame({
+    'i':            hh.values,
+    'animal':       _map_codes(srcn['s17q02'], ehcvm_map).values,
+    'HeadCount':    pd.to_numeric(srcn['s17q06'], errors='coerce').values,
+    'HeadAcquired': pd.to_numeric(srcn['s17q08'], errors='coerce').values,
+    'HeadSold':     pd.to_numeric(srcn['s17q10'], errors='coerce').values,
+})
+
+df = _finish_livestock(df, '2018-19')
+
+assert len(df) > 0, 'livestock 2018-19 produced no rows'
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Niger/2021-22/_/livestock.py
+++ b/lsms_library/countries/Niger/2021-22/_/livestock.py
@@ -1,0 +1,52 @@
+"""Build livestock for Niger EHCVM 2021-22 (GAP 4, item-level).
+
+Single source file: s17_me_ner2021.dta — the EHCVM section-17 livestock
+('Élevage') roster, one row per (household, species).  Same instrument as
+2018-19 EXCEPT the species code lives in s17q01 (s17q02 is absent in
+2021-22); the 1-11 value scheme is identical (elevage__id).  The roster is
+already restricted to owned species (s17q03 == 1 for every row).
+
+Columns:
+  s17q01  species code (1-11; harmonize_species_ehcvm -> animal)
+  s17q03  owned/raised this species? (1=Oui / 2=Non) — gate (all ==1 here)
+  s17q06  number belonging to the household (HeadCount owned now)
+  s17q08  number bought in the last 12 months (HeadAcquired)
+  s17q10  number sold on the hoof in the last 12 months (HeadSold)
+
+No current herd-value question (see 2018-19), so Value is not emitted.  i
+is the EHCVM composite id ('E_' + grappe + '0' + zero-padded menage) via
+niger.i, matching sample().  Grain (t, i, animal); no v level (livestock
+is in the framework _no_v_join set).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import i as niger_i, _species_maps, _map_codes, _finish_livestock
+
+
+srcn = get_dataframe('../Data/s17_me_ner2021.dta', convert_categoricals=False)
+
+_, ehcvm_map = _species_maps()
+
+# The roster only carries owned species, but keep the gate for parity / safety.
+owned = srcn['s17q03'] == 1
+srcn = srcn[owned.values]
+
+hh = srcn.apply(lambda r: niger_i(pd.Series([r['grappe'], r['menage']],
+                                            index=['grappe', 'menage'])), axis=1)
+
+df = pd.DataFrame({
+    'i':            hh.values,
+    'animal':       _map_codes(srcn['s17q01'], ehcvm_map).values,
+    'HeadCount':    pd.to_numeric(srcn['s17q06'], errors='coerce').values,
+    'HeadAcquired': pd.to_numeric(srcn['s17q08'], errors='coerce').values,
+    'HeadSold':     pd.to_numeric(srcn['s17q10'], errors='coerce').values,
+})
+
+df = _finish_livestock(df, '2021-22')
+
+assert len(df) > 0, 'livestock 2021-22 produced no rows'
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Niger/_/Makefile
+++ b/lsms_library/countries/Niger/_/Makefile
@@ -47,6 +47,20 @@ $(VAR_DIR)/plot_inputs.parquet: plot_inputs.py niger.py categorical_mapping.org 
 ../%/_/plot_inputs.parquet: ../%/_/plot_inputs.py niger.py categorical_mapping.org
 	(cd $(@D) && python plot_inputs.py)
 
+# livestock (GAP 4, item-level).  Same shape as crop_production / plot_inputs:
+# the country-level var/ parquet is built by the concatenator, which reads
+# each wave's parquet; the country script is run unconditionally to (re)build
+# the wave parquets it reads, then concatenates.
+LIVESTOCK_WAVES := 2011-12 2014-15 2018-19 2021-22
+
+$(VAR_DIR)/livestock.parquet: livestock.py niger.py categorical_mapping.org \
+		$(foreach w,$(LIVESTOCK_WAVES),../$(w)/_/livestock.py)
+	$(foreach w,$(LIVESTOCK_WAVES),(cd ../$(w)/_ && python livestock.py);)
+	python livestock.py
+
+../%/_/livestock.parquet: ../%/_/livestock.py niger.py categorical_mapping.org
+	(cd $(@D) && python livestock.py)
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Niger/_/categorical_mapping.org
+++ b/lsms_library/countries/Niger/_/categorical_mapping.org
@@ -924,3 +924,98 @@
 | Plants/boutures de tubercules | Autre crop          |
 | Autres semences               | Autre crop          |
 | 20                            | Autre crop          |
+
+* Livestock Species (livestock — the animal axis)
+
+# harmonize_species (GAP 4 livestock, parity loop 2026-06-14).  Maps each
+# wave's raw livestock-roster animal CODE onto a shared species taxonomy
+# `Preferred Label`.  The reported item-level `livestock` feature (grain
+# (t, i, animal)) puts this Preferred Label on its `animal` index level.
+#
+# WHY TWO CODE-KEYED TABLES (not one string-keyed like harmonize_food):
+# Niger's two survey programs use DISJOINT, but internally clean, integer
+# code schemes, while the convert_categoricals=True species NAME strings
+# carry wave-specific mojibake ('B\x9cuf' in 2011-12 vs 'B?oeuf' in
+# 2014-15) that make a string key brittle.  The integer code is the stable
+# key WITHIN each program, so the wave scripts load convert_categoricals=
+# False and map the code via _map_codes (the same mechanism as
+# harmonize_tenure / harmonize_soil).  Two tables because the ECVMA 3-digit
+# codes and the EHCVM 1-11 codes overlap in value (e.g. 11 = Canards in
+# ECVMA 2014-15 vs Autres volailles in EHCVM) — a single Code table could
+# not disambiguate them.
+#
+# A. harmonize_species_ecvma — ECVMA waves (2011-12 ecvmaas4a_p2 as4aq04,
+#    2014-15 ECVMA2_AS4AP2 AS4AQ04).  The 3-digit code's first one-or-two
+#    digits give the species class; the trailing digit is sex/age subtype
+#    (bœuf/taureau/vache/veau all -> Cattle), which is harmonized away —
+#    cross-subtype variation is unimportant for the species axis.  Class 2
+#    splits on the 2nd digit: 21x/22x (mouton/brebis) -> Sheep, 23x/24x
+#    (bouc/chèvre) -> Goats.  Code 11 (Canards, 2014-15 only) -> Ducks.
+#
+# B. harmonize_species_ehcvm — EHCVM waves (2018-19 s17 species code
+#    s17q02, 2021-22 s17 species code s17q01 — the column moved but the
+#    1-11 value scheme is identical).  Codes are the elevage__id value
+#    labels: 1 Bovins, 2 Ovins, 3 Caprins, 4 Camelins, 5 Equins, 6 Asins,
+#    7 Porcins, 8 Lapins, 9 Poules, 10 Pintades, 11 Autres volailles.
+#    (Code 7 Porcins is absent from the Niger data — predominantly Muslim —
+#    but kept for completeness.)
+#
+# The Preferred Label vocabulary is shared across both tables so the
+# `animal` axis is consistent across all four waves:
+#   Cattle, Sheep, Goats, Camels, Horses, Donkeys, Pigs, Rabbits,
+#   Chicken, Guinea Fowl, Ducks, Other Poultry.
+# Referenced from the wave-level _/livestock.py via
+#   tools.get_categorical_mapping('harmonize_species_{ecvma,ehcvm}',
+#                                 'Code', 'Preferred Label').
+
+#+NAME: harmonize_species_ecvma
+| Code | Preferred Label |
+|------+-----------------|
+|   11 | Ducks           |
+|  111 | Cattle          |
+|  112 | Cattle          |
+|  121 | Cattle          |
+|  122 | Cattle          |
+|  131 | Cattle          |
+|  132 | Cattle          |
+|  141 | Cattle          |
+|  142 | Cattle          |
+|  151 | Cattle          |
+|  152 | Cattle          |
+|  161 | Cattle          |
+|  162 | Cattle          |
+|  211 | Sheep           |
+|  212 | Sheep           |
+|  221 | Sheep           |
+|  222 | Sheep           |
+|  231 | Goats           |
+|  232 | Goats           |
+|  241 | Goats           |
+|  242 | Goats           |
+|  311 | Camels          |
+|  321 | Camels          |
+|  331 | Camels          |
+|  411 | Donkeys         |
+|  511 | Horses          |
+|  611 | Pigs            |
+|  621 | Pigs            |
+|  711 | Chicken         |
+|  721 | Chicken         |
+|  722 | Chicken         |
+|  811 | Guinea Fowl     |
+|  911 | Other Poultry   |
+
+#+NAME: harmonize_species_ehcvm
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Cattle          |
+|    2 | Sheep           |
+|    3 | Goats           |
+|    4 | Camels          |
+|    5 | Horses          |
+|    6 | Donkeys         |
+|    7 | Pigs            |
+|    8 | Rabbits         |
+|    9 | Chicken         |
+|   10 | Guinea Fowl     |
+|   11 | Other Poultry   |

--- a/lsms_library/countries/Niger/_/data_scheme.yml
+++ b/lsms_library/countries/Niger/_/data_scheme.yml
@@ -204,3 +204,44 @@ Data Scheme:
     Purchased: bool
     Quantity_purchased: float
     materialize: make
+
+  livestock:
+    # Item-level livestock roster (GAP 4, parity loop 2026-06-14).  One row
+    # per REPORTED (household, species) the household owns/raises — the
+    # pre-collapse roster the WB .do code (NER_ECVMA1.do:1103-1108,
+    # NER_ECVMA2.do:1170-1177) reads then THROWS AWAY down to a single
+    # engaged-in-livestock y/n binary (recode as4aq05 ...; collapse (max)).
+    # Their HH binary is recoverable as groupby(['t','i']).any() over these
+    # rows; TLU is a Σ(head × species-factor) transformation — neither is a
+    # column here (item-level / reported-values discipline).
+    #
+    # GRAIN (t, i, animal) — NO v level: 'livestock' is in the framework's
+    # _no_v_join set (country.py ~L1852), so the household-level rows carry no
+    # cluster level and the framework does NOT join one from sample().
+    # `animal` is the harmonized species Preferred Label (harmonize_species_
+    # ecvma for the 3-digit ECVMA codes, harmonize_species_ehcvm for the 1-11
+    # EHCVM codes; both resolve to one shared vocabulary: Cattle / Sheep /
+    # Goats / Camels / Horses / Donkeys / Pigs / Rabbits / Chicken / Guinea
+    # Fowl / Ducks / Other Poultry).
+    #
+    # All four waves have a livestock roster (script-path):
+    #   2011-12 ecvmaas4a_p2   as4aq04 species, as4aq11 head, as4aq43 bought,
+    #                          as4aq51 sold; as4aq05 owned(1/2) gate.
+    #   2014-15 ECVMA2_AS4AP2  same, UPPERCASE; i from (GRAPPE, MENAGE).
+    #   2018-19 s17_me_ner2018 s17q02 species, s17q06 head, s17q08 bought,
+    #                          s17q10 sold; roster pre-filtered to owned.
+    #   2021-22 s17_me_ner2021 same as 2018-19 EXCEPT species code is s17q01.
+    #
+    # COLUMNS (reported, item-level): HeadCount (owned now), HeadAcquired
+    # (number bought in the last 12 months — the single reported acquisition
+    # flow; births / gifts are separate flows, not folded in), HeadSold
+    # (number sold on the hoof in the last 12 months).  A `Value` (herd value)
+    # column is intentionally OMITTED: NO Niger wave asks a current herd value
+    # (the surveys record only purchase / sale FLOW values), so an all-NaN
+    # Value column would only trip the sanity checker (GAP rule "only include
+    # columns the source actually records").
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    materialize: make

--- a/lsms_library/countries/Niger/_/livestock.py
+++ b/lsms_library/countries/Niger/_/livestock.py
@@ -1,0 +1,41 @@
+"""Concatenate wave-level livestock for Niger (GAP 4, item-level).
+
+Each wave's ``Niger/<wave>/_/livestock.py`` writes a parquet indexed by
+``(t, i, animal)`` with the reported per-species columns (HeadCount,
+HeadAcquired, HeadSold).  This script concatenates the four waves
+(2011-12, 2014-15, 2018-19, 2021-22), each of which has a livestock
+roster.  ``v`` is NOT baked in: 'livestock' is in the framework
+``_no_v_join`` set, so the household-level rows carry no cluster level and
+the framework does not join one from ``sample()``.
+
+As in the crop_production / plot_inputs siblings, this does NOT apply
+``id_walk`` here; the framework runs it in ``_finalize_result`` on every
+read.  Each wave's ``_finish_livestock`` already sums the ECVMA animal
+sub-type lines (bœuf/vache/... -> Cattle) onto one row per (household,
+canonical species), so the ``(t, i, animal)`` index is UNIQUE within each
+wave and the concatenation stays unique across waves (the four ``t`` values
+are disjoint).  No rows are lost to the framework's canonical-index de-dup.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2011-12', '2014-15', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/livestock.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for livestock (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, 'livestock: no wave-level parquets found'
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/livestock.parquet')

--- a/lsms_library/countries/Niger/_/niger.py
+++ b/lsms_library/countries/Niger/_/niger.py
@@ -552,3 +552,113 @@ def _finish_plot_inputs(df, t):
     df = df[[c for c in keep if c in df.columns]]
     df = df.set_index(['t', 'i', 'input', 'crop', 'u'])
     return df
+
+
+# ---------------------------------------------------------------------------
+# livestock (GAP 4 — item-level livestock at (t, i, animal))
+# ---------------------------------------------------------------------------
+#
+# One row per REPORTED (household, species) the household owns/raised.  This
+# is the raw livestock roster the WB .do code (NER_ECVMA1.do:1103-1108,
+# NER_ECVMA2.do:1170-1177) reads and then THROWS AWAY down to a single
+# engaged-in-livestock y/n binary (recode as4aq05 ... ; collapse (max)).  We
+# keep the pre-collapse roster: head count owned now, head acquired/sold, and
+# herd value where the source reports it.  The WB HH binary is recoverable as
+# groupby(['t','i']).any() over these rows; TLU is a Σ(head × factor)
+# transform — neither is a column here (item-level / reported-values rule).
+#
+# GRAIN = (t, i, animal): ONE row per (household, canonical species owned).
+# NO `v`: 'livestock' is in the framework's _no_v_join set, so the
+# household-level rows carry no cluster level and the framework does NOT join
+# one from sample().  `animal` is the harmonized species Preferred Label.
+#
+# SUB-TYPE COLLAPSE (why the wave tail sums within (t, i, animal)).  The
+# ECVMA roster lists each animal SUB-TYPE on its own line — bœuf, taureau,
+# vache, taurillon, génisse and veau are six separate rows that all
+# harmonize to the single species "Cattle" (likewise mouton/brebis ->
+# Sheep, bouc/chèvre -> Goats, the three camel sub-types -> Camels, ...).
+# Those sub-type lines are NOT independent species items: they are age/sex
+# strata of one species the household owns.  So the per-species head count
+# IS the natural item grain (a household owning 2 bœuf + 1 vache owns 3
+# Cattle), and _finish_livestock SUMS HeadCount / HeadAcquired / HeadSold
+# within (t, i, animal).  This is the species-level item, NOT a forbidden
+# aggregation: TLU (cross-species Σ head×factor), a herd-value total, and
+# the WB engaged-in-livestock binary are the transformations the GAP rule
+# forbids as columns — all three are CROSS-species rollups, recovered by a
+# transformations fn over these rows (the binary = groupby(['t','i']).any()).
+# Summing age/sex strata of ONE species is not a cross-species rollup.  The
+# EHCVM waves already report one row per species (codes 1-11), so the sum is
+# a no-op there; it only merges the ECVMA sub-type lines.  After the sum the
+# (t, i, animal) index is unique, so no rows are lost to the framework's
+# canonical-index de-dup collapse (groupby().first()).
+#
+# Livestock instrument by wave (all four waves have one):
+#   2011-12  ecvmaas4a_p2  : as4aq04 species code, as4aq05 owned(1/2) gate,
+#                            as4aq11 head owned by HH, as4aq38 head 12mo ago,
+#                            as4aq43 head bought, as4aq51 head sold on hoof,
+#                            as4aq55 net sale value.  NO current herd value.
+#   2014-15  ECVMA2_AS4AP2 : same layout, UPPERCASE columns (AS4AQ*); i from
+#                            (GRAPPE, MENAGE, EXTENSION).
+#   2018-19  s17_me_ner2018: s17q02 species code, s17q03 owned(1/2) gate (all
+#                            rows ==1 — roster pre-filtered to owned species),
+#                            s17q06 head owned by HH, s17q08 head bought,
+#                            s17q10 head sold on hoof.  NO current herd value.
+#   2021-22  s17_me_ner2021: same as 2018-19 EXCEPT the species code lives in
+#                            s17q01 (s17q02 absent); 1-11 value scheme is
+#                            identical.
+#
+# Columns by wave: HeadCount (owned now) and HeadSold are in every wave;
+# HeadAcquired = number bought in the last 12 months (the single reported
+# "acquired" flow, matching EHCVM s17q08 "Combien avez-vous achetés"; births
+# and gifts are separate flows, not folded in).  Value = herd value where the
+# source records it — NO Niger wave asks a current herd value, so Value is
+# all-NaN and therefore OMITTED from the schema entirely (an all-NaN column
+# would only trip the sanity checker; per the GAP rule "only include columns
+# the source actually records").  The reported sale value (as4aq55) is a
+# FLOW value, not a herd stock value, so it is deliberately not emitted as
+# Value.
+
+
+def _species_maps():
+    """Load the two species code->Preferred Label dicts (ECVMA 3-digit
+    codes, EHCVM 1-11 codes) from categorical_mapping.org.  Keyed on the
+    integer Code, like harmonize_tenure / harmonize_soil — so the wave
+    scripts load convert_categoricals=False and map the raw integer code."""
+    ecvma = _harmonized_codes('harmonize_species_ecvma')
+    ehcvm = _harmonized_codes('harmonize_species_ehcvm')
+    return ecvma, ehcvm
+
+
+def _finish_livestock(df, t):
+    """Common tail for the wave-level livestock scripts: coerce numeric
+    columns, drop unresolved-species placeholder rows, SUM the head counts
+    within (t, i, animal) so each (household, canonical species) is one row,
+    and build the (t, i, animal) index.  Mirrors _finish_crop_production /
+    _finish_plot_inputs in shape, but unlike those it aggregates: the ECVMA
+    roster's animal SUB-TYPE lines (bœuf/vache/... all -> Cattle) are
+    age/sex strata of one species, so the per-species head count is the
+    natural item grain (see module note).  HeadCount / HeadAcquired /
+    HeadSold are Float64 (head counts, nullable); the sum uses min_count=1
+    so an all-NaN group stays NaN rather than becoming 0.  Value is NOT a
+    column: no Niger wave records a current herd value (see module note)."""
+    cols = ['HeadCount', 'HeadAcquired', 'HeadSold']
+    for col in cols:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    df['t'] = t
+    df['animal'] = df['animal'].astype('string')
+    # Drop rows with no resolved species (animal NA) — a roster placeholder
+    # line, not a reported owned-animal record.  i must also be non-null for
+    # a valid household key.
+    df = df[df['animal'].notna() & df['i'].notna()]
+    # Sum sub-type strata onto the canonical species (no-op for the EHCVM
+    # waves, which already report one row per species).  min_count=1 keeps an
+    # all-NaN group NaN.
+    df = (df.groupby(['t', 'i', 'animal'], dropna=False)[cols]
+            .sum(min_count=1)
+            .reset_index())
+    keep = ['t', 'i', 'animal'] + cols
+    df = df[keep]
+    df = df.set_index(['t', 'i', 'animal'])
+    return df

--- a/lsms_library/countries/Nigeria/_/categorical_mapping.org
+++ b/lsms_library/countries/Nigeria/_/categorical_mapping.org
@@ -721,3 +721,63 @@
 |    6 | Pesticide                  | pesticide         | pesticide         | pesticide           | pesticide          | pesticide          |
 |    7 | Herbicide                  | herbicide         | herbicide         | herbicide           | herbicide          | herbicide          |
 |    8 | Animal Traction            | animal traction   | animal traction   | animal traction     | animal traction    | animal traction    |
+
+* Livestock (livestock, GAP 4)
+
+** harmonize_species -- animal identity (the livestock `animal` axis)
+
+  The livestock feature's ``animal`` index level carries the ``Preferred
+  Label`` from this table.  The country-level ``_/livestock.py`` script
+  resolves each wave's native animal code (101--123, a single STABLE
+  scheme across all five GHS-Panel waves) to the Preferred Label directly
+  (mirroring how crop_production resolves crops via harmonize_food and
+  plot_inputs resolves inputs via harmonize_input), so this table is the
+  canonical REGISTRY for the cross-wave animal taxonomy.
+
+  Two label granularities, both retained as columns:
+  - ``Preferred Label`` keeps the ITEM as the survey records it -- the
+    cattle life-stages (Calf-Female / Calf-Male / Heifer / Steer / Cow /
+    Bull / Ox) and the chicken types (Chicken-Layer / Chicken-Local /
+    Chicken-Broiler / Chicken-Cockerel) stay DISTINCT, because each is a
+    separately-reported herd row for a household.  Collapsing them would
+    fold several reported (i, animal) rows into one index tuple and
+    destroy item-level detail (the whole point of going richer than the
+    WB single engaged-y/n binary).  This is the ``animal`` index value.
+  - ``Species`` is the canonical biological-species rollup (Cattle /
+    Donkeys / Horses / Goats / Sheep / Pigs / Poultry / Rabbits / Fish /
+    Camels / Other), where the cross-life-stage / cross-breed variation
+    is unimportant.  It is NOT an index level -- a downstream tlu /
+    herd-aggregation transformation groups the item rows by Species.
+
+  Code 123 (Other-Specify) maps to Preferred Label "Other Livestock"
+  (Species "Other").  ``v`` is NOT joined (livestock is in the framework
+  ``_no_v_join`` set -- the grain is (t, i, animal)).  The per-wave
+  columns record the native decoded animal label; ``---`` means the wave
+  does not enumerate that animal (W4/W5 dropped Rabbit 119 and Fish 121).
+
+#+NAME: harmonize_species
+| Code | Preferred Label | Species  | 2010-11         | 2012-13         | 2015-16            | 2018-19            | 2023-24            |
+|------+-----------------+----------+-----------------+-----------------+--------------------+--------------------+--------------------|
+|  101 | Calf-Female     | Cattle   | calf female     | CALF FEMALE     | 101. CALF FEMALE   | 101. CALF FEMALE   | 101. CALF FEMALE   |
+|  102 | Calf-Male       | Cattle   | calf male       | CALF MALE       | 102. CALF MALE     | 102. CALF MALE     | 102. CALF MALE     |
+|  103 | Heifer          | Cattle   | heifer          | HEIFER          | 103. HEIFER        | 103. HEIFER        | 103. HEIFER        |
+|  104 | Steer           | Cattle   | steer           | STEER           | 104. STEER         | 104. STEER         | 104. STEER         |
+|  105 | Cow             | Cattle   | cow             | COW             | 105. COW           | 105. COW           | 105. COW           |
+|  106 | Bull            | Cattle   | bull            | BULL            | 106. BULL          | 106. BULL          | 106. BULL          |
+|  107 | Ox              | Cattle   | ox              | OX              | 107. OX            | 107. OX            | 107. OX            |
+|  108 | Donkey          | Donkeys  | donkey          | DONKEY          | 108. DONKEY        | 108. DONKEY        | 108. DONKEY        |
+|  109 | Horse           | Horses   | horse           | HORSE           | 109. HORSE         | 109. HORSE         | 109. HORSE         |
+|  110 | Goat            | Goats    | goat            | GOAT            | 110. GOAT          | 110. GOAT          | 110. GOAT          |
+|  111 | Sheep           | Sheep    | sheep           | SHEEP           | 111. SHEEP         | 111. SHEEP         | 111. SHEEP         |
+|  112 | Pig             | Pigs     | pig             | PIG             | 112. PIG           | 112. PIG           | 112. PIG           |
+|  113 | Chicken-Layer   | Poultry  | chicken-layer   | CHICKEN-LAYER   | 113. CHICKEN-LAYER | 113. CHICKEN-LAYER | 113. CHICKEN-LAYER |
+|  114 | Chicken-Local   | Poultry  | chicken-local   | CHICKEN-LOCAL   | 114. CHICKEN-LOCAL | 114. CHICKEN-LOCAL | 114. CHICKEN-LOCAL |
+|  115 | Chicken-Broiler | Poultry  | chicken-broiler | CHICKEN-BROILER | 115. CHICKEN-BROILER | 115. CHICKEN-BROILER | 115. CHICKEN-BROILER |
+|  116 | Chicken-Cockerel| Poultry  | chicken-cockery | CHICKEN-COCKERY | 116. CHICKEN-COCKERY | 116. CHICKEN-COCKERY | 116. CHICKEN-COCKEREL |
+|  117 | Turkey          | Poultry  | turkey          | TURKEY          | 117. TURKEY        | 117. TURKEY        | 117. TURKEY        |
+|  118 | Duck            | Poultry  | duck            | DUCK            | 118. DUCK          | 118. DUCK          | 118. DUCK          |
+|  119 | Rabbit          | Rabbits  | rabbit          | RABBIT          | 119. RABBIT        | ---                | ---                |
+|  120 | Guinea Fowl     | Poultry  | guinea fowl     | GUINEA FOWL     | 120. GUINEA FOWL   | 120. GUINEA FOWL   | 120. GUINEA FOWL   |
+|  121 | Fish            | Fish     | fish            | FISH            | 121. FISH          | ---                | ---                |
+|  122 | Camel           | Camels   | camel           | CAMEL           | 122. CAMEL         | 122. CAMEL         | 122. CAMEL         |
+|  123 | Other Livestock | Other    | other (specify) | OTHER (SPECIFY) | 123. OTHER (SPECIFY) | 123. OTHER (SPECIFY) | 123. OTHER (SPECIFY) |

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -189,4 +189,42 @@ Data Scheme:
     Days: int
     materialize: make
 
+  livestock:
+    # Item-level reported livestock holdings (GAP 4) at natural grain
+    # (t, i, animal).  Source: the GHS-Panel livestock roster
+    # sect11i_planting{wN} -- the PRE-collapse roster the WB code reads
+    # then throws away down to a single household engaged-in-livestock
+    # y/n binary (NGA_GHS1.do:992-998 recodes s11iq1 then `collapse
+    # (max) livestock, by(hhid)`).  We keep the roster richer: per-animal
+    # head counts, acquisitions, sales, and reported per-head value.
+    #
+    # Collected in the post-planting round only, so each wave maps to a
+    # single t = PP_QUARTER[wave] (2010Q3 / 2012Q3 / 2015Q3 / 2018Q3 /
+    # 2023Q3), matching plot_features / plot_inputs; hhid aligns via
+    # format_id.  Country-level script (_/livestock.py) resolves each
+    # wave's native animal code (101-123, one stable scheme) to a
+    # harmonize_species Preferred Label and reshapes per wave ->
+    # materialize: make.
+    #
+    # NO `v` level: livestock is in the framework `_no_v_join` set, so the
+    # grain is exactly (t, i, animal) -- no cluster join at API time.
+    #
+    # Stores REPORTED item-level fields ONLY:
+    #   HeadCount      head owned/kept now (s11iq2 W1-W3/W5; s11iq2a W4)
+    #   HeadAcquired   head bought to raise (s11iq10 W1-W4; s11iq17 W5)
+    #   HeadSold       head sold alive      (s11iq16 W1-W4; s11iq23 W5)
+    #   Value          reported reservation value of ONE head -- "if you
+    #                  sold one today, how much would you receive"
+    #                  (s11iq3 W1-W4; s11iq7 W5).  Per-head reported price,
+    #                  NOT a herd-value total and NOT the WB engaged
+    #                  binary.
+    # NO TLU, NO herd-value total, NO engaged-in-livestock binary -- those
+    # are transformations over these rows (their binary = groupby.any()).
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    Value: float
+    materialize: make
+
   nonfood_expenditures: !make

--- a/lsms_library/countries/Nigeria/_/livestock.py
+++ b/lsms_library/countries/Nigeria/_/livestock.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+"""Build item-level livestock for Nigeria GHS-Panel (GAP 4).
+
+Natural grain (t, i, animal): one row per species/herd a household reports
+owning, from the GHS-Panel livestock roster sect11i_planting{wN}.dta.  This
+is the PRE-collapse roster the WB code reads then throws away down to a
+single household engaged-in-livestock y/n binary (NGA_GHS1.do:992-998
+recodes s11iq1 then `collapse (max) livestock, by(hhid)`).  We keep the
+roster richer: per-animal head counts, acquisitions, sales, and the
+reported per-head reservation value.
+
+Stores REPORTED item-level fields ONLY -- HeadCount (owned/kept now),
+HeadAcquired (bought to raise), HeadSold (sold alive), Value (reported
+reservation value of ONE head).  NO TLU, NO herd-value total, NO
+engaged-in-livestock binary (those are transformations over these rows;
+their binary = groupby.any()).
+
+`animal` (index) is the harmonize_species Preferred Label, resolved in
+nigeria.livestock_for_wave from the wave's native animal code (101-123,
+one stable scheme across all five waves).  No `v` level: livestock is in
+the framework `_no_v_join` set, so the grain is exactly (t, i, animal).
+
+Per-wave source structure (livestock roster lives in the post-planting
+round; each wave maps to a single t = PP_QUARTER[wave]):
+
+  W1 2010-11  sect11i_plantingw1   item_cd  ; file already filtered to
+              (Post Planting Wave 1/Agriculture)  owned rows (own=1)
+  W2 2012-13  sect11i_plantingw2   animal_cd; full roster grid, s11iq1 own
+  W3 2015-16  sect11i_plantingw3   animal_cd; full roster grid, s11iq1 own
+  W4 2018-19  sect11i_plantingw4   animal_cd; full grid; kept/owned split:
+              HeadCount=s11iq2a (kept), acquire/sold/value unchanged
+  W5 2023-24  sect11i_plantingw5   animal_cd; already owned rows; renumbered
+              questions (HeadCount s11iq2, acquire s11iq17, sold s11iq23,
+              value s11iq7)
+
+Column-name map (HeadCount | HeadAcquired | HeadSold | Value):
+  W1  s11iq2  | s11iq10 | s11iq16 | s11iq3
+  W2  s11iq2  | s11iq10 | s11iq16 | s11iq3
+  W3  s11iq2  | s11iq10 | s11iq16 | s11iq3
+  W4  s11iq2a | s11iq10 | s11iq16 | s11iq3
+  W5  s11iq2  | s11iq17 | s11iq23 | s11iq7
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import PP_QUARTER, _species_labels, livestock_for_wave
+
+species_labels = _species_labels()
+
+# (wave, file, animal_code, owned, HeadCount, HeadAcquired, HeadSold, Value)
+SPECS = [
+    ('2010-11',
+     '../2010-11/Data/Post Planting Wave 1/Agriculture/sect11i_plantingw1.dta',
+     'item_cd', 's11iq1', 's11iq2', 's11iq10', 's11iq16', 's11iq3'),
+    ('2012-13',
+     '../2012-13/Data/Post Planting Wave 2/Agriculture/sect11i_plantingw2.dta',
+     'animal_cd', 's11iq1', 's11iq2', 's11iq10', 's11iq16', 's11iq3'),
+    ('2015-16',
+     '../2015-16/Data/sect11i_plantingw3.dta',
+     'animal_cd', 's11iq1', 's11iq2', 's11iq10', 's11iq16', 's11iq3'),
+    ('2018-19',
+     '../2018-19/Data/sect11i_plantingw4.dta',
+     'animal_cd', 's11iq1', 's11iq2a', 's11iq10', 's11iq16', 's11iq3'),
+    ('2023-24',
+     '../2023-24/Data/Post Planting Wave 5/Agriculture/sect11i_plantingw5.dta',
+     'animal_cd', 's11iq1', 's11iq2', 's11iq17', 's11iq23', 's11iq7'),
+]
+
+pieces = []
+for (wave, f, code, owned, head_now, head_acq, head_sold, value) in SPECS:
+    t = PP_QUARTER[wave]
+    raw = get_dataframe(f, convert_categoricals=False)
+    pieces.append(livestock_for_wave(
+        t, raw, animal_code=code, owned=owned, head_now=head_now,
+        head_acquired=head_acq, head_sold=head_sold, value=value,
+        species_labels=species_labels))
+
+df = pd.concat(pieces, axis=0)
+df = df.sort_index()
+
+to_parquet(df, '../var/livestock.parquet')

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -679,6 +679,144 @@ def assemble_plot_inputs(t, parts):
 
 
 # ---------------------------------------------------------------------
+# livestock (GAP 4) -- item-level reported livestock holdings
+# ---------------------------------------------------------------------
+#
+# Natural grain (t, i, animal): one row per species/herd a household
+# reports owning, from the GHS-Panel livestock roster sect11i.  This is
+# the PRE-collapse roster the WB code reads then throws away down to a
+# single household engaged-in-livestock y/n binary (NGA_GHS1.do:992-998
+# recodes s11iq1 then `collapse (max) livestock, by(hhid)`).  We keep the
+# roster richer: per-animal head counts, acquisitions, sales, and the
+# reported per-head reservation value.
+#
+# `animal` (index) is the harmonize_species Preferred Label, resolved
+# in-script from the wave's native animal code (101--123, one stable
+# scheme across all five waves), mirroring how crop_production resolves
+# crops via harmonize_food.  No `v` level: livestock is in the framework
+# `_no_v_join` set, so the grain is exactly (t, i, animal).
+#
+# Stores REPORTED item-level fields ONLY:
+#   HeadCount      head owned/kept now (s11iq2 W1-W3; s11iq2a "kept" W4;
+#                  s11iq2 "kept" W5 -- W4/W5 split kept vs owned-subset,
+#                  we carry the primary kept/owned-now count)
+#   HeadAcquired   head bought to raise this period (s11iq10 W1-W4;
+#                  s11iq17 W5)
+#   HeadSold       head sold alive this period (s11iq16 W1-W4; s11iq23 W5)
+#   Value          reported reservation value of ONE head -- "if you sold
+#                  one today, how much would you receive" (s11iq3 W1-W4;
+#                  s11iq7 W5).  This is a per-head reported price, NOT a
+#                  herd-value total and NOT the WB engaged binary; a herd
+#                  value (HeadCount x Value) and TLU are transformations.
+# NO TLU, NO herd-value total, NO engaged-in-livestock binary -- those
+# are transformations over these rows (their binary = groupby.any()).
+#
+# Each wave maps to a single t = PP_QUARTER[wave]: sect11i is collected
+# in the post-planting round only (matching plot_features / plot_inputs;
+# hhid aligns via format_id).
+
+
+def _species_labels():
+    """{int animal_code: Preferred Label} from harmonize_species."""
+    from lsms_library.local_tools import get_categorical_mapping
+    raw = get_categorical_mapping(tablename='harmonize_species',
+                                  idxvars='Code',
+                                  **{'Preferred Label': 'Preferred Label'})
+    out = {}
+    for k, v in raw.items():
+        try:
+            ik = int(k)
+        except (TypeError, ValueError):
+            continue
+        if pd.isna(v) or str(v).strip() in ('', '---'):
+            continue
+        out[ik] = str(v).strip()
+    return out
+
+
+def livestock_for_wave(t, df, animal_code, owned, head_now, head_acquired,
+                       head_sold, value, species_labels, own_yes=1):
+    """Assemble item-level livestock for one Nigeria GHS-Panel wave.
+
+    Parameters
+    ----------
+    t : str
+        PP-quarter wave id (e.g. '2010Q3'), used as the `t` index.
+    df : DataFrame
+        Raw livestock roster (convert_categoricals=False), one row per
+        (household, animal).
+    animal_code : str
+        Column holding the native animal code (101-123).
+    owned : str or None
+        Ownership y/n column (s11iq1).  Rows kept only where this == own_yes
+        (1).  None keeps every row (W1/W5 files are already filtered to
+        owned rows).
+    head_now, head_acquired, head_sold, value : str or None
+        Reported column names for HeadCount / HeadAcquired / HeadSold /
+        Value.  None -> that column is all-NA for the wave.
+    species_labels : dict
+        {int animal_code: Preferred Label} from harmonize_species.
+
+    Returns
+    -------
+    DataFrame indexed by (t, i, animal) with reported numeric columns.
+    Keeps a row when the animal label resolves AND the household reports
+    something for it (any of HeadCount / HeadAcquired / HeadSold / Value
+    non-missing-and-nonzero) so the roster grid's never-owned all-zero
+    rows (W2-W4 enumerate every animal for every HH) do not bloat the
+    feature.  A row with own==yes but all-zero quantities is still kept
+    (the household engaged with that species).
+    """
+    n = len(df)
+    i = df['hhid'].apply(format_id)
+    code = pd.to_numeric(df[animal_code], errors='coerce').astype('Int64')
+    animal = code.map(species_labels).astype('string')
+
+    def num(col):
+        if col is not None and col in df.columns:
+            return pd.to_numeric(df[col], errors='coerce')
+        return pd.Series(pd.NA, index=df.index, dtype='Float64')
+
+    piece = pd.DataFrame({
+        'i': i.values,
+        'animal': animal.values,
+        'HeadCount': num(head_now).astype('Float64').values,
+        'HeadAcquired': num(head_acquired).astype('Float64').values,
+        'HeadSold': num(head_sold).astype('Float64').values,
+        'Value': num(value).astype('Float64').values,
+    }, index=df.index)
+
+    if owned is not None and owned in df.columns:
+        own = pd.to_numeric(df[owned], errors='coerce')
+        piece['_own'] = (own == own_yes).values
+    else:
+        # File already filtered to owned rows.
+        piece['_own'] = True
+
+    piece['t'] = t
+
+    # Keep rows the HH actually engaged with: either flagged owned, or any
+    # reported quantity is non-null and nonzero.  Drop the roster-grid
+    # not-owned all-zero filler rows (W2-W4) and unresolved animal labels.
+    qcols = ['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']
+    has_qty = pd.Series(False, index=piece.index)
+    for c in qcols:
+        v = piece[c]
+        has_qty = has_qty | (v.notna() & (v != 0))
+    keep = piece['animal'].notna() & piece['i'].notna() & (piece['_own'] | has_qty)
+    out = piece[keep].copy()
+
+    # Dedup on the index grain (defensive: a species code can appear twice
+    # for one HH in a malformed roster); keep the first/largest record.
+    out = out.sort_values(['i', 'animal', 'HeadCount'],
+                          ascending=[True, True, False])
+    out = out.drop_duplicates(subset=['t', 'i', 'animal'], keep='first')
+
+    out = out.set_index(['t', 'i', 'animal']).sort_index()
+    return out[['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']]
+
+
+# ---------------------------------------------------------------------
 # food_coping (#332, Family B: coping-strategies / rCSI)
 # ---------------------------------------------------------------------
 #

--- a/lsms_library/countries/Tanzania/2019-20/_/livestock.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/livestock.py
@@ -1,0 +1,31 @@
+"""livestock for Tanzania NPS 2019-20 (NPS-SDD, Extended Panel;
+parity-loop GAP 4).
+
+Item-level herd at grain (t, i, animal) from the livestock roster LF_SEC_02
+(one row per (household, lvstckid)).  We keep only OWNED rows (lf02_01 == 1),
+resolve lvstckid -> canonical species via harmonize_species, and carry the
+reported head counts:
+  HeadCount    = lf02_04_1 (indigenous) + lf02_04_2 (improved/exotic)
+  HeadAcquired = lf02_07  (bought alive in past 12 months)
+  HeadSold     = lf02_25  (sold alive in past 12 months)
+Emits raw sdd_hhid as ``i``; the country-level concatenator applies id_walk.
+'livestock' is in the framework _no_v_join set, so NO v level is joined.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import livestock_for_wave
+
+
+lf = get_dataframe('../Data/LF_SEC_02.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='sdd_hhid', animal='lvstckid', own='lf02_01',
+    owned=['lf02_04_1', 'lf02_04_2'], bought='lf02_07', sold='lf02_25',
+    species_col='2019-20')
+
+df = livestock_for_wave('2019-20', lf, colmap)
+assert df.index.is_unique, "livestock 2019-20: (t,i,animal) not unique"
+assert len(df) > 0
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Tanzania/2020-21/_/livestock.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/livestock.py
@@ -1,0 +1,31 @@
+"""livestock for Tanzania NPS 2020-21 (NPS Y5 Refresh Panel;
+parity-loop GAP 4).
+
+Item-level herd at grain (t, i, animal) from the livestock roster lf_sec_02
+(one row per (household, lvstckid)).  We keep only OWNED rows (lf02_01 == 1),
+resolve lvstckid -> canonical species via harmonize_species, and carry the
+reported head counts:
+  HeadCount    = lf02_04_1 (indigenous) + lf02_04_2 (improved/exotic)
+  HeadAcquired = lf02_07  (bought alive in past 12 months)
+  HeadSold     = lf02_25  (sold alive in past 12 months)
+Emits raw y5_hhid as ``i``; the country-level concatenator applies id_walk.
+'livestock' is in the framework _no_v_join set, so NO v level is joined.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import livestock_for_wave
+
+
+lf = get_dataframe('../Data/lf_sec_02.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='y5_hhid', animal='lvstckid', own='lf02_01',
+    owned=['lf02_04_1', 'lf02_04_2'], bought='lf02_07', sold='lf02_25',
+    species_col='2020-21')
+
+df = livestock_for_wave('2020-21', lf, colmap)
+assert df.index.is_unique, "livestock 2020-21: (t,i,animal) not unique"
+assert len(df) > 0
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Tanzania/_/Makefile
+++ b/lsms_library/countries/Tanzania/_/Makefile
@@ -84,6 +84,15 @@ $(VAR_DIR)/plot_inputs.parquet: plot_inputs.py $(plot_inputs_parquet)
 ../%/_/plot_inputs.parquet:
 	(cd $(@D) && python plot_inputs.py)
 
+livestock = $(shell find $(rounds) -name livestock.py)
+livestock_parquet := $(livestock:.py=.parquet)
+
+$(VAR_DIR)/livestock.parquet: livestock.py $(livestock_parquet)
+	python livestock.py
+
+../%/_/livestock.parquet:
+	(cd $(@D) && python livestock.py)
+
 %.parquet: %.py CONTENTS.org tanzania.py
 	(cd $(@D) && python ./$(<F))
 

--- a/lsms_library/countries/Tanzania/_/categorical_mapping.org
+++ b/lsms_library/countries/Tanzania/_/categorical_mapping.org
@@ -769,3 +769,55 @@
 |      | Organic Fertilizer |      |         |
 |      | Herbicide       |         |         |
 |      | Pesticide       |         |         |
+
+# Livestock species (parity-loop GAP 4 -- the `animal` index level of the
+# `livestock` feature).  The LF_SEC_02 livestock roster records ownership at
+# the (household, lvstckid) grain -- one row per animal TYPE the household was
+# asked about.  This table maps each wave's raw `lvstckid` code to a canonical
+# species/type Preferred Label, which becomes the `animal` index value.
+#
+# It is RICHER than the WB cleaning code, which recodes the own-y/n flag
+# (lf02_01 / s10aq2 / ag10a_02) and collapse(max)es every animal type down to a
+# single household "engaged-in-livestock" binary -- discarding the species,
+# head counts, purchases, sales and values.  Here every owned-species row is
+# kept (their binary = our `groupby(['t','i']).size() > 0`).
+#
+# The cattle sub-types (Bulls / Cows / Steers / Heifers / Male & Female
+# Calves) are kept DISTINCT, matching the questionnaire's own item grain; a
+# coarser "Cattle" rollup is a transformation over these rows, not a stored
+# label.  Codes are stable across waves for 1..14 EXCEPT code 13 (2019-20
+# "HARE" vs 2020-21 "rabbits" -- same family, one label "Rabbits"); the
+# pet/other tail diverges: 2019-20 has 15=DOGS, 16=OTHER; 2020-21 has 15=dogs,
+# 16=cats, 17=other.  Only 2019-20 / 2020-21 are buildable (the 2008-15
+# multi-round folder has no livestock source on disk -- same deferral as
+# plot_features / crop_production / plot_inputs, GH #167); the SEC_10A
+# (2008-09) / AG_SEC10A (2010-11) rosters are documented in the comment but
+# have no code column here because their .dta is not present.
+#
+# DOGS / CATS / OTHER are pets, NOT livestock: their Preferred Label is blank
+# (-> pd.NA), so `_map_plot_codes` drops them and they never become `animal`
+# rows -- mirroring the WB `drop if inlist(animal, 15, 16)` exclusion and
+# keeping our distinct livestock-owning-HH count comparable to their binary.
+# The wave-script resolves each wave's RAW lvstckid through that wave's own
+# code column (NOT the canonical Code), so the 13/15/16/17 divergence is
+# handled without fabricating a cross-wave code identity.
+#+name: harmonize_species
+| Code | Preferred Label | 2019-20 | 2020-21 |
+|------+-----------------+---------+---------|
+| 1    | Bulls           | 1       | 1       |
+| 2    | Cows            | 2       | 2       |
+| 3    | Steers          | 3       | 3       |
+| 4    | Heifers         | 4       | 4       |
+| 5    | Male Calves     | 5       | 5       |
+| 6    | Female Calves   | 6       | 6       |
+| 7    | Goats           | 7       | 7       |
+| 8    | Sheep           | 8       | 8       |
+| 9    | Pigs            | 9       | 9       |
+| 10   | Chickens        | 10      | 10      |
+| 11   | Ducks           | 11      | 11      |
+| 12   | Other Poultry   | 12      | 12      |
+| 13   | Rabbits         | 13      | 13      |
+| 14   | Donkeys         | 14      | 14      |
+| 15   |                 | 15      | 15      |
+| 16   |                 | 16      | 16      |
+| 17   |                 |         | 17      |

--- a/lsms_library/countries/Tanzania/_/data_scheme.yml
+++ b/lsms_library/countries/Tanzania/_/data_scheme.yml
@@ -183,3 +183,44 @@ Data Scheme:
     Quantity_purchased: float
     Improved: bool
     materialize: make
+
+  livestock:
+    # Item-level livestock herd (parity-loop GAP 4) at the natural grain
+    # (t, i, animal) -- one row per species/animal-type the household OWNS,
+    # from the livestock roster LF_SEC_02 (one source row per (household,
+    # lvstckid)).  RICHER than the WB cleaning code, which recodes the own-y/n
+    # flag (lf02_01 / s10aq2 / ag10a_02) and collapse(max)es every animal type
+    # down to a single household "engaged-in-livestock" BINARY -- discarding
+    # species, head counts, purchases and sales.  Their binary is recoverable
+    # as a transformation: livestock.groupby(['t','i']).size() > 0.
+    #   animal : canonical species/type Preferred Label from harmonize_species
+    #            (Bulls / Cows / Steers / Heifers / Male & Female Calves / Goats
+    #            / Sheep / Pigs / Chickens / Ducks / Other Poultry / Rabbits /
+    #            Donkeys).  Cattle sub-types are kept DISTINCT (the
+    #            questionnaire's own item grain); a coarser "Cattle" rollup and
+    #            a TLU index are transformations, NOT stored labels.  Pets
+    #            (Dogs / Cats / Other) are dropped, mirroring the WB
+    #            drop-if-inlist(animal, 15, 16) exclusion.
+    #   HeadCount    : currently owned = lf02_04_1 (indigenous) + lf02_04_2
+    #                  (improved/exotic).  Reported current stock.
+    #   HeadAcquired : bought alive in the past 12 months (lf02_07) -- the
+    #                  directly-reported acquisition flow that parallels
+    #                  HeadSold; births (lf02_05) / gifts (lf02_10) are separate
+    #                  reported flows, NOT summed in.
+    #   HeadSold     : sold alive in the past 12 months (lf02_25).
+    # A herd VALUE column is omitted: the NPS livestock module records no
+    # current-herd valuation (only transaction values lf02_08 purchase /
+    # lf02_26 sale), so carrying Value all-null would fail the
+    # no_all_null_columns sanity check -- the same discipline crop_production
+    # uses for the absent planting_month.
+    # Only 2019-20 (NPS-SDD Extended Panel) and 2020-21 (NPS Y5 Refresh Panel)
+    # are buildable; the 2008-15 multi-round folder has no livestock source on
+    # disk (same deferral as plot_features / crop_production / plot_inputs,
+    # GH #167).
+    # NO v level: 'livestock' is in the framework _no_v_join set, so the grain
+    # stays (t, i, animal) -- the framework does not join a cluster v.
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    materialize: make

--- a/lsms_library/countries/Tanzania/_/livestock.py
+++ b/lsms_library/countries/Tanzania/_/livestock.py
@@ -1,0 +1,46 @@
+"""Concatenate wave-level livestock data for Tanzania NPS
+(parity-loop GAP 4).
+
+Each buildable wave's ``Tanzania/<wave>/_/livestock.py`` produces a parquet
+with index ``(t, i, animal)`` and the canonical reported columns from
+data_scheme.yml (HeadCount, HeadAcquired, HeadSold).  This script concatenates
+the per-wave parquets and applies cross-wave id_walk so the household index
+uses the panel canonical id scheme.
+
+Only 2019-20 (NPS-SDD Extended Panel) and 2020-21 (NPS Y5 Refresh Panel) are
+buildable: the 2008-15 multi-round folder has no livestock source file on disk
+(only the household upd4_hh_* modules), so those four NPS rounds are deferred
+-- exactly as for plot_features / crop_production / plot_inputs (GH #167).
+
+'livestock' is in the framework _no_v_join set, so the framework joins NO v
+cluster level: the API grain stays (t, i, animal).
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import id_walk
+
+
+WAVES = ['2019-20', '2020-21']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/livestock.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built.  DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "livestock: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids, hh_index='i')
+
+to_parquet(p, '../var/livestock.parquet')

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -1213,3 +1213,139 @@ def plot_inputs_for_wave(t, sec3a, sec4a, colmap):
         })
     df = df[PLOT_INPUTS_COLUMNS]
     return df
+
+
+# Livestock feature (parity-loop GAP 4).  Item-level herd at the natural grain
+# (t, i, animal) -- one row per species/animal-type the household OWNS --
+# carrying ONLY reported survey fields.  No TLU, no herd-value total, no
+# engaged-in-livestock binary: those are transformations over these rows (the
+# WB binary = our ``groupby(['t','i']).size() > 0``).
+#
+# 'livestock' is in the framework ``_no_v_join`` set, so the grain is (t, i,
+# animal) with NO ``v`` cluster level joined.
+LIVESTOCK_COLUMNS = ['HeadCount', 'HeadAcquired', 'HeadSold']
+# NB: a herd VALUE column is part of the GAP-4 schema "where the source reports
+# it", but the Tanzania NPS livestock module (LF_SEC_02) records no current-
+# herd valuation -- only purchase value (lf02_08), sale value (lf02_26) and
+# loss values, each a transaction value, not a stock value.  So Value is
+# omitted here rather than carried all-null (which fails the
+# no_all_null_columns sanity check) -- the same discipline crop_production uses
+# for the absent planting_month.  A purchase/sale value is recoverable as a
+# transformation over HeadAcquired / HeadSold should a valuation be wanted.
+
+
+# Plausibility ceiling for a 12-month head-count FLOW (bought / sold).  The
+# largest legitimate flow observed is ~2500 head (a poultry operation); two
+# rows carry an obvious data-entry error where the TSH value was typed into the
+# count field (2019-20: HH 0525-001-001 "bought 324000" == its 324000-TSH
+# purchase value; 2020-21: HH 3722-001-01 "sold 100000" of its 10 owned
+# chickens for 10 TSH).  Clamp flows above 50000 to NaN -- well above any
+# plausible smallholder flow, so only the corrupt entries are dropped.  This is
+# the same plausibility-clamp discipline plot_features uses for >2500-acre
+# parcels (GH #167).
+_LIVESTOCK_FLOW_CEILING = 50000
+
+
+def _livestock_count(series, ceiling=None):
+    """Coerce a reported head-count column to nullable Float64 (>=0; negatives
+    -> NaN).  When ``ceiling`` is given, values above it (data-entry errors
+    where a TSH value landed in the count field) are also set to NaN."""
+    v = pd.to_numeric(series, errors='coerce').astype('Float64')
+    v = v.where(v >= 0, pd.NA)
+    if ceiling is not None:
+        v = v.where(v <= ceiling, pd.NA)
+    return v
+
+
+def livestock_for_wave(t, lf, colmap):
+    """Build canonical ``livestock`` for one Tanzania NPS wave.
+
+    The livestock roster (LF_SEC_02 in 2019-20 / 2020-21) is at the
+    (household, lvstckid) grain -- one row per animal TYPE the household was
+    asked about.  We keep ONLY the rows the household actually OWNS
+    (``lf02_01`` == 1), so the emitted grain is one row per (household, owned
+    species).  Each raw ``lvstckid`` is resolved to a canonical species
+    Preferred Label via this wave's column of the ``harmonize_species``
+    categorical table; pets (Dogs / Cats / Other -> blank label -> NaN) are
+    dropped, mirroring the WB ``drop if inlist(animal, 15, 16)``.
+
+    Reported item-level fields carried (NO aggregation):
+      HeadCount    -- currently owned = lf02_04_1 (indigenous) + lf02_04_2
+                      (improved/exotic).  Reported current stock.
+      HeadAcquired -- bought alive in the past 12 months (lf02_07).  The
+                      directly-reported acquisition flow that parallels
+                      HeadSold; births (lf02_05) and gifts received (lf02_10)
+                      are separate reported flows, NOT summed in here.
+      HeadSold     -- sold alive in the past 12 months (lf02_25).
+
+    Parameters
+    ----------
+    t : str          wave id ('2019-20' or '2020-21'); the ``t`` value.
+    lf : pd.DataFrame
+        raw LF_SEC_02 frame (convert_categoricals=False, so lvstckid carries
+        the integer code).
+    colmap : dict with keys
+        hhid    -- household id column (sdd_hhid / y5_hhid)
+        animal  -- animal-type code column (lvstckid)
+        own     -- own-y/n flag           (lf02_01; 1=yes, 2=no)
+        owned   -- [indigenous, improved] current-stock columns
+                   (['lf02_04_1', 'lf02_04_2'])
+        bought  -- head bought alive      (lf02_07)
+        sold    -- head sold alive        (lf02_25)
+        species_col -- this wave's column name in harmonize_species
+                       ('2019-20' / '2020-21')
+
+    Returns
+    -------
+    pd.DataFrame indexed by (t, i, animal) with columns LIVESTOCK_COLUMNS.
+    Emits raw hhid as ``i``; the country-level concatenator applies id_walk.
+    """
+    c = colmap
+    species_map = _plot_harmonized_codes('harmonize_species',
+                                         value='Preferred Label')
+    # _plot_harmonized_codes keys on the canonical 'Code' column, but the raw
+    # lvstckid uses this wave's own code column; for Tanzania the two coincide
+    # for every species we keep (1..14) and the divergent pet/other tail maps
+    # to NA either way -- but resolve through the wave column to be exact.
+    from lsms_library.local_tools import get_categorical_mapping
+    raw = get_categorical_mapping(tablename='harmonize_species',
+                                  idxvars=c['species_col'],
+                                  **{'Preferred Label': 'Preferred Label'})
+    species_map = {}
+    for k, v in raw.items():
+        try:
+            k = int(k)
+        except (TypeError, ValueError):
+            pass
+        species_map[k] = (pd.NA if (pd.isna(v) or str(v).strip() in ('', '---'))
+                          else str(v).strip())
+
+    out = pd.DataFrame(index=lf.index)
+    out['i'] = lf[c['hhid']].apply(format_id)
+    out['animal'] = _map_plot_codes(lf[c['animal']], species_map)
+
+    owned = lf[c['owned']].apply(pd.to_numeric, errors='coerce')
+    head = owned.sum(axis=1, min_count=1).astype('Float64')
+    out['HeadCount'] = head.where((head >= 0) & (head <= _LIVESTOCK_FLOW_CEILING),
+                                  pd.NA)
+    out['HeadAcquired'] = _livestock_count(lf[c['bought']],
+                                           ceiling=_LIVESTOCK_FLOW_CEILING)
+    out['HeadSold'] = _livestock_count(lf[c['sold']],
+                                       ceiling=_LIVESTOCK_FLOW_CEILING)
+
+    own = pd.to_numeric(lf[c['own']], errors='coerce')
+
+    # Keep only OWNED rows (own-flag == yes) with a resolvable species label.
+    out = out[(own == 1) & out['animal'].notna()].copy()
+
+    out['t'] = t
+    out = out.set_index(['t', 'i', 'animal'])
+    # Guard against a duplicated (t,i,animal): sum reported head counts.
+    if not out.index.is_unique:
+        out = out.groupby(level=['t', 'i', 'animal']).agg({
+            'HeadCount': lambda s: s.sum(min_count=1),
+            'HeadAcquired': lambda s: s.sum(min_count=1),
+            'HeadSold': lambda s: s.sum(min_count=1),
+        })
+    out = out[LIVESTOCK_COLUMNS]
+    return out

--- a/lsms_library/countries/Uganda/2009-10/_/livestock.py
+++ b/lsms_library/countries/Uganda/2009-10/_/livestock.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""livestock for Uganda UNPS 2009-10 (GAP 4 item-level build).
+
+Reads the livestock roster (AGSEC6A large ruminants / AGSEC6B small ruminants
+/ AGSEC6C poultry & other) via get_dataframe and emits a canonical
+(t, i, animal) parquet of REPORTED head counts / acquired / sold / per-head
+value.  This is the PRE-collapse roster the WB code (UGA_UNPS1.do:710-720)
+reads only to build a single engaged-livestock binary.
+
+2009-10 carries the animal type as a label STRING (no integer codes), so each
+section is loaded with convert_categoricals=True; livestock_for_wave maps the
+strings to canonical species via uganda._species_string_map().
+See uganda.LIVESTOCK_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import livestock_for_wave, LIVESTOCK_COLMAPS
+
+t = '2009-10'
+colmap = LIVESTOCK_COLMAPS[t]
+
+
+def _load(path, section):
+    cats = colmap.get(section, {}).get('type_kind') == 'string'
+    try:
+        return get_dataframe(path, convert_categoricals=cats)
+    except Exception:
+        return None
+
+
+df6a = _load('../Data/AGSEC6A.dta', 'A')
+df6b = _load('../Data/AGSEC6B.dta', 'B')
+df6c = _load('../Data/AGSEC6C.dta', 'C')
+
+df = livestock_for_wave(t, df6a, df6b, df6c, colmap)
+assert len(df) > 0, f"livestock produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique livestock index for {t}"
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Uganda/2010-11/_/livestock.py
+++ b/lsms_library/countries/Uganda/2010-11/_/livestock.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""livestock for Uganda UNPS 2010-11 (GAP 4 item-level build).
+
+Reads the livestock roster (AGSEC6A large ruminants / AGSEC6B small ruminants
+/ AGSEC6C poultry & other) via get_dataframe and emits a canonical
+(t, i, animal) parquet of REPORTED head counts / acquired / sold / per-head
+value.  This is the PRE-collapse roster the WB code (UGA_UNPS1.do:710-720)
+reads only to build a single engaged-livestock binary.
+
+The animal type is integer-coded here, so sections are loaded with
+convert_categoricals=False; livestock_for_wave maps the codes to canonical
+species via the harmonize_species categorical table (with the 2010-11 6B
+code_overrides where that wave's scheme diverges).  See
+uganda.LIVESTOCK_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import livestock_for_wave, LIVESTOCK_COLMAPS
+
+t = '2010-11'
+colmap = LIVESTOCK_COLMAPS[t]
+
+
+def _load(path, section):
+    cats = colmap.get(section, {}).get('type_kind') == 'string'
+    try:
+        return get_dataframe(path, convert_categoricals=cats)
+    except Exception:
+        return None
+
+
+df6a = _load('../Data/AGSEC6A.dta', 'A')
+df6b = _load('../Data/AGSEC6B.dta', 'B')
+df6c = _load('../Data/AGSEC6C.dta', 'C')
+
+df = livestock_for_wave(t, df6a, df6b, df6c, colmap)
+assert len(df) > 0, f"livestock produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique livestock index for {t}"
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Uganda/2011-12/_/livestock.py
+++ b/lsms_library/countries/Uganda/2011-12/_/livestock.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""livestock for Uganda UNPS 2011-12 (GAP 4 item-level build).
+
+Reads the livestock roster (AGSEC6A large ruminants / AGSEC6B small ruminants
+/ AGSEC6C poultry & other) via get_dataframe and emits a canonical
+(t, i, animal) parquet of REPORTED head counts / acquired / sold / per-head
+value.  This is the PRE-collapse roster the WB code (UGA_UNPS1.do:710-720)
+reads only to build a single engaged-livestock binary.
+
+The animal type is integer-coded here, so sections are loaded with
+convert_categoricals=False; livestock_for_wave maps the codes to canonical
+species via the harmonize_species categorical table (with the 2010-11 6B
+code_overrides where that wave's scheme diverges).  See
+uganda.LIVESTOCK_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import livestock_for_wave, LIVESTOCK_COLMAPS
+
+t = '2011-12'
+colmap = LIVESTOCK_COLMAPS[t]
+
+
+def _load(path, section):
+    cats = colmap.get(section, {}).get('type_kind') == 'string'
+    try:
+        return get_dataframe(path, convert_categoricals=cats)
+    except Exception:
+        return None
+
+
+df6a = _load('../Data/AGSEC6A.dta', 'A')
+df6b = _load('../Data/AGSEC6B.dta', 'B')
+df6c = _load('../Data/AGSEC6C.dta', 'C')
+
+df = livestock_for_wave(t, df6a, df6b, df6c, colmap)
+assert len(df) > 0, f"livestock produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique livestock index for {t}"
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Uganda/2013-14/_/livestock.py
+++ b/lsms_library/countries/Uganda/2013-14/_/livestock.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""livestock for Uganda UNPS 2013-14 (GAP 4 item-level build).
+
+Reads the livestock roster (AGSEC6A large ruminants / AGSEC6B small ruminants
+/ AGSEC6C poultry & other) via get_dataframe and emits a canonical
+(t, i, animal) parquet of REPORTED head counts / acquired / sold / per-head
+value.  This is the PRE-collapse roster the WB code (UGA_UNPS1.do:710-720)
+reads only to build a single engaged-livestock binary.
+
+The animal type is integer-coded here, so sections are loaded with
+convert_categoricals=False; livestock_for_wave maps the codes to canonical
+species via the harmonize_species categorical table (with the 2010-11 6B
+code_overrides where that wave's scheme diverges).  See
+uganda.LIVESTOCK_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import livestock_for_wave, LIVESTOCK_COLMAPS
+
+t = '2013-14'
+colmap = LIVESTOCK_COLMAPS[t]
+
+
+def _load(path, section):
+    cats = colmap.get(section, {}).get('type_kind') == 'string'
+    try:
+        return get_dataframe(path, convert_categoricals=cats)
+    except Exception:
+        return None
+
+
+df6a = _load('../Data/AGSEC6A.dta', 'A')
+df6b = _load('../Data/AGSEC6B.dta', 'B')
+df6c = _load('../Data/AGSEC6C.dta', 'C')
+
+df = livestock_for_wave(t, df6a, df6b, df6c, colmap)
+assert len(df) > 0, f"livestock produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique livestock index for {t}"
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Uganda/2015-16/_/livestock.py
+++ b/lsms_library/countries/Uganda/2015-16/_/livestock.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""livestock for Uganda UNPS 2015-16 (GAP 4 item-level build).
+
+Reads the livestock roster (AGSEC6A large ruminants / AGSEC6B small ruminants
+/ AGSEC6C poultry & other) via get_dataframe and emits a canonical
+(t, i, animal) parquet of REPORTED head counts / acquired / sold / per-head
+value.  This is the PRE-collapse roster the WB code (UGA_UNPS1.do:710-720)
+reads only to build a single engaged-livestock binary.
+
+The animal type is integer-coded here, so sections are loaded with
+convert_categoricals=False; livestock_for_wave maps the codes to canonical
+species via the harmonize_species categorical table (with the 2010-11 6B
+code_overrides where that wave's scheme diverges).  See
+uganda.LIVESTOCK_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import livestock_for_wave, LIVESTOCK_COLMAPS
+
+t = '2015-16'
+colmap = LIVESTOCK_COLMAPS[t]
+
+
+def _load(path, section):
+    cats = colmap.get(section, {}).get('type_kind') == 'string'
+    try:
+        return get_dataframe(path, convert_categoricals=cats)
+    except Exception:
+        return None
+
+
+df6a = _load('../Data/AGSEC6A.dta', 'A')
+df6b = _load('../Data/AGSEC6B.dta', 'B')
+df6c = _load('../Data/AGSEC6C.dta', 'C')
+
+df = livestock_for_wave(t, df6a, df6b, df6c, colmap)
+assert len(df) > 0, f"livestock produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique livestock index for {t}"
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Uganda/2018-19/_/livestock.py
+++ b/lsms_library/countries/Uganda/2018-19/_/livestock.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""livestock for Uganda UNPS 2018-19 (GAP 4 item-level build).
+
+Reads the livestock roster (AGSEC6A large ruminants / AGSEC6B small ruminants
+/ AGSEC6C poultry & other) via get_dataframe and emits a canonical
+(t, i, animal) parquet of REPORTED head counts / acquired / sold / per-head
+value.  This is the PRE-collapse roster the WB code (UGA_UNPS1.do:710-720)
+reads only to build a single engaged-livestock binary.
+
+The animal type is integer-coded here, so sections are loaded with
+convert_categoricals=False; livestock_for_wave maps the codes to canonical
+species via the harmonize_species categorical table (with the 2010-11 6B
+code_overrides where that wave's scheme diverges).  See
+uganda.LIVESTOCK_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import livestock_for_wave, LIVESTOCK_COLMAPS
+
+t = '2018-19'
+colmap = LIVESTOCK_COLMAPS[t]
+
+
+def _load(path, section):
+    cats = colmap.get(section, {}).get('type_kind') == 'string'
+    try:
+        return get_dataframe(path, convert_categoricals=cats)
+    except Exception:
+        return None
+
+
+df6a = _load('../Data/AGSEC6A.dta', 'A')
+df6b = _load('../Data/AGSEC6B.dta', 'B')
+df6c = _load('../Data/AGSEC6C.dta', 'C')
+
+df = livestock_for_wave(t, df6a, df6b, df6c, colmap)
+assert len(df) > 0, f"livestock produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique livestock index for {t}"
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Uganda/2019-20/_/livestock.py
+++ b/lsms_library/countries/Uganda/2019-20/_/livestock.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""livestock for Uganda UNPS 2019-20 (GAP 4 item-level build).
+
+Reads the livestock roster (agsec6a large ruminants / agsec6b small ruminants
+/ agsec6c poultry & other, under Data1/Agric/) via get_dataframe and emits a
+canonical (t, i, animal) parquet of REPORTED head counts / acquired / sold /
+per-head value.  This is the PRE-collapse roster the WB code reads only to
+build a single engaged-livestock binary.
+
+The animal type is integer-coded here (codes 1-27, same scheme as 2011-12+),
+so sections are loaded with convert_categoricals=False and mapped to canonical
+species via the harmonize_species categorical table.  See
+uganda.LIVESTOCK_COLMAPS for the per-wave column map.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import livestock_for_wave, LIVESTOCK_COLMAPS
+
+t = '2019-20'
+colmap = LIVESTOCK_COLMAPS[t]
+
+
+def _load(path, section):
+    cats = colmap.get(section, {}).get('type_kind') == 'string'
+    try:
+        return get_dataframe(path, convert_categoricals=cats)
+    except Exception:
+        return None
+
+
+df6a = _load('../Data1/Agric/agsec6a.dta', 'A')
+df6b = _load('../Data1/Agric/agsec6b.dta', 'B')
+df6c = _load('../Data1/Agric/agsec6c.dta', 'C')
+
+df = livestock_for_wave(t, df6a, df6b, df6c, colmap)
+assert len(df) > 0, f"livestock produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique livestock index for {t}"
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Uganda/_/Makefile
+++ b/lsms_library/countries/Uganda/_/Makefile
@@ -25,6 +25,7 @@ var = $(VAR_DIR)/shocks.parquet $(VAR_DIR)/nonfood_expenditures.parquet $(VAR_DI
 	  $(VAR_DIR)/plot_features.parquet \
 	  $(VAR_DIR)/crop_production.parquet \
 	  $(VAR_DIR)/plot_inputs.parquet \
+	  $(VAR_DIR)/livestock.parquet \
 	  $(VAR_DIR)/months_food_inadequate.parquet
 
 all: $(parquet) $(var)
@@ -94,6 +95,12 @@ plot_inputs_parquet := $(plot_inputs:.py=.parquet)
 
 $(VAR_DIR)/plot_inputs.parquet: plot_inputs.py $(plot_inputs_parquet)
 	python plot_inputs.py
+
+livestock = $(shell find $(rounds) -name livestock.py)
+livestock_parquet := $(livestock:.py=.parquet)
+
+$(VAR_DIR)/livestock.parquet: livestock.py $(livestock_parquet)
+	python livestock.py
 
 months_food_inadequate = $(shell find $(rounds) -name months_food_inadequate.py)
 months_food_inadequate_parquet := $(months_food_inadequate:.py=.parquet)

--- a/lsms_library/countries/Uganda/_/categorical_mapping.org
+++ b/lsms_library/countries/Uganda/_/categorical_mapping.org
@@ -878,3 +878,71 @@
 |------+-----------------|
 |    1 | Kg              |
 |    2 | Litre           |
+
+# harmonize_species: livestock animal-type Code -> canonical species Preferred
+# Label for the livestock feature (GAP 4).  One row per REPORTED species/herd
+# a household owns, ``animal`` axis.  Source: the UNPS livestock roster the WB
+# code (UGA_UNPS1.do:710-720) reads only to collapse to a single engaged-y/n
+# binary; we keep the PRE-collapse roster.  Three roster sections per wave:
+#   AGSEC6A  large ruminants / draft  (cattle, donkeys, horses)   codes 1-12
+#   AGSEC6B  small ruminants          (goats, sheep, pigs)        codes 13-22
+#   AGSEC6C  poultry & other          (chicken, other birds,      codes 23-28
+#            rabbits, bees)                                      (2011-12+);
+#            the 2010-11 AGSEC6C roster uses a SEPARATE 31-42 code block for
+#            the same animals (Rabbits 31, chicken 32-38, turkeys/ducks/geese
+#            39-41, beehives 42) -- both blocks are folded into this one table.
+# The codes carry exotic/cross vs indigenous AND age/sex detail (Calves, Bulls,
+# Oxen, Heifer, Cows; Male/Female goats/sheep; Layers, Broilers, Pullets, ...);
+# that cross-row variation collapses to the SPECIES here -- the exotic/indigenous
+# and age/sex splits are sub-species detail recoverable from the raw codes if
+# needed, but unimportant for the harmonized species axis.  Per-head value and
+# herd value are NOT in this table (Value is a reported column; herd value =
+# Value x HeadCount is a transformation).
+#
+# 2009-10 and the AGSEC6A/6B sections of 2010-11 carry NO integer value labels
+# (the type comes through as a label STRING, e.g. 'Bulls and Oxen', 'Backyard
+# chicke'); uganda._species_string_map() maps those wave-specific strings to the
+# same canonical species, so a single Preferred Label set spans all waves.
+#+name: harmonize_species
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Cattle          |
+|    2 | Cattle          |
+|    3 | Cattle          |
+|    4 | Cattle          |
+|    5 | Cattle          |
+|    6 | Cattle          |
+|    7 | Cattle          |
+|    8 | Cattle          |
+|    9 | Cattle          |
+|   10 | Cattle          |
+|   11 | Donkeys         |
+|   12 | Horses          |
+|   13 | Goats           |
+|   14 | Goats           |
+|   15 | Sheep           |
+|   16 | Sheep           |
+|   17 | Pigs            |
+|   18 | Goats           |
+|   19 | Goats           |
+|   20 | Sheep           |
+|   21 | Sheep           |
+|   22 | Pigs            |
+|   23 | Chicken         |
+|   24 | Chicken         |
+|   25 | Chicken         |
+|   26 | Other Poultry   |
+|   27 | Rabbits         |
+|   28 | Bees            |
+|   31 | Rabbits         |
+|   32 | Chicken         |
+|   33 | Chicken         |
+|   34 | Chicken         |
+|   35 | Chicken         |
+|   36 | Chicken         |
+|   37 | Chicken         |
+|   38 | Chicken         |
+|   39 | Other Poultry   |
+|   40 | Other Poultry   |
+|   41 | Other Poultry   |
+|   42 | Bees            |

--- a/lsms_library/countries/Uganda/_/data_scheme.yml
+++ b/lsms_library/countries/Uganda/_/data_scheme.yml
@@ -172,4 +172,40 @@ Data Scheme:
     Quantity_purchased: float
     Improved: bool
     materialize: make
+  livestock:
+    # Item-level livestock roster (GAP 4 parity build).  One row per
+    # REPORTED species/herd a household owns.  Source: the UNPS livestock
+    # roster (AGSEC6A large ruminants / AGSEC6B small ruminants / AGSEC6C
+    # poultry & other) that the WB code (UGA_UNPS1.do:710-720) reads only
+    # to collapse to a single engaged-livestock y/n binary.  We keep the
+    # PRE-collapse roster -- strictly richer than the WB construct.
+    #
+    # Grain (t, i, animal):
+    #   animal — canonical SPECIES on the 'harmonize_species' Preferred
+    #            Labels: Cattle, Goats, Sheep, Pigs, Donkeys, Horses,
+    #            Chicken, Other Poultry, Rabbits, Bees.  The roster's
+    #            exotic/indigenous and age/sex splits collapse to species
+    #            here (sub-species detail recoverable from raw codes).
+    #
+    # Columns are REPORTED values only (missing-in-wave -> NaN):
+    #   HeadCount     — head owned now
+    #   HeadAcquired  — head bought to raise (last reference period)
+    #   HeadSold      — head sold alive
+    #   Value         — reported per-head animal value ('value if you sold
+    #                   one today' in 2009-10/2010-11; 'average value of
+    #                   each one sold' for 2011-12+, which dropped the
+    #                   sell-today question)
+    # The WB engaged-livestock binary = groupby(['t','i']).any() over these
+    # rows; herd value = Value * HeadCount; TLU = sum(head * TLU-factor).
+    # All three are TRANSFORMATIONS -- never stored here.
+    #
+    # No v level: livestock is in the framework _no_v_join set
+    # (country.py), so the (t, i, animal) grain is final.  2005-06 is
+    # excluded (no canonical AGSEC6 roster; the WB panel starts at 2009-10).
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    Value: float
+    materialize: make
   nonfood_expenditures: !make

--- a/lsms_library/countries/Uganda/_/livestock.py
+++ b/lsms_library/countries/Uganda/_/livestock.py
@@ -1,0 +1,41 @@
+"""Concatenate wave-level livestock data for Uganda (GAP 4).
+
+Each wave's ``Uganda/<wave>/_/livestock.py`` produces a parquet indexed
+``(t, i, animal)`` with the REPORTED livestock columns (HeadCount,
+HeadAcquired, HeadSold, Value).  This script concatenates them across waves
+and applies cross-wave id_walk so the household index uses the panel
+canonical id scheme.
+
+Source: the UNPS livestock roster (AGSEC6A/6B/6C) that the WB code reads
+only to collapse to a single engaged-livestock binary.  2005-06 is
+intentionally absent: it has no AGSEC6C poultry roster in the canonical
+form and the UNPS agriculture panel the WB harmonise effort tracks starts
+at wave 1 = 2009-10.
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import Waves, id_walk
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/livestock.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for livestock (no .py / parquet, e.g. 2005-06).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "livestock: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/livestock.parquet')

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -1454,3 +1454,269 @@ INPUT_COLMAPS = {
                  'qty': 's4aq11a', 'unit': 's4aq11b', 'seed_type': 's4aq13'},
     },
 }
+
+
+# ---------------------------------------------------------------------------
+# livestock  (GAP 4 — item-level livestock roster)
+# ---------------------------------------------------------------------------
+#
+# One row per REPORTED species/herd a household owns, grain (t, i, animal).
+# Source: the UNPS livestock roster (AGSEC6A large ruminants / AGSEC6B small
+# ruminants / AGSEC6C poultry & other) that UGA_UNPS1.do:710-720 reads only to
+# collapse to a single engaged-livestock y/n binary.  We keep the PRE-collapse
+# roster and harmonise the animal type to the canonical SPECIES axis via the
+# harmonize_species table (Code | Preferred Label).
+#
+# Reported item-level columns (missing-in-wave -> NaN):
+#   HeadCount      head owned now              (q5 / q5a / q3a / s..q03a)
+#   HeadAcquired   head bought to raise        (q12 / q13a / s..q13a)
+#   HeadSold       head sold alive             (q14 / q14a / s..q14a)
+#   Value          reported per-head value     (q6 'value if sold one today',
+#                  2009-10/2010-11; q14b 's..q14b' 'avg value of each sold' for
+#                  2011-12+ which dropped the sell-today question)
+# Herd value (= Value x HeadCount), TLU, and the WB engaged-livestock binary
+# (= groupby.any over these rows) are TRANSFORMATIONS, never stored here.
+#
+# Per-wave the animal type lives in different columns and two encodings:
+#   * integer codes 1-42 (2010-11 6B/6C via q3, all of 2011-12+) -> harmonize_species
+#   * label STRINGS (2009-10 all sections; 2010-11 6A q2) -> _species_string_map()
+# The COLMAP 'type' entry names the column; 'type_kind' is 'code' or 'string'.
+
+_SPECIES_TABLE = 'harmonize_species'
+
+
+def _species_code_map():
+    """Code (int 1-42) -> canonical species Preferred Label."""
+    return _harmonized_codes(_SPECIES_TABLE)
+
+
+# 2009-10 (all sections) and 2010-11 AGSEC6A carry the animal type as a label
+# string with NO integer value labels.  Map those wave-specific strings to the
+# same canonical species the integer codes resolve to.  Keys are lower-cased
+# and whitespace-stripped; truncated UNPS strings ('backyard chicke', 'parent
+# stock fo', 'geese and other', 'behives') are included verbatim.
+_SPECIES_STRING_MAP = {
+    # cattle / draft
+    'calves': 'Cattle', 'bulls': 'Cattle', 'oxen': 'Cattle',
+    'bulls and oxen': 'Cattle', 'heifer': 'Cattle', 'cows': 'Cattle',
+    'heifer and cows': 'Cattle',
+    'donkeys': 'Donkeys',
+    'mules / horses': 'Horses', 'mules/horses': 'Horses', 'horses': 'Horses',
+    # small ruminants
+    'male goats': 'Goats', 'female goats': 'Goats',
+    'male sheep': 'Sheep', 'female sheep': 'Sheep',
+    'pigs': 'Pigs',
+    # poultry & other (2009-10 strings, some truncated)
+    'backyard chicke': 'Chicken', 'backyard chicken': 'Chicken',
+    'parent stock fo': 'Chicken', 'parent stock for broilers': 'Chicken',
+    'parent stock for layers': 'Chicken',
+    'layers': 'Chicken', 'pullet chicken': 'Chicken', 'growers': 'Chicken',
+    'broilers': 'Chicken',
+    'turkeys': 'Other Poultry', 'ducks': 'Other Poultry',
+    'geese and other': 'Other Poultry', 'geese and other birds': 'Other Poultry',
+    'rabbits': 'Rabbits',
+    'behives': 'Bees', 'beehives': 'Bees',
+}
+
+
+def _species_string_map():
+    return dict(_SPECIES_STRING_MAP)
+
+
+def livestock_for_wave(t, df6a, df6b, df6c, colmap):
+    """Build canonical ``livestock`` for one Uganda UNPS wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2013-14"``).
+    df6a, df6b, df6c : pd.DataFrame | None
+        Raw AGSEC6A (large ruminants) / AGSEC6B (small ruminants) /
+        AGSEC6C (poultry & other) livestock-roster modules.  ``None``
+        permitted (section absent in a wave).  Code-typed sections must
+        be loaded with ``convert_categoricals=False`` (integer codes);
+        string-typed sections (2009-10, 2010-11 6A) with
+        ``convert_categoricals=True`` (label strings) -- the wave script
+        loads each section with the kind its colmap declares.
+    colmap : dict
+        Per-section column maps keyed by ``'A'`` / ``'B'`` / ``'C'``.  Each
+        value is a dict with keys:
+            hhid       — household id column
+            type       — animal-type column (int code or label string)
+            type_kind  — 'code' (map via harmonize_species) | 'string'
+                         (map via _species_string_map)
+            headcount  — head owned now column (or None)
+            acquired   — head bought column (or None)
+            sold       — head sold column (or None)
+            value      — reported per-head value column (or None)
+
+    Returns
+    -------
+    pd.DataFrame indexed ``(t, i, animal)`` with Float64 columns
+        ``HeadCount``, ``HeadAcquired``, ``HeadSold``, ``Value``.
+        One row per (household, species) -- duplicate species rows within
+        a household (e.g. exotic + indigenous cattle, both mapping to
+        'Cattle') are summed for the head columns and value-weighted-mean
+        for ``Value`` so the (t, i, animal) index is unique.  NO TLU, NO
+        herd-value total, NO engaged binary (all transformations).
+    """
+    code_map = _species_code_map()
+    str_map = _species_string_map()
+
+    pieces = []
+    for section, df6 in (('A', df6a), ('B', df6b), ('C', df6c)):
+        if df6 is None or len(df6) == 0:
+            continue
+        cm = colmap.get(section)
+        if cm is None:
+            continue
+
+        hh = df6[cm['hhid']].apply(format_id)
+
+        # --- resolve canonical species ---
+        tcol = cm['type']
+        if tcol not in df6.columns:
+            continue
+        if cm.get('type_kind') == 'string':
+            keys = df6[tcol].astype('string').str.strip().str.lower()
+            animal = keys.map(lambda s: str_map.get(s, pd.NA) if pd.notna(s) else pd.NA)
+        else:
+            # Per-section integer-code overrides (for waves whose code scheme
+            # diverges from the shared harmonize_species table -- e.g. the
+            # 2010-11 AGSEC6B roster, whose codes 17/19/20/21 mean different
+            # species than the 2011-12+ scheme baked into the table).
+            ov = cm.get('code_overrides') or {}
+            wmap = {**code_map, **ov}
+            code = _to_int_code(df6[tcol])
+            animal = code.map(lambda c: wmap.get(int(c), pd.NA) if pd.notna(c) else pd.NA)
+
+        def _num(key):
+            col = cm.get(key)
+            if col and col in df6.columns:
+                return pd.to_numeric(df6[col], errors='coerce')
+            return pd.Series([pd.NA] * len(df6), index=df6.index, dtype='Float64')
+
+        piece = pd.DataFrame({
+            't':            t,
+            'i':            hh.values,
+            'animal':       animal.values,
+            'HeadCount':    _num('headcount').values,
+            'HeadAcquired': _num('acquired').values,
+            'HeadSold':     _num('sold').values,
+            'Value':        _num('value').values,
+        })
+        pieces.append(piece)
+
+    cols = ['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']
+    if not pieces:
+        return pd.DataFrame(columns=cols)
+
+    df = pd.concat(pieces, ignore_index=True)
+
+    # Drop rows that carry no species label and rows with nothing reported
+    # at all (empty roster placeholders).  A household line that lists a
+    # species but reports zero/NaN everywhere is dropped (it did not own
+    # that animal -- the roster pre-lists every species).
+    df = df[df['animal'].notna()]
+    for c in cols:
+        df[c] = pd.to_numeric(df[c], errors='coerce')
+    measure = ['HeadCount', 'HeadAcquired', 'HeadSold']
+    # Keep a row when ANY head measure is a positive number (owned now,
+    # bought, or sold).  Value alone (per-head price with no head count)
+    # is not evidence of ownership.
+    has_head = (df[measure].fillna(0) > 0).any(axis=1)
+    df = df[has_head]
+
+    # Collapse to (t, i, animal): the roster splits a species across
+    # exotic/indigenous and age/sex lines; those are the SAME species for
+    # this axis, so sum the head columns and take a head-weighted mean of
+    # the reported per-head Value (NaN where no line reported a value).
+    df['_w'] = df['HeadCount'].fillna(0)
+    df['_vw'] = df['Value'] * df['_w']
+    grouped = df.groupby(['t', 'i', 'animal'], dropna=False)
+    out = grouped[measure].sum(min_count=1)
+    vw_sum = grouped['_vw'].sum(min_count=1)
+    w_sum = grouped['_w'].sum(min_count=1)
+    value = vw_sum / w_sum.where(w_sum > 0, pd.NA)
+    # Fall back to a simple mean of reported values where head weights are
+    # all zero/NaN but a value was nonetheless reported.
+    plain = grouped['Value'].mean()
+    out['Value'] = value.where(value.notna(), plain)
+
+    for c in cols:
+        out[c] = pd.to_numeric(out[c], errors='coerce').astype('Float64')
+    return out
+
+
+# Per-wave column maps for livestock_for_wave.  ``type`` is the animal-type
+# column; ``type_kind`` 'code' (harmonize_species) or 'string'
+# (_species_string_map).  Value is the reported per-head animal value: the
+# 'sell one today' question (q6) where the wave asks it (2009-10, 2010-11),
+# else the 'average value of each sold' (q14b) for 2011-12+.
+LIVESTOCK_COLMAPS = {
+    '2009-10': {
+        'A': {'hhid': 'HHID', 'type': 'a6aq2', 'type_kind': 'string',
+              'headcount': 'a6aq5', 'acquired': 'a6aq12', 'sold': 'a6aq14', 'value': 'a6aq6'},
+        'B': {'hhid': 'HHID', 'type': 'a6bq2', 'type_kind': 'string',
+              'headcount': 'a6bq5', 'acquired': 'a6bq12', 'sold': 'a6bq14', 'value': 'a6bq6'},
+        'C': {'hhid': 'HHID', 'type': 'a6cq2', 'type_kind': 'string',
+              'headcount': 'a6cq5', 'acquired': 'a6cq12', 'sold': 'a6cq14', 'value': 'a6cq6'},
+    },
+    '2010-11': {
+        # 6A carries the type as a string (a6aq2); 6B/6C carry the integer
+        # 'Livestock code' (a6bq3 / a6cq3, codes 13-21 / 31-42).
+        'A': {'hhid': 'HHID', 'type': 'a6aq3', 'type_kind': 'code',
+              'headcount': 'a6aq5a', 'acquired': 'a6aq12', 'sold': 'a6aq14', 'value': 'a6aq6'},
+        # 2010-11 AGSEC6B code scheme diverges from 2011-12+: codes 17/19/20/21
+        # mean (17=Indigenous male goats, 19=Indigenous male sheep, 20=Indig.
+        # female sheep, 21=Indig. male goats [dup]) -- overridden here so they
+        # resolve to the right species despite the shared table's 2011-12+
+        # meanings (17=Pigs, 19=Goats, 20/21=Sheep).  Codes 13-16/18 already
+        # agree with the table.  No Pigs code in 2010-11 6B.
+        'B': {'hhid': 'HHID', 'type': 'a6bq3', 'type_kind': 'code',
+              'headcount': 'a6bq5a', 'acquired': 'a6bq12', 'sold': 'a6bq14', 'value': 'a6bq6',
+              'code_overrides': {17: 'Goats', 19: 'Sheep', 20: 'Sheep', 21: 'Goats'}},
+        'C': {'hhid': 'HHID', 'type': 'a6cq3', 'type_kind': 'code',
+              'headcount': 'a6cq5a', 'acquired': 'a6cq12', 'sold': 'a6cq14', 'value': 'a6cq6'},
+    },
+    '2011-12': {
+        'A': {'hhid': 'HHID', 'type': 'lvstid', 'type_kind': 'code',
+              'headcount': 'a6aq3a', 'acquired': 'a6aq13a', 'sold': 'a6aq14a', 'value': 'a6aq14b'},
+        'B': {'hhid': 'HHID', 'type': 'lvstid', 'type_kind': 'code',
+              'headcount': 'a6bq3a', 'acquired': 'a6bq13a', 'sold': 'a6bq14a', 'value': 'a6bq14b'},
+        'C': {'hhid': 'HHID', 'type': 'lvstid', 'type_kind': 'code',
+              'headcount': 'a6cq3a', 'acquired': 'a6cq13a', 'sold': 'a6cq14a', 'value': 'a6cq14b'},
+    },
+    '2013-14': {
+        'A': {'hhid': 'HHID', 'type': 'LiveStockID', 'type_kind': 'code',
+              'headcount': 'a6aq3a', 'acquired': 'a6aq13a', 'sold': 'a6aq14a', 'value': 'a6aq14b'},
+        'B': {'hhid': 'HHID', 'type': 'ALiveStock_Small_ID', 'type_kind': 'code',
+              'headcount': 'a6bq3a', 'acquired': 'a6bq13a', 'sold': 'a6bq14a', 'value': 'a6bq14b'},
+        'C': {'hhid': 'HHID', 'type': 'APCode', 'type_kind': 'code',
+              'headcount': 'a6cq3a', 'acquired': 'a6cq13a', 'sold': 'a6cq14a', 'value': 'a6cq14b'},
+    },
+    '2015-16': {
+        'A': {'hhid': 'HHID', 'type': 'LiveStockID', 'type_kind': 'code',
+              'headcount': 'a6aq3a', 'acquired': 'a6aq13a', 'sold': 'a6aq14a', 'value': 'a6aq14b'},
+        'B': {'hhid': 'HHID', 'type': 'ALiveStock_Small_ID', 'type_kind': 'code',
+              'headcount': 'a6bq3a', 'acquired': 'a6bq13a', 'sold': 'a6bq14a', 'value': 'a6bq14b'},
+        'C': {'hhid': 'HHID', 'type': 'APCode', 'type_kind': 'code',
+              'headcount': 'a6cq3a', 'acquired': 'a6cq13a', 'sold': 'a6cq14a', 'value': 'a6cq14b'},
+    },
+    '2018-19': {
+        'A': {'hhid': 'hhid', 'type': 'LiveStockID', 'type_kind': 'code',
+              'headcount': 's6aq03a', 'acquired': 's6aq13a', 'sold': 's6aq14a', 'value': 's6aq14b'},
+        'B': {'hhid': 'hhid', 'type': 'ALiveStock_Small_ID', 'type_kind': 'code',
+              'headcount': 's6bq03a', 'acquired': 's6bq13a', 'sold': 's6bq14a', 'value': 's6bq14b'},
+        'C': {'hhid': 'hhid', 'type': 'APCode', 'type_kind': 'code',
+              'headcount': 's6cq03a', 'acquired': 's6cq13a', 'sold': 's6cq14a', 'value': 's6cq14b'},
+    },
+    '2019-20': {
+        'A': {'hhid': 'hhid', 'type': 'LiveStockID', 'type_kind': 'code',
+              'headcount': 's6aq03a', 'acquired': 's6aq13a', 'sold': 's6aq14a', 'value': 's6aq14b'},
+        'B': {'hhid': 'hhid', 'type': 'ALiveStock_Small_ID', 'type_kind': 'code',
+              'headcount': 's6bq03a', 'acquired': 's6bq13a', 'sold': 's6bq14a', 'value': 's6bq14b'},
+        'C': {'hhid': 'hhid', 'type': 'APCode', 'type_kind': 'code',
+              'headcount': 's6cq03a', 'acquired': 's6cq13a', 'sold': 's6cq14a', 'value': 's6cq14b'},
+    },
+}


### PR DESCRIPTION
GAP 4 of the WB-parity loop. Item-level `livestock` at `(t, i, animal)` from the livestock roster — **reported** HeadCount / HeadAcquired / HeadSold (+ Value where the source records it). Leapfrogs the WB single engaged-in-livestock binary (recoverable as `groupby.any()` transform). NO aggregates (TLU, herd-value totals, the engaged binary are `transformations`).

- Species labels in a new `harmonize_species` table; grain `(t,i,animal)`.
- `v`-free: `livestock` already in the framework `_no_v_join` set — **no framework edit** (adversary confirmed `country.py`/`transformations.py` untouched).
- Coverage ≥ WB per wave (our roster covers livestock-only HHs the WB plot/holder cover binary omits); item-level over (household, species) vs their single y/n.
- Tanzania partial (NPS 2019-20/2020-21; older panel rounds deferred, GH #167 — like its siblings); Mali EHCVM / Malawi IHS2 correctly skipped (no roster).
- Adversary PASS: every groupby is a within-species roll-up to the item grain (not a cross-species total); no framework edits; scope clean; no sibling regression (food_acquired/crop_production/plot_inputs exact-match cold rebuild).

244 table-structure/schema tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>