### PR TITLE
feat(parity): GAP 3 — labor (plot_labor + people_last7days) across 7 LSMS-ISA countries

### DIFF
--- a/lsms_library/countries/Ethiopia/2011-12/_/people_last7days.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/people_last7days.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+"""Build people_last7days for Ethiopia ESS 2011-12 (Wave 1; GAP 3.1).
+
+Individual 7-day activity at (t, i, pid) from §4 labor roster
+(sect4_hh_w1), mirroring Uganda's per-individual schema.  Reproduces the
+REPORTED per-individual data the WB labor block reads
+(ETH_ESS1.do:1242-1264) -- NOT the WB nb_members_working_age household-sum
+or the six ind_* dummies (the single reported industry label is kept;
+the dummies derive from it).
+
+W1 source vars (hh_s4* prefix): farm hours hh_s4q04, SOB hours hh_s4q05,
+wage hours hh_s4q07 (the WB recodes each else=1 -> work dummy, so the
+dummies are recoded from these hours).  employed-gate hh_s4q09 (==2 or
+missing blanks the wage-work industry).  industry hh_s4q11_b.
+working_age = (hh_s4q01 == "X").
+i = household_id, pid = individual_id (match household_roster for W1).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import people_last7days_for_wave
+
+
+lab = get_dataframe('../Data/sect4_hh_w1.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', pid='individual_id',
+    # W1-W3 record only HOURS; recode the did-activity dummies from them.
+    dummy_from_hours=True,
+    farm_hrs='hh_s4q04', sb_hrs='hh_s4q05', wage_hrs='hh_s4q07',
+    industry='hh_s4q11_b',
+    employed_gate='hh_s4q09', employed_no=2,
+    working_age='hh_s4q01', working_age_marker='X',
+)
+
+df = people_last7days_for_wave('2011-12', lab, colmap)
+
+assert len(df) > 0, "people_last7days 2011-12 produced no rows"
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Ethiopia/2011-12/_/plot_labor.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/plot_labor.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+"""Build plot_labor for Ethiopia ESS 2011-12 (Wave 1; GAP 3.2).
+
+Plot labor person-DAYS at (t, i, plot_id, source) with source in
+{family, hired, other}, plus the reported cash wage paid to hired labor.
+Reproduces the REPORTED item-level data the WB code reads
+(ETH_ESS1.do:554-799) -- NOT the WB total_labor_days / total_*_labor_days
+sums or the valuation_median_wages imputed wage.
+
+W1 sources / vars:
+  post-PLANTING §3 plot roster (sect3_pp_w1): hired pp_s3q28_a..i
+    (a=#men b=days/man c=man-wage d=#women e=days/woman f=woman-wage
+    g=#child h=days/child i=child-wage); family pp_s3q27_* (6 member slots,
+    did/weeks/days at letter-stride 4); other pp_s3q29_a..f (a=#men
+    b=days/man c=#women d=days/woman e=#child f=days/child).
+    Restricted to cultivated plots (pp_s3q03 in {1,2}), as the WB does.
+  post-HARVEST §10 labor (sect10_ph_w1): hired ph_s10q01_a..i; family
+    ph_s10q02_* (8 member slots); other ph_s10q03_a..f.  This file is
+    plot x crop; the helper sums its days over crops to the plot.
+i = household_id (matches sample().i for W1).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_labor_for_wave, labor_family_triples
+
+
+pp = get_dataframe('../Data/sect3_pp_w1.dta',  convert_categoricals=False)
+ph = get_dataframe('../Data/sect10_ph_w1.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+    pp_filter=('pp_s3q03', (1, 2)),
+    # PP hired
+    pp_h_n_m='pp_s3q28_a', pp_h_d_m='pp_s3q28_b', pp_h_w_m='pp_s3q28_c',
+    pp_h_n_w='pp_s3q28_d', pp_h_d_w='pp_s3q28_e', pp_h_w_w='pp_s3q28_f',
+    pp_h_n_c='pp_s3q28_g', pp_h_d_c='pp_s3q28_h', pp_h_w_c='pp_s3q28_i',
+    # PP family (6 member slots)
+    pp_f_members=labor_family_triples('pp_s3q27', 6),
+    # PP other
+    pp_o_n_m='pp_s3q29_a', pp_o_d_m='pp_s3q29_b',
+    pp_o_n_w='pp_s3q29_c', pp_o_d_w='pp_s3q29_d',
+    pp_o_n_c='pp_s3q29_e', pp_o_d_c='pp_s3q29_f',
+    # PH hired
+    ph_h_n_m='ph_s10q01_a', ph_h_d_m='ph_s10q01_b', ph_h_w_m='ph_s10q01_c',
+    ph_h_n_w='ph_s10q01_d', ph_h_d_w='ph_s10q01_e', ph_h_w_w='ph_s10q01_f',
+    ph_h_n_c='ph_s10q01_g', ph_h_d_c='ph_s10q01_h', ph_h_w_c='ph_s10q01_i',
+    # PH family (8 member slots)
+    ph_f_members=labor_family_triples('ph_s10q02', 8),
+    # PH other
+    ph_o_n_m='ph_s10q03_a', ph_o_d_m='ph_s10q03_b',
+    ph_o_n_w='ph_s10q03_c', ph_o_d_w='ph_s10q03_d',
+    ph_o_n_c='ph_s10q03_e', ph_o_d_c='ph_s10q03_f',
+)
+
+df = plot_labor_for_wave('2011-12', pp, ph, colmap)
+
+assert len(df) > 0, "plot_labor 2011-12 produced no rows"
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Ethiopia/2013-14/_/people_last7days.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/people_last7days.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""Build people_last7days for Ethiopia ESS 2013-14 (Wave 2; GAP 3.1).
+
+Individual 7-day activity at (t, i, pid) from §4 (sect4_hh_w2).  Same
+hh_s4* variable scheme as W1 (farm/SOB/wage HOURS hh_s4q04/05/07; industry
+hh_s4q11_b; gate hh_s4q09; working_age hh_s4q01=="X").
+i = household_id2, pid = individual_id2 (match household_roster for W2).
+See ../../2011-12/_/people_last7days.py for the column layout.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import people_last7days_for_wave
+
+
+lab = get_dataframe('../Data/sect4_hh_w2.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id2', pid='individual_id2',
+    dummy_from_hours=True,
+    farm_hrs='hh_s4q04', sb_hrs='hh_s4q05', wage_hrs='hh_s4q07',
+    industry='hh_s4q11_b',
+    employed_gate='hh_s4q09', employed_no=2,
+    working_age='hh_s4q01', working_age_marker='X',
+)
+
+df = people_last7days_for_wave('2013-14', lab, colmap)
+
+assert len(df) > 0, "people_last7days 2013-14 produced no rows"
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Ethiopia/2013-14/_/plot_labor.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/plot_labor.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Build plot_labor for Ethiopia ESS 2013-14 (Wave 2; GAP 3.2).
+
+Plot labor person-DAYS at (t, i, plot_id, source).  Same §3-PP / §10-PH
+variable naming as W1 (pp_s3q27/28/29, ph_s10q01/02/03); the PP/PH family
+blocks carry 7 / 8 member slots this wave (28 / 32 sub-columns).
+i = household_id2 (matches sample().i / plot_features for W2).
+See ../../2011-12/_/plot_labor.py for the column-block layout.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_labor_for_wave, labor_family_triples
+
+
+pp = get_dataframe('../Data/sect3_pp_w2.dta',  convert_categoricals=False)
+ph = get_dataframe('../Data/sect10_ph_w2.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id2', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+    pp_filter=('pp_s3q03', (1, 2)),
+    pp_h_n_m='pp_s3q28_a', pp_h_d_m='pp_s3q28_b', pp_h_w_m='pp_s3q28_c',
+    pp_h_n_w='pp_s3q28_d', pp_h_d_w='pp_s3q28_e', pp_h_w_w='pp_s3q28_f',
+    pp_h_n_c='pp_s3q28_g', pp_h_d_c='pp_s3q28_h', pp_h_w_c='pp_s3q28_i',
+    pp_f_members=labor_family_triples('pp_s3q27', 7),
+    pp_o_n_m='pp_s3q29_a', pp_o_d_m='pp_s3q29_b',
+    pp_o_n_w='pp_s3q29_c', pp_o_d_w='pp_s3q29_d',
+    pp_o_n_c='pp_s3q29_e', pp_o_d_c='pp_s3q29_f',
+    ph_h_n_m='ph_s10q01_a', ph_h_d_m='ph_s10q01_b', ph_h_w_m='ph_s10q01_c',
+    ph_h_n_w='ph_s10q01_d', ph_h_d_w='ph_s10q01_e', ph_h_w_w='ph_s10q01_f',
+    ph_h_n_c='ph_s10q01_g', ph_h_d_c='ph_s10q01_h', ph_h_w_c='ph_s10q01_i',
+    ph_f_members=labor_family_triples('ph_s10q02', 8),
+    ph_o_n_m='ph_s10q03_a', ph_o_d_m='ph_s10q03_b',
+    ph_o_n_w='ph_s10q03_c', ph_o_d_w='ph_s10q03_d',
+    ph_o_n_c='ph_s10q03_e', ph_o_d_c='ph_s10q03_f',
+)
+
+df = plot_labor_for_wave('2013-14', pp, ph, colmap)
+
+assert len(df) > 0, "plot_labor 2013-14 produced no rows"
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Ethiopia/2015-16/_/people_last7days.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/people_last7days.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""Build people_last7days for Ethiopia ESS 2015-16 (Wave 3; GAP 3.1).
+
+Individual 7-day activity at (t, i, pid) from §4 (sect4_hh_w3).  Same
+hh_s4* variable scheme as W1/W2 (farm/SOB/wage HOURS hh_s4q04/05/07;
+industry hh_s4q11_b; gate hh_s4q09; working_age hh_s4q01=="X").
+i = household_id2, pid = individual_id2 (match household_roster for W3).
+See ../../2011-12/_/people_last7days.py for the column layout.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import people_last7days_for_wave
+
+
+lab = get_dataframe('../Data/sect4_hh_w3.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id2', pid='individual_id2',
+    dummy_from_hours=True,
+    farm_hrs='hh_s4q04', sb_hrs='hh_s4q05', wage_hrs='hh_s4q07',
+    industry='hh_s4q11_b',
+    employed_gate='hh_s4q09', employed_no=2,
+    working_age='hh_s4q01', working_age_marker='X',
+)
+
+df = people_last7days_for_wave('2015-16', lab, colmap)
+
+assert len(df) > 0, "people_last7days 2015-16 produced no rows"
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Ethiopia/2015-16/_/plot_labor.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/plot_labor.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Build plot_labor for Ethiopia ESS 2015-16 (Wave 3; GAP 3.2).
+
+Plot labor person-DAYS at (t, i, plot_id, source).  Same §3-PP / §10-PH
+variable naming as W1/W2 (pp_s3q27/28/29, ph_s10q01/02/03); the PP/PH
+family blocks carry 4 member slots this wave (16 sub-columns each).
+i = household_id2 (matches sample().i / plot_features for W3).
+See ../../2011-12/_/plot_labor.py for the column-block layout.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_labor_for_wave, labor_family_triples
+
+
+pp = get_dataframe('../Data/sect3_pp_w3.dta',  convert_categoricals=False)
+ph = get_dataframe('../Data/sect10_ph_w3.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id2', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+    pp_filter=('pp_s3q03', (1, 2)),
+    pp_h_n_m='pp_s3q28_a', pp_h_d_m='pp_s3q28_b', pp_h_w_m='pp_s3q28_c',
+    pp_h_n_w='pp_s3q28_d', pp_h_d_w='pp_s3q28_e', pp_h_w_w='pp_s3q28_f',
+    pp_h_n_c='pp_s3q28_g', pp_h_d_c='pp_s3q28_h', pp_h_w_c='pp_s3q28_i',
+    pp_f_members=labor_family_triples('pp_s3q27', 4),
+    pp_o_n_m='pp_s3q29_a', pp_o_d_m='pp_s3q29_b',
+    pp_o_n_w='pp_s3q29_c', pp_o_d_w='pp_s3q29_d',
+    pp_o_n_c='pp_s3q29_e', pp_o_d_c='pp_s3q29_f',
+    ph_h_n_m='ph_s10q01_a', ph_h_d_m='ph_s10q01_b', ph_h_w_m='ph_s10q01_c',
+    ph_h_n_w='ph_s10q01_d', ph_h_d_w='ph_s10q01_e', ph_h_w_w='ph_s10q01_f',
+    ph_h_n_c='ph_s10q01_g', ph_h_d_c='ph_s10q01_h', ph_h_w_c='ph_s10q01_i',
+    ph_f_members=labor_family_triples('ph_s10q02', 4),
+    ph_o_n_m='ph_s10q03_a', ph_o_d_m='ph_s10q03_b',
+    ph_o_n_w='ph_s10q03_c', ph_o_d_w='ph_s10q03_d',
+    ph_o_n_c='ph_s10q03_e', ph_o_d_c='ph_s10q03_f',
+)
+
+df = plot_labor_for_wave('2015-16', pp, ph, colmap)
+
+assert len(df) > 0, "plot_labor 2015-16 produced no rows"
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Ethiopia/2018-19/_/people_last7days.py
+++ b/lsms_library/countries/Ethiopia/2018-19/_/people_last7days.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""Build people_last7days for Ethiopia ESS 2018-19 (Wave 4; GAP 3.1).
+
+Individual 7-day activity at (t, i, pid) from §4 (sect4_hh_w4).  W4
+RENUMBERED and split the labor module (s4* prefix; SEPARATE did-activity
+dummies and hours columns, unlike the hours-only W1-W3):
+  farm dummy s4q05 / hours s4q06 ; SOB dummy s4q08 / hours s4q09 ;
+  wage dummy s4q12 / hours s4q13 ; industry s4q34d ;
+  working_age = (s4q00 == 1).
+i = household_id, pid = individual_id (match household_roster for W4).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import people_last7days_for_wave
+
+
+lab = get_dataframe('../Data/sect4_hh_w4.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', pid='individual_id',
+    # W4-W5 carry explicit 1=yes/2=no did-activity dummies separate from hours.
+    farm_work='s4q05', sob_work='s4q08', wage_work='s4q12',
+    farm_hrs='s4q06', sb_hrs='s4q09', wage_hrs='s4q13',
+    industry='s4q34d',
+    working_age='s4q00', working_age_marker=1,
+)
+
+df = people_last7days_for_wave('2018-19', lab, colmap)
+
+assert len(df) > 0, "people_last7days 2018-19 produced no rows"
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Ethiopia/2018-19/_/plot_labor.py
+++ b/lsms_library/countries/Ethiopia/2018-19/_/plot_labor.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""Build plot_labor for Ethiopia ESS 2018-19 (Wave 4; GAP 3.2).
+
+Plot labor person-DAYS at (t, i, plot_id, source).  W4 RENUMBERED the §3-PP
+labor blocks vs W1-W3 (and dropped the hh_/pp_ prefix): hired s3q30a..i,
+family s3q29* (4 member slots), other s3q31a..f.  §10-PH labor: hired
+s10q01a..i, family s10q02* (4 member slots), other s10q03a..f.  The W4 §10
+file has NO crop_code, but our grain is (plot, source) so the helper sums
+over crops to the plot regardless.
+i = household_id (W4 is an entirely new sample; matches sample().i).
+See ../../2011-12/_/plot_labor.py for the column-block layout.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_labor_for_wave, labor_family_triples
+
+
+pp = get_dataframe('../Data/sect3_pp_w4.dta',  convert_categoricals=False)
+ph = get_dataframe('../Data/sect10_ph_w4.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+    pp_filter=('s3q03', (1, 2)),
+    pp_h_n_m='s3q30a', pp_h_d_m='s3q30b', pp_h_w_m='s3q30c',
+    pp_h_n_w='s3q30d', pp_h_d_w='s3q30e', pp_h_w_w='s3q30f',
+    pp_h_n_c='s3q30g', pp_h_d_c='s3q30h', pp_h_w_c='s3q30i',
+    pp_f_members=labor_family_triples('s3q29', 4, sep=''),
+    pp_o_n_m='s3q31a', pp_o_d_m='s3q31b',
+    pp_o_n_w='s3q31c', pp_o_d_w='s3q31d',
+    pp_o_n_c='s3q31e', pp_o_d_c='s3q31f',
+    ph_h_n_m='s10q01a', ph_h_d_m='s10q01b', ph_h_w_m='s10q01c',
+    ph_h_n_w='s10q01d', ph_h_d_w='s10q01e', ph_h_w_w='s10q01f',
+    ph_h_n_c='s10q01g', ph_h_d_c='s10q01h', ph_h_w_c='s10q01i',
+    ph_f_members=labor_family_triples('s10q02', 4, sep=''),
+    ph_o_n_m='s10q03a', ph_o_d_m='s10q03b',
+    ph_o_n_w='s10q03c', ph_o_d_w='s10q03d',
+    ph_o_n_c='s10q03e', ph_o_d_c='s10q03f',
+)
+
+df = plot_labor_for_wave('2018-19', pp, ph, colmap)
+
+assert len(df) > 0, "plot_labor 2018-19 produced no rows"
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Ethiopia/2021-22/_/people_last7days.py
+++ b/lsms_library/countries/Ethiopia/2021-22/_/people_last7days.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""Build people_last7days for Ethiopia ESS 2021-22 (Wave 5; GAP 3.1).
+
+Individual 7-day activity at (t, i, pid) from §4 (sect4_hh_w5).  Same s4*
+scheme as W4 (separate did-activity dummies + hours):
+  farm dummy s4q05 / hours s4q06 ; SOB dummy s4q08 / hours s4q09 ;
+  wage dummy s4q12 / hours s4q13 ; industry s4q34d ;
+  working_age = (s4q00 == 1).
+i = household_id, pid = individual_id (match household_roster for W5).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import people_last7days_for_wave
+
+
+lab = get_dataframe('../Data/sect4_hh_w5.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', pid='individual_id',
+    farm_work='s4q05', sob_work='s4q08', wage_work='s4q12',
+    farm_hrs='s4q06', sb_hrs='s4q09', wage_hrs='s4q13',
+    industry='s4q34d',
+    working_age='s4q00', working_age_marker=1,
+)
+
+df = people_last7days_for_wave('2021-22', lab, colmap)
+
+assert len(df) > 0, "people_last7days 2021-22 produced no rows"
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Ethiopia/2021-22/_/plot_labor.py
+++ b/lsms_library/countries/Ethiopia/2021-22/_/plot_labor.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""Build plot_labor for Ethiopia ESS 2021-22 (Wave 5; GAP 3.2).
+
+Plot labor person-DAYS at (t, i, plot_id, source).  Same RENUMBERED §3-PP /
+§10-PH scheme as W4 (hired s3q30a..i / s10q01a..i; family s3q29* / s10q02*,
+4 member slots; other s3q31a..f / s10q03a..f).  W5 adds a parallel set of
+'c2/f2/i2' in-kind-wage columns that the WB code ignores -- we use the cash
+daily wage (a..i base columns) for the reported Wage, as the .do does.
+i = household_id (matches sample().i for W5).
+See ../../2011-12/_/plot_labor.py for the column-block layout.
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import plot_labor_for_wave, labor_family_triples
+
+
+pp = get_dataframe('../Data/sect3_pp_w5.dta',  convert_categoricals=False)
+ph = get_dataframe('../Data/sect10_ph_w5.dta', convert_categoricals=False)
+
+colmap = dict(
+    hhid='household_id', holder_id='holder_id',
+    parcel_id='parcel_id', field_id='field_id',
+    pp_filter=('s3q03', (1, 2)),
+    pp_h_n_m='s3q30a', pp_h_d_m='s3q30b', pp_h_w_m='s3q30c',
+    pp_h_n_w='s3q30d', pp_h_d_w='s3q30e', pp_h_w_w='s3q30f',
+    pp_h_n_c='s3q30g', pp_h_d_c='s3q30h', pp_h_w_c='s3q30i',
+    pp_f_members=labor_family_triples('s3q29', 4, sep=''),
+    pp_o_n_m='s3q31a', pp_o_d_m='s3q31b',
+    pp_o_n_w='s3q31c', pp_o_d_w='s3q31d',
+    pp_o_n_c='s3q31e', pp_o_d_c='s3q31f',
+    ph_h_n_m='s10q01a', ph_h_d_m='s10q01b', ph_h_w_m='s10q01c',
+    ph_h_n_w='s10q01d', ph_h_d_w='s10q01e', ph_h_w_w='s10q01f',
+    ph_h_n_c='s10q01g', ph_h_d_c='s10q01h', ph_h_w_c='s10q01i',
+    ph_f_members=labor_family_triples('s10q02', 4, sep=''),
+    ph_o_n_m='s10q03a', ph_o_d_m='s10q03b',
+    ph_o_n_w='s10q03c', ph_o_d_w='s10q03d',
+    ph_o_n_c='s10q03e', ph_o_d_c='s10q03f',
+)
+
+df = plot_labor_for_wave('2021-22', pp, ph, colmap)
+
+assert len(df) > 0, "plot_labor 2021-22 produced no rows"
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Ethiopia/_/Makefile
+++ b/lsms_library/countries/Ethiopia/_/Makefile
@@ -19,7 +19,8 @@ var = \
       $(VAR_DIR)/shocks.parquet $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet \
       $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/crop_production.parquet \
       $(VAR_DIR)/plot_inputs.parquet $(VAR_DIR)/livestock.parquet \
-      $(VAR_DIR)/anthropometry.parquet
+      $(VAR_DIR)/anthropometry.parquet $(VAR_DIR)/plot_labor.parquet \
+      $(VAR_DIR)/people_last7days.parquet
 
 all: panel_ids.json updated_ids.json $(parquet) $(var)
 
@@ -128,6 +129,34 @@ anthropometry_parquet := $(anthropometry:.py=.parquet)
 
 $(VAR_DIR)/anthropometry.parquet: anthropometry.py $(anthropometry_parquet)
 	python anthropometry.py
+
+# plot_labor (GAP 3.2; ESS §3-PP + §10-PH plot labor person-days at
+# (t, i, plot_id, source) with source in {family, hired, other}).  Mirrors
+# the crop_production convention: the framework's grab_data calls
+# `make ../<wave>/_/plot_labor.parquet`, whose pattern rule runs the wave
+# script; the VAR_DIR rule concatenates them via the country script.
+plot_labor = $(shell find $(rounds) -name plot_labor.py)
+plot_labor_parquet := $(plot_labor:.py=.parquet)
+
+../%/_/plot_labor.parquet: ../%/_/plot_labor.py
+	(cd $(@D) && python plot_labor.py)
+
+$(VAR_DIR)/plot_labor.parquet: plot_labor.py $(plot_labor_parquet)
+	python plot_labor.py
+
+# people_last7days (GAP 3.1; ESS §4 individual 7-day activity at (t, i, pid),
+# mirroring Uganda's per-individual schema).  Mirrors the crop_production
+# convention: the framework's grab_data calls
+# `make ../<wave>/_/people_last7days.parquet`, whose pattern rule runs the
+# wave script; the VAR_DIR rule concatenates them via the country script.
+people_last7days = $(shell find $(rounds) -name people_last7days.py)
+people_last7days_parquet := $(people_last7days:.py=.parquet)
+
+../%/_/people_last7days.parquet: ../%/_/people_last7days.py
+	(cd $(@D) && python people_last7days.py)
+
+$(VAR_DIR)/people_last7days.parquet: people_last7days.py $(people_last7days_parquet)
+	python people_last7days.py
 
 $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet: nutrition.py categorical_mapping.org $(VAR_DIR)/food_acquired.parquet
 	python nutrition.py

--- a/lsms_library/countries/Ethiopia/_/categorical_mapping.org
+++ b/lsms_library/countries/Ethiopia/_/categorical_mapping.org
@@ -715,3 +715,40 @@ count, but ride the same roster row; carried for completeness.)
 | 2021-22 |   14 | Mules           |
 | 2021-22 |   15 | Donkeys         |
 | 2021-22 |   16 | Beehives        |
+
+* harmonize_industry (wage-work industry -- GAP 3, people_last7days)
+
+The section-4 wage-work industry code (=hh_s4q11_b= W1-W3, =s4q34d= W4-W5)
+-> a coarse ISIC-style industry the WB code recodes into six dummies
+(=ind_ag= / =ind_fish= / =ind_mining= / =ind_manuf= / =ind_const= /
+=ind_serv=; ETH_ESS1.do:1242-1248).  We keep the single REPORTED industry
+*label* per individual instead (richer than six dummies, which are
+trivially derived downstream).  The code->coarse-industry collapse is the
+SAME across every ESS wave (1=Agriculture; 2=Fishing; 3=Mining; 4|5=
+Manufacturing; 6=Construction; 7-18=Services), so the table is plain (not
+wave-keyed).  Codes 19+ (a handful of "other / not stated" sector codes that
+appear in some waves) fall outside the WB 1-18 industry range and map to
+=pd.NA= (no Preferred Label row), matching the WB code that only classifies
+1-18.
+
+#+name: harmonize_industry
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Agriculture     |
+|    2 | Fishing         |
+|    3 | Mining          |
+|    4 | Manufacturing   |
+|    5 | Manufacturing   |
+|    6 | Construction    |
+|    7 | Services        |
+|    8 | Services        |
+|    9 | Services        |
+|   10 | Services        |
+|   11 | Services        |
+|   12 | Services        |
+|   13 | Services        |
+|   14 | Services        |
+|   15 | Services        |
+|   16 | Services        |
+|   17 | Services        |
+|   18 | Services        |

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -291,6 +291,101 @@ Data Scheme:
     Sex: str
     materialize: make
 
+  plot_labor:
+    # GAP 3.2 -- item-level plot labor at (t, i, plot_id, source).  One row
+    # per (plot, labor SOURCE) with source in {family, hired, other},
+    # carrying ONLY reported fields:
+    #   PersonDays  reported person-days of that source applied to the plot.
+    #               The ESS asks plot labor in two modules -- post-PLANTING
+    #               (§3 plot roster sect3_pp: hired pp_s3q28*/s3q30*, family
+    #               pp_s3q27*/s3q29* as weeks x days/week per member, other
+    #               pp_s3q29*/s3q31*) and post-HARVEST (§10 labor sect10_ph:
+    #               hired ph_s10q01*/s10q01*, family ph_s10q02*/s10q02*, other
+    #               ph_s10q03*/s10q03*).  The WB code (ETH_ESS1.do:554-799)
+    #               sums man+woman+child member rows of ONE source to a per-
+    #               source person-day total; THAT per-source total is the
+    #               natural item datum here (like livestock summing within-
+    #               species sub-codes), NOT the banned total_labor_days (which
+    #               is an egen rowtotal ACROSS sources / across PP+PH).  PP and
+    #               PH person-days of the SAME source are summed onto one
+    #               (plot, source) row (the survey's two-season split of that
+    #               source's labor -- WITHIN a single source, not cross-source).
+    #               The §10 file is plot x crop; person-days are summed over
+    #               crops to the plot (our grain is plot, not plot-crop).
+    #   Wage        reported cash daily wage PAID to hired labor (mean of the
+    #               reported man/woman/child wages pp_s3q28_c/f/i (PP) and
+    #               ph_s10q01_c/f/i (PH)).  This is the SURVEYED cash wage, NOT
+    #               the WB valuation_median_wages median-wage IMPUTATION; NaN
+    #               for family / other rows (the survey records no wage there).
+    #
+    # source axis: inline {family, hired, other} labels (3 fixed values,
+    # identical across every ESS wave -- emitted in-script, no org table).
+    # plot_id and i match plot_features / crop_production / plot_inputs
+    # exactly (holder_parcel_field plot_id; i = household_id2 for W2/W3, else
+    # household_id), so plot_labor joins them on (t, i, plot_id).
+    #
+    # NO total_labor_days / total_family_labor_days / total_hired_labor_days
+    # (cross-source / cross-module SUM transforms) and NO hired_labor_value
+    # (median-wage valuation) baked in -- all are transformations over these
+    # item rows (GAP 3 / GAP 7).  Grain is (t, i, plot_id, source); v is NOT
+    # baked in -- the framework auto-joins it from sample() at query time
+    # (plot_labor is household-linked and NOT in the _no_v_join set).  Per-
+    # wave var renumbering (W1-W3 hh_/pp_/ph_ prefix; W4-W5 bare s* stems) +
+    # multi-module within-source sum => script (materialize: make).
+    index: (t, i, plot_id, source)
+    PersonDays: float
+    # Wage is reported only on hired rows where the survey records a cash
+    # daily wage; family / other rows and unreported hired rows are NaN.
+    # Mark optional so the all-null sanity check exempts it on a hypothetical
+    # wage-free wave while the canonical column stays declared.
+    Wage:
+      type: float
+      optional: true
+    materialize: make
+
+  people_last7days:
+    # GAP 3.1 -- item-level individual 7-day activity at (t, i, pid).  One
+    # row per §4 labor-roster member (sect4_hh_w{N}), mirroring Uganda's
+    # existing per-individual schema (the one country we already have for
+    # this feature).  Carries ONLY the REPORTED per-individual data the WB
+    # labor block reads (ETH_ESS1.do:1242-1264):
+    #   farm_work / SOB_work / wage_work  did-this-activity dummies (worked
+    #                 on the HH farm / own non-farm business / for a wage in
+    #                 the last 7 days; nullable bool).  W1-W3 record only
+    #                 HOURS (hh_s4q04/05/07) and the WB recodes a dummy from
+    #                 them (hours>0 -> worked); W4-W5 carry explicit 1/2
+    #                 dummies (s4q05/08/12) separate from the hours.
+    #   farm_hrs / SB_hrs / wage_hrs      reported hours on each activity
+    #                 (hh_s4q04/05/07 W1-W3; s4q06/09/13 W4-W5).
+    #   industry      the single REPORTED wage-work industry Preferred Label
+    #                 (harmonize_industry: Agriculture / Fishing / Mining /
+    #                 Manufacturing / Construction / Services), from the same
+    #                 code (hh_s4q11_b W1-W3 / s4q34d W4-W5) the WB recodes
+    #                 into the six ind_* dummies -- we keep the label (the six
+    #                 dummies are trivially derived from it downstream).
+    #                 Blanked where the member is not employed (the WB gate
+    #                 hh_s4q09==2/.).
+    #   working_age   reported working-age flag (hh_s4q01=="X" W1-W3;
+    #                 s4q00==1 W4-W5; nullable bool).
+    #
+    # i / pid match household_roster exactly (household_id2 / individual_id2
+    # for W2/W3, else household_id / individual_id).  NO household rollups:
+    # the WB nb_members_working_age (egen-total) and the six ind_* dummies
+    # are transformations over these per-individual rows, never stored.  v is
+    # auto-joined from sample() at query time (people_last7days is household-
+    # linked, NOT in _no_v_join).  Per-wave var renumbering + code->industry
+    # harmonization + dummy-from-hours recode => script (materialize: make).
+    index: (t, i, pid)
+    farm_work: bool
+    SOB_work: bool
+    wage_work: bool
+    farm_hrs: float
+    SB_hrs: float
+    wage_hrs: float
+    industry: str
+    working_age: bool
+    materialize: make
+
   # food_expenditures, food_prices, food_quantities are derived at
   # runtime from food_acquired — see _FOOD_DERIVED in country.py.  Do
   # NOT register them here (per CLAUDE.md "Derived Tables").

--- a/lsms_library/countries/Ethiopia/_/ethiopia.py
+++ b/lsms_library/countries/Ethiopia/_/ethiopia.py
@@ -1732,3 +1732,475 @@ def anthropometry_for_wave(t, health, roster, colmap):
     # Collapse any accidental duplicate measurement rows for an individual.
     out = out[~out.index.duplicated(keep='first')]
     return out.sort_index()
