### PR TITLE
feat(parity): GAP 5 — item-level anthropometry (t,i,pid) across 5 LSMS-ISA countries

### DIFF
--- a/lsms_library/countries/Ethiopia/2011-12/_/anthropometry.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/anthropometry.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""Build anthropometry for Ethiopia ESS 2011-12 (Wave 1; GAP 5).
+
+Item-level body measures at (t, i, pid).  One row per measured individual
+from the §3 health module (sect3_hh_w1), carrying only the REPORTED
+weight/height the WB code feeds into zscore06 (ETH_ESS1.do:1217-1235) --
+NOT the z-score outputs.  Age_months / Sex are joined from the §1 roster
+(sect1_hh_w1) so the row is self-describing for the downstream z-score
+transform.
+
+W1 source vars:
+  weight  hh_s3q22  (kg)
+  height  hh_s3q23  (cm; >200 -> NaN)
+  age     hh_s1q04_a (years) / hh_s1q04_b (months remainder)
+  sex     hh_s1q03  (1=Male, 2=Female)
+No MUAC in W1 (no ESS wave asks it).
+i = household_id, pid = individual_id (match household_roster for W1).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import anthropometry_for_wave
+
+
+health = get_dataframe('../Data/sect3_hh_w1.dta', convert_categoricals=False)
+roster = get_dataframe('../Data/sect1_hh_w1.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', pid='individual_id',
+    weight='hh_s3q22', height='hh_s3q23',
+    r_hhid='household_id', r_pid='individual_id',
+    age_yr='hh_s1q04_a', age_mo='hh_s1q04_b', sex='hh_s1q03',
+)
+
+df = anthropometry_for_wave('2011-12', health, roster, colmap)
+
+assert len(df) > 0, "anthropometry 2011-12 produced no rows"
+to_parquet(df, 'anthropometry.parquet')

--- a/lsms_library/countries/Ethiopia/2013-14/_/anthropometry.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/anthropometry.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Build anthropometry for Ethiopia ESS 2013-14 (Wave 2; GAP 5).
+
+Item-level body measures at (t, i, pid).  One row per measured individual
+from the §3 health module (sect3_hh_w2), carrying only the REPORTED
+weight/height the WB code feeds into zscore06 (ETH_ESS2.do:1306-1331) --
+NOT the z-score outputs.  Age_months / Sex joined from §1 (sect1_hh_w2).
+
+W2 uses the SECOND id scheme (household_id2 / individual_id2) to match
+household_roster's (i, pid) for this wave -- both the §3 and §1 files
+carry household_id2 / individual_id2.
+
+W2 source vars:
+  weight  hh_s3q22  (kg)
+  height  hh_s3q23  (cm; >200 -> NaN)
+  age     hh_s1q04_a (years) / hh_s1q04_b (months remainder)
+  sex     hh_s1q03  (1=Male, 2=Female)
+No MUAC in W2.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import anthropometry_for_wave
+
+
+health = get_dataframe('../Data/sect3_hh_w2.dta', convert_categoricals=False)
+roster = get_dataframe('../Data/sect1_hh_w2.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id2', pid='individual_id2',
+    weight='hh_s3q22', height='hh_s3q23',
+    r_hhid='household_id2', r_pid='individual_id2',
+    age_yr='hh_s1q04_a', age_mo='hh_s1q04_b', sex='hh_s1q03',
+)
+
+df = anthropometry_for_wave('2013-14', health, roster, colmap)
+
+assert len(df) > 0, "anthropometry 2013-14 produced no rows"
+to_parquet(df, 'anthropometry.parquet')