+
+
+# =====================================================================
+# GAP 3 -- LABOR / TIME-USE.  TWO distinct natural grains (do NOT collapse
+# them into one wide table):
+#   (1) plot_labor       (t, i, plot_id, source)  -- plot labor person-DAYS
+#                        by source {family, hired, other}, with the reported
+#                        cash wage paid to hired labor (NaN family/other).
+#   (2) people_last7days (t, i, pid)              -- individual 7-day activity
+#                        dummies / hours / wage-work industry / working_age.
+#
+# Both reproduce the *reported* item-level data the WB ESS code reads
+# (plot days ETH_ESS1.do:554-799; individual ETH_ESS1.do:1242-1264).  We do
+# NOT bake in the WB rollups -- total_labor_days / total_family_labor_days /
+# total_hired_labor_days (egen rowtotal across sources) and hired_labor_value
+# (valuation_median_wages median-wage imputation) are SUM / median-wage
+# TRANSFORMS over these item rows, never stored columns.
+# =====================================================================
+
+# Canonical labor-source labels for the `source` index level of plot_labor.
+# A small inline mapping (3 fixed values, identical across all ESS waves);
+# no wave-keyed org table is needed because each source block is emitted
+# in-script (analogous to crop_production emitting crop labels directly).
+LABOR_SOURCES = ('family', 'hired', 'other')
+
+
+def labor_family_triples(prefix, n_members, sep='_'):
+    """Generate the (did, weeks, days) column triples for an ESS family-labor
+    block.  The §3-PP / §10-PH family roster lays each member's sub-columns
+    out at a stride of 4 letters: a=did-work, b=#weeks, c=days/week, d=hours
+    (then e,f,g,h for the next member, ...).  After 'z' the ESS questionnaire
+    continues 'ka','la','ma','na','oa','pa' (the W1/W2 PH family block uses
+    up to that extension for its 8 member slots).  We only need (did, weeks,
+    days) -- person-days = weeks * days, gated on did != 0.
+
+    Parameters
+    ----------
+    prefix : str
+        Column stem, e.g. ``'pp_s3q27'`` (W1-W3) or ``'s3q29'`` (W4-W5).
+    n_members : int
+        Number of member slots the wave records (6 PP / 8 PH for W1-W2;
+        4 for W3-W5).
+    sep : str
+        Separator between stem and letter -- ``'_'`` for the hh_/pp_/ph_
+        waves (W1-W3), ``''`` for the bare-stem waves (W4-W5).
+    """
+    import string
+    seq = list(string.ascii_lowercase) + ['ka', 'la', 'ma', 'na', 'oa',
+                                           'pa', 'qa', 'ra', 'sa', 'ta']
+    out = []
+    for m in range(n_members):
+        i = m * 4
+        out.append((f'{prefix}{sep}{seq[i]}',
+                    f'{prefix}{sep}{seq[i + 1]}',
+                    f'{prefix}{sep}{seq[i + 2]}'))
+    return out
+
+
+def _eth_industry_label_map():
+    """Load the harmonize_industry code -> Preferred Label dict.
+
+    The wage-work industry of section 4 (hh_s4q11_b W1-W3 / s4q34d W4-W5)
+    is recoded by the WB code into six dummies (ind_ag / ind_fish /
+    ind_mining / ind_manuf / ind_const / ind_serv).  We keep the single
+    REPORTED industry label per individual instead (richer than six
+    dummies; the dummies are trivially derived downstream).  The
+    code->coarse-industry collapse (1=Agriculture, 2=Fishing, 3=Mining,
+    4|5=Manufacturing, 6=Construction, 7-18=Services) is the SAME across
+    every ESS wave, so the table is plain (not wave-keyed)."""
+    return _harmonize_code_label('harmonize_industry')
+
+
+def plot_labor_for_wave(t, pp_roster, ph_labor, colmap):
+    """Build canonical ``plot_labor`` for one Ethiopia ESS wave (GAP 3.2).
+
+    Plot labor person-DAYS at ``(t, i, plot_id, source)`` -- one row per
+    (plot, labor source) with ``source`` in {family, hired, other},
+    carrying ONLY reported fields:
+
+      PersonDays  reported person-days of that source applied to the plot.
+                  The WB code builds per-source days as a SUM over the
+                  man / woman / child member rows on the plot (egen rowtotal
+                  of days_per_member; ETH_ESS1.do:561-655 for PP, 667-799 for
+                  PH).  Summing the man/woman/child rows of ONE source to the
+                  (plot, source) grain is the natural item-level datum here
+                  (analogous to livestock summing within-species sub-codes) --
+                  it is NOT the banned ``total_labor_days`` (an egen rowtotal
+                  ACROSS sources / across PP+PH; ETH_ESS1.do:785-797).
+      Wage        reported cash wage PAID to hired labor (mean of the reported
+                  man / woman / child daily wages, pp_s3q28_c/f/i for PP and
+                  ph_s10q01_c/f/i for PH).  This is the SURVEYED cash wage, NOT
+                  the WB ``valuation_median_wages`` median-wage imputation
+                  (ETH_ESS1.do:588-593) -- NaN for family / other rows.
+
+    The ESS asks plot labor in TWO modules, both summed onto the same plot:
+      * post-PLANTING (§3 plot roster, sect3_pp): hired pp_s3q28_* /
+        s3q30* ; family pp_s3q27_* / s3q29* (weeks x days/week per member);
+        other pp_s3q29_* / s3q31*.
+      * post-HARVEST (§10 labor file, sect10_ph): hired ph_s10q01_* /
+        s10q01* ; family ph_s10q02_* / s10q02* ; other ph_s10q03_* /
+        s10q03*.  The PH file is plot x crop -- we sum its days over crops
+        to the plot, since our grain is (plot, source), not (plot, crop).
+    PP and PH person-days of the SAME source are summed onto one
+    (plot, source) row (the survey's own two-season split of the same
+    source's labor).  This stays WITHIN a single source, so it is not the
+    forbidden cross-source rollup.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2011-12"``) -- the ``t`` index value.
+    pp_roster : pd.DataFrame or None
+        Raw §3 post-planting plot roster (sect3_pp_w{N}.dta),
+        convert_categoricals=False.
+    ph_labor : pd.DataFrame or None
+        Raw §10 post-harvest labor file (sect10_ph_w{N}.dta), same loading.
+    colmap : dict
+        Per-wave column map.  Keys (a block is skipped if its frame is None
+        or its keys are absent):
+            hhid, holder_id, parcel_id, field_id  -- id / plot_id columns
+            pp_filter        optional (col, keep_values) to drop non-cultivated
+                             PP plots (the WB ``drop if !inlist(pp_s3q03,1,2)``)
+          PP hired:  pp_h_n_m, pp_h_d_m, pp_h_w_m   (#men, days/man, wage/man)
+                     pp_h_n_w, pp_h_d_w, pp_h_w_w   (women)
+                     pp_h_n_c, pp_h_d_c, pp_h_w_c   (children)
+          PP family: pp_f_members = list of (did_col, weeks_col, days_col)
+                     triples (one per member slot; person-days = weeks*days).
+          PP other:  pp_o_n_m, pp_o_d_m / _w / _c   (#, days/member; no wage)
+          PH hired:  ph_h_*  (same shape as PP hired)
+          PH family: ph_f_members  (list of (did_col, weeks_col, days_col))
+          PH other:  ph_o_*  (same shape as PP other)
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot_id, source)`` with columns
+        ``PersonDays`` (Float64), ``Wage`` (Float64, NaN for family/other).
+    """
+    c = colmap
+
+    def _num(df, key):
+        col = c.get(key)
+        if col is None or df is None or col not in df.columns:
+            return None
+        return pd.to_numeric(df[col], errors='coerce').astype('Float64')
+
+    def _member_days(df, n_key, d_key):
+        """person-days for one (#workers, days-per-worker) member group.
+
+        Mirrors the WB ``replace days=0 if number==0; gen days =
+        days_av * number``: zero workers contribute zero days; otherwise
+        days-per-worker x number of workers."""
+        n = _num(df, n_key)
+        d = _num(df, d_key)
+        if n is None or d is None:
+            return None
+        d = d.where(n != 0, 0)
+        return d * n
+
+    def _hired_block(df, prefix):
+        """(PersonDays, Wage) for a hired block (man/woman/child days +
+        reported daily wages)."""
+        if df is None:
+            return None, None
+        parts = [
+            _member_days(df, f'{prefix}_n_m', f'{prefix}_d_m'),
+            _member_days(df, f'{prefix}_n_w', f'{prefix}_d_w'),
+            _member_days(df, f'{prefix}_n_c', f'{prefix}_d_c'),
+        ]
+        parts = [p for p in parts if p is not None]
+        if not parts:
+            return None, None
+        days = parts[0]
+        for p in parts[1:]:
+            days = days.add(p, fill_value=0)
+        # reported cash daily wages (NOT a median imputation); zero out the
+        # wage where that member group did not work, as the WB does before
+        # taking medians, then average the reported member wages.
+        wparts = []
+        for n_key, w_key in ((f'{prefix}_n_m', f'{prefix}_w_m'),
+                             (f'{prefix}_n_w', f'{prefix}_w_w'),
+                             (f'{prefix}_n_c', f'{prefix}_w_c')):
+            w = _num(df, w_key)
+            n = _num(df, n_key)
+            if w is None:
+                continue
+            if n is not None:
+                w = w.where(n != 0)          # only members actually hired
+            wparts.append(w)
+        if wparts:
+            wage = pd.concat(wparts, axis=1).mean(axis=1)
+        else:
+            wage = pd.Series(pd.NA, index=df.index, dtype='Float64')
+        return days, wage.astype('Float64')
+
+    def _other_block(df, prefix):
+        """PersonDays for an other/exchange block (no wage)."""
+        if df is None:
+            return None
+        parts = [
+            _member_days(df, f'{prefix}_n_m', f'{prefix}_d_m'),
+            _member_days(df, f'{prefix}_n_w', f'{prefix}_d_w'),
+            _member_days(df, f'{prefix}_n_c', f'{prefix}_d_c'),
+        ]
+        parts = [p for p in parts if p is not None]
+        if not parts:
+            return None
+        days = parts[0]
+        for p in parts[1:]:
+            days = days.add(p, fill_value=0)
+        return days
+
+    def _family_block(df, members):
+        """PersonDays for a family block = Sum over member slots of
+        weeks x days-per-week (WB: family_labor_days = number_weeks *
+        days_per_week, summed across the member loop)."""
+        if df is None or not members:
+            return None
+        total = None
+        for did_col, weeks_col, days_col in members:
+            weeks = pd.to_numeric(df[weeks_col], errors='coerce').astype('Float64') \
+                if weeks_col in df.columns else None
+            days = pd.to_numeric(df[days_col], errors='coerce').astype('Float64') \
+                if days_col in df.columns else None
+            if weeks is None or days is None:
+                continue
+            if did_col and did_col in df.columns:
+                did = pd.to_numeric(df[did_col], errors='coerce')
+                weeks = weeks.where(did != 0, 0)
+                days = days.where(did != 0, 0)
+            md = weeks * days
+            total = md if total is None else total.add(md, fill_value=0)
+        return total
+
+    def _apply_pp_filter(df):
+        if df is None:
+            return None
+        f = c.get('pp_filter')
+        if not f:
+            return df
+        col, keep = f
+        if col not in df.columns:
+            return df
+        v = pd.to_numeric(df[col], errors='coerce')
+        return df[v.isin(keep)].copy()
+
+    pp = _apply_pp_filter(pp_roster)
+    ph = ph_labor
+
+    pieces = []   # list of (frame_with_plot_id+i, source, days_series, wage_series_or_None)
+
+    # ----- post-PLANTING (§3 plot roster) -----
+    if pp is not None:
+        pp_pid = _plot_id_from(pp, c)
+        pp_i = pp[c['hhid']].apply(format_id)
+        h_days, h_wage = _hired_block(pp, 'pp_h')
+        f_days = _family_block(pp, c.get('pp_f_members'))
+        o_days = _other_block(pp, 'pp_o')
+        for src, days, wage in (('hired', h_days, h_wage),
+                                ('family', f_days, None),
+                                ('other', o_days, None)):
+            if days is None:
+                continue
+            d = pd.DataFrame({'i': pp_i.values, 'plot_id': pp_pid.values,
+                              'source': src, 'PersonDays': days.values})
+            d['Wage'] = wage.values if wage is not None else pd.NA
+            pieces.append(d)
+
+    # ----- post-HARVEST (§10 labor file; plot x crop -> sum over crops) -----
+    if ph is not None:
+        ph_pid = _plot_id_from(ph, c)
+        ph_i = ph[c['hhid']].apply(format_id)
+        h_days, h_wage = _hired_block(ph, 'ph_h')
+        f_days = _family_block(ph, c.get('ph_f_members'))
+        o_days = _other_block(ph, 'ph_o')
+        for src, days, wage in (('hired', h_days, h_wage),
+                                ('family', f_days, None),
+                                ('other', o_days, None)):
+            if days is None:
+                continue
+            d = pd.DataFrame({'i': ph_i.values, 'plot_id': ph_pid.values,
+                              'source': src, 'PersonDays': days.values})
+            d['Wage'] = wage.values if wage is not None else pd.NA
+            pieces.append(d)
+
+    if not pieces:
+        return pd.DataFrame(
+            columns=['PersonDays', 'Wage'],
+            index=pd.MultiIndex.from_arrays([[], [], [], []],
+                                            names=['t', 'i', 'plot_id', 'source']))
+
+    out = pd.concat(pieces, ignore_index=True)
+    out['PersonDays'] = pd.to_numeric(out['PersonDays'], errors='coerce').astype('Float64')
+    out['Wage'] = pd.to_numeric(out['Wage'], errors='coerce').astype('Float64')
+
+    # Drop rows with no reported days for that source (the source was not
+    # used on that plot -- nothing reported, not a zero).
+    out = out.dropna(subset=['plot_id'])
+    out = out[out['PersonDays'].notna()].copy()
+    out = out[out['i'].notna()].copy()
+
+    # Aggregate PP + PH person-days of the SAME source onto one plot-source
+    # row (the survey's two-season split of one source's labor; within-source,
+    # NOT a cross-source rollup).  Wage = mean of reported wages across the
+    # contributing hired rows (NaN where no cash wage reported).
+    out['t'] = t
+    out['i'] = out['i'].astype('string')
+    out['plot_id'] = out['plot_id'].astype('string')
+    out['source'] = out['source'].astype('string')
+    g = out.groupby(['t', 'i', 'plot_id', 'source'], dropna=False)
+    res = g.agg(PersonDays=('PersonDays', 'sum'),
+                Wage=('Wage', 'mean'))
+    res['PersonDays'] = res['PersonDays'].astype('Float64')
+    res['Wage'] = res['Wage'].astype('Float64')
+    res = res[['PersonDays', 'Wage']]
+    return res.sort_index()
+
+
+def people_last7days_for_wave(t, lab, colmap):
+    """Build canonical ``people_last7days`` for one Ethiopia ESS wave (GAP 3.1).
+
+    Individual 7-day activity at ``(t, i, pid)`` -- one row per roster
+    member of section 4 (lab_roster, sect4_hh_w{N}.dta), carrying ONLY the
+    REPORTED per-individual data the WB labor block reads
+    (ETH_ESS1.do:1242-1264).  Mirrors Uganda's existing per-individual
+    schema (the country we already have for this feature) so the six
+    new countries match:
+
+      farm_work / SOB_work / wage_work  reported did-this-activity dummies
+                  (worked on the household farm / own non-farm business /
+                  for a wage in the last 7 days; nullable bool).
+      farm_hrs / SB_hrs / wage_hrs      reported hours on each activity.
+      industry    the wage-work industry Preferred Label (harmonize_industry:
+                  Agriculture / Fishing / Mining / Manufacturing /
+                  Construction / Services), from the SAME code the WB recodes
+                  into ind_ag..ind_serv dummies -- we keep the single label.
+      working_age reported working-age flag (nullable bool).
+
+    NO household rollups (the WB ``nb_members_working_age`` egen-total is a
+    SUM transform over these rows; the ind_* six dummies are trivially
+    derived from ``industry``).
+
+    Per-wave source variables (confirmed via get_dataframe):
+      W1-W3 (hh_s4* prefix; sect4_hh_w{1,2,3}):
+        farm  hh_s4q04 (hours; recode else=1 -> work dummy)
+        SOB   hh_s4q05 ; wage hh_s4q07
+        employed-gate hh_s4q09 (==2 or missing zeroes the industry dummies)
+        industry hh_s4q11_b ; working_age = (hh_s4q01 == "X")
+        W2/W3 emit household_id2 / individual_id2.
+      W4-W5 (s4* prefix; sect4_hh_w{4,5}):
+        farm dummy s4q05 ; SOB dummy s4q08 ; wage dummy s4q12
+        farm hrs s4q06 ; SB hrs s4q09 ; wage hrs s4q13
+        working_age = (s4q00 == 1) ; industry s4q34d.
+
+    Parameters
+    ----------
+    t : str
+        Wave id -- the ``t`` index value.
+    lab : pd.DataFrame
+        Raw §4 labor roster (sect4_hh_w{N}.dta), convert_categoricals=False.
+    colmap : dict
+        Per-wave column map.  Keys:
+            hhid, pid                 id columns EMITTED as i / pid (must match
+                                      household_roster: household_id2 /
+                                      individual_id2 for W2/W3, else
+                                      household_id / individual_id).
+          activity dummies (present where the wave records a separate dummy):
+            farm_work, sob_work, wage_work
+          activity hours:
+            farm_hrs, sb_hrs, wage_hrs
+          where the wave records ONLY hours (W1-W3), pass the hours column as
+          BOTH the *_hrs and the *_work key with ``dummy_from_hours=True`` so
+          the dummy is recoded from the hours (hours>0 -> worked).
+            dummy_from_hours          bool -- recode dummies from hours columns
+            industry                  wage-work industry code column
+            employed_gate             optional code; ==no_code or missing
+                                      zeroes the industry (WB hh_s4q09==2/.)
+            employed_no               value of employed_gate meaning "not
+                                      employed" (default 2)
+            working_age               working-age flag column
+            working_age_marker        value meaning working-age:
+                                      "X" (W1-W3 string) or 1 (W4-W5 numeric)
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, pid)`` with columns
+        farm_work, SOB_work, wage_work (boolean),
+        farm_hrs, SB_hrs, wage_hrs (Float64),
+        industry (string), working_age (boolean).
+    """
+    c = colmap
+    df = lab.copy()
+    industry_map = _eth_industry_label_map()
+
+    def _hours(key):
+        col = c.get(key)
+        if col is None or col not in df.columns:
+            return pd.Series(pd.NA, index=df.index, dtype='Float64')
+        return pd.to_numeric(df[col], errors='coerce').astype('Float64')
+
+    def _dummy(work_key, hours_series):
+        """nullable-bool did-activity dummy.  If the wave has its own dummy
+        column (1=yes/2=no), use it; otherwise recode from hours
+        (hours>0 -> True, ==0 -> False, missing -> NA; WB recode 0=0 else=1)."""
+        col = c.get(work_key)
+        if c.get('dummy_from_hours') or col is None or col not in df.columns:
+            h = hours_series
+            out = pd.Series(pd.NA, index=df.index, dtype='boolean')
+            return out.mask(h > 0, True).mask(h == 0, False)
+        return _yesno_bool(df[col], yes=1, no=2)
+
+    farm_hrs = _hours('farm_hrs')
+    sb_hrs = _hours('sb_hrs')
+    wage_hrs = _hours('wage_hrs')
+
+    farm_work = _dummy('farm_work', farm_hrs)
+    sob_work = _dummy('sob_work', sb_hrs)
+    wage_work = _dummy('wage_work', wage_hrs)
+
+    # working_age flag
+    wa_col = c.get('working_age')
+    marker = c.get('working_age_marker', 'X')
+    if wa_col and wa_col in df.columns:
+        col = df[wa_col]
+        if isinstance(marker, str):
+            working_age = (col.astype('string').str.strip() == marker)
+        else:
+            working_age = (pd.to_numeric(col, errors='coerce') == marker)
+        working_age = working_age.astype('boolean')
+    else:
+        working_age = pd.Series(pd.NA, index=df.index, dtype='boolean')
+
+    # wage-work industry label (reported, single label -- not the six dummies)
+    ind_col = c.get('industry')
+    if ind_col and ind_col in df.columns:
+        industry = _map_int_codes(df[ind_col], industry_map)
+        # WB zeroes the industry dummies for the not-employed; we blank the
+        # reported industry label there so a stray code does not survive.
+        gate = c.get('employed_gate')
+        if gate and gate in df.columns:
+            no = c.get('employed_no', 2)
+            g = pd.to_numeric(df[gate], errors='coerce')
+            industry = industry.where(~(g.isna() | (g == no)), pd.NA)
+    else:
+        industry = pd.Series(pd.NA, index=df.index, dtype='string')
+
+    out = pd.DataFrame({
+        'i':          df[c['hhid']].apply(format_id).values,
+        'pid':        df[c['pid']].apply(format_id).values,
+        'farm_work':  farm_work.values,
+        'SOB_work':   sob_work.values,
+        'wage_work':  wage_work.values,
+        'farm_hrs':   farm_hrs.values,
+        'SB_hrs':     sb_hrs.values,
+        'wage_hrs':   wage_hrs.values,
+        'industry':   industry.astype('string').values,
+        'working_age': working_age.values,
+    })
+    out['t'] = t
+    out['i'] = out['i'].astype('string')
+    out['pid'] = out['pid'].astype('string')
+    out = out.dropna(subset=['i', 'pid'])
+    out = out.set_index(['t', 'i', 'pid'])
+    out = out[['farm_work', 'SOB_work', 'wage_work',
+               'farm_hrs', 'SB_hrs', 'wage_hrs', 'industry', 'working_age']]
+    for col in ['farm_work', 'SOB_work', 'wage_work', 'working_age']:
+        out[col] = out[col].astype('boolean')
+    for col in ['farm_hrs', 'SB_hrs', 'wage_hrs']:
+        out[col] = out[col].astype('Float64')
+    out['industry'] = out['industry'].astype('string')
+    # Collapse accidental duplicate roster rows for an individual.
+    out = out[~out.index.duplicated(keep='first')]
+    return out.sort_index()

--- a/lsms_library/countries/Ethiopia/_/people_last7days.py
+++ b/lsms_library/countries/Ethiopia/_/people_last7days.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""Concatenate wave-level people_last7days data for Ethiopia (GAP 3.1).
+
+Each wave's ``Ethiopia/<wave>/_/people_last7days.py`` produces a parquet
+with index ``(t, i, pid)`` and the canonical people_last7days columns
+(farm_work, SOB_work, wage_work, farm_hrs, SB_hrs, wage_hrs, industry,
+working_age).  This script concatenates them across the five ESS waves and
+applies the cross-wave ``id_walk`` so the household index uses the panel
+canonical id scheme (the same conversion ``sample()`` receives at API time;
+people_last7days is household-linked and NOT in ``_no_v_join``, so v
+auto-joins from sample()).
+
+``id_walk`` is idempotent (it sets ``attrs['id_converted']``), so the
+framework's ``_finalize_result`` skips re-applying it.  The wave parquets
+emit the wave-native household / individual id that matches the household
+roster (``household_id2`` / ``individual_id2`` for W2/W3, else
+``household_id`` / ``individual_id``), so people_last7days joins the roster
+on ``(t, i, pid)``.
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, id_walk, to_parquet
+from ethiopia import Waves
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/people_last7days.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet built / parquet absent (DVC raises PathMissingError).
+        continue
+    pieces.append(df)
+
+assert pieces, "people_last7days: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/people_last7days.parquet')

--- a/lsms_library/countries/Ethiopia/_/plot_labor.py
+++ b/lsms_library/countries/Ethiopia/_/plot_labor.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Concatenate wave-level plot_labor data for Ethiopia (GAP 3.2).
+
+Each wave's ``Ethiopia/<wave>/_/plot_labor.py`` produces a parquet with
+index ``(t, i, plot_id, source)`` and the canonical plot_labor columns
+(PersonDays, Wage).  This script concatenates them across the five ESS
+waves and applies the cross-wave ``id_walk`` so the household index uses
+the panel canonical id scheme (the same conversion ``sample()`` receives at
+API time, keeping the ``_join_v_from_sample`` join aligned -- plot_labor is
+household-linked and NOT in the framework ``_no_v_join`` set, so v auto-joins).
+
+``id_walk`` is idempotent (it sets ``attrs['id_converted']``), so the
+framework's ``_finalize_result`` skips re-applying it.  The wave parquets
+emit the wave-native household id that matches ``sample().i``
+(``household_id2`` for W2/W3, ``household_id`` elsewhere) -- identical to
+plot_features / crop_production / plot_inputs, so plot_labor joins them on
+``(t, i, plot_id)``.
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, id_walk, to_parquet
+from ethiopia import Waves
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/plot_labor.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet built / parquet absent (DVC raises PathMissingError).
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_labor: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/plot_labor.parquet')

--- a/lsms_library/countries/Malawi/2010-11/_/people_last7days.py
+++ b/lsms_library/countries/Malawi/2010-11/_/people_last7days.py
@@ -1,0 +1,39 @@
+"""Build people_last7days for Malawi IHS3 2010-11 (GAP 3, individual grain).
+
+Item-level (t, i, pid) 7-day individual time-use feature, mirroring
+Uganda's people_last7days at the per-individual grain GAP_RANKING.org
+specifies.  Source (Full_Sample/Household):
+  * hh_mod_e -- the household labor module.  IHS3 (legacy) layout: farm =
+    hh_e07, SOB = hh_e08, wage = hh_e11 (+ ganyu hh_e10); working_age =
+    (hh_e02 != "X"); industry hh_e20b.
+
+i = format_id(case_id), pid = format_id(id_code) -- the SAME (i, pid)
+household_roster emits for this wave.  This is the SAME Module E the World
+Bank cleaning code (MWI_IHPS1.do:1234-1269) reads to build the farm_work /
+SOB_work / wage_work dummies, hours, and ind_* industry one-hots; we keep
+the per-individual reported record (industry as one harmonize_industry
+label instead of six dummies).  See
+lsms_library/countries/Malawi/_/malawi.py:_people_last7days_block.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import _people_last7days_block, assemble_people_last7days
+
+
+WAVE = '2010-11'
+BASE = '../Data/Full_Sample/Household/'
+
+labor = get_dataframe(BASE + 'hh_mod_e.dta', convert_categoricals=False)
+
+piece = _people_last7days_block(
+    labor, t=WAVE, hhid='case_id', pid='id_code', layout='legacy',
+)
+
+df = assemble_people_last7days(WAVE, [piece])
+
+assert df.index.is_unique, f"Non-unique (t,i,pid) in people_last7days {WAVE}"
+assert len(df) > 0, f"people_last7days {WAVE} produced no rows"
+
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Malawi/2010-11/_/plot_labor.py
+++ b/lsms_library/countries/Malawi/2010-11/_/plot_labor.py
@@ -1,0 +1,41 @@
+"""Build plot_labor for Malawi IHS3 2010-11 (GAP 3, plot grain).
+
+Item-level (t, i, plot, source) plot-labor feature -- one reported row per
+labor source (family / hired / other) applied to a plot.  Source
+(Full_Sample/Agriculture):
+  * ag_mod_d -- the plot-input/plot-labor module.  Family labor is the
+    day*#people products in the ag_d42/43/44 {b/c,f/g,j/k,n/o} person-slot
+    blocks; hired labor is ag_d47a/ag_d48a (man), ag_d47c/ag_d48c (woman),
+    ag_d47e/ag_d48e (child) days with wages ag_d47b/d/f, ag_d48b/d/f; other
+    (free) labor is ag_d52a/b/c + ag_d54a/b/c.  Plot key ag_d00 (the same
+    R{n} key as plot_inputs / crop_production), i = format_id(case_id).
+
+This is the SAME Module D block the World Bank cleaning code
+(MWI_IHPS1.do:703-757) reads then collapses to per-plot total_*_labor_days
+/ hired_labor_value.  We keep the PRE-collapse reported person-days per
+source; the across-source sum + median-wage valuation are transformations.
+See lsms_library/countries/Malawi/_/malawi.py:_plot_labor_block.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import _plot_labor_block, assemble_plot_labor
+
+
+WAVE = '2010-11'
+BASE = '../Data/Full_Sample/Agriculture/'
+
+d = get_dataframe(BASE + 'ag_mod_d.dta', convert_categoricals=False)
+d['hhid'] = d['case_id'].apply(format_id)
+d['plotkey'] = d['ag_d00'].apply(format_id)
+
+piece = _plot_labor_block(d, hhid='hhid', plotkey='plotkey', t=WAVE,
+                          hired_suffix='', include_other=True)
+
+df = assemble_plot_labor(WAVE, [piece])
+
+assert df.index.is_unique, f"Non-unique (t,i,plot,source) in plot_labor {WAVE}"
+assert len(df) > 0, f"plot_labor {WAVE} produced no rows"
+
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Malawi/2013-14/_/people_last7days.py
+++ b/lsms_library/countries/Malawi/2013-14/_/people_last7days.py
@@ -1,0 +1,37 @@
+"""Build people_last7days for Malawi IHPS 2013-14 (GAP 3, individual grain).
+
+Item-level (t, i, pid) 7-day individual time-use feature.  Source (flat
+Data/):
+  * HH_MOD_E_13 -- the household labor module.  IHS3/IHPS-2013 (legacy)
+    layout: farm = hh_e07, SOB = hh_e08, wage = hh_e11 (+ ganyu hh_e10);
+    working_age = (hh_e02 != "X"); industry hh_e20b.
+
+ID NOTE: household_roster for 2013-14 uses pid: hh_b01 (the within-HH line
+number 1,2,3...).  The labor module carries the same line number as hh_e01
+(verified 2026-06-14: all 20219 (y2_hhid, hh_e01) keys are in the roster
+and unique), so we key on hh_e01 -> pid to align with household_roster.
+i = format_id(y2_hhid).  The framework applies panel id_walk + joins v at
+API time.  This is the SAME Module E the WB code (MWI_IHPS2.do labor block)
+reads.  See lsms_library/countries/Malawi/_/malawi.py:_people_last7days_block.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import _people_last7days_block, assemble_people_last7days
+
+
+WAVE = '2013-14'
+
+labor = get_dataframe('../Data/HH_MOD_E_13.dta', convert_categoricals=False)
+
+piece = _people_last7days_block(
+    labor, t=WAVE, hhid='y2_hhid', pid='hh_e01', layout='legacy',
+)
+
+df = assemble_people_last7days(WAVE, [piece])
+
+assert df.index.is_unique, f"Non-unique (t,i,pid) in people_last7days {WAVE}"
+assert len(df) > 0, f"people_last7days {WAVE} produced no rows"
+
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Malawi/2013-14/_/plot_labor.py
+++ b/lsms_library/countries/Malawi/2013-14/_/plot_labor.py
@@ -1,0 +1,37 @@
+"""Build plot_labor for Malawi IHPS 2013-14 (GAP 3, plot grain).
+
+Item-level (t, i, plot, source) plot-labor feature.  Variable layout tracks
+2010-11 (the IHS3/IHPS-2013 generation) except the household id (y2_hhid).
+Source (flat Data/):
+  * AG_MOD_D_13 -- plot key ag_d00.  Family labor = day*#people in the
+    ag_d42/43/44 {b/c,f/g,j/k,n/o} person-slot blocks; hired = ag_d47a/c/e +
+    ag_d48a/c/e days with wages ag_d47b/d/f + ag_d48b/d/f; other =
+    ag_d52a/b/c + ag_d54a/b/c.
+
+i = format_id(y2_hhid), aligning with plot_inputs / crop_production.  This
+is the SAME Module D block the WB code (MWI_IHPS2.do:757-) reads then
+collapses to per-plot totals.  See
+lsms_library/countries/Malawi/_/malawi.py:_plot_labor_block.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import _plot_labor_block, assemble_plot_labor
+
+
+WAVE = '2013-14'
+
+d = get_dataframe('../Data/AG_MOD_D_13.dta', convert_categoricals=False)
+d['hhid'] = d['y2_hhid'].apply(format_id)
+d['plotkey'] = d['ag_d00'].apply(format_id)
+
+piece = _plot_labor_block(d, hhid='hhid', plotkey='plotkey', t=WAVE,
+                          hired_suffix='', include_other=True)
+
+df = assemble_plot_labor(WAVE, [piece])
+
+assert df.index.is_unique, f"Non-unique (t,i,plot,source) in plot_labor {WAVE}"
+assert len(df) > 0, f"plot_labor {WAVE} produced no rows"
+
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Malawi/2016-17/_/people_last7days.py
+++ b/lsms_library/countries/Malawi/2016-17/_/people_last7days.py
@@ -1,0 +1,54 @@
+"""Build people_last7days for Malawi IHS4 / IHPS 2016-17 (GAP 3, individual).
+
+Item-level (t, i, pid) 7-day individual time-use feature.  IHS4 ships a
+Cross_Sectional half (cs-17-prefixed case_id, pid: pid) and a Panel half
+(y3_hhid, pid: id_code), concatenated into the single 2016-17 wave --
+exactly like household_roster / anthropometry.  Source: hh_mod_e (labor
+module) per half, joined to hh_mod_b (roster) for working_age.
+
+Module E layout is the IHS4/IHS5 (modern) generation: farm = hh_e07a (+
+livestock hh_e07b, fishing hh_e07c), SOB = hh_e08 (+ hh_e09), wage = hh_e11
+(+ ganyu hh_e10); industry hh_e20b.  IHS4/IHS5 drop the within-module
+working-age marker, so working_age = (roster age hh_b05a >= 5), reproducing
+the WB MWI_IHPS3.do:1315 definition, joined from the roster half.
+
+This is the SAME Module E the WB code (MWI_IHPS3.do:1294-1343) reads; we
+keep the per-individual reported record (industry as one harmonize_industry
+label instead of six dummies).  See
+lsms_library/countries/Malawi/_/malawi.py:_people_last7days_block.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import _people_last7days_block, assemble_people_last7days
+
+
+WAVE = '2016-17'
+
+pieces = []
+
+# --- Cross_Sectional half (cs-17 prefix; pid: pid) ---
+e_xs = get_dataframe('../Data/Cross_Sectional/hh_mod_e.dta',
+                     convert_categoricals=False)
+b_xs = get_dataframe('../Data/Cross_Sectional/hh_mod_b.dta',
+                     convert_categoricals=False)
+pieces.append(_people_last7days_block(
+    e_xs, t=WAVE, hhid='case_id', pid='pid', layout='modern',
+    i_prefix='cs-17-', roster=b_xs, roster_hhid='case_id', roster_pid='pid',
+))
+
+# --- Panel half (bare y3_hhid; pid: id_code) ---
+e_pn = get_dataframe('../Data/Panel/hh_mod_e_16.dta', convert_categoricals=False)
+b_pn = get_dataframe('../Data/Panel/hh_mod_b_16.dta', convert_categoricals=False)
+pieces.append(_people_last7days_block(
+    e_pn, t=WAVE, hhid='y3_hhid', pid='id_code', layout='modern',
+    roster=b_pn, roster_hhid='y3_hhid', roster_pid='id_code',
+))
+
+df = assemble_people_last7days(WAVE, pieces)
+
+assert df.index.is_unique, f"Non-unique (t,i,pid) in people_last7days {WAVE}"
+assert len(df) > 0, f"people_last7days {WAVE} produced no rows"
+
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Malawi/2016-17/_/plot_labor.py
+++ b/lsms_library/countries/Malawi/2016-17/_/plot_labor.py
@@ -1,0 +1,101 @@
+"""Build plot_labor for Malawi IHS4 / IHPS 2016-17 (GAP 3, plot grain).
+
+Item-level (t, i, plot, source) plot-labor feature.  IHS4 ships a
+Cross_Sectional half (cs-17-prefixed case_id) and a Panel half (bare
+y3_hhid), concatenated into the single 2016-17 wave -- exactly like
+plot_inputs / crop_production.  Plot key is gardenid_plotid in both halves.
+
+Module D plot-labor layout is the IHS4/IHS5 generation:
+  * family labor = ag_d4{2,3,4}b{n} * ag_d4{2,3,4}c{n} day*#people products
+    across occurrence suffixes n;
+  * hired labor  = ag_d47a1/a2/a3 + ag_d48a1/a2/a3 days, wages ag_d47b1/b2/b3
+    + ag_d48b1/b2/b3 (the '1/2/3' hired suffix);
+  * other labor  = ag_d52a/b/c + ag_d54a/b/c -- PRESENT in the Panel half,
+    but the Cross_Sectional Module D drops those columns, so the CS half
+    emits only family + hired rows (reported, not faked).
+
+The Cross_Sectional ag_mod_d.dta has a latin-1 bad byte in an unused
+free-text column; we read only the labor columns via _read_usecols (same
+recipe as plot_inputs 2016-17).  This is the SAME Module D block the WB
+code (MWI_IHPS3.do:737-) reads then collapses to per-plot totals.  See
+lsms_library/countries/Malawi/_/malawi.py:_plot_labor_block.
+"""
+import os
+import sys
+import tempfile
+
+sys.path.append('../../_/')
+import pyreadstat
+
+from lsms_library.local_tools import (get_dataframe, to_parquet, format_id,
+                                       DVCFS, _ensure_dvc_pulled,
+                                       _dvc_working_directory, _COUNTRIES_DIR)
+from malawi import _plot_labor_block, assemble_plot_labor
+
+
+WAVE = '2016-17'
+
+# Module D labor columns (avoid the latin-1 free-text column by restricting
+# the read on the Cross_Sectional half).
+_D_LABOR_COLS = ['case_id', 'y3_hhid', 'gardenid', 'plotid']
+for _blk in ('ag_d42', 'ag_d43', 'ag_d44'):
+    for _n in range(1, 14):
+        _D_LABOR_COLS += [f'{_blk}b{_n}', f'{_blk}c{_n}']
+for _n in (1, 2, 3):
+    _D_LABOR_COLS += [f'ag_d47a{_n}', f'ag_d47b{_n}',
+                      f'ag_d48a{_n}', f'ag_d48b{_n}']
+# "other" labor columns (present only in the Panel half).
+_D_LABOR_COLS += ['ag_d52a', 'ag_d52b', 'ag_d52c',
+                  'ag_d54a', 'ag_d54b', 'ag_d54c']
+
+
+def _read_usecols(countries_rel, usecols):
+    """Read only ``usecols`` from a DVC-tracked .dta that a full read cannot
+    decode (latin-1 bad byte in an unused column).  Absent columns are
+    silently skipped by pyreadstat."""
+    _ensure_dvc_pulled(countries_rel)
+    with _dvc_working_directory(_COUNTRIES_DIR):
+        with DVCFS.open(countries_rel) as f:
+            data = f.read()
+    with tempfile.NamedTemporaryFile(suffix='.dta', delete=False) as tmp:
+        tmp.write(data)
+        tmp_path = tmp.name
+    try:
+        # Restrict to columns actually present (usecols errors on absent).
+        df0, meta = pyreadstat.read_dta(tmp_path, metadataonly=True)
+        present = [c for c in usecols if c in meta.column_names]
+        df, _ = pyreadstat.read_dta(tmp_path, usecols=present,
+                                    apply_value_formats=False)
+        return df
+    finally:
+        os.unlink(tmp_path)
+
+
+def _plotkey(df):
+    return (df['gardenid'].apply(format_id) + '_'
+            + df['plotid'].apply(format_id))
+
+
+pieces = []
+
+# --- Cross_Sectional half (cs-17 prefix; no "other" labor columns) ---
+d_xs = _read_usecols('Malawi/2016-17/Data/Cross_Sectional/ag_mod_d.dta',
+                     _D_LABOR_COLS)
+d_xs['hhid'] = 'cs-17-' + d_xs['case_id'].apply(format_id)
+d_xs['plotkey'] = _plotkey(d_xs)
+pieces.append(_plot_labor_block(d_xs, hhid='hhid', plotkey='plotkey', t=WAVE,
+                                hired_suffix='1/2/3', include_other=False))
+
+# --- Panel half (bare y3_hhid; has "other" labor) ---
+d_pn = get_dataframe('../Data/Panel/ag_mod_d_16.dta', convert_categoricals=False)
+d_pn['hhid'] = d_pn['y3_hhid'].apply(format_id)
+d_pn['plotkey'] = _plotkey(d_pn)
+pieces.append(_plot_labor_block(d_pn, hhid='hhid', plotkey='plotkey', t=WAVE,
+                                hired_suffix='1/2/3', include_other=True))
+
+df = assemble_plot_labor(WAVE, pieces)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot,source) in plot_labor {WAVE}"
+assert len(df) > 0, f"plot_labor {WAVE} produced no rows"
+
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Malawi/2019-20/_/people_last7days.py
+++ b/lsms_library/countries/Malawi/2019-20/_/people_last7days.py
@@ -1,0 +1,55 @@
+"""Build people_last7days for Malawi IHS5 / IHPS 2019-20 (GAP 3, individual).
+
+Item-level (t, i, pid) 7-day individual time-use feature.  IHS5 ships a
+Cross_Sectional half (bare case_id, pid: PID) and a Panel half (y4_hhid,
+pid: id_code), concatenated into the single 2019-20 wave -- exactly like
+household_roster / anthropometry.  Source: HH_MOD_E (labor module) per half,
+joined to HH_MOD_B (roster) for working_age.
+
+ID NOTE: like anthropometry, the 2019-20 household_roster's final
+Cross_Sectional i is the RAW 12-digit case_id (NO 'cs-19-' prefix; the
+Panel y4_hhid is walked to that id space by updated_ids), so we emit the
+raw case_id for the CS half (no i_prefix) and key pid on PID (the roster's
+CS pid).  The framework id_walk remaps the Panel half + joins v at API time.
+
+Module E layout is the IHS4/IHS5 (modern) generation: farm = hh_e07a (+
+hh_e07b, hh_e07c), SOB = hh_e08 (+ hh_e09), wage = hh_e11 (+ ganyu
+hh_e10); industry hh_e20b; working_age = (roster hh_b05a >= 5).  This is
+the SAME Module E the WB code (MWI_IHPS4.do:1314-1365) reads.  See
+lsms_library/countries/Malawi/_/malawi.py:_people_last7days_block.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import _people_last7days_block, assemble_people_last7days
+
+
+WAVE = '2019-20'
+
+pieces = []
+
+# --- Cross_Sectional half (raw case_id, no prefix; pid: PID) ---
+e_xs = get_dataframe('../Data/Cross_Sectional/HH_MOD_E.dta',
+                     convert_categoricals=False)
+b_xs = get_dataframe('../Data/Cross_Sectional/HH_MOD_B.dta',
+                     convert_categoricals=False)
+pieces.append(_people_last7days_block(
+    e_xs, t=WAVE, hhid='case_id', pid='PID', layout='modern',
+    roster=b_xs, roster_hhid='case_id', roster_pid='PID',
+))
+
+# --- Panel half (y4_hhid; pid: id_code) ---
+e_pn = get_dataframe('../Data/Panel/hh_mod_e_19.dta', convert_categoricals=False)
+b_pn = get_dataframe('../Data/Panel/hh_mod_b_19.dta', convert_categoricals=False)
+pieces.append(_people_last7days_block(
+    e_pn, t=WAVE, hhid='y4_hhid', pid='id_code', layout='modern',
+    roster=b_pn, roster_hhid='y4_hhid', roster_pid='id_code',
+))
+
+df = assemble_people_last7days(WAVE, pieces)
+
+assert df.index.is_unique, f"Non-unique (t,i,pid) in people_last7days {WAVE}"
+assert len(df) > 0, f"people_last7days {WAVE} produced no rows"
+
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Malawi/2019-20/_/plot_labor.py
+++ b/lsms_library/countries/Malawi/2019-20/_/plot_labor.py
@@ -1,0 +1,61 @@
+"""Build plot_labor for Malawi IHS5 / IHPS 2019-20 (GAP 3, plot grain).
+
+Item-level (t, i, plot, source) plot-labor feature.  IHS5 ships a
+Cross_Sectional half (bare case_id -- sample().i for 2019-20 is the bare
+case_id, NOT cs-prefixed) and a Panel half (y4_hhid), concatenated into the
+single 2019-20 wave -- exactly like plot_inputs / crop_production.  Plot key
+is gardenid_plotid in both halves.
+
+Module D plot-labor layout is the IHS4/IHS5 generation:
+  * family = ag_d4{2,3,4}b{n} * ag_d4{2,3,4}c{n} day*#people products;
+  * hired  = ag_d47a1/a2/a3 + ag_d48a1/a2/a3 days, wages ag_d47b1/b2/b3 +
+    ag_d48b1/b2/b3 ('1/2/3' hired suffix);
+  * other  = ag_d52a/b/c + ag_d54a/b/c -- PRESENT in the Panel half, but the
+    Cross_Sectional Module D drops those columns, so the CS half emits only
+    family + hired rows (reported, not faked).
+
+This is the SAME Module D block the WB code (MWI_IHPS4.do:739-) reads then
+collapses to per-plot totals (the IHPS4 .do also folds a separate
+post-harvest family-labor file, ag_i00b*ag_i00c, into total_family_labor_
+days; that is an across-source SUM transform we do not bake in -- we carry
+only the Module D plot-labor reported days).  See
+lsms_library/countries/Malawi/_/malawi.py:_plot_labor_block.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from malawi import _plot_labor_block, assemble_plot_labor
+
+
+WAVE = '2019-20'
+
+
+def _plotkey(df):
+    return (df['gardenid'].apply(format_id) + '_'
+            + df['plotid'].apply(format_id))
+
+
+pieces = []
+
+# --- Cross_Sectional half (bare case_id; no "other" labor columns) ---
+d_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_d.dta',
+                     convert_categoricals=False)
+d_xs['hhid'] = d_xs['case_id'].apply(format_id)
+d_xs['plotkey'] = _plotkey(d_xs)
+pieces.append(_plot_labor_block(d_xs, hhid='hhid', plotkey='plotkey', t=WAVE,
+                                hired_suffix='1/2/3', include_other=False))
+
+# --- Panel half (y4_hhid; has "other" labor) ---
+d_pn = get_dataframe('../Data/Panel/ag_mod_d_19.dta', convert_categoricals=False)
+d_pn['hhid'] = d_pn['y4_hhid'].apply(format_id)
+d_pn['plotkey'] = _plotkey(d_pn)
+pieces.append(_plot_labor_block(d_pn, hhid='hhid', plotkey='plotkey', t=WAVE,
+                                hired_suffix='1/2/3', include_other=True))
+
+df = assemble_plot_labor(WAVE, pieces)
+
+assert df.index.is_unique, f"Non-unique (t,i,plot,source) in plot_labor {WAVE}"
+assert len(df) > 0, f"plot_labor {WAVE} produced no rows"
+
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Malawi/_/Makefile
+++ b/lsms_library/countries/Malawi/_/Makefile
@@ -12,7 +12,7 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 # _ROSTER_DERIVED — no country-level parquet is built or consulted.
 # See GH #218.
 
-all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet $(VAR_DIR)/crop_production.parquet $(VAR_DIR)/plot_inputs.parquet $(VAR_DIR)/livestock.parquet $(VAR_DIR)/anthropometry.parquet
+all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet $(VAR_DIR)/crop_production.parquet $(VAR_DIR)/plot_inputs.parquet $(VAR_DIR)/livestock.parquet $(VAR_DIR)/anthropometry.parquet $(VAR_DIR)/plot_labor.parquet $(VAR_DIR)/people_last7days.parquet
 
 food_acquired = $(shell find $(rounds) -name food_acquired.py)
 # Wave-level parquets live in data_root, not in-tree
@@ -102,6 +102,37 @@ $(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/anthropometry.parquet: malawi.py
 
 $(VAR_DIR)/anthropometry.parquet: anthropometry.py $(anthropometry_parquet)
 	python anthropometry.py
+
+# --- plot_labor (GAP 3, plot grain) ---------------------------------------
+# Item-level (t, i, plot, source) plot labor (PersonDays, Wage) for the four
+# IHS3+/IHPS waves.  source in {family, hired, other}.  Each wave script
+# writes its parquet into data_root; the country script concatenates.
+# 2004-05 (IHS2) is ABSENT (household-level aggregated ag file, no
+# plot-level labor roster).  total_*_labor_days / hired_labor_value are
+# transformations, NOT stored.
+plot_labor_waves := 2010-11 2013-14 2016-17 2019-20
+plot_labor_parquet := $(foreach r,$(plot_labor_waves),$(LSMS_DATA_ROOT)/$(COUNTRY)/$(r)/_/plot_labor.parquet)
+
+$(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/plot_labor.parquet: malawi.py
+	(cd ../$(*)/_/ && python plot_labor.py)
+
+$(VAR_DIR)/plot_labor.parquet: plot_labor.py $(plot_labor_parquet)
+	python plot_labor.py
+
+# --- people_last7days (GAP 3, individual grain) ---------------------------
+# Item-level (t, i, pid) 7-day individual time-use for the four IHS3+/IHPS
+# waves carrying the hh_mod_e labor module.  Each wave script writes its
+# parquet into data_root; the country script concatenates.  2004-05 (IHS2)
+# is ABSENT (predates the 7-day activity battery).  The six WB ind_* dummies
+# collapse to one wage_industry label; per-industry dummies are transforms.
+people_last7days_waves := 2010-11 2013-14 2016-17 2019-20
+people_last7days_parquet := $(foreach r,$(people_last7days_waves),$(LSMS_DATA_ROOT)/$(COUNTRY)/$(r)/_/people_last7days.parquet)
+
+$(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/people_last7days.parquet: malawi.py
+	(cd ../$(*)/_/ && python people_last7days.py)
+
+$(VAR_DIR)/people_last7days.parquet: people_last7days.py $(people_last7days_parquet)
+	python people_last7days.py
 
 %.parquet: %.py malawi.py
 	(cd $(@D) && python ./$(<F))

--- a/lsms_library/countries/Malawi/_/categorical_mapping.org
+++ b/lsms_library/countries/Malawi/_/categorical_mapping.org
@@ -712,3 +712,46 @@
 | 3305 | Donkey/Horse      |
 | 3310 | Chicken           |
 | 3314 | Turkey/Guinea Fowl|
+
+# harmonize_labor_source: plot-labor source identity for the plot_labor
+# feature (GAP 3, plot grain).  The Module D plot-labor block records three
+# distinct labor sources on a plot, each in its own set of person-day
+# columns: household (family) members, hired (paid) labor, and free /
+# exchange ("other") labor.  These are the `source` axis of plot_labor's
+# (t, i, plot, source) grain.  Stable across all four IHS3+/IHPS waves.
+# Code is a synthetic small-integer identity (the source is read from the
+# COLUMN block in Module D, not a numeric code in the data), so this table
+# is a label-stabilizer / documentation map rather than a code lookup.
+#+name: harmonize_labor_source
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | family          |
+|    2 | hired           |
+|    3 | other           |
+
+# harmonize_industry: wage-job industry identity for the people_last7days
+# feature (GAP 3, individual grain).  The labor module records each
+# individual's main wage-job industry as a 2-digit ISIC-style code
+# (hh_e20b).  The World Bank cleaning code (MWI_IHPS{1-4}.do labor block)
+# bins this code into six one-hot dummies (ind_ag / ind_fish / ind_mining /
+# ind_manuf / ind_const / ind_serv) via numeric ranges:
+#   11,12 -> Agriculture; 13 -> Fishing; 29 -> Mining;
+#   31-42 -> Manufacturing; 50 -> Construction; 61-96 -> Services.
+# We keep ONE harmonized industry label per individual (the natural
+# item-level form) instead of the six wide dummies; a per-industry dummy
+# (e.g. wage_industry == 'Agriculture') is then a trivial transformation.
+# Codes outside the six WB bins map to 'Other'; missing/no-wage-job -> NaN.
+# This table is read by malawi.py:_industry_label, which applies the WB
+# numeric-range bins (a range map, not a 1:1 code lookup), so the Code
+# column below lists only the canonical bin LABELS for reference, keyed by a
+# synthetic ordinal -- the actual hh_e20b->label binning lives in code.
+#+name: harmonize_industry
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Agriculture     |
+|    2 | Fishing         |
+|    3 | Mining          |
+|    4 | Manufacturing   |
+|    5 | Construction    |
+|    6 | Services        |
+|    7 | Other           |

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -250,5 +250,82 @@ Data Scheme:
     Age_months: float
     Sex: str
     materialize: make
+  plot_labor:
+    # Item-level (t, i, plot, source) plot-labor feature for the four
+    # IHS3+/IHPS waves (2010-11, 2013-14, 2016-17, 2019-20); GAP 3 (plot
+    # grain).  One REPORTED row per labor source applied to a plot, with
+    # source in {family, hired, other} on the harmonize_labor_source
+    # Preferred Labels.  Source: the Module D (ag_mod_d) plot-labor block --
+    # the SAME columns the World Bank cleaning code (MWI_IHPS{1-4}.do
+    # labor-days block) reads then collapses to per-plot total_*_labor_days /
+    # hired_labor_value.  We keep the PRE-collapse reported person-days per
+    # source:
+    #   PersonDays -- reported person-days of that source on the plot.  For
+    #                 family labor the survey records (days x #people) per
+    #                 person-slot/week block, so PersonDays sums those
+    #                 day*count products; for hired/other it sums the reported
+    #                 man/woman/child day counts across the two visit columns.
+    #   Wage       -- reported cash daily wage paid to HIRED labor (mean of
+    #                 the reported man/woman/child daily wages recorded for
+    #                 that plot); NaN for family / other (no wage paid).  This
+    #                 is the REPORTED per-day wage, NOT the WB median-wage
+    #                 valuation.
+    # The WB total_labor_days (sum ACROSS sources), the per-source HH-level
+    # rollups, and hired_labor_value (median-wage valuation) are ALL
+    # transformations, NEVER stored columns here.  Plot grain aligns with
+    # crop_production / plot_inputs (join on (t, i, plot)).  Variable layout
+    # differs by questionnaire generation: IHS3/IHPS-2013 (2010-11, 2013-14)
+    # use the ag_d47{a,c,e}/d48 hired layout + ag_d4{2,3,4}{b/c,f/g,j/k,n/o}
+    # family slots; IHS4/IHS5 (2016-17, 2019-20) use ag_d47{a1,a2,a3}/d48
+    # hired + ag_d4{2,3,4}{b}{n}*{c}{n} family.  The IHS4/IHS5
+    # Cross_Sectional halves drop the "other" (ag_d52*/ag_d54*) columns, so
+    # those halves carry no `other` rows (reported, not faked).  2004-05
+    # (IHS2) is DEFERRED (household-level aggregated ag file, no plot-labor
+    # roster).  See _/malawi.py:_plot_labor_block / assemble_plot_labor.
+    index: (t, i, plot, source)
+    PersonDays: float
+    Wage: float
+    materialize: make
+  people_last7days:
+    # Item-level (t, i, pid) 7-day individual time-use feature for the four
+    # IHS3+/IHPS waves (2010-11, 2013-14, 2016-17, 2019-20); GAP 3
+    # (individual grain).  Mirrors Uganda's people_last7days at the
+    # per-individual grain GAP_RANKING.org specifies (Uganda's existing
+    # feature is an HH-level Men/Women/Boys/Girls count; the parity target is
+    # the per-individual activity record).  Source: the household labor
+    # module (hh_mod_e) -- the SAME module the World Bank cleaning code
+    # (MWI_IHPS{1-4}.do labor block) reads to build the farm_work/SOB_work/
+    # wage_work dummies, hours, six ind_* industry one-hots, and working_age.
+    # We keep the per-individual REPORTED record:
+    #   farm_work  -- worked on HH agric/livestock/fishing in last 7 days
+    #   SOB_work   -- helped/ran a non-farm HH business in last 7 days
+    #   wage_work  -- worked for a wage/salary OR ganyu in last 7 days
+    #   farm_hrs   -- hours on HH agric (+livestock/fishing where split)
+    #   SB_hrs     -- hours on the non-farm HH business
+    #   wage_hrs   -- hours of wage work + ganyu (the WB wage_hrs sum)
+    #   wage_industry -- main wage-job industry on the harmonize_industry
+    #                 Preferred Labels (Agriculture/Fishing/Mining/
+    #                 Manufacturing/Construction/Services/Other), binned from
+    #                 hh_e20b by the WB numeric ranges; NaN where no wage job.
+    #                 Replaces the six WB ind_* dummies (a per-industry dummy
+    #                 is then a trivial transformation).
+    #   working_age -- the WB working_age flag (hh_e02 != "X" in IHS3/
+    #                 IHPS-2013; roster age hh_b05a >= 5 in IHS4/IHS5).
+    # Variable names differ by questionnaire generation (legacy hh_e07 single
+    # farm col vs modern hh_e07a/b/c + roster-derived working_age); see
+    # _/malawi.py:_people_last7days_block.  Grain is individual (t, i, pid),
+    # aligned with household_roster's (i, pid); v auto-joins from sample() at
+    # API time.  2004-05 (IHS2) is DEFERRED (its labor module predates the
+    # 7-day activity battery).  See _/malawi.py:assemble_people_last7days.
+    index: (t, i, pid)
+    farm_work: bool
+    SOB_work: bool
+    wage_work: bool
+    farm_hrs: float
+    SB_hrs: float
+    wage_hrs: float
+    wage_industry: str
+    working_age: bool
+    materialize: make
   food_expenditures:
   food_prices:

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -1764,3 +1764,399 @@ def assemble_anthropometry(t, pieces):
     out = cat.set_index(['t', 'i', 'pid'])
     assert out.index.is_unique, f"Non-unique (t,i,pid) in anthropometry {t}"
     return out
+
+
+# --- plot_labor (GAP 3, plot grain) ---------------------------------------
+# Item-level (t, i, plot, source) plot-labor feature for the four IHS3+/IHPS
+# waves.  Source: the Module D (ag_mod_d) plot-labor block -- the SAME
+# columns the World Bank cleaning code (MWI_IHPS{1-4}.do labor-days block)
+# reads then collapses to per-plot total_*_labor_days / hired_labor_value.
+# We keep the PRE-collapse REPORTED person-days for each of the survey's
+# three labor sources (family / hired / other), as the `source` axis of the
+# (t, i, plot, source) grain -- one row per (plot, source).  The
+# WB total_labor_days (sum ACROSS sources), the per-source HH-level
+# rollups, and hired_labor_value (median-wage valuation) are ALL
+# transformations, NEVER stored columns here.
+#
+# Reported columns:
+#   PersonDays -- reported person-days of that source on the plot.  For
+#                 family labor the survey records (days x #people) per
+#                 person-slot/week block, so PersonDays sums those
+#                 day*count products (the WB temp_* / total_family_labor_days
+#                 numerator BEFORE the across-source sum).  For hired/other
+#                 the survey records day counts directly across man/woman/
+#                 child categories and two visit columns, so PersonDays sums
+#                 those reported day counts.
+#   Wage       -- reported cash daily wage paid to HIRED labor (the mean of
+#                 the reported man/woman/child daily wages that the survey
+#                 recorded for that plot); NaN for family / other sources
+#                 (no wage is paid).  This is the REPORTED per-day wage, NOT
+#                 the median-wage valuation the WB code derives.
+#
+# The hired/other "person-day" columns differ by questionnaire generation:
+#   IHS3 / IHPS-2013 (2010-11, 2013-14):
+#     hired man  = ag_d47a + ag_d48a   wage man  = ag_d47b, ag_d48b
+#     hired woman= ag_d47c + ag_d48c   wage woman= ag_d47d, ag_d48d
+#     hired child= ag_d47e + ag_d48e   wage child= ag_d47f, ag_d48f
+#   IHS4 / IHS5 (2016-17, 2019-20):
+#     hired man  = ag_d47a1 + ag_d48a1 wage man  = ag_d47b1, ag_d48b1
+#     hired woman= ag_d47a2 + ag_d48a2 wage woman= ag_d47b2, ag_d48b2
+#     hired child= ag_d47a3 + ag_d48a3 wage child= ag_d47b3, ag_d48b3
+# Other (free / exchange) labor is the same in every wave:
+#     other man  = ag_d52a + ag_d54a
+#     other woman= ag_d52b + ag_d54b
+#     other child= ag_d52c + ag_d54c
+# NOTE: the IHS4/IHS5 Cross_Sectional halves drop the Module D "other"
+# labor columns (ag_d52*/ag_d54* absent), so those halves emit no `other`
+# rows -- reported, not faked.
+
+def _labor_source_code_map():
+    """{Preferred Label: synthetic code} for harmonize_labor_source (for
+    documentation / round-trip).  The plot_labor `source` axis carries the
+    Preferred Labels directly, not the codes."""
+    return _malawi_code_map('harmonize_labor_source')
+
+
+def _sum_products(df, pairs):
+    """Row-wise Sum over a list of (days_col, count_col) pairs of
+    days*count, treating absent columns / NaN as 0; the whole result is NaN
+    only when EVERY contributing cell is NaN (matching Stata's
+    `egen rowtotal, missing`)."""
+    total = pd.Series(0.0, index=df.index)
+    any_present = pd.Series(False, index=df.index)
+    for dcol, ccol in pairs:
+        if dcol not in df.columns or ccol not in df.columns:
+            continue
+        d = pd.to_numeric(df[dcol], errors='coerce')
+        c = pd.to_numeric(df[ccol], errors='coerce')
+        prod = d * c
+        total = total + prod.fillna(0.0)
+        any_present = any_present | prod.notna()
+    return total.where(any_present, np.nan)
+
+
+def _sum_cols(df, cols):
+    """Row-wise sum over ``cols`` (absent cols skipped); NaN only when every
+    present cell is NaN (Stata rowtotal-missing semantics)."""
+    total = pd.Series(0.0, index=df.index)
+    any_present = pd.Series(False, index=df.index)
+    for col in cols:
+        if col not in df.columns:
+            continue
+        v = pd.to_numeric(df[col], errors='coerce')
+        total = total + v.fillna(0.0)
+        any_present = any_present | v.notna()
+    return total.where(any_present, np.nan)
+
+
+def _mean_cols(df, cols):
+    """Row-wise mean over the NON-null values among ``cols`` (absent cols
+    skipped); NaN when every present cell is NaN.  Used for the reported
+    hired daily wage across man/woman/child categories."""
+    present = [c for c in cols if c in df.columns]
+    if not present:
+        return pd.Series(np.nan, index=df.index)
+    sub = df[present].apply(lambda s: pd.to_numeric(s, errors='coerce'))
+    return sub.mean(axis=1, skipna=True)
+
+
+def _family_labor_pairs(df):
+    """The (days, count) family-labor column pairs present in ``df``.
+
+    Handles both questionnaire layouts:
+      * IHS3/IHPS-2013: ag_d4{2,3,4}{b/c, f/g, j/k, n/o} -- four person
+        slots (b*c, f*g, j*k, n*o) across the 2nd/3rd/4th week blocks.
+      * IHS4/IHS5: ag_d4{2,3,4}{b}{n} * ag_d4{2,3,4}{c}{n} -- one (b,c)
+        day*count pair per occurrence-suffix n (n = 1..13).
+    Returns a list of (days_col, count_col) tuples, only those present.
+    """
+    pairs = []
+    blocks = ('ag_d42', 'ag_d43', 'ag_d44')
+    # IHS3/IHPS-2013 layout: 4 person-slots, bare suffixes.
+    legacy_slots = [('b', 'c'), ('f', 'g'), ('j', 'k'), ('n', 'o')]
+    legacy = [(blk + d, blk + c) for blk in blocks for d, c in legacy_slots
+              if (blk + d) in df.columns and (blk + c) in df.columns]
+    if legacy:
+        pairs += legacy
+    # IHS4/IHS5 layout: (b{n}, c{n}) day*count per occurrence suffix.
+    for blk in blocks:
+        for n in range(1, 14):
+            dcol, ccol = f'{blk}b{n}', f'{blk}c{n}'
+            if dcol in df.columns and ccol in df.columns:
+                pairs.append((dcol, ccol))
+    return pairs
+
+
+def _plot_labor_block(df, *, hhid, plotkey, t, hired_suffix,
+                      include_other=True):
+    """Build one wave-half's reported (i, plot, source) plot-labor block.
+
+    ``df`` is a raw Module D frame that already carries an ``hhid`` string
+    column and a ``plotkey`` string column.  ``hired_suffix`` selects the
+    hired-labor column naming: '' for the IHS3/IHPS-2013 a/c/e + b/d/f
+    layout, '1/2/3' for the IHS4/IHS5 a1/a2/a3 + b1/b2/b3 layout.
+    ``include_other`` is False for the IHS4/IHS5 Cross_Sectional halves that
+    drop the ag_d52*/ag_d54* "other" columns.
+
+    Returns a long DataFrame at grain (t, i, plot, source) with the reported
+    item columns PersonDays and Wage (Wage non-null only for source=hired).
+    NO across-source sum, NO per-plot HH rollup.
+    """
+    work = pd.DataFrame({
+        'i':    df[hhid].astype('string').values,
+        'plot': df[plotkey].astype('string').values,
+    }, index=df.index)
+
+    rows = []
+
+    # --- family: PersonDays = Sum(days * #people) over the slot/week pairs.
+    fam_days = _sum_products(df, _family_labor_pairs(df))
+    fam = work.copy()
+    fam['source'] = 'family'
+    fam['PersonDays'] = fam_days.values
+    fam['Wage'] = np.nan
+    rows.append(fam)
+
+    # --- hired: PersonDays = Sum reported man/woman/child day counts across
+    # the two visit columns; Wage = mean reported daily wage across the
+    # man/woman/child categories that were recorded.
+    if hired_suffix == '':
+        day_cols = ['ag_d47a', 'ag_d48a', 'ag_d47c', 'ag_d48c',
+                    'ag_d47e', 'ag_d48e']
+        wage_cols = ['ag_d47b', 'ag_d48b', 'ag_d47d', 'ag_d48d',
+                     'ag_d47f', 'ag_d48f']
+    else:
+        day_cols = ['ag_d47a1', 'ag_d48a1', 'ag_d47a2', 'ag_d48a2',
+                    'ag_d47a3', 'ag_d48a3']
+        wage_cols = ['ag_d47b1', 'ag_d48b1', 'ag_d47b2', 'ag_d48b2',
+                     'ag_d47b3', 'ag_d48b3']
+    hired = work.copy()
+    hired['source'] = 'hired'
+    hired['PersonDays'] = _sum_cols(df, day_cols).values
+    hired['Wage'] = _mean_cols(df, wage_cols).values
+    rows.append(hired)
+
+    # --- other (free / exchange): PersonDays = Sum reported man/woman/child
+    # day counts across the two visit columns; no wage.
+    if include_other:
+        other_cols = ['ag_d52a', 'ag_d54a', 'ag_d52b', 'ag_d54b',
+                      'ag_d52c', 'ag_d54c']
+        if any(c in df.columns for c in other_cols):
+            other = work.copy()
+            other['source'] = 'other'
+            other['PersonDays'] = _sum_cols(df, other_cols).values
+            other['Wage'] = np.nan
+            rows.append(other)
+
+    out = pd.concat(rows, ignore_index=True)
+    out['t'] = t
+    # Drop rows with no reported person-days for that source on that plot
+    # (the survey did not record that source -> not a real item row).
+    out = out[out['PersonDays'].notna() & (out['PersonDays'] > 0)
+              | (out['source'] == 'hired') & out['Wage'].notna()]
+    return out
+
+
+def assemble_plot_labor(t, pieces):
+    """Combine per-half plot-labor blocks (_plot_labor_block) into the
+    canonical plot_labor DataFrame for wave ``t``.
+
+    Returns a DataFrame indexed (t, i, plot, source) with columns PersonDays
+    and Wage.  A (plot, source) reached on two source rows (e.g. the same
+    plot reported across CS/Panel overlap, which should not happen but is
+    guarded) sums PersonDays (additive) and takes the first reported Wage.
+    """
+    cat = pd.concat(pieces, ignore_index=True)
+    cat['t'] = t
+    grp = cat.groupby(['t', 'i', 'plot', 'source'], as_index=False,
+                      dropna=False).agg({
+        'PersonDays': 'sum',
+        'Wage':       'first',
+    })
+    out = grp.set_index(['t', 'i', 'plot', 'source'])
+    assert out.index.is_unique, f"Non-unique (t,i,plot,source) in plot_labor {t}"
+    return out
+
+
+# --- people_last7days (GAP 3, individual grain) ---------------------------
+# Item-level (t, i, pid) 7-day individual time-use feature, mirroring
+# Uganda's people_last7days but at the individual grain GAP_RANKING.org
+# specifies (Uganda's existing feature is an HH-level Men/Women/Boys/Girls
+# count; the parity target is the per-individual activity record).  Source:
+# the household labor module (hh_mod_e) -- the SAME module the World Bank
+# cleaning code (MWI_IHPS{1-4}.do labor block) reads to build farm_work /
+# SOB_work / wage_work dummies, farm_hrs / SB_hrs / wage_hrs, the six
+# ind_* industry one-hots, and working_age.  We keep the per-individual
+# REPORTED record (no HH rollup):
+#   farm_work  (bool) -- worked on HH agric/livestock/fishing in last 7 days
+#   SOB_work   (bool) -- helped/ran a non-farm HH business in last 7 days
+#   wage_work  (bool) -- worked for a wage/salary OR ganyu in last 7 days
+#   farm_hrs   (float)-- hours on HH agric (+livestock/fishing where split)
+#   SB_hrs     (float)-- hours on the non-farm HH business
+#   wage_hrs   (float)-- hours of wage work + ganyu (the WB wage_hrs sum)
+#   wage_industry (str)-- main wage-job industry on the harmonize_industry
+#                         Preferred Labels (Agriculture/Fishing/Mining/
+#                         Manufacturing/Construction/Services/Other), binned
+#                         from hh_e20b by the WB numeric ranges; NaN where
+#                         no wage job / not asked.  Replaces the six WB
+#                         ind_* dummies (a per-industry dummy is then a
+#                         trivial transformation).
+#   working_age (bool)-- the WB working_age flag.
+#
+# The variable names differ by questionnaire generation:
+#   IHS3 / IHPS-2013 (2010-11, 2013-14):
+#     farm  = hh_e07 (single agric hours col)        -> farm_work/farm_hrs
+#     SOB   = hh_e08                                  -> SOB_work/SB_hrs
+#     wage  = hh_e11 (wage) + hh_e10 (ganyu)          -> wage_work/wage_hrs
+#     working_age = (hh_e02 != "X")
+#   IHS4 / IHS5 (2016-17, 2019-20):
+#     farm  = hh_e07a (+ hh_e07b livestock, hh_e07c fishing) -> farm_work/hrs
+#     SOB   = hh_e08 (+ hh_e09)                        -> SOB_work/SB_hrs
+#     wage  = hh_e11 (wage) + hh_e10 (ganyu)           -> wage_work/wage_hrs
+#     working_age = (roster age hh_b05a >= 5), joined from the roster.
+# Industry hh_e20b (2-digit ISIC) is present in every wave.
+
+# WB hh_e20b industry-range bins (MWI_IHPS{1-4}.do): code -> label.
+def _industry_label(code_series):
+    """Bin the hh_e20b 2-digit industry code into the harmonize_industry
+    Preferred Label, reproducing the WB numeric ranges:
+      11,12 -> Agriculture; 13 -> Fishing; 29 -> Mining;
+      31-42 -> Manufacturing; 50 -> Construction; 61-96 -> Services;
+      any other recorded code -> Other; missing -> NaN.
+    """
+    code = pd.to_numeric(code_series, errors='coerce')
+
+    def _one(c):
+        if pd.isna(c):
+            return pd.NA
+        c = int(c)
+        if c in (11, 12):
+            return 'Agriculture'
+        if c == 13:
+            return 'Fishing'
+        if c == 29:
+            return 'Mining'
+        if 31 <= c <= 42:
+            return 'Manufacturing'
+        if c == 50:
+            return 'Construction'
+        if 61 <= c <= 96:
+            return 'Services'
+        return 'Other'
+
+    return pd.Series([_one(c) for c in code], index=code_series.index,
+                     dtype='string')
+
+
+def _dummy_from_hours(series):
+    """Reproduce the WB `recode (0=0)(.=.)(else=1)`: >0 -> True, ==0 ->
+    False, NaN -> NA (a nullable boolean)."""
+    v = pd.to_numeric(series, errors='coerce')
+    out = pd.Series(pd.NA, index=v.index, dtype='boolean')
+    out[v == 0] = False
+    out[v > 0] = True
+    return out
+
+
+def _people_last7days_block(labor, *, t, hhid, pid, layout,
+                            i_prefix=None, roster=None,
+                            roster_hhid=None, roster_pid=None):
+    """Build one wave-half's reported (i, pid) 7-day time-use block.
+
+    Parameters
+    ----------
+    labor : pd.DataFrame -- raw hh_mod_e labor module for this half
+        (convert_categoricals=False so hh_e20b is numeric).
+    t : str -- wave id.
+    hhid, pid : str -- HH-id and person-id columns in ``labor`` (must resolve
+        to the SAME (i, pid) household_roster emits, after ``i_prefix``).
+    layout : 'legacy' | 'modern'
+        'legacy' = IHS3/IHPS-2013 (hh_e07 single farm col, hh_e02 working
+        age); 'modern' = IHS4/IHS5 (hh_e07a/b/c, working age from roster
+        age).
+    i_prefix : str | None -- prepended to the formatted HH id (e.g. 'cs-17-'
+        for the IHS4 Cross_Sectional half) to match household_roster.
+    roster, roster_hhid, roster_pid : optional -- the Module B roster half
+        (convert_categoricals=False) used to derive working_age = age>=5 in
+        the 'modern' layout.  Ignored for 'legacy'.
+
+    Returns a DataFrame [i, pid, farm_work, SOB_work, wage_work, farm_hrs,
+    SB_hrs, wage_hrs, wage_industry, working_age] (index reset).
+    """
+    pre = (lambda s: (i_prefix + s)) if i_prefix else (lambda s: s)
+    d = labor.copy()
+    out = pd.DataFrame(index=d.index)
+    out['i'] = d[hhid].apply(format_id).map(pre)
+    out['pid'] = d[pid].apply(format_id)
+
+    if layout == 'legacy':
+        farm_hrs = _sum_cols(d, ['hh_e07'])
+        sb_hrs = _sum_cols(d, ['hh_e08'])
+    else:
+        farm_hrs = _sum_cols(d, ['hh_e07a', 'hh_e07b', 'hh_e07c'])
+        sb_hrs = _sum_cols(d, ['hh_e08', 'hh_e09'])
+    wage_hrs = _sum_cols(d, ['hh_e11', 'hh_e10'])  # wage + ganyu, both waves
+
+    out['farm_work'] = _dummy_from_hours(farm_hrs).values
+    out['SOB_work'] = _dummy_from_hours(sb_hrs).values
+    # wage_work = worked for wage OR ganyu (either hours > 0).
+    wage_dummy = _dummy_from_hours(pd.to_numeric(d.get('hh_e11'),
+                                                 errors='coerce'))
+    ganyu_dummy = _dummy_from_hours(pd.to_numeric(d.get('hh_e10'),
+                                                  errors='coerce'))
+    ww = pd.Series(pd.NA, index=d.index, dtype='boolean')
+    ww[(wage_dummy == False) & (ganyu_dummy == False)] = False
+    ww[(wage_dummy == True) | (ganyu_dummy == True)] = True
+    out['wage_work'] = ww.values
+
+    out['farm_hrs'] = farm_hrs.astype('Float64').values
+    out['SB_hrs'] = sb_hrs.astype('Float64').values
+    out['wage_hrs'] = wage_hrs.astype('Float64').values
+
+    if 'hh_e20b' in d.columns:
+        out['wage_industry'] = _industry_label(d['hh_e20b']).values
+    else:
+        out['wage_industry'] = pd.Series(pd.NA, index=d.index, dtype='string')
+
+    # working_age
+    if layout == 'legacy' and 'hh_e02' in d.columns:
+        wa = d['hh_e02'].astype('string').str.strip().str.upper() != 'X'
+        out['working_age'] = wa.astype('boolean').values
+    elif roster is not None and roster_hhid is not None:
+        r = roster.copy()
+        r['_i'] = r[roster_hhid].apply(format_id).map(pre)
+        r['_pid'] = r[roster_pid].apply(format_id)
+        age = pd.to_numeric(r.get('hh_b05a'), errors='coerce')
+        r['_wa'] = (age >= 5).astype('boolean')
+        key = r[['_i', '_pid', '_wa']].drop_duplicates(['_i', '_pid'])
+        merged = out.merge(key, left_on=['i', 'pid'],
+                           right_on=['_i', '_pid'], how='left')
+        out['working_age'] = merged['_wa'].values
+    else:
+        out['working_age'] = pd.Series(pd.NA, index=d.index, dtype='boolean')
+
+    out['t'] = t
+    return out.reset_index(drop=True)
+
+
+def assemble_people_last7days(t, pieces):
+    """Combine per-half people_last7days blocks into the canonical frame.
+
+    Returns a DataFrame indexed (t, i, pid) with the reported per-individual
+    7-day columns.  A duplicate (i, pid) keeps the first reported record
+    (one labor-module row per individual per half).
+    """
+    cat = pd.concat(pieces, ignore_index=True)
+    cat = cat.groupby(['t', 'i', 'pid'], as_index=False, dropna=False).agg({
+        'farm_work':     'first',
+        'SOB_work':      'first',
+        'wage_work':     'first',
+        'farm_hrs':      'first',
+        'SB_hrs':        'first',
+        'wage_hrs':      'first',
+        'wage_industry': 'first',
+        'working_age':   'first',
+    })
+    out = cat.set_index(['t', 'i', 'pid'])
+    assert out.index.is_unique, f"Non-unique (t,i,pid) in people_last7days {t}"
+    return out

--- a/lsms_library/countries/Malawi/_/people_last7days.py
+++ b/lsms_library/countries/Malawi/_/people_last7days.py
@@ -1,0 +1,38 @@
+"""Concatenate wave-level people_last7days parquets for Malawi (GAP 3,
+individual grain).
+
+Each buildable wave's ``Malawi/<wave>/_/people_last7days.py`` produces a
+parquet indexed (t, i, pid) with the canonical per-individual 7-day columns
+(farm_work, SOB_work, wage_work, farm_hrs, SB_hrs, wage_hrs, wage_industry,
+working_age).  This script concatenates them.  Cross-wave id_walk (panel-id
+chaining) and the join of the cluster id ``v`` are applied by the framework
+at API time in _finalize_result.
+
+Only the four IHS3+ IHPS waves are buildable (2010-11, 2013-14, 2016-17,
+2019-20) -- the waves with a standard hh_mod_e labor module.  2004-05
+(IHS2) is DEFERRED: its labor module predates the 7-day activity battery
+this feature reads.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2010-11', '2013-14', '2016-17', '2019-20']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/people_last7days.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built (DVC raises
+        # PathMissingError here, not FileNotFoundError).
+        continue
+    pieces.append(df)
+
+assert pieces, "people_last7days: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/people_last7days.parquet')