--- a/lsms_library/countries/Ethiopia/2015-16/_/anthropometry.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/anthropometry.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+"""Build anthropometry for Ethiopia ESS 2015-16 (Wave 3; GAP 5).
+
+Item-level body measures at (t, i, pid).  One row per measured individual
+from the §3 health module (sect3_hh_w3), carrying only the REPORTED
+weight/height the WB code feeds into zscore06 (ETH_ESS3.do:1318-1331) --
+NOT the z-score outputs.  Age_months / Sex joined from §1 (sect1_hh_w3).
+
+W3, like W2, uses the SECOND id scheme (household_id2 / individual_id2) to
+match household_roster's (i, pid) for this wave.
+
+W3 source vars (NB: §1 age vars are the NON-underscore variants this wave --
+hh_s1q04a / hh_s1q04b -- which is what the W3 household_roster uses too; the
+underscore hh_s1q04_b in this file is a different 1/2-coded question):
+  weight  hh_s3q22  (kg)
+  height  hh_s3q23  (cm; >200 -> NaN)
+  age     hh_s1q04a (years) / hh_s1q04b (months remainder)
+  sex     hh_s1q03  (1=Male, 2=Female)
+No MUAC in W3.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import anthropometry_for_wave
+
+
+health = get_dataframe('../Data/sect3_hh_w3.dta', convert_categoricals=False)
+roster = get_dataframe('../Data/sect1_hh_w3.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id2', pid='individual_id2',
+    weight='hh_s3q22', height='hh_s3q23',
+    r_hhid='household_id2', r_pid='individual_id2',
+    age_yr='hh_s1q04a', age_mo='hh_s1q04b', sex='hh_s1q03',
+)
+
+df = anthropometry_for_wave('2015-16', health, roster, colmap)
+
+assert len(df) > 0, "anthropometry 2015-16 produced no rows"
+to_parquet(df, 'anthropometry.parquet')

--- a/lsms_library/countries/Ethiopia/2018-19/_/anthropometry.py
+++ b/lsms_library/countries/Ethiopia/2018-19/_/anthropometry.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Build anthropometry for Ethiopia ESS 2018-19 (Wave 4; GAP 5).
+
+Item-level body measures at (t, i, pid).  One row per measured individual
+from the §3 health module (sect3_hh_w4), carrying only the REPORTED
+weight/height the WB code feeds into zscore06 (ETH_ESS4.do:1358-1363) --
+NOT the z-score outputs.  Age_months / Sex joined from §1 (sect1_hh_w4).
+
+W4/W5 renumber the §3 anthro vars (s3q37/s3q38, NOT hh_s3q22/23 which here
+are fertilizer-use flags) and the §1 age/sex vars (s1q03a/s1q03b, s1q02).
+i = household_id, pid = individual_id (match household_roster for W4).
+
+W4 source vars:
+  weight  s3q37  (kg)
+  height  s3q38  (cm; >200 -> NaN)
+  age     s1q03a (years) / s1q03b (months remainder)
+  sex     s1q02  (1=Male, 2=Female)
+No MUAC in W4.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import anthropometry_for_wave
+
+
+health = get_dataframe('../Data/sect3_hh_w4.dta', convert_categoricals=False)
+roster = get_dataframe('../Data/sect1_hh_w4.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', pid='individual_id',
+    weight='s3q37', height='s3q38',
+    r_hhid='household_id', r_pid='individual_id',
+    age_yr='s1q03a', age_mo='s1q03b', sex='s1q02',
+)
+
+df = anthropometry_for_wave('2018-19', health, roster, colmap)
+
+assert len(df) > 0, "anthropometry 2018-19 produced no rows"
+to_parquet(df, 'anthropometry.parquet')

--- a/lsms_library/countries/Ethiopia/2021-22/_/anthropometry.py
+++ b/lsms_library/countries/Ethiopia/2021-22/_/anthropometry.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""Build anthropometry for Ethiopia ESS 2021-22 (Wave 5; GAP 5).
+
+Item-level body measures at (t, i, pid).  One row per measured individual
+from the §3 health module (sect3_hh_w5), carrying only the REPORTED
+weight/height the WB code feeds into zscore06 (ETH_ESS5.do:1411-1418) --
+NOT the z-score outputs.  Age_months / Sex joined from §1 (sect1_hh_w5).
+
+W5 shares the W4 variable scheme (s3q37/s3q38, s1q03a/s1q03b, s1q02).
+i = household_id, pid = individual_id (match household_roster for W5).
+
+W5 source vars:
+  weight  s3q37  (kg)
+  height  s3q38  (cm; >200 -> NaN)
+  age     s1q03a (years) / s1q03b (months remainder)
+  sex     s1q02  (1=Male, 2=Female)
+No MUAC in W5.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import anthropometry_for_wave
+
+
+health = get_dataframe('../Data/sect3_hh_w5.dta', convert_categoricals=False)
+roster = get_dataframe('../Data/sect1_hh_w5.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', pid='individual_id',
+    weight='s3q37', height='s3q38',
+    r_hhid='household_id', r_pid='individual_id',
+    age_yr='s1q03a', age_mo='s1q03b', sex='s1q02',
+)
+
+df = anthropometry_for_wave('2021-22', health, roster, colmap)
+
+assert len(df) > 0, "anthropometry 2021-22 produced no rows"
+to_parquet(df, 'anthropometry.parquet')

--- a/lsms_library/countries/Ethiopia/_/Makefile
+++ b/lsms_library/countries/Ethiopia/_/Makefile
@@ -18,7 +18,8 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 var = \
       $(VAR_DIR)/shocks.parquet $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet \
       $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/crop_production.parquet \
-      $(VAR_DIR)/plot_inputs.parquet $(VAR_DIR)/livestock.parquet
+      $(VAR_DIR)/plot_inputs.parquet $(VAR_DIR)/livestock.parquet \
+      $(VAR_DIR)/anthropometry.parquet
 
 all: panel_ids.json updated_ids.json $(parquet) $(var)
 
@@ -113,6 +114,20 @@ food_coping_parquet := $(food_coping:.py=.parquet)
 
 $(VAR_DIR)/food_coping.parquet: food_coping.py $(food_coping_parquet)
 	python food_coping.py
+
+# anthropometry (GAP 5; NEW item-level body measures at (t, i, pid) from
+# the ESS §3 health module + §1 roster age/sex).  Mirrors the livestock
+# convention: the framework's grab_data calls
+# `make ../<wave>/_/anthropometry.parquet`, whose pattern rule runs the wave
+# script; the VAR_DIR rule concatenates them via the country script.
+anthropometry = $(shell find $(rounds) -name anthropometry.py)
+anthropometry_parquet := $(anthropometry:.py=.parquet)
+
+../%/_/anthropometry.parquet: ../%/_/anthropometry.py
+	(cd $(@D) && python anthropometry.py)
+
+$(VAR_DIR)/anthropometry.parquet: anthropometry.py $(anthropometry_parquet)
+	python anthropometry.py
 
 $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet: nutrition.py categorical_mapping.org $(VAR_DIR)/food_acquired.parquet
 	python nutrition.py

--- a/lsms_library/countries/Ethiopia/_/anthropometry.py
+++ b/lsms_library/countries/Ethiopia/_/anthropometry.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""Concatenate wave-level anthropometry data for Ethiopia (GAP 5).
+
+Each wave's ``Ethiopia/<wave>/_/anthropometry.py`` produces a parquet with
+index ``(t, i, pid)`` and the canonical reported columns (Weight, Height,
+MUAC, Age_months, Sex).  This script concatenates them across the five ESS
+waves and applies the cross-wave ``id_walk`` so the household index uses the
+panel canonical id scheme -- the same conversion ``sample()`` receives at
+API time.  ``v`` is then auto-joined from ``sample()`` by the framework
+(``_join_v_from_sample`` in country.py) at query time: do NOT bake it in.
+
+anthropometry is INDIVIDUAL-level (one row per measured child), so the
+household id ``i`` carries the framework panel conversion exactly as
+household_roster does (W2/W3 emit household_id2 to match the roster's i/pid;
+W1/W4/W5 emit household_id).  ``id_walk`` is idempotent (it sets
+``attrs['id_converted']``) so ``_finalize_result`` skips re-applying it.
+
+This is a NEW, separate feature from ``nutrition`` (which is nutrient
+*intake*, a different construct).  No z-scores (haz06/waz06/whz06/bmiz06) or
+wasting/stunting are stored here -- those are WHO-2006-reference transforms
+computed at query time, never data-layer columns.
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, id_walk, to_parquet
+from ethiopia import Waves
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/anthropometry.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet built / parquet absent (DVC raises PathMissingError).
+        continue
+    pieces.append(df)
+
+assert pieces, "anthropometry: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/anthropometry.parquet')

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -250,6 +250,47 @@ Data Scheme:
     Days: int
     materialize: make
 
+  anthropometry:
+    # GAP 5 -- NEW item-level feature at (t, i, pid) [individual].  One row
+    # per measured individual from the ESS §3 health module (sect3_hh),
+    # carrying ONLY the REPORTED body measures the WB code feeds into its
+    # zscore06 call (ETH_ESS1.do:1217-1235 and the parallel ESS2-5 blocks):
+    #   Weight      reported weight in kg (hh_s3q22 W1-W3 / s3q37 W4-W5).
+    #   Height      reported height in cm (hh_s3q23 W1-W3 / s3q38 W4-W5);
+    #               the WB data-clean (>200 cm -> NaN) drops unit-error
+    #               outliers (raw §3 carries 971/993 cm typos).
+    #   MUAC        mid-upper-arm circumference -- declared for cross-country
+    #               alignment but legitimately ALL-NaN for Ethiopia: NO ESS
+    #               wave asks a MUAC question.
+    #   Age_months  child age in completed months, and
+    #   Sex         M/F,
+    #               both joined from the §1 roster so the row is
+    #               self-describing for the downstream z-score transform
+    #               (the WB ``cage = age*12``; ``female = sex==2``).
+    #
+    # This is a DISTINCT feature from ``nutrition`` (nutrient intake), NOT a
+    # reuse of it.  The WHO-2006 z-scores (haz06/waz06/whz06/bmiz06) and
+    # wasting/stunting are NOT stored: they require the WHO reference
+    # population and are TRANSFORMS computed at query time over these raw
+    # measures, never data-layer columns.
+    #
+    # Grain is (t, i, pid) -- individual-level.  i/pid match
+    # household_roster exactly (W2/W3 emit household_id2/individual_id2; the
+    # other waves household_id/individual_id), so anthropometry joins the
+    # roster on (t, i, pid).  v is NOT baked in -- the framework auto-joins
+    # it from sample() at query time.  Cross-file join (§3 measures + §1
+    # age/sex) + per-wave var renumbering + within-individual de-dup =>
+    # script (materialize: make).
+    index: (t, i, pid)
+    Weight: float
+    Height: float
+    MUAC:
+      type: float
+      optional: true
+    Age_months: float
+    Sex: str
+    materialize: make
+
   # food_expenditures, food_prices, food_quantities are derived at
   # runtime from food_acquired — see _FOOD_DERIVED in country.py.  Do
   # NOT register them here (per CLAUDE.md "Derived Tables").

--- a/lsms_library/countries/Ethiopia/_/ethiopia.py
+++ b/lsms_library/countries/Ethiopia/_/ethiopia.py
@@ -1587,3 +1587,148 @@ def livestock_for_wave(t, count, txn, colmap):
     agg = agg.set_index(['t', 'i', 'animal'])
     agg = agg[['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']]
     return agg.sort_index()
+
+
+def anthropometry_for_wave(t, health, roster, colmap):
+    """Build item-level ``anthropometry`` for one Ethiopia ESS wave (GAP 5).
+
+    Individual-level body measures at ``(t, i, pid)`` -- one row per
+    measured individual, carrying only the REPORTED anthropometric data the
+    ESS §3 health module records, plus the child Age/Sex needed to make the
+    row self-describing for the downstream WHO-2006 z-score transform.
+
+    This reproduces the *inputs* to the WB ``zscore06`` call
+    (``ETH_ESS1.do:1217-1235`` and the parallel blocks in ESS2-5), NOT its
+    outputs.  We deliberately DO NOT compute or store haz06 / waz06 / whz06 /
+    bmiz06 / wasting / stunting: those require the WHO-2006 reference
+    population and are a *transform* applied at query time, never a data-
+    layer column.
+
+    Source variables (confirmed per wave via get_dataframe):
+      weight  hh_s3q22 (W1-W3) / s3q37 (W4-W5)   -- kg
+      height  hh_s3q23 (W1-W3) / s3q38 (W4-W5)   -- cm; >200 set to NaN
+              (the WB ``replace height=. if height>200`` data-clean; the
+              raw §3 column carries clear unit-error outliers e.g. 971/993).
+    No ESS wave records a MUAC (mid-upper-arm circumference) question, so
+    the canonical ``MUAC`` column is declared for cross-country alignment but
+    is legitimately all-NaN for Ethiopia.
+
+    Age_months / Sex come from the §1 household roster (the same merge the
+    WB code does: ``merge 1:1 household_id individual_id using household_roster``):
+      Age_months = age_years * 12, falling back to the §1 age-in-months
+                   remainder column where age-in-years is missing (mirrors
+                   the WB ``gen cage = age*12; replace cage = <months> if
+                   age==.``).  The downstream zscore06 transform consumes
+                   age in completed months.
+      Sex        = M / F from the §1 sex code (1=Male, 2=Female; the WB
+                   ``female = sex==2``), via the same code map the roster
+                   uses.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2011-12"``) -- the ``t`` index value.
+    health : pd.DataFrame
+        Raw §3 health file (sect3_hh), loaded convert_categoricals=False so
+        the weight/height columns are numeric.
+    roster : pd.DataFrame
+        Raw §1 roster file (sect1_hh), convert_categoricals=False, carrying
+        the age (years + months remainder) and sex codes.  Joined on the
+        wave's (hhid, pid) key so Age_months/Sex attach per individual.
+    colmap : dict
+        Per-wave column map.  Required keys:
+            hhid    household-id column EMITTED as ``i`` (and the merge key);
+                    household_id2 for W2/W3 -- so i/pid MATCH household_roster
+                    -- else household_id.
+            pid     individual-id column EMITTED as ``pid`` (individual_id2
+                    for W2/W3, else individual_id).
+            weight  reported weight (kg) column in ``health``.
+            height  reported height (cm) column in ``health``.
+            r_hhid  hhid column in ``roster`` (for the merge; same scheme as
+                    ``hhid``).
+            r_pid   pid column in ``roster``.
+            age_yr  age-in-years column in ``roster``.
+            age_mo  age-in-months-remainder column in ``roster``.
+            sex     sex code column in ``roster`` (1=Male, 2=Female).
+        Optional keys (NaN where the wave does not ask):
+            muac    mid-upper-arm-circumference column (no ESS wave has one).
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, pid)`` with columns
+        Weight (Float64, kg), Height (Float64, cm), MUAC (Float64, cm),
+        Age_months (Float64), Sex (string, M/F).
+    Only individuals with at least one reported body measure (Weight,
+    Height, or MUAC) are kept -- the §3 module is administered only to the
+    sampled children, so the roster's un-measured members are dropped.
+    """
+    c = colmap
+
+    def _num(df, key):
+        col = c.get(key)
+        if col is None or col not in df.columns:
+            return None
+        return pd.to_numeric(df[col], errors='coerce').astype('Float64')
+
+    h = health.copy()
+    weight = _num(h, 'weight')
+    height = _num(h, 'height')
+    if height is not None:
+        # WB data-clean: implausible heights (>200 cm) are unit errors.
+        height = height.mask(height > 200)
+    muac = _num(h, 'muac')
+    if muac is None:
+        muac = pd.Series(pd.NA, index=h.index, dtype='Float64')
+    if weight is None:
+        weight = pd.Series(pd.NA, index=h.index, dtype='Float64')
+    if height is None:
+        height = pd.Series(pd.NA, index=h.index, dtype='Float64')
+
+    anthro = pd.DataFrame({
+        'i':      h[c['hhid']].apply(format_id).values,
+        'pid':    h[c['pid']].apply(format_id).values,
+        'Weight': weight.values,
+        'Height': height.values,
+        'MUAC':   muac.values,
+    })
+
+    # Keep only measured individuals (the §3 child-anthro sub-sample).
+    measured = (anthro['Weight'].notna() | anthro['Height'].notna()
+                | anthro['MUAC'].notna())
+    anthro = anthro[measured].copy()
+
+    # ---- attach self-describing Age_months / Sex from the §1 roster ----
+    r = roster.copy()
+    age_yr = pd.to_numeric(r[c['age_yr']], errors='coerce').astype('Float64')
+    age_mo = (pd.to_numeric(r[c['age_mo']], errors='coerce').astype('Float64')
+              if c.get('age_mo') and c['age_mo'] in r.columns else None)
+    # cage = age*12; fall back to the months-remainder column when years
+    # is missing (WB: replace cage = <months> if age==.).
+    age_months = age_yr * 12
+    if age_mo is not None:
+        age_months = age_months.fillna(age_mo)
+
+    sex_code = pd.to_numeric(r[c['sex']], errors='coerce').astype('Int64')
+    sex = sex_code.map({1: 'M', 2: 'F'}).astype('string')
+
+    rinfo = pd.DataFrame({
+        'i':          r[c['r_hhid']].apply(format_id).values,
+        'pid':        r[c['r_pid']].apply(format_id).values,
+        'Age_months': age_months.values,
+        'Sex':        sex.values,
+    }).drop_duplicates(subset=['i', 'pid'])
+
+    out = anthro.merge(rinfo, on=['i', 'pid'], how='left')
+
+    out['t'] = t
+    out['i'] = out['i'].astype('string')
+    out['pid'] = out['pid'].astype('string')
+    for col in ['Weight', 'Height', 'MUAC', 'Age_months']:
+        out[col] = out[col].astype('Float64')
+    out['Sex'] = out['Sex'].astype('string')
+
+    out = out.set_index(['t', 'i', 'pid'])
+    out = out[['Weight', 'Height', 'MUAC', 'Age_months', 'Sex']]
+    # Collapse any accidental duplicate measurement rows for an individual.
+    out = out[~out.index.duplicated(keep='first')]
+    return out.sort_index()

--- a/lsms_library/countries/Malawi/2010-11/_/anthropometry.py
+++ b/lsms_library/countries/Malawi/2010-11/_/anthropometry.py
@@ -1,0 +1,43 @@
+"""Build anthropometry for Malawi IHS3 2010-11 (GAP 5).
+
+Item-level (t, i, pid) body-measurement feature.  Source
+(Full_Sample/Household):
+  * hh_mod_v -- Module V anthropometry, one row per (HH, person).
+    Weight = hh_v08 (kg), Height = hh_v09 (cm); no MUAC in this module.
+  * hh_mod_b -- Module B roster, for the child Age_months (cage logic:
+    hh_b05a years x 12, else infant months hh_b05b) and Sex (hh_b03).
+
+i = format_id(case_id), pid = format_id(id_code) -- the SAME (i, pid)
+household_roster emits for this wave (its YAML uses i: case_id,
+pid: id_code on the Full_Sample module-b file).  The framework applies
+panel id_walk + joins v from sample() at API time.
+
+This is the SAME Module V the World Bank cleaning code reads then collapses
+to WHO-2006 z-scores (MWI_IHPS1.do:1213-1231); we keep the RAW measures.
+See lsms_library/countries/Malawi/_/malawi.py:_anthropometry_block.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import _anthropometry_block, assemble_anthropometry
+
+
+WAVE = '2010-11'
+BASE = '../Data/Full_Sample/Household/'
+
+health = get_dataframe(BASE + 'hh_mod_v.dta')
+roster = get_dataframe(BASE + 'hh_mod_b.dta')
+
+piece = _anthropometry_block(
+    health, roster, t=WAVE,
+    hh_id_health='case_id', pid_health='id_code',
+    hh_id_roster='case_id', pid_roster='id_code',
+)
+
+df = assemble_anthropometry(WAVE, [piece])
+
+assert df.index.is_unique, f"Non-unique (t,i,pid) in anthropometry {WAVE}"
+assert len(df) > 0, f"anthropometry {WAVE} produced no rows"
+
+to_parquet(df, 'anthropometry.parquet')

--- a/lsms_library/countries/Malawi/2013-14/_/anthropometry.py
+++ b/lsms_library/countries/Malawi/2013-14/_/anthropometry.py
@@ -1,0 +1,53 @@
+"""Build anthropometry for Malawi IHPS 2013-14 (GAP 5).
+
+Item-level (t, i, pid) body-measurement feature.  Source:
+  * HH_MOD_V_13 -- Module V anthropometry, one row per (HH, person).
+    Weight = hh_v08 (kg), Height = hh_v09 (cm); no MUAC in this module.
+    Keyed on (y2_hhid, PID), where PID is the long string id ('000101').
+  * HH_MOD_B_13 -- Module B roster, for Age_months (cage logic) and Sex.
+
+ID NOTE: household_roster for 2013-14 uses pid: hh_b01 (the within-HH
+person line number 1,2,3...), NOT the long-string PID.  So pid =
+format_id(hh_b01) = '1','2',...  Module V carries only PID, so we first
+remap (y2_hhid, PID) -> hh_b01 via the roster (a unique 1:1 map, verified
+2026-06-14: all 2534 measured rows match), then key anthropometry on
+hh_b01 so its (i, pid) aligns with household_roster.  i = format_id
+(y2_hhid).  The framework applies panel id_walk + joins v at API time.
+
+This is the SAME Module V the World Bank cleaning code reads then collapses
+to WHO-2006 z-scores (MWI_IHPS2.do anthropometry block); we keep the RAW
+measures.  See lsms_library/countries/Malawi/_/malawi.py:_anthropometry_block.
+"""
+import sys
+
+import pandas as pd
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import _anthropometry_block, assemble_anthropometry
+
+
+WAVE = '2013-14'
+BASE = '../Data/'
+
+health = get_dataframe(BASE + 'HH_MOD_V_13.dta')
+roster = get_dataframe(BASE + 'HH_MOD_B_13.dta')
+
+# Remap the health module's long-string PID to the roster's hh_b01 line
+# number, so the emitted pid matches household_roster.  (y2_hhid, PID) is a
+# unique key in the roster.
+key = roster[['y2_hhid', 'PID', 'hh_b01']].drop_duplicates(['y2_hhid', 'PID'])
+health = health.merge(key, on=['y2_hhid', 'PID'], how='left')
+
+piece = _anthropometry_block(
+    health, roster, t=WAVE,
+    hh_id_health='y2_hhid', pid_health='hh_b01',
+    hh_id_roster='y2_hhid', pid_roster='hh_b01',
+)
+
+df = assemble_anthropometry(WAVE, [piece])
+
+assert df.index.is_unique, f"Non-unique (t,i,pid) in anthropometry {WAVE}"
+assert len(df) > 0, f"anthropometry {WAVE} produced no rows"
+
+to_parquet(df, 'anthropometry.parquet')