--- a/lsms_library/countries/Malawi/_/plot_labor.py
+++ b/lsms_library/countries/Malawi/_/plot_labor.py
@@ -1,0 +1,36 @@
+"""Concatenate wave-level plot_labor parquets for Malawi (GAP 3, plot grain).
+
+Each buildable wave's ``Malawi/<wave>/_/plot_labor.py`` produces a parquet
+indexed (t, i, plot, source) with the canonical item-level columns
+(PersonDays, Wage).  This script concatenates them.  Cross-wave id_walk
+(panel-id chaining) and the join of the cluster id ``v`` are applied by the
+framework at API time in _finalize_result.
+
+Only the four IHS3+ IHPS waves are buildable (2010-11, 2013-14, 2016-17,
+2019-20) -- the same waves as crop_production / plot_inputs.  2004-05
+(IHS2) is DEFERRED: its agricultural file is household-level aggregated,
+with no plot-level labor roster.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2010-11', '2013-14', '2016-17', '2019-20']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_labor.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built (DVC raises
+        # PathMissingError here, not FileNotFoundError).
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_labor: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/plot_labor.parquet')

--- a/lsms_library/countries/Mali/2014-15/_/people_last7days.py
+++ b/lsms_library/countries/Mali/2014-15/_/people_last7days.py
@@ -1,0 +1,165 @@
+"""Build people_last7days (per-individual 7-day activity) for Mali EACI
+2014-15.
+
+GAP 3b (parity loop).  One row per (t, i, pid), mirroring Uganda's
+per-individual labor/time-use feature.
+
+Source: EACIIND_p1.dta (the individual roster, which carries both the s01
+demographic block and the s04 labor/time-use block).  pid = (grappe,
+menage, s01q00), the SAME person key as household_roster.
+
+REPORTED per-individual columns only (no rollups):
+  farm_work / SOB_work / wage_work — 7-day activity dummies (s04q01/02/03).
+  farm_hrs  / SB_hrs / wage_hrs    — average weekly hours per activity, the
+                                     WB (months*days*hours)/52 construction
+                                     attributed to whichever job is of that
+                                     type.
+  Industry — wage-work industry (harmonize_industry Code) from the WB ind_*
+             split over s04q22 (zeroed for self-employment).
+  working_age — s01q04a >= 6 (the WB floor).
+
+Variable map traced from MLI_EACI1.do:1435-1520:
+  farm_work s04q01 (Non->0, else 1); SOB_work s04q02; wage_work s04q03.
+  working_age = s01q04a >= 6.
+  industry over s04q22: ag 11-40, fish 51-52, mining 71-72, manuf 81-292,
+    const 301-302, serv 310-430; zeroed where s04q23==4 (self-employed).
+  hours: job1 = s04q24(months)*s04q25(hours)*s04q26(days)/52; job2 = the
+    s04q47/48/49 analogues; attributed to farm/SB/wage by the job's
+    occupation code (s04q21 / s04q44).  Filter zeros where the person
+    answered 'no' to the activity filter (s04q05==2 & s04q06==2) or did not
+    work (s04q19==2).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+import numpy as np
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import i as mali_i, pid as mali_pid, people_last7days_finalize
+
+WAVE = '2014-15'
+
+# convert_categoricals=False keeps the integer survey codes that the WB
+# recodes expect (dummies 1=Oui/2=Non/9=Manquant; industry/occupation
+# integer codes); the labelled-string default would break every numeric cut.
+src = get_dataframe('../Data/EACIIND_p1.dta', convert_categoricals=False).copy()
+src['i'] = src.apply(lambda r: mali_i(pd.Series([r['grappe'], r['menage']])), axis=1)
+src['pid'] = src.apply(
+    lambda r: mali_pid(pd.Series([r['grappe'], r['menage'], r['s01q00']])), axis=1)
+
+
+def _num(col):
+    if col in src.columns:
+        return pd.to_numeric(src[col], errors='coerce')
+    return pd.Series(np.nan, index=src.index)
+
+
+def _dummy(col):
+    """WB recode `(2=0)(9 .=NA)(else=1)` on the integer Oui/Non code:
+    1 (Oui) -> True, 2 (Non) -> False, 9 / NA (Manquant) -> NA."""
+    s = _num(col)
+    out = pd.Series(pd.NA, index=src.index, dtype='boolean')
+    out = out.mask(s.eq(2), False)
+    out = out.mask(s.eq(1), True)
+    return out
+
+
+# 7-day activity dummies
+farm_work = _dummy('s04q01')
+SOB_work = _dummy('s04q02')
+wage_work = _dummy('s04q03')
+
+# working_age = age >= 6
+age = _num('s01q04a')
+working_age = (age >= 6)
+working_age = working_age.astype('boolean').mask(age.isna(), pd.NA)
+
+# industry over s04q22 (primary-job occupation/industry code), zeroed for
+# self-employment (s04q23 == 'A son propre compte' coded 4 in the WB recode).
+ind = _num('s04q22')
+# WB: `replace ind_* = 0 if s04q23==4` (self-employment / own-account).
+self_emp = _num('s04q23').eq(4)
+ind_ag = (ind.between(11, 40))
+ind_fish = (ind.between(51, 52))
+ind_mining = (ind.isin([71, 72]))
+ind_manuf = (ind.between(81, 292))
+ind_const = (ind.isin([301, 302]))
+ind_serv = (ind.between(310, 430))
+ind_frame = pd.DataFrame({
+    'ind_ag': ind_ag, 'ind_fish': ind_fish, 'ind_mining': ind_mining,
+    'ind_manuf': ind_manuf, 'ind_const': ind_const, 'ind_serv': ind_serv,
+})
+# zero out self-employment (matches the WB `replace = 0 if s04q23==4`)
+ind_frame = ind_frame.mask(self_emp, False)
+# reduce to one Code per individual (first True; NA if none)
+def _first_industry(row):
+    for c in ['ind_ag', 'ind_fish', 'ind_mining', 'ind_manuf', 'ind_const', 'ind_serv']:
+        if bool(row[c]):
+            return c
+    return pd.NA
+Industry = ind_frame.apply(_first_industry, axis=1).astype('string')
+
+# average weekly hours per job, then attributed to farm/SB/wage by job type.
+# Clear the EACI "Manquant" sentinel (99) on each component first, so a
+# missing months/hours/days code does not multiply into an impossible
+# >168-hour week (e.g. 99*99*99/52).
+_HRS_SENTINELS = [99, 999, 9999]
+
+
+def _hrs_num(col):
+    s = _num(col)
+    return s.mask(s.isin(_HRS_SENTINELS))
+
+
+def _av_hours(month_c, hour_c, day_c):
+    return (_hrs_num(month_c) * _hrs_num(hour_c) * _hrs_num(day_c)) / 52.0
+
+av1 = _av_hours('s04q24', 's04q25', 's04q26')   # job 1
+av2 = _av_hours('s04q47', 's04q48', 's04q49')   # job 2
+
+# occupation code of each job -> activity class (WB recode of s04q21/s04q44).
+occ1 = _num('s04q21')
+occ2 = _num('s04q44')
+
+
+def _farm_job(occ):
+    return occ.isin([11, 12])
+
+
+def _sb_job(occ):
+    return occ.eq(62)
+
+
+def _wage_job(occ):
+    return occ.isin([21, 22, 23, 24, 25, 41, 42, 43, 51, 52, 61, 63, 71, 72, 81])
+
+
+def _act_hrs(jobmask1, av_1, jobmask2, av_2, work_dummy):
+    h = pd.Series(np.nan, index=src.index)
+    h = h.where(~jobmask1.fillna(False), av_1)
+    h2 = pd.Series(np.nan, index=src.index)
+    h2 = h2.where(~jobmask2.fillna(False), av_2)
+    total = h.add(h2, fill_value=0)
+    # zero out where the person did not do that activity at all
+    total = total.where(work_dummy.fillna(False).astype(bool), 0.0)
+    return total
+
+
+farm_hrs = _act_hrs(_farm_job(occ1), av1, _farm_job(occ2), av2, farm_work)
+SB_hrs = _act_hrs(_sb_job(occ1), av1, _sb_job(occ2), av2, SOB_work)
+wage_hrs = _act_hrs(_wage_job(occ1), av1, _wage_job(occ2), av2, wage_work)
+
+df = pd.DataFrame({
+    't': WAVE, 'i': src['i'], 'pid': src['pid'],
+    'farm_work': farm_work, 'SOB_work': SOB_work, 'wage_work': wage_work,
+    'farm_hrs': farm_hrs, 'SB_hrs': SB_hrs, 'wage_hrs': wage_hrs,
+    'Industry': Industry, 'working_age': working_age,
+})
+
+df = people_last7days_finalize(df)
+
+assert len(df) > 0, "people_last7days 2014-15 produced no rows"
+assert df.index.is_unique, "Non-unique (t,i,pid) in people_last7days 2014-15"
+
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Mali/2014-15/_/plot_labor.py
+++ b/lsms_library/countries/Mali/2014-15/_/plot_labor.py
@@ -1,0 +1,163 @@
+"""Build plot_labor (item-level plot labor by source) for Mali EACI 2014-15.
+
+GAP 3a (parity loop).  One row per (t, i, plot, source), source in
+{family, hired, other}.
+
+Sources (both at the plot grain):
+  - EACIMAINOUVRE_p1.dta  post-planting (PP) plot-labor roster, s2b vars.
+  - EACIS2F_p2.dta        post-harvest (PH) plot-labor roster, s2f vars.
+
+plot = "{field}_{parcel}" (s2bq01_s2bq02 for PP; s2fq01_s2fq02 for PH) —
+the SAME plot id as crop_production / plot_inputs / plot_features.
+
+REPORTED person-days per source only:
+  PersonDays = persons * days-each, summed over the man/woman/child
+               demographic splits and the two passages (PP + PH).
+  Wage       = reported cash paid to hired labor (FCFA); NA for family/other.
+NO total_labor_days / total_*_labor_days / hired_labor_value — those are
+transformations over these rows.
+
+Variable map traced from MLI_EACI1.do (WB harmonised plot-labor section):
+  PP family (gate s2bq04): man s2bq05a*s2bq05b, woman s2bq05d*s2bq05e,
+                           child s2bq05g*s2bq05h.
+  PP hired  (gate s2bq06): man s2bq07a*s2bq07b (wage s2bq07c),
+                           woman s2bq07d*s2bq07e (wage s2bq07f),
+                           child s2bq07g*s2bq07h (wage s2bq07i).
+  PP other  (gate s2bq08): man s2bq09a*s2bq09b, woman s2bq09d*s2bq09e,
+                           child s2bq09g*s2bq09h.
+  PH family (gates s2fq03/s2fq09): two activity blocks
+                           q04 (a/b,c/d,e/f) and q10 (a/b,c/d,e/f).
+  PH hired  (gates s2fq05/s2fq11): q06 (a/b wage c; d/e wage f; g/h wage i)
+                           and q12 (a/b wage c; d/e wage f; g/h wage i).
+  PH other  (gates s2fq07/s2fq13): q08 (a/b,d/e,g/h) and q14 (a/b,d/e,g/h).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import i as mali_i, plot_labor_finalize
+
+WAVE = '2014-15'
+
+
+def _hhid(df):
+    return df.apply(lambda r: mali_i(pd.Series([r['grappe'], r['menage']])), axis=1)
+
+
+def _plot(df, fcol, pcol):
+    f = df[fcol].astype('Int64').astype('string')
+    p = df[pcol].astype('Int64').astype('string')
+    return (f + '_' + p).where(f.notna() & p.notna(), pd.NA)
+
+
+# EACI "Manquant" / refusal sentinels on the persons / days / wage
+# components (cf. MLI_EACI1.do:720-722, 756-758 which `replace = . if
+# ==99|999|99999999` BEFORE forming persons*days).  Cleared at the COMPONENT
+# level so a sentinel never multiplies into a spurious huge person-day total.
+_SENTINELS = [99, 999, 9999, 99999, 999999, 9999999, 99999999]
+
+
+def _num(df, col):
+    if col in df.columns:
+        s = pd.to_numeric(df[col], errors='coerce')
+        return s.mask(s.isin(_SENTINELS))
+    return pd.Series(pd.NA, index=df.index, dtype='Float64')
+
+
+def _prod(df, persons_col, days_col):
+    """persons * days-each -> reported person-days for one demographic split."""
+    return _num(df, persons_col) * _num(df, days_col)
+
+
+pieces = []
+
+# ---------------- post-planting (PP) roster: s2b -------------------------
+pp = get_dataframe('../Data/EACIMAINOUVRE_p1.dta').copy()
+pp['i'] = _hhid(pp)
+pp['plot'] = _plot(pp, 's2bq01', 's2bq02')
+
+# family: sum man/woman/child person-days
+fam_days = (_prod(pp, 's2bq05a', 's2bq05b')
+            .add(_prod(pp, 's2bq05d', 's2bq05e'), fill_value=0)
+            .add(_prod(pp, 's2bq05g', 's2bq05h'), fill_value=0))
+pieces.append(pd.DataFrame({
+    't': WAVE, 'i': pp['i'], 'plot': pp['plot'], 'source': 'family',
+    'PersonDays': fam_days, 'Wage': pd.NA,
+}))
+
+# hired: person-days + reported cash wage
+hir_days = (_prod(pp, 's2bq07a', 's2bq07b')
+            .add(_prod(pp, 's2bq07d', 's2bq07e'), fill_value=0)
+            .add(_prod(pp, 's2bq07g', 's2bq07h'), fill_value=0))
+hir_wage = (_num(pp, 's2bq07c')
+            .add(_num(pp, 's2bq07f'), fill_value=0)
+            .add(_num(pp, 's2bq07i'), fill_value=0))
+pieces.append(pd.DataFrame({
+    't': WAVE, 'i': pp['i'], 'plot': pp['plot'], 'source': 'hired',
+    'PersonDays': hir_days, 'Wage': hir_wage,
+}))
+
+# other (free / exchange) labor
+oth_days = (_prod(pp, 's2bq09a', 's2bq09b')
+            .add(_prod(pp, 's2bq09d', 's2bq09e'), fill_value=0)
+            .add(_prod(pp, 's2bq09g', 's2bq09h'), fill_value=0))
+pieces.append(pd.DataFrame({
+    't': WAVE, 'i': pp['i'], 'plot': pp['plot'], 'source': 'other',
+    'PersonDays': oth_days, 'Wage': pd.NA,
+}))
+
+# ---------------- post-harvest (PH) roster: s2f --------------------------
+ph = get_dataframe('../Data/EACIS2F_p2.dta').copy()
+ph['i'] = _hhid(ph)
+ph['plot'] = _plot(ph, 's2fq01', 's2fq02')
+
+# family: two activity blocks (q04, q10)
+ph_fam = (_prod(ph, 's2fq04a', 's2fq04b')
+          .add(_prod(ph, 's2fq04c', 's2fq04d'), fill_value=0)
+          .add(_prod(ph, 's2fq04e', 's2fq04f'), fill_value=0)
+          .add(_prod(ph, 's2fq10a', 's2fq10b'), fill_value=0)
+          .add(_prod(ph, 's2fq10c', 's2fq10d'), fill_value=0)
+          .add(_prod(ph, 's2fq10e', 's2fq10f'), fill_value=0))
+pieces.append(pd.DataFrame({
+    't': WAVE, 'i': ph['i'], 'plot': ph['plot'], 'source': 'family',
+    'PersonDays': ph_fam, 'Wage': pd.NA,
+}))
+
+# hired: two activity blocks (q06, q12) + wages (c/f/i)
+ph_hir = (_prod(ph, 's2fq06a', 's2fq06b')
+          .add(_prod(ph, 's2fq06d', 's2fq06e'), fill_value=0)
+          .add(_prod(ph, 's2fq06g', 's2fq06h'), fill_value=0)
+          .add(_prod(ph, 's2fq12a', 's2fq12b'), fill_value=0)
+          .add(_prod(ph, 's2fq12d', 's2fq12e'), fill_value=0)
+          .add(_prod(ph, 's2fq12g', 's2fq12h'), fill_value=0))
+ph_hir_wage = (_num(ph, 's2fq06c').add(_num(ph, 's2fq06f'), fill_value=0)
+               .add(_num(ph, 's2fq06i'), fill_value=0)
+               .add(_num(ph, 's2fq12c'), fill_value=0)
+               .add(_num(ph, 's2fq12f'), fill_value=0)
+               .add(_num(ph, 's2fq12i'), fill_value=0))
+pieces.append(pd.DataFrame({
+    't': WAVE, 'i': ph['i'], 'plot': ph['plot'], 'source': 'hired',
+    'PersonDays': ph_hir, 'Wage': ph_hir_wage,
+}))
+
+# other: two activity blocks (q08, q14)
+ph_oth = (_prod(ph, 's2fq08a', 's2fq08b')
+          .add(_prod(ph, 's2fq08d', 's2fq08e'), fill_value=0)
+          .add(_prod(ph, 's2fq08g', 's2fq08h'), fill_value=0)
+          .add(_prod(ph, 's2fq14a', 's2fq14b'), fill_value=0)
+          .add(_prod(ph, 's2fq14d', 's2fq14e'), fill_value=0)
+          .add(_prod(ph, 's2fq14g', 's2fq14h'), fill_value=0))
+pieces.append(pd.DataFrame({
+    't': WAVE, 'i': ph['i'], 'plot': ph['plot'], 'source': 'other',
+    'PersonDays': ph_oth, 'Wage': pd.NA,
+}))
+
+df = pd.concat(pieces, ignore_index=True)
+df = plot_labor_finalize(df)
+
+assert len(df) > 0, "plot_labor 2014-15 produced no rows"
+assert df.index.is_unique, "Non-unique (t,i,plot,source) in plot_labor 2014-15"
+
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Mali/2017-18/_/people_last7days.py
+++ b/lsms_library/countries/Mali/2017-18/_/people_last7days.py
@@ -1,0 +1,163 @@
+"""Build people_last7days (per-individual 7-day activity) for Mali EACI
+2017-18.
+
+GAP 3b (parity loop).  One row per (t, i, pid), mirroring Uganda's
+per-individual labor/time-use feature.
+
+Source: eaci17_s04p1.dta (the s4 labor/time-use block) merged with
+eaci17_s01p1.dta (the s01 demographic block, for the s1q04a age needed by
+working_age) on (grappe, exploitation, codeid).  pid = (grappe,
+exploitation, codeid), the SAME person key as household_roster.
+
+REPORTED per-individual columns only (no rollups):
+  farm_work / SOB_work / wage_work — 7-day activity dummies (s4q01/02/03).
+  farm_hrs  / SB_hrs / wage_hrs    — average weekly hours per activity, the
+                                     WB (months*days*hours)/52 construction.
+  Industry — wage-work industry (harmonize_industry Code) from the WB ind_*
+             split over s4q13 (zeroed for self-employment / no-work).
+  working_age — s1q04a >= 6.
+
+Variable map traced from MLI_EACI2.do:1340-1427:
+  farm_work s4q01; SOB_work s4q02; wage_work s4q03.
+  working_age = s1q04a >= 6.
+  industry over s4q13: ag 1-4, fish 5, mining 6-7, manuf 8-29, const 30,
+    serv 31-43; zeroed where s4q14==3 | s4q18 in {7,8,9} (self-emp) or
+    s4q11==2 (did not work).
+  hours: job1 = s4q15(months)*s4q17(hours)*s4q16(days)/52; job2 = the
+    s4q30/32/31 analogues; attributed by occupation code (s4q12/s4q27).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+import numpy as np
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import i as mali_i, pid as mali_pid, people_last7days_finalize
+
+WAVE = '2017-18'
+
+# convert_categoricals=False keeps the integer survey codes that the WB
+# recodes expect (dummies 1=Oui/2=Non; industry/occupation integer codes).
+lab = get_dataframe('../Data/eaci17_s04p1.dta', convert_categoricals=False).copy()
+ros = get_dataframe('../Data/eaci17_s01p1.dta', convert_categoricals=False).copy()
+
+# Bring the age variable s1q04a in from the roster; merge on the person key.
+keys = ['grappe', 'exploitation', 'codeid']
+age_cols = keys + (['s1q04a'] if 's1q04a' in ros.columns else [])
+src = lab.merge(ros[age_cols], on=keys, how='left', suffixes=('', '_ros'))
+
+src['i'] = src.apply(lambda r: mali_i(pd.Series([r['grappe'], r['exploitation']])), axis=1)
+src['pid'] = src.apply(
+    lambda r: mali_pid(pd.Series([r['grappe'], r['exploitation'], r['codeid']])), axis=1)
+
+
+def _num(col):
+    if col in src.columns:
+        return pd.to_numeric(src[col], errors='coerce')
+    return pd.Series(np.nan, index=src.index)
+
+
+def _dummy(col):
+    """WB recode `(2=0)(.=NA)(else=1)` on the integer Oui/Non code:
+    1 (Oui) -> True, 2 (Non) -> False, NA -> NA."""
+    s = _num(col)
+    out = pd.Series(pd.NA, index=src.index, dtype='boolean')
+    out = out.mask(s.eq(2), False)
+    out = out.mask(s.eq(1), True)
+    return out
+
+
+farm_work = _dummy('s4q01')
+SOB_work = _dummy('s4q02')
+wage_work = _dummy('s4q03')
+
+age = _num('s1q04a')
+working_age = (age >= 6)
+working_age = working_age.astype('boolean').mask(age.isna(), pd.NA)
+
+# industry over s4q13, zeroed for self-employment / no-work.
+ind = _num('s4q13')
+q14 = _num('s4q14')
+q18 = _num('s4q18')
+q11 = _num('s4q11')
+zero_ind = (q14.eq(3) | q18.isin([7, 8, 9]) | q11.eq(2))
+ind_frame = pd.DataFrame({
+    'ind_ag': ind.between(1, 4),
+    'ind_fish': ind.eq(5),
+    'ind_mining': ind.isin([6, 7]),
+    'ind_manuf': ind.between(8, 29),
+    'ind_const': ind.eq(30),
+    'ind_serv': ind.between(31, 43),
+})
+ind_frame = ind_frame.mask(zero_ind, False)
+def _first_industry(row):
+    for c in ['ind_ag', 'ind_fish', 'ind_mining', 'ind_manuf', 'ind_const', 'ind_serv']:
+        if bool(row[c]):
+            return c
+    return pd.NA
+Industry = ind_frame.apply(_first_industry, axis=1).astype('string')
+
+
+# Clear the EACI "Manquant" sentinel (99) on each component first (none
+# present in 2017-18, but kept for parity with the 2014-15 script so a
+# missing months/hours/days code can never multiply into an impossible
+# >168-hour week).
+_HRS_SENTINELS = [99, 999, 9999]
+
+
+def _hrs_num(col):
+    s = _num(col)
+    return s.mask(s.isin(_HRS_SENTINELS))
+
+
+def _av_hours(month_c, hour_c, day_c):
+    return (_hrs_num(month_c) * _hrs_num(hour_c) * _hrs_num(day_c)) / 52.0
+
+
+av1 = _av_hours('s4q15', 's4q17', 's4q16')   # job 1
+av2 = _av_hours('s4q30', 's4q32', 's4q31')   # job 2
+
+occ1 = _num('s4q12')
+occ2 = _num('s4q27')
+
+
+def _farm_job(occ):
+    return occ.isin([11, 12])
+
+
+def _sb_job(occ):
+    return occ.eq(62)
+
+
+def _wage_job(occ):
+    return occ.isin([20, 21, 22, 23, 24, 25, 31, 41, 42, 43, 51, 52, 61, 63, 71, 72, 81])
+
+
+def _act_hrs(jobmask1, av_1, jobmask2, av_2, work_dummy):
+    h = pd.Series(np.nan, index=src.index)
+    h = h.where(~jobmask1.fillna(False), av_1)
+    h2 = pd.Series(np.nan, index=src.index)
+    h2 = h2.where(~jobmask2.fillna(False), av_2)
+    total = h.add(h2, fill_value=0)
+    total = total.where(work_dummy.fillna(False).astype(bool), 0.0)
+    return total
+
+
+farm_hrs = _act_hrs(_farm_job(occ1), av1, _farm_job(occ2), av2, farm_work)
+SB_hrs = _act_hrs(_sb_job(occ1), av1, _sb_job(occ2), av2, SOB_work)
+wage_hrs = _act_hrs(_wage_job(occ1), av1, _wage_job(occ2), av2, wage_work)
+
+df = pd.DataFrame({
+    't': WAVE, 'i': src['i'], 'pid': src['pid'],
+    'farm_work': farm_work, 'SOB_work': SOB_work, 'wage_work': wage_work,
+    'farm_hrs': farm_hrs, 'SB_hrs': SB_hrs, 'wage_hrs': wage_hrs,
+    'Industry': Industry, 'working_age': working_age,
+})
+
+df = people_last7days_finalize(df)
+
+assert len(df) > 0, "people_last7days 2017-18 produced no rows"
+assert df.index.is_unique, "Non-unique (t,i,pid) in people_last7days 2017-18"
+
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Mali/2017-18/_/plot_labor.py
+++ b/lsms_library/countries/Mali/2017-18/_/plot_labor.py
@@ -1,0 +1,151 @@
+"""Build plot_labor (item-level plot labor by source) for Mali EACI 2017-18.
+
+GAP 3a (parity loop).  One row per (t, i, plot, source), source in
+{family, hired, other}.
+
+Sources (both at the plot grain):
+  - eaci17_s11ep1.dta  post-planting (PP) plot-labor roster, s11e vars.
+  - eaci17_s7ep2.dta   post-harvest (PH) plot-labor roster, s7e vars.
+
+plot = "{field}_{parcel}" (s11eq01_s11eq02 for PP; s7eq01_s7eq02 for PH) —
+the SAME plot id as crop_production / plot_inputs / plot_features.  i is
+built from (grappe, exploitation) (the 2017-18 EACI household key).
+
+REPORTED person-days per source only:
+  PersonDays = persons * days-each, summed over the man/woman/child
+               demographic splits and the two passages (PP + PH).
+  Wage       = reported cash paid to hired labor (FCFA); NA for family/other.
+NO total_labor_days / total_*_labor_days / hired_labor_value — those are
+transformations over these rows.
+
+Variable map traced from MLI_EACI2.do (WB harmonised plot-labor section):
+  PP family (gate s11eq04): man s11eq05a1*s11eq05a2, woman s11eq05b1*05b2,
+                            child s11eq05c1*05c2.
+  PP hired  (gate s11eq06): man s11eq07a1*07a2 (wage s11eq07a3),
+                            woman s11eq07b1*07b2 (wage s11eq07b3),
+                            child s11eq07c1*07c2 (wage s11eq07c3).
+  PP other  (gate s11eq08): man s11eq09a1*09a2, woman s11eq09b1*09b2,
+                            child s11eq09c1*09c2.
+  PH family: blocks q05 (a1/a2,b1/b2,c1/c2) and q11 (a1/a2,b1/b2,c1/c2).
+  PH hired:  blocks q07 (a1/a2 wage a3; b...; c...) and q13 (a1/a2 wage a3;
+             ...).  NB: the WB .do uses `s7eq13c1*s7eq13c3` for child days
+             (c3 is the WAGE column) — a copy-paste slip; we use the
+             consistent persons*days `s7eq13c1*s7eq13c2` so a wage value
+             never leaks into PersonDays.
+  PH other:  blocks q09 (a1/a2,b1/b2,c1/c2) and q15 (a1/a2,b1/b2,c1/c2).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import i as mali_i, plot_labor_finalize
+
+WAVE = '2017-18'
+
+
+def _hhid(df):
+    return df.apply(lambda r: mali_i(pd.Series([r['grappe'], r['exploitation']])), axis=1)
+
+
+def _plot(df, fcol, pcol):
+    f = df[fcol].astype('Int64').astype('string')
+    p = df[pcol].astype('Int64').astype('string')
+    return (f + '_' + p).where(f.notna() & p.notna(), pd.NA)
+
+
+# EACI "Manquant" / refusal sentinels on the persons / days / wage
+# components (cf. MLI_EACI2.do which clears 99/999/99999999 before forming
+# persons*days).  Cleared at the COMPONENT level so a sentinel never
+# multiplies into a spurious huge person-day total.
+_SENTINELS = [99, 999, 9999, 99999, 999999, 9999999, 99999999]
+
+
+def _num(df, col):
+    if col in df.columns:
+        s = pd.to_numeric(df[col], errors='coerce')
+        return s.mask(s.isin(_SENTINELS))
+    return pd.Series(pd.NA, index=df.index, dtype='Float64')
+
+
+def _prod(df, persons_col, days_col):
+    return _num(df, persons_col) * _num(df, days_col)
+
+
+def _sumcols(*series):
+    out = series[0]
+    for s in series[1:]:
+        out = out.add(s, fill_value=0)
+    return out
+
+
+pieces = []
+
+# ---------------- post-planting (PP) roster: s11e ------------------------
+pp = get_dataframe('../Data/eaci17_s11ep1.dta').copy()
+pp['i'] = _hhid(pp)
+pp['plot'] = _plot(pp, 's11eq01', 's11eq02')
+
+fam = _sumcols(_prod(pp, 's11eq05a1', 's11eq05a2'),
+               _prod(pp, 's11eq05b1', 's11eq05b2'),
+               _prod(pp, 's11eq05c1', 's11eq05c2'))
+pieces.append(pd.DataFrame({'t': WAVE, 'i': pp['i'], 'plot': pp['plot'],
+                            'source': 'family', 'PersonDays': fam, 'Wage': pd.NA}))
+
+hir = _sumcols(_prod(pp, 's11eq07a1', 's11eq07a2'),
+               _prod(pp, 's11eq07b1', 's11eq07b2'),
+               _prod(pp, 's11eq07c1', 's11eq07c2'))
+hir_wage = _sumcols(_num(pp, 's11eq07a3'), _num(pp, 's11eq07b3'),
+                    _num(pp, 's11eq07c3'))
+pieces.append(pd.DataFrame({'t': WAVE, 'i': pp['i'], 'plot': pp['plot'],
+                            'source': 'hired', 'PersonDays': hir, 'Wage': hir_wage}))
+
+oth = _sumcols(_prod(pp, 's11eq09a1', 's11eq09a2'),
+               _prod(pp, 's11eq09b1', 's11eq09b2'),
+               _prod(pp, 's11eq09c1', 's11eq09c2'))
+pieces.append(pd.DataFrame({'t': WAVE, 'i': pp['i'], 'plot': pp['plot'],
+                            'source': 'other', 'PersonDays': oth, 'Wage': pd.NA}))
+
+# ---------------- post-harvest (PH) roster: s7e --------------------------
+ph = get_dataframe('../Data/eaci17_s7ep2.dta').copy()
+ph['i'] = _hhid(ph)
+ph['plot'] = _plot(ph, 's7eq01', 's7eq02')
+
+ph_fam = _sumcols(_prod(ph, 's7eq05a1', 's7eq05a2'),
+                  _prod(ph, 's7eq05b1', 's7eq05b2'),
+                  _prod(ph, 's7eq05c1', 's7eq05c2'),
+                  _prod(ph, 's7eq11a1', 's7eq11a2'),
+                  _prod(ph, 's7eq11b1', 's7eq11b2'),
+                  _prod(ph, 's7eq11c1', 's7eq11c2'))
+pieces.append(pd.DataFrame({'t': WAVE, 'i': ph['i'], 'plot': ph['plot'],
+                            'source': 'family', 'PersonDays': ph_fam, 'Wage': pd.NA}))
+
+ph_hir = _sumcols(_prod(ph, 's7eq07a1', 's7eq07a2'),
+                  _prod(ph, 's7eq07b1', 's7eq07b2'),
+                  _prod(ph, 's7eq07c1', 's7eq07c2'),
+                  _prod(ph, 's7eq13a1', 's7eq13a2'),
+                  _prod(ph, 's7eq13b1', 's7eq13b2'),
+                  _prod(ph, 's7eq13c1', 's7eq13c2'))
+ph_hir_wage = _sumcols(_num(ph, 's7eq07a3'), _num(ph, 's7eq07b3'),
+                       _num(ph, 's7eq07c3'), _num(ph, 's7eq13a3'),
+                       _num(ph, 's7eq13b3'), _num(ph, 's7eq13c3'))
+pieces.append(pd.DataFrame({'t': WAVE, 'i': ph['i'], 'plot': ph['plot'],
+                            'source': 'hired', 'PersonDays': ph_hir, 'Wage': ph_hir_wage}))
+
+ph_oth = _sumcols(_prod(ph, 's7eq09a1', 's7eq09a2'),
+                  _prod(ph, 's7eq09b1', 's7eq09b2'),
+                  _prod(ph, 's7eq09c1', 's7eq09c2'),
+                  _prod(ph, 's7eq15a1', 's7eq15a2'),
+                  _prod(ph, 's7eq15b1', 's7eq15b2'),
+                  _prod(ph, 's7eq15c1', 's7eq15c2'))
+pieces.append(pd.DataFrame({'t': WAVE, 'i': ph['i'], 'plot': ph['plot'],
+                            'source': 'other', 'PersonDays': ph_oth, 'Wage': pd.NA}))
+
+df = pd.concat(pieces, ignore_index=True)
+df = plot_labor_finalize(df)
+
+assert len(df) > 0, "plot_labor 2017-18 produced no rows"
+assert df.index.is_unique, "Non-unique (t,i,plot,source) in plot_labor 2017-18"
+
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Mali/_/Makefile
+++ b/lsms_library/countries/Mali/_/Makefile
@@ -58,6 +58,27 @@ $(VAR_DIR)/plot_inputs.parquet: plot_inputs.py ../2014-15/_/plot_inputs.parquet 
 $(VAR_DIR)/livestock.parquet: livestock.py ../2014-15/_/livestock.parquet ../2017-18/_/livestock.parquet
 	python livestock.py
 
+# plot_labor (item-level plot labor by source, GAP 3a / parity loop).  The
+# plot-labor module lives in the EACI waves only (2014-15, 2017-18).  The
+# wave pattern rule materializes each wave parquet; the country-level
+# concatenator (plot_labor.py) aggregates into var/plot_labor.parquet.
+../%/_/plot_labor.parquet: ../%/_/plot_labor.py
+	(cd $(@D) && python plot_labor.py)
+
+$(VAR_DIR)/plot_labor.parquet: plot_labor.py ../2014-15/_/plot_labor.parquet ../2017-18/_/plot_labor.parquet
+	python plot_labor.py
+
+# people_last7days (per-individual 7-day activity, GAP 3b / parity loop).
+# The individual labor/time-use module lives in the EACI waves only
+# (2014-15, 2017-18).  The wave pattern rule materializes each wave parquet;
+# the country-level concatenator (people_last7days.py) aggregates into
+# var/people_last7days.parquet.
+../%/_/people_last7days.parquet: ../%/_/people_last7days.py
+	(cd $(@D) && python people_last7days.py)
+
+$(VAR_DIR)/people_last7days.parquet: people_last7days.py ../2014-15/_/people_last7days.parquet ../2017-18/_/people_last7days.parquet
+	python people_last7days.py
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Mali/_/categorical_mapping.org
+++ b/lsms_library/countries/Mali/_/categorical_mapping.org
@@ -566,3 +566,39 @@
 |  730 | Other Poultry      | Autres volailles      | Autres volailles      |
 |  810 | Pigs               | Porcs                 | Porcs                 |
 |  910 | Rabbits            | Lapins                | Lapins                |
+
+# harmonize_labor_source — the labor-source (`source` index level) taxonomy
+# for plot_labor (GAP 3a, parity loop).  The three sources are FIXED
+# questionnaire blocks in the EACI plot-labor rosters (post-planting
+# lab_roster: family s2bq04/s11eq04, hired s2bq06/s11eq06, other/exchange
+# s2bq08/s11eq08; post-harvest lab_roster2: the analogous s2f/s7e blocks),
+# NOT a decoded label column.  The wave scripts emit a synthetic `Code` per
+# source (identical across waves, hence one shared column), and this table
+# maps it to the canonical Preferred Label.  'other' is the EACI "free /
+# exchange / mutual-aid" labor the WB code calls "other (free) labor".
+#+name: harmonize_labor_source
+| Code   | Preferred Label | 2014-15 | 2017-18 |
+|--------+-----------------+---------+---------|
+| family | Family          | x       | x       |
+| hired  | Hired           | x       | x       |
+| other  | Other           | x       | x       |
+
+# harmonize_industry — the wage-work industry (`Industry` column) taxonomy
+# for people_last7days (GAP 3b, parity loop).  The WB MLI_EACI*.do code
+# splits the individual's primary-job industry code (s04q22 in 2014-15
+# EACIIND_p1; s4q13 in 2017-18 eaci17_s04p1) into six mutually-exclusive
+# dummies ind_ag / ind_fish / ind_mining / ind_manuf / ind_const / ind_serv
+# (MLI_EACI1.do:1450-1456; MLI_EACI2.do:1355-1361, different raw cut-points
+# per wave but the SAME six target classes).  The wave script reduces those
+# six dummies back to one `Code` (the dummy stem) per individual; this table
+# maps it to the canonical Preferred Label.  Industry is non-NA only for
+# wage workers (the dummies are zeroed for self-employment / no-work).
+#+name: harmonize_industry
+| Code       | Preferred Label | 2014-15 | 2017-18 |
+|------------+-----------------+---------+---------|
+| ind_ag     | Agriculture     | x       | x       |
+| ind_fish   | Fishing         | x       | x       |
+| ind_mining | Mining          | x       | x       |
+| ind_manuf  | Manufacturing   | x       | x       |
+| ind_const  | Construction    | x       | x       |
+| ind_serv   | Services        | x       | x       |

--- a/lsms_library/countries/Mali/_/data_scheme.yml
+++ b/lsms_library/countries/Mali/_/data_scheme.yml
@@ -223,3 +223,78 @@ Data Scheme:
     HeadSold: float
     Value: float
     materialize: make
+  plot_labor:
+    # Item-level plot labor by source, GAP 3a (parity loop).  One row per
+    # (t, i, plot, source): the REPORTED person-days the survey records per
+    # labor source, NOT the WB per-plot collapsed totals
+    # (total_family_labor_days / total_hired_labor_days /
+    # total_other_labor_days / total_labor_days) or the median-wage
+    # valuation (hired_labor_value) — all of those are transformations.py
+    # rollups over these item rows.  The plot-labor module lives in the EACI
+    # waves only (2014-15 EACIMAINOUVRE_p1 [PP, s2b] + EACIS2F_p2 [PH, s2f];
+    # 2017-18 eaci17_s11ep1 [PP, s11e] + eaci17_s7ep2 [PH, s7e]).  The EHCVM
+    # waves (2018-19, 2021-22) carry no plot-labor roster — deferred (the
+    # same wave split as crop_production / plot_inputs / livestock).
+    #
+    # plot   = "{field}_{parcel}" — the SAME plot id as crop_production /
+    #          plot_inputs / plot_features (join on (t, i, plot)).
+    # source = harmonize_labor_source Preferred Label (Family / Hired /
+    #          Other), a FIXED questionnaire block, not a decoded column.
+    #
+    # PersonDays = reported person-days of that source on the plot, summed
+    #              over the two passages (post-planting + post-harvest) and
+    #              the man/woman/child demographic splits within a source
+    #              (PersonDays = persons * days-each, the product the WB
+    #              code forms before summing).  Units: person-days.
+    # Wage       = reported cash paid to HIRED labor (FCFA) where recorded;
+    #              NaN for family / other (no cash wage asked).
+    # Built by per-wave scripts + a country-level concatenator.  v auto-joins
+    # from sample() at API time (plot_labor is NOT in _no_v_join).
+    index: (t, i, plot, source)
+    PersonDays: float
+    Wage: float
+    materialize: make
+  people_last7days:
+    # Per-individual 7-day activity / time-use, GAP 3b (parity loop).  One
+    # row per (t, i, pid), mirroring Uganda's per-individual labor feature
+    # so the six labor-gap countries match the one we already have.  The
+    # REPORTED per-individual values the survey records, NOT any household
+    # roll-up (nb_members_working_age etc., which are transformations).  The
+    # individual labor/time-use module lives in the EACI waves only (2014-15
+    # EACIIND_p1 s04 block; 2017-18 eaci17_s04p1 s4 block, merged with
+    # eaci17_s01p1 for age).  The EHCVM waves (2018-19, 2021-22) carry no
+    # individual labor module — deferred (the same wave split as plot_labor).
+    #
+    # pid — the individual key, matching household_roster's pid (2014-15:
+    #       grappe-menage-s01q00; 2017-18: grappe-exploitation-codeid).  v
+    #       auto-joins from sample() at API time (NOT in _no_v_join).
+    #
+    # farm_work / SOB_work / wage_work — 7-day activity dummies (worked on
+    #       the household farm / own non-farm business / for a wage); NA
+    #       where the question was not answered (Manquant/NSP).
+    # farm_hrs / SB_hrs / wage_hrs — average WEEKLY hours in each activity,
+    #       the WB (months * days * hours) / 52 construction attributed to
+    #       the job of that type.  Units: hours/week.
+    # Industry — primary-job industry on harmonize_industry Preferred
+    #       Labels (Agriculture / Fishing / Mining / Manufacturing /
+    #       Construction / Services), decoded from the WB ind_* split over
+    #       the primary-job industry code (s04q22 / s4q13), exactly as the
+    #       WB code derives it: zeroed (-> NA) for self-employment / own-
+    #       account work and (2017-18) no-work, NA where the industry code
+    #       is missing or outside the six classes.  It is NOT gated on the
+    #       wage_work dummy, so a non-wage primary job in a recognized
+    #       industry still carries a label (faithful to the WB ind_*
+    #       construction; restrict to df.wage_work if a wage-only cut is
+    #       wanted — a transformation, not a stored column).
+    # working_age — nullable bool (the WB working_age = age >= 6 floor).
+    # Built by per-wave scripts + a country-level concatenator.
+    index: (t, i, pid)
+    farm_work: bool
+    SOB_work: bool
+    wage_work: bool
+    farm_hrs: float
+    SB_hrs: float
+    wage_hrs: float
+    Industry: str
+    working_age: bool
+    materialize: make

--- a/lsms_library/countries/Mali/_/mali.py
+++ b/lsms_library/countries/Mali/_/mali.py
@@ -529,3 +529,183 @@ def livestock_finalize(df):
     })
     out = out[['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']]
     return out.sort_index()
+
+
+# ---------------------------------------------------------------------------
+# plot_labor (GAP 3a; parity loop) — item-level (t, i, plot, source)
+# ---------------------------------------------------------------------------
+#
+# One row per (plot, labor source).  source in {family, hired, other}, on
+# the shared `harmonize_labor_source` Preferred Labels.  Source: the EACI
+# plot-labor rosters that the WB MLI_EACI*.do code reads then collapses to
+# the per-plot totals (total_family_labor_days / total_hired_labor_days /
+# total_other_labor_days / total_labor_days) and the median-wage valuation
+# (hired_labor_value).  We keep the PRE-collapse REPORTED person-days per
+# source — strictly richer than the WB collapsed totals, which are
+# transformations.py rollups over these item rows.
+#
+# Two questionnaire passages contribute, both at the plot grain:
+#   - post-planting (PP): MLI_EACI1.do:667-748 (lab_roster, s2b vars);
+#     MLI_EACI2.do:603-674 (s11e vars).
+#   - post-harvest  (PH): MLI_EACI1.do:750-868 (lab_roster2, s2f vars);
+#     MLI_EACI2.do:676-769 (s7e vars).
+# The wave script computes person-days for each (source, passage,
+# gender-split) and hands a long (t, i, plot, source) frame to
+# `plot_labor_finalize`, which sums the passages and gender splits to the
+# REPORTED person-days per (plot, source) and carries the reported hired
+# cash wage.  PersonDays = persons * days-each (s..05a * s..05b style), the
+# same product the WB code forms before it sums.
+#
+# REPORTED item-level columns ONLY:
+#   PersonDays — reported person-days of that source applied to the plot,
+#                summed over passages (PP+PH) and the man/woman/child
+#                demographic splits within a source.
+#   Wage       — reported cash paid to HIRED labor (FCFA) where the survey
+#                records it; NaN for family / other (no cash wage asked).
+# NO total_labor_days / total_family_labor_days / total_hired_labor_days /
+# hired_labor_value — all four are transformations.py rollups over these
+# rows (total_* = groupby-sum by source; hired_labor_value = median-wage
+# valuation over the hired rows).
+
+# EACI "Manquant" / refusal sentinels on the reported day/persons/wage
+# columns (cf. MLI_EACI1.do:720-722 `replace = . if ==99|999|99999999`).
+_LABOR_SENTINELS = [99, 999, 9999, 99999, 999999, 9999999, 99999999]
+
+
+def _labor_source_labels(series):
+    """Map a Series of harmonize_labor_source Codes (family/hired/other)
+    -> Preferred Label."""
+    m = tools.get_categorical_mapping(tablename='harmonize_labor_source',
+                                      idxvars='Code',
+                                      **{'Preferred Label': 'Preferred Label'})
+    out = series.astype('string').str.strip().map(m)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_labor_finalize(df):
+    """Common post-processing for a plot_labor wave DataFrame.
+
+    Expects raw columns already assembled, one row per
+    (t, i, plot, source, <passage/gender split>):
+        t, i, plot, source (harmonize_labor_source Code: family/hired/other),
+        PersonDays (reported person-days for that split), Wage (reported cash
+        wage for hired rows; NA otherwise).
+    Maps the source code -> Preferred Label, coerces the reported columns to
+    numeric (clearing the EACI Manquant sentinels), drops content-free rows
+    (a source/split with no reported person-days and no wage), sets the
+    (t, i, plot, source) index, and collapses to ONE row per (plot, source)
+    by SUMMING the reported person-days over passages and gender splits
+    (min_count=1 so an all-NA group stays NA, not a spurious 0) and summing
+    the reported hired wage over the splits.
+    """
+    df = df.copy()
+    df['source'] = _labor_source_labels(df['source'])
+    df = df.dropna(subset=['source'])  # drop unmapped source codes
+
+    for c in ('PersonDays', 'Wage'):
+        if c not in df.columns:
+            df[c] = pd.NA
+        df[c] = pd.to_numeric(df[c], errors='coerce')
+        df.loc[df[c].isin(_LABOR_SENTINELS), c] = pd.NA
+
+    # Drop content-free rows: a (plot, source, split) for which the survey
+    # reported neither person-days nor a wage.  A reported positive
+    # PersonDays or a reported positive Wage counts as content; an
+    # all-zero/all-NA split does not (the roster has fixed slots per source
+    # and gender, with zeros where that source did not work the plot —
+    # keeping them would emit empty rows on every plot).
+    has_content = (df['PersonDays'].fillna(0).gt(0)
+                   | df['Wage'].fillna(0).gt(0))
+    df = df[has_content]
+
+    df['plot'] = df['plot'].astype('string')
+
+    keys = ['t', 'i', 'plot', 'source']
+    g = df.groupby(keys, dropna=False, as_index=True)
+    out = pd.DataFrame({
+        'PersonDays': g['PersonDays'].sum(min_count=1),
+        'Wage':       g['Wage'].sum(min_count=1),
+    })
+    out = out[['PersonDays', 'Wage']]
+    return out.sort_index()
+
+
+# ---------------------------------------------------------------------------
+# people_last7days (GAP 3b; parity loop) — item-level (t, i, pid)
+# ---------------------------------------------------------------------------
+#
+# One row per individual, mirroring Uganda's per-individual 7-day activity
+# feature so the six labor-gap countries match the one we already have.
+# Source: the EACI individual labor/time-use module the WB MLI_EACI*.do
+# code reads (MLI_EACI1.do:1435-1520, indiv_roster EACIIND_p1 s04 vars;
+# MLI_EACI2.do:1340-1427, indiv_labor eaci17_s04p1 s4 vars).
+#
+# REPORTED per-individual columns ONLY (no rollups):
+#   farm_work / SOB_work / wage_work — nullable-bool 7-day activity dummies
+#       (worked on the household farm / own non-farm business / for a wage).
+#   farm_hrs / SB_hrs / wage_hrs     — average weekly hours in each activity
+#       ((months * days * hours) / 52, the WB av_hours construction).
+#   Industry — primary-job industry on the `harmonize_industry` Preferred
+#       Labels (Agriculture / Fishing / Mining / Manufacturing /
+#       Construction / Services), decoded from the WB ind_* dummy split over
+#       the primary-job industry code.  Zeroed (-> NA) for self-employment /
+#       no-work as the WB code does; NOT gated on wage_work (so a non-wage
+#       primary job in a recognized industry still carries a label — a
+#       wage-only cut is a transformation over (Industry, wage_work)).
+#   working_age — nullable bool (the WB working_age = age >= 6 floor).
+# These are per-individual REPORTED values; the household roll-ups
+# (nb_members_working_age etc.) are transformations.py, never stored.
+
+# The six WB ind_* dummies map to one canonical Industry label.  Code is the
+# WB dummy stem; Preferred Label resolves via the harmonize_industry table.
+_INDUSTRY_CODES = ['ind_ag', 'ind_fish', 'ind_mining',
+                   'ind_manuf', 'ind_const', 'ind_serv']
+
+
+def _industry_labels(series):
+    """Map a Series of harmonize_industry Codes (ind_ag .. ind_serv)
+    -> Preferred Label."""
+    m = tools.get_categorical_mapping(tablename='harmonize_industry',
+                                      idxvars='Code',
+                                      **{'Preferred Label': 'Preferred Label'})
+    out = series.astype('string').str.strip().map(m)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def people_last7days_finalize(df):
+    """Common post-processing for a people_last7days wave DataFrame.
+
+    Expects raw columns already assembled, one row per (t, i, pid):
+        t, i, pid, farm_work, SOB_work, wage_work (nullable bool dummies),
+        farm_hrs, SB_hrs, wage_hrs (float weekly hours),
+        Industry (harmonize_industry Code or NA), working_age (nullable bool).
+    Maps the Industry code -> Preferred Label, coerces dtypes, sets the
+    (t, i, pid) index, and (defensively) collapses any exact-duplicate
+    (t, i, pid) by taking the any/first of the reported values.
+    """
+    df = df.copy()
+    df['Industry'] = _industry_labels(df['Industry'])
+
+    for c in ('farm_work', 'SOB_work', 'wage_work', 'working_age'):
+        df[c] = df[c].astype('boolean')
+    for c in ('farm_hrs', 'SB_hrs', 'wage_hrs'):
+        df[c] = pd.to_numeric(df[c], errors='coerce')
+
+    df['pid'] = df['pid'].astype('string')
+    keys = ['t', 'i', 'pid']
+    df = df.dropna(subset=['pid'])
+
+    g = df.groupby(keys, dropna=False, as_index=True)
+    out = pd.DataFrame({
+        'farm_work':   g['farm_work'].max(),
+        'SOB_work':    g['SOB_work'].max(),
+        'wage_work':   g['wage_work'].max(),
+        'farm_hrs':    g['farm_hrs'].sum(min_count=1),
+        'SB_hrs':      g['SB_hrs'].sum(min_count=1),
+        'wage_hrs':    g['wage_hrs'].sum(min_count=1),
+        'Industry':    g['Industry'].first(),
+        'working_age': g['working_age'].max(),
+    })
+    out = out[['farm_work', 'SOB_work', 'wage_work',
+               'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']]
+    return out.sort_index()

--- a/lsms_library/countries/Mali/_/people_last7days.py
+++ b/lsms_library/countries/Mali/_/people_last7days.py
@@ -1,0 +1,36 @@
+"""Concatenate wave-level people_last7days for Mali (GAP 3b; parity loop).
+
+Each EACI wave's ``Mali/<wave>/_/people_last7days.py`` writes a parquet
+indexed by ``(t, i, pid)`` with the reported per-individual 7-day activity
+columns (farm_work, SOB_work, wage_work, farm_hrs, SB_hrs, wage_hrs,
+Industry, working_age).  The individual labor/time-use module lives in the
+EACI waves only (2014-15 EACIIND_p1, 2017-18 eaci17_s04p1).  The EHCVM
+waves (2018-19, 2021-22) carry no individual labor module, so they
+contribute nothing — the same wave split as plot_labor / crop_production.
+
+``v`` is NOT baked in — the framework joins it from ``sample()`` at API
+time (people_last7days is household-linked and is NOT in the framework
+``_no_v_join`` set).  ``id_walk`` is left to ``_finalize_result``.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+WAVES = ['2014-15', '2017-18', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/people_last7days.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        continue
+    pieces.append(df)
+
+assert pieces, "people_last7days: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, pid) after concat"
+
+to_parquet(p, '../var/people_last7days.parquet')

--- a/lsms_library/countries/Mali/_/plot_labor.py
+++ b/lsms_library/countries/Mali/_/plot_labor.py
@@ -1,0 +1,40 @@
+"""Concatenate wave-level plot_labor for Mali (GAP 3a; parity loop).
+
+Each EACI wave's ``Mali/<wave>/_/plot_labor.py`` writes a parquet indexed by
+``(t, i, plot, source)`` with the reported item-level columns (PersonDays,
+Wage).  The plot-labor module lives in the EACI waves only (2014-15
+EACIMAINOUVRE_p1 + EACIS2F_p2, 2017-18 eaci17_s11ep1 + eaci17_s7ep2).  The
+EHCVM waves (2018-19, 2021-22) carry no plot-labor roster, so they
+contribute nothing — the same wave split as crop_production / plot_inputs /
+livestock.
+
+``v`` is NOT baked in — the framework joins it from ``sample()`` at API
+time (plot_labor is household-linked and is NOT in the framework
+``_no_v_join`` set).  ``id_walk`` is left to ``_finalize_result`` (cached
+parquets store pre-transformation data), matching the crop_production /
+plot_inputs / food_coping pattern.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+WAVES = ['2014-15', '2017-18', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_labor.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired (no .py script / no parquet); DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_labor: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, i, plot, source) after concat"
+
+to_parquet(p, '../var/plot_labor.parquet')

--- a/lsms_library/countries/Niger/2011-12/_/people_last7days.py
+++ b/lsms_library/countries/Niger/2011-12/_/people_last7days.py
@@ -1,0 +1,119 @@
+"""Build people_last7days for Niger ECVMA 2011-12 (GAP 3, item-level).
+
+Single source file: ecvmaind_p1p2.dta (the individual roster, which carries
+the ms04 employment / time-use module).  Mirrors the WB .do individual-labor
+recipe (NER_ECVMA1.do:1372-1449) exactly, but keeps the REPORTED
+per-individual values — no nb_members_working_age rollup.
+
+ID / grain: i = str(int(hid)) (2011-12 hid = grappe*100+menage); pid =
+format_id(ms01q00), matching household_roster's pid.  Grain (t, i, pid).
+
+Reported fields:
+  farm_work  ms04q03 (1=Oui worked on own farm last 7 days)
+  SOB_work   ms04q05 (1=Oui worked in own business last 7 days)
+  wage_work  ms04q02 (1=Oui worked for a wage last 7 days)
+  working_age ms01q06a (age) >= 6  (the survey's working-age threshold)
+  Industry   ms04q24 activity-section code -> broad industry label
+             (Agriculture/Fishing/Mining/Manufacturing/Construction/Services)
+  farm_hrs / SB_hrs / wage_hrs : usual weekly hours, computed as the WB does
+             — av weekly hours per job = month*day*hour/52 (ms04q29-31 job1,
+             ms04q55-57 job2), allocated to farm / own-business (SB) / wage
+             by the job's occupation code (ms04q23 / ms04q51), then summed
+             across the two jobs.  Set to 0 for non-working-age members
+             (matching the WB code).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from niger import (i as niger_i, _industry_label, _yn_bool,
+                   _finish_people_last7days)
+
+
+# Occupation-code sets the WB uses to classify a job as farm vs own-business
+# (SB) vs wage (NER_ECVMA1.do:1417-1428).
+FARM_CODES = {1101, 1102, 1103, 1104, 1105, 1106, 1107,
+              1201, 1202, 1203, 1204, 1205}
+SB_CODES = {6101, 6202, 6203, 6204, 6205, 6206, 6207,
+            6209, 6210, 6211, 6212}
+
+
+src = get_dataframe('../Data/NER_2011_ECVMA_v01_M_Stata8/ecvmaind_p1p2.dta',
+                    convert_categoricals=False)
+
+
+def _num(col):
+    return pd.to_numeric(src[col], errors='coerce')
+
+
+i_val = src['hid'].apply(lambda x: niger_i(x) if pd.notna(x) else pd.NA)
+pid = src['ms01q00'].apply(format_id)
+
+age = _num('ms01q06a')
+working_age = (age >= 6)
+
+farm_work = _yn_bool(src['ms04q03'])
+SOB_work = _yn_bool(src['ms04q05'])
+wage_work = _yn_bool(src['ms04q02'])
+
+industry = _industry_label(src['ms04q24'])
+# Self-employment / not-worked filter the WB applies before keeping industry.
+self_emp = _num('ms04q26').isin([4]) | _num('ms04q25').isin([6, 7, 8])
+not_worked = _num('ms04q22') == 2
+industry = industry.where(~(self_emp | not_worked).values, pd.NA)
+
+# --- usual weekly hours per job, allocated to farm/SB/wage --------------
+unemployed = (_num('ms04q11') == 2) & (_num('ms04q12') == 2)
+
+
+def _job_hours(month_c, day_c, hour_c):
+    m, d, h = _num(month_c), _num(day_c), _num(hour_c)
+    hrs = (m * d * h) / 52
+    return hrs.where(~unemployed, 0)
+
+
+av_hours1 = _job_hours('ms04q29', 'ms04q31', 'ms04q30')
+av_hours2 = _job_hours('ms04q55', 'ms04q57', 'ms04q56')
+
+
+def _classify(occ_col):
+    occ = _num(occ_col)
+    farm = occ.isin(FARM_CODES)
+    sb = occ.isin(SB_CODES)
+    wage = occ.notna() & ~farm & ~sb
+    return farm, sb, wage
+
+
+farm1, sb1, wage1 = _classify('ms04q23')
+farm2, sb2, wage2 = _classify('ms04q51')
+
+farm_hrs = (av_hours1.where(farm1, 0).fillna(0)
+            + av_hours2.where(farm2, 0).fillna(0))
+SB_hrs = (av_hours1.where(sb1, 0).fillna(0)
+          + av_hours2.where(sb2, 0).fillna(0))
+wage_hrs = (av_hours1.where(wage1, 0).fillna(0)
+            + av_hours2.where(wage2, 0).fillna(0))
+
+# WB zeroes the activity fields for non-working-age members.
+for s in (farm_hrs, SB_hrs, wage_hrs):
+    s[~working_age.values] = 0
+
+df = pd.DataFrame({
+    'i': i_val.values,
+    'pid': pid.values,
+    'farm_work': farm_work.values,
+    'SOB_work': SOB_work.values,
+    'wage_work': wage_work.values,
+    'farm_hrs': farm_hrs.values,
+    'SB_hrs': SB_hrs.values,
+    'wage_hrs': wage_hrs.values,
+    'Industry': industry.values,
+    'working_age': working_age.values,
+})
+
+df = _finish_people_last7days(df, '2011-12')
+
+assert len(df) > 0, 'people_last7days 2011-12 produced no rows'
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Niger/2011-12/_/plot_labor.py
+++ b/lsms_library/countries/Niger/2011-12/_/plot_labor.py
@@ -1,0 +1,100 @@
+"""Build plot_labor for Niger ECVMA 2011-12 (GAP 3, item-level).
+
+Two source files (the WB ${lab_roster} / ${lab_roster2}):
+  ecvmaas1_p1.dta — post-planting (PP) plot labor.  Family days
+    as02aq20b..as02aq25b; hired as02aq27{a gate / b,c,d days / e wage};
+    other (free) as02aq26{a gate / b,c,d days}.  plot = (as01q03, as01q05).
+  ecvmaas1_p2.dta — post-harvest (PH) plot labor.  Family days
+    as02aq28b..33b, 36b..41b; hired as02aq35{a/b-d/e} + as02aq43{a/b-d/e};
+    other as02aq34{a/b-d} + as02aq42{a/b-d}.  plot = (as01q03, as01q05).
+
+One row per (plot, source); PersonDays = reported person-days of that
+source (man + woman + child or per-family-member cells, summed within the
+source — NOT a cross-source rollup; see niger.py module note).  Wage = cash
+paid to hired labor (NaN for family/other).  PP and PH rows for the same
+(plot, source) are concatenated and summed by _finish_plot_labor.
+
+``hid`` already equals grappe*100+menage (the canonical 2011-12 household
+id).  plot = "{as01q03}_{as01q05}" aligns with crop_production's plot key.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from niger import (i as niger_i, _coerce_days, _coerce_wage,
+                   _finish_plot_labor, LABOR_SOURCE_FAMILY,
+                   LABOR_SOURCE_HIRED, LABOR_SOURCE_OTHER)
+
+
+def _plot_key(df):
+    hid = df['hid'].apply(lambda x: niger_i(x) if pd.notna(x) else pd.NA)
+    field = df['as01q03'].apply(format_id)
+    parcel = df['as01q05'].apply(format_id)
+    plot = field.astype('string') + '_' + parcel.astype('string')
+    return hid, plot
+
+
+def _rows(df, source, day_cols, gate_col=None, wage_col=None):
+    """One reported (plot, source) row per source-line: PersonDays = sum of
+    the day cells (man/woman/child or per-family-member), gated to NA where
+    the survey's "did you use this source?" gate says No (==2)."""
+    hid, plot = _plot_key(df)
+    days = sum(_coerce_days(df[c]).fillna(0) for c in day_cols)
+    # Restore NA where every cell was NA (fillna(0) above masked that).
+    any_reported = pd.concat([_coerce_days(df[c]).notna() for c in day_cols],
+                             axis=1).any(axis=1)
+    days = days.where(any_reported, pd.NA)
+    if gate_col is not None:
+        gate = pd.to_numeric(df[gate_col], errors='coerce')
+        days = days.where(gate != 2, 0)  # gate==No -> zero days, not NA
+    wage = _coerce_wage(df[wage_col]) if wage_col is not None else pd.NA
+    return pd.DataFrame({
+        'i': hid.values,
+        'plot': plot.values,
+        'source': source,
+        'PersonDays': days.values,
+        'Wage': wage.values if wage_col is not None else pd.NA,
+    })
+
+
+pp = get_dataframe('../Data/NER_2011_ECVMA_v01_M_Stata8/ecvmaas1_p1.dta',
+                   convert_categoricals=False)
+ph = get_dataframe('../Data/NER_2011_ECVMA_v01_M_Stata8/ecvmaas1_p2.dta',
+                   convert_categoricals=False)
+
+frames = []
+# --- post-planting (p1) ---------------------------------------------------
+frames.append(_rows(pp, LABOR_SOURCE_FAMILY,
+                    ['as02aq20b', 'as02aq21b', 'as02aq22b',
+                     'as02aq23b', 'as02aq24b', 'as02aq25b']))
+frames.append(_rows(pp, LABOR_SOURCE_HIRED,
+                    ['as02aq27b', 'as02aq27c', 'as02aq27d'],
+                    gate_col='as02aq27a', wage_col='as02aq27e'))
+frames.append(_rows(pp, LABOR_SOURCE_OTHER,
+                    ['as02aq26b', 'as02aq26c', 'as02aq26d'],
+                    gate_col='as02aq26a'))
+# --- post-harvest (p2) ----------------------------------------------------
+frames.append(_rows(ph, LABOR_SOURCE_FAMILY,
+                    ['as02aq28b', 'as02aq29b', 'as02aq30b', 'as02aq31b',
+                     'as02aq32b', 'as02aq33b', 'as02aq36b', 'as02aq37b',
+                     'as02aq38b', 'as02aq39b', 'as02aq40b', 'as02aq41b']))
+frames.append(_rows(ph, LABOR_SOURCE_HIRED,
+                    ['as02aq35b', 'as02aq35c', 'as02aq35d'],
+                    gate_col='as02aq35a', wage_col='as02aq35e'))
+frames.append(_rows(ph, LABOR_SOURCE_HIRED,
+                    ['as02aq43b', 'as02aq43c', 'as02aq43d'],
+                    gate_col='as02aq43a', wage_col='as02aq43e'))
+frames.append(_rows(ph, LABOR_SOURCE_OTHER,
+                    ['as02aq34b', 'as02aq34c', 'as02aq34d'],
+                    gate_col='as02aq34a'))
+frames.append(_rows(ph, LABOR_SOURCE_OTHER,
+                    ['as02aq42b', 'as02aq42c', 'as02aq42d'],
+                    gate_col='as02aq42a'))
+
+df = pd.concat(frames, ignore_index=True)
+df = _finish_plot_labor(df, '2011-12')
+
+assert len(df) > 0, 'plot_labor 2011-12 produced no rows'
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Niger/2014-15/_/people_last7days.py
+++ b/lsms_library/countries/Niger/2014-15/_/people_last7days.py
@@ -1,0 +1,123 @@
+"""Build people_last7days for Niger ECVMA 2014-15 (GAP 3, item-level).
+
+Two source files (the WB ${labor_hh} merged to ${indiv_roster}):
+  ECVMA2_MS04P1.dta — the ms04 employment / time-use module (one row per
+    person; person line number in MS04Q00).
+  ECVMA2_MS01P1.dta — the individual roster (age in MS01Q06A; person line
+    number in MS01Q00).
+Merged on (GRAPPE, MENAGE, EXTENSION, person line number), exactly as
+NER_ECVMA2.do:1392-1473.  Keeps the REPORTED per-individual values — no
+nb_members_working_age rollup.
+
+ID / grain: i from (GRAPPE, MENAGE) via niger.i (matching household_roster /
+sample, which omit EXTENSION); pid = format_id(MS01Q00), matching
+household_roster's pid.  Grain (t, i, pid).
+
+Reported fields:
+  farm_work  MS04Q01 (1=Oui own farm last 7 days)
+  SOB_work   MS04Q02 (1=Oui own business last 7 days)
+  wage_work  MS04Q03 (1=Oui wage work last 7 days)
+  working_age MS01Q06A (age) >= 6
+  Industry   MS04Q23 activity-section code -> broad industry label
+  farm_hrs/SB_hrs/wage_hrs : usual weekly hours, av per job =
+             month*week*day*hour/52 (MS04Q25-28 job1, MS04Q51-53/51B job2),
+             allocated farm/SB/wage by occupation code (MS04Q22/MS04Q48),
+             summed across jobs, zeroed for non-working-age members.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from niger import (i as niger_i, _industry_label, _yn_bool,
+                   _finish_people_last7days)
+
+
+FARM_CODES = {1101, 1102, 1103, 1104, 1105, 1106, 1107,
+              1201, 1202, 1203, 1204, 1205}
+SB_CODES = {6101, 6202, 6203, 6204, 6205, 6206, 6207,
+            6209, 6210, 6211, 6212}
+
+base = '../Data/NER_2014_ECVMA-II_v02_M_STATA8/'
+lab = get_dataframe(base + 'ECVMA2_MS04P1.dta', convert_categoricals=False)
+ros = get_dataframe(base + 'ECVMA2_MS01P1.dta', convert_categoricals=False)
+
+key = ['GRAPPE', 'MENAGE', 'EXTENSION']
+ros_small = ros[key + ['MS01Q00', 'MS01Q06A']].copy()
+lab = lab.rename(columns={'MS04Q00': 'MS01Q00'})
+src = lab.merge(ros_small, on=key + ['MS01Q00'], how='left')
+
+
+def _num(col):
+    return pd.to_numeric(src[col], errors='coerce')
+
+
+i_val = src.apply(lambda r: niger_i(pd.Series([r['GRAPPE'], r['MENAGE']],
+                                              index=['GRAPPE', 'MENAGE'])),
+                  axis=1)
+pid = src['MS01Q00'].apply(format_id)
+
+age = _num('MS01Q06A')
+working_age = (age >= 6)
+
+farm_work = _yn_bool(src['MS04Q01'])
+SOB_work = _yn_bool(src['MS04Q02'])
+wage_work = _yn_bool(src['MS04Q03'])
+
+industry = _industry_label(src['MS04Q23'])
+self_emp = _num('MS04Q24').isin([4]) | _num('MS04Q29').isin([7, 8, 9])
+not_worked = _num('MS04Q20') == 2
+industry = industry.where(~(self_emp | not_worked).values, pd.NA)
+
+unemployed = (_num('MS04Q05') == 2) & (_num('MS04Q06') == 2)
+
+
+def _job_hours(month_c, week_c, day_c, hour_c):
+    m, w, d, h = _num(month_c), _num(week_c), _num(day_c), _num(hour_c)
+    hrs = (m * w * d * h) / 52
+    return hrs.where(~unemployed, 0)
+
+
+av_hours1 = _job_hours('MS04Q25', 'MS04Q26', 'MS04Q27', 'MS04Q28')
+av_hours2 = _job_hours('MS04Q51', 'MS04Q51B', 'MS04Q53', 'MS04Q52')
+
+
+def _classify(occ_col):
+    occ = _num(occ_col)
+    farm = occ.isin(FARM_CODES)
+    sb = occ.isin(SB_CODES)
+    wage = occ.notna() & ~farm & ~sb
+    return farm, sb, wage
+
+
+farm1, sb1, wage1 = _classify('MS04Q22')
+farm2, sb2, wage2 = _classify('MS04Q48')
+
+farm_hrs = (av_hours1.where(farm1, 0).fillna(0)
+            + av_hours2.where(farm2, 0).fillna(0))
+SB_hrs = (av_hours1.where(sb1, 0).fillna(0)
+          + av_hours2.where(sb2, 0).fillna(0))
+wage_hrs = (av_hours1.where(wage1, 0).fillna(0)
+            + av_hours2.where(wage2, 0).fillna(0))
+
+for s in (farm_hrs, SB_hrs, wage_hrs):
+    s[~working_age.values] = 0
+
+df = pd.DataFrame({
+    'i': i_val.values,
+    'pid': pid.values,
+    'farm_work': farm_work.values,
+    'SOB_work': SOB_work.values,
+    'wage_work': wage_work.values,
+    'farm_hrs': farm_hrs.values,
+    'SB_hrs': SB_hrs.values,
+    'wage_hrs': wage_hrs.values,
+    'Industry': industry.values,
+    'working_age': working_age.values,
+})
+
+df = _finish_people_last7days(df, '2014-15')
+
+assert len(df) > 0, 'people_last7days 2014-15 produced no rows'
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Niger/2014-15/_/plot_labor.py
+++ b/lsms_library/countries/Niger/2014-15/_/plot_labor.py
@@ -1,0 +1,87 @@
+"""Build plot_labor for Niger ECVMA 2014-15 (GAP 3, item-level).
+
+Two source files (the WB ${lab_roster} / ${lab_roster2}):
+  ECVMA2_AS2AP1.dta — post-planting (PP) plot labor.  Family days
+    AS02AQ17B..AS02AQ22B; hired AS02AQ24{a gate / b,c,d days / e wage};
+    other AS02AQ23{a gate / b,c,d days}.  plot = (AS01Q01, AS01Q03).
+  ECVMA2_AS2AP2.dta — post-harvest (PH) plot labor.  Family days
+    AS02AQ28B..33B, 36B..41B; hired AS02AQ35{a/b-d/e}; other
+    AS02AQ34{a/b-d}.  plot = (AS02AQ01, AS02AQ03).
+
+One row per (plot, source); PersonDays summed within source (man/woman/child
+or per-member cells); Wage = cash paid to hired labor.  i from
+(GRAPPE, MENAGE) via niger.i (matching crop_production / sample, which omit
+EXTENSION).  plot = "{field}_{parcel}" aligns with crop_production's plot key.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from niger import (i as niger_i, _coerce_days, _coerce_wage,
+                   _finish_plot_labor, LABOR_SOURCE_FAMILY,
+                   LABOR_SOURCE_HIRED, LABOR_SOURCE_OTHER)
+
+
+def _hh(df):
+    return df.apply(lambda r: niger_i(pd.Series([r['GRAPPE'], r['MENAGE']],
+                                                index=['GRAPPE', 'MENAGE'])),
+                    axis=1)
+
+
+def _rows(df, source, field_col, parcel_col, day_cols,
+          gate_col=None, wage_col=None):
+    hid = _hh(df)
+    field = df[field_col].apply(format_id)
+    parcel = df[parcel_col].apply(format_id)
+    plot = field.astype('string') + '_' + parcel.astype('string')
+    days = sum(_coerce_days(df[c]).fillna(0) for c in day_cols)
+    any_reported = pd.concat([_coerce_days(df[c]).notna() for c in day_cols],
+                             axis=1).any(axis=1)
+    days = days.where(any_reported, pd.NA)
+    if gate_col is not None:
+        gate = pd.to_numeric(df[gate_col], errors='coerce')
+        days = days.where(gate != 2, 0)
+    wage = _coerce_wage(df[wage_col]) if wage_col is not None else pd.NA
+    return pd.DataFrame({
+        'i': hid.values,
+        'plot': plot.values,
+        'source': source,
+        'PersonDays': days.values,
+        'Wage': wage.values if wage_col is not None else pd.NA,
+    })
+
+
+base = '../Data/NER_2014_ECVMA-II_v02_M_STATA8/'
+pp = get_dataframe(base + 'ECVMA2_AS2AP1.dta', convert_categoricals=False)
+ph = get_dataframe(base + 'ECVMA2_AS2AP2.dta', convert_categoricals=False)
+
+frames = []
+# --- post-planting (AS2AP1; plot = AS01Q01_AS01Q03) -----------------------
+frames.append(_rows(pp, LABOR_SOURCE_FAMILY, 'AS01Q01', 'AS01Q03',
+                    ['AS02AQ17B', 'AS02AQ18B', 'AS02AQ19B',
+                     'AS02AQ20B', 'AS02AQ21B', 'AS02AQ22B']))
+frames.append(_rows(pp, LABOR_SOURCE_HIRED, 'AS01Q01', 'AS01Q03',
+                    ['AS02AQ24B', 'AS02AQ24C', 'AS02AQ24D'],
+                    gate_col='AS02AQ24A', wage_col='AS02AQ24E'))
+frames.append(_rows(pp, LABOR_SOURCE_OTHER, 'AS01Q01', 'AS01Q03',
+                    ['AS02AQ23B', 'AS02AQ23C', 'AS02AQ23D'],
+                    gate_col='AS02AQ23A'))
+# --- post-harvest (AS2AP2; plot = AS02AQ01_AS02AQ03) ----------------------
+frames.append(_rows(ph, LABOR_SOURCE_FAMILY, 'AS02AQ01', 'AS02AQ03',
+                    ['AS02AQ28B', 'AS02AQ29B', 'AS02AQ30B', 'AS02AQ31B',
+                     'AS02AQ32B', 'AS02AQ33B', 'AS02AQ36B', 'AS02AQ37B',
+                     'AS02AQ38B', 'AS02AQ39B', 'AS02AQ40B', 'AS02AQ41B']))
+frames.append(_rows(ph, LABOR_SOURCE_HIRED, 'AS02AQ01', 'AS02AQ03',
+                    ['AS02AQ35B', 'AS02AQ35C', 'AS02AQ35D'],
+                    gate_col='AS02AQ35A', wage_col='AS02AQ35E'))
+frames.append(_rows(ph, LABOR_SOURCE_OTHER, 'AS02AQ01', 'AS02AQ03',
+                    ['AS02AQ34B', 'AS02AQ34C', 'AS02AQ34D'],
+                    gate_col='AS02AQ34A'))
+
+df = pd.concat(frames, ignore_index=True)
+df = _finish_plot_labor(df, '2014-15')
+
+assert len(df) > 0, 'plot_labor 2014-15 produced no rows'
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Niger/2018-19/_/people_last7days.py
+++ b/lsms_library/countries/Niger/2018-19/_/people_last7days.py
@@ -1,0 +1,30 @@
+"""Build people_last7days for Niger EHCVM 2018-19 (GAP 3, item-level).
+
+Two source files:
+  s04_me_ner2018.dta — the 7-day employment module (participation dummies).
+  s01_me_ner2018.dta — the individual roster (age for working_age).
+Merged on (grappe, menage, s01q00a) — the same person key household_roster
+uses.  Grain (t, i, pid); pid = s01q00a; i = EHCVM composite via niger.i.
+
+EHCVM's 7-day module records only the three participation DUMMIES in an
+ECVMA-comparable form (s04q06 farm, s04q07 own-business, s04q08 wage) and
+working_age (roster Age >= 6).  It does NOT record productive-work hours or
+the WB 7-day industry section code, so farm_hrs / SB_hrs / wage_hrs and
+Industry are NA (declared for cross-wave schema parity).  Build shared with
+2021-22 via niger.people_last7days_ehcvm.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import people_last7days_ehcvm, _finish_people_last7days
+
+
+s04 = get_dataframe('../Data/s04_me_ner2018.dta', convert_categoricals=False)
+s01 = get_dataframe('../Data/s01_me_ner2018.dta', convert_categoricals=False)
+
+df = people_last7days_ehcvm(s04, s01, '2018-19', survey_year=2018)
+df = _finish_people_last7days(df, '2018-19')
+
+assert len(df) > 0, 'people_last7days 2018-19 produced no rows'
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Niger/2018-19/_/plot_labor.py
+++ b/lsms_library/countries/Niger/2018-19/_/plot_labor.py
@@ -1,0 +1,39 @@
+"""Build plot_labor for Niger EHCVM 2018-19 (GAP 3, item-level).
+
+Single source file: s16a_me_ner2018.dta (agriculture-parcel module — the
+same file plot_features reads, so plot ids align by construction).  EHCVM
+records plot labor at the parcel level, family vs non-family (hired) only
+(NO free/exchange "other" labor):
+
+  Family labor (per family member, member-grid suffix _1.._N, three phases):
+    s16aq33b_*  days each member worked, prep/sowing phase
+    s16aq35b_*  days each member worked, maintenance phase
+    s16aq37b_*  days each member worked, harvest phase
+  -> family PersonDays = Σ over members & phases of those member-day cells.
+
+  Non-family / hired labor (per worker gender category, grid suffix _1.._4,
+  three phases; a = #workers, b = days each, c = wage paid):
+    s16aq39{a,b,c}_*  prep/sowing phase
+    s16aq41{a,b,c}_*  maintenance phase
+    s16aq43{a,b,c}_*  harvest phase
+  -> hired PersonDays = Σ over categories & phases of (a workers × b days);
+     hired Wage       = Σ over categories & phases of c (cash paid).
+
+One row per (plot, source); plot = "{s16aq02}_{s16aq03}" aligns with
+crop_production / plot_features plot_id.  i = EHCVM composite via niger.i.
+The build is shared with 2021-22 (niger.plot_labor_ehcvm — identical s16a
+labor-grid scheme).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import plot_labor_ehcvm, _finish_plot_labor
+
+
+src = get_dataframe('../Data/s16a_me_ner2018.dta', convert_categoricals=False)
+df = plot_labor_ehcvm(src, '2018-19')
+df = _finish_plot_labor(df, '2018-19')
+
+assert len(df) > 0, 'plot_labor 2018-19 produced no rows'
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Niger/2021-22/_/people_last7days.py
+++ b/lsms_library/countries/Niger/2021-22/_/people_last7days.py
@@ -1,0 +1,33 @@
+"""Build people_last7days for Niger EHCVM 2021-22 (GAP 3, item-level).
+
+Two source files:
+  s04a_me_ner2021.dta — the 7-day employment module (participation dummies).
+  s01_me_ner2021.dta  — the individual roster (age for working_age).
+Merged on (grappe, menage, membres__id) — the same person key
+household_roster uses this wave.  Grain (t, i, pid); pid = membres__id;
+i = EHCVM composite via niger.i.
+
+As in 2018-19, EHCVM's 7-day module records only the three participation
+DUMMIES (s04q06 farm, s04q07 own-business, s04q08 wage) and working_age
+(roster Age >= 6); productive-work hours and the WB 7-day industry code are
+not recorded, so farm_hrs / SB_hrs / wage_hrs and Industry are NA.  Build
+shared with 2018-19 via niger.people_last7days_ehcvm (here the person key is
+membres__id, not 2018-19's s01q00a).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import people_last7days_ehcvm, _finish_people_last7days
+
+
+s04 = get_dataframe('../Data/s04a_me_ner2021.dta', convert_categoricals=False)
+s01 = get_dataframe('../Data/s01_me_ner2021.dta', convert_categoricals=False)
+
+df = people_last7days_ehcvm(s04, s01, '2021-22',
+                            pid_col='membres__id', age_col='s01q04a',
+                            survey_year=2021)
+df = _finish_people_last7days(df, '2021-22')
+
+assert len(df) > 0, 'people_last7days 2021-22 produced no rows'
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Niger/2021-22/_/plot_labor.py
+++ b/lsms_library/countries/Niger/2021-22/_/plot_labor.py
@@ -1,0 +1,29 @@
+"""Build plot_labor for Niger EHCVM 2021-22 (GAP 3, item-level).
+
+Single source file: s16a_me_ner2021.dta (agriculture-parcel module — the
+same file plot_features reads, so plot ids align by construction).  The
+s16a labor-grid scheme is identical to 2018-19, so the build is shared via
+niger.plot_labor_ehcvm:
+
+  Family labor (member-grids s16aq33b_*/35b_*/37b_*, three phases)
+    -> family PersonDays = Σ member-day cells across members & phases.
+  Non-family / hired (grids s16aq39/41/43 {a=#workers, b=days, c=wage})
+    -> hired PersonDays = Σ (a × b); hired Wage = Σ c.
+
+EHCVM records family vs non-family (hired) only (no free/exchange "other").
+plot = "{s16aq02}_{s16aq03}" aligns with crop_production / plot_features;
+i = EHCVM composite via niger.i.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import plot_labor_ehcvm, _finish_plot_labor
+
+
+src = get_dataframe('../Data/s16a_me_ner2021.dta', convert_categoricals=False)
+df = plot_labor_ehcvm(src, '2021-22')
+df = _finish_plot_labor(df, '2021-22')
+
+assert len(df) > 0, 'plot_labor 2021-22 produced no rows'
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Niger/_/Makefile
+++ b/lsms_library/countries/Niger/_/Makefile
@@ -61,6 +61,33 @@ $(VAR_DIR)/livestock.parquet: livestock.py niger.py categorical_mapping.org \
 ../%/_/livestock.parquet: ../%/_/livestock.py niger.py categorical_mapping.org
 	(cd $(@D) && python livestock.py)
 
+# plot_labor (GAP 3, item-level).  Same shape as the siblings above: the
+# country-level var/ parquet is built by the concatenator, which reads each
+# wave's parquet; the country script is run unconditionally to (re)build the
+# wave parquets it reads, then concatenates.  (No categorical table dep --
+# the labor `source` vocabulary is an inline code mapping.)
+PLOT_LABOR_WAVES := 2011-12 2014-15 2018-19 2021-22
+
+$(VAR_DIR)/plot_labor.parquet: plot_labor.py niger.py \
+		$(foreach w,$(PLOT_LABOR_WAVES),../$(w)/_/plot_labor.py)
+	$(foreach w,$(PLOT_LABOR_WAVES),(cd ../$(w)/_ && python plot_labor.py);)
+	python plot_labor.py
+
+../%/_/plot_labor.parquet: ../%/_/plot_labor.py niger.py
+	(cd $(@D) && python plot_labor.py)
+
+# people_last7days (GAP 3, item-level).  Same shape; Industry / hours are
+# derived in code (no categorical table dep).
+PEOPLE7_WAVES := 2011-12 2014-15 2018-19 2021-22
+
+$(VAR_DIR)/people_last7days.parquet: people_last7days.py niger.py \
+		$(foreach w,$(PEOPLE7_WAVES),../$(w)/_/people_last7days.py)
+	$(foreach w,$(PEOPLE7_WAVES),(cd ../$(w)/_ && python people_last7days.py);)
+	python people_last7days.py
+
+../%/_/people_last7days.parquet: ../%/_/people_last7days.py niger.py
+	(cd $(@D) && python people_last7days.py)
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Niger/_/data_scheme.yml
+++ b/lsms_library/countries/Niger/_/data_scheme.yml
@@ -245,3 +245,101 @@ Data Scheme:
     HeadAcquired: float
     HeadSold: float
     materialize: make
+
+  plot_labor:
+    # Item-level plot labor (GAP 3, parity loop 2026-06-14).  One row per
+    # REPORTED labor SOURCE on a plot -- the reported person-days the WB .do
+    # (NER_ECVMA1.do:676-858, NER_ECVMA2.do:768-...) reads then COLLAPSES to
+    # total_labor_days / total_family_labor_days / total_hired_labor_days /
+    # hired_labor_value (a median-wage valuation).  ALL of those sums /
+    # valuations are TRANSFORMATIONS over these rows, never columns here:
+    #   total_labor_days        = Σ PersonDays over all sources on a plot
+    #   total_family_labor_days = Σ PersonDays where source=='family'
+    #   total_hired_labor_days  = Σ PersonDays where source=='hired'
+    #   hired_labor_value       = median-wage valuation over the hired rows
+    #
+    # GRAIN (t, i, plot, source):
+    #   plot   -- "{field_no}_{parcel_no}", aligned with crop_production's
+    #             plot key and plot_features' plot_id (100% on the EHCVM
+    #             waves; ~78-92% on the ECVMA waves -- labor is reported on
+    #             plots with no harvest record too, which is expected).
+    #   source -- 'family' / 'hired' / 'other'.  'other' (free / exchange
+    #             labor) exists only in the ECVMA waves (2011-12, 2014-15);
+    #             the EHCVM s16a parcel module records family vs non-family
+    #             (hired) only, so its rows are {family, hired}.  Small fixed
+    #             vocabulary assigned in code (inline mapping, no categorical
+    #             table).
+    #
+    # COLUMNS (reported, item-level):
+    #   PersonDays -- reported person-days of that source on the plot.  The
+    #                 survey reports a source as several day cells (per family
+    #                 member, or per hired-worker gender category, across the
+    #                 post-planting + post-harvest seasons / phases); these are
+    #                 strata of the SAME (plot, source) item, so PersonDays is
+    #                 their within-source sum (NOT a forbidden cross-source
+    #                 rollup -- mirrors livestock summing age/sex strata).
+    #                 EHCVM hired person-days = Σ(#workers × days) over the
+    #                 non-family grids.  days in days.
+    #   Wage       -- cash PAID to hired labor where the survey records it
+    #                 (CFA francs).  NaN for family / other (no cash paid).
+    #
+    # All four waves have a plot-labor module (script-path):
+    #   2011-12 ecvmaas1_p1 (PP) + ecvmaas1_p2 (PH)
+    #   2014-15 ECVMA2_AS2AP1 (PP) + ECVMA2_AS2AP2 (PH)
+    #   2018-19 s16a_me_ner2018  (family + non-family grids; no 'other')
+    #   2021-22 s16a_me_ner2021  (same s16a labor-grid scheme)
+    # v is NOT baked in (household-linked); the framework joins it from
+    # sample().  units: PersonDays in days; Wage in CFA francs.
+    index: (t, i, plot, source)
+    PersonDays: float
+    Wage: float
+    materialize: make
+
+  people_last7days:
+    # Item-level individual 7-day labor (GAP 3, parity loop 2026-06-14).  One
+    # row per individual, carrying the REPORTED last-7-days labor
+    # participation -- the per-individual activity feature the GAP ranking
+    # targets (Uganda's legacy HH-level Men/Women/Boys/Girls count is a
+    # DIFFERENT, older construct; this is the new (t, i, pid) feature the 6
+    # WB-only labor countries are meant to gain).  No rollups: the WB
+    # nb_members_working_age HH total is a transformation, not a column here.
+    #
+    # GRAIN (t, i, pid): pid matches household_roster's pid each wave
+    # (2011-12 ms01q00; 2014-15 MS01Q00; 2018-19 s01q00a; 2021-22
+    # membres__id).  v auto-joins from sample() (people_last7days is NOT in
+    # the framework _no_v_join set).
+    #
+    # COLUMNS (reported, per-individual):
+    #   farm_work / SOB_work / wage_work -- worked >=1h on own farm /
+    #       own business / for a wage in the last 7 days (nullable bool).
+    #   farm_hrs / SB_hrs / wage_hrs     -- usual weekly hours in each
+    #       activity (av per job = month*[week]*day*hour/52, allocated by the
+    #       job's occupation code, summed across jobs; ECVMA waves only).
+    #   Industry -- broad industry of the job (Agriculture / Fishing / Mining
+    #       / Manufacturing / Construction / Services) from the WB activity-
+    #       section-code ranges (NER_ECVMA1.do:1386-1391).  ONE harmonized
+    #       label rather than the WB's six ind_* dummies (a wide encoding of
+    #       one categorical); the ranges don't vary across waves, so the map
+    #       lives in code.  ECVMA waves only.
+    #   working_age -- member is of working age (Age >= 6, the survey
+    #       threshold ms01q06a>=6).
+    #
+    # WAVE COVERAGE: the two ECVMA waves (2011-12 ecvmaind_p1p2 ms04 module;
+    # 2014-15 ECVMA2_MS04P1 merged to ECVMA2_MS01P1) carry the FULL schema.
+    # The EHCVM waves (2018-19 s04_me_ner2018; 2021-22 s04a_me_ner2021,
+    # merged to s01 for working_age) carry the three participation dummies +
+    # working_age; their 7-day module records hours only for unpaid domestic
+    # tasks and the industry only as 12-month occupation codes (not the WB
+    # 7-day section ranges), so farm_hrs / SB_hrs / wage_hrs / Industry are
+    # NA in EHCVM (declared for cross-wave schema parity).
+    # units: hours in hours.
+    index: (t, i, pid)
+    farm_work: bool
+    SOB_work: bool
+    wage_work: bool
+    farm_hrs: float
+    SB_hrs: float
+    wage_hrs: float
+    Industry: str
+    working_age: bool
+    materialize: make

--- a/lsms_library/countries/Niger/_/niger.py
+++ b/lsms_library/countries/Niger/_/niger.py
@@ -662,3 +662,351 @@ def _finish_livestock(df, t):
     df = df[keep]
     df = df.set_index(['t', 'i', 'animal'])
     return df
+
+
+# ---------------------------------------------------------------------------
+# plot_labor (GAP 3 — item-level plot labor at (t, i, plot, source))
+# ---------------------------------------------------------------------------
+#
+# One row per REPORTED labor SOURCE on a plot.  source in {family, hired,
+# other} (the "other" = free / exchange labor exists only in the ECVMA
+# waves; the EHCVM s16a parcel module records family vs non-family only, so
+# it emits {family, hired}).  COLUMNS, reported values only:
+#   PersonDays — reported person-days of that source on the plot.
+#   Wage       — cash PAID to hired labor (where the survey records it);
+#                NaN for family / other (no cash changes hands).
+#
+# This is the REPORTED person-day item, NOT the WB collapsed plot total.
+# The WB .do (NER_ECVMA1.do:676-858, NER_ECVMA2.do:768-...) reads exactly
+# these reported day cells, rowtotals them into PPtotal_/PHtotal_*_labor_days
+# and finally total_labor_days / total_family_labor_days /
+# total_hired_labor_days / hired_labor_value (a median-wage valuation).  ALL
+# of those sums / valuations are TRANSFORMATIONS over these rows, never
+# columns here (item-level / reported-values discipline):
+#   total_labor_days        = Σ PersonDays over all sources on a plot
+#   total_family_labor_days = Σ PersonDays where source=='family'
+#   total_hired_labor_days  = Σ PersonDays where source=='hired'
+#   hired_labor_value       = median-wage valuation over the hired rows
+#
+# WITHIN-SOURCE SUM is NOT a forbidden rollup (mirrors livestock summing
+# age/sex strata).  The surveys report a labor source as several reported
+# day cells — one per family member, or per hired-worker gender category,
+# and across the post-planting (PP) and post-harvest (PH) seasons / phases.
+# Those cells are strata of the SAME (plot, source) labor item, so the
+# per-(plot, source) person-day total IS the natural item grain.  The
+# forbidden rollups are the CROSS-source ones (total_labor_days) and the
+# wage VALUATION — both recovered by a transformations fn over these rows.
+#
+# GRAIN = (t, i, plot, source).  `plot` = "{field_no}_{parcel_no}" aligns
+# with crop_production's plot key and plot_features' plot_id (verified
+# 100% on the EHCVM waves, ~78-92% on the ECVMA waves — labor is reported
+# on plots that carry no harvest record, which is expected).  v is NOT baked
+# in (household-linked; the framework joins it from sample()).
+#
+# Plot-labor instrument by wave:
+#   2011-12  ecvmaas1_p1 (PP) + ecvmaas1_p2 (PH).  Family days
+#            as02aq20b..25b (PP) / as02aq28b..33b,36b..41b (PH); hired
+#            as02aq27{a/b-d/e} (PP) / as02aq35,43 (PH) with e=wage; other
+#            as02aq26 (PP) / as02aq34,42 (PH).  Day sentinel 99/999, wage
+#            sentinel 999999.  plot = concat(hid, as01q03, as01q05).
+#   2014-15  ECVMA2_AS2AP1 (PP) + ECVMA2_AS2AP2 (PH).  Same scheme,
+#            UPPERCASE; PP plot = (AS01Q01, AS01Q03), PH plot =
+#            (AS02AQ01, AS02AQ03); i from (GRAPPE, MENAGE).
+#   2018-19  s16a_me_ner2018 — family days s16aq33b_*/35b_*/37b_* (per
+#            member, prep/maint/harvest); non-family (hired)
+#            s16aq39/41/43 {a=#workers, b=days, c=wage} per gender category.
+#            EHCVM has no "other" labor.  plot = (s16aq02, s16aq03).
+#   2021-22  s16a_me_ner2021 — identical s16a labor-grid scheme.
+#
+# A wave with no plot-labor module is silently skipped by the country-level
+# concatenator (no parquet emitted); see _/plot_labor.py.
+
+
+# Canonical labor-source Preferred Labels (the `source` index level).  Tiny
+# fixed vocabulary assigned in code (not read from a raw label column), so it
+# is an inline mapping rather than a categorical_mapping table.
+LABOR_SOURCE_FAMILY = 'family'
+LABOR_SOURCE_HIRED = 'hired'
+LABOR_SOURCE_OTHER = 'other'
+
+
+def _coerce_days(series, sentinels=(99, 999)):
+    """Numeric person-day cell -> Float64, with the survey's day sentinels
+    (99 family / 999 hired-or-other 'no answer') mapped to NA."""
+    s = pd.to_numeric(series, errors='coerce').astype('Float64')
+    for sv in sentinels:
+        s = s.where(s != sv, pd.NA)
+    return s
+
+
+def _coerce_wage(series, sentinel=999999):
+    """Numeric wage cell -> Float64, with the 999999 'no answer' sentinel
+    mapped to NA.  Used for the cash paid to hired labor."""
+    s = pd.to_numeric(series, errors='coerce').astype('Float64')
+    return s.where(s != sentinel, pd.NA)
+
+
+def plot_labor_ehcvm(src, t):
+    """Build plot_labor for one EHCVM wave (2018-19 / 2021-22) from its
+    s16a parcel module.  EHCVM records family vs non-family (hired) plot
+    labor only (no free / exchange 'other' source).  Shared by the two
+    EHCVM wave scripts since the s16a labor-grid scheme is identical
+    (member-day grids s16aq{33,35,37}b_*, hired grids s16aq{39,41,43}{a,b,c}_*;
+    a = #workers, b = days, c = wage).  See the wave scripts' docstrings and
+    the module note for the grain / column contract.
+
+    Returns the long (i, plot, source, PersonDays, Wage) frame ready for
+    _finish_plot_labor (which sums onto the (t, i, plot, source) grain)."""
+    cols = list(src.columns)
+
+    def _num(col):
+        return pd.to_numeric(src[col], errors='coerce').astype('Float64')
+
+    hh = src.apply(lambda r: i(pd.Series([r['grappe'], r['menage']],
+                                         index=['grappe', 'menage'])),
+                   axis=1)
+    field = src['s16aq02'].apply(tools.format_id)
+    parcel = src['s16aq03'].apply(tools.format_id)
+    plot = field.astype('string') + '_' + parcel.astype('string')
+
+    # family: sum member-day cells across the three phase grids
+    fam_cols = [c for c in cols
+                if c.startswith('s16aq33b_')
+                or c.startswith('s16aq35b_')
+                or c.startswith('s16aq37b_')]
+    fam_days = sum(_num(c).fillna(0) for c in fam_cols)
+    fam_any = pd.concat([_num(c).notna() for c in fam_cols], axis=1).any(axis=1)
+    fam_days = fam_days.where(fam_any.values, pd.NA)
+    fam = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_FAMILY,
+        'PersonDays': fam_days.values, 'Wage': pd.NA,
+    })
+
+    # hired: Σ(#workers × days) person-days, Σ wage, over phase × category
+    hired_days = pd.Series(0.0, index=src.index, dtype='Float64')
+    hired_wage = pd.Series(0.0, index=src.index, dtype='Float64')
+    any_days = pd.Series(False, index=src.index)
+    any_wage = pd.Series(False, index=src.index)
+    for base in ['s16aq39', 's16aq41', 's16aq43']:
+        for ac in [c for c in cols if c.startswith(base + 'a_')]:
+            suf = ac[len(base + 'a'):]   # e.g. '_1' (keeps the underscore)
+            bc, cc = base + 'b' + suf, base + 'c' + suf
+            workers = _num(ac)
+            days = _num(bc) if bc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            wage = _num(cc) if cc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            pd_cell = workers * days
+            hired_days = hired_days.add(pd_cell.fillna(0))
+            any_days = any_days | pd_cell.notna().values
+            hired_wage = hired_wage.add(wage.fillna(0))
+            any_wage = any_wage | wage.notna().values
+    hired_days = hired_days.where(any_days.values, pd.NA)
+    hired_wage = hired_wage.where(any_wage.values, pd.NA)
+    hired = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_HIRED,
+        'PersonDays': hired_days.values, 'Wage': hired_wage.values,
+    })
+
+    return pd.concat([fam, hired], ignore_index=True)
+
+
+def _finish_plot_labor(df, t):
+    """Common tail for the wave-level plot_labor scripts.
+
+    `df` arrives with columns [i, plot, source, PersonDays, Wage] — one row
+    per (plot, source) labor cell already reduced to a person-day count and
+    (for hired) a wage.  This SUMS PersonDays / Wage within
+    (t, i, plot, source) so the strata (family members, hired-worker gender
+    categories, PP/PH seasons) collapse onto the natural (plot, source) item
+    grain (see module note — a within-source sum, NOT a cross-source rollup).
+    min_count=1 keeps an all-NA group NA rather than 0.  Rows with no plot,
+    no source, or no person-days at all are dropped (roster placeholders, not
+    reported labor)."""
+    df = df.copy()
+    df['t'] = t
+    df['source'] = df['source'].astype('string')
+    df['plot'] = df['plot'].astype('string')
+    df['PersonDays'] = pd.to_numeric(df.get('PersonDays'), errors='coerce').astype('Float64')
+    if 'Wage' not in df.columns:
+        df['Wage'] = pd.NA
+    df['Wage'] = pd.to_numeric(df['Wage'], errors='coerce').astype('Float64')
+    df = df[df['i'].notna() & df['plot'].notna() & df['source'].notna()]
+    df = (df.groupby(['t', 'i', 'plot', 'source'], dropna=False)[['PersonDays', 'Wage']]
+            .sum(min_count=1)
+            .reset_index())
+    # Drop (plot, source) rows that carry no reported labor at all (both
+    # PersonDays and Wage NA) — a survey skip, not a reported labor item.
+    df = df[df['PersonDays'].notna() | df['Wage'].notna()]
+    df = df.set_index(['t', 'i', 'plot', 'source'])
+    return df
+
+
+# ---------------------------------------------------------------------------
+# people_last7days (GAP 3 — individual 7-day activity at (t, i, pid))
+# ---------------------------------------------------------------------------
+#
+# One row per individual, carrying the REPORTED 7-day (last-week) labor
+# participation the survey records.  Mirrors the target schema in the GAP
+# ranking (the per-individual activity feature; Uganda's existing
+# `people_last7days` is a legacy HH-level Men/Women/Boys/Girls count and is a
+# DIFFERENT, older construct — this is the (t, i, pid) individual feature the
+# 6 new countries are meant to gain).  COLUMNS, reported per-individual:
+#   farm_work  — worked on own farm/garden/livestock in the last 7 days (bool)
+#   SOB_work   — worked in own business / commerce in the last 7 days (bool)
+#   wage_work  — worked for a wage / employer in the last 7 days (bool)
+#   farm_hrs   — usual weekly hours on farm work (float; ECVMA only)
+#   SB_hrs     — usual weekly hours in own business (float; ECVMA only)
+#   wage_hrs   — usual weekly hours in wage work (float; ECVMA only)
+#   Industry   — broad industry of the (main) job: Agriculture / Fishing /
+#                Mining / Manufacturing / Construction / Services (str;
+#                ECVMA only — derived from the WB code's section-code ranges)
+#   working_age— member is of working age (Age >= 6, the survey threshold)
+#
+# NO rollups (the WB nb_members_working_age HH total is a transformation, not
+# a column here).  Industry is stored as ONE harmonized label rather than the
+# WB's six ind_* dummies (a wide encoding of one categorical); the ranges
+# come straight from the WB .do (NER_ECVMA1.do:1386-1391) and do not vary
+# across waves, so the mapping lives in code (no per-wave label variation to
+# harmonize via a categorical table).
+#
+# 7-day instrument by wave:
+#   2011-12  ecvmaind_p1p2 — ms04q03/05/02 (farm/SOB/wage work, 1=Oui),
+#            ms04q24 industry section code, ms04q29-31/55-57 month/day/hour
+#            per job (av weekly hours = month*day*hour/52), ms04q23/51 the
+#            job's occupation code -> farm/SB/wage job classifier, ms01q06a
+#            age (working_age = age>=6).  ID = hid-ms01q00.
+#   2014-15  ECVMA2_MS04P1 merged to ECVMA2_MS01P1 — MS04Q01/02/03
+#            (farm/SOB/wage), MS04Q23 industry, MS04Q25-28/51-53 + week
+#            (av weekly hours = month*week*day*hour/52), MS01Q06A age.
+#            ID = hhid-MS01Q00 with i from (GRAPPE, MENAGE).
+#   2018-19  s04_me_ner2018 — 7-day dummies s04q06 (own farm/garden/
+#            livestock/fishing -> farm_work), s04q07 (paid own account ->
+#            SOB_work), s04q08 (paid employee/State/employer -> wage_work).
+#            The EHCVM 7-day module records hours only for UNPAID domestic
+#            tasks (q01-05), not for productive work in an ECVMA-comparable
+#            per-activity form, and the industry is recorded as 12-month
+#            occupation codes, not the WB 7-day section ranges — so
+#            farm_hrs/SB_hrs/wage_hrs and Industry are NA in EHCVM (declared
+#            for cross-wave schema parity).  working_age from s01 Age>=6.
+#            pid = s01q00a (matches household_roster).
+#   2021-22  s04a_me_ner2021 — same s04 7-day dummy scheme (s04q06/07/08).
+#
+# The two ECVMA waves carry the full schema; the EHCVM waves carry the
+# dummies + working_age and leave hours / Industry NA.  Every wave has a
+# 7-day labor module, so all four are wired.
+
+
+# WB industry section-code ranges (NER_ECVMA1.do:1386-1391 / ECVMA2:1409-14).
+# The code is a section of the national activity classification; the WB
+# buckets it into six broad industries.  Stored as one `Industry` label.
+def _industry_label(code_series):
+    """Map a numeric activity-section code to a broad Industry Preferred
+    Label using the WB .do ranges.  Returns NA where the code is missing /
+    out of every range (e.g. the not-working / no-job sentinel)."""
+    c = pd.to_numeric(code_series, errors='coerce')
+    out = pd.Series(pd.NA, index=c.index, dtype='string')
+    out = out.mask((c >= 11) & (c <= 40), 'Agriculture')
+    out = out.mask((c == 51) | (c == 52), 'Fishing')
+    out = out.mask((c >= 60) & (c <= 72), 'Mining')
+    out = out.mask((c >= 81) & (c <= 292), 'Manufacturing')
+    out = out.mask((c >= 301) & (c <= 302), 'Construction')
+    out = out.mask((c >= 310) & (c <= 430), 'Services')
+    return out
+
+
+def _yn_bool(series, yes=1, no=2):
+    """Map a 1=Oui / 2=Non survey item to nullable boolean (other codes,
+    e.g. 9 'no answer', -> NA)."""
+    s = pd.to_numeric(series, errors='coerce')
+    out = pd.Series(pd.NA, index=s.index, dtype='boolean')
+    out = out.mask(s == yes, True)
+    out = out.mask(s == no, False)
+    return out
+
+
+def people_last7days_ehcvm(s04, s01, t, pid_col='s01q00a', age_col='s01q04a',
+                           dob_year_col='s01q03c', survey_year=None):
+    """Build people_last7days for one EHCVM wave (2018-19 / 2021-22).
+
+    EHCVM's 7-day labor module (s04) records only the three participation
+    DUMMIES in an ECVMA-comparable form:
+      s04q06 -> farm_work (worked >=1h on own farm/garden/livestock/fishing)
+      s04q07 -> SOB_work  (worked >=1h for own account / own business)
+      s04q08 -> wage_work (worked >=1h for an employer / the State / others)
+    The module records HOURS only for UNPAID domestic tasks (q01-05), and the
+    industry only as 12-month occupation codes (not the WB 7-day section
+    ranges), so farm_hrs / SB_hrs / wage_hrs and Industry are left NA (the
+    _finish tail fills them).  working_age = roster Age >= 6; Age (`age_col`)
+    is merged from the s01 roster on (grappe, menage, `pid_col`) — the same
+    person key household_roster uses.  pid = `pid_col`.
+
+    The person key differs by wave: 2018-19 uses ``s01q00a``; 2021-22 uses
+    ``membres__id`` (matching each wave's household_roster pid).  Returns the
+    (i, pid, farm_work, SOB_work, wage_work, working_age) frame ready for
+    _finish_people_last7days.
+
+    AGE: the EHCVM s01 roster fills age-in-years (`age_col`, s01q04a) for only
+    ~27% of people and birth-year (`dob_year_col`, s01q03c) for the rest --
+    exactly the two inputs household_roster's age_handler resolves.  We mirror
+    that: prefer reported years, else survey_year - birth_year (9999 sentinel
+    -> NA).  working_age = Age >= 6 (the survey threshold)."""
+    key = ['grappe', 'menage', pid_col]
+    roster_cols = [age_col, dob_year_col]
+    merged = s04[key + ['s04q06', 's04q07', 's04q08']].merge(
+        s01[key + roster_cols], on=key, how='left')
+
+    hh = merged.apply(lambda r: i(pd.Series([r['grappe'], r['menage']],
+                                            index=['grappe', 'menage'])),
+                      axis=1)
+    pid = merged[pid_col].apply(tools.format_id)
+
+    age = pd.to_numeric(merged[age_col], errors='coerce')
+    if survey_year is not None:
+        birth = pd.to_numeric(merged[dob_year_col], errors='coerce')
+        birth = birth.where((birth >= 1900) & (birth <= survey_year), pd.NA)
+        age_from_dob = survey_year - birth
+        age = age.where(age.notna(), age_from_dob)
+    working_age = (age >= 6)
+    # Keep working_age NA where age is entirely unknown (rather than False).
+    working_age = working_age.where(age.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        'i': hh.values,
+        'pid': pid.values,
+        'farm_work': _yn_bool(merged['s04q06']).values,
+        'SOB_work': _yn_bool(merged['s04q07']).values,
+        'wage_work': _yn_bool(merged['s04q08']).values,
+        'working_age': working_age.values,
+    })
+    return df
+
+
+def _finish_people_last7days(df, t):
+    """Common tail for the wave-level people_last7days scripts: coerce dtypes,
+    guarantee the full schema column set (NA where a wave lacks a field),
+    drop rows with no individual key, and build the (t, i, pid) index."""
+    df = df.copy()
+    df['t'] = t
+    df['pid'] = df['pid'].astype('string')
+    for col in ['farm_work', 'SOB_work', 'wage_work', 'working_age']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = df[col].astype('boolean')
+    for col in ['farm_hrs', 'SB_hrs', 'wage_hrs']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Industry' not in df.columns:
+        df['Industry'] = pd.NA
+    df['Industry'] = df['Industry'].astype('string')
+    df = df[df['i'].notna() & df['pid'].notna()]
+    # One row per (t, i, pid): keep the first reported line per individual
+    # (the source rosters are already one-row-per-person; this guards the
+    # 2014-15 m:1 labor->roster merge against any stray duplicate).
+    keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
+            'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
+    df = df[keep]
+    df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
+    df = df.set_index(['t', 'i', 'pid'])
+    return df

--- a/lsms_library/countries/Niger/_/people_last7days.py
+++ b/lsms_library/countries/Niger/_/people_last7days.py
@@ -1,0 +1,38 @@
+"""Concatenate wave-level people_last7days for Niger (GAP 3, item-level).
+
+Each wave's ``Niger/<wave>/_/people_last7days.py`` writes a parquet indexed
+by ``(t, i, pid)`` with the reported per-individual 7-day activity columns
+(farm_work, SOB_work, wage_work, farm_hrs, SB_hrs, wage_hrs, Industry,
+working_age).  This script concatenates the four waves (2011-12, 2014-15,
+2018-19, 2021-22), each of which has a 7-day labor module.  ``v`` is NOT
+baked in — the framework joins it from ``sample()`` at API time.
+
+As in the crop_production / plot_inputs / livestock siblings, this does NOT
+apply ``id_walk`` here; the framework runs it in ``_finalize_result`` on
+every read.  The ``(t, i, pid)`` index is unique within each wave
+(``_finish_people_last7days`` collapses to one row per individual), so no
+rows are lost to the framework's canonical-index de-dup collapse.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2011-12', '2014-15', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/people_last7days.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for people_last7days (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, 'people_last7days: no wave-level parquets found'
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/people_last7days.parquet')

--- a/lsms_library/countries/Niger/_/plot_labor.py
+++ b/lsms_library/countries/Niger/_/plot_labor.py
@@ -1,0 +1,37 @@
+"""Concatenate wave-level plot_labor for Niger (GAP 3, item-level).
+
+Each wave's ``Niger/<wave>/_/plot_labor.py`` writes a parquet indexed by
+``(t, i, plot, source)`` with the reported per-(plot, source) labor columns
+(PersonDays, Wage).  This script concatenates the four waves (2011-12,
+2014-15, 2018-19, 2021-22), each of which has a plot-labor module.  ``v`` is
+NOT baked in — the framework joins it from ``sample()`` at API time.
+
+As in the crop_production / plot_inputs / livestock siblings, this does NOT
+apply ``id_walk`` here; the framework runs it in ``_finalize_result`` on
+every read.  The ``(t, i, plot, source)`` index is unique within each wave
+(``_finish_plot_labor`` sums the labor strata onto the (plot, source) grain),
+so no rows are lost to the framework's canonical-index de-dup collapse.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2011-12', '2014-15', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_labor.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for plot_labor (no .py script / no parquet).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, 'plot_labor: no wave-level parquets found'
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/plot_labor.parquet')