--- a/lsms_library/countries/Malawi/2016-17/_/anthropometry.py
+++ b/lsms_library/countries/Malawi/2016-17/_/anthropometry.py
@@ -1,0 +1,55 @@
+"""Build anthropometry for Malawi IHS4 / IHPS 2016-17 (GAP 5).
+
+Item-level (t, i, pid) body-measurement feature.  Sources mirror this
+wave's household_roster, which concatenates a Cross_Sectional and a Panel
+half:
+  * Cross_Sectional/hh_mod_v + hh_mod_b -- keyed i: case_id (with the
+    roster's cs_i mapping -> 'cs-17-'+case_id), pid: pid.
+  * Panel/hh_mod_v_16 + hh_mod_b_16 -- keyed i: y3_hhid, pid: id_code.
+Weight = hh_v08 (kg), Height = hh_v09 (cm); no MUAC in Module V.
+Age_months (cage logic) and Sex (hh_b03) come from the matching roster
+half via _anthropometry_block's join.
+
+The 'cs-17-' prefix reproduces the roster feature's cs_i so the
+Cross_Sectional i aligns with household_roster (verified 2026-06-14: the
+roster keeps 53885 cs-17- rows + 12266 panel rows).  The framework applies
+panel id_walk + joins v at API time.
+
+This is the SAME Module V the World Bank cleaning code reads then collapses
+to WHO-2006 z-scores (MWI_IHPS3.do anthropometry block); we keep the RAW
+measures.  See lsms_library/countries/Malawi/_/malawi.py:_anthropometry_block.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import _anthropometry_block, assemble_anthropometry
+
+
+WAVE = '2016-17'
+
+# Cross_Sectional half (cs_i -> 'cs-17-' prefix).
+cs_health = get_dataframe('../Data/Cross_Sectional/hh_mod_v.dta')
+cs_roster = get_dataframe('../Data/Cross_Sectional/hh_mod_b.dta')
+cs_piece = _anthropometry_block(
+    cs_health, cs_roster, t=WAVE,
+    hh_id_health='case_id', pid_health='pid',
+    hh_id_roster='case_id', pid_roster='pid',
+    i_prefix='cs-17-',
+)
+
+# Panel half (raw y3_hhid).
+pn_health = get_dataframe('../Data/Panel/hh_mod_v_16.dta')
+pn_roster = get_dataframe('../Data/Panel/hh_mod_b_16.dta')
+pn_piece = _anthropometry_block(
+    pn_health, pn_roster, t=WAVE,
+    hh_id_health='y3_hhid', pid_health='id_code',
+    hh_id_roster='y3_hhid', pid_roster='id_code',
+)
+
+df = assemble_anthropometry(WAVE, [cs_piece, pn_piece])
+
+assert df.index.is_unique, f"Non-unique (t,i,pid) in anthropometry {WAVE}"
+assert len(df) > 0, f"anthropometry {WAVE} produced no rows"
+
+to_parquet(df, 'anthropometry.parquet')

--- a/lsms_library/countries/Malawi/2019-20/_/anthropometry.py
+++ b/lsms_library/countries/Malawi/2019-20/_/anthropometry.py
@@ -1,0 +1,56 @@
+"""Build anthropometry for Malawi IHS5 / IHPS 2019-20 (GAP 5).
+
+Item-level (t, i, pid) body-measurement feature.  Sources mirror this
+wave's household_roster, which concatenates a Cross_Sectional and a Panel
+half:
+  * Cross_Sectional/HH_MOD_V + HH_MOD_B -- keyed i: case_id, pid: PID.
+  * Panel/hh_mod_v_19 + hh_mod_b_19 -- keyed i: y4_hhid, pid: id_code.
+Weight = hh_v08 (kg), Height = hh_v09 (cm); no MUAC in Module V.
+Age_months (cage logic) and Sex (hh_b03) come from the matching roster
+half via _anthropometry_block's join.
+
+ID NOTE: unlike 2016-17 (which keeps a 'cs-17-' prefix), the 2019-20
+household_roster's final Cross_Sectional i is the RAW 12-digit case_id
+(NO 'cs-19-' prefix), with the Panel y4_hhid walked to that same id space
+by updated_ids (verified 2026-06-14: the roster has 0 cs-19- rows; all i
+are plain 12-digit, some with id_walk's _N split suffix).  So we emit the
+raw case_id for the CS half (no i_prefix) and let the framework's id_walk
+remap the Panel half + join v at API time.
+
+This is the SAME Module V the World Bank cleaning code reads then collapses
+to WHO-2006 z-scores (MWI_IHPS4.do anthropometry block); we keep the RAW
+measures.  See lsms_library/countries/Malawi/_/malawi.py:_anthropometry_block.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import _anthropometry_block, assemble_anthropometry
+
+
+WAVE = '2019-20'
+
+# Cross_Sectional half (raw case_id, no prefix -- see ID NOTE).
+cs_health = get_dataframe('../Data/Cross_Sectional/HH_MOD_V.dta')
+cs_roster = get_dataframe('../Data/Cross_Sectional/HH_MOD_B.dta')
+cs_piece = _anthropometry_block(
+    cs_health, cs_roster, t=WAVE,
+    hh_id_health='case_id', pid_health='PID',
+    hh_id_roster='case_id', pid_roster='PID',
+)
+
+# Panel half (raw y4_hhid; framework id_walk remaps to the case_id space).
+pn_health = get_dataframe('../Data/Panel/hh_mod_v_19.dta')
+pn_roster = get_dataframe('../Data/Panel/hh_mod_b_19.dta')
+pn_piece = _anthropometry_block(
+    pn_health, pn_roster, t=WAVE,
+    hh_id_health='y4_hhid', pid_health='id_code',
+    hh_id_roster='y4_hhid', pid_roster='id_code',
+)
+
+df = assemble_anthropometry(WAVE, [cs_piece, pn_piece])
+
+assert df.index.is_unique, f"Non-unique (t,i,pid) in anthropometry {WAVE}"
+assert len(df) > 0, f"anthropometry {WAVE} produced no rows"
+
+to_parquet(df, 'anthropometry.parquet')

--- a/lsms_library/countries/Malawi/_/Makefile
+++ b/lsms_library/countries/Malawi/_/Makefile
@@ -12,7 +12,7 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 # _ROSTER_DERIVED — no country-level parquet is built or consulted.
 # See GH #218.
 
-all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet $(VAR_DIR)/crop_production.parquet $(VAR_DIR)/plot_inputs.parquet $(VAR_DIR)/livestock.parquet
+all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet $(VAR_DIR)/crop_production.parquet $(VAR_DIR)/plot_inputs.parquet $(VAR_DIR)/livestock.parquet $(VAR_DIR)/anthropometry.parquet
 
 food_acquired = $(shell find $(rounds) -name food_acquired.py)
 # Wave-level parquets live in data_root, not in-tree
@@ -87,6 +87,21 @@ $(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/livestock.parquet: malawi.py
 
 $(VAR_DIR)/livestock.parquet: livestock.py $(livestock_parquet)
 	python livestock.py
+
+# --- anthropometry (GAP 5) ------------------------------------------------
+# Item-level (t, i, pid) body measures (Weight/Height/Age_months/Sex)
+# for the four IHS3+/IHPS waves carrying Module V.  Each wave script writes
+# its parquet into data_root; the country script concatenates.  2004-05
+# (IHS2) is ABSENT (no Module V body-measurement roster).  z-scores /
+# wasting / stunting are transformations, NOT stored.
+anthropometry_waves := 2010-11 2013-14 2016-17 2019-20
+anthropometry_parquet := $(foreach r,$(anthropometry_waves),$(LSMS_DATA_ROOT)/$(COUNTRY)/$(r)/_/anthropometry.parquet)
+
+$(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/anthropometry.parquet: malawi.py
+	(cd ../$(*)/_/ && python anthropometry.py)
+
+$(VAR_DIR)/anthropometry.parquet: anthropometry.py $(anthropometry_parquet)
+	python anthropometry.py
 
 %.parquet: %.py malawi.py
 	(cd $(@D) && python ./$(<F))

--- a/lsms_library/countries/Malawi/_/anthropometry.py
+++ b/lsms_library/countries/Malawi/_/anthropometry.py
@@ -1,0 +1,41 @@
+"""Concatenate wave-level anthropometry parquets for Malawi (GAP 5).
+
+Each buildable wave's ``Malawi/<wave>/_/anthropometry.py`` produces a
+parquet indexed (t, i, pid) with the reported item-level columns (Weight,
+Height, Age_months, Sex).  This script concatenates them.  Cross-wave
+id_walk (panel-id chaining) and the v-join from sample() are applied by the
+framework at API time in _finalize_result.
+
+Only the four IHS3+/IHPS waves carrying Module V anthropometry are
+buildable (2010-11, 2013-14, 2016-17, 2019-20) -- the same waves as
+crop_production / plot_inputs / livestock.  2004-05 (IHS2) is DEFERRED: its
+household questionnaire carries no Module V body-measurement roster.
+
+The WHO-2006 z-scores (haz06/waz06/whz06/bmiz06) and wasting/stunting that
+the World Bank cleaning code derives from these measures are TRANSFORMS
+(they require the WHO-2006 reference population); they are computed at query
+time, NEVER stored here.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2010-11', '2013-14', '2016-17', '2019-20']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/anthropometry.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built (DVC raises
+        # PathMissingError here, not FileNotFoundError).
+        continue
+    pieces.append(df)
+
+assert pieces, "anthropometry: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/anthropometry.parquet')

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -220,5 +220,35 @@ Data Scheme:
     HeadSold: float
     Value: float
     materialize: make
+  anthropometry:
+    # Item-level (t, i, pid) body-measurement feature for the four IHS3+/
+    # IHPS waves (2010-11, 2013-14, 2016-17, 2019-20); GAP 5.  One reported
+    # row per measured individual, from Module V (hh_mod_v) of the household
+    # questionnaire -- the SAME module the World Bank cleaning code reads
+    # then collapses to WHO-2006 z-scores (MWI_IHPS{1-4}.do:1213-1231:
+    # weight=hh_v08; height=hh_v09; cage=age*12 | hh_b05b; zscore06 ->
+    # haz06/waz06/whz06/bmiz06).  We keep the PRE-zscore RAW measures:
+    #   Weight      (hh_v08, kg),
+    #   Height      (hh_v09, cm),
+    #   Age_months  (the .do `cage`: roster years hh_b05a x 12, falling back
+    #                to infant months-of-age hh_b05b -- self-describing for
+    #                the z-score transform),
+    #   Sex         (roster hh_b03, normalised to F/M).
+    # NO MUAC column: Module V records no mid-upper-arm circumference in any
+    # IHS/IHPS wave (we carry only the columns the source actually records;
+    # a country whose Module V has MUAC declares and populates it itself).
+    # The WHO-2006 z-scores (haz06/waz06/whz06/bmiz06) and wasting/stunting
+    # are TRANSFORMS (they require the WHO-2006 reference population),
+    # computed at query time, NEVER stored here.  Grain is individual
+    # (t, i, pid), aligned with household_roster's (i, pid); v auto-joins
+    # from sample() at API time, so the returned grain is (t, i, v, pid).
+    # 2004-05 (IHS2) deferred: no Module V body-measurement roster.  See
+    # _/malawi.py:_anthropometry_block / assemble_anthropometry.
+    index: (t, i, pid)
+    Weight: float
+    Height: float
+    Age_months: float
+    Sex: str
+    materialize: make
   food_expenditures:
   food_prices:

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -1613,3 +1613,154 @@ def assemble_livestock(t, pieces):
     out = grp.set_index(['t', 'i', 'animal'])
     assert out.index.is_unique, f"Non-unique (t,i,animal) in livestock {t}"
     return out
+
+
+# --- anthropometry (GAP 5) ------------------------------------------------
+# Item-level (t, i, pid) body-measurement feature for the four IHS3+/IHPS
+# waves.  Source: Module V (hh_mod_v) of the household questionnaire -- the
+# SAME module the World Bank cleaning code reads then collapses to
+# WHO-2006 z-scores (MWI_IHPS{1-4}.do:1213-1231:
+#   gen weight = hh_v08
+#   gen height = hh_v09
+#   gen cage   = age*12 ; replace cage = hh_b05b if age==.
+#   zscore06 ... -> haz06/waz06/whz06/bmiz06).
+# We keep the RAW reported measures (Weight kg = hh_v08, Height cm = hh_v09)
+# plus the child Age_months and Sex the z-score transform needs to be
+# self-describing.  The z-scores / wasting / stunting are TRANSFORMS (they
+# require the WHO-2006 reference population), computed at query time, NEVER
+# stored here.  Module V records no MUAC (mid-upper-arm circumference) in
+# any IHS/IHPS wave, so Malawi anthropometry carries no MUAC column -- we
+# store only the columns the source actually records.
+#
+# Age_months reproduces the .do `cage`: years-of-age (hh_b05a) x 12, falling
+# back to the infant months-of-age (hh_b05b) where years is missing -- both
+# read from the roster (Module B), joined on the wave's native HH+person
+# id keys.  Sex is the roster's hh_b03 (Female/Male), normalised to F/M.
+
+
+_SEX_TO_FM = {
+    'female': 'F', 'f': 'F', '2': 'F',
+    'male':   'M', 'm': 'M', '1': 'M',
+}
+
+
+def _norm_sex(x):
+    """Roster hh_b03 label -> canonical 'F'/'M' (NaN otherwise)."""
+    if pd.isna(x):
+        return pd.NA
+    return _SEX_TO_FM.get(str(x).strip().lower(), pd.NA)
+
+
+def _age_months(years, months):
+    """Reproduce the .do `cage`: age-in-years*12, else infant months-of-age.
+
+    ``years`` = roster hh_b05a (whole years); ``months`` = roster hh_b05b
+    (months-of-age for under-1s).  Returns months as a float, NaN if both
+    are missing.
+    """
+    if pd.notna(years):
+        return float(years) * 12.0
+    if pd.notna(months):
+        return float(months)
+    return np.nan
+
+
+def _anthropometry_block(health, roster, *, t,
+                         hh_id_health, pid_health,
+                         hh_id_roster, pid_roster,
+                         weight='hh_v08', height='hh_v09',
+                         i_prefix=None):
+    """Build one wave-half's reported (i, pid) anthropometry block.
+
+    Parameters
+    ----------
+    health, roster : pd.DataFrame
+        Raw Module V (anthropometry) and Module B (roster) frames for the
+        SAME sample half (Cross_Sectional or Panel), read via get_dataframe
+        with convert_categoricals=True.
+    t : str -- wave id, used as the ``t`` index value.
+    hh_id_health, pid_health : str
+        HH-id and person-id column names in ``health``.
+    hh_id_roster, pid_roster : str
+        HH-id and person-id column names in ``roster`` -- these MUST resolve
+        to the SAME (i, pid) the framework's household_roster feature emits
+        (so anthropometry's grain aligns with household_roster).  Age/Sex
+        are joined from the roster on (hh_id, pid).
+    weight, height : str -- Module V measurement columns (default hh_v08/09).
+    i_prefix : str | None
+        Prepended to the formatted HH id (e.g. 'cs-17-' for the
+        Cross_Sectional half of IHS4/IHS5), reproducing the roster
+        feature's ``cs_i`` mapping so anthropometry's ``i`` aligns with
+        household_roster.  The Age/Sex roster join happens on the *raw*
+        formatted ids (the roster half is read with the matching prefix
+        applied too, so the join is internally consistent), then the
+        prefix is applied to the emitted ``i``.
+
+    Returns
+    -------
+    pd.DataFrame with columns [i, pid, Weight, Height, Age_months, Sex]
+    (Sex/Age from the roster join).  No MUAC column: Module V records no
+    mid-upper-arm circumference in any IHS/IHPS wave.  Index reset; the
+    caller concatenates halves and sets the index.
+    """
+    pre = (lambda s: (i_prefix + s)) if i_prefix else (lambda s: s)
+
+    h = health.copy()
+    h['i'] = h[hh_id_health].apply(format_id).map(pre)
+    h['pid'] = h[pid_health].apply(format_id)
+    h['Weight'] = pd.to_numeric(h[weight], errors='coerce')
+    h['Height'] = pd.to_numeric(h[height], errors='coerce')
+    # Module V records no mid-upper-arm circumference in any IHS/IHPS wave,
+    # so Malawi anthropometry carries no MUAC column (only the columns the
+    # source actually records).  Countries whose Module V has MUAC declare
+    # and populate it themselves.
+    h = h[['i', 'pid', 'Weight', 'Height']]
+
+    # Keep only rows that actually carry a reported measure -- the rest of
+    # Module V is the "was the person measured?" administrivia (hh_v05/06).
+    h = h[h['Weight'].notna() | h['Height'].notna()]
+
+    r = roster.copy()
+    r['i'] = r[hh_id_roster].apply(format_id).map(pre)
+    r['pid'] = r[pid_roster].apply(format_id)
+    r['Sex'] = r['hh_b03'].apply(_norm_sex)
+    years = r['hh_b05a'] if 'hh_b05a' in r.columns else pd.Series(pd.NA, index=r.index)
+    months = r['hh_b05b'] if 'hh_b05b' in r.columns else pd.Series(pd.NA, index=r.index)
+    r['Age_months'] = [
+        _age_months(y, m) for y, m in zip(years, months)
+    ]
+    r = r[['i', 'pid', 'Sex', 'Age_months']].drop_duplicates(['i', 'pid'])
+
+    out = h.merge(r, on=['i', 'pid'], how='left')
+    out['t'] = t
+    return out
+
+
+def assemble_anthropometry(t, pieces):
+    """Combine per-half anthropometry blocks into the canonical frame.
+
+    Parameters
+    ----------
+    t : str -- wave id.
+    pieces : list[pd.DataFrame] -- outputs of _anthropometry_block.
+
+    Returns
+    -------
+    pd.DataFrame indexed (t, i, pid) with columns Weight, Height,
+    Age_months, Sex.  Reported item-level values only.
+    """
+    cat = pd.concat(pieces, ignore_index=True)
+
+    # A measured individual appears once per sample half; if the same
+    # (i, pid) is reported twice (e.g. CS/Panel overlap), keep the first
+    # non-null measurement -- the measures are a single physical reading,
+    # not additive.
+    cat = cat.groupby(['t', 'i', 'pid'], as_index=False, dropna=False).agg({
+        'Weight':     'first',
+        'Height':     'first',
+        'Age_months': 'first',
+        'Sex':        'first',
+    })
+    out = cat.set_index(['t', 'i', 'pid'])
+    assert out.index.is_unique, f"Non-unique (t,i,pid) in anthropometry {t}"
+    return out

--- a/lsms_library/countries/Nigeria/_/Makefile
+++ b/lsms_library/countries/Nigeria/_/Makefile
@@ -165,6 +165,12 @@ $(VAR_DIR)/food_coping.parquet: food_coping.py $(food_coping_parquet)
 ../%/_/individual_education.parquet: ../%/_/individual_education.py
 	(cd $(@D) && python individual_education.py)
 
+# anthropometry (GAP 5).  Single country-level script reads each wave's
+# post-harvest anthropometry section (sect4a/sect4b_harvest) + roster
+# (sect1_harvest, for Sex/Age) and concatenates to var/anthropometry.parquet.
+$(VAR_DIR)/anthropometry.parquet: anthropometry.py
+	python anthropometry.py
+
 ../2010-11/_/housing.parquet: ../2010-11/_/housing.py
 	(cd ../2010-11/_; python housing.py)
 

--- a/lsms_library/countries/Nigeria/_/anthropometry.py
+++ b/lsms_library/countries/Nigeria/_/anthropometry.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+"""Build item-level anthropometry for Nigeria GHS-Panel (GAP 5).
+
+Natural grain (t, i, pid): one row per measured individual, carrying the
+REPORTED body measures the GHS-Panel anthropometry module collects --
+Weight (kg) and Height (cm) -- plus the individual's Sex and reported Age
+(years), so the row is self-describing for the downstream WHO-2006 z-score
+transform.
+
+This is a NEW feature, distinct from `nutrition` (nutrient intake): it holds
+the RAW measured body dimensions the WB code (NGA_GHS1.do:1296-1308) reads,
+feeds into `zscore06` to derive haz06/waz06/whz06/bmiz06 and a `wasting`
+flag, then discards down to the z-scores.  We store ONLY the raw reported
+measures: the z-scores and wasting/stunting are TRANSFORMS (they require the
+WHO-2006 reference population and child age-in-months), computed at query
+time, never stored.
+
+Anthropometry is collected in the post-harvest round only, so each wave maps
+to a single t = PH_QUARTER[wave] (2011Q1 / 2013Q1 / 2016Q1 / 2019Q1 /
+2024Q1), matching the post-harvest slice of household_roster.  The
+individual key (i = format_id(hhid), pid = str(int(indiv))) aligns 100% with
+household_roster on measured rows.
+
+`v` is NOT baked in: anthropometry is an ordinary household/individual table,
+so the framework joins `v` from sample() at API time (it is NOT in the
+`_no_v_join` set).
+
+Per-wave source structure (anthropometry section + roster section that
+supplies Sex/Age, merged on (hhid, indiv)):
+
+  wave     anthro file                 weight cols              height cols              roster file (Sex s1q2, Age)
+  W1 10-11 sect4a_harvestw1            s4aq52                   s4aq53                   sect1_harvestw1 (Age s1q4)
+  W2 12-13 sect4a_harvestw2            s4aq52                   s4aq53                   sect1_harvestw2 (Age s1q4)
+  W3 15-16 sect4a_harvestw3            s4aq52                   s4aq53                   sect1_harvestw3 (Age s1q4)
+  W4 18-19 sect4a_harvestw4            s4aq52_1/_2/_3 (median)  s4aq53_1/_2/_3 (median)  sect1_harvestw4 (Age s1q4)
+  W5 23-24 sect4b_harvestw5            s4bq8a/b/c (median)      s4bq12a/b/c (median)     sect1_harvestw5 (Age s1q6)
+
+W4/W5 took three readings per measure; the WB uses their row median (egen
+rowmedian) -- mirrored here (measurement-error reduction, not an aggregation
+across the item grain).
+
+MUAC (mid-upper-arm circumference) is NOT recorded in any Nigeria GHS wave ->
+no MUAC column.  Age_months is NOT stored (it is derived from interview-month
+minus birth-month -- a transform); the z-score helper derives months from
+Age + interview_date.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import PH_QUARTER, anthropometry_for_wave
+
+# (wave, anthro file, [weight cols], [height cols], roster file, age col)
+SPECS = [
+    ('2010-11',
+     '../2010-11/Data/Post Harvest Wave 1/Household/sect4a_harvestw1.dta',
+     ['s4aq52'], ['s4aq53'],
+     '../2010-11/Data/Post Harvest Wave 1/Household/sect1_harvestw1.dta', 's1q4'),
+    ('2012-13',
+     '../2012-13/Data/Post Harvest Wave 2/Household/sect4a_harvestw2.dta',
+     ['s4aq52'], ['s4aq53'],
+     '../2012-13/Data/Post Harvest Wave 2/Household/sect1_harvestw2.dta', 's1q4'),
+    ('2015-16',
+     '../2015-16/Data/sect4a_harvestw3.dta',
+     ['s4aq52'], ['s4aq53'],
+     '../2015-16/Data/sect1_harvestw3.dta', 's1q4'),
+    ('2018-19',
+     '../2018-19/Data/sect4a_harvestw4.dta',
+     ['s4aq52_1', 's4aq52_2', 's4aq52_3'],
+     ['s4aq53_1', 's4aq53_2', 's4aq53_3'],
+     '../2018-19/Data/sect1_harvestw4.dta', 's1q4'),
+    ('2023-24',
+     '../2023-24/Data/Post Harvest Wave 5/Household/sect4b_harvestw5.dta',
+     ['s4bq8a', 's4bq8b', 's4bq8c'],
+     ['s4bq12a', 's4bq12b', 's4bq12c'],
+     '../2023-24/Data/Post Harvest Wave 5/Household/sect1_harvestw5.dta', 's1q6'),
+]
+
+pieces = []
+for (wave, anthro_f, wcols, hcols, roster_f, age_col) in SPECS:
+    t = PH_QUARTER[wave]
+    anthro = get_dataframe(anthro_f, convert_categoricals=False)
+    # Roster supplies Sex / reported Age; convert_categoricals=False keeps
+    # the raw 'n. NAME' / 'male' labels, normalized inside the helper.
+    roster = get_dataframe(roster_f, convert_categoricals=False)
+    pieces.append(anthropometry_for_wave(
+        t, anthro, roster, weight_cols=wcols, height_cols=hcols,
+        sex_col='s1q2', age_col=age_col))
+
+df = pd.concat(pieces, axis=0).sort_index()
+
+to_parquet(df, '../var/anthropometry.parquet')

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -227,4 +227,47 @@ Data Scheme:
     Value: float
     materialize: make
 
+  anthropometry:
+    # Item-level reported anthropometry (GAP 5) at natural grain
+    # (t, i, pid) [individual].  A NEW feature, distinct from `nutrition`
+    # (which is nutrient *intake*): this holds the RAW measured body
+    # dimensions the WB code (NGA_GHS1.do:1296-1308) reads, feeds into
+    # `zscore06` to derive haz06/waz06/whz06/bmiz06 + a `wasting` flag,
+    # then discards down to the z-scores.  We store ONLY the reported
+    # measures.  The z-scores and wasting/stunting are TRANSFORMS (they
+    # require the WHO-2006 reference population + child age-in-months,
+    # computed at query time) -- NEVER stored here.
+    #
+    # Source: the post-harvest anthropometry section (sect4a_harvest{wN}
+    # W1-W4; sect4b_harvest{w5} W5).  Collected in the post-harvest round
+    # only, so each wave maps to a single t = PH_QUARTER[wave] (2011Q1 /
+    # 2013Q1 / 2016Q1 / 2019Q1 / 2024Q1), matching the post-harvest slice
+    # of household_roster.  The individual key (i = format_id(hhid),
+    # pid = str(int(indiv))) aligns 100% with household_roster on measured
+    # rows.  Country-level script (_/anthropometry.py) reads each wave's
+    # weight/height (W4/W5 take three readings -> row median, mirroring
+    # the WB egen rowmedian) and merges Sex + reported Age from the same
+    # wave's roster section (sect1_harvest s1q2 / s1q4 [W1-W4] or s1q6
+    # [W5]) so the row is self-describing for the z-score transform ->
+    # materialize: make.
+    #
+    # `v` auto-joins from sample() at API time (anthropometry is NOT in
+    # the framework `_no_v_join` set).  Reported columns ONLY:
+    #   Weight  body weight in kg   (s4aq52 W1-W3; median s4aq52_* W4;
+    #                                median s4bq8* W5)
+    #   Height  standing/recumbent height in cm (s4aq53 W1-W3; median
+    #                                s4aq53_* W4; median s4bq12* W5)
+    #   Sex     M / F  (from roster s1q2; self-describing for z-scores)
+    #   Age     reported age in completed years (from roster s1q4 / s1q6)
+    # MUAC is NOT recorded in any Nigeria GHS wave -> no MUAC column.
+    # Age_months is NOT stored (derived from interview-month minus
+    # birth-month -- a transform; the z-score helper derives it from
+    # Age + interview_date).
+    index: (t, i, pid)
+    Weight: float
+    Height: float
+    Sex: str
+    Age: float
+    materialize: make
+
   nonfood_expenditures: !make

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -1104,3 +1104,157 @@ def plot_features_for_wave(t, area, detail, colmap):
     pieces = pieces.set_index(['t', 'i', 'plot_id'])
     return pieces
 
+
+# ---------------------------------------------------------------------
+# anthropometry (GAP 5) -- item-level reported body measures
+# ---------------------------------------------------------------------
+#
+# Natural grain (t, i, pid): one row per measured individual, carrying the
+# REPORTED body measures the GHS-Panel anthropometry module collects --
+# Weight (kg) and Height (cm) -- plus the individual's Sex and reported Age
+# (years) so the row is self-describing for the downstream WHO-2006 z-score
+# transform.  Source: the post-harvest anthropometry section
+# (sect4a_harvest{wN} W1-W4; sect4b_harvest{w5} W5).  The WB code
+# (NGA_GHS1.do:1296-1308) reads these same weight/height vars, merges sex +
+# age from the roster, calls `zscore06` to produce haz06/waz06/whz06/bmiz06
+# and a `wasting` flag, then keeps only the z-scores.  We keep ONLY the raw
+# reported measures: the z-scores are a TRANSFORM (they require the WHO-2006
+# reference population and child age-in-months), computed at query time,
+# never stored.
+#
+# `Age_months` is NOT stored: the survey records reported age in YEARS; the
+# WB derives age-in-months as (harvest-interview-month - birth-month), a
+# transform.  The z-score helper derives months from Age + interview_date.
+# MUAC (mid-upper-arm circumference) is NOT recorded in any Nigeria GHS wave
+# -> no MUAC column.
+#
+# Anthropometry is collected in the post-harvest round only, so each wave
+# maps to a single t = PH_QUARTER[wave] (2011Q1 / 2013Q1 / 2016Q1 / 2019Q1 /
+# 2024Q1), matching the post-harvest slice of household_roster.  The
+# individual key aligns exactly with household_roster: i = format_id(hhid),
+# pid = str(int(indiv)) (verified 100% (i, pid) overlap on measured rows).
+#
+# Per-wave weight/height column map (verified against the .dta):
+#   W1 2010-11  sect4a_harvestw1  Weight=s4aq52        Height=s4aq53
+#   W2 2012-13  sect4a_harvestw2  Weight=s4aq52        Height=s4aq53
+#   W3 2015-16  sect4a_harvestw3  Weight=s4aq52        Height=s4aq53
+#   W4 2018-19  sect4a_harvestw4  Weight=median(s4aq52_1..3)  Height=median(s4aq53_1..3)
+#   W5 2023-24  sect4b_harvestw5  Weight=median(s4bq8a..c)    Height=median(s4bq12a..c)
+# W4/W5 took three readings per measure; the WB uses their row median
+# (egen rowmedian) -- we mirror that (a measurement-error reduction, not an
+# aggregation that crosses the item grain).
+
+
+def _to_pid(indiv_series):
+    """indiv -> canonical pid string ('1'), matching household_roster's pid
+    (raw indiv as string).  NA where indiv is missing."""
+    num = pd.to_numeric(indiv_series, errors='coerce').astype('Int64')
+    return num.astype('string').where(num.notna(), pd.NA)
+
+
+def _norm_sex(sex_series):
+    """Normalize the GHS roster sex variable (s1q2) to canonical 'M' / 'F'.
+
+    Emit the canonical Sex values directly (M / F), matching what
+    household_roster surfaces at API time.  The Sex canonical-spelling map
+    in data_info.yml is registered under household_roster only, so it is
+    NOT applied to anthropometry by _enforce_canonical_spellings; emitting
+    M / F here keeps anthropometry's Sex consistent with the roster without
+    touching the shared data_info.yml.
+
+    Read with convert_categoricals=False the column is the numeric code
+    1 (male) / 2 (female), stable across all five waves; read with labels
+    it is 'male' / 'MALE' / '1. MALE' etc.  Handle both: numeric 1/2 ->
+    M/F; otherwise strip any 'n. NAME' prefix, titlecase, and map the
+    leading letter.  Returns a 'string'-dtype Series, NA where unresolved."""
+    num = pd.to_numeric(sex_series, errors='coerce')
+    if num.notna().any():
+        return num.map({1: 'M', 2: 'F'}).astype('string')
+    label = (sex_series.astype('string')
+             .str.split('. ').str[-1]
+             .str.strip().str.title())
+    return label.map({'Male': 'M', 'Female': 'F'}).astype('string')
+
+
+def anthropometry_for_wave(t, anthro, roster, weight_cols, height_cols,
+                           hhid='hhid', indiv='indiv', sex_col='s1q2',
+                           age_col='s1q4'):
+    """Assemble item-level anthropometry for one Nigeria GHS-Panel PH wave.
+
+    Parameters
+    ----------
+    t : str
+        PH-quarter wave id (e.g. '2011Q1'), used as the `t` index.
+    anthro : DataFrame
+        Raw post-harvest anthropometry section (convert_categoricals as the
+        caller chose), one row per (household, individual).
+    roster : DataFrame or None
+        Raw post-harvest roster section (sect1_harvest{wN}) supplying Sex +
+        reported Age, merged on (hhid, indiv).  None -> Sex/Age all-NA.
+    weight_cols, height_cols : list of str
+        One or more reported weight / height columns.  A single column is
+        used as-is; multiple columns are reduced by their row median (the
+        W4/W5 three-reading case, mirroring the WB egen rowmedian).
+    hhid, indiv : str
+        ID columns in `anthro` (and `roster`).
+    sex_col, age_col : str
+        Sex / reported-age columns in `roster`.
+
+    Returns
+    -------
+    DataFrame indexed by (t, i, pid) with columns
+    [Weight, Height, Sex, Age].  Keeps a row only where at least one of
+    Weight / Height is reported (the module enumerates every household
+    member; only measured members carry a body measure).  Stores REPORTED
+    fields only -- no z-scores, no wasting/stunting (transforms).
+    """
+    def _median(df, cols):
+        present = [c for c in cols if c in df.columns]
+        if not present:
+            return pd.Series(np.nan, index=df.index)
+        block = df[present].apply(pd.to_numeric, errors='coerce')
+        # Row median across the (up to three) readings; NaN where all NaN.
+        return block.median(axis=1, skipna=True)
+
+    i = anthro[hhid].apply(format_id)
+    pid = _to_pid(anthro[indiv])
+    weight = _median(anthro, weight_cols)
+    height = _median(anthro, height_cols)
+
+    piece = pd.DataFrame({
+        'i': i.values,
+        'pid': pid.values,
+        'Weight': pd.to_numeric(weight, errors='coerce').astype('Float64').values,
+        'Height': pd.to_numeric(height, errors='coerce').astype('Float64').values,
+    }, index=anthro.index)
+
+    # Merge Sex + reported Age from the roster on (i, pid).
+    if roster is not None and sex_col in roster.columns:
+        ri = roster[hhid].apply(format_id)
+        rpid = _to_pid(roster[indiv])
+        ros = pd.DataFrame({'i': ri.values, 'pid': rpid.values})
+        ros['Sex'] = _norm_sex(roster[sex_col]).values
+        if age_col in roster.columns:
+            ros['Age'] = pd.to_numeric(roster[age_col],
+                                       errors='coerce').astype('Float64').values
+        else:
+            ros['Age'] = pd.Series(pd.NA, index=roster.index, dtype='Float64').values
+        ros = ros.dropna(subset=['i', 'pid']).drop_duplicates(subset=['i', 'pid'])
+        piece = piece.merge(ros, on=['i', 'pid'], how='left')
+    else:
+        piece['Sex'] = pd.Series(pd.NA, index=piece.index, dtype='string')
+        piece['Age'] = pd.Series(pd.NA, index=piece.index, dtype='Float64')
+
+    piece['t'] = t
+
+    # Keep measured individuals only: at least one of Weight / Height
+    # reported, and a resolvable individual key.
+    measured = piece['Weight'].notna() | piece['Height'].notna()
+    keep = measured & piece['i'].notna() & piece['pid'].notna()
+    out = piece[keep].copy()
+
+    # Defensive dedup on the index grain (a member should appear once).
+    out = out.drop_duplicates(subset=['t', 'i', 'pid'], keep='first')
+    out = out.set_index(['t', 'i', 'pid']).sort_index()
+    return out[['Weight', 'Height', 'Sex', 'Age']]
+

--- a/lsms_library/countries/Tanzania/2008-15/_/anthropometry.py
+++ b/lsms_library/countries/Tanzania/2008-15/_/anthropometry.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""Tanzania 2008-15 anthropometry -- reported body measures (SECTION V).
+
+Source file: ``upd4_hh_v.dta`` -- the multi-round "Anthropometry" module
+covering NPS rounds 1-4 (waves 2008-09, 2010-11, 2012-13, 2014-15), stacked
+with a ``round`` column.  As with the other multi-round Tanzania scripts this
+writes ONE parquet carrying all rounds with ``t`` in the index;
+``Wave.grab_data`` filters to the requested sub-wave.
+
+This is parity-loop GAP 5 -- a NEW item-level feature, distinct from our
+``nutrition`` feature (which is nutrient *intake*).  We store ONLY the RAW
+reported measures the WB cleaning code feeds into ``zscore06``; the WHO/2006
+z-scores (haz06 / waz06 / whz06 / bmiz06) and the wasting/stunting flags are a
+query-time TRANSFORM (they require the WHO reference population), never stored
+here.  See GAP_RANKING.org GAP 5 and TZA_NPS1.do:1002-1024.
+
+The module is INDIVIDUAL-level (one measured row per (round, r_hhid, UPI)).
+Panel keys match household_roster exactly:
+    r_hhid  -> i    (household id, household_roster i)
+    UPI     -> pid  (individual panel id, household_roster pid; formatted the
+                     same way as household_roster.py: float -> int -> str)
+    round   -> t    (round 1..4 mapped to wave label)
+
+Reported columns (from the .dta variable labels, confirmed via pyreadstat):
+    hv_06   WEIGHT (KG)                    -> Weight
+    hv_07   HEIGHT (CM)                    -> Height
+    hv_10   UPPER ARM CIRCUMFERENCE (CM)   -> MUAC
+
+NB the WB Reproduction code (TZA_NPS1.do) reads the per-round raw files
+(suq4/suq5 etc.); we read the harmonised panel file ``upd4_hh_v.dta`` whose
+section is "V" (hv_*), and where weight/height/MUAC are hv_06/hv_07/hv_10.
+The WB panel keeps only rounds 1-3 for anthropometry (NPS4 dropped it for
+"confidential birth dates", NPS5 used pre-computed SDD z-scores); we keep all
+four rounds' RAW measures because z-scores are not our concern.
+
+Sex and Age live in household_roster at the same (t, i, pid) grain and join
+there for the z-score transform, so we keep this feature narrow (reported body
+measures only) rather than duplicating roster characteristics.  Cluster
+identity (v) is joined from sample() at API time, not baked here.
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+round_match = {1: '2008-09', 2: '2010-11', 3: '2012-13', 4: '2014-15'}
+
+df = get_dataframe('../Data/upd4_hh_v.dta', convert_categoricals=False)
+
+anthro = pd.DataFrame({
+    'i': df['r_hhid'].astype(str),
+    'round': pd.to_numeric(df['round'], errors='coerce'),
+    'pid': df['UPI'],
+    'Weight': pd.to_numeric(df['hv_06'], errors='coerce'),   # WEIGHT (KG)
+    'Height': pd.to_numeric(df['hv_07'], errors='coerce'),   # HEIGHT (CM)
+    'MUAC': pd.to_numeric(df['hv_10'], errors='coerce'),     # UPPER ARM CIRC (CM)
+})
+
+# pid formatted exactly like household_roster.py ("1.0" -> "1")
+anthro['pid'] = anthro['pid'].astype(float).astype('Int64').astype(str).replace('<NA>', pd.NA)
+anthro['t'] = anthro['round'].map(round_match)
+anthro = anthro.drop(columns=['round'])
+
+# Keep only rows with at least one reported measure (drop members who were not
+# measured -- hv_04 == NO / skipped -- so the parquet carries genuine readings).
+anthro = anthro.dropna(subset=['Weight', 'Height', 'MUAC'], how='all')
+anthro = anthro.dropna(subset=['t', 'pid'])
+
+out = anthro[['t', 'i', 'pid', 'Weight', 'Height', 'MUAC']].set_index(['t', 'i', 'pid'])
+
+if not out.index.is_unique:
+    out = out.groupby(level=out.index.names).first()
+
+to_parquet(out, 'anthropometry.parquet')

--- a/lsms_library/countries/Tanzania/2019-20/_/anthropometry.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/anthropometry.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""Tanzania 2019-20 (NPS-SDD Extended Panel) anthropometry -- reported body
+measures (HH_SEC_V).
+
+Parity-loop GAP 5 -- a NEW item-level feature, distinct from ``nutrition``
+(nutrient intake).  Stores ONLY the RAW reported measures; the WHO/2006
+z-scores (haz06 / waz06 / whz06) and wasting/stunting flags are a query-time
+TRANSFORM, never stored here.  See GAP_RANKING.org GAP 5 and TZA_NPS5.do.
+
+Source: ``HH_SEC_V.dta`` (the raw section-V anthropometry roster).  We read
+this rather than ``nps_sdd.child.anthro.dta`` because the latter carries ONLY
+the pre-computed z-scores (zwxa/zhxa/zwxh) -- it has no raw weight/height -- and
+is child-only; HH_SEC_V carries the reported Weight/Height/MUAC for every
+measured member.
+
+Panel keys match household_roster (data_info.yml idxvars i=sdd_hhid,
+pid=sdd_indid):
+    sdd_hhid   -> i    (household id)
+    sdd_indid  -> pid  (individual id; format_id matches roster pid)
+
+Reported columns (from the .dta variable labels):
+    hh_v05   Weight (KG)                  -> Weight
+    hh_v06   Height (CM)                  -> Height
+    hh_v09   Upper arm circumference (CM) -> MUAC
+
+Sex and Age live in household_roster at the same (t, i, pid) grain; kept narrow
+here.  Cluster identity (v) is joined from sample() at API time.
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+
+t = '2019-20'
+
+df = get_dataframe('../Data/HH_SEC_V.dta', convert_categoricals=False)
+
+anthro = pd.DataFrame({
+    'i': df['sdd_hhid'].apply(format_id),
+    'pid': df['sdd_indid'].apply(format_id),
+    'Weight': pd.to_numeric(df['hh_v05'], errors='coerce'),  # Weight (KG)
+    'Height': pd.to_numeric(df['hh_v06'], errors='coerce'),  # Height (CM)
+    'MUAC': pd.to_numeric(df['hh_v09'], errors='coerce'),    # Upper arm circ (CM)
+})
+anthro['t'] = t
+
+# Keep only genuinely-measured rows (at least one reported reading).
+anthro = anthro.dropna(subset=['Weight', 'Height', 'MUAC'], how='all')
+anthro = anthro.dropna(subset=['pid'])
+
+out = anthro[['t', 'i', 'pid', 'Weight', 'Height', 'MUAC']].set_index(['t', 'i', 'pid'])
+
+if not out.index.is_unique:
+    out = out.groupby(level=out.index.names).first()
+
+to_parquet(out, 'anthropometry.parquet')

--- a/lsms_library/countries/Tanzania/2020-21/_/anthropometry.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/anthropometry.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""Tanzania 2020-21 (NPS Y5 Refresh Panel) anthropometry -- reported body
+measures (hh_sec_v).
+
+Parity-loop GAP 5 -- a NEW item-level feature, distinct from ``nutrition``
+(nutrient intake).  Stores ONLY the RAW reported measures; the WHO/2006
+z-scores and wasting/stunting flags are a query-time TRANSFORM, never stored
+here.  See GAP_RANKING.org GAP 5.
+
+Source: ``hh_sec_v.dta`` (section-V anthropometry roster).  Panel keys match
+household_roster (data_info.yml idxvars i=y5_hhid, pid=indidy5):
+    y5_hhid   -> i    (household id)
+    indidy5   -> pid  (individual id; format_id matches roster pid)
+
+Reported columns (from the .dta variable labels):
+    hh_v05   Weight (KG)                  -> Weight
+    hh_v06   Height (CM)                  -> Height
+    hh_v09   Upper arm circumference (CM) -> MUAC
+
+Sex and Age live in household_roster at the same (t, i, pid) grain; kept narrow
+here.  Cluster identity (v) is joined from sample() at API time.
+"""
+import pandas as pd
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+
+t = '2020-21'
+
+df = get_dataframe('../Data/hh_sec_v.dta', convert_categoricals=False)
+
+anthro = pd.DataFrame({
+    'i': df['y5_hhid'].apply(format_id),
+    'pid': df['indidy5'].apply(format_id),
+    'Weight': pd.to_numeric(df['hh_v05'], errors='coerce'),  # Weight (KG)
+    'Height': pd.to_numeric(df['hh_v06'], errors='coerce'),  # Height (CM)
+    'MUAC': pd.to_numeric(df['hh_v09'], errors='coerce'),    # Upper arm circ (CM)
+})
+anthro['t'] = t
+
+# Keep only genuinely-measured rows (at least one reported reading).
+anthro = anthro.dropna(subset=['Weight', 'Height', 'MUAC'], how='all')
+anthro = anthro.dropna(subset=['pid'])
+
+out = anthro[['t', 'i', 'pid', 'Weight', 'Height', 'MUAC']].set_index(['t', 'i', 'pid'])
+
+if not out.index.is_unique:
+    out = out.groupby(level=out.index.names).first()
+
+to_parquet(out, 'anthropometry.parquet')

--- a/lsms_library/countries/Tanzania/_/Makefile
+++ b/lsms_library/countries/Tanzania/_/Makefile
@@ -93,6 +93,15 @@ $(VAR_DIR)/livestock.parquet: livestock.py $(livestock_parquet)
 ../%/_/livestock.parquet:
 	(cd $(@D) && python livestock.py)
 
+anthropometry = $(shell find $(rounds) -name anthropometry.py)
+anthropometry_parquet := $(anthropometry:.py=.parquet)
+
+$(VAR_DIR)/anthropometry.parquet: anthropometry.py $(anthropometry_parquet)
+	python anthropometry.py
+
+../%/_/anthropometry.parquet:
+	(cd $(@D) && python anthropometry.py)
+
 %.parquet: %.py CONTENTS.org tanzania.py
 	(cd $(@D) && python ./$(<F))
 

--- a/lsms_library/countries/Tanzania/_/anthropometry.py
+++ b/lsms_library/countries/Tanzania/_/anthropometry.py
@@ -1,0 +1,61 @@
+"""Concatenate wave-level anthropometry data for Tanzania NPS
+(parity-loop GAP 5).
+
+anthropometry is a NEW item-level feature: reported body measures (Weight,
+Height, MUAC) at the individual grain (t, i, pid).  It is DISTINCT from our
+``nutrition`` feature (nutrient intake).  The WHO/2006 z-scores
+(haz06 / waz06 / whz06 / bmiz06) and the wasting/stunting flags are a
+query-time TRANSFORM over these raw measures -- never stored here.
+
+Each buildable wave's ``Tanzania/<wave>/_/anthropometry.py`` writes a parquet
+indexed ``(t, i, pid)`` with columns Weight / Height / MUAC.  The 2008-15
+multi-round folder's parquet carries all four NPS rounds (2008-09, 2010-11,
+2012-13, 2014-15) from the harmonised section-V panel file ``upd4_hh_v.dta``;
+the 2019-20 and 2020-21 folders carry one wave each (HH_SEC_V / hh_sec_v).
+
+We load by folder (Waves.keys()), concatenate, then id_walk to harmonize
+household ids across waves (pid is left untouched -- id_walk renames only the
+``i`` level).  ``anthropometry`` is individual-level; the framework joins the
+cluster ``v`` from sample() at API time (it is NOT in the _no_v_join set).
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from lsms_library.paths import data_root
+from tanzania import Waves, id_walk
+import warnings
+
+pieces = {}
+for t in Waves.keys():
+    candidates = [
+        str(data_root('Tanzania') / t / '_' / 'anthropometry.parquet'),
+        '../' + t + '/_/anthropometry.parquet',
+    ]
+    for path in candidates:
+        try:
+            pieces[t] = get_dataframe(path)
+            break
+        except (FileNotFoundError, Exception):
+            continue
+    if t not in pieces:
+        warnings.warn(f'Could not load anthropometry for {t}')
+
+assert pieces, "anthropometry: no wave-level parquets found"
+
+p = pd.concat(pieces.values())
+
+# Ensure the canonical (t, i, pid) index.
+target_idx = ['t', 'i', 'pid']
+if list(p.index.names) != target_idx:
+    p = p.reset_index()
+    p = p.set_index(target_idx)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids, hh_index='i')
+
+if not p.index.is_unique:
+    p = p.groupby(level=p.index.names).first()
+
+to_parquet(p, '../var/anthropometry.parquet')

--- a/lsms_library/countries/Tanzania/_/data_scheme.yml
+++ b/lsms_library/countries/Tanzania/_/data_scheme.yml
@@ -38,6 +38,36 @@ Data Scheme:
     Educational Attainment: str
     materialize: make
 
+  anthropometry:
+    # Item-level body measures (parity-loop GAP 5) at the natural grain
+    # (t, i, pid) -- one row per MEASURED individual.  A NEW feature, DISTINCT
+    # from 'nutrition' (which is nutrient intake): this stores the RAW reported
+    # anthropometric readings the WHO/2006 z-score transform consumes.
+    #   Weight : reported body weight, kilograms (hv_06 / hh_v05).
+    #   Height : reported standing-or-lying height/length, centimetres
+    #            (hv_07 / hh_v06).
+    #   MUAC   : mid-upper-arm circumference, centimetres (hv_10 / hh_v09);
+    #            recorded for children only, so partially null by construction.
+    # STORES REPORTED MEASURES ONLY -- the WHO/2006 reference-population z-scores
+    # (haz06 / waz06 / whz06 / bmiz06) and the wasting / stunting flags are a
+    # query-time TRANSFORM (reference lookup), NEVER stored here.  Sex and Age
+    # for the z-score transform join from household_roster at the same
+    # (t, i, pid) grain, so this feature stays narrow.
+    # SCOPE: all six NPS waves field section V -- 2008-09 / 2010-11 / 2012-13 /
+    # 2014-15 come from the 2008-15 multi-round panel file upd4_hh_v.dta
+    # (hv_06/hv_07/hv_10), 2019-20 from HH_SEC_V and 2020-21 from hh_sec_v
+    # (hh_v05/hh_v06/hh_v09).  The WB Reproduction panel keeps only rounds 1-3
+    # (NPS4 dropped anthropometry for "confidential birth dates", NPS5 carried
+    # only pre-computed SDD z-scores); we additionally retain the raw 2014-15,
+    # 2019-20 and 2020-21 readings because z-scores are not stored.
+    # v (cluster) joins from sample() at API time -- anthropometry is NOT in the
+    # framework _no_v_join set.
+    index: (t, i, pid)
+    Weight: float
+    Height: float
+    MUAC: float
+    materialize: make
+
   life_satisfaction:
     # Domain-satisfaction battery (Section G "Subjective Welfare", item
     # hh_g03_* / hg_03_*).  Present in ALL Tanzania waves: 2008-09, 2010-11,

--- a/lsms_library/countries/Uganda/2009-10/_/anthropometry.py
+++ b/lsms_library/countries/Uganda/2009-10/_/anthropometry.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""anthropometry for Uganda UNPS — one wave (GAP 5 item-level build).
+
+Reads the GSEC6 anthropometry module via get_dataframe and emits a canonical
+(t, i, pid) parquet of the REPORTED body measures (Weight kg, Height cm,
+MUAC cm, Age_months).  This is the raw input the WB cleaning code
+(UGA_UNPS{1..8}.do anthro section) feeds into ``zscore06`` — we keep ONLY the
+reported measures, never the z-scores or wasting/stunting flags (those are
+WHO-2006 reference-population transforms, computed at query time).
+
+The wave id is the parent folder name; the source file and column map come
+from uganda.ANTHRO_FILES / uganda.ANTHRO_COLMAPS.
+"""
+import os
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import anthropometry_for_wave, ANTHRO_COLMAPS, ANTHRO_FILES
+
+t = os.path.basename(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+colmap = ANTHRO_COLMAPS[t]
+
+df = get_dataframe(ANTHRO_FILES[t])
+
+out = anthropometry_for_wave(t, df, colmap)
+assert len(out) > 0, f"anthropometry produced no rows for {t}"
+assert out.index.is_unique, f"Non-unique anthropometry index for {t}"
+to_parquet(out, 'anthropometry.parquet')

--- a/lsms_library/countries/Uganda/2010-11/_/anthropometry.py
+++ b/lsms_library/countries/Uganda/2010-11/_/anthropometry.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""anthropometry for Uganda UNPS — one wave (GAP 5 item-level build).
+
+Reads the GSEC6 anthropometry module via get_dataframe and emits a canonical
+(t, i, pid) parquet of the REPORTED body measures (Weight kg, Height cm,
+MUAC cm, Age_months).  This is the raw input the WB cleaning code
+(UGA_UNPS{1..8}.do anthro section) feeds into ``zscore06`` — we keep ONLY the
+reported measures, never the z-scores or wasting/stunting flags (those are
+WHO-2006 reference-population transforms, computed at query time).
+
+The wave id is the parent folder name; the source file and column map come
+from uganda.ANTHRO_FILES / uganda.ANTHRO_COLMAPS.
+"""
+import os
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import anthropometry_for_wave, ANTHRO_COLMAPS, ANTHRO_FILES
+
+t = os.path.basename(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+colmap = ANTHRO_COLMAPS[t]
+
+df = get_dataframe(ANTHRO_FILES[t])
+
+out = anthropometry_for_wave(t, df, colmap)
+assert len(out) > 0, f"anthropometry produced no rows for {t}"
+assert out.index.is_unique, f"Non-unique anthropometry index for {t}"
+to_parquet(out, 'anthropometry.parquet')

--- a/lsms_library/countries/Uganda/2011-12/_/anthropometry.py
+++ b/lsms_library/countries/Uganda/2011-12/_/anthropometry.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""anthropometry for Uganda UNPS — one wave (GAP 5 item-level build).
+
+Reads the GSEC6 anthropometry module via get_dataframe and emits a canonical
+(t, i, pid) parquet of the REPORTED body measures (Weight kg, Height cm,
+MUAC cm, Age_months).  This is the raw input the WB cleaning code
+(UGA_UNPS{1..8}.do anthro section) feeds into ``zscore06`` — we keep ONLY the
+reported measures, never the z-scores or wasting/stunting flags (those are
+WHO-2006 reference-population transforms, computed at query time).
+
+The wave id is the parent folder name; the source file and column map come
+from uganda.ANTHRO_FILES / uganda.ANTHRO_COLMAPS.
+"""
+import os
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import anthropometry_for_wave, ANTHRO_COLMAPS, ANTHRO_FILES
+
+t = os.path.basename(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+colmap = ANTHRO_COLMAPS[t]
+
+df = get_dataframe(ANTHRO_FILES[t])
+
+out = anthropometry_for_wave(t, df, colmap)
+assert len(out) > 0, f"anthropometry produced no rows for {t}"
+assert out.index.is_unique, f"Non-unique anthropometry index for {t}"
+to_parquet(out, 'anthropometry.parquet')

--- a/lsms_library/countries/Uganda/2013-14/_/anthropometry.py
+++ b/lsms_library/countries/Uganda/2013-14/_/anthropometry.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""anthropometry for Uganda UNPS — one wave (GAP 5 item-level build).
+
+Reads the GSEC6 anthropometry module via get_dataframe and emits a canonical
+(t, i, pid) parquet of the REPORTED body measures (Weight kg, Height cm,
+MUAC cm, Age_months).  This is the raw input the WB cleaning code
+(UGA_UNPS{1..8}.do anthro section) feeds into ``zscore06`` — we keep ONLY the
+reported measures, never the z-scores or wasting/stunting flags (those are
+WHO-2006 reference-population transforms, computed at query time).
+
+The wave id is the parent folder name; the source file and column map come
+from uganda.ANTHRO_FILES / uganda.ANTHRO_COLMAPS.
+"""
+import os
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import anthropometry_for_wave, ANTHRO_COLMAPS, ANTHRO_FILES
+
+t = os.path.basename(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+colmap = ANTHRO_COLMAPS[t]
+
+df = get_dataframe(ANTHRO_FILES[t])
+
+out = anthropometry_for_wave(t, df, colmap)
+assert len(out) > 0, f"anthropometry produced no rows for {t}"
+assert out.index.is_unique, f"Non-unique anthropometry index for {t}"
+to_parquet(out, 'anthropometry.parquet')

--- a/lsms_library/countries/Uganda/2015-16/_/anthropometry.py
+++ b/lsms_library/countries/Uganda/2015-16/_/anthropometry.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""anthropometry for Uganda UNPS — one wave (GAP 5 item-level build).
+
+Reads the GSEC6 anthropometry module via get_dataframe and emits a canonical
+(t, i, pid) parquet of the REPORTED body measures (Weight kg, Height cm,
+MUAC cm, Age_months).  This is the raw input the WB cleaning code
+(UGA_UNPS{1..8}.do anthro section) feeds into ``zscore06`` — we keep ONLY the
+reported measures, never the z-scores or wasting/stunting flags (those are
+WHO-2006 reference-population transforms, computed at query time).
+
+The wave id is the parent folder name; the source file and column map come
+from uganda.ANTHRO_FILES / uganda.ANTHRO_COLMAPS.
+"""
+import os
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import anthropometry_for_wave, ANTHRO_COLMAPS, ANTHRO_FILES
+
+t = os.path.basename(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+colmap = ANTHRO_COLMAPS[t]
+
+df = get_dataframe(ANTHRO_FILES[t])
+
+out = anthropometry_for_wave(t, df, colmap)
+assert len(out) > 0, f"anthropometry produced no rows for {t}"
+assert out.index.is_unique, f"Non-unique anthropometry index for {t}"
+to_parquet(out, 'anthropometry.parquet')

--- a/lsms_library/countries/Uganda/2018-19/_/anthropometry.py
+++ b/lsms_library/countries/Uganda/2018-19/_/anthropometry.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""anthropometry for Uganda UNPS — one wave (GAP 5 item-level build).
+
+Reads the GSEC6 anthropometry module via get_dataframe and emits a canonical
+(t, i, pid) parquet of the REPORTED body measures (Weight kg, Height cm,
+MUAC cm, Age_months).  This is the raw input the WB cleaning code
+(UGA_UNPS{1..8}.do anthro section) feeds into ``zscore06`` — we keep ONLY the
+reported measures, never the z-scores or wasting/stunting flags (those are
+WHO-2006 reference-population transforms, computed at query time).
+
+The wave id is the parent folder name; the source file and column map come
+from uganda.ANTHRO_FILES / uganda.ANTHRO_COLMAPS.
+"""
+import os
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import anthropometry_for_wave, ANTHRO_COLMAPS, ANTHRO_FILES
+
+t = os.path.basename(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+colmap = ANTHRO_COLMAPS[t]
+
+df = get_dataframe(ANTHRO_FILES[t])
+
+out = anthropometry_for_wave(t, df, colmap)
+assert len(out) > 0, f"anthropometry produced no rows for {t}"
+assert out.index.is_unique, f"Non-unique anthropometry index for {t}"
+to_parquet(out, 'anthropometry.parquet')

--- a/lsms_library/countries/Uganda/2019-20/_/anthropometry.py
+++ b/lsms_library/countries/Uganda/2019-20/_/anthropometry.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""anthropometry for Uganda UNPS — one wave (GAP 5 item-level build).
+
+Reads the GSEC6 anthropometry module via get_dataframe and emits a canonical
+(t, i, pid) parquet of the REPORTED body measures (Weight kg, Height cm,
+MUAC cm, Age_months).  This is the raw input the WB cleaning code
+(UGA_UNPS{1..8}.do anthro section) feeds into ``zscore06`` — we keep ONLY the
+reported measures, never the z-scores or wasting/stunting flags (those are
+WHO-2006 reference-population transforms, computed at query time).
+
+The wave id is the parent folder name; the source file and column map come
+from uganda.ANTHRO_FILES / uganda.ANTHRO_COLMAPS.
+"""
+import os
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import anthropometry_for_wave, ANTHRO_COLMAPS, ANTHRO_FILES
+
+t = os.path.basename(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+colmap = ANTHRO_COLMAPS[t]
+
+df = get_dataframe(ANTHRO_FILES[t])
+
+out = anthropometry_for_wave(t, df, colmap)
+assert len(out) > 0, f"anthropometry produced no rows for {t}"
+assert out.index.is_unique, f"Non-unique anthropometry index for {t}"
+to_parquet(out, 'anthropometry.parquet')

--- a/lsms_library/countries/Uganda/_/Makefile
+++ b/lsms_library/countries/Uganda/_/Makefile
@@ -26,6 +26,7 @@ var = $(VAR_DIR)/shocks.parquet $(VAR_DIR)/nonfood_expenditures.parquet $(VAR_DI
 	  $(VAR_DIR)/crop_production.parquet \
 	  $(VAR_DIR)/plot_inputs.parquet \
 	  $(VAR_DIR)/livestock.parquet \
+	  $(VAR_DIR)/anthropometry.parquet \
 	  $(VAR_DIR)/months_food_inadequate.parquet
 
 all: $(parquet) $(var)
@@ -101,6 +102,12 @@ livestock_parquet := $(livestock:.py=.parquet)
 
 $(VAR_DIR)/livestock.parquet: livestock.py $(livestock_parquet)
 	python livestock.py
+
+anthropometry = $(shell find $(rounds) -name anthropometry.py)
+anthropometry_parquet := $(anthropometry:.py=.parquet)
+
+$(VAR_DIR)/anthropometry.parquet: anthropometry.py $(anthropometry_parquet)
+	python anthropometry.py
 
 months_food_inadequate = $(shell find $(rounds) -name months_food_inadequate.py)
 months_food_inadequate_parquet := $(months_food_inadequate:.py=.parquet)

--- a/lsms_library/countries/Uganda/_/anthropometry.py
+++ b/lsms_library/countries/Uganda/_/anthropometry.py
@@ -1,0 +1,43 @@
+"""Concatenate wave-level anthropometry data for Uganda (GAP 5).
+
+Each wave's ``Uganda/<wave>/_/anthropometry.py`` produces a parquet indexed
+``(t, i, pid)`` with the REPORTED body measures (Weight, Height, MUAC,
+Age_months).  This script concatenates them across waves and applies
+cross-wave id_walk so the household index uses the panel canonical id scheme
+(the 2018-19 / 2019-20 GSEC6 files carry the hashed survey hhid; id_walk
+maps it to the same canonical ``i`` household_roster uses).
+
+Source: the GSEC6 anthropometry module that the WB code reads to compute
+z-scores.  We keep only the raw measures it feeds in — the z-scores
+(haz06/waz06/whz06/bmiz06) and wasting/stunting flags are WHO-2006
+reference-population TRANSFORMS, never stored here.  2005-06 is intentionally
+absent: it has no GSEC6 anthropometry module and the UNPS panel the WB
+harmonise effort tracks starts at wave 1 = 2009-10.
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import Waves, id_walk
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/anthropometry.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for anthropometry (no .py / parquet, e.g. 2005-06).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "anthropometry: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/anthropometry.parquet')

--- a/lsms_library/countries/Uganda/_/data_scheme.yml
+++ b/lsms_library/countries/Uganda/_/data_scheme.yml
@@ -208,4 +208,51 @@ Data Scheme:
     HeadSold: float
     Value: float
     materialize: make
+  anthropometry:
+    # Item-level anthropometry module (GAP 5 parity build).  One row per
+    # MEASURED individual.  Source: the GSEC6 anthropometry module of the
+    # UNPS questionnaire, the raw weight/height the WB code
+    # (UGA_UNPS{1..8}.do anthro section) feeds into ``zscore06`` — we keep
+    # ONLY the reported measures, never the z-scores / wasting flags.
+    #
+    # NEW feature, distinct from ``nutrition`` (which is nutrient INTAKE,
+    # consumption x food-composition tables).  anthropometry is body
+    # measurement.
+    #
+    # Grain (t, i, pid) [individual]:
+    #   pid — the individual key, matching household_roster's pid so the
+    #         child's Sex (and integer Age) join from the roster.  v auto-
+    #         joins from sample() at API time (anthropometry is NOT in the
+    #         framework _no_v_join set).
+    #
+    # Columns are REPORTED values ONLY (missing-in-wave -> NaN):
+    #   Weight     — kg
+    #   Height     — cm (lying-down length preferred, else standing height)
+    #   MUAC       — mid-upper-arm circumference, cm.  NaN throughout: no
+    #                UNPS wave records arm circumference (declared for
+    #                cross-country schema parity only).
+    #   Age_months — child age in months as recorded by the survey.  <NA>
+    #                in 2018-19 / 2019-20 (those waves dropped the in-module
+    #                age-in-months question; the WB code derives child age
+    #                from the roster there).
+    #
+    # NO haz06 / waz06 / whz06 / bmiz06 / wasting / stunting — all of those
+    # are WHO-2006 reference-population TRANSFORMS, computed at query time
+    # over (Weight, Height, child Age/Sex), never stored.
+    #
+    # Wired for 2009-10 .. 2019-20 (every wave with a GSEC6 anthro module).
+    # 2005-06 has no anthropometry module (the UNPS panel starts at 2009-10).
+    index: (t, i, pid)
+    Weight: float
+    Height: float
+    # No UNPS wave records mid-upper-arm circumference, so MUAC is
+    # legitimately all-NaN for Uganda.  Mark optional so the all-null
+    # sanity check exempts it while the canonical column stays declared
+    # for cross-country alignment (other countries — e.g. Ethiopia ESS —
+    # do record MUAC).
+    MUAC:
+      type: float
+      optional: true
+    Age_months: float
+    materialize: make
   nonfood_expenditures: !make

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -1720,3 +1720,163 @@ LIVESTOCK_COLMAPS = {
               'headcount': 's6cq03a', 'acquired': 's6cq13a', 'sold': 's6cq14a', 'value': 's6cq14b'},
     },
 }
+
+
+def _anthro_num(series, length):
+    """Coerce an anthropometry measure column to Float64, treating
+    non-positive sentinels (0 / negatives) as missing.
+
+    Uganda's GSEC6 anthropometry records 0.0 in the height columns where
+    a child was measured on the OTHER height instrument (lying vs.
+    standing), and the WB cleaning code (UGA_UNPS{1..8}.do) treats those
+    as ``.`` before feeding ``zscore06``.  Weight/height/MUAC are strictly
+    positive physical quantities, so a 0 or negative reading is an absent
+    or invalid measurement, not a real value.
+    """
+    if series is None:
+        return pd.Series([pd.NA] * length, dtype='Float64')
+    v = pd.to_numeric(series, errors='coerce')
+    v = v.where(v > 0, other=pd.NA)
+    return v.astype('Float64')
+
+
+def anthropometry_for_wave(t, df, colmap):
+    """Build the canonical ``anthropometry`` table for one Uganda UNPS wave.
+
+    Item-level, individual-grain ``(t, i, pid)``.  Carries ONLY the
+    REPORTED body measures the GSEC6 anthropometry module records:
+
+        Weight     — kg            (q27 / q27a / s6q27a)
+        Height     — cm            (lying-down q28a/s6q28a2 preferred,
+                                    falling back to standing q28b/s6q28b2,
+                                    matching the WB ``gen height = ...;
+                                    replace height = ...b if height==.``)
+        MUAC       — mid-upper-arm circumference, cm  (NaN for Uganda —
+                     no UNPS wave records arm circumference; the column is
+                     declared for cross-country schema parity only)
+        Age_months — child age in months as recorded by the survey
+                     (q04 / q4; <NA> in 2018-19 / 2019-20, which dropped
+                     the in-module age-in-months question — the WB code
+                     sets ``age_months=.`` for those waves and derives the
+                     child age from the roster instead)
+
+    NO z-scores (haz06/waz06/whz06/bmiz06), NO wasting/stunting: those are
+    WHO-2006 reference-population TRANSFORMS computed at query time, never
+    stored.  Sex is NOT carried here — the GSEC6 module records only the
+    caregiver's relationship, not the child's sex; the child's ``Sex``
+    (and integer ``Age``) join from ``household_roster`` on the shared
+    ``(t, i, pid)`` key.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2009-10"``).
+    df : pd.DataFrame
+        Raw GSEC6 anthropometry module for the wave.
+    colmap : dict
+        Column map with keys ``hhid``, ``pid``, ``weight``,
+        ``height_lying``, ``height_standing``, ``age_months`` (any of the
+        measure keys may be ``None`` when the wave lacks that column).
+
+    Returns
+    -------
+    pd.DataFrame indexed ``(t, i, pid)`` with Float64 columns
+        ``Weight``, ``Height``, ``MUAC``, ``Age_months``.  One row per
+        measured individual: a roster line is kept only when AT LEAST ONE
+        of Weight / Height is reported (the module pre-lists every child,
+        and rows with no measurement at all are empty placeholders).
+    """
+    n = len(df)
+    hh = df[colmap['hhid']].apply(format_id)
+    pid = df[colmap['pid']].apply(format_id)
+
+    weight = _anthro_num(df.get(colmap.get('weight')), n)
+
+    lying = _anthro_num(df.get(colmap.get('height_lying')), n)
+    standing = _anthro_num(df.get(colmap.get('height_standing')), n)
+    # Lying-down length is recorded for the youngest children; standing
+    # height for older ones.  Prefer whichever is present (lying first,
+    # mirroring the WB ``gen height = ...a; replace = ...b if height==.``).
+    height = lying.where(lying.notna(), standing)
+
+    muac = _anthro_num(df.get(colmap.get('muac')), n)
+
+    age_months = _anthro_num(df.get(colmap.get('age_months')), n)
+
+    out = pd.DataFrame({
+        't':          t,
+        'i':          hh.values,
+        'pid':        pid.values,
+        'Weight':     weight.values,
+        'Height':     height.values,
+        'MUAC':       muac.values,
+        'Age_months': age_months.values,
+    })
+
+    # Keep only rows that carry at least one body measure.
+    has_measure = out['Weight'].notna() | out['Height'].notna() | out['MUAC'].notna()
+    out = out[has_measure]
+
+    # Drop rows missing an id (cannot key into the roster).
+    out = out[out['i'].notna() & out['pid'].notna()]
+
+    # A roster may list a child twice (e.g. re-measured); keep the row with
+    # the most non-null measures so the (t, i, pid) index is unique.
+    out['_nn'] = out[['Weight', 'Height', 'MUAC', 'Age_months']].notna().sum(axis=1)
+    out = (out.sort_values('_nn', ascending=False)
+              .drop_duplicates(['t', 'i', 'pid'])
+              .drop(columns='_nn'))
+
+    out = out.set_index(['t', 'i', 'pid'])
+    for c in ['Weight', 'Height', 'MUAC', 'Age_months']:
+        out[c] = pd.to_numeric(out[c], errors='coerce').astype('Float64')
+    return out
+
+
+# Per-wave column maps for anthropometry_for_wave.  Source files / variable
+# names from the GSEC6 anthropometry module, confirmed against the actual
+# .dta via get_dataframe (Stata is case-insensitive but pandas is not, so
+# the casing below is the real on-disk casing, NOT the WB .do casing):
+#   2009-10  GSEC6.dta      weight h6q27   height h6q28a/b   age h6q04
+#   2010-11  GSEC6.dta      weight h6q27   height h6q28a/b   age h6q4
+#   2011-12  GSEC6A.dta     weight h6q27   height h6q28a/b   age h6q4
+#   2013-14  GSEC6_1.dta    weight h6q27a  height h6q28a/b   age h6q4
+#   2015-16  gsec6_1.dta    weight h6q27a  height h6q28a/b   age h6q4
+#   2018-19  GSEC6_5.dta    weight s6q27a  height s6q28a2/b2 (no in-module age)
+#   2019-20  HH/gsec6_5.dta weight s6q27a  height s6q28a2/b2 (no in-module age)
+# No UNPS wave records MUAC (arm circumference); 'muac' is therefore None
+# everywhere and Uganda's MUAC column is NaN throughout.
+ANTHRO_COLMAPS = {
+    '2009-10': {'hhid': 'HHID', 'pid': 'PID', 'weight': 'h6q27',
+                'height_lying': 'h6q28a', 'height_standing': 'h6q28b',
+                'muac': None, 'age_months': 'h6q04'},
+    '2010-11': {'hhid': 'HHID', 'pid': 'PID', 'weight': 'h6q27',
+                'height_lying': 'h6q28a', 'height_standing': 'h6q28b',
+                'muac': None, 'age_months': 'h6q4'},
+    '2011-12': {'hhid': 'HHID', 'pid': 'PID', 'weight': 'h6q27',
+                'height_lying': 'h6q28a', 'height_standing': 'h6q28b',
+                'muac': None, 'age_months': 'h6q4'},
+    '2013-14': {'hhid': 'HHID', 'pid': 'PID', 'weight': 'h6q27a',
+                'height_lying': 'h6q28a', 'height_standing': 'h6q28b',
+                'muac': None, 'age_months': 'h6q4'},
+    '2015-16': {'hhid': 'hhid', 'pid': 'pid', 'weight': 'h6q27a',
+                'height_lying': 'h6q28a', 'height_standing': 'h6q28b',
+                'muac': None, 'age_months': 'h6q4'},
+    '2018-19': {'hhid': 'hhid', 'pid': 'PID', 'weight': 's6q27a',
+                'height_lying': 's6q28a2', 'height_standing': 's6q28b2',
+                'muac': None, 'age_months': None},
+    '2019-20': {'hhid': 'hhid', 'pid': 'pid', 'weight': 's6q27a',
+                'height_lying': 's6q28a2', 'height_standing': 's6q28b2',
+                'muac': None, 'age_months': None},
+}
+
+# Per-wave anthropometry source file (relative to the wave's _/ dir).
+ANTHRO_FILES = {
+    '2009-10': '../Data/GSEC6.dta',
+    '2010-11': '../Data/GSEC6.dta',
+    '2011-12': '../Data/GSEC6A.dta',
+    '2013-14': '../Data/GSEC6_1.dta',
+    '2015-16': '../Data/gsec6_1.dta',
+    '2018-19': '../Data/GSEC6_5.dta',
+    '2019-20': '../Data/HH/gsec6_5.dta',
+}


### PR DESCRIPTION
GAP 5: NEW `anthropometry` feature (distinct from intake-`nutrition`) at `(t,i,pid)` — reported Weight/Height/MUAC (+age/sex). WHO-2006 z-scores (haz06/whz06/wasting/stunting) stay `transformations`, never stored. `v` auto-joins; no framework edits. Exact WB weight/height parity (Ethiopia/Malawi). Independent cold-build of all 5 green; adversary PASS (no z-score leakage, nutrition untouched). Ethiopia/Uganda `nutrition` (intake) still builds unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>