--- a/lsms_library/countries/Nigeria/_/categorical_mapping.org
+++ b/lsms_library/countries/Nigeria/_/categorical_mapping.org
@@ -781,3 +781,48 @@
 |  121 | Fish            | Fish     | fish            | FISH            | 121. FISH          | ---                | ---                |
 |  122 | Camel           | Camels   | camel           | CAMEL           | 122. CAMEL         | 122. CAMEL         | 122. CAMEL         |
 |  123 | Other Livestock | Other    | other (specify) | OTHER (SPECIFY) | 123. OTHER (SPECIFY) | 123. OTHER (SPECIFY) | 123. OTHER (SPECIFY) |
+
+* Labor (plot_labor + people_last7days, GAP 3)
+
+** harmonize_labor_source -- the plot_labor `source` axis
+
+  The plot_labor feature's ``source`` index level carries one of these
+  three Preferred Labels.  The country-level ``_/plot_labor.py`` script
+  emits the canonical label directly (mirroring how livestock emits the
+  harmonize_species label), so this table is the canonical REGISTRY for the
+  plot-labor source taxonomy.  Every GHS-Panel post-harvest plot labor
+  roster (secta2) splits reported plot labor into exactly these three
+  acquisition channels:
+  - ``family``  household-member labor (the worker-slot block, sa2q1[a-d]*).
+  - ``hired``   paid hired labor (man / woman / child blocks; carries Wage).
+  - ``other``   free / exchange labor (sa2q12a/b/c; no cash wage).
+
+#+NAME: harmonize_labor_source
+| Code | Preferred Label | Concept                                         |
+|------+-----------------+-------------------------------------------------|
+|    1 | family          | household-member labor (worker-slot roster)     |
+|    2 | hired           | paid hired labor (carries reported Wage)        |
+|    3 | other           | free / exchange labor (no cash wage)            |
+
+** harmonize_industry -- the people_last7days `Industry` axis
+
+  The people_last7days feature's ``Industry`` column carries one of these
+  Preferred Labels (the harmonized industry of a member's wage/main work;
+  ``<NA>`` for non-wage-workers / non-working-age).  The country-level
+  ``_/people_last7days.py`` script resolves each wave's native industry
+  code to the Preferred Label directly (W1-W4 the section-3 ``s3q14``
+  1--14 code grouping; W5 the ISIC-style ``s4aq41_code`` ranges), so this
+  table is the canonical REGISTRY for the wage-work industry taxonomy.
+  The grouping mirrors NGA_GHS{1..5}.do's ``ind_ag``..``ind_serv``
+  branches (no Fishing branch in the W1-W4 code list -> Fishing only
+  appears in W5).
+
+#+NAME: harmonize_industry
+| Code | Preferred Label | s3q14 (W1-W4) | s4aq41_code (W5) |
+|------+-----------------+---------------+------------------|
+|    1 | Agriculture     | 1             | 101--299         |
+|    2 | Fishing         | ---           | 301--399         |
+|    3 | Mining          | 2             | 501--999         |
+|    4 | Manufacturing   | 3--5          | 1010--4000       |
+|    5 | Construction    | 6             | 4100--4500       |
+|    6 | Services        | 7--14         | 4501--10000      |

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -270,4 +270,77 @@ Data Scheme:
     Age: float
     materialize: make
 
+  plot_labor:
+    # Item-level reported plot labor by source (GAP 3, grain 2) at natural
+    # grain (t, i, plot, source), source in {family, hired, other}.
+    # Source: the post-harvest plot labor roster secta2_harvest{wN} (W1-W3
+    # a single wide file with the sa2q* family-slot / hired man-woman-child
+    # / other scheme; W4 splits into secta2a family roster + secta2b
+    # hired/other).  This is the construct NGA_GHS{1..5}.do reads then
+    # collapses to total_labor_days / total_family_labor_days /
+    # total_hired_labor_days / hired_labor_value; we keep the PRE-collapse
+    # per-(plot, source) rows.  Country-level script (_/plot_labor.py)
+    # reshapes per wave -> materialize: make.
+    #
+    # Stores REPORTED item-level fields ONLY:
+    #   PersonDays  reported person-days of that source on the plot
+    #               (family = Sigma worker-slots #workers*days; hired/other
+    #               = Sigma man/woman/child #*days -- the per-group products
+    #               BEFORE the WB rowtotal/total collapse).
+    #   Wage        cash paid to hired labor = Sigma man/woman/child of
+    #               (reported daily wage * hired days).  NaN for
+    #               family / other (no cash wage reported).
+    # NO total_labor_days / total_family_labor_days / total_hired_labor_days
+    # / hired_labor_value -- those are SUM / median-wage TRANSFORMATIONS
+    # over these rows, NEVER stored here.
+    #
+    # `source` (index) is a harmonize_labor_source Preferred Label.  `v`
+    # auto-joins from sample() at API time (plot_labor is NOT in the
+    # framework `_no_v_join` set).  plot (= plotid, format_id) aligns with
+    # crop_production / plot_inputs on (t, i, plot); t = PH_QUARTER[wave]
+    # (post-harvest round).  PP-round plot labor (sect11c1_planting{wN}) is
+    # NOT folded in (would require a PP+PH SUM = the forbidden total).
+    # Wired W1-W4; W5 secta2 uses a divergent variable scheme (sa2aq1/2/3,
+    # sa2bq*_N) that the W4 helper / the W5 .do cannot read faithfully ->
+    # documented partial, follow-up.
+    index: (t, i, plot, source)
+    PersonDays: float
+    Wage: float
+    materialize: make
+
+  people_last7days:
+    # Item-level reported 7-day labor activity (GAP 3, grain 1) at natural
+    # grain (t, i, pid) [individual].  Nigeria LACKS this feature; built
+    # here mirroring the per-individual construct Uganda already exposes,
+    # from the GHS-Panel labor module (sect3_planting{wN} W1-W4 / s3aq*
+    # W2; sect4a_harvestw5 W5).  Country-level script
+    # (_/people_last7days.py) maps each wave's labor module -> materialize:
+    # make.
+    #
+    # Stores REPORTED per-individual fields ONLY (no household rollups):
+    #   farm_work / SOB_work / wage_work   0/1 did farm / own-business /
+    #                                      wage work in the last 7 days
+    #   farm_hrs / SB_hrs / wage_hrs       hours on each activity
+    #   Industry                           harmonized industry of wage work
+    #                                      (harmonize_industry Preferred
+    #                                      Label; <NA> for non-wage-workers)
+    #   working_age                        0/1 working-age filter (s3q1 /
+    #                                      s4aq1)
+    # `pid` matches household_roster's pid (raw indiv as string).  `v`
+    # auto-joins from sample() at API time (people_last7days is NOT in
+    # `_no_v_join`).  t is the round-quarter the labor module sits in
+    # (W1-W4 PP_QUARTER, W5 PH_QUARTER).  W1/W2 record hours only as
+    # job-1/job-2 totals (no per-activity split) -> a coarse joblogic split;
+    # W3-W5 have direct per-activity hours.
+    index: (t, i, pid)
+    farm_work: float
+    SOB_work: float
+    wage_work: float
+    farm_hrs: float
+    SB_hrs: float
+    wage_hrs: float
+    Industry: str
+    working_age: float
+    materialize: make
+
   nonfood_expenditures: !make

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -1258,3 +1258,413 @@ def anthropometry_for_wave(t, anthro, roster, weight_cols, height_cols,
     out = out.set_index(['t', 'i', 'pid']).sort_index()
     return out[['Weight', 'Height', 'Sex', 'Age']]
 
+
+# ---------------------------------------------------------------------
+# plot_labor (GAP 3, grain 2) -- item-level reported plot labor by source
+# ---------------------------------------------------------------------
+#
+# Natural grain (t, i, plot, source): one row per labor SOURCE used on a
+# plot, source in {family, hired, other}.  Source: the post-harvest plot
+# labor roster (secta2_harvest{wN}; W4/W5 split it into secta2a family +
+# secta2b hired/other).  This is the construct NGA_GHS{1..5}.do reads then
+# collapses to the household totals total_labor_days / total_family_labor_
+# days / total_hired_labor_days / hired_labor_value.  We keep the
+# PRE-collapse per-(plot, source) rows:
+#   PersonDays  reported person-days of that source on the plot.
+#               family = Sigma over worker slots of (#workers * days each)
+#                        (or days alone where #workers is missing -- mirrors
+#                        the WB `replace hh_labordays = days if persons==.`).
+#               hired  = Sigma over man/woman/child of (#hired * days each).
+#               other  = Sigma over man/woman/child of reported free/exchange
+#                        person-days.
+#   Wage        cash paid to hired labor on the plot = Sigma over
+#               man/woman/child of (reported daily wage * hired days).
+#               NaN for family / other (no cash wage reported).
+# NO total_labor_days / total_family_labor_days / total_hired_labor_days /
+# hired_labor_value -- those are HH / cross-source SUM / median-wage
+# transformations over these rows, NEVER stored here.
+#
+# `source` (index) carries a harmonize_labor_source Preferred Label
+# (family / hired / other).  `v` auto-joins from sample() at API time
+# (plot_labor is NOT in the framework `_no_v_join` set).  plot (= plotid,
+# format_id) aligns with crop_production / plot_inputs on (t, i, plot)
+# (post-harvest round; t = PH_QUARTER[wave], matching crop_production).
+#
+# PP-round plot labor (sect11c1_planting{wN}, W2-W5) is NOT included: it is
+# a SECOND round of the same source on the same plot, and folding it onto
+# the same (plot, source) row would require a PP+PH SUM (the forbidden
+# total) while a separate round level is outside the GAP-3 grain.  Documented
+# partial -- the PH roster is present and consistent for all five waves.
+
+LABOR_FAMILY = 'family'
+LABOR_HIRED = 'hired'
+LABOR_OTHER = 'other'
+
+
+def _num(df, col):
+    """pd.to_numeric on df[col] if present, else an all-NaN float Series."""
+    if col in df.columns:
+        return pd.to_numeric(df[col], errors='coerce')
+    return pd.Series(np.nan, index=df.index, dtype='float64')
+
+
+def _family_days_wide(df, slots=('a', 'b', 'c', 'd'),
+                      id_t='sa2q1{let}1', n_t='sa2q1{let}2', d_t='sa2q1{let}3'):
+    """Family person-days from the wide W1-W3 secta2 roster: Sigma over worker
+    slots a-d of (#workers * days), using days alone where #workers is
+    missing (mirrors NGA_GHS1.do:642-643).  NaN where no slot is filled."""
+    total = pd.Series(0.0, index=df.index)
+    any_slot = pd.Series(False, index=df.index)
+    for let in slots:
+        present = _num(df, id_t.format(let=let)).notna()
+        n = _num(df, n_t.format(let=let))
+        d = _num(df, d_t.format(let=let))
+        slot = (n * d).where(n.notna(), d)
+        total = total.add(slot.where(present, 0.0).fillna(0.0), fill_value=0.0)
+        any_slot = any_slot | present
+    return total.where(any_slot, np.nan)
+
+
+def _mwc_days(df, n_cols, d_cols):
+    """Sigma over (man, woman, child) of #persons * days.  n_cols / d_cols are
+    3-tuples of (count, days) column names.  NaN where no group is reported."""
+    total = pd.Series(0.0, index=df.index)
+    any_grp = pd.Series(False, index=df.index)
+    for nc, dc in zip(n_cols, d_cols):
+        n = _num(df, nc)
+        d = _num(df, dc)
+        total = total.add((n * d).fillna(0.0), fill_value=0.0)
+        any_grp = any_grp | n.notna()
+    return total.where(any_grp, np.nan)
+
+
+def _mwc_days_direct(df, d_cols):
+    """Sigma over (man, woman, child) of reported person-days (each a single
+    column, the W1-W3 `other` block sa2q12a/b/c).  NaN where none reported."""
+    total = pd.Series(0.0, index=df.index)
+    any_grp = pd.Series(False, index=df.index)
+    for dc in d_cols:
+        d = _num(df, dc)
+        total = total.add(d.fillna(0.0), fill_value=0.0)
+        any_grp = any_grp | d.notna()
+    return total.where(any_grp, np.nan)
+
+
+def _hired_cash(df, n_cols, d_cols, w_cols):
+    """Cash paid to hired labor = Sigma over (man, woman, child) of
+    (daily wage * hired person-days).  hired person-days for a group =
+    #hired * days.  NaN where no group reports both a wage and days."""
+    total = pd.Series(0.0, index=df.index)
+    any_pay = pd.Series(False, index=df.index)
+    for nc, dc, wc in zip(n_cols, d_cols, w_cols):
+        n = _num(df, nc)
+        d = _num(df, dc)
+        w = _num(df, wc)
+        days = n * d
+        pay = days * w
+        total = total.add(pay.fillna(0.0), fill_value=0.0)
+        any_pay = any_pay | (days.notna() & w.notna())
+    return total.where(any_pay, np.nan)
+
+
+def _plot_labor_assemble(t, hhid, plot, family, hired, other, wage):
+    """Build the (t, i, plot, source) frame from per-plot day/cash Series.
+
+    family / hired / other : person-days Series aligned to the plot rows.
+    wage : hired-labor cash Series (NaN for family/other rows).
+    Returns DataFrame indexed by (t, i, plot, source) with PersonDays, Wage.
+    """
+    i = hhid.apply(format_id)
+    p = plot.apply(format_id)
+    rows = []
+    for source, days in ((LABOR_FAMILY, family),
+                         (LABOR_HIRED, hired),
+                         (LABOR_OTHER, other)):
+        piece = pd.DataFrame({
+            'i': i.values,
+            'plot': p.values,
+            'source': source,
+            'PersonDays': pd.to_numeric(days, errors='coerce').values,
+        })
+        if source == LABOR_HIRED:
+            piece['Wage'] = pd.to_numeric(wage, errors='coerce').values
+        else:
+            piece['Wage'] = np.nan
+        rows.append(piece)
+    out = pd.concat(rows, ignore_index=True)
+    out['t'] = t
+    # Drop rows with no household / plot key or no reported person-days
+    # (a source not used on the plot -> no item row).
+    out = out[out['i'].notna() & out['plot'].notna() & out['PersonDays'].notna()]
+    out = out.sort_values(['i', 'plot', 'source'])
+    out = out.drop_duplicates(subset=['t', 'i', 'plot', 'source'], keep='first')
+    out = out.set_index(['t', 'i', 'plot', 'source']).sort_index()
+    return out[['PersonDays', 'Wage']]
+
+
+def plot_labor_wide(t, df):
+    """Assemble plot_labor for a W1-W3 wide secta2 PH labor roster
+    (sa2q* variable scheme; one row per (hhid, plotid))."""
+    family = _family_days_wide(df)
+    hired = _mwc_days(df, ('sa2q2', 'sa2q5', 'sa2q8'),
+                      ('sa2q3', 'sa2q6', 'sa2q9'))
+    other = _mwc_days_direct(df, ('sa2q12a', 'sa2q12b', 'sa2q12c'))
+    wage = _hired_cash(df, ('sa2q2', 'sa2q5', 'sa2q8'),
+                       ('sa2q3', 'sa2q6', 'sa2q9'),
+                       ('sa2q4', 'sa2q7', 'sa2q10'))
+    return _plot_labor_assemble(t, df['hhid'], df['plotid'],
+                                family, hired, other, wage)
+
+
+def plot_labor_split(t, fam_df, hired_df, fam_days_col='sa2aq1b',
+                     n_cols=('sa2bq2', 'sa2bq5', 'sa2bq8'),
+                     d_cols=('sa2bq3', 'sa2bq6', 'sa2bq9'),
+                     w_cols=('sa2bq4', 'sa2bq7', 'sa2bq10'),
+                     other_n=('sa2bq14a', 'sa2bq14b', 'sa2bq14c'),
+                     other_d=('sa2bq15a', 'sa2bq15b', 'sa2bq15c')):
+    """Assemble plot_labor for the W4 split PH roster: a long family roster
+    (secta2a, one row per family worker, days in `fam_days_col`) summed to
+    plot level, joined to the plot-level hired/other roster (secta2b).
+    Mirrors NGA_GHS4.do:788-838 (sa2aq*/sa2bq* scheme)."""
+    fam = fam_df.copy()
+    fam['_i'] = fam['hhid'].apply(format_id)
+    fam['_plot'] = fam['plotid'].apply(format_id)
+    fam['_days'] = pd.to_numeric(fam.get(fam_days_col), errors='coerce')
+    fam_plot = (fam.groupby(['_i', '_plot'])['_days']
+                .sum(min_count=1).rename('family').reset_index())
+
+    h = hired_df.copy()
+    h['_i'] = h['hhid'].apply(format_id)
+    h['_plot'] = h['plotid'].apply(format_id)
+    h['hired'] = _mwc_days(h, n_cols, d_cols).values
+    h['other'] = _mwc_days(h, other_n, other_d).values
+    h['wage'] = _hired_cash(h, n_cols, d_cols, w_cols).values
+    h_plot = h[['_i', '_plot', 'hired', 'other', 'wage']].drop_duplicates(
+        ['_i', '_plot'])
+
+    merged = fam_plot.merge(h_plot, on=['_i', '_plot'], how='outer')
+    hhid = merged['_i']
+    plot = merged['_plot']
+    # _i / _plot are already format_id-applied; pass through identity so
+    # _plot_labor_assemble's format_id is a no-op on the canonical strings.
+    family = merged['family']
+    hired = merged.get('hired')
+    other = merged.get('other')
+    wage = merged.get('wage')
+    rows = []
+    for source, days in ((LABOR_FAMILY, family),
+                         (LABOR_HIRED, hired),
+                         (LABOR_OTHER, other)):
+        piece = pd.DataFrame({
+            'i': hhid.values,
+            'plot': plot.values,
+            'source': source,
+            'PersonDays': pd.to_numeric(days, errors='coerce').values
+            if days is not None else np.nan,
+        })
+        piece['Wage'] = (pd.to_numeric(wage, errors='coerce').values
+                         if source == LABOR_HIRED and wage is not None else np.nan)
+        rows.append(piece)
+    out = pd.concat(rows, ignore_index=True)
+    out['t'] = t
+    out = out[out['i'].notna() & out['plot'].notna() & out['PersonDays'].notna()]
+    out = out.sort_values(['i', 'plot', 'source'])
+    out = out.drop_duplicates(subset=['t', 'i', 'plot', 'source'], keep='first')
+    out = out.set_index(['t', 'i', 'plot', 'source']).sort_index()
+    return out[['PersonDays', 'Wage']]
+
+
+# ---------------------------------------------------------------------
+# people_last7days (GAP 3, grain 1) -- individual 7-day activity
+# ---------------------------------------------------------------------
+#
+# Natural grain (t, i, pid): one row per household member, with the
+# reported last-7-days labor-activity items the WB code (NGA_GHS{1..5}.do
+# labor section) builds:
+#   farm_work / SOB_work / wage_work  0/1 did the member do farm work /
+#                                     own-business work / wage work in the
+#                                     last 7 days
+#   farm_hrs / SB_hrs / wage_hrs      hours spent on each (last 7 days)
+#   Industry                          harmonized industry of the member's
+#                                     wage/main work (harmonize_industry
+#                                     Preferred Label; <NA> for non-workers)
+#   working_age                       0/1 member is of working age (the WB
+#                                     `s3q1==1` / `s4aq1==1` filter)
+# Reported per-individual ONLY -- no household rollups.  `v` auto-joins
+# from sample() at API time (people_last7days is NOT in `_no_v_join`).
+# `pid` matches household_roster's pid (raw indiv as string).
+#
+# Per-wave source (the labor module):
+#   W1 2010-11  sect3_plantingw1   s3q* ; hours via job-type logic (s3q18/30)
+#   W2 2012-13  sect3a_plantingw2  s3aq*; hours via s3aq18/31
+#   W3 2015-16  sect3_plantingw3   s3q* ; hours direct s3q5b/6b/4b
+#   W4 2018-19  sect3_plantingw4   s3q* ; hours direct s3q5b/6b/4b
+#   W5 2023-24  sect4a_harvestw5   s4aq*; own scheme (post-harvest module)
+
+# WB industry grouping over the section-3 industry code (s3q14, 1-14):
+#   1 -> Agriculture; 2 -> Mining; 3-5 -> Manufacturing; 6 -> Construction;
+#   7-14 -> Services.  (No Fishing branch in this code list.)  Registered in
+#   harmonize_industry.  W5 uses ISIC-style s4aq41_code ranges instead.
+def _industry_from_s3q14(code):
+    c = pd.to_numeric(code, errors='coerce')
+    out = pd.Series(pd.NA, index=c.index, dtype='string')
+    out = out.mask(c == 1, 'Agriculture')
+    out = out.mask(c == 2, 'Mining')
+    out = out.mask(c.between(3, 5), 'Manufacturing')
+    out = out.mask(c == 6, 'Construction')
+    out = out.mask(c.between(7, 14), 'Services')
+    return out
+
+
+def _industry_from_isic(code):
+    """W5 ISIC-style code (s4aq41_code) -> harmonized industry label,
+    mirroring NGA_GHS5.do:1315-1320 ranges."""
+    c = pd.to_numeric(code, errors='coerce')
+    out = pd.Series(pd.NA, index=c.index, dtype='string')
+    out = out.mask((c > 100) & (c < 300), 'Agriculture')
+    out = out.mask((c > 300) & (c < 400), 'Fishing')
+    out = out.mask((c > 500) & (c < 1000), 'Mining')
+    out = out.mask((c >= 1010) & (c <= 4000), 'Manufacturing')
+    out = out.mask((c >= 4100) & (c <= 4500), 'Construction')
+    out = out.mask((c >= 4501) & (c <= 10000), 'Services')
+    return out
+
+
+def _dummy01(series, yes=1, no=2):
+    """Recode a yes/no item to 1.0/0.0 (yes->1, no->0); NaN otherwise."""
+    c = pd.to_numeric(series, errors='coerce')
+    out = pd.Series(np.nan, index=c.index, dtype='float64')
+    out = out.where(~(c == yes), 1.0)
+    out = out.where(~(c == no), 0.0)
+    return out
+
+
+def people_last7days_from_s3q(t, df, hhid='hhid', indiv='indiv',
+                              farm='s3q5', sob='s3q6', wage='s3q4',
+                              working='s3q1', industry='s3q14',
+                              hrs_mode='direct',
+                              farm_hrs='s3q5b', sb_hrs='s3q6b', wage_hrs='s3q4b',
+                              hour_job1='s3q18', hour_job2='s3q30'):
+    """Build people_last7days for a section-3 (s3q*/s3aq*) labor module.
+
+    hrs_mode='direct'  hours read straight from per-activity columns
+                       (W3/W4 s3q5b/6b/4b).
+    hrs_mode='joblogic' hours derived from job-1/job-2 totals (W1/W2):
+                       a coarse fallback -- assign the reported job hours to
+                       farm if the member did farm work, else to wage work,
+                       so per-activity hours are at least non-degenerate.
+    """
+    farm_work = _dummy01(df[farm]) if farm in df.columns else pd.Series(np.nan, index=df.index)
+    sob_work = _dummy01(df[sob]) if sob in df.columns else pd.Series(np.nan, index=df.index)
+    wage_work = _dummy01(df[wage]) if wage in df.columns else pd.Series(np.nan, index=df.index)
+    working_age = (pd.to_numeric(df[working], errors='coerce') == 1).astype('float64') \
+        if working in df.columns else pd.Series(np.nan, index=df.index)
+
+    if hrs_mode == 'direct':
+        fh = _num(df, farm_hrs)
+        sh = _num(df, sb_hrs)
+        wh = _num(df, wage_hrs)
+        # WB zeros the activity hours where the activity dummy is 'no'.
+        fh = fh.where(~(farm_work == 0), 0.0)
+        sh = sh.where(~(sob_work == 0), 0.0)
+        wh = wh.where(~(wage_work == 0), 0.0)
+    else:  # joblogic (W1/W2): coarse split of reported job hours
+        h1 = _num(df, hour_job1)
+        h2 = _num(df, hour_job2)
+        tot = h1.add(h2, fill_value=0).where(h1.notna() | h2.notna(), np.nan)
+        fh = tot.where(farm_work == 1, 0.0)
+        wh = tot.where((wage_work == 1) & ~(farm_work == 1), 0.0)
+        sh = tot.where((sob_work == 1) & ~(farm_work == 1) & ~(wage_work == 1), 0.0)
+
+    ind = (_industry_from_s3q14(df[industry])
+           if industry in df.columns
+           else pd.Series(pd.NA, index=df.index, dtype='string'))
+    # WB zeros activity items for non-working-age members; mirror by
+    # blanking work dummies / hours / industry where working_age==0.
+    notwa = (working_age == 0)
+    for s in (farm_work, sob_work, wage_work):
+        s.loc[notwa] = 0.0
+    for s in (fh, sh, wh):
+        s.loc[notwa] = 0.0
+    ind = ind.mask(notwa, pd.NA)
+    # Industry only meaningful for wage workers.
+    ind = ind.where(wage_work == 1, pd.NA)
+
+    out = pd.DataFrame({
+        'i': df[hhid].apply(format_id).values,
+        'pid': _to_pid(df[indiv]).values,
+        'farm_work': farm_work.values,
+        'SOB_work': sob_work.values,
+        'wage_work': wage_work.values,
+        'farm_hrs': fh.values,
+        'SB_hrs': sh.values,
+        'wage_hrs': wh.values,
+        'Industry': ind.values,
+        'working_age': working_age.values,
+    })
+    out['t'] = t
+    out = out[out['i'].notna() & out['pid'].notna()]
+    out = out.drop_duplicates(subset=['t', 'i', 'pid'], keep='first')
+    out = out.set_index(['t', 'i', 'pid']).sort_index()
+    return out[['farm_work', 'SOB_work', 'wage_work',
+                'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']]
+
+
+def people_last7days_from_s4aq(t, df, hhid='hhid', indiv='indiv'):
+    """Build people_last7days for the W5 post-harvest labor module
+    (sect4a_harvestw5, s4aq* scheme), mirroring NGA_GHS5.do:1299-1337."""
+    # farm_work = farmed for hh (s4aq10) OR worked on hh farm (s4aq11)
+    fw1 = _dummy01(df['s4aq10']) if 's4aq10' in df.columns else pd.Series(np.nan, index=df.index)
+    fw2 = _dummy01(df['s4aq11']) if 's4aq11' in df.columns else pd.Series(np.nan, index=df.index)
+    farm_work = pd.Series(np.nan, index=df.index, dtype='float64')
+    farm_work = farm_work.where(~((fw1 == 1) | (fw2 == 1)), 1.0)
+    farm_work = farm_work.where(~(fw1 == 0), 0.0)
+    sob_work = _dummy01(df['s4aq6']) if 's4aq6' in df.columns else pd.Series(np.nan, index=df.index)
+    # wage_work: a non-zero occupation code (s4aq40_code), zeroed where no
+    # wage work (s4aq32==2).
+    occ = pd.to_numeric(df.get('s4aq40_code'), errors='coerce')
+    wage_work = pd.Series(np.nan, index=df.index, dtype='float64')
+    wage_work = wage_work.where(~(occ == 0), 0.0)
+    wage_work = wage_work.where(~(occ > 0), 1.0)
+    if 's4aq32' in df.columns:
+        wage_work = wage_work.where(~(pd.to_numeric(df['s4aq32'], errors='coerce') == 2), 0.0)
+    working_age = (pd.to_numeric(df['s4aq1'], errors='coerce') == 1).astype('float64') \
+        if 's4aq1' in df.columns else pd.Series(np.nan, index=df.index)
+
+    farm_hrs = _num(df, 's4aq12')
+    sb_hrs = _num(df, 's4aq7')
+    wage_hrs = _num(df, 's4aq5')
+    if 's4aq11' in df.columns:
+        farm_hrs = farm_hrs.where(~(pd.to_numeric(df['s4aq11'], errors='coerce') == 2), 0.0)
+    if 's4aq6' in df.columns:
+        sb_hrs = sb_hrs.where(~(pd.to_numeric(df['s4aq6'], errors='coerce') == 2), 0.0)
+    if 's4aq4' in df.columns:
+        wage_hrs = wage_hrs.where(~(pd.to_numeric(df['s4aq4'], errors='coerce') == 2), 0.0)
+
+    ind = (_industry_from_isic(df['s4aq41_code'])
+           if 's4aq41_code' in df.columns
+           else pd.Series(pd.NA, index=df.index, dtype='string'))
+    notwa = (working_age == 0)
+    for s in (farm_work, sob_work, wage_work, farm_hrs, sb_hrs, wage_hrs):
+        s.loc[notwa] = 0.0
+    ind = ind.mask(notwa, pd.NA).where(wage_work == 1, pd.NA)
+
+    out = pd.DataFrame({
+        'i': df[hhid].apply(format_id).values,
+        'pid': _to_pid(df[indiv]).values,
+        'farm_work': farm_work.values,
+        'SOB_work': sob_work.values,
+        'wage_work': wage_work.values,
+        'farm_hrs': farm_hrs.values,
+        'SB_hrs': sb_hrs.values,
+        'wage_hrs': wage_hrs.values,
+        'Industry': ind.values,
+        'working_age': working_age.values,
+    })
+    out['t'] = t
+    out = out[out['i'].notna() & out['pid'].notna()]
+    out = out.drop_duplicates(subset=['t', 'i', 'pid'], keep='first')
+    out = out.set_index(['t', 'i', 'pid']).sort_index()
+    return out[['farm_work', 'SOB_work', 'wage_work',
+                'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']]
+

--- a/lsms_library/countries/Nigeria/_/people_last7days.py
+++ b/lsms_library/countries/Nigeria/_/people_last7days.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""Build item-level people_last7days for Nigeria GHS-Panel (GAP 3, grain 1).
+
+Natural grain (t, i, pid): one row per household member with the reported
+last-7-days labor-activity items the WB code (NGA_GHS{1..5}.do labor
+section) builds.  Nigeria LACKS this feature; we build it mirroring the
+construct Uganda already exposes (per-individual 7-day activity), so the
+six new GAP-3 countries match the one we already had.
+
+Stores REPORTED per-individual fields ONLY (no household rollups):
+  farm_work / SOB_work / wage_work  0/1 did farm / own-business / wage work
+  farm_hrs / SB_hrs / wage_hrs      hours on each activity (last 7 days)
+  Industry                          harmonized industry of wage work
+                                    (harmonize_industry Preferred Label;
+                                    <NA> for non-wage-workers)
+  working_age                       0/1 working-age filter (s3q1 / s4aq1)
+
+`pid` matches household_roster's pid (raw indiv as string); `v` auto-joins
+from sample() at API time (people_last7days is NOT in `_no_v_join`).
+
+Per-wave source (the labor module; one t per wave):
+  W1 2010-11  sect3_plantingw1   s3q* ; hours via job-type logic (PP round)
+  W2 2012-13  sect3a_plantingw2  s3aq*; hours via job-type logic (PP round)
+  W3 2015-16  sect3_plantingw3   s3q* ; direct hours s3q5b/6b/4b (PP round)
+  W4 2018-19  sect3_plantingw4   s3q* ; direct hours s3q5b/6b/4b (PP round)
+  W5 2023-24  sect4a_harvestw5   s4aq*; post-harvest labor module
+
+t is the round-quarter the module sits in: W1-W4 the post-planting quarter
+(PP_QUARTER), W5 the post-harvest quarter (PH_QUARTER), matching the round
+each labor module belongs to.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import (PP_QUARTER, PH_QUARTER,
+                     people_last7days_from_s3q, people_last7days_from_s4aq)
+
+pieces = []
+
+# ----------------------------- W1 2010-11 -----------------------------
+# s3q* scheme; hours only available as job-1/job-2 totals -> joblogic.
+t = PP_QUARTER['2010-11']
+raw = get_dataframe('../2010-11/Data/Post Planting Wave 1/Household/sect3_plantingw1.dta',
+                    convert_categoricals=False)
+pieces.append(people_last7days_from_s3q(
+    t, raw, farm='s3q5', sob='s3q6', wage='s3q4', working='s3q1',
+    industry='s3q14', hrs_mode='joblogic',
+    hour_job1='s3q18', hour_job2='s3q30'))
+
+# ----------------------------- W2 2012-13 -----------------------------
+# s3aq* scheme; hours job-1/job-2 totals (s3aq18 / s3aq31) -> joblogic.
+t = PP_QUARTER['2012-13']
+raw = get_dataframe('../2012-13/Data/Post Planting Wave 2/Household/sect3a_plantingw2.dta',
+                    convert_categoricals=False)
+pieces.append(people_last7days_from_s3q(
+    t, raw, farm='s3aq5', sob='s3aq6', wage='s3aq4', working='s3aq1',
+    industry='s3aq14', hrs_mode='joblogic',
+    hour_job1='s3aq18', hour_job2='s3aq31'))
+
+# ----------------------------- W3 2015-16 -----------------------------
+# s3q* scheme; direct per-activity hours s3q5b/6b/4b.
+t = PP_QUARTER['2015-16']
+raw = get_dataframe('../2015-16/Data/sect3_plantingw3.dta',
+                    convert_categoricals=False)
+pieces.append(people_last7days_from_s3q(
+    t, raw, farm='s3q5', sob='s3q6', wage='s3q4', working='s3q1',
+    industry='s3q14', hrs_mode='direct',
+    farm_hrs='s3q5b', sb_hrs='s3q6b', wage_hrs='s3q4b'))
+
+# ----------------------------- W4 2018-19 -----------------------------
+t = PP_QUARTER['2018-19']
+raw = get_dataframe('../2018-19/Data/sect3_plantingw4.dta',
+                    convert_categoricals=False)
+pieces.append(people_last7days_from_s3q(
+    t, raw, farm='s3q5', sob='s3q6', wage='s3q4', working='s3q1',
+    industry='s3q14', hrs_mode='direct',
+    farm_hrs='s3q5b', sb_hrs='s3q6b', wage_hrs='s3q4b'))
+
+# ----------------------------- W5 2023-24 -----------------------------
+# Post-harvest labor module (sect4a_harvestw5, s4aq* scheme).
+t = PH_QUARTER['2023-24']
+raw = get_dataframe('../2023-24/Data/Post Harvest Wave 5/Household/sect4a_harvestw5.dta',
+                    convert_categoricals=False)
+pieces.append(people_last7days_from_s4aq(t, raw))
+
+# ----------------------------- combine -------------------------------
+df = pd.concat(pieces, axis=0)
+df = df.sort_index()
+
+to_parquet(df, '../var/people_last7days.parquet')

--- a/lsms_library/countries/Nigeria/_/plot_labor.py
+++ b/lsms_library/countries/Nigeria/_/plot_labor.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+"""Build item-level plot_labor for Nigeria GHS-Panel (GAP 3, grain 2).
+
+Natural grain (t, i, plot, source): one row per labor SOURCE used on a
+plot, source in {family, hired, other}.  Source: the post-harvest plot
+labor roster secta2_harvest{wN} (W1-W3 a single wide file; W4/W5 split it
+into secta2a_harvest{wN} family + secta2b_harvest{wN} hired/other).  This
+is the construct NGA_GHS{1..5}.do reads then collapses to the household
+totals total_labor_days / total_family_labor_days / total_hired_labor_days
+/ hired_labor_value.  We keep the PRE-collapse per-(plot, source) rows.
+
+Stores REPORTED item-level fields ONLY:
+  PersonDays  reported person-days of that source on the plot
+              (family = Sigma slots #workers*days; hired/other = Sigma
+              man/woman/child #*days; mirrors the WB per-group products
+              BEFORE the rowtotal/total collapse).
+  Wage        cash paid to hired labor = Sigma man/woman/child of
+              (reported daily wage * hired days).  NaN for family/other.
+NO total_labor_days / total_family_labor_days / total_hired_labor_days /
+hired_labor_value -- those are SUM / median-wage transformations over
+these rows, NEVER stored here.
+
+`source` (index) is a harmonize_labor_source Preferred Label; `v`
+auto-joins from sample() at API time.  plot (= plotid, format_id) aligns
+with crop_production / plot_inputs on (t, i, plot); t = PH_QUARTER[wave]
+(post-harvest round, matching crop_production).
+
+Per-wave source structure:
+
+  W1 2010-11  secta2_harvestw1   wide sa2q* (family slots a-d, hired
+              man/woman/child, other sa2q12a/b/c).
+  W2 2012-13  secta2_harvestw2   wide sa2q* (same scheme as W1).
+  W3 2015-16  secta2_harvestw3   wide sa2q* (same scheme as W1).
+  W4 2018-19  secta2a_harvestw4  long family roster (sa2aq1b days);
+              secta2b_harvestw4  plot-level hired/other (sa2bq* scheme).
+  W5 2023-24  secta2a_harvestw5  long family roster (sa2aq* differs --
+              sa2aq1/2/3, NOT sa2aq1b); secta2b_harvestw5 (sa2bq*_N
+              indexed).  W5's secta2 variable scheme diverges sharply from
+              W4 and from the W5 .do (which still references W4 names), so
+              W5 plot_labor is left to a follow-up -- documented partial.
+
+PP-round plot labor (sect11c1_planting{wN}, W2-W5) is NOT included: it is
+a second round of the same source on the same plot; folding it onto the
+same (plot, source) row would need a PP+PH SUM (the forbidden total).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import (PH_QUARTER, plot_labor_wide, plot_labor_split)
+
+pieces = []
+
+# ----------------------------- W1 2010-11 -----------------------------
+t = PH_QUARTER['2010-11']
+f = '../2010-11/Data/Post Harvest Wave 1/Agriculture/secta2_harvestw1.dta'
+raw = get_dataframe(f, convert_categoricals=False)
+pieces.append(plot_labor_wide(t, raw))
+
+# ----------------------------- W2 2012-13 -----------------------------
+t = PH_QUARTER['2012-13']
+f = '../2012-13/Data/Post Harvest Wave 2/Agriculture/secta2_harvestw2.dta'
+raw = get_dataframe(f, convert_categoricals=False)
+pieces.append(plot_labor_wide(t, raw))
+
+# ----------------------------- W3 2015-16 -----------------------------
+t = PH_QUARTER['2015-16']
+f = '../2015-16/Data/secta2_harvestw3.dta'
+raw = get_dataframe(f, convert_categoricals=False)
+pieces.append(plot_labor_wide(t, raw))
+
+# ----------------------------- W4 2018-19 -----------------------------
+t = PH_QUARTER['2018-19']
+fam = get_dataframe('../2018-19/Data/secta2a_harvestw4.dta',
+                    convert_categoricals=False)
+hire = get_dataframe('../2018-19/Data/secta2b_harvestw4.dta',
+                     convert_categoricals=False)
+pieces.append(plot_labor_split(t, fam, hire))
+
+# ----------------------------- W5 2023-24 -----------------------------
+# secta2a_harvestw5 / secta2b_harvestw5 use a divergent variable scheme
+# (sa2aq1/2/3, sa2bq*_N) that neither the W4 helper nor the W5 .do (which
+# references W4-style names) can read faithfully.  Left as a documented
+# partial; the four earlier waves are wired.
+
+# ----------------------------- combine -------------------------------
+df = pd.concat(pieces, axis=0)
+df = df.sort_index()
+
+to_parquet(df, '../var/plot_labor.parquet')

--- a/lsms_library/countries/Tanzania/2019-20/_/people_last7days.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/people_last7days.py
@@ -1,0 +1,27 @@
+"""people_last7days for Tanzania NPS 2019-20 (NPS-SDD, Extended Panel;
+parity-loop GAP 3).
+
+Per-individual 7-day activity at grain (t, i, pid) from HH_SEC_E1, mirroring
+Uganda's people_last7days construct: work dummies (farm_work / SOB_work /
+wage_work), hours (farm_hrs / SB_hrs / wage_hrs), wage-work industry and
+working_age.  Source vars hh_e07/hh_e05/hh_e03 (7-day activity), hh_e08/hh_e06/
+hh_e04 (hours), hh_e31b_2 (ISIC sector), hh_e01_1 (working age); see
+``tanzania.people_last7days_for_wave``.  i/pid (sdd_hhid/sdd_indid) match the
+household_roster keys; the country-level concatenator applies id_walk and the
+framework joins ``v`` from sample().
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import people_last7days_for_wave
+
+
+sec = get_dataframe('../Data/HH_SEC_E1.dta', convert_categoricals=False)
+
+colmap = dict(hhid='sdd_hhid', pid='sdd_indid')
+
+df = people_last7days_for_wave('2019-20', sec, colmap)
+assert df.index.is_unique, "people_last7days 2019-20: (t,i,pid) not unique"
+assert len(df) > 0
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Tanzania/2019-20/_/plot_labor.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/plot_labor.py
@@ -1,0 +1,31 @@
+"""plot_labor for Tanzania NPS 2019-20 (NPS-SDD, Extended Panel;
+parity-loop GAP 3).
+
+Item-level plot labor at grain (t, i, plot_id, source) from AG_SEC_3A:
+  HIRED  -- ag3a_73 (hired y/n) + ag3a_74_{1,2,3}{a,b,c} (per-gender days per
+            task) and ag3a_74_{1,2,3}d (cash wage paid, TSH).
+  FAMILY -- the 2019-20 family-labor block records only the WORKER ROSTER IDs
+            per task (ag3a_72b/f/j_*), NOT days, so family person-days are not
+            reported this wave -> no family rows are emitted (we do not
+            fabricate; the WB NPS5.do rowtotals the ID columns, which we do not
+            reproduce).  Family days ARE reported in 2020-21.
+Emits raw sdd_hhid as ``i`` and the within-HH plotnum as ``plot_id`` (the same
+plot key as crop_production / plot_inputs, so plot_labor joins them on
+(t, i, plot_id)); the country-level concatenator applies id_walk and the
+framework joins ``v`` from sample().
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import plot_labor_for_wave
+
+
+sec3a = get_dataframe('../Data/AG_SEC_3A.dta', convert_categoricals=False)
+
+colmap = dict(hhid='sdd_hhid', plot='plotnum')
+
+df = plot_labor_for_wave('2019-20', sec3a, colmap)
+assert df.index.is_unique, "plot_labor 2019-20: (t,i,plot_id,source) not unique"
+assert len(df) > 0
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Tanzania/2020-21/_/people_last7days.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/people_last7days.py
@@ -1,0 +1,25 @@
+"""people_last7days for Tanzania NPS 2020-21 (NPS Y5 Refresh Panel;
+parity-loop GAP 3).
+
+Same HH_SEC_E1 module and variable names as 2019-20 (identical NPS
+questionnaire); only the file name (lowercase) and the household / individual
+id columns differ (y5_hhid / indidy5).  See
+``tanzania.people_last7days_for_wave`` for the schema.  i/pid match the
+household_roster keys; the country-level concatenator applies id_walk and the
+framework joins ``v`` from sample().
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import people_last7days_for_wave
+
+
+sec = get_dataframe('../Data/hh_sec_e1.dta', convert_categoricals=False)
+
+colmap = dict(hhid='y5_hhid', pid='indidy5')
+
+df = people_last7days_for_wave('2020-21', sec, colmap)
+assert df.index.is_unique, "people_last7days 2020-21: (t,i,pid) not unique"
+assert len(df) > 0
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Tanzania/2020-21/_/plot_labor.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/plot_labor.py
@@ -1,0 +1,28 @@
+"""plot_labor for Tanzania NPS 2020-21 (NPS Y5 Refresh Panel;
+parity-loop GAP 3).
+
+Same AG_SEC_3A module and variable names as 2019-20 (identical NPS
+questionnaire) for HIRED labor (ag3a_73 / ag3a_74_*).  The Y5 instrument
+ALSO records per-member FAMILY DAYS (ag3a_72c_* prep / ag3a_72g_* weeding /
+ag3a_72k_* harvest), so family rows ARE emitted this wave (unlike 2019-20,
+whose family block holds worker IDs only).  See ``tanzania.plot_labor_for_wave``
+for the schema.  File names are lowercase and the id columns differ
+(y5_hhid / plot_id).  Emits raw y5_hhid as ``i`` and the within-HH plot_id as
+``plot_id``; the country-level concatenator applies id_walk and the framework
+joins ``v`` from sample().
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import plot_labor_for_wave
+
+
+sec3a = get_dataframe('../Data/ag_sec_3a.dta', convert_categoricals=False)
+
+colmap = dict(hhid='y5_hhid', plot='plot_id')
+
+df = plot_labor_for_wave('2020-21', sec3a, colmap)
+assert df.index.is_unique, "plot_labor 2020-21: (t,i,plot_id,source) not unique"
+assert len(df) > 0
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Tanzania/_/Makefile
+++ b/lsms_library/countries/Tanzania/_/Makefile
@@ -102,6 +102,24 @@ $(VAR_DIR)/anthropometry.parquet: anthropometry.py $(anthropometry_parquet)
 ../%/_/anthropometry.parquet:
 	(cd $(@D) && python anthropometry.py)
 
+plot_labor = $(shell find $(rounds) -name plot_labor.py)
+plot_labor_parquet := $(plot_labor:.py=.parquet)
+
+$(VAR_DIR)/plot_labor.parquet: plot_labor.py $(plot_labor_parquet)
+	python plot_labor.py
+
+../%/_/plot_labor.parquet:
+	(cd $(@D) && python plot_labor.py)
+
+people_last7days = $(shell find $(rounds) -name people_last7days.py)
+people_last7days_parquet := $(people_last7days:.py=.parquet)
+
+$(VAR_DIR)/people_last7days.parquet: people_last7days.py $(people_last7days_parquet)
+	python people_last7days.py
+
+../%/_/people_last7days.parquet:
+	(cd $(@D) && python people_last7days.py)
+
 %.parquet: %.py CONTENTS.org tanzania.py
 	(cd $(@D) && python ./$(<F))
 

--- a/lsms_library/countries/Tanzania/_/data_scheme.yml
+++ b/lsms_library/countries/Tanzania/_/data_scheme.yml
@@ -214,6 +214,87 @@ Data Scheme:
     Improved: bool
     materialize: make
 
+  plot_labor:
+    # Item-level plot labor (parity-loop GAP 3, first of TWO labor grains) at
+    # the natural grain (t, i, plot_id, source) -- one row per (plot, source).
+    # Source from AG_SEC_3A; aligns plot_id with crop_production / plot_inputs
+    # so plot_labor joins them on (t, i, plot_id).
+    #   source : the labor source -- 'family' (household members' own days) or
+    #            'hired' (paid labor).  The GAP-3 schema also allows
+    #            'other'/'exchange' cross-country, but the NPS-SDD / Y5 AG_SEC_3A
+    #            instrument records NO free / exchange labor block, so no 'other'
+    #            rows arise for Tanzania (we do not fabricate them).  No raw-code
+    #            mapping is needed: the wave script emits the canonical 'family'
+    #            / 'hired' label directly.
+    #   PersonDays : REPORTED person-days of that source on the plot --
+    #                hired = Sum over the three farm tasks (Land Prep / Weeding /
+    #                Harvest) of the per-gender day cells ag3a_74_{1,2,3}{a,b,c};
+    #                family = Sum over members and tasks of the reported day
+    #                cells (2020-21: ag3a_72c_*/72g_*/72k_*).
+    #   Wage       : REPORTED cash wage PAID to hired labor (TSH), Sum over tasks
+    #                of ag3a_74_{1,2,3}d.  NaN for family rows (no cash wage).
+    # STORES REPORTED PERSON-DAYS / WAGE ONLY -- the WB aggregates
+    # total_labor_days / total_family_labor_days / total_hired_labor_days (sums
+    # over source) and hired_labor_value (median-wage valuation over the hired
+    # rows) are TRANSFORMATIONS, NEVER stored here.
+    # A per-cell plausibility clamp (>730 person-days per gender/task -> NaN)
+    # drops the ~0.7% of hired cells where a TSH value was typed into a day field
+    # (2020-21 ag3a_74_1c reaches 450000) -- same discipline livestock /
+    # plot_features use (GH #167).
+    # WAVE SCOPE: only 2019-20 (NPS-SDD Extended Panel) and 2020-21 (NPS Y5
+    # Refresh Panel) are buildable; the 2008-15 multi-round folder has no
+    # agriculture source on disk (same deferral as plot_features /
+    # crop_production / plot_inputs, GH #167).  FAMILY rows are emitted for
+    # 2020-21 only: the 2019-20 family-labor block records worker ROSTER IDs but
+    # NO days (ag3a_72b/f/j_*), so 2019-20 carries HIRED rows only -- we do not
+    # fabricate family person-days from the ID columns (which the WB NPS5.do
+    # erroneously rowtotals).  v (cluster) joins from sample() at API time --
+    # plot_labor is NOT in the framework _no_v_join set.
+    index: (t, i, plot_id, source)
+    PersonDays: float
+    Wage: float
+    materialize: make
+
+  people_last7days:
+    # Per-INDIVIDUAL 7-day activity (parity-loop GAP 3, second of TWO labor
+    # grains) at the natural grain (t, i, pid) -- one row per household member.
+    # NEW feature for Tanzania, mirroring Uganda's people_last7days construct
+    # (the one country that already has it).  Source HH_SEC_E1, following the WB
+    # NPS5.do labor block but using the LABEL-CORRECT dummy<->hours pairing (the
+    # .do swaps farm_hrs/wage_hrs relative to its own dummies; we pair each hours
+    # item with the activity it actually times, per the questionnaire labels).
+    #   farm_work / SOB_work / wage_work : REPORTED 7-day activity dummies --
+    #            did the member work in HH agriculture (hh_e07) / run an own
+    #            non-farm business (hh_e05) / work as a wage employee (hh_e03) in
+    #            the last 7 days.
+    #   farm_hrs / SB_hrs / wage_hrs : REPORTED hours in that activity in the
+    #            last 7 days (hh_e08 / hh_e06 / hh_e04); 0 where the matching
+    #            dummy is False.
+    #   industry : coarse ISIC class of the WAGE job (hh_e31b_2) -- Agriculture /
+    #            Fishing / Mining / Manufacturing / Construction / Services;
+    #            non-null only for wage workers (gated by hh_e28).
+    #   working_age : member is 5 years or above (hh_e01_1==1).  Below working
+    #            age, every activity dummy / hours is zeroed (the WB convention)
+    #            but the row is kept with working_age=False.
+    # REPORTED PER-INDIVIDUAL VALUES ONLY -- no household rollups / counts /
+    # labor-force-participation rates (those are transformations).
+    # WAVE SCOPE: 2019-20 and 2020-21 only.  2008-15 is deferred: its harmonised
+    # panel labor module (upd4_hh_e) is a "last 12 months" employment screen with
+    # NO 7-day HOURS items, so it cannot populate farm_hrs / SB_hrs / wage_hrs
+    # (the WB code reads the per-round raw SEC_B_C_D_E1_F_G1_U.dta 7-day `seq*`
+    # block, which is not the file present in our 2008-15 panel folder).
+    # i/pid match household_roster; v joins from sample() at API time.
+    index: (t, i, pid)
+    farm_work: bool
+    SOB_work: bool
+    wage_work: bool
+    farm_hrs: float
+    SB_hrs: float
+    wage_hrs: float
+    industry: str
+    working_age: bool
+    materialize: make
+
   livestock:
     # Item-level livestock herd (parity-loop GAP 4) at the natural grain
     # (t, i, animal) -- one row per species/animal-type the household OWNS,

--- a/lsms_library/countries/Tanzania/_/people_last7days.py
+++ b/lsms_library/countries/Tanzania/_/people_last7days.py
@@ -1,0 +1,47 @@
+"""Concatenate wave-level people_last7days data for Tanzania NPS
+(parity-loop GAP 3).
+
+Each buildable wave's ``Tanzania/<wave>/_/people_last7days.py`` produces a
+parquet with index ``(t, i, pid)`` and the canonical reported columns from
+data_scheme.yml (farm_work, SOB_work, wage_work, farm_hrs, SB_hrs, wage_hrs,
+industry, working_age).  This script concatenates the per-wave parquets and
+applies cross-wave id_walk so the household index uses the panel canonical id
+scheme.
+
+Only 2019-20 (NPS-SDD Extended Panel) and 2020-21 (NPS Y5 Refresh Panel) are
+buildable: the 2008-15 multi-round folder carries the HARMONISED panel labor
+module (upd4_hh_e), which is a "last 12 months" employment screen with NO 7-day
+HOURS items -- it cannot populate the farm_hrs / SB_hrs / wage_hrs columns this
+feature requires, so those four NPS rounds are deferred (the WB cleaning code
+reads the per-round raw SEC_B_C_D_E1_F_G1_U.dta with its 7-day `seq*` block,
+which is not the file present in our 2008-15 panel folder).
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import id_walk
+
+
+WAVES = ['2019-20', '2020-21']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/people_last7days.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built.  DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "people_last7days: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids, hh_index='i')
+
+to_parquet(p, '../var/people_last7days.parquet')

--- a/lsms_library/countries/Tanzania/_/plot_labor.py
+++ b/lsms_library/countries/Tanzania/_/plot_labor.py
@@ -1,0 +1,44 @@
+"""Concatenate wave-level plot_labor data for Tanzania NPS
+(parity-loop GAP 3).
+
+Each buildable wave's ``Tanzania/<wave>/_/plot_labor.py`` produces a parquet
+with index ``(t, i, plot_id, source)`` and the canonical reported columns from
+data_scheme.yml (PersonDays, Wage).  This script concatenates the per-wave
+parquets and applies cross-wave id_walk so the household index uses the panel
+canonical id scheme.
+
+Only 2019-20 (NPS-SDD Extended Panel) and 2020-21 (NPS Y5 Refresh Panel) are
+buildable: the 2008-15 multi-round folder has no agriculture source file on
+disk (only the household upd4_hh_* modules), so those four NPS rounds are
+deferred -- exactly as for plot_features / crop_production / plot_inputs
+(GH #167).
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import id_walk
+
+
+WAVES = ['2019-20', '2020-21']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/plot_labor.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built.  DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_labor: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids, hh_index='i')
+
+to_parquet(p, '../var/plot_labor.parquet')

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -1349,3 +1349,250 @@ def livestock_for_wave(t, lf, colmap):
         })
     out = out[LIVESTOCK_COLUMNS]
     return out
+
+
+# ---------------------------------------------------------------------------
+# Labor features (parity-loop GAP 3).  TWO distinct natural grains:
+#
+#   plot_labor        (t, i, plot_id, source)  -- plot-level person-days of
+#                     labor by source {family, hired}, from AG_SEC_3A, joins
+#                     crop_production / plot_inputs on (t, i, plot_id).
+#   people_last7days  (t, i, pid)              -- per-INDIVIDUAL 7-day activity
+#                     dummies / hours / wage-work industry, from HH_SEC_E1.
+#
+# Both store REPORTED person-level/plot-level fields ONLY.  The WB aggregate
+# constructs (total_labor_days / total_family_labor_days /
+# total_hired_labor_days = sums over plot_labor by source; hired_labor_value =
+# median-wage valuation over the hired rows) are TRANSFORMATIONS over these
+# rows, NEVER stored here.
+# ---------------------------------------------------------------------------
+
+# plot_labor at the natural grain (t, i, plot_id, source) -- one row per
+# (plot, source) -- carrying REPORTED person-days and (hired only) reported
+# cash wage.  source in {family, hired}; the GAP-3 schema also allows
+# {other/exchange} cross-country, but the NPS-SDD / Y5 AG_SEC_3A instrument
+# records no free / exchange labor block, so no 'other' rows arise for Tanzania
+# (we do not fabricate them).
+PLOT_LABOR_COLUMNS = ['PersonDays', 'Wage']
+
+# Plausibility ceiling for a per-(plot, gender, task) person-day cell.  A
+# single farm task in one season cannot legitimately absorb hundreds of
+# person-days from one gender group; values this large are data-entry errors
+# where a TSH wage amount was typed into a day field (2020-21 ag3a_74_1c reaches
+# 450000, ~0.7% of hired-labor plots carry such a corrupt cell).  Clamp cells
+# above 730 (two person-years) to NaN -- well above any plausible single-task
+# smallholder figure, so only the corrupt entries drop.  Same plausibility-clamp
+# discipline livestock / plot_features already use (GH #167).
+_PLOT_LABOR_DAY_CEILING = 730
+
+
+def _clamp_days(series):
+    """Coerce a reported person-day column to nullable Float64 (>=0; negatives
+    and values above the plausibility ceiling -> NaN)."""
+    v = pd.to_numeric(series, errors='coerce').astype('Float64')
+    return v.where((v >= 0) & (v <= _PLOT_LABOR_DAY_CEILING), pd.NA)
+
+
+def plot_labor_for_wave(t, sec3a, colmap):
+    """Build canonical ``plot_labor`` for one Tanzania NPS wave from AG_SEC_3A.
+
+    Item-level plot labor at grain (t, i, plot_id, source), source in
+    {family, hired}:
+
+      HIRED -- gated by ag3a_73 (did you hire labor? 1=yes/2=no).  PersonDays =
+        Sum over the three farm tasks (Land Prep / Weeding / Harvest, blocks
+        1/2/3) of the per-gender day cells ag3a_74_{1,2,3}{a,b,c} (woman / man /
+        child).  Wage = Sum over tasks of the cash paid ag3a_74_{1,2,3}d [TSH].
+        When ag3a_73==2 (no hired labor) PersonDays and Wage are 0.
+
+      FAMILY -- the household members' own reported days on the plot.  In
+        2020-21 (Y5) the questionnaire records per-member DAYS for each of the
+        three tasks (ag3a_72c_* prep / ag3a_72g_* weeding / ag3a_72k_*
+        harvest); PersonDays = the rowtotal over all member slots and tasks.
+        In 2019-20 (NPS-SDD) the family block records only the WORKER ROSTER IDs
+        per task (ag3a_72b/f/j_*) and NO day columns, so family person-days are
+        NOT reported that wave -- we emit NO family rows for 2019-20 rather than
+        fabricate a count (the WB NPS5.do rowtotals the ID columns as "days",
+        which we deliberately do NOT reproduce).  Wage is NaN for family rows.
+
+    Parameters
+    ----------
+    t : str            wave id ('2019-20' or '2020-21').
+    sec3a : pd.DataFrame   raw AG_SEC_3A (convert_categoricals=False).
+    colmap : dict with keys hhid, plot (the id columns: sdd_hhid/plotnum for
+        2019-20, y5_hhid/plot_id for 2020-21).
+
+    Returns
+    -------
+    pd.DataFrame indexed by (t, i, plot_id, source) with columns
+    PLOT_LABOR_COLUMNS (PersonDays, Wage).
+    """
+    c = colmap
+    hh = sec3a[c['hhid']].apply(format_id)
+    plot = sec3a[c['plot']].apply(format_id)
+
+    rows = []
+
+    # --- HIRED labor (ag3a_73 / ag3a_74_*) ------------------------------
+    hire_yn = pd.to_numeric(sec3a['ag3a_73'], errors='coerce')
+    day_cols = [f'ag3a_74_{task}{g}'
+                for task in (1, 2, 3) for g in ('a', 'b', 'c')]
+    wage_cols = [f'ag3a_74_{task}d' for task in (1, 2, 3)]
+    hired_days = pd.concat([_clamp_days(sec3a[col]) for col in day_cols],
+                           axis=1).sum(axis=1, min_count=1)
+    hired_wage = pd.concat(
+        [pd.to_numeric(sec3a[col], errors='coerce').astype('Float64')
+         for col in wage_cols],
+        axis=1).sum(axis=1, min_count=1)
+    # ag3a_73==2 -> the household hired no labor: 0 days, 0 wage.
+    hired_days = hired_days.where(hire_yn != 2, 0)
+    hired_wage = hired_wage.where(hire_yn != 2, 0)
+    hired = pd.DataFrame({
+        'i': hh.values, 'plot_id': plot.values, 'source': 'hired',
+        'PersonDays': hired_days.values, 'Wage': hired_wage.values,
+    })
+    # Keep a hired row only where the hire question was answered.
+    hired = hired[hire_yn.notna().values]
+    rows.append(hired)
+
+    # --- FAMILY labor -- DAYS only where the wave records them -----------
+    # 2020-21: ag3a_72c_* (prep) + ag3a_72g_* (weeding) + ag3a_72k_* (harvest).
+    fam_day_prefixes = ['ag3a_72c_', 'ag3a_72g_', 'ag3a_72k_']
+    fam_day_cols = [col for col in sec3a.columns
+                    if any(col.startswith(p) and col[len(p):].isdigit()
+                           for p in fam_day_prefixes)]
+    if fam_day_cols:
+        fam_days = pd.concat([_clamp_days(sec3a[col]) for col in fam_day_cols],
+                             axis=1).sum(axis=1, min_count=1)
+        family = pd.DataFrame({
+            'i': hh.values, 'plot_id': plot.values, 'source': 'family',
+            'PersonDays': fam_days.values,
+            'Wage': pd.array([pd.NA] * len(sec3a), dtype='Float64'),
+        })
+        # Keep a family row only where a day total is reported (>=0).
+        family = family[fam_days.notna().values]
+        rows.append(family)
+    # else (2019-20): family block is worker-IDs only, no days -> no family
+    # rows for this wave.
+
+    df = pd.concat([r for r in rows if r is not None and len(r)],
+                   ignore_index=True)
+    df['t'] = t
+    df = df.set_index(['t', 'i', 'plot_id', 'source'])
+    # Collapse the rare duplicate (t,i,plot_id,source): sum reported days,
+    # sum reported wage (min_count=1 keeps an all-NA group NA).
+    if not df.index.is_unique:
+        def _sum1(s):
+            return s.sum(min_count=1)
+        df = df.groupby(level=['t', 'i', 'plot_id', 'source']).agg({
+            'PersonDays': _sum1, 'Wage': _sum1,
+        })
+    df = df[PLOT_LABOR_COLUMNS]
+    return df
+
+
+# people_last7days at the natural grain (t, i, pid) -- one row per INDIVIDUAL,
+# carrying the REPORTED 7-day activity dummies / hours / wage-work industry,
+# mirroring Uganda's (the one country that already has this feature) construct.
+# Source HH_SEC_E1, following the NPS5.do labor block (lines 1026-1058) but
+# using the LABEL-CORRECT dummy<->hours pairing (the .do swaps farm_hrs/wage_hrs
+# relative to its own dummies; we pair each hours item with the activity it
+# actually times, per the questionnaire labels).
+PEOPLE_LAST7DAYS_COLUMNS = [
+    'farm_work', 'SOB_work', 'wage_work',
+    'farm_hrs', 'SB_hrs', 'wage_hrs',
+    'industry', 'working_age',
+]
+
+
+def _industry_from_isic(sec, isic_col, in_wage_emp):
+    """Classify the ISIC-division sector code (hh_e31b_2) into the canonical
+    coarse industry label, following the NPS .do ranges.  Only meaningful for
+    individuals in wage employment (``in_wage_emp`` True); others -> NA."""
+    s = pd.to_numeric(sec[isic_col], errors='coerce')
+    ind = pd.Series(pd.NA, index=sec.index, dtype='object')
+    ind = ind.mask((s == 1) | (s == 2), 'Agriculture')
+    ind = ind.mask(s == 3, 'Fishing')
+    ind = ind.mask((s >= 5) & (s <= 9), 'Mining')
+    ind = ind.mask((s >= 10) & (s <= 37), 'Manufacturing')
+    ind = ind.mask((s >= 41) & (s <= 43), 'Construction')
+    ind = ind.mask((s >= 45) & (s <= 4000), 'Services')
+    ind = ind.where(in_wage_emp.fillna(False), pd.NA)
+    return ind.astype('string')
+
+
+def people_last7days_for_wave(t, sec, colmap):
+    """Build canonical ``people_last7days`` for one Tanzania NPS wave.
+
+    Per-individual 7-day activity at grain (t, i, pid) from HH_SEC_E1:
+      farm_work  = hh_e07 (worked in HH agriculture, last 7 days)  1->1 / 2->0
+      SOB_work   = hh_e05 (ran an own non-farm business, last 7 days)
+      wage_work  = hh_e03 (worked as a wage employee, last 7 days)
+      farm_hrs   = hh_e08 (hours in HH ag),  0 if farm_work==0
+      SB_hrs     = hh_e06 (hours in own business), 0 if SOB_work==0
+      wage_hrs   = hh_e04 (hours in wage work), 0 if wage_work==0
+      industry   = coarse ISIC class of the wage job (hh_e31b_2), wage workers
+                   only (gated by hh_e28, "is the answer to wage-work Q yes?")
+      working_age= hh_e01_1==1 (member is 5 years or above)
+    All dummies / hours are set to 0 for members below working age, mirroring
+    the WB .do (every activity is zeroed when working_age==0).
+
+    Parameters
+    ----------
+    t : str            wave id ('2019-20' or '2020-21').
+    sec : pd.DataFrame    raw HH_SEC_E1 (convert_categoricals=False).
+    colmap : dict with keys hhid, pid (sdd_hhid/sdd_indid for 2019-20,
+        y5_hhid/indidy5 for 2020-21).
+
+    Returns
+    -------
+    pd.DataFrame indexed by (t, i, pid) with columns PEOPLE_LAST7DAYS_COLUMNS.
+    """
+    c = colmap
+    working_age = (pd.to_numeric(sec['hh_e01_1'], errors='coerce') == 1)
+
+    def _dummy(col):
+        v = pd.to_numeric(sec[col], errors='coerce').astype('Int64')
+        return v.map({1: True, 2: False}).astype('boolean')
+
+    def _hrs(col, work_dummy):
+        v = pd.to_numeric(sec[col], errors='coerce').astype('Float64')
+        # hours are meaningful only for those who did the activity; set 0 where
+        # the activity dummy is False (matching the .do gating).
+        return v.where(work_dummy.fillna(False), 0)
+
+    farm_work = _dummy('hh_e07')
+    sob_work = _dummy('hh_e05')
+    wage_work = _dummy('hh_e03')
+    in_wage_emp = (pd.to_numeric(sec['hh_e28'], errors='coerce') == 1)
+
+    out = pd.DataFrame({
+        'i': sec[c['hhid']].apply(format_id).values,
+        'pid': sec[c['pid']].apply(format_id).values,
+        'farm_work': farm_work.values,
+        'SOB_work': sob_work.values,
+        'wage_work': wage_work.values,
+        'farm_hrs': _hrs('hh_e08', farm_work).values,
+        'SB_hrs': _hrs('hh_e06', sob_work).values,
+        'wage_hrs': _hrs('hh_e04', wage_work).values,
+        'industry': _industry_from_isic(sec, 'hh_e31b_2', in_wage_emp).values,
+        'working_age': working_age.values,
+    })
+
+    # Below working age: zero every activity dummy / hours (the .do convention),
+    # but keep the row -- working_age itself stays the truthful flag.
+    not_wa = ~out['working_age']
+    for col in ('farm_work', 'SOB_work', 'wage_work'):
+        out.loc[not_wa, col] = False
+    for col in ('farm_hrs', 'SB_hrs', 'wage_hrs'):
+        out.loc[not_wa, col] = 0
+    out.loc[not_wa, 'industry'] = pd.NA
+
+    out['working_age'] = out['working_age'].astype('boolean')
+    out['t'] = t
+    out = out.set_index(['t', 'i', 'pid'])
+    # Drop rows whose every activity field is null (no labor screen answered).
+    if not out.index.is_unique:
+        out = out.groupby(level=['t', 'i', 'pid']).first()
+    out = out[PEOPLE_LAST7DAYS_COLUMNS]
+    return out

--- a/lsms_library/countries/Uganda/2009-10/_/plot_labor.py
+++ b/lsms_library/countries/Uganda/2009-10/_/plot_labor.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""plot_labor for Uganda UNPS 2009-10 (GAP 3 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules via
+get_dataframe and emits a canonical (t,i,plot,source,season) parquet of
+REPORTED plot-labor person-days (PersonDays) and the reported hired wage
+(Wage).  Source axis in {family, hired, other}.  See uganda.LABOR_COLMAPS
+for the per-wave column map.  Only REPORTED person-days are kept -- the WB
+per-parcel total_*_labor_days sums and median-wage hired_labor_value are
+transformations, never stored here.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_labor_for_wave, LABOR_COLMAPS
+
+t = '2009-10'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/AGSEC3A.dta')
+df3b = _try('../Data/AGSEC3B.dta')
+
+df = plot_labor_for_wave(t, df3a, df3b, LABOR_COLMAPS[t])
+assert len(df) > 0, f"plot_labor produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_labor index for {t}"
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Uganda/2010-11/_/plot_labor.py
+++ b/lsms_library/countries/Uganda/2010-11/_/plot_labor.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""plot_labor for Uganda UNPS 2010-11 (GAP 3 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules via
+get_dataframe and emits a canonical (t,i,plot,source,season) parquet of
+REPORTED plot-labor person-days (PersonDays) and the reported hired wage
+(Wage).  Source axis in {family, hired, other}.  See uganda.LABOR_COLMAPS
+for the per-wave column map.  Only REPORTED person-days are kept -- the WB
+per-parcel total_*_labor_days sums and median-wage hired_labor_value are
+transformations, never stored here.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_labor_for_wave, LABOR_COLMAPS
+
+t = '2010-11'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/AGSEC3A.dta')
+df3b = _try('../Data/AGSEC3B.dta')
+
+df = plot_labor_for_wave(t, df3a, df3b, LABOR_COLMAPS[t])
+assert len(df) > 0, f"plot_labor produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_labor index for {t}"
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Uganda/2011-12/_/plot_labor.py
+++ b/lsms_library/countries/Uganda/2011-12/_/plot_labor.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""plot_labor for Uganda UNPS 2011-12 (GAP 3 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules via
+get_dataframe and emits a canonical (t,i,plot,source,season) parquet of
+REPORTED plot-labor person-days (PersonDays) and the reported hired wage
+(Wage).  Source axis in {family, hired, other}.  See uganda.LABOR_COLMAPS
+for the per-wave column map.  Only REPORTED person-days are kept -- the WB
+per-parcel total_*_labor_days sums and median-wage hired_labor_value are
+transformations, never stored here.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_labor_for_wave, LABOR_COLMAPS
+
+t = '2011-12'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/AGSEC3A.dta')
+df3b = _try('../Data/AGSEC3B.dta')
+
+df = plot_labor_for_wave(t, df3a, df3b, LABOR_COLMAPS[t])
+assert len(df) > 0, f"plot_labor produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_labor index for {t}"
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Uganda/2013-14/_/plot_labor.py
+++ b/lsms_library/countries/Uganda/2013-14/_/plot_labor.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""plot_labor for Uganda UNPS 2013-14 (GAP 3 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules via
+get_dataframe and emits a canonical (t,i,plot,source,season) parquet of
+REPORTED plot-labor person-days (PersonDays) and the reported hired wage
+(Wage).  Source axis in {family, hired, other}.  See uganda.LABOR_COLMAPS
+for the per-wave column map.  Only REPORTED person-days are kept -- the WB
+per-parcel total_*_labor_days sums and median-wage hired_labor_value are
+transformations, never stored here.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_labor_for_wave, LABOR_COLMAPS
+
+t = '2013-14'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/AGSEC3A.dta')
+df3b = _try('../Data/AGSEC3B.dta')
+
+df = plot_labor_for_wave(t, df3a, df3b, LABOR_COLMAPS[t])
+assert len(df) > 0, f"plot_labor produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_labor index for {t}"
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Uganda/2015-16/_/plot_labor.py
+++ b/lsms_library/countries/Uganda/2015-16/_/plot_labor.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""plot_labor for Uganda UNPS 2015-16 (GAP 3 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules via
+get_dataframe and emits a canonical (t,i,plot,source,season) parquet of
+REPORTED plot-labor person-days (PersonDays) and the reported hired wage
+(Wage).  Source axis in {family, hired, other}.  See uganda.LABOR_COLMAPS
+for the per-wave column map.  Only REPORTED person-days are kept -- the WB
+per-parcel total_*_labor_days sums and median-wage hired_labor_value are
+transformations, never stored here.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_labor_for_wave, LABOR_COLMAPS
+
+t = '2015-16'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/AGSEC3A.dta')
+df3b = _try('../Data/AGSEC3B.dta')
+
+df = plot_labor_for_wave(t, df3a, df3b, LABOR_COLMAPS[t])
+assert len(df) > 0, f"plot_labor produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_labor index for {t}"
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Uganda/2018-19/_/plot_labor.py
+++ b/lsms_library/countries/Uganda/2018-19/_/plot_labor.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""plot_labor for Uganda UNPS 2018-19 (GAP 3 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules via
+get_dataframe and emits a canonical (t,i,plot,source,season) parquet of
+REPORTED plot-labor person-days (PersonDays) and the reported hired wage
+(Wage).  Source axis in {family, hired, other}.  See uganda.LABOR_COLMAPS
+for the per-wave column map.  Only REPORTED person-days are kept -- the WB
+per-parcel total_*_labor_days sums and median-wage hired_labor_value are
+transformations, never stored here.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_labor_for_wave, LABOR_COLMAPS
+
+t = '2018-19'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/AGSEC3A.dta')
+df3b = _try('../Data/AGSEC3B.dta')
+
+df = plot_labor_for_wave(t, df3a, df3b, LABOR_COLMAPS[t])
+assert len(df) > 0, f"plot_labor produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_labor index for {t}"
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Uganda/2019-20/_/plot_labor.py
+++ b/lsms_library/countries/Uganda/2019-20/_/plot_labor.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""plot_labor for Uganda UNPS 2019-20 (GAP 3 item-level build).
+
+Reads AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules via
+get_dataframe and emits a canonical (t,i,plot,source,season) parquet of
+REPORTED plot-labor person-days (PersonDays) and the reported hired wage
+(Wage).  Source axis in {family, hired, other}.  See uganda.LABOR_COLMAPS
+for the per-wave column map.  Only REPORTED person-days are kept -- the WB
+per-parcel total_*_labor_days sums and median-wage hired_labor_value are
+transformations, never stored here.
+"""
+import sys
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import plot_labor_for_wave, LABOR_COLMAPS
+
+t = '2019-20'
+
+def _try(path):
+    try:
+        return get_dataframe(path, convert_categoricals=False)
+    except Exception:
+        return None
+
+df3a = _try('../Data/Agric/agsec3a.dta')
+df3b = _try('../Data/Agric/agsec3b.dta')
+
+df = plot_labor_for_wave(t, df3a, df3b, LABOR_COLMAPS[t])
+assert len(df) > 0, f"plot_labor produced no rows for {t}"
+assert df.index.is_unique, f"Non-unique plot_labor index for {t}"
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Uganda/_/Makefile
+++ b/lsms_library/countries/Uganda/_/Makefile
@@ -25,6 +25,7 @@ var = $(VAR_DIR)/shocks.parquet $(VAR_DIR)/nonfood_expenditures.parquet $(VAR_DI
 	  $(VAR_DIR)/plot_features.parquet \
 	  $(VAR_DIR)/crop_production.parquet \
 	  $(VAR_DIR)/plot_inputs.parquet \
+	  $(VAR_DIR)/plot_labor.parquet \
 	  $(VAR_DIR)/livestock.parquet \
 	  $(VAR_DIR)/anthropometry.parquet \
 	  $(VAR_DIR)/months_food_inadequate.parquet
@@ -96,6 +97,12 @@ plot_inputs_parquet := $(plot_inputs:.py=.parquet)
 
 $(VAR_DIR)/plot_inputs.parquet: plot_inputs.py $(plot_inputs_parquet)
 	python plot_inputs.py
+
+plot_labor = $(shell find $(rounds) -name plot_labor.py)
+plot_labor_parquet := $(plot_labor:.py=.parquet)
+
+$(VAR_DIR)/plot_labor.parquet: plot_labor.py $(plot_labor_parquet)
+	python plot_labor.py
 
 livestock = $(shell find $(rounds) -name livestock.py)
 livestock_parquet := $(livestock:.py=.parquet)

--- a/lsms_library/countries/Uganda/_/data_scheme.yml
+++ b/lsms_library/countries/Uganda/_/data_scheme.yml
@@ -255,4 +255,65 @@ Data Scheme:
       optional: true
     Age_months: float
     materialize: make
+  plot_labor:
+    # Item-level plot-labor module (GAP 3 parity build).  One row per
+    # REPORTED labor source on a plot-season.  Source: AGSEC3A (season 1) +
+    # AGSEC3B (season 2) plot-input modules -- the SAME files plot_inputs
+    # reads, whose labor block the WB code (UGA_UNPS1.do:467-509, and the
+    # corresponding block in UNPS2..8) reads only to build the per-parcel
+    # SUM columns total_labor_days / total_family_labor_days /
+    # total_hired_labor_days and the median-wage hired_labor_value.  We keep
+    # the PRE-collapse REPORTED person-days -- strictly richer than the WB
+    # construct, and those sums / the wage valuation are TRANSFORMATIONS,
+    # never stored here.
+    #
+    # Grain (t, i, plot, source, season):
+    #   plot   — hhid-parcel-plot, mirroring the WB harmonised plot_id and
+    #            the crop_production / plot_inputs / plot_features plot key
+    #            (join on (t, i, plot)); its parcel component is the parcel
+    #            plot_features keys on.
+    #   source — the labor identity, a tiny controlled vocabulary emitted
+    #            directly by the builder (uganda.LABOR_SOURCES): 'family'
+    #            (household labor), 'hired' (paid labor), 'other' (exchange /
+    #            communal labor — only recorded in 2011-12).  NOT a
+    #            categorical_mapping table: the label is assigned by the
+    #            builder, not decoded from a raw survey code.
+    #   season — 'A' (first season) / 'B' (second season).  Carried in the
+    #            grain (as in crop_production) because the same plot id
+    #            appears in BOTH AGSEC3A and AGSEC3B for ~64% of plots and the
+    #            labor question is per plot-season; collapsing the two seasons
+    #            into one (plot, source) row would require summing across
+    #            seasons (a transformation).
+    #
+    # Columns are REPORTED values only (missing-in-wave -> NaN):
+    #   PersonDays — reported person-days of that source on the plot-season.
+    #                For 'hired' / 'other' this is the row-sum of the survey's
+    #                own man/woman/child day cells of ONE labor question (the
+    #                reported quantity that question measures); for 'family' in
+    #                2013-14/2015-16 it is the row-sum of the per-family-worker
+    #                day cells of one question.  It is NOT a cross-plot /
+    #                cross-source aggregate (total_*_labor_days are those, and
+    #                stay in transformations).
+    #   Wage       — reported cash paid to HIRED labor (the survey's q43/q36
+    #                wage cell).  NaN on family / other rows.
+    #
+    # Coverage (family / hired availability per wave):
+    #   2009-10, 2010-11  family (q39) + hired (q42a-c) + wage (q43)
+    #   2011-12           family (q32) + hired (q35a-c) + wage (q36) + OTHER
+    #                     (exchange q47-q49) — the only wave with 'other'
+    #   2013-14, 2015-16  family (q33a_1..e_1) + hired (q35a-c) + wage (q36)
+    #   2018-19           hired (s3aq35a-c) + wage (s3aq36) ONLY — the WB code
+    #                     sets family to missing; AGSEC3B labor block absent so
+    #                     no season-B rows
+    #   2019-20           hired (s3aq35a-c) + wage (s3aq36) for BOTH seasons;
+    #                     NO family rows (family roster is in a separate
+    #                     AGSEC3A_1 file not in-repo) — documented partial
+    #
+    # No v level baked in: v auto-joins from sample() at API time (plot_labor
+    # is NOT in the framework _no_v_join set).  2005-06 is excluded (no
+    # plot-input/labor module; the UNPS panel starts at 2009-10).
+    index: (t, i, plot, source, season)
+    PersonDays: float
+    Wage: float
+    materialize: make
   nonfood_expenditures: !make

--- a/lsms_library/countries/Uganda/_/plot_labor.py
+++ b/lsms_library/countries/Uganda/_/plot_labor.py
@@ -1,0 +1,44 @@
+"""Concatenate wave-level plot_labor data for Uganda (GAP 3).
+
+Each wave's ``Uganda/<wave>/_/plot_labor.py`` produces a parquet indexed
+``(t, i, plot, source, season)`` with the REPORTED plot-labor columns
+(PersonDays, Wage).  This script concatenates them across waves and applies
+cross-wave id_walk so the household index uses the panel canonical id scheme.
+
+Source: AGSEC3A (season 1) + AGSEC3B (season 2) plot-input modules -- the
+labor block the WB code (UGA_UNPS1.do:467-509) reads only to build the
+per-parcel total_labor_days / total_family_labor_days / total_hired_labor_days
+SUM columns and the median-wage hired_labor_value.  We keep the PRE-collapse
+REPORTED person-days; those sums and the wage valuation are transformations,
+not stored here.
+
+2005-06 is intentionally absent: it has no plot-input/labor module (the UNPS
+agriculture panel starts at wave 1 = 2009-10).
+"""
+import json
+
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from uganda import Waves, id_walk
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/plot_labor.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for plot_labor (no .py / parquet, e.g. 2005-06).
+        # DVC raises PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "plot_labor: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+updated_ids = json.load(open('updated_ids.json'))
+p = id_walk(p, updated_ids)
+
+to_parquet(p, '../var/plot_labor.parquet')

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -1880,3 +1880,250 @@ ANTHRO_FILES = {
     '2018-19': '../Data/GSEC6_5.dta',
     '2019-20': '../Data/HH/gsec6_5.dta',
 }
+
+
+# ---------------------------------------------------------------------------
+# plot_labor  (GAP 3 — item-level plot-labor person-days)
+# ---------------------------------------------------------------------------
+#
+# One row per REPORTED labor source on a plot-season, grain
+# (t, i, plot, source, season).  Source: the AGSEC3A (season 1) / AGSEC3B
+# (season 2) plot-input modules -- the SAME files plot_inputs reads -- whose
+# labor block the WB code (UGA_UNPS1.do:467-509, and the corresponding block
+# in UNPS2..8) reads only to build the per-parcel SUM columns
+# total_labor_days / total_family_labor_days / total_hired_labor_days and the
+# median-wage hired_labor_value.  We keep the PRE-collapse REPORTED rows:
+#   PersonDays  -- reported person-days of that source on the plot-season
+#   Wage        -- reported cash paid to HIRED labor (NaN for family/other)
+# The WB sums and median-wage valuation are TRANSFORMATIONS, never stored here
+# (total_labor_days = groupby(['t','i']).PersonDays.sum(); hired_labor_value =
+# median-wage x hired PersonDays).
+#
+# ``source`` is a tiny controlled vocabulary emitted directly by this builder
+# (no per-wave code lookup needed) -- the three canonical labels below.  It is
+# NOT a categorical_mapping table because the builder assigns the label, it is
+# not decoded from a raw survey code.
+LABOR_SOURCES = ('family', 'hired', 'other')
+
+# ``season`` is carried in the grain (mirroring crop_production) because the
+# SAME (hhid-parcel-plot) plot id appears in BOTH AGSEC3A and AGSEC3B for ~64%
+# of plots, and the labor question is asked per plot-SEASON.  Collapsing the
+# two seasons into one (plot, source) row would require summing across seasons
+# -- a transformation.  Keeping ``season`` in {A, B} preserves the reported
+# per-plot-season rows.  ``plot`` itself is the bare hhid-parcel-plot (no
+# season suffix) so a plot_labor row joins crop_production / plot_inputs /
+# plot_features on (t, i, plot) [+ season for crop_production].
+
+# Per-wave column maps for plot_labor_for_wave.  Three questionnaire vintages:
+#
+#   2009-10 / 2010-11 (UNPS1/2):
+#     family  q39  (single cell, person-days)   gate used q38 (q38==0 -> 0)
+#     hired   q42a/q42b/q42c (man/woman/child)  gate hired-flag q41 (q41==2 -> 0)
+#     wage    q43
+#   2011-12 (UNPS3):
+#     family  q32  (single cell)                no separate gate
+#     hired   q35a/q35b/q35c                     gate q34 (q34==2 -> 0)
+#     wage    q36
+#     other   q47/q48/q49 (exchange man/woman/child days)  [only this wave]
+#   2013-14 / 2015-16 (UNPS4/5):
+#     family  q33a_1 .. q33e_1 (up to 5 family-worker day cells)  no gate
+#     hired   q35a/q35b/q35c                     gate q34 (q34==2 -> 0)
+#     wage    q36
+#   2018-19 (UNPS7):
+#     family  ABSENT  (the WB code sets total_family_labor_days = .)
+#     hired   s3aq35a/b/c                        gate s3aq34 (==2 -> 0)
+#     wage    s3aq36
+#     season B: the AGSEC3B labor block is not present (only s3bq35b), so no
+#               season-B labor rows are emitted for this wave.
+#   2019-20 (UNPS8):
+#     family  in a SEPARATE AGSEC3A_1 family-roster file that is NOT in-repo,
+#             so no family rows are emitted (documented partial).
+#     hired   s3aq35a/b/c                        gate s3aq34 (==2 -> 0)
+#     wage    s3aq36
+#
+# Prefix is the only season-B difference (a3aq->a3bq, s3aq->s3bq) except the
+# 2011-12 "other" cells, which are upper-case A3AQ47.. / A3BQ47.. in the raw
+# .dta.  Each season sub-map names: hhid/parcel/plot id columns, the family
+# day cell(s) (``family`` -> list), the hired day cells (``hired`` -> list) +
+# its used-flag (``hired_flag``), the ``wage`` cell, and the optional ``other``
+# day cells (``other`` -> list).  A missing key means that source is not
+# recorded for that wave/season.
+LABOR_COLMAPS = {
+    '2009-10': {
+        'A': {'hhid': 'HHID', 'parcel': 'a3aq1', 'plot': 'a3aq3',
+              'family': ['a3aq39'], 'family_flag': 'a3aq38',
+              'hired': ['a3aq42a', 'a3aq42b', 'a3aq42c'], 'hired_flag': 'a3aq41',
+              'wage': 'a3aq43'},
+        'B': {'hhid': 'HHID', 'parcel': 'a3bq1', 'plot': 'a3bq3',
+              'family': ['a3bq39'], 'family_flag': 'a3bq38',
+              'hired': ['a3bq42a', 'a3bq42b', 'a3bq42c'], 'hired_flag': 'a3bq41',
+              'wage': 'a3bq43'},
+    },
+    '2010-11': {
+        'A': {'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid',
+              'family': ['a3aq39'], 'family_flag': 'a3aq38',
+              'hired': ['a3aq42a', 'a3aq42b', 'a3aq42c'], 'hired_flag': 'a3aq41',
+              'wage': 'a3aq43'},
+        'B': {'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid',
+              'family': ['a3bq39'], 'family_flag': 'a3bq38',
+              'hired': ['a3bq42a', 'a3bq42b', 'a3bq42c'], 'hired_flag': 'a3bq41',
+              'wage': 'a3bq43'},
+    },
+    '2011-12': {
+        'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+              'family': ['a3aq32'],
+              'hired': ['a3aq35a', 'a3aq35b', 'a3aq35c'], 'hired_flag': 'a3aq34',
+              'wage': 'a3aq36',
+              'other': ['A3AQ47', 'A3AQ48', 'A3AQ49']},
+        'B': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+              'family': ['a3bq32'],
+              'hired': ['a3bq35a', 'a3bq35b', 'a3bq35c'], 'hired_flag': 'a3bq34',
+              'wage': 'a3bq36',
+              'other': ['A3BQ47', 'A3BQ48', 'A3BQ49']},
+    },
+    '2013-14': {
+        'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+              'family': ['a3aq33a_1', 'a3aq33b_1', 'a3aq33c_1', 'a3aq33d_1', 'a3aq33e_1'],
+              'hired': ['a3aq35a', 'a3aq35b', 'a3aq35c'], 'hired_flag': 'a3aq34',
+              'wage': 'a3aq36'},
+        'B': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+              'family': ['a3bq33a_1', 'a3bq33b_1', 'a3bq33c_1', 'a3bq33d_1', 'a3bq33e_1'],
+              'hired': ['a3bq35a', 'a3bq35b', 'a3bq35c'], 'hired_flag': 'a3bq34',
+              'wage': 'a3bq36'},
+    },
+    '2015-16': {
+        'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+              'family': ['a3aq33a_1', 'a3aq33b_1', 'a3aq33c_1', 'a3aq33d_1', 'a3aq33e_1'],
+              'hired': ['a3aq35a', 'a3aq35b', 'a3aq35c'], 'hired_flag': 'a3aq34',
+              'wage': 'a3aq36'},
+        'B': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
+              'family': ['a3bq33a_1', 'a3bq33b_1', 'a3bq33c_1', 'a3bq33d_1', 'a3bq33e_1'],
+              'hired': ['a3bq35a', 'a3bq35b', 'a3bq35c'], 'hired_flag': 'a3bq34',
+              'wage': 'a3bq36'},
+    },
+    '2018-19': {
+        # No family-labor cells; season-B labor block absent (only s3bq35b).
+        'A': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+              'hired': ['s3aq35a', 's3aq35b', 's3aq35c'], 'hired_flag': 's3aq34',
+              'wage': 's3aq36'},
+    },
+    '2019-20': {
+        # Family labor lives in a separate AGSEC3A_1 roster not in-repo.
+        'A': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+              'hired': ['s3aq35a', 's3aq35b', 's3aq35c'], 'hired_flag': 's3aq34',
+              'wage': 's3aq36'},
+        'B': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
+              'hired': ['s3bq35a', 's3bq35b', 's3bq35c'], 'hired_flag': 's3bq34',
+              'wage': 's3bq36'},
+    },
+}
+
+
+def _labor_persondays(df, cols, flag_col=None, flag_zero_code=None):
+    """Sum the REPORTED person-day cells in ``cols`` row-wise (NaN where ALL
+    cells are missing, mirroring Stata ``egen rowtotal(), missing``).  When a
+    ``flag_col`` is given, set the result to 0 where the flag equals
+    ``flag_zero_code`` (the survey "did you use this source? No" branch), again
+    mirroring the WB ``replace ... = 0 if flag==code`` logic.
+
+    The sum is over the survey's own disaggregated cells of a SINGLE labor
+    question (man/woman/child day cells, or per-family-worker day cells); it is
+    the reported person-day quantity that question measures, NOT a cross-row /
+    cross-plot aggregate (those stay in transformations)."""
+    present = [c for c in cols if c in df.columns]
+    if not present:
+        return pd.Series([np.nan] * len(df), index=df.index)
+    block = df[present].apply(lambda s: pd.to_numeric(s, errors='coerce'))
+    # rowtotal(..., missing): NaN only when every cell is NaN, else sum.
+    out = block.sum(axis=1, min_count=1)
+    if flag_col is not None and flag_col in df.columns and flag_zero_code is not None:
+        flag = _to_int_code(df[flag_col])
+        out = out.where(flag != flag_zero_code, 0.0)
+    return out
+
+
+def plot_labor_for_wave(t, df3a, df3b, colmap):
+    """Build canonical ``plot_labor`` for one Uganda UNPS wave.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2011-12"``).
+    df3a, df3b : pd.DataFrame | None
+        Raw AGSEC3A (season 1) / AGSEC3B (season 2) plot-input modules,
+        loaded with ``convert_categoricals=False`` so code columns carry
+        integer codes.  ``None`` permitted (season absent).
+    colmap : dict
+        Per-wave column map; see ``LABOR_COLMAPS``.
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, i, plot, source, season)`` with REPORTED
+    columns ``PersonDays`` (Float64) and ``Wage`` (Float64, hired rows only;
+    NaN for family/other).  One row per (plot, source, season) with a non-NaN
+    reported PersonDays value.
+    """
+    pieces = []
+    for season, df3 in (('A', df3a), ('B', df3b)):
+        if df3 is None or len(df3) == 0:
+            continue
+        cm = (colmap or {}).get(season)
+        if not cm:
+            continue
+        hh = df3[cm['hhid']].apply(format_id)
+        parcel = df3[cm['parcel']].apply(format_id)
+        plot = (df3[cm['plot']].apply(format_id)
+                if cm.get('plot') and cm['plot'] in df3.columns
+                else pd.Series([''] * len(df3), index=df3.index))
+        plot_id = hh.astype(str) + '-' + parcel.astype(str) + '-' + plot.astype(str)
+
+        # Reported person-days per source (one Series each, aligned to df3).
+        source_days = {}
+        if cm.get('family'):
+            source_days['family'] = _labor_persondays(
+                df3, cm['family'], cm.get('family_flag'),
+                flag_zero_code=0 if cm.get('family_flag') else None)
+        if cm.get('hired'):
+            source_days['hired'] = _labor_persondays(
+                df3, cm['hired'], cm.get('hired_flag'), flag_zero_code=2)
+        if cm.get('other'):
+            source_days['other'] = _labor_persondays(df3, cm['other'])
+
+        # Reported hired wage (cash paid to hired labor).
+        wage = (pd.to_numeric(df3[cm['wage']], errors='coerce')
+                if cm.get('wage') and cm['wage'] in df3.columns
+                else pd.Series([np.nan] * len(df3), index=df3.index))
+
+        for source, days in source_days.items():
+            piece = pd.DataFrame({
+                't': t,
+                'i': hh.values,
+                'plot': plot_id.values,
+                'source': source,
+                'season': season,
+                'PersonDays': days.values,
+                'Wage': (wage.values if source == 'hired'
+                         else np.full(len(df3), np.nan)),
+            })
+            # Keep only rows with a reported person-day value (drop the
+            # question-not-asked NaNs); a plot with 0 reported days for a
+            # source that WAS asked is a genuine reported zero and stays.
+            piece = piece[piece['PersonDays'].notna()]
+            if len(piece):
+                pieces.append(piece)
+
+    if not pieces:
+        return pd.DataFrame(
+            columns=['PersonDays', 'Wage'],
+            index=pd.MultiIndex.from_arrays(
+                [[]] * 5, names=['t', 'i', 'plot', 'source', 'season']))
+
+    out = pd.concat(pieces, ignore_index=True)
+    out['PersonDays'] = out['PersonDays'].astype('Float64')
+    out['Wage'] = out['Wage'].astype('Float64')
+    # Collapse exact-duplicate (plot, source, season) keys that can arise when
+    # a wave repeats a plot row; keep the max reported days / wage so the index
+    # is unique without summing distinct reported observations.
+    out = (out.groupby(['t', 'i', 'plot', 'source', 'season'], dropna=False)
+              .agg({'PersonDays': 'max', 'Wage': 'max'}))
+    return out


### PR DESCRIPTION
GAP 3: two distinct labor grains. `plot_labor` (t,i,plot,source) ×7 — reported PersonDays by {family,hired,other} source + hired Wage. `people_last7days` (t,i,pid) ×6 (Uganda already had it) — per-individual 7-day work dummies/hours/industry. total_labor_days / hired_labor_value stay `transformations`, never stored. Grains kept separate; `v` auto-joins; no framework edits. Documented partials (Nigeria W5 divergent vars; Tanzania panel rounds — like ag siblings). Independent cold-build of all 13 green; adversary PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>