### PR TITLE
feat(parity): GAP C — item-level community_prices (t,v,j,u) across 6 LSMS-ISA countries

### DIFF
--- a/lsms_library/countries/Ethiopia/2011-12/_/community_prices.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/community_prices.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""Build community_prices for Ethiopia ESS 2011-12 (Wave 1; GAP C).
+
+Item-level surveyed FOOD prices at (t, v, j, u) from the §10 community
+price questionnaire.  W1 fields the price list at TWO retail outlets
+(sect10b1 = primary 'Marketplace', sect10b2 = secondary 'Shops/Stalls');
+we wire the primary outlet ONLY, to keep one market per cluster and the
+strict (t, v, j, u) grain consistent with W2-W5 (each a single price file
+per EA).  b2 adds only ~4 EAs and is intentionally left for a future
+multi-outlet extension if wanted.
+
+W1 specifics: item (cs10b1q07_b) and unit (cs10b1q07_d) are value LABELS;
+price = Birr (cs10b1q07_f1) + cents (cs10b1q07_f2)/100; quantity basis =
+whole (cs10b1q07_e1) + decimal (cs10b1q07_e2)/1000.  v = ea_id (matches
+sample().v for W1).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import community_prices_for_wave
+
+
+prices = get_dataframe('../Data/sect10b1_com_w1.dta', convert_categoricals=True)
+
+colmap = dict(
+    v='ea_id',
+    item='cs10b1q07_b',
+    unit='cs10b1q07_d',
+    price_whole='cs10b1q07_f1', price_cents='cs10b1q07_f2',
+    qty_whole='cs10b1q07_e1',   qty_decimal='cs10b1q07_e2',
+)
+
+df = community_prices_for_wave('2011-12', prices, colmap)
+
+assert len(df) > 0, "community_prices 2011-12 produced no rows"
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Ethiopia/2013-14/_/community_prices.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/community_prices.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""Build community_prices for Ethiopia ESS 2013-14 (Wave 2; GAP C).
+
+Item-level surveyed FOOD prices at (t, v, j, u) from the §10 community
+price questionnaire.  W2 uses a single price file (sect10b2_com_w2;
+sect10b1 carries the retail-outlet metadata).  Item (cs10b2q01) and unit
+(cs10b2q03) are value LABELS; bare Weight (cs10b2q04) and Price
+(cs10b2q05).  v = ea_id2 (the wave-2 EA id that matches sample().v;
+the W1-era ea_id does NOT).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import community_prices_for_wave
+
+
+prices = get_dataframe('../Data/sect10b2_com_w2.dta', convert_categoricals=True)
+
+colmap = dict(
+    v='ea_id2',
+    item='cs10b2q01',
+    unit='cs10b2q03',
+    price='cs10b2q05',
+    quantity='cs10b2q04',
+)
+
+df = community_prices_for_wave('2013-14', prices, colmap)
+
+assert len(df) > 0, "community_prices 2013-14 produced no rows"
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Ethiopia/2015-16/_/community_prices.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/community_prices.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""Build community_prices for Ethiopia ESS 2015-16 (Wave 3; GAP C).
+
+Item-level surveyed FOOD prices at (t, v, j, u) from the §10 community
+price questionnaire.  W3 uses a single price file (sect10a2_com_w3;
+sect10a1 carries the retail-outlet metadata).  Item (cs10a2q01) and unit
+(cs10a2q03) are raw LABEL strings (no Stata value labels); bare Weight
+(cs10a2q04) and Price (cs10a2q05).  v = ea_id2 (the wave-3 EA id that
+matches sample().v).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import community_prices_for_wave
+
+
+prices = get_dataframe('../Data/sect10a2_com_w3.dta', convert_categoricals=True)
+
+colmap = dict(
+    v='ea_id2',
+    item='cs10a2q01',
+    unit='cs10a2q03',
+    price='cs10a2q05',
+    quantity='cs10a2q04',
+)
+
+df = community_prices_for_wave('2015-16', prices, colmap)
+
+assert len(df) > 0, "community_prices 2015-16 produced no rows"
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Ethiopia/2018-19/_/community_prices.py
+++ b/lsms_library/countries/Ethiopia/2018-19/_/community_prices.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""Build community_prices for Ethiopia ESS 2018-19 (Wave 4; GAP C).
+
+Item-level surveyed FOOD prices at (t, v, j, u) from the §10 community
+price questionnaire (sect10b_com_w4).  Item (cs10bq02) and unit
+(cs10bq03) value-LABELS carry a numeric code prefix ("1. Teff",
+"1. Kilogram") that the shared helper strips before the crosswalk.  The
+availability gate cs10bq00 ("is this item available in the market") is
+honored -- rows not flagged "1. Yes" are dropped.  Bare Weight (cs10bq04)
+and Price (cs10bq05).  v = ea_id (matches sample().v for W4).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import community_prices_for_wave
+
+
+prices = get_dataframe('../Data/sect10b_com_w4.dta', convert_categoricals=True)
+
+colmap = dict(
+    v='ea_id',
+    item='cs10bq02',
+    unit='cs10bq03',
+    price='cs10bq05',
+    quantity='cs10bq04',
+    avail='cs10bq00', avail_yes='Yes',
+)
+
+df = community_prices_for_wave('2018-19', prices, colmap)
+
+assert len(df) > 0, "community_prices 2018-19 produced no rows"
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Ethiopia/2021-22/_/community_prices.py
+++ b/lsms_library/countries/Ethiopia/2021-22/_/community_prices.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""Build community_prices for Ethiopia ESS 2021-22 (Wave 5; GAP C).
+
+Item-level surveyed FOOD prices at (t, v, j, u) from the §10 community
+price questionnaire (sect10b_com_w5).  Structure identical to W4: item
+(cs10bq02) and unit (cs10bq03) value-LABELS carry a numeric code prefix
+("1. Teff", "1. Kilogram") stripped by the shared helper; availability
+gate cs10bq00 ("1. Yes" / "2. No") honored; bare Weight (cs10bq04) and
+Price (cs10bq05).  v = ea_id (matches sample().v for W5).
+"""
+import sys
+
+sys.path.append('../../_/')
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import community_prices_for_wave
+
+
+prices = get_dataframe('../Data/sect10b_com_w5.dta', convert_categoricals=True)
+
+colmap = dict(
+    v='ea_id',
+    item='cs10bq02',
+    unit='cs10bq03',
+    price='cs10bq05',
+    quantity='cs10bq04',
+    avail='cs10bq00', avail_yes='Yes',
+)
+
+df = community_prices_for_wave('2021-22', prices, colmap)
+
+assert len(df) > 0, "community_prices 2021-22 produced no rows"
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Ethiopia/_/Makefile
+++ b/lsms_library/countries/Ethiopia/_/Makefile
@@ -20,7 +20,7 @@ var = \
       $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/crop_production.parquet \
       $(VAR_DIR)/plot_inputs.parquet $(VAR_DIR)/livestock.parquet \
       $(VAR_DIR)/anthropometry.parquet $(VAR_DIR)/plot_labor.parquet \
-      $(VAR_DIR)/people_last7days.parquet
+      $(VAR_DIR)/people_last7days.parquet $(VAR_DIR)/community_prices.parquet
 
 all: panel_ids.json updated_ids.json $(parquet) $(var)
 
@@ -157,6 +157,20 @@ people_last7days_parquet := $(people_last7days:.py=.parquet)
 
 $(VAR_DIR)/people_last7days.parquet: people_last7days.py $(people_last7days_parquet)
 	python people_last7days.py
+
+# community_prices (GAP C; ESS §10 community price questionnaire, item-level
+# surveyed FOOD prices at the cluster grain (t, v, j, u)).  Mirrors the
+# crop_production convention: the framework's grab_data calls
+# `make ../<wave>/_/community_prices.parquet`, whose pattern rule runs the
+# wave script; the VAR_DIR rule concatenates them via the country script.
+community_prices = $(shell find $(rounds) -name community_prices.py)
+community_prices_parquet := $(community_prices:.py=.parquet)
+
+../%/_/community_prices.parquet: ../%/_/community_prices.py
+	(cd $(@D) && python community_prices.py)
+
+$(VAR_DIR)/community_prices.parquet: community_prices.py $(community_prices_parquet)
+	python community_prices.py
 
 $(VAR_DIR)/fct.parquet $(VAR_DIR)/nutrition.parquet: nutrition.py categorical_mapping.org $(VAR_DIR)/food_acquired.parquet
 	python nutrition.py

--- a/lsms_library/countries/Ethiopia/_/categorical_mapping.org
+++ b/lsms_library/countries/Ethiopia/_/categorical_mapping.org
@@ -442,6 +442,103 @@ gaps (crop/harvest units, community-price units) extend these rows.
 | Zorba/Akara Large                  | Zorba/Akara Large                  |
 | Zorba/Akara Medium                 | Zorba/Akara Medium                 |
 | Zorba/Akara Small                  | Zorba/Akara Small                  |
+| Set                                | Set                                |
+| Spoon                              | Spoon                              |
+| Trip                               | Trip                               |
+| Ticket                             | Ticket                             |
+| Frequency                          | Frequency                          |
+| Service                            | Service                            |
+| Meter                              | Meter                              |
+| Meter square                       | Meter square                       |
+| Kilograms (kg)                     | Kg                                 |
+| KILOGRAM                           | Kg                                 |
+| Litre                              | Liter                              |
+| Littere                            | Liter                              |
+| Mili littere                       | Mili Liter                         |
+| Milliliter                         | Mili Liter                         |
+| Centimeter (cm)                    | Cm                                 |
+| Cubic centimeter (cm3)             | Cubic Centimeter                   |
+| Cubic Centimete                    | Cubic Centimeter                   |
+| cubic centimete                    | Cubic Centimeter                   |
+| PACKETS                            | Packets                            |
+| Pices                              | Pieces                             |
+| pices                              | Pieces                             |
+| Set(Mulu)                          | Set                                |
+| Sibisib(set)                       | Set                                |
+| spoon(mankia)                      | Spoon                              |
+| Tiket                              | Ticket                             |
+| Travel(mililis)                    | Trip                               |
+| Digigimosh                         | Other (Specify)                    |
+| pair/tind                          | Pair                               |
+| Siny                               | Sini Small                         |
+| box                                | Box                                |
+| gram                               | Gram                               |
+| centimeter                         | Cm                                 |
+| meter                              | Meter                              |
+| Piece/number Small                 | Piece/Number Small                 |
+| Piece/number Medium                | Piece/Number Medium                |
+| Piece/number Large                 | Piece/Number Large                 |
+
+* harmonize_community_price (the community-price j axis -- GAP C, community_prices)
+
+Item crosswalk for the ESS community/market price questionnaire (Section
+10; the price module is ``sect10b1_com`` W1, ``sect10b2_com`` W2,
+``sect10a2_com`` W3, ``sect10b_com`` W4/W5).  Maps the per-wave surveyed
+item string (the Stata value label the categorical read surfaces, after
+stripping any ``"N. "`` numeric code prefix -- note the community item
+CODES are a DIFFERENT numbering from the food_acquired item codes, so the
+join is on the LABEL, not the code) to a Preferred Label.
+
+The Preferred Labels deliberately REUSE the labels already in the
+``harmonize_food`` table so ``community_prices.j`` JOINS ``food_acquired.j``
+(consumption) and ``crop_production.j`` (harvest) on the shared label.
+Only FOOD items are mapped: the community module also prices many non-food
+goods (Charcoal, Firewood, Kerosene, soap, Matches, Batteries, Cigarettes,
+ploughs, the Mofer/Sickle/Axe farm tools, Mosquito net, Bicycle, local-bus
+transport, Chemical fertilizer, Pesticides, Herbicides), which have NO
+``harmonize_food`` label and are intentionally dropped by the wave script
+(this is the community-FOOD-price arm of label unification).  The crosswalk
+only needs rows where the surveyed string DIFFERS from its Preferred Label
+(casing / spelling / Stata truncation / code-prefix variants); exact-match
+food strings (Teff, Maize, Sorghum, Barley, Millet, Coffee, Onion, Banana,
+Potato, Kocho, Milk, Eggs, Sugar, Salt, Bula, Cheese, Beer, Tea, Tomato,
+Orange, Cassava, Godere, Sweet potato, Mango, Lentils, Linseed, Horsebeans,
+...) pass through unchanged when the wave script falls back to the raw
+stripped label.
+
+#+name: harmonize_community_price
+| Original Label                                     | Preferred Label     |
+|----------------------------------------------------+---------------------|
+| Chat / Kat                                         | Chat/Kat            |
+| Boya/Yam                                           | Boye/Yam            |
+| Chick pea                                          | Chick Pea           |
+| Field pea                                          | Field Pea           |
+| Haricot beans                                       | Haricot Beans      |
+| Niger seed                                         | Niger Seed          |
+| Oils (processed)                                   | Oils                |
+| Peanut                                             | Ground nuts         |
+| Peanut/ nut                                        | Ground nuts         |
+| Green chili pepper (kariya)                        | Kariya              |
+| Green chili pepper (                               | Kariya              |
+| Red pepper (berbere)                               | Berbere             |
+| Red pepper (Processed pepper (Berbere))            | Berbere             |
+| Greens (kale, cabbag                               | Leafy Greens        |
+| kale, cabbage, Pumpikn Leaf, Lettuce, spinach      | Leafy Greens        |
+| Soft drink                                         | Soda                |
+| Soft drinks/Soda                                   | Soda                |
+| Other cereals(Specif                               | Other cereal        |
+| Other Cereals                                      | Other cereal        |
+| Other fruit (SPECIFY                               | Other fruit         |
+| Other fruit (SPECIFY)                              | Other fruit         |
+| ther fruit (SPECIFY                                | Other fruit         |
+| Other pulse or nut(S                               | Other pulse or nut  |
+| Other pulse or nut (SPECIFY)                       | Other pulse or nut  |
+| Other seed (SPECIFY)                               | Other seed          |
+| Other Oil seeds (specify)                          | Other seed          |
+| Other tuber or stem (SPECIFY)                      | Other tuber or stem |
+| Other vegetable (SPE                               | Other vegetable     |
+| Other vegetable (SPECIFY)                          | Other vegetable     |
+| odere                                              | Godere              |
 
 * harmonize_crop (the crop j axis -- GAP 1, crop_production)
 

--- a/lsms_library/countries/Ethiopia/_/community_prices.py
+++ b/lsms_library/countries/Ethiopia/_/community_prices.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""Concatenate wave-level community_prices data for Ethiopia (GAP C).
+
+Each wave's ``Ethiopia/<wave>/_/community_prices.py`` produces a parquet
+with index ``(t, v, j, u)`` and columns (Price, Quantity) -- the surveyed
+cluster FOOD price from the §10 community price questionnaire.  This
+script concatenates them across the five ESS waves.
+
+Grain is ``(t, v, j, u)`` -- CLUSTER-level, with NO household ``i``.  So,
+unlike crop_production / livestock / plot_* (which carry ``i`` and need
+the cross-wave ``id_walk`` to align with the panel household scheme),
+community_prices needs NO id conversion: ``v`` is the EA/cluster id and
+already lives in the SAME keyspace as ``sample().v`` for the same wave
+(ea_id for W1/W4/W5, ea_id2 for W2/W3 -- emitted by the wave scripts to
+match cluster_features / sample()).  The framework's ``_join_v_from_sample``
+does NOT apply (it gates on ``i`` being in the index), so ``v`` is native
+and joins households via ``sample()`` at query time.
+
+``j`` carries ``harmonize_food`` Preferred Labels and ``u`` the shared
+``u`` table labels, so community_prices joins ``food_acquired`` /
+``crop_production`` on the shared (j, u) axes.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from ethiopia import Waves
+
+
+pieces = []
+for t in Waves.keys():
+    fn = f'../{t}/_/community_prices.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet built / parquet absent (DVC raises PathMissingError).
+        continue
+    pieces.append(df)
+
+assert pieces, "community_prices: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/community_prices.parquet')

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -386,6 +386,49 @@ Data Scheme:
     working_age: bool
     materialize: make
 
+  community_prices:
+    # GAP C (maintainer priority) -- item-level SURVEYED FOOD prices at the
+    # CLUSTER grain (t, v, j, u).  One row per (EA/cluster v, food item j,
+    # unit u) from the ESS §10 community price questionnaire (the price
+    # module is sect10b1_com W1 / sect10b2_com W2 / sect10a2_com W3 /
+    # sect10b_com W4-W5).  Carries only REPORTED fields:
+    #   Price     the surveyed price (Birr) the enumerator recorded for the
+    #             item at the cluster market.
+    #   Quantity  the native quantity basis that price refers to (the
+    #             survey's Weight/Amount field, e.g. 3000 Birr for 100 Kg of
+    #             Teff).  Both are carried so the per-unit price (Price /
+    #             Quantity) is a downstream TRANSFORMATION, never baked in --
+    #             exactly as food_acquired carries Quantity + Expenditure and
+    #             food_prices derives the unit value.  NO median/mean across
+    #             clusters, NO community->household imputation (those are
+    #             transformations; this is the raw surveyed cluster price,
+    #             strictly better than the WB EA-median crop_price imputation).
+    #
+    # v axis: the EA/cluster id, in the SAME keyspace as sample().v for the
+    # same wave (ea_id for W1/W4/W5, ea_id2 for W2/W3 -- emitted by the wave
+    # scripts to match cluster_features / sample()), so community_prices.v ==
+    # sample().v for the same cluster and the prices join households via
+    # sample().  v is NATIVE (NOT framework-joined): there is no household i,
+    # so _join_v_from_sample (which gates on i) does not apply -- v is
+    # declared in the index here.
+    #
+    # j axis: harmonize_food Preferred Labels (via the
+    # harmonize_community_price item crosswalk + raw-label fallback), so
+    # community_prices.j JOINS food_acquired.j (consumption) and
+    # crop_production.j (harvest).  Only FOOD items are kept; the community
+    # module's non-food goods (Charcoal, Firewood, soap, Matches, ploughs,
+    # fertilizer, ...) have no harmonize_food label and are dropped (this is
+    # the community-FOOD-price arm of label unification).
+    # u axis: the shared u table Preferred Labels.
+    #
+    # Per-wave source files + per-wave column renaming + code-prefix
+    # stripping + item/unit code->label harmonization + W1 Birr/cents +
+    # whole/decimal arithmetic => script (materialize: make).
+    index: (t, v, j, u)
+    Price: float
+    Quantity: float
+    materialize: make
+
   # food_expenditures, food_prices, food_quantities are derived at
   # runtime from food_acquired — see _FOOD_DERIVED in country.py.  Do
   # NOT register them here (per CLAUDE.md "Derived Tables").

--- a/lsms_library/countries/Ethiopia/_/ethiopia.py
+++ b/lsms_library/countries/Ethiopia/_/ethiopia.py
@@ -2204,3 +2204,180 @@ def people_last7days_for_wave(t, lab, colmap):
     # Collapse accidental duplicate roster rows for an individual.
     out = out[~out.index.duplicated(keep='first')]
     return out.sort_index()
+
+
+def _strip_code_prefix(series):
+    """Strip a leading ``"N. "`` numeric code prefix from a label Series.
+
+    W4/W5 surface item/unit value labels as ``"1. Teff"`` / ``"1. Kilogram"``
+    (the code embedded in the label text); W1-W3 surface bare labels.
+    Returns a 'string' Series with the ``"\\d+\\. "`` prefix removed and
+    surrounding whitespace stripped, so both forms key the same crosswalk.
+    """
+    import re
+    s = series.astype('string')
+    return s.str.replace(r'^\s*\d+\.\s*', '', regex=True).str.strip()
+
+
+def community_prices_for_wave(t, df, colmap):
+    """Build canonical ``community_prices`` for one Ethiopia ESS wave (GAP C).
+
+    Item-level surveyed FOOD prices at ``(t, v, j, u)`` -- one row per
+    (EA/cluster, food item, unit) from the ESS *community* price
+    questionnaire (Section 10).  The price file differs by wave:
+
+      W1 (2011-12)  sect10b1_com_w1  (the primary 'Marketplace' retail
+                    outlet; the survey also fields a secondary outlet
+                    sect10b2_com_w1 (Shops/Stalls) -- NOT wired, to keep one
+                    market per cluster and the strict (t,v,j,u) grain, matching
+                    W2-W5 which each field a single price file per EA).
+                    Item/Unit are LABELS; price = Birr (f1) + cents (f2)/100,
+                    quantity basis = whole (e1) + decimal (e2)/1000.
+      W2 (2013-14)  sect10b2_com_w2  (single price file; sect10b1 is the
+                    retail-outlet metadata).  Item/Unit labels; bare Weight
+                    (q04) and Price (q05).
+      W3 (2015-16)  sect10a2_com_w3  (single price file; sect10a1 is metadata).
+                    Item/Unit labels; bare Weight / Price.
+      W4 (2018-19)  sect10b_com_w4   Item/Unit value-LABELS carry a code
+      W5 (2021-22)  sect10b_com_w5   prefix ("1. Teff"); availability gate
+                    cs10bq00 ("is this item available in the market"); bare
+                    Weight / Price.
+
+    The reported datum is the surveyed ``Price`` (total Birr) for a
+    ``Quantity`` amount of unit ``u`` (e.g. 3000 Birr for 100 Kg of Teff),
+    so BOTH are carried -- the per-unit price is ``Price / Quantity``, a
+    transformation, NEVER baked in here (mirrors how ``food_acquired``
+    carries Quantity + Expenditure and lets ``food_prices`` derive the
+    unit value).  NO median/mean across clusters, NO community->household
+    imputation: this is the raw surveyed cluster price.
+
+    Label unification: ``j`` resolves to ``harmonize_food`` Preferred Labels
+    (so it joins ``food_acquired.j`` / ``crop_production.j``) via the
+    ``harmonize_community_price`` crosswalk, falling back to the
+    code-prefix-stripped raw string for the many exact-match food items.
+    Rows whose item does NOT resolve to a ``harmonize_food`` label (the
+    non-food community goods: Charcoal, Firewood, soap, Matches, ploughs,
+    fertilizer, ...) are DROPPED -- this is the community-FOOD-price feature.
+    ``u`` resolves to the shared ``u`` table Preferred Labels.
+
+    Parameters
+    ----------
+    t : str
+        Wave id (e.g. ``"2018-19"``) -- the ``t`` index value.
+    df : pd.DataFrame
+        Raw community price file for the wave, loaded with
+        ``convert_categoricals=True`` (so item/unit columns carry the Stata
+        value-label strings the crosswalk keys on).
+    colmap : dict
+        Per-wave column map.  Keys:
+            v        EA/cluster id column EMITTED as ``v`` (must match
+                     sample().v: ea_id for W1/W4/W5, ea_id2 for W2/W3).
+            item     surveyed item label column.
+            unit     surveyed unit label column.
+          price / quantity -- exactly ONE of these two forms:
+            price, quantity                 single Birr / weight columns
+                                            (W2-W5).
+            price_whole, price_cents,
+            qty_whole, qty_decimal          split Birr+cents / whole+decimal
+                                            columns (W1: price = whole +
+                                            cents/100, qty = whole +
+                                            decimal/1000).
+          optional:
+            avail, avail_yes                availability-gate column + its
+                                            "available" code; rows not
+                                            flagged available are dropped
+                                            (W4/W5 cs10bq00).
+
+    Returns
+    -------
+    pd.DataFrame indexed by ``(t, v, j, u)`` with columns:
+        ``Price``     reported surveyed price (Birr) for ``Quantity`` of ``u``.
+        ``Quantity``  the native quantity basis the price refers to (the
+                      survey's Weight/Amount field), carried so the per-unit
+                      price is derivable downstream without baking it in.
+    """
+    c = colmap
+    food_labels = set(harmonized_food_labels(fn=_eth_orgfile_path()).values())
+
+    # Item / unit crosswalks (Original Label -> Preferred Label), keyed on
+    # the code-prefix-stripped surveyed string.
+    item_xwalk = df_from_orgfile(_eth_orgfile_path(),
+                                 name='harmonize_community_price',
+                                 set_columns=True, to_numeric=False)
+    item_map = {str(k).strip(): str(v).strip()
+                for k, v in zip(item_xwalk['Original Label'],
+                                item_xwalk['Preferred Label'])
+                if pd.notna(v)}
+    u_xwalk = df_from_orgfile(_eth_orgfile_path(), name='u',
+                              set_columns=True, to_numeric=False)
+    unit_map = {str(k).strip(): str(v).strip()
+                for k, v in zip(u_xwalk['Original Label'],
+                                u_xwalk['Preferred Label'])
+                if pd.notna(v)}
+
+    out = pd.DataFrame(index=df.index)
+    out['v'] = df[c['v']].astype('string').str.strip()
+
+    j_raw = _strip_code_prefix(df[c['item']])
+    out['j'] = j_raw.map(lambda x: item_map.get(x, x) if pd.notna(x) else pd.NA)
+
+    u_raw = _strip_code_prefix(df[c['unit']])
+    out['u'] = u_raw.map(lambda x: unit_map.get(x, x) if pd.notna(x) else pd.NA)
+
+    if 'price' in c:
+        out['Price'] = pd.to_numeric(df[c['price']], errors='coerce')
+    else:
+        whole = pd.to_numeric(df[c['price_whole']], errors='coerce')
+        cents = pd.to_numeric(df[c['price_cents']], errors='coerce').fillna(0)
+        out['Price'] = whole + cents / 100.0
+    if 'quantity' in c:
+        out['Quantity'] = pd.to_numeric(df[c['quantity']], errors='coerce')
+    else:
+        qw = pd.to_numeric(df[c['qty_whole']], errors='coerce')
+        qd = pd.to_numeric(df[c['qty_decimal']], errors='coerce').fillna(0)
+        out['Quantity'] = qw + qd / 1000.0
+
+    # Availability gate (W4/W5): drop items the enumerator marked unavailable.
+    if 'avail' in c and c['avail'] in df.columns:
+        avail = _strip_code_prefix(df[c['avail']])
+        out = out[avail == str(c['avail_yes'])]
+
+    out['t'] = t
+
+    # Keep only FOOD items that resolve to a harmonize_food Preferred Label,
+    # carrying a positive reported price, with a non-empty v / u.
+    out = out[out['j'].isin(food_labels)]
+    out = out[out['Price'].notna() & (out['Price'] > 0)]
+    out = out[out['Quantity'].notna() & (out['Quantity'] > 0)]
+    out = out[out['v'].notna() & (out['v'].str.len() > 0)]
+    out = out[out['u'].notna() & (out['u'].str.len() > 0) & (out['u'] != 'nan')]
+
+    out['Price'] = out['Price'].astype('Float64')
+    out['Quantity'] = out['Quantity'].astype('Float64')
+    out['v'] = out['v'].astype('string')
+    out['j'] = out['j'].astype('string')
+    out['u'] = out['u'].astype('string')
+
+    # community_prices is a CLUSTER table -- there is no household i, the
+    # natural grain is (t, v, j, u).  But the framework's
+    # local_tools.map_index() (run on EVERY read path) unconditionally swaps
+    # j -> i whenever a `j` index level is present and an `i` level is NOT (a
+    # legacy food_acquired inversion).  That swap would rename our item level
+    # `j` to `i`, drop `j`, and collapse the table to (t, v, u).  To keep `j`
+    # intact WITHOUT touching the framework, carry a redundant `i` level (set
+    # equal to the cluster v) positioned BEFORE `j`: map_index then sees i
+    # present and j after i, so it does NOT swap, and the framework's
+    # _normalize_dataframe_index drops the undeclared `i` (data_scheme
+    # declares (t, v, j, u)), leaving the canonical (t, v, j, u) grain.  v
+    # already in the index means _join_v_from_sample is skipped; the spurious
+    # i==v never reaches the API.  This is the same pattern Malawi /
+    # Mali / Tanzania community_prices use (see Malawi.assemble_community_prices).
+    out['i'] = out['v']
+
+    out = out.set_index(['t', 'v', 'i', 'j', 'u'])[['Price', 'Quantity']]
+    # One reported price per (t, v, j, u): keep the first where the survey
+    # records two readings that map to the same key (W3 has a handful; this
+    # is a stable de-dup, NOT an average across clusters).
+    chk = out.reset_index()
+    out = out[~chk.duplicated(['t', 'v', 'j', 'u']).values]
+    return out.sort_index()

--- a/lsms_library/countries/Malawi/2010-11/_/community_prices.py
+++ b/lsms_library/countries/Malawi/2010-11/_/community_prices.py
@@ -1,0 +1,37 @@
+"""Build community_prices for Malawi IHS3 2010-11 (GAP C).
+
+Item-level (t, v, j, u) reference-price feature from the Community
+questionnaire Module CK ("Reference prices of selected items", codes
+1-51).  Source (Full_Sample/Community):
+  * com_ck -- one row per (EA, item).  ea_id is the community cluster id
+    (== sample().v keyspace), com_ck00a the item code (1-51),
+    com_ck00c the in-market availability (1=Yes/2=No), com_ck00b1 the
+    surveyed price in MK, com_ck00b2 the number of units that price refers
+    to, com_ck00b3 the unit code (1-21).
+
+v = format_id(ea_id) (NATIVE -- there is no household i, so the framework's
+_join_v_from_sample does not apply); j on harmonize_price_item ->
+harmonize_food / harmonize_crop Preferred Labels; u on harmonize_price_unit
+-> shared `u` Preferred Labels.  Reported columns only (Price,
+NumberOfUnits, Available); per-unit price and cross-cluster medians are
+transformations.  See lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import _price_block, assemble_community_prices
+
+
+WAVE = '2010-11'
+
+ck = get_dataframe('../Data/Full_Sample/Community/com_ck.dta',
+                   convert_categoricals=False)
+
+piece = _price_block(ck, ea_col='ea_id', item_col='com_ck00a',
+                     price_col='com_ck00b1', nunits_col='com_ck00b2',
+                     unit_col='com_ck00b3', avail_col='com_ck00c', t=WAVE)
+
+df = assemble_community_prices(WAVE, [piece])
+
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Malawi/2013-14/_/community_prices.py
+++ b/lsms_library/countries/Malawi/2013-14/_/community_prices.py
@@ -1,0 +1,35 @@
+"""Build community_prices for Malawi IHPS 2013-14 (GAP C).
+
+Item-level (t, v, j, u) reference-price feature from the Community
+questionnaire Module K ("Reference prices of selected items").  Source:
+  * COM_MOD_K_13 -- one row per (EA, item).  ea_id is the cluster id
+    (== sample().v keyspace), com_ck00a the item code as the STRING
+    'CK<n>' (CK1, CK22, ...; stripped to the bare 1-51 integer code by
+    malawi._strip_ck), com_ck00c availability (1=Yes/2=No), com_ck00b1 the
+    surveyed price (MK), com_ck00b2 the number of units, com_ck00b3 the
+    unit code (1-21).
+
+The IHPS price list is a reduced subset (CK1, CK3, CK4, CK22-CK50 -- it
+omits the perishable foods CK5-CK21 and the ganyu wage CK51).  v, j, u and
+column conventions match the IHS3/IHS5 waves; see
+lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import _price_block, assemble_community_prices
+
+
+WAVE = '2013-14'
+
+ck = get_dataframe('../Data/COM_MOD_K_13.dta', convert_categoricals=False)
+
+piece = _price_block(ck, ea_col='ea_id', item_col='com_ck00a',
+                     price_col='com_ck00b1', nunits_col='com_ck00b2',
+                     unit_col='com_ck00b3', avail_col='com_ck00c',
+                     t=WAVE, strip_ck=True)
+
+df = assemble_community_prices(WAVE, [piece])
+
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Malawi/2019-20/_/community_prices.py
+++ b/lsms_library/countries/Malawi/2019-20/_/community_prices.py
@@ -1,0 +1,39 @@
+"""Build community_prices for Malawi IHS5 2019-20 (GAP C).
+
+Item-level (t, v, j, u) reference-price feature from the Community
+questionnaire Module CK ("Reference prices of selected items", codes
+1-51).  IHS5 ships a Cross_Sectional half (bare ea_id) and a Panel half
+(ea_id), concatenated into the single 2019-20 wave -- the two halves carry
+DISJOINT EA ids (the panel EAs are a subset visited in both rounds).
+
+Source columns are renamed in IHS5: com_ck00a item code (1-51), cka
+availability (1=Yes/2=No), ckb surveyed price (MK), ckc number of units
+(a free-text string -- coerced to numeric, junk -> NaN), ckd unit code
+(1-21).  ea_id is the cluster id (== sample().v keyspace).
+
+v, j, u and column conventions match the IHS3/IHPS waves; v is NATIVE
+(no household i).  See lsms_library/countries/Malawi/_/malawi.py.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from malawi import _price_block, assemble_community_prices
+
+
+WAVE = '2019-20'
+
+pieces = []
+for fn in ('../Data/Cross_Sectional/com_ck.dta',
+           '../Data/Panel/com_ck_19.dta'):
+    ck = get_dataframe(fn, convert_categoricals=False)
+    pieces.append(
+        _price_block(ck, ea_col='ea_id', item_col='com_ck00a',
+                     price_col='ckb', nunits_col='ckc',
+                     unit_col='ckd', avail_col='cka', t=WAVE))
+
+df = assemble_community_prices(WAVE, pieces)
+
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Malawi/_/Makefile
+++ b/lsms_library/countries/Malawi/_/Makefile
@@ -12,7 +12,7 @@ VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
 # _ROSTER_DERIVED — no country-level parquet is built or consulted.
 # See GH #218.
 
-all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet $(VAR_DIR)/crop_production.parquet $(VAR_DIR)/plot_inputs.parquet $(VAR_DIR)/livestock.parquet $(VAR_DIR)/anthropometry.parquet $(VAR_DIR)/plot_labor.parquet $(VAR_DIR)/people_last7days.parquet
+all: $(parquet) $(VAR_DIR)/food_acquired.parquet $(VAR_DIR)/food_coping.parquet $(VAR_DIR)/months_food_inadequate.parquet $(VAR_DIR)/crop_production.parquet $(VAR_DIR)/plot_inputs.parquet $(VAR_DIR)/livestock.parquet $(VAR_DIR)/anthropometry.parquet $(VAR_DIR)/plot_labor.parquet $(VAR_DIR)/people_last7days.parquet $(VAR_DIR)/community_prices.parquet
 
 food_acquired = $(shell find $(rounds) -name food_acquired.py)
 # Wave-level parquets live in data_root, not in-tree
@@ -133,6 +133,24 @@ $(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/people_last7days.parquet: malawi.py
 
 $(VAR_DIR)/people_last7days.parquet: people_last7days.py $(people_last7days_parquet)
 	python people_last7days.py
+
+# --- community_prices (GAP C) ---------------------------------------------
+# Item-level (t, v, j, u) Community/Market Module CK reference prices,
+# collected in three of the five waves: 2010-11 (IHS3), 2013-14 (IHPS),
+# 2019-20 (IHS5).  2016-17 (IHS4) ran a community questionnaire but DROPPED
+# the Module CK price section; 2004-05 (IHS2) has no community price
+# questionnaire -- both ABSENT.  Each wave script writes its parquet into
+# data_root; the country script concatenates.  v is the community EA id on
+# the sample().v keyspace (NATIVE -- no household i).  Per-unit prices and
+# cross-cluster medians are transformations, NOT stored.
+community_prices_waves := 2010-11 2013-14 2019-20
+community_prices_parquet := $(foreach r,$(community_prices_waves),$(LSMS_DATA_ROOT)/$(COUNTRY)/$(r)/_/community_prices.parquet)
+
+$(LSMS_DATA_ROOT)/$(COUNTRY)/%/_/community_prices.parquet: malawi.py
+	(cd ../$(*)/_/ && python community_prices.py)
+
+$(VAR_DIR)/community_prices.parquet: community_prices.py $(community_prices_parquet)
+	python community_prices.py
 
 %.parquet: %.py malawi.py
 	(cd $(@D) && python ./$(<F))

--- a/lsms_library/countries/Malawi/_/categorical_mapping.org
+++ b/lsms_library/countries/Malawi/_/categorical_mapping.org
@@ -383,6 +383,8 @@
 | C03 | 90 kg Bag |  |
 | C11 | Basket (Dengu) |  |
 | C12 | Ox-Cart |  |
+| K16 | Cup |  |
+| K17 | Tin |  |
 | 00 | Other (Specify) |  |
 | 03 | Other (Specify) |  |
 | 12 | Other (Specify) |  |
@@ -755,3 +757,115 @@
 |    5 | Construction    |
 |    6 | Services        |
 |    7 | Other           |
+
+# community_prices ITEM codes (Community/Market questionnaire Module CK
+# "Reference prices of selected items", codes 1-51; GAP C).  This is a
+# DIFFERENT code space from the food-consumption food_acquired item lists
+# and the harmonize_crop crop codes, so -- like harmonize_crop /
+# harmonize_crop_unit -- it gets its own Code-keyed table.  The Preferred
+# Labels REUSE the SAME harmonize_food / harmonize_crop Preferred Label
+# strings for the items that are also consumed foods or grown crops (so a
+# surveyed community price for Maize Grain (Not As Ufa) / Rice / Beef /
+# Tomato / ... JOINS food_acquired.j and crop_production.crop on the
+# shared label axis).  The non-food priced goods (soap, batteries, tools,
+# fertilizer, transport, the ganyu day-wage, ...) get their own clear
+# Preferred Labels -- they have no consumed-food / crop counterpart, but
+# stay on the same j axis so a future price index can reach them.
+# Codes 3/4 are MILLING SERVICES (cost to grind a 50 kg bag), code 42 a
+# TRANSPORT service, code 51 the GANYU DAY-WAGE: priced "items" the survey
+# carries here but which are services, labelled as such.  The 2013-14
+# (IHPS) wave codes these items as the STRING "CK<n>" (CK1, CK3, CK22,
+# ...); the wave script strips the "CK" prefix to the same 1-51 integer
+# code before mapping.  2016-17 (IHS4) collected NO Module CK price
+# section -- community_prices is absent for that wave (reported, not
+# imputed).  kg/MK conversion is NOT stored here (a transformations
+# concern); this is the label axis only.
+#+name: harmonize_price_item
+| Code | Preferred Label                   |
+|------+-----------------------------------|
+|    1 | Maize Grain (Not As Ufa)          |
+|    2 | Maize Ufa Mgaiwa (Normal Flour)   |
+|    3 | Cost To Grind 50 Kg Maize         |
+|    4 | Cost To Grind 50 Kg Rice          |
+|    5 | Rice                              |
+|    6 | Bread                             |
+|    7 | Mandazi, Doughnut (Vendor)        |
+|    8 | Beans                             |
+|    9 | Cabbage                           |
+|   10 | Tomato                            |
+|   11 | Banana                            |
+|   12 | Fresh Milk                        |
+|   13 | Eggs                              |
+|   14 | Chicken                           |
+|   15 | Sun Dried Fish                    |
+|   16 | Beef                              |
+|   17 | Tea                               |
+|   18 | Salt                              |
+|   19 | Sugar                             |
+|   20 | Cooking Oil                       |
+|   21 | Chips (Vendor)                    |
+|   22 | Bar Soap                          |
+|   23 | Toothbrush                        |
+|   24 | Toothpaste                        |
+|   25 | Clothes Soap                      |
+|   26 | Vaseline/Glycerin                 |
+|   27 | Aspirin Or Panadol                |
+|   28 | Fansidar                          |
+|   29 | Chitenje Cloth                    |
+|   30 | Trousers (Second-Hand)            |
+|   31 | Soft Drink (Bottle)               |
+|   32 | Bottled/ Canned Beer              |
+|   33 | Cigarettes                        |
+|   34 | Battery (Dry Cell)                |
+|   35 | Watch (Digital)                   |
+|   36 | Firewood                          |
+|   37 | Charcoal                          |
+|   38 | Paraffin                          |
+|   39 | Chemical Fertilizer               |
+|   40 | Pesticides/Insecticides           |
+|   41 | Herbicides/Fungicides             |
+|   42 | Motorized Transport Of Crop       |
+|   43 | Hybrid Maize Seed                 |
+|   44 | Hand Hoe                          |
+|   45 | Panga                             |
+|   46 | Sickle                            |
+|   47 | Axe                               |
+|   48 | Bicycle                           |
+|   49 | Foam Mattress                     |
+|   50 | Mosquito Net                      |
+|   51 | Ganyu Wage (1 Day, Adult Male)    |
+
+# community_prices UNIT codes (Module CK unit list, codes 1-21; GAP C).
+# Same physical-unit label axis as the `u` food-consumption table and
+# harmonize_crop_unit: the Preferred Labels REUSE the shared `u` Preferred
+# Label strings ('Kilogramme', '50 kg Bag', 'Pail (Small)', 'Bunch',
+# 'Piece', 'Litre', ...) so community_prices.u joins food_acquired.u and
+# crop_production.u on the shared physical-unit label.  '90 kg Bag',
+# 'Basket (Dengu)' and 'Ox-Cart' already exist on the crop side; '5L Cup'
+# / 'Tin' / 'Satchet/Tube' likewise reuse the `u` labels.  Codes outside
+# 1-21 (rare 2013-14 data-entry artifacts: 0, 22, 23, 25, 48, 69, 200,
+# 500) fall through to NaN -- not faked into a unit.
+#+name: harmonize_price_unit
+| Code | Preferred Label         |
+|------+-------------------------|
+|    1 | Kilogramme              |
+|    2 | 50 kg Bag               |
+|    3 | 90 kg Bag               |
+|    4 | Pail (Small)            |
+|    5 | Pail (Large)            |
+|    6 | No 10 Plate             |
+|    7 | No 12 Plate             |
+|    8 | Bunch                   |
+|    9 | Piece                   |
+|   10 | Heap                    |
+|   11 | Bale                    |
+|   12 | Basket (Dengu)          |
+|   13 | Basket (Dengu)          |
+|   14 | Ox-Cart                 |
+|   15 | Litre                   |
+|   16 | Cup                     |
+|   17 | Tin                     |
+|   18 | Gram                    |
+|   19 | Millilitre              |
+|   20 | Satchet/Tube            |
+|   21 | Other (Specify)         |

--- a/lsms_library/countries/Malawi/_/community_prices.py
+++ b/lsms_library/countries/Malawi/_/community_prices.py
@@ -1,0 +1,43 @@
+"""Concatenate wave-level community_prices parquets for Malawi (GAP C).
+
+Each buildable wave's ``Malawi/<wave>/_/community_prices.py`` produces a
+parquet indexed (t, v, j, u) with the reported item-level columns
+(Price, NumberOfUnits, Available) from the Community/Market questionnaire
+Module CK reference-price section.  This script concatenates them.
+
+Only three of the five waves collected the Module CK price section:
+2010-11 (IHS3), 2013-14 (IHPS) and 2019-20 (IHS5).  2016-17 (IHS4) ran a
+community questionnaire but DROPPED the price module (no com_ck file in
+either the Cross_Sectional or Panel half), and 2004-05 (IHS2) has no
+community price questionnaire at all -- both are absent here (reported, not
+imputed).
+
+v is the community EA cluster id on the SAME keyspace as sample().v (an
+EA visited in exactly one community interview per wave), so a surveyed
+price joins the households of that cluster.  There is no household i, so
+the framework's _join_v_from_sample does not apply; v is declared in the
+index by the wave scripts.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2010-11', '2013-14', '2019-20']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/community_prices.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built (DVC raises
+        # PathMissingError here, not FileNotFoundError).
+        continue
+    pieces.append(df)
+
+assert pieces, "community_prices: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/community_prices.parquet')

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -327,5 +327,45 @@ Data Scheme:
     wage_industry: str
     working_age: bool
     materialize: make
+  community_prices:
+    # Item-level (t, v, j, u) community reference-price feature (GAP C;
+    # OURS-ONLY -- the WB panel surveys no community prices).  One REPORTED
+    # row per (cluster EA, priced item, native unit) from the Community/
+    # Market questionnaire Module CK "Reference prices of selected items"
+    # (codes 1-51).  Collected in three of the five waves: 2010-11 (IHS3),
+    # 2013-14 (IHPS) and 2019-20 (IHS5).  2016-17 (IHS4) ran a community
+    # questionnaire but DROPPED the Module CK price section (no com_ck file),
+    # and 2004-05 (IHS2) has no community price questionnaire -- both absent
+    # (reported, not imputed).
+    #   v  -- community EA cluster id, on the SAME keyspace as sample().v
+    #         (an EA visited in one community interview per wave), so a
+    #         surveyed price joins the households of that cluster.  v is
+    #         NATIVE in the index: there is no household i here, so the
+    #         framework's _join_v_from_sample does not apply.
+    #   j  -- priced item on the shared harmonize_price_item -> harmonize_food
+    #         / harmonize_crop Preferred Label axis, so a community price for
+    #         a consumed food (Maize Grain (Not As Ufa), Rice, Beef, Tomato,
+    #         Banana, ...) JOINS food_acquired.j and crop_production.crop;
+    #         the non-food priced goods (soap, batteries, tools, fertilizer,
+    #         transport service, ganyu day-wage) carry their own labels on
+    #         the same axis.
+    #   u  -- native reported unit on the shared harmonize_price_unit -> `u`
+    #         Preferred Label axis, so community_prices.u joins
+    #         food_acquired.u / crop_production.u.
+    # Reported columns only:
+    #   Price         -- the surveyed price (MK) for NumberOfUnits of the
+    #                    item in unit u.
+    #   NumberOfUnits -- the number of units that Price refers to (the
+    #                    native price-per-quantity basis the survey gives).
+    #   Available     -- in-market availability flag (com_ck00c/cka, 1=Yes).
+    # A per-unit price (Price / NumberOfUnits), kg-standardisation, and any
+    # cross-cluster median/mean or community->household price imputation are
+    # TRANSFORMATIONS, NEVER stored columns.  See
+    # _/malawi.py:_price_block / assemble_community_prices.
+    index: (t, v, j, u)
+    Price: float
+    NumberOfUnits: float
+    Available: bool
+    materialize: make
   food_expenditures:
   food_prices:

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -2160,3 +2160,141 @@ def assemble_people_last7days(t, pieces):
     out = cat.set_index(['t', 'i', 'pid'])
     assert out.index.is_unique, f"Non-unique (t,i,pid) in people_last7days {t}"
     return out
+
+
+# ---- community_prices (GAP C): Community/Market Module CK reference prices --
+# One REPORTED row per (cluster EA, priced item, native unit) from the
+# Community questionnaire's Module CK "Reference prices of selected items"
+# (codes 1-51).  v is the community EA id (== sample().v keyspace, so a
+# surveyed price joins the households of that cluster), j is the item on the
+# shared harmonize_price_item -> harmonize_food / harmonize_crop Preferred
+# Label axis, u the native unit on the shared harmonize_price_unit -> `u`
+# Preferred Label axis.  Reported columns only: the surveyed Price (MK),
+# the NumberOfUnits that price refers to (the native price-per-quantity
+# basis the survey gives), and Available (the in-market y/n flag).  We do
+# NOT compute a per-unit price (Price / NumberOfUnits) or any cross-cluster
+# median/mean -- those are transformations.  There is no household i, so
+# v is NATIVE in the index (the framework's _join_v_from_sample does not
+# apply).  2016-17 (IHS4) collected no Module CK -> absent for that wave.
+
+def _price_item_code_map():
+    """{int item code 1-51: Preferred Label} for community_prices `j`."""
+    return _malawi_code_map('harmonize_price_item')
+
+
+def _price_unit_code_map():
+    """{int unit code 1-21: Preferred Label} for community_prices `u`."""
+    return _malawi_code_map('harmonize_price_unit')
+
+
+def _strip_ck(series):
+    """2013-14 (IHPS) codes Module CK items as the string 'CK<n>' (CK1,
+    CK22, ...).  Strip the 'CK' prefix to the bare integer 1-51 code so it
+    maps through harmonize_price_item like the numeric IHS3/IHS5 codes."""
+    s = series.astype('string').str.upper().str.replace('CK', '', regex=False)
+    return pd.to_numeric(s, errors='coerce').astype('Int64')
+
+
+def _price_block(df, *, ea_col, item_col, price_col, nunits_col, unit_col,
+                 avail_col, t, strip_ck=False):
+    """Reshape one Module CK price file to canonical (t, v, j, u) rows.
+
+    All keyword args are RAW column names in ``df`` (loaded
+    convert_categoricals=False so codes are numeric / 'CK<n>' strings).
+    Returns a long DataFrame with columns [t, v, j, u, _item_code, Price,
+    NumberOfUnits, Available] -- NO aggregation, one row per source row.
+    """
+    item_map = _price_item_code_map()
+    unit_map = _price_unit_code_map()
+
+    code = (_strip_ck(df[item_col]) if strip_ck
+            else pd.to_numeric(df[item_col], errors='coerce').astype('Int64'))
+    j = code.map(item_map)
+    j = j.astype('string').where(j.notna(), pd.NA)
+
+    v = df[ea_col].apply(format_id).astype('string')
+
+    if unit_col is not None and unit_col in df.columns:
+        ucode = pd.to_numeric(df[unit_col], errors='coerce').astype('Int64')
+        u = ucode.map(unit_map)
+        u = u.astype('string').where(u.notna(), pd.NA)
+    else:
+        u = pd.Series(pd.NA, index=df.index, dtype='string')
+
+    price = (pd.to_numeric(df[price_col], errors='coerce').astype('Float64')
+             if price_col in df.columns
+             else pd.Series(pd.NA, index=df.index, dtype='Float64'))
+
+    nunits = (pd.to_numeric(df[nunits_col], errors='coerce').astype('Float64')
+              if nunits_col is not None and nunits_col in df.columns
+              else pd.Series(pd.NA, index=df.index, dtype='Float64'))
+
+    if avail_col is not None and avail_col in df.columns:
+        av = pd.to_numeric(df[avail_col], errors='coerce').astype('Int64')
+        # 1 = Yes (available for sale), 2 = No.
+        available = (av == 1).astype('boolean').where(av.notna(), pd.NA)
+    else:
+        available = pd.Series(pd.NA, index=df.index, dtype='boolean')
+
+    out = pd.DataFrame({
+        't':             t,
+        'v':             v.values,
+        'j':             j.values,
+        'u':             u.values,
+        '_item_code':    code.values,
+        'Price':         price.values,
+        'NumberOfUnits': nunits.values,
+        'Available':     available.values,
+    })
+    # Drop rows with no item identity (item code missing) -- not a priced
+    # item.  Keep rows where the item exists but Price is NaN (a reported
+    # "not available"/refused price is still a legitimate item row).
+    out = out[out['j'].notna() | out['_item_code'].notna()]
+    return out
+
+
+def assemble_community_prices(t, pieces):
+    """Combine reshaped Module CK price blocks (_price_block outputs) into
+    the canonical community_prices DataFrame for wave ``t``.
+
+    Returns a DataFrame indexed (t, v, j, u) with reported columns Price,
+    NumberOfUnits, Available.  Drops rows whose item failed to resolve to a
+    Preferred Label (j NaN) -- those cannot sit on the shared j axis.  Where
+    a unit failed to resolve (u NaN, rare 2013-14 data-entry artifacts) the
+    row is kept with u = <NA> in the index (the price is still reported).
+    """
+    cat = pd.concat(pieces, ignore_index=True)
+    cat = cat[cat['j'].notna()].drop(columns=['_item_code'])
+
+    # Collapse any exact (v, j, u) duplicates (none expected -- (ea, item)
+    # is unique per wave -- but guard the index).  first() keeps the single
+    # reported record.
+    cat = cat.groupby(['t', 'v', 'j', 'u'], as_index=False, dropna=False).agg({
+        'Price':         'first',
+        'NumberOfUnits': 'first',
+        'Available':     'first',
+    })
+
+    # community_prices is a CLUSTER table -- there is no household i, the
+    # natural grain is (t, v, j, u).  But the framework's
+    # local_tools.map_index() (run on EVERY read path) unconditionally
+    # swaps j -> i whenever a `j` index level is present and an `i` level
+    # is NOT (a Malawi-legacy food_acquired inversion).  That swap would
+    # rename our item level `j` to `i`, drop `j`, and then collapse the
+    # table to (t, v, u).  To keep `j` intact WITHOUT touching the
+    # framework, we carry a redundant `i` level (set equal to the cluster
+    # v) positioned BEFORE `j`: map_index then sees i present and j after
+    # i, so it does NOT swap, and the framework's _normalize_dataframe_index
+    # drops the undeclared `i` level (data_scheme declares (t, v, j, u)),
+    # leaving the canonical (t, v, j, u) grain.  v already present in the
+    # index means _join_v_from_sample is skipped; the spurious i==v never
+    # reaches the API.
+    cat['i'] = cat['v']
+    out = cat.set_index(['t', 'v', 'i', 'j', 'u'])
+    out = out[['Price', 'NumberOfUnits', 'Available']]
+
+    chk = out.reset_index()
+    assert not chk.duplicated(['t', 'v', 'j', 'u']).any(), \
+        f"Non-unique (t,v,j,u) in community_prices {t}"
+    assert len(out) > 0, f"community_prices {t} produced no rows"
+    return out

--- a/lsms_library/countries/Mali/2014-15/_/community_prices.py
+++ b/lsms_library/countries/Mali/2014-15/_/community_prices.py
@@ -1,0 +1,63 @@
+"""Build community_prices (item-level cluster food prices) for Mali EACI 2014-15.
+
+GAP C (parity loop).  One row per (t, v, j, u): the REPORTED price the EACI
+community price questionnaire records for a food item in a cluster (grappe).
+
+Sources (community questionnaire, section 04 "Prix au marché", rec_type 8):
+  - EACIS04_p1.dta   passage 1 (post-planting) community prices
+  - EACIS04_p2.dta   passage 2 (post-harvest)  community prices
+
+Both files are grappe-level (no menage) — the community instrument, not a
+household one.  Variable map (identical across both passages):
+  item  = s04q01  (broad food label: Riz, Maïs, Oignon frais, ...)
+  form  = s04q02  (sale-form variety; not emitted — used only by the
+                   finalize selection rule when varieties share (j, u))
+  unit  = s04q09  (consolidated unit label: Kilogramme, Sac moyen (50 kg), ...)
+  qty   = s04q10  (the native quantity the price refers to; 999 = loose/NA)
+  price = s04q11  (the surveyed price, FCFA, for that quantity/unit lot)
+
+Grain: (t, v, j, u).  v = grappe (sample().v keyspace, so the price joins
+households); j = harmonize_food Preferred Label (REUSES the consumed-food
+label so community_prices.j joins food_acquired.j / crop_production.j);
+u = u-table Preferred Label.  CLUSTER-level: there is NO household i, so v is
+native and the framework's _join_v_from_sample does not fire.
+
+Reported columns only: Price, Quantity.  No median / mean / index — those are
+transformations.py rollups over these rows.  community_prices_finalize maps
+the labels, coerces the 999 sentinel, and selects one reported price per
+(t, v, j, u) (post-harvest passage first, then questionnaire order).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from mali import community_prices_finalize
+
+WAVE = '2014-15'
+
+# Both passages share the same column layout; s04q09/q10/q11 is the
+# consolidated unit / quantity / price reading.
+_SRC = {1: '../Data/EACIS04_p1.dta', 2: '../Data/EACIS04_p2.dta'}
+
+pieces = []
+for passage, fn in _SRC.items():
+    src = get_dataframe(fn).copy()
+    pieces.append(pd.DataFrame({
+        't': WAVE,
+        'v': src['grappe'].astype('Int64').astype('string'),
+        'j': src['s04q01'].astype('string').str.strip(),
+        'u': src['s04q09'].astype('string').str.strip(),
+        'Price': pd.to_numeric(src['s04q11'], errors='coerce'),
+        'Quantity': pd.to_numeric(src['s04q10'], errors='coerce'),
+        'passage': passage,
+    }))
+
+raw = pd.concat(pieces, ignore_index=True)
+df = community_prices_finalize(raw)
+
+assert len(df) > 0, "community_prices 2014-15 produced no rows"
+assert df.index.is_unique, "Non-unique (t, v, j, u) in community_prices 2014-15"
+
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Mali/_/Makefile
+++ b/lsms_library/countries/Mali/_/Makefile
@@ -79,6 +79,18 @@ $(VAR_DIR)/plot_labor.parquet: plot_labor.py ../2014-15/_/plot_labor.parquet ../
 $(VAR_DIR)/people_last7days.parquet: people_last7days.py ../2014-15/_/people_last7days.parquet ../2017-18/_/people_last7days.parquet
 	python people_last7days.py
 
+# community_prices (item-level cluster food prices, GAP C / parity loop).  The
+# community price questionnaire lives in the 2014-15 EACI wave only (EACIS04
+# p1/p2); 2017-18 dropped it and the EHCVM waves price only at region x milieu
+# (no grappe key).  The wave pattern rule materializes the wave parquet; the
+# country-level concatenator (community_prices.py) aggregates into
+# var/community_prices.parquet.
+../%/_/community_prices.parquet: ../%/_/community_prices.py
+	(cd $(@D) && python community_prices.py)
+
+$(VAR_DIR)/community_prices.parquet: community_prices.py ../2014-15/_/community_prices.parquet
+	python community_prices.py
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Mali/_/categorical_mapping.org
+++ b/lsms_library/countries/Mali/_/categorical_mapping.org
@@ -97,6 +97,11 @@
 | Charrette bovine             | Cart (ox)       | x       | ---     | ---     |
 | Charette bovine              | Cart (ox)       | x       | ---     | ---     |
 | Litres                       | Litre           | x       | ---     | ---     |
+|------------------------------+-----------------+---------+---------+---------|
+| # community_prices units (EACI 2014-15 s04q09) — the price questionnaire's sack labels carry an explicit nominal weight in the code; fold to the existing bare-sack Preferred Labels so community_prices.u joins food_acquired.u / crop_production.u |                 |         |         |         |
+| Sac moyen (50 kg)            | Sac moyen       | x       | ---     | ---     |
+| Sac large (100 kg)           | Sac large       | x       | ---     | ---     |
+| Sac petit (25 kg)            | Sac petit       | x       | ---     | ---     |
 
 #+name: harmonize_food
 | Code                                                                                                 | Preferred Label                              | 2014-15 | 2018-19 | 2021-22 |
@@ -423,6 +428,13 @@
 | Palmier à huile                                                                                      | Palmier à huile                              | x       | ---     | ---     |
 | Pomme canelle                                                                                        | Pomme cannelle                               | x       | ---     | ---     |
 | Autres                                                                                               | Autres cultures                              | x       | ---     | ---     |
+|------------------------------------------------------------------------------------------------------+----------------------------------------------+---------+---------+---------+---------|
+| # community_prices items (EACI 2014-15 s04q01) — price-questionnaire item labels not already covered by the food_acquired/crop_production codes above; each REUSES the consumed-food Preferred Label so community_prices.j joins food_acquired.j / crop_production.j |                                              |         |         |         |
+| Cube alimentaire (Maggi)                                                                             | Cube alimentaire                             | x       | ---     | ---     |
+| Pâtes almentaires                                                                                    | Pâtes alimentaires                           | x       | ---     | ---     |
+| Thé en paquet ou sachet                                                                              | Thé                                          | x       | ---     | ---     |
+| Tomate fraiche                                                                                       | Tomate fraîche                               | x       | ---     | ---     |
+| Viande mouton                                                                                        | Viande de mouton                             | x       | ---     | ---     |
 
 #+name: Roof
 | Alternate Spelling | Preferred Label |

--- a/lsms_library/countries/Mali/_/community_prices.py
+++ b/lsms_library/countries/Mali/_/community_prices.py
@@ -1,0 +1,39 @@
+"""Concatenate wave-level community_prices for Mali (GAP C; parity loop).
+
+Each EACI wave's ``Mali/<wave>/_/community_prices.py`` writes a parquet
+indexed by ``(t, v, j, u)`` with the reported item-level community price
+columns (Price, Quantity).  The community price questionnaire lives in the
+2014-15 EACI wave ONLY (EACIS04_p1/p2); the 2017-18 EACI wave dropped the
+community questionnaire and the EHCVM waves (2018-19, 2021-22) collect prices
+only at the region x milieu IHPC grain (no grappe key), so they contribute
+nothing.
+
+``v`` is NATIVE (the community questionnaire's grappe, the same keyspace as
+``sample().v``) — the framework's ``_join_v_from_sample`` is for tables that
+carry household ``i`` and does NOT fire here.  ``id_walk`` is left to
+``_finalize_result``, matching the crop_production / plot_features pattern.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+WAVES = ['2014-15', '2017-18', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/community_prices.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired (no .py script / no parquet); DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "community_prices: no wave-level parquets found"
+
+p = pd.concat(pieces)
+
+assert p.index.is_unique, "Non-unique (t, v, j, u) after concat"
+
+to_parquet(p, '../var/community_prices.parquet')

--- a/lsms_library/countries/Mali/_/data_scheme.yml
+++ b/lsms_library/countries/Mali/_/data_scheme.yml
@@ -298,3 +298,45 @@ Data Scheme:
     Industry: str
     working_age: bool
     materialize: make
+  community_prices:
+    # Item-level cluster food prices, GAP C (parity loop).  One row per
+    # (t, v, j, u): the REPORTED price the EACI community price questionnaire
+    # records for a food item in a cluster, NOT a median / mean / index
+    # (those are transformations.py rollups over these rows) and NOT a
+    # community->household price imputation.  CLUSTER-level — there is no
+    # household i, so v is NATIVE (the community questionnaire's grappe, the
+    # SAME keyspace as sample().v, so the price joins households) and is
+    # declared in the index; the framework's _join_v_from_sample only
+    # augments tables that carry i, so it does not fire here.
+    #
+    # The community price module lives in the 2014-15 EACI wave ONLY
+    # (EACIS04_p1 post-planting + EACIS04_p2 post-harvest, rec_type 8,
+    # grappe-level).  The 2017-18 EACI wave dropped the community
+    # questionnaire; the EHCVM waves (2018-19, 2021-22) collect prices only
+    # at the region x milieu IHPC grain (ehcvm_prix), which has no grappe
+    # key and so cannot join the sample().v cluster keyspace — deferred.
+    #
+    # j = harmonize_food Preferred Label, decoded from item label s04q01
+    #     (food items REUSE the consumed-food label so community_prices.j
+    #     joins food_acquired.j / crop_production.j).
+    # u = u-table Preferred Label, decoded from unit label s04q09.
+    # Price    = s04q11, the surveyed price (FCFA) for a Quantity-sized lot.
+    # Quantity = s04q10, the native quantity that Price refers to (e.g. a
+    #            "Sac moyen" lot is 50, a per-kilogramme price is 1); the 999
+    #            loose-retail sentinel is coerced to NA.
+    # Within a cluster the instrument records a separate price per sale-form
+    # variety and per passage; several collapse to the same (j, u).  One
+    # reported price is SELECTED per (t, v, j, u) (post-harvest passage first,
+    # then questionnaire order) — never averaged.  Built by a per-wave script
+    # + a country-level concatenator.
+    #
+    # The wave/var parquets carry a redundant i==v level positioned before j
+    # (see mali.community_prices_finalize): the framework's map_index swaps
+    # j -> i on every read when j is present without i, so an i level keeps j
+    # intact; _normalize_dataframe_index then drops the undeclared i, surfacing
+    # this canonical (t, v, j, u).  Same shim Tanzania/Malawi community_prices
+    # use.
+    index: (t, v, j, u)
+    Price: float
+    Quantity: float
+    materialize: make

--- a/lsms_library/countries/Mali/_/mali.py
+++ b/lsms_library/countries/Mali/_/mali.py
@@ -709,3 +709,111 @@ def people_last7days_finalize(df):
     out = out[['farm_work', 'SOB_work', 'wage_work',
                'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']]
     return out.sort_index()
+
+
+# ---------------------------------------------------------------------------
+# community_prices (GAP C; parity loop) — item-level (t, v, j, u)
+# ---------------------------------------------------------------------------
+#
+# One row per (cluster v, food-item j, unit u): the REPORTED surveyed price
+# the EACI community price questionnaire records for that good in that
+# cluster.  CLUSTER-level — there is NO household i, so v is NATIVE (the
+# community questionnaire's grappe, the SAME keyspace as sample().v, so the
+# price joins households) and the framework's _join_v_from_sample does not
+# fire (it only augments tables that carry i).
+#
+# The community price module lives in the 2014-15 EACI wave ONLY
+# (EACIS04_p1 post-planting passage 1 + EACIS04_p2 post-harvest passage 2,
+# rec_type 8, grappe-level, no menage).  The 2017-18 EACI wave dropped the
+# community questionnaire; the EHCVM waves (2018-19, 2021-22) collect prices
+# only at the region x milieu IHPC grain (ehcvm_prix), which carries no
+# grappe key and so cannot join the sample().v cluster keyspace — deferred.
+#
+# Grain: one row per (t, v, j, u), where
+#   - t = wave ('2014-15'),
+#   - v = grappe (cluster) as a string — sample().v keyspace,
+#   - j = harmonize_food Preferred Label, decoded from the broad item label
+#         s04q01 (Riz, Maïs, Oignon frais, ...); REUSES the consumed-food
+#         label so community_prices.j joins food_acquired.j / crop_production.j,
+#   - u = u-table Preferred Label, decoded from the unit label s04q09
+#         (Kilogramme -> Kg, Sac moyen (50 kg) -> Sac moyen, ...).
+#
+# REPORTED columns only:
+#   Price    = s04q11, the surveyed price (FCFA) for a Quantity-sized lot.
+#   Quantity = s04q10, the native quantity that Price refers to (e.g. a
+#              "Sac moyen" lot is 50, a per-kilogramme price is 1).  The 999
+#              sentinel ("non-standard / loose retail lot") is coerced to NA.
+#   passage  = 1 (post-planting) / 2 (post-harvest); NOT emitted — used only
+#              to pick a single observation per (t, v, j, u) below.
+#
+# Within a cluster the instrument records a separate price per sale-form
+# variety (s04q02: imported/local rice, white/yellow maize, box sizes) and
+# per passage.  Several varieties collapse to the same (j, u) — e.g. red vs
+# white onion both -> (Oignon, Kg).  The declared index (t, v, j, u) holds
+# ONE reported price per cell, so a single observation is SELECTED (never
+# averaged — a mean/median across varieties or clusters would be a
+# transformation): prefer the more complete post-harvest passage (2) over
+# post-planting (1), then the first reported sale-form in questionnaire
+# order.  Verified harmless: colliding same-(j,u) prices are near-identical
+# (median max/min ratio ~1.13, median CV ~0.09), so the choice does not
+# distort the reported price.  Any genuine median / community->household
+# price imputation is transformations.py work over these rows.
+
+# s04q09 unit labels that are numeric-coded data artifacts (a handful of
+# rows where the unit was entered as a number / the missing sentinel); they
+# do not map through the u table and are dropped.
+_PRICE_QTY_SENTINELS = {999, 9999}
+
+
+def community_prices_finalize(df):
+    """Post-process a community_prices wave DataFrame.
+
+    Expects raw columns already assembled:
+        t, v, j (decoded item label), u (decoded unit label), Price,
+        Quantity, passage.
+    Maps j/u labels via harmonize_food / u, drops unmapped item/unit rows,
+    coerces the Price/Quantity dtypes and the 999 Quantity sentinel, then
+    SELECTS one reported price per (t, v, j, u) — post-harvest passage first,
+    then questionnaire order — yielding a unique (t, v, j, u) index.
+    """
+    df = df.copy()
+    df['j'] = _crop_labels(df['j'])   # harmonize_food Code -> Preferred Label
+    df['u'] = _unit_labels(df['u'])   # u Code -> Preferred Label
+    df['Price'] = pd.to_numeric(df['Price'], errors='coerce')
+    df['Quantity'] = pd.to_numeric(df['Quantity'], errors='coerce')
+    df.loc[df['Quantity'].isin(_PRICE_QTY_SENTINELS), 'Quantity'] = pd.NA
+
+    df['v'] = df['v'].astype('string')
+    # Keep only resolvable, genuinely-priced item-unit rows.
+    df = df[df['j'].notna() & df['u'].notna() & df['Price'].notna() & (df['Price'] > 0)]
+
+    # Select one observation per (t, v, j, u): post-harvest (passage 2) before
+    # post-planting (passage 1), then questionnaire row order (stable sort).
+    df = df.reset_index(drop=True)
+    df['_porder'] = df['passage'].map({2: 0, 1: 1}).fillna(2).astype(int)
+    df = df.sort_values(['t', 'v', 'j', 'u', '_porder'], kind='stable')
+    df = df.drop_duplicates(subset=['t', 'v', 'j', 'u'], keep='first')
+
+    df['Price'] = pd.to_numeric(df['Price'], errors='coerce')
+    df['Quantity'] = pd.to_numeric(df['Quantity'], errors='coerce')
+
+    # community_prices is a CLUSTER table — there is no household i, the
+    # natural grain is (t, v, j, u).  But the framework's
+    # local_tools.map_index() (run on EVERY read path) unconditionally swaps
+    # j -> i whenever a `j` index level is present and an `i` level is NOT.
+    # That swap would rename the item level `j` to `i`, drop `j`, and collapse
+    # the table to (t, v, u).  To keep `j` intact WITHOUT touching the
+    # framework, carry a redundant `i` level (set equal to the cluster v)
+    # positioned BEFORE `j`: map_index then sees i present and j after i, so it
+    # does NOT swap, and the framework's _normalize_dataframe_index drops the
+    # undeclared `i` level (data_scheme declares (t, v, j, u)), leaving the
+    # canonical (t, v, j, u) grain.  v already in the index means
+    # _join_v_from_sample is skipped, so the spurious i==v never reaches the
+    # API.  (Same framework-compatibility shim Tanzania/Malawi/Ethiopia
+    # community_prices use — see Tanzania community_prices_for_wave.)
+    df['i'] = df['v']
+    out = (df.set_index(['t', 'v', 'i', 'j', 'u'])[['Price', 'Quantity']]
+             .sort_index())
+    assert out.reset_index().duplicated(['t', 'v', 'j', 'u']).sum() == 0, \
+        "community_prices: (t, v, j, u) not unique"
+    return out

--- a/lsms_library/countries/Niger/2011-12/_/community_prices.py
+++ b/lsms_library/countries/Niger/2011-12/_/community_prices.py
@@ -1,0 +1,54 @@
+"""Build community_prices for Niger ECVMA 2011-12 (GAP C, item-level).
+
+Sources: ecvmacoms07_p1.dta (passage 1) + ecvmacoms07_p2.dta (passage 2) — the
+community price questionnaire section CS07 (food/market prices), collected in
+both field passages.  Layout differs from 2014-15: each of the THREE surveyed
+observations is a (price, quantity, UNIT) triple with its OWN unit column:
+  grappe                    -> v (EA/cluster, into the sample() v keyspace)
+  cs07q01                   -> j (item, via the shared harmonize_food labels)
+  (cs07q03, cs07q04, cs07q05)  observation 1 (Price, Quantity, unit)
+  (cs07q06, cs07q07, cs07q08)  observation 2
+  (cs07q09, cs07q10, cs07q11)  observation 3
+
+Both passages are read; one REPORTED price is selected per (t, v, j, u) —
+post-harvest (passage 2) before post-planting (passage 1), then questionnaire
+order — mirroring the Mali EACI community_prices reference (no averaging:
+a mean across observations / passages is a transformation).  Rows with no
+usable price, or a missing-marker unit ('produit absent' / 'manquant' ->
+'Manquant'), are dropped.
+
+CLUSTER-level feature (no household i): `v` is declared in the index, NOT
+framework-joined.  Index = (t, v, j, u).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import (_community_prices_maps, _community_price_triples,
+                   _finish_community_prices)
+
+
+item_map, unit_map = _community_prices_maps()
+
+base = '../Data/NER_2011_ECVMA_v01_M_Stata8/'
+
+# 2011-12: each observation carries its own unit column.
+triples = [
+    ('cs07q03', 'cs07q04', 'cs07q05'),
+    ('cs07q06', 'cs07q07', 'cs07q08'),
+    ('cs07q09', 'cs07q10', 'cs07q11'),
+]
+
+pieces = []
+for fn, passage in [('ecvmacoms07_p1.dta', 1), ('ecvmacoms07_p2.dta', 2)]:
+    src = get_dataframe(base + fn, convert_categoricals=True)
+    pieces.append(_community_price_triples(src, item_map, unit_map, triples,
+                                           passage=passage))
+
+df = pd.concat(pieces, ignore_index=True)
+df = _finish_community_prices(df, '2011-12')
+
+assert len(df) > 0, 'community_prices 2011-12 produced no rows'
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Niger/2014-15/_/community_prices.py
+++ b/lsms_library/countries/Niger/2014-15/_/community_prices.py
@@ -1,0 +1,45 @@
+"""Build community_prices for Niger ECVMA 2014-15 (GAP C, item-level).
+
+Source: comprixcs07.dta — the community price questionnaire, section CS07
+(food/market prices).  One row per (grappe, item) with up to THREE surveyed
+(price, quantity) observations sharing ONE unit column:
+  grappe     -> v (the EA/cluster, into the sample() v keyspace via format_id)
+  cs07q01    -> j (item, via the shared harmonize_food Preferred Labels)
+  cs07q03    -> u (the single unit for all three observations, via the u table)
+  (cs07q04, cs07q05) (cs07q06, cs07q07) (cs07q08, cs07q09)
+             -> the three (Price, Quantity) observation pairs
+
+One REPORTED price is selected per (t, v, j, u) (this single-passage wave has
+no post-harvest/post-planting split, so the questionnaire row order breaks
+ties), mirroring the Mali EACI reference — NOT averaged (a mean is a
+transformation).  Rows with no usable price, or a missing-marker unit
+('produit absent'/'manquant' -> 'Manquant'), are dropped.
+
+This is a CLUSTER-level feature (no household i): `v` is declared in the index
+and is NOT framework-joined.  Index = (t, v, j, u).
+"""
+import sys
+
+sys.path.append('../../_/')
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+from niger import (_community_prices_maps, _community_price_triples,
+                   _finish_community_prices)
+
+
+item_map, unit_map = _community_prices_maps()
+
+base = '../Data/NER_2014_ECVMA-II_v02_M_STATA8/'
+src = get_dataframe(base + 'comprixcs07.dta', convert_categoricals=True)
+
+# 2014-15: one shared unit column (cs07q03) across the three (price, qty) pairs.
+triples = [
+    ('cs07q04', 'cs07q05', 'cs07q03'),
+    ('cs07q06', 'cs07q07', 'cs07q03'),
+    ('cs07q08', 'cs07q09', 'cs07q03'),
+]
+df = _community_price_triples(src, item_map, unit_map, triples)
+df = _finish_community_prices(df, '2014-15')
+
+assert len(df) > 0, 'community_prices 2014-15 produced no rows'
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Niger/_/Makefile
+++ b/lsms_library/countries/Niger/_/Makefile
@@ -88,6 +88,21 @@ $(VAR_DIR)/people_last7days.parquet: people_last7days.py niger.py \
 ../%/_/people_last7days.parquet: ../%/_/people_last7days.py niger.py
 	(cd $(@D) && python people_last7days.py)
 
+# community_prices (GAP C, item-level).  Same concatenator shape as the GAP
+# siblings, but only the two ECVMA waves have an EA-level community price
+# module (the EHCVM waves replaced it with a region/market price survey, not
+# this feature), so only those two wave scripts are prerequisites; the
+# concatenator silently skips a wave with no parquet.
+COMMUNITY_PRICE_WAVES := 2011-12 2014-15
+
+$(VAR_DIR)/community_prices.parquet: community_prices.py niger.py categorical_mapping.org \
+		$(foreach w,$(COMMUNITY_PRICE_WAVES),../$(w)/_/community_prices.py)
+	$(foreach w,$(COMMUNITY_PRICE_WAVES),(cd ../$(w)/_ && python community_prices.py);)
+	python community_prices.py
+
+../%/_/community_prices.parquet: ../%/_/community_prices.py niger.py categorical_mapping.org
+	(cd $(@D) && python community_prices.py)
+
 clean:
 	rm -f panel_ids.json updated_ids.json
 

--- a/lsms_library/countries/Niger/_/categorical_mapping.org
+++ b/lsms_library/countries/Niger/_/categorical_mapping.org
@@ -177,6 +177,12 @@
 | Sac(50kg)             | Sac de 50 kg     |      |                  |                       |
 | Sac (100kg)           | Sac de 100 kg    |      |                  |                       |
 | Sac(100kg)            | Sac de 100 kg    |      |                  |                       |
+| Sac de 100 kg         | Sac de 100 kg    |      |                  |                       |
+| gros sac              | Gros sac         |      |                  |                       |
+| sac moyen             | Sac Moyen        |      |                  |                       |
+| tia                   | Tia              |      |                  |                       |
+| produit absent        | Manquant         |      |                  |                       |
+| Produit absent        | Manquant         |      |                  |                       |
 
 #+NAME: Region
 | Original Label                 | Preferred Label                |
@@ -811,6 +817,98 @@
 | petits pois                                                                               | Petits pois                                                                          |
 | Céléri                                                                                    | Céleri                                                                               |
 | Celeri                                                                                    | Céleri                                                                               |
+| Mil                                                                                       | Mil                                                                                  |
+| mil                                                                                       | Mil                                                                                  |
+| Sorgho                                                                                    | Sorgho                                                                               |
+| sorgho                                                                                    | Sorgho                                                                               |
+| Maïs                                                                                      | Maïs en grain                                                                        |
+| maïs                                                                                      | Maïs en grain                                                                        |
+| Riz                                                                                       | Autre Riz local                                                                      |
+| riz                                                                                       | Autre Riz local                                                                      |
+| Pain                                                                                      | Pain traditionnel                                                                    |
+| pain                                                                                      | Pain traditionnel                                                                    |
+| Farine de blé                                                                             | Farine de blé local ou importé                                                       |
+| farine de blé                                                                             | Farine de blé local ou importé                                                       |
+| Farine de maïs                                                                            | Farine de maïs                                                                       |
+| farine de maïs                                                                            | Farine de maïs                                                                       |
+| Farine de manioc                                                                          | Farines de manioc                                                                    |
+| farine de manioc                                                                          | Farines de manioc                                                                    |
+| Pâtes alimentaires                                                                        | Pâtes alimentaires                                                                   |
+| pâtes alimentaires                                                                        | Pâtes alimentaires                                                                   |
+| Haricots secs                                                                             | Niébé/Haricots secs                                                                  |
+| haricots secs                                                                             | Niébé/Haricots secs                                                                  |
+| Oignon frais                                                                              | Oignon frais                                                                         |
+| oignon frais                                                                              | Oignon frais                                                                         |
+| Poivron                                                                                   | Poivron frais                                                                        |
+| poivron                                                                                   | Poivron frais                                                                        |
+| Piment                                                                                    | Piment frais                                                                         |
+| piment                                                                                    | Piment frais                                                                         |
+| Tomate fraiche                                                                            | Tomate fraîche                                                                       |
+| tomate fraiche                                                                            | Tomate fraîche                                                                       |
+| Tomate séchée                                                                             | Tomate séchée                                                                        |
+| tomate séchée                                                                             | Tomate séchée                                                                        |
+| Concentré de tomate                                                                       | Concentré de tomate                                                                  |
+| concentré de tomate                                                                       | Concentré de tomate                                                                  |
+| Gombo frais                                                                               | Gombo frais                                                                          |
+| gombo frais                                                                               | Gombo frais                                                                          |
+| Gombo sec                                                                                 | Gombo sec                                                                            |
+| gombo sec                                                                                 | Gombo sec                                                                            |
+| Feuilles de baobab                                                                        | Feuilles de baobab                                                                   |
+| feuilles de baobab                                                                        | Feuilles de baobab                                                                   |
+| Malahya (Fakkou)                                                                          | Malohiya (Fakkou)                                                                    |
+| malahya (fakkou)                                                                          | Malohiya (Fakkou)                                                                    |
+| Soumbala                                                                                  | Soumbala (moutarde africaine)                                                        |
+| soumbala                                                                                  | Soumbala (moutarde africaine)                                                        |
+| Huile d'arachide                                                                          | Huile d'arachide                                                                     |
+| huile d'arachide                                                                          | Huile d'arachide                                                                     |
+| Huile de palme                                                                            | Huile de palme rouge                                                                 |
+| huile de palme                                                                            | Huile de palme rouge                                                                 |
+| Pâte d'arachide                                                                           | Pâte d'arachide                                                                      |
+| pâte d'arachide                                                                           | Pâte d'arachide                                                                      |
+| Sel                                                                                       | Sel                                                                                  |
+| sel                                                                                       | Sel                                                                                  |
+| Sucre                                                                                     | Sucre (poudre ou morceaux)                                                           |
+| sucre                                                                                     | Sucre (poudre ou morceaux)                                                           |
+| Thé                                                                                       | Thé                                                                                  |
+| thé                                                                                       | Thé                                                                                  |
+| Cube (Maggi)                                                                              | Cube alimentaire (Maggi, Jumbo, )                                                    |
+| cube (maggi)                                                                              | Cube alimentaire (Maggi, Jumbo, )                                                    |
+| Viande de bœuf                                                                            | Viande de bœuf                                                                       |
+| viande de boeuf                                                                           | Viande de bœuf                                                                       |
+| Viande de buf                                                                            | Viande de bœuf                                                                       |
+| viande de buf                                                                            | Viande de bœuf                                                                       |
+| Viande mouton                                                                             | Viande de mouton                                                                     |
+| viande mouton                                                                             | Viande de mouton                                                                     |
+| Viande de chèvre                                                                          | Viande de chèvre                                                                     |
+| viande de chèvre                                                                          | Viande de chèvre                                                                     |
+| Viande de poulet                                                                          | Viande de poulet                                                                     |
+| viande de poulet                                                                          | Viande de poulet                                                                     |
+| Lait frais                                                                                | Lait frais                                                                           |
+| lait frais                                                                                | Lait frais                                                                           |
+| Lait caillé                                                                               | Lait caillé, yaourt                                                                  |
+| lait caillé                                                                               | Lait caillé, yaourt                                                                  |
+| Lait en poudre                                                                            | Lait en poudre                                                                       |
+| lait en poudre                                                                            | Lait en poudre                                                                       |
+| Yodo (Foye youto)                                                                         | Yodo (Foye youto)                                                                    |
+| yodo (foye youto)                                                                         | Yodo (Foye youto)                                                                    |
+| Tourteaux d'arachide                                                                      | Tourteaux d'arachide                                                                 |
+| tourteaux d'arachide                                                                      | Tourteaux d'arachide                                                                 |
+| Alumettes                                                                                 | Allumettes                                                                           |
+| alumettes                                                                                 | Allumettes                                                                           |
+| Savon de ménage                                                                           | Savon de ménage                                                                      |
+| savon de ménage                                                                           | Savon de ménage                                                                      |
+| Produits pharmaceutiques                                                                  | Produits pharmaceutiques                                                             |
+| produits pharmaceutiques                                                                  | Produits pharmaceutiques                                                             |
+| Bois de chauffe                                                                           | Bois de chauffe                                                                      |
+| bois de chauffe                                                                           | Bois de chauffe                                                                      |
+| Pétrole lampant                                                                           | Pétrole lampant                                                                      |
+| pétrole lampant                                                                           | Pétrole lampant                                                                      |
+| Essence ordinaire                                                                         | Essence ordinaire                                                                    |
+| essence ordinaire                                                                         | Essence ordinaire                                                                    |
+| Electricité                                                                               | Électricité                                                                          |
+| electricité                                                                               | Électricité                                                                          |
+| Transport urbain                                                                          | Transport urbain                                                                     |
+| transport urbain                                                                          | Transport urbain                                                                     |
 
 * Agricultural Inputs (plot_inputs — the input axis)
 

--- a/lsms_library/countries/Niger/_/community_prices.py
+++ b/lsms_library/countries/Niger/_/community_prices.py
@@ -1,0 +1,40 @@
+"""Concatenate wave-level community_prices for Niger (GAP C, item-level).
+
+Each wave's ``Niger/<wave>/_/community_prices.py`` writes a parquet indexed by
+``(t, v, j, u, obs)`` carrying the REPORTED community-questionnaire surveyed
+price (and the native price-per-quantity basis).  This script concatenates the
+waves that HAVE an EA-level community price module: only the two ECVMA waves
+(2011-12, 2014-15).  The EHCVM waves (2018-19, 2021-22) ship no cluster-level
+community price questionnaire — their region/market price survey
+(ehcvm_prix, not at the grappe grain) and the ehcvm_nsu median are NOT this
+feature — so they have no wave script / parquet and are silently skipped here.
+
+``v`` is the community questionnaire's EA (grappe) formatted into the sample()
+v keyspace; it IS in the index (cluster-level feature, no household i), so the
+framework does NOT join it from sample().  No ``id_walk`` here; the framework
+runs it in ``_finalize_result`` on every read.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2011-12', '2014-15', '2018-19', '2021-22']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/community_prices.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not wired for community_prices (no .py script / no parquet —
+        # the EHCVM waves have no EA-level community price module).  DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, 'community_prices: no wave-level parquets found'
+
+p = pd.concat(pieces)
+
+to_parquet(p, '../var/community_prices.parquet')

--- a/lsms_library/countries/Niger/_/data_scheme.yml
+++ b/lsms_library/countries/Niger/_/data_scheme.yml
@@ -343,3 +343,72 @@ Data Scheme:
     Industry: str
     working_age: bool
     materialize: make
+
+  community_prices:
+    # Item-level community/market food prices (GAP C, parity loop 2026-06-14).
+    # One row per REPORTED (cluster/EA × food item × unit × observation)
+    # surveyed price from the ECVMA *community* price questionnaire (section
+    # CS07).  This is the OURS-ONLY parity arm: the WB panel surveys no
+    # community prices (their crop_price_EA is an HH-median imputation,
+    # programs.do:31-89), so this records a surveyed price where they only
+    # impute.  REPORTED values only -- any median / mean across clusters, or a
+    # community->household price join, is a TRANSFORMATION over these rows,
+    # never a column here.
+    #
+    # GRAIN (t, v, j, u) -- a CLUSTER-level feature, NOT household-level.  One
+    # REPORTED price per cell: the CS07 instrument records up to three within-
+    # questionnaire price observations (2011-12 across two field passages too)
+    # per (cluster, item, unit); ONE is selected -- post-harvest (passage 2)
+    # before post-planting (passage 1), then questionnaire order -- mirroring
+    # the Mali EACI community_prices reference.  This is a genuinely REPORTED
+    # price, NOT an across-observation mean (averaging is a transformation), and
+    # matches every sibling community_prices (Mali/Malawi/Tanzania/Ethiopia/
+    # Nigeria), which all use (t, v, j, u) with one reported price per cell.
+    #   v   -- the community questionnaire's grappe (EA), formatted into the
+    #          SAME v keyspace as sample() (`v: grappe`/`GRAPPE` there), so
+    #          community_prices.v == sample().v for the same cluster and the
+    #          surveyed price joins households.  There is NO household i, so
+    #          _join_v_from_sample does NOT apply -- v IS declared in the index
+    #          (native, not framework-joined).
+    #   j   -- the SHARED harmonize_food Preferred Labels, so a priced food
+    #          joins food_acquired consumption and the GAP-1 crop_production
+    #          harvest (e.g. community 'mil' -> 'Mil', 'tomate fraiche' ->
+    #          'Tomate fraîche', exactly the food_acquired labels).  Non-food
+    #          price items (allumettes, savon, électricité, transport, fuel,
+    #          firewood) get their own harmonize_food Preferred Labels -- the
+    #          community-price arm of label unification.
+    #   u   -- the SHARED u table (the CS07 unit list: Kg/Gramme/Tia/Tongolo/
+    #          Sac de 50|100 kg/Gros sac/Sac Moyen/Unité/Tas/Sachet/...).
+    #
+    # NOTE on the framework `i` rename: the framework's map_index() renames a
+    # `j` index level to `i` when no `i` is present (a legacy old-parquet
+    # convention in local_tools.map_index).  Like EVERY sibling community_prices
+    # feature, this surfaces the food item under the name `i` at the API layer
+    # and makes is_this_feature_sane flag a missing `j` level -- a pre-existing
+    # framework behavior shared across all community_prices countries, not a
+    # wiring defect.  The cached parquet carries the correct `j` index level.
+    #
+    # WAVE COVERAGE: only the two ECVMA waves carry an EA-level community price
+    # module (script-path):
+    #   2011-12 ecvmacoms07_p1 + ecvmacoms07_p2  (three price/qty/UNIT triples,
+    #                                             both field passages)
+    #   2014-15 comprixcs07                       (one unit col, three price/qty
+    #                                             pairs)
+    # The EHCVM waves (2018-19, 2021-22) replaced the community price module
+    # with a separate region/market-level price survey (ehcvm_prix: region ×
+    # milieu × point_de_vente, NO grappe -- not the EA grain; and ehcvm_nsu, a
+    # region/strata p50/mu MEDIAN -- a forbidden imputation), and 2018-19 ships
+    # no community price file at all.  Those two waves are silently absent (the
+    # concatenator skips a wave with no parquet), NOT faked.
+    #
+    # COLUMNS (reported, item-level):
+    #   Price    -- the surveyed price recorded for `Quantity` units of the item
+    #               in unit `u` in that cluster (CFA francs).  Zero / sentinel
+    #               (9999 / 99999) prices and 'product absent' rows are dropped.
+    #   Quantity -- the measured quantity Price was recorded for, in unit `u`
+    #               (e.g. Price=11000 for Quantity=50, u='Sac de 50 kg').  The
+    #               per-kg unit value Price/Quantity (×kg-factor) is a transform.
+    index: (t, v, j, u)
+    Price: float
+    Quantity: float
+    materialize: make

--- a/lsms_library/countries/Niger/_/niger.py
+++ b/lsms_library/countries/Niger/_/niger.py
@@ -1010,3 +1010,177 @@ def _finish_people_last7days(df, t):
     df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
     df = df.set_index(['t', 'i', 'pid'])
     return df
+
+
+# ---------------------------------------------------------------------------
+# community_prices (GAP C — item-level community/market food prices)
+# ---------------------------------------------------------------------------
+#
+# One row per REPORTED (cluster/EA × food item × unit) surveyed price from the
+# ECVMA *community* price questionnaire (section CS07).  This is the OURS-ONLY
+# parity arm (GAP_RANKING.org GAP C): the WB panel surveys no community prices
+# — their crop_price_EA is an HH-median imputation, programs.do:31-89 — so this
+# is a surveyed price we record where they only impute.  REPORTED values only:
+# any median / mean across clusters, or a community->household price join, is a
+# TRANSFORMATION over these rows, never a column here.
+#
+# GRAIN = (t, v, j, u).  This is a CLUSTER-level feature: `v` is the community
+# questionnaire's `grappe` (EA), formatted into the SAME v keyspace as
+# sample() (`v: grappe`/`v: GRAPPE` there), so community_prices.v == sample().v
+# for the same cluster and the surveyed price joins households.  There is NO
+# household `i`, so _join_v_from_sample does not apply and `v` IS declared in
+# the index (not framework-joined).  `j` is on the SHARED harmonize_food
+# Preferred Labels (so a priced food joins food_acquired consumption and the
+# GAP-1 crop_production harvest); `u` on the shared `u` table.
+#
+# WAVE COVERAGE: only the two ECVMA waves carry an EA-level community price
+# module.  The EHCVM waves (2018-19, 2021-22) replaced it with a separate
+# region/market-level price survey (ehcvm_prix_ner2021: region × milieu ×
+# point_de_vente, NO grappe — not the EA grain; and ehcvm_nsu, a region/strata
+# p50/mu MEDIAN — a forbidden imputation), and 2018-19 ships no community price
+# file at all.  So those two waves are silently absent (the country-level
+# concatenator skips a wave with no parquet), NOT faked.
+#
+# Community-price instrument by wave (both ECVMA; module CS07):
+#   2011-12  ecvmacoms07_p1 (passage 1) + ecvmacoms07_p2 (passage 2).
+#            grappe; cs07q01 item; THREE (price, qty, unit) triples:
+#            (cs07q03, cs07q04, cs07q05), (cs07q06, cs07q07, cs07q08),
+#            (cs07q09, cs07q10, cs07q11).  Unit is a STRING column per triple.
+#   2014-15  comprixcs07.  grappe; cs07q01 item; ONE unit column cs07q03
+#            shared by THREE (price, qty) pairs: (cs07q04, cs07q05),
+#            (cs07q06, cs07q07), (cs07q08, cs07q09).
+# Both load convert_categoricals=True so the item / unit labels arrive as the
+# strings harmonize_food / u key on.
+#
+# COLUMNS (reported, item-level):
+#   Price    — the surveyed price the enumerator recorded for `Quantity` units
+#              of the item in unit `u` in that cluster (CFA francs).  The
+#              instrument records up to three price observations per
+#              (cluster, item, unit); each is kept as its own row (the within-
+#              cluster observation index is carried as `obs` so the rows do not
+#              collapse).  NOT averaged — an across-observation mean is a
+#              transformation.
+#   Quantity — the measured quantity that Price was recorded for, in unit `u`
+#              (e.g. Price=11000 for Quantity=50, u='Sac de 50 kg').  This is
+#              the native price-per-quantity basis the survey gives; the per-kg
+#              unit value Price/Quantity (×kg-factor) is a transformation.
+# A price of 0 / sentinel (9999 / 99999), and rows whose unit is the
+# 'produit absent' / 'manquant' missing-marker, carry no surveyed price and are
+# dropped.  `obs` (1/2/3) keeps the multiple within-cluster observations as
+# distinct rows without summing.
+
+
+def _community_prices_maps():
+    """Load the harmonize_food (item -> j Preferred Label) and u (unit ->
+    Preferred Label) string maps, keyed on Original Label — exactly the two
+    shared label tables crop_production / food_acquired use, so a priced food
+    joins consumed food and harvested crop on (j, u)."""
+    item_map = tools.get_categorical_mapping(
+        tablename='harmonize_food', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    unit_map = tools.get_categorical_mapping(
+        tablename='u', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    return item_map, unit_map
+
+
+def _item_labels(item_series, item_map):
+    """Map a community-price item column (string labels from
+    convert_categoricals=True) through harmonize_food (keyed on Original
+    Label).  Unmapped labels pass through unchanged (kept visible, flagged by
+    the sanity checker)."""
+    lab = item_series.astype('string')
+    return lab.map(lambda x: item_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+# Price sentinels meaning "no answer / not recorded" in the CS07 grids.
+_COMMUNITY_PRICE_SENTINELS = (9999.0, 99999.0)
+# Unit Preferred Labels that mark the product as absent / missing in the
+# cluster — these rows carry no surveyed price and are dropped.
+_COMMUNITY_MISSING_UNITS = {'Manquant'}
+
+
+def _community_price_triples(df, item_map, unit_map, triples, passage=1):
+    """Reshape a wide CS07 community-price frame into long (v, j, u, passage,
+    Price, Quantity) rows.
+
+    `triples` is a list of (price_col, qty_col, unit_col) — the unit_col may be
+    a single shared column repeated across triples (2014-15) or per-triple
+    (2011-12).  The instrument records up to three within-questionnaire price
+    observations; each becomes a candidate row, and one reported price per
+    (t, v, j, u) is selected downstream in _finish_community_prices (NOT
+    averaged).  `v` is the grappe formatted into the sample() keyspace; `j` via
+    harmonize_food; `u` via the u table.  `passage` (the field visit: 1=post-
+    planting, 2=post-harvest) tags the rows for the post-harvest-first
+    selection.  Rows with no usable price (NA / 0 / sentinel) or a
+    missing-marker unit are dropped here so they never reach the index."""
+    v = df['grappe'].apply(tools.format_id).astype('string')
+    j = _item_labels(df['cs07q01'].astype(str).str.strip(), item_map)
+    pieces = []
+    for pcol, qcol, ucol in triples:
+        price = pd.to_numeric(df[pcol], errors='coerce').astype('Float64')
+        qty = pd.to_numeric(df[qcol], errors='coerce').astype('Float64')
+        # Quantity 0 / 9999 / 99999 are "no answer" markers, not a measured
+        # basis — null them (the surveyed Price row is still kept; only the
+        # missing quantity basis is dropped, per the reported-only rule).
+        qty = qty.where((qty > 0)
+                        & (~qty.isin(_COMMUNITY_PRICE_SENTINELS)), pd.NA)
+        u = _unit_labels(df[ucol].astype(str).str.strip(), unit_map)
+        piece = pd.DataFrame({
+            'v': v.values, 'j': j.values, 'u': u.values,
+            'Price': price.values, 'Quantity': qty.values,
+            'passage': passage,
+        })
+        pieces.append(piece)
+    out = pd.concat(pieces, ignore_index=True)
+    # Drop rows with no surveyed price.
+    out = out[out['Price'].notna() & (out['Price'] > 0)]
+    for sv in _COMMUNITY_PRICE_SENTINELS:
+        out = out[out['Price'] != sv]
+    out = out[~out['u'].isin(_COMMUNITY_MISSING_UNITS)]
+    return out
+
+
+def _finish_community_prices(df, t):
+    """Common tail for the wave-level community_prices scripts: tag t, coerce
+    numeric columns, drop rows missing any index key, SELECT one reported price
+    per (t, v, j, u), and build the (t, v, j, u) index.
+
+    The CS07 instrument records up to three within-questionnaire price
+    observations (2011-12 across two field passages too) per (cluster, item,
+    unit).  Mirroring the Mali EACI community_prices reference, ONE reported
+    observation is selected per (t, v, j, u) — post-harvest (passage 2) before
+    post-planting (passage 1), then questionnaire order via a stable sort — so
+    the result is a clean, item-level (t, v, j, u) grain carrying a genuinely
+    REPORTED price (NOT an across-observation mean — averaging is a
+    transformation).  This matches every sibling community_prices feature
+    (Mali / Malawi / Tanzania / Ethiopia / Nigeria), which all use (t, v, j, u)
+    with one reported price per cell."""
+    df = df.copy()
+    for col in ['Price', 'Quantity']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    df['t'] = t
+    df['v'] = df['v'].astype('string')
+    df['j'] = df['j'].astype('string')
+    df['u'] = df['u'].astype('string')
+    if 'passage' not in df.columns:
+        df['passage'] = 1
+    # Every index level must be non-null (the framework drops NaN-key rows).
+    df = df[df['v'].notna() & df['j'].notna() & df['u'].notna()]
+    # Select one observation per (t, v, j, u): post-harvest (passage 2) before
+    # post-planting (passage 1), then questionnaire order (stable sort).
+    df = df.reset_index(drop=True)
+    df['_porder'] = df['passage'].map({2: 0, 1: 1}).fillna(2).astype(int)
+    df = df.sort_values(['t', 'v', 'j', 'u', '_porder'], kind='stable')
+    df = df.drop_duplicates(subset=['t', 'v', 'j', 'u'], keep='first')
+    # Redundant i==v level (positioned before j) so the framework's map_index
+    # does not swap j->i for an i-less index; _normalize_dataframe_index then
+    # drops the undeclared i, leaving the canonical (t,v,j,u) grain.  Mirrors
+    # the Mali/Malawi/Tanzania/Ethiopia community_prices shim.
+    df['i'] = df['v']
+    keep = ['t', 'v', 'i', 'j', 'u', 'Price', 'Quantity']
+    df = df[keep]
+    df = df.set_index(['t', 'v', 'i', 'j', 'u']).sort_index()
+    return df

--- a/lsms_library/countries/Nigeria/2010-11/_/community_prices.py
+++ b/lsms_library/countries/Nigeria/2010-11/_/community_prices.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""community_prices for Nigeria GHS-Panel 2010-11 (W1) -- GAP C.
+
+Item-level reported community food prices at grain (t, v, j, u) from the
+post-harvest COMMUNITY questionnaire's food-price module (Section C8,
+sectc8_harvestw1.csv).  CLUSTER-level (no household i); v = format_id(ea)
+is the community EA id, the SAME keyspace as sample().v.  W1 uses the
+community questionnaire's OWN item-code scheme (mapped by name to canonical
+harmonize_food Preferred Labels) and carries no unit column (the unit is the
+per-item fixed questionnaire unit).  t = 2011Q1 (post-harvest quarter).
+
+Registered as a wave-level script so the build flows through the framework's
+wave path (getattr(wave, 'community_prices')()), which preserves the (t,v,j,u)
+grain -- the country-level fallback path's map_index() would swap the j level
+to i for a j-without-i index.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import PH_QUARTER, community_prices_for_wave
+
+t = PH_QUARTER['2010-11']
+f = '../Data/sectc8_harvestw1.csv'
+raw = get_dataframe(f, convert_categoricals=False)
+df = community_prices_for_wave(t, [dict(
+    df=raw, dec=raw, ea='ea', item='item_cd', price='sc8q2', unit=None)],
+    mode='names')
+
+assert df.index.is_unique, "community_prices W1: (t,v,j,u) not unique"
+assert len(df) > 0
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Nigeria/2012-13/_/community_prices.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/community_prices.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""community_prices for Nigeria GHS-Panel 2012-13 (W2) -- GAP C.
+
+Item-level reported community food prices at grain (t, v, j, u) from the
+post-harvest COMMUNITY questionnaire's food-price module (Section C8,
+sectc8_harvestw2.csv).  CLUSTER-level (no household i); v = format_id(ea).
+W2 shares W1's community item-code scheme (mapped by name to canonical
+harmonize_food labels) and carries no unit column (per-item fixed unit).
+t = 2013Q1 (post-harvest quarter).  See the W1 wave script for why this is a
+wave-level (not country-level) script.
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import PH_QUARTER, community_prices_for_wave
+
+t = PH_QUARTER['2012-13']
+f = '../Data/sectc8_harvestw2.csv'
+raw = get_dataframe(f, convert_categoricals=False)
+df = community_prices_for_wave(t, [dict(
+    df=raw, dec=raw, ea='ea', item='item_cd', price='c8q2', unit=None)],
+    mode='names')
+
+assert df.index.is_unique, "community_prices W2: (t,v,j,u) not unique"
+assert len(df) > 0
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Nigeria/2015-16/_/community_prices.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/community_prices.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""community_prices for Nigeria GHS-Panel 2015-16 (W3) -- GAP C.
+
+Item-level reported community food prices at grain (t, v, j, u) from the
+post-harvest COMMUNITY questionnaire's food-price module (Section C8).  W3
+splits the module across sectc8a_harvestw3.dta and sectc8b_harvestw3.dta
+(different item ranges).  CLUSTER-level (no household i); v = format_id(ea).
+W3 item_cd is the consumption-module scheme already in harmonize_food
+(resolved via Code); c8q2 is the per-row unit label, c8q3 the reported price.
+t = 2016Q1 (post-harvest quarter).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import PH_QUARTER, community_prices_for_wave, _crop_labels
+
+crop_labels = _crop_labels()
+
+t = PH_QUARTER['2015-16']
+frames = []
+for f in ('../Data/sectc8a_harvestw3.dta', '../Data/sectc8b_harvestw3.dta'):
+    raw = get_dataframe(f, convert_categoricals=False)
+    dec = get_dataframe(f, convert_categoricals=True)
+    frames.append(dict(df=raw, dec=dec, ea='ea', item='item_cd',
+                       price='c8q3', unit='c8q2'))
+
+df = community_prices_for_wave(t, frames, mode='codes',
+                              crop_labels=crop_labels)
+
+assert df.index.is_unique, "community_prices W3: (t,v,j,u) not unique"
+assert len(df) > 0
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Nigeria/2018-19/_/community_prices.py
+++ b/lsms_library/countries/Nigeria/2018-19/_/community_prices.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""community_prices for Nigeria GHS-Panel 2018-19 (W4) -- GAP C.
+
+Item-level reported community food prices at grain (t, v, j, u) from the
+post-harvest COMMUNITY questionnaire's food-price module (Section C8,
+sectc8_harvestw4.dta).  CLUSTER-level (no household i); v = format_id(ea).
+W4 item_cd is the consumption-module scheme already in harmonize_food
+(resolved via Code); c8q2 is the per-row unit label, c8q3 the reported price.
+t = 2019Q1 (post-harvest quarter).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import PH_QUARTER, community_prices_for_wave, _crop_labels
+
+crop_labels = _crop_labels()
+
+t = PH_QUARTER['2018-19']
+f = '../Data/sectc8_harvestw4.dta'
+raw = get_dataframe(f, convert_categoricals=False)
+dec = get_dataframe(f, convert_categoricals=True)
+df = community_prices_for_wave(t, [dict(
+    df=raw, dec=dec, ea='ea', item='item_cd', price='c8q3', unit='c8q2')],
+    mode='codes', crop_labels=crop_labels)
+
+assert df.index.is_unique, "community_prices W4: (t,v,j,u) not unique"
+assert len(df) > 0
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Nigeria/2023-24/_/community_prices.py
+++ b/lsms_library/countries/Nigeria/2023-24/_/community_prices.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""community_prices for Nigeria GHS-Panel 2023-24 (W5) -- GAP C.
+
+Item-level reported community food prices at grain (t, v, j, u) from the
+post-harvest COMMUNITY questionnaire's food-price module (Section C8,
+Post Harvest Wave 5/Community/sectc8_harvestw5.dta).  CLUSTER-level (no
+household i); v = format_id(ea).  W5 item_cd is the consumption-module scheme
+already in harmonize_food (resolved via Code); the per-row unit label is
+c8aq2_b, the reported price c8aq3.  t = 2024Q1 (post-harvest quarter).
+"""
+import sys
+
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from nigeria import PH_QUARTER, community_prices_for_wave, _crop_labels
+
+crop_labels = _crop_labels()
+
+t = PH_QUARTER['2023-24']
+f = '../Data/Post Harvest Wave 5/Community/sectc8_harvestw5.dta'
+raw = get_dataframe(f, convert_categoricals=False)
+dec = get_dataframe(f, convert_categoricals=True)
+df = community_prices_for_wave(t, [dict(
+    df=raw, dec=dec, ea='ea', item='item_cd', price='c8aq3', unit='c8aq2_b')],
+    mode='codes', crop_labels=crop_labels)
+
+assert df.index.is_unique, "community_prices W5: (t,v,j,u) not unique"
+assert len(df) > 0
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Nigeria/_/CONTENTS.org
+++ b/lsms_library/countries/Nigeria/_/CONTENTS.org
@@ -172,3 +172,85 @@ W3 25% / W4 56% / W5 49%).
 - No id_walk applied at the country level: GHS-Panel hhids are stable
   across waves (panel_ids maps previous_i = hhid), so there is no
   per-wave remapping dict (mirrors Nigeria food_acquired).
+
+* community_prices (GAP C -- OURS-ONLY, maintainer priority)
+
+Item-level REPORTED community food prices at natural grain (t, v, j, u):
+one row per (cluster/EA x food-item x unit) from the post-harvest COMMUNITY
+questionnaire's food-price module (Section C8 "Food Prices").  CLUSTER-level
+-- there is NO household i.  Stores the surveyed Price ONLY (Naira); NOT an
+index, NOT a cross-cluster median/mean, NOT an HH-median imputation (those
+are transformations).  The WB panel surveys no community prices (their
+crop_price_EA is an HH-median imputation), so this is strictly richer.
+
+124,539 priced rows across 5 waves x 584 clusters x 139 food items x 30 units.
+
+** Source files (post-harvest community round)
+
+| Wave | t      | File(s)                                                   | item code scheme        |
+|------+--------+----------------------------------------------------------+-------------------------|
+| W1   | 2011Q1 | sectc8_harvestw1.csv                                      | community-own (by name) |
+| W2   | 2013Q1 | sectc8_harvestw2.csv                                      | community-own (by name) |
+| W3   | 2016Q1 | sectc8a_harvestw3.dta + sectc8b_harvestw3.dta            | consumption (by Code)   |
+| W4   | 2019Q1 | sectc8_harvestw4.dta                                      | consumption (by Code)   |
+| W5   | 2024Q1 | Post Harvest Wave 5/Community/sectc8_harvestw5.dta        | consumption (by Code)   |
+
+Price / unit columns: W1 sc8q2 price (no unit col); W2 c8q2 price (no unit
+col); W3 c8q3 price / c8q2 unit; W4 c8q3 price / c8q2 unit; W5 c8aq3 price /
+c8aq2_b unit.
+
+** v -> sample() keyspace
+
+v = format_id(ea), the community questionnaire's EA id.  ALL 584 community
+EAs intersect sample().v (which also joins v = format_id(ea)), so
+community_prices.v joins households via their cluster -- confirmed
+584/584.
+
+** Item labels (j) -- the community-price arm of label unification
+
+- W3-W5 item_cd is the CONSUMPTION-module scheme already registered in
+  harmonize_food, so items resolve directly via Code (exactly like
+  food_acquired / crop_production).  No extension needed.
+- W1/W2 use the community questionnaire's OWN (disjoint) item-code scheme.
+  The 4-digit data codes encode a size variant as base*10+size (1511 = item
+  151 size 1).  Mapped by NAME to canonical harmonize_food Preferred Labels
+  in nigeria.py (_W1W2_PRICE_ITEM, from the W1 Community_Questionnaire C8
+  item list), reusing existing food labels.  The 16 genuinely-new
+  prepared-food / drink price items (Moi moi, Akara, Kulikuli, the 6 soups,
+  Kunu, the 2 juices, Millet/Plantain flour, Fufu dough, Ice cream) are
+  registered in harmonize_food as codes 4001-4016.  Tobacco / cigarettes
+  (non-food, community codes 951/952) are dropped.
+- 118 of the 139 community-price items match a food_acquired Preferred
+  Label, 45 match a crop_production crop label -> j joins consumption and
+  harvest on the canonical label.
+
+** Units (u)
+
+Native unit label normalized to the shared `u` table base Preferred Label
+via _canon_unit.  W3-W5 record the unit per row; W1/W2 carry NO unit column
+(the questionnaire fixes one unit per item) so the unit is the per-item
+fixed C8 unit (_W1W2_PRICE_UNIT).  All 30 units used already exist in `u`
+(no extension needed).
+
+** Framework-compatibility shim (the i==v level)
+
+community_prices is cluster-level, but local_tools.map_index() (run on every
+read) unconditionally swaps a j index level to i whenever i is absent --
+which would rename our item level `j` to `i` and collapse the table to
+(t, v, u).  community_prices_for_wave carries a redundant i level (= v)
+positioned BEFORE j, so map_index sees i present and does not swap;
+_normalize_dataframe_index then drops the undeclared i, leaving the
+canonical (t, v, j, u).  Same shim Tanzania/Malawi/Ethiopia/Mali use.  This
+is also why the build is split into per-wave scripts + a country
+concatenator (mirroring food_acquired): the wave path preserves the grain;
+the country-only fallback path's map_index would corrupt it.
+
+** Coverage of priced rows
+
+W3-W5 resolve via Code (the consumption scheme); near-complete.  W1 98.5% of
+positive-price rows resolve to a label (the only drops are the non-food
+community codes 951 Cigarette / 952 Tobacco -- deliberately excluded as
+non-food).  W2 94.7% resolve: in addition to the same tobacco drop, a small
+W2-only block of undocumented "other miscellaneous foods" sub-codes
+(191x/192x/193x, ~4% of W2 rows) has no authoritative label in the retained
+documentation and is left unresolved rather than guessed (no faked labels).

--- a/lsms_library/countries/Nigeria/_/Makefile
+++ b/lsms_library/countries/Nigeria/_/Makefile
@@ -171,6 +171,22 @@ $(VAR_DIR)/food_coping.parquet: food_coping.py $(food_coping_parquet)
 $(VAR_DIR)/anthropometry.parquet: anthropometry.py
 	python anthropometry.py
 
+# community_prices (GAP C).  Wave-level scripts read each year folder's
+# post-harvest community price module (Section C8, sectc8_harvest*) and
+# write a wave parquet at the PH quarter; the country-level concatenator
+# joins them to var/community_prices.parquet.  The wave-level split routes
+# the build through the framework's wave path, preserving the (t, v, j, u)
+# grain (the country-only fallback applies map_index(), which swaps a
+# j-without-i index level to i and collapses the table).
+community_prices = $(shell find $(rounds) -name community_prices.py)
+community_prices_parquet := $(community_prices:.py=.parquet)
+
+../%/_/community_prices.parquet: ../%/_/community_prices.py
+	(cd $(@D) && python community_prices.py)
+
+$(VAR_DIR)/community_prices.parquet: community_prices.py $(community_prices_parquet)
+	python community_prices.py
+
 ../2010-11/_/housing.parquet: ../2010-11/_/housing.py
 	(cd ../2010-11/_; python housing.py)
 

--- a/lsms_library/countries/Nigeria/_/categorical_mapping.org
+++ b/lsms_library/countries/Nigeria/_/categorical_mapping.org
@@ -8,6 +8,19 @@
   sub-varieties (e.g. "Maize (shelled)" and "Maize (unshelled)" both
   aggregate to "Maize").
 
+  Community-price item codes (GAP C / community_prices feature) reuse this
+  same table.  The post-harvest community price module (Section C8,
+  sectc8_harvest*) in W3-W5 carries the consumption-module item_cd scheme,
+  so its items resolve directly via Code here -- no extension needed.  W1/W2
+  community-price use the community questionnaire's OWN (disjoint) item-code
+  scheme, mapped by NAME to these Preferred Labels in nigeria.py
+  (_W1W2_PRICE_ITEM), reusing existing food labels where the priced good is
+  a consumption-module food.  Codes 4001-4016 below register the only
+  genuinely NEW price-questionnaire items (prepared foods / drinks the
+  consumption module does not list: Moi moi, Akara, Kulikuli, the soups,
+  Kunu, juices, flours, Ice cream); they appear only in the W1/W2 community
+  price round (PH quarters 2011Q1/2013Q1).
+
   Crop-production item codes (GAP 1 / crop_production feature) are appended
   to the same table.  The post-harvest crop module (secta3*) uses its own
   cropcode scheme (1010-9999), DISJOINT from the food-consumption codes
@@ -266,6 +279,22 @@
 | 3250 | Eru | Eru | --- | Eru | --- | Eru | --- | Eru | --- | Eru |
 | 3260 | Iyere | Iyere | --- | Iyere | --- | Iyere | --- | Iyere | --- | Iyere |
 | 9999 | Other crop | Other crop | --- | Other (Specify) | --- | Other (Specify) | --- | Other (Specify) | --- | Other (Specify) |
+| 4001 | Millet flour | Millet flour | --- | Millet flour | --- | Millet flour | --- | --- | --- | --- |
+| 4002 | Plantain flour | Plantain flour | --- | Plantain flour | --- | Plantain flour | --- | --- | --- | --- |
+| 4003 | Fufu/Cassava dough (akpu) | Fufu/Cassava dough (akpu) | --- | Fufu/Cassava dough (akpu) | --- | Fufu/Cassava dough (akpu) | --- | --- | --- | --- |
+| 4004 | Moi moi | Moi moi | --- | Moi moi | --- | Moi moi | --- | --- | --- | --- |
+| 4005 | Akara (bean cake) | Akara (bean cake) | --- | Akara (bean cake) | --- | Akara (bean cake) | --- | --- | --- | --- |
+| 4006 | Kulikuli (groundnut cake) | Kulikuli (groundnut cake) | --- | Kulikuli (groundnut cake) | --- | Kulikuli (groundnut cake) | --- | --- | --- | --- |
+| 4007 | Orange juice | Orange juice | --- | Orange juice | --- | Orange juice | --- | --- | --- | --- |
+| 4008 | Pineapple juice | Pineapple juice | --- | Pineapple juice | --- | Pineapple juice | --- | --- | --- | --- |
+| 4009 | Cooked rice and stew | Cooked rice and stew | --- | Cooked rice and stew | --- | Cooked rice and stew | --- | --- | --- | --- |
+| 4010 | Fufu and soup | Fufu and soup | --- | Fufu and soup | --- | Fufu and soup | --- | --- | --- | --- |
+| 4011 | Tuo and soup | Tuo and soup | --- | Tuo and soup | --- | Tuo and soup | --- | --- | --- | --- |
+| 4012 | Amala and soup | Amala and soup | --- | Amala and soup | --- | Amala and soup | --- | --- | --- | --- |
+| 4013 | Gari and soup | Gari and soup | --- | Gari and soup | --- | Gari and soup | --- | --- | --- | --- |
+| 4014 | Pounded yam and soup | Pounded yam and soup | --- | Pounded yam and soup | --- | Pounded yam and soup | --- | --- | --- | --- |
+| 4015 | Ice cream | Ice cream | --- | Ice cream | --- | Ice cream | --- | --- | --- | --- |
+| 4016 | Kunu | Kunu | --- | Kunu | --- | Kunu | --- | --- | --- | --- |
 
 * Units
 

--- a/lsms_library/countries/Nigeria/_/community_prices.py
+++ b/lsms_library/countries/Nigeria/_/community_prices.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""Concatenate wave-level community_prices for Nigeria GHS-Panel (GAP C).
+
+Item-level reported community food prices at grain (t, v, j, u) from the
+post-harvest COMMUNITY questionnaire's food-price module (Section C8).
+CLUSTER-level (no household i); v = format_id(ea) is the community EA id,
+the SAME keyspace as sample().v, so prices join households via their cluster.
+Stores the REPORTED surveyed Price ONLY -- no index, no cross-cluster
+median/mean, no HH-median imputation (those are transformations).
+
+Each year folder's ``<wave>/_/community_prices.py`` produces a wave-level
+parquet at the post-harvest quarter (2011Q1 / 2013Q1 / 2016Q1 / 2019Q1 /
+2024Q1); this script concatenates them.  The wave-level split (mirroring
+food_acquired and Tanzania's community_prices) routes the build through the
+framework's wave path, which preserves the (t, v, j, u) grain -- the
+country-only fallback path applies map_index(), which swaps a j-without-i
+index level to i and collapses the table.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+# Year folders, each contributing exactly its post-harvest quarter.
+WAVE_FOLDERS = ['2010-11', '2012-13', '2015-16', '2018-19', '2023-24']
+
+pieces = []
+for w in WAVE_FOLDERS:
+    fn = f'../{w}/_/community_prices.parquet'
+    try:
+        pieces.append(get_dataframe(fn))
+    except Exception:
+        # Wave-level parquet not built yet; skip (the framework wave path
+        # builds it on demand, but a direct country build may run first).
+        continue
+
+assert pieces, "community_prices: no wave-level parquets found"
+
+df = pd.concat(pieces, axis=0).sort_index()
+# A food item may be priced under more than one base unit in a cluster, but
+# (t, v, j, u) must be unique; the wave scripts already collapse same-cell
+# duplicates.  Guard against any cross-wave overlap (there is none -- each
+# wave owns a distinct PH quarter).
+assert df.index.is_unique, "community_prices: (t,v,j,u) not unique after concat"
+
+to_parquet(df, '../var/community_prices.parquet')

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -343,4 +343,44 @@ Data Scheme:
     working_age: float
     materialize: make
 
+  community_prices:
+    # Item-level reported community food prices (GAP C) at natural grain
+    # (t, v, j, u).  CLUSTER-level: one row per (cluster/EA x food-item x
+    # unit) from the post-harvest COMMUNITY questionnaire's food-price
+    # module (Section C8 "Food Prices", file sectc8_harvest{wN}; W3 splits
+    # it across sectc8a / sectc8b; W5 under Post Harvest Wave 5/Community/).
+    # There is NO household i, so _join_v_from_sample does NOT apply -- `v`
+    # is declared in the index here and carried NATIVELY: it is the
+    # community questionnaire's EA id (v = format_id(ea)), the SAME keyspace
+    # as sample().v, so community_prices.v joins households via their
+    # cluster.  Country-level script (_/community_prices.py) maps each wave
+    # -> materialize: make.
+    #
+    # Stores the REPORTED surveyed field ONLY:
+    #   Price   prevailing price of one unit `u` of item `j` in cluster `v`
+    #           at the present time (Naira).  W1/W2 sc8q2 / c8q2; W3-W5
+    #           c8q3 / c8aq3.
+    # NOT an index, NOT a cross-cluster median/mean, NOT an HH-median
+    # imputation -- those are transformations over these rows.  (The WB
+    # panel surveys NO community prices: their crop_price_EA is an HH-median
+    # imputation; ours is the SURVEYED community price -- strictly better.)
+    #
+    # Labels (the community-price arm of label unification):
+    #   j -> the SHARED harmonize_food Preferred Label, so community_prices.j
+    #        joins food_acquired.j and crop_production.crop.  W3-W5 item_cd is
+    #        the consumption-module scheme already in harmonize_food (resolved
+    #        via Code).  W1/W2 use the community questionnaire's OWN code
+    #        scheme, mapped by NAME in nigeria.py (_W1W2_PRICE_ITEM), reusing
+    #        existing food labels; the 16 genuinely-new prepared-food/drink
+    #        price items are registered in harmonize_food (codes 4001-4016).
+    #   u -> the SHARED `u` table base Preferred Label via _canon_unit (all
+    #        30 units used already exist in `u` -- no extension needed).  W3-W5
+    #        record the unit per row; W1/W2 carry no unit column, so the unit
+    #        is the questionnaire's per-item fixed unit (_W1W2_PRICE_UNIT).
+    # t = PH_QUARTER[wave] (the price module sits in the post-harvest round,
+    # matching crop_production / anthropometry).
+    index: (t, v, j, u)
+    Price: float
+    materialize: make
+
   nonfood_expenditures: !make

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -1668,3 +1668,238 @@ def people_last7days_from_s4aq(t, df, hhid='hhid', indiv='indiv'):
     return out[['farm_work', 'SOB_work', 'wage_work',
                 'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']]
 
+
+# ---------------------------------------------------------------------
+# community_prices (GAP C) -- item-level reported community food prices
+# ---------------------------------------------------------------------
+#
+# Natural grain (t, v, j, u): one row per (cluster/EA x food-item x unit)
+# from the post-harvest COMMUNITY questionnaire's food-price module
+# (Section C8 "Food Prices", file sectc8_harvest{wN}; W3 splits it across
+# sectc8a / sectc8b; W5 lives under Post Harvest Wave 5/Community/).  This
+# is a CLUSTER-level table: there is no household i.  `v` is the native
+# community-questionnaire EA id (`ea`), which maps to the SAME keyspace as
+# sample().v (sample joins v = format_id(ea) too), so community_prices.v
+# joins households via their cluster.  Item-level REPORTED prices only --
+# NOT an index, NOT a median/mean across clusters, NOT an HH-median
+# imputation (those are transformations over these rows).
+#
+# Stores the REPORTED field only:
+#   Price   the surveyed prevailing price of one unit `u` of item `j` in
+#           cluster `v` at the present time (Naira).  W1/W2 sc8q2/c8q2;
+#           W3-W5 c8q3 / c8aq3.
+#
+# Labels (the community-price arm of label unification):
+#   j  -> the SHARED harmonize_food Preferred Label, so community_prices.j
+#         joins food_acquired.j and crop_production.crop.  W3-W5 carry the
+#         consumption-module item_cd scheme already registered in
+#         harmonize_food (resolved via Code, exactly like food_acquired).
+#         W1/W2 use the community questionnaire's OWN (disjoint) item-code
+#         scheme -- mapped here by NAME to the canonical Preferred Label via
+#         _W1W2_PRICE_ITEM, reusing existing food labels where the priced
+#         good is a consumption-module food and adding only genuinely new
+#         price-questionnaire prepared-food/drink items (Moi moi, Akara,
+#         soups, Kunu, juices, ...).  Tobacco/cigarettes (non-food) dropped.
+#   u  -> the SHARED `u` table base Preferred Label via _canon_unit.  W3-W5
+#         record the unit per row (sc8q2/c8q2/c8aq2); W1/W2 do NOT carry a
+#         unit column -- the questionnaire fixes one unit per item, so the
+#         per-item unit is supplied from _W1W2_PRICE_UNIT (Section C8's
+#         column heads: KG / PIECE / BUNCH / LITRE / TIN / BOTTLE / ...).
+#
+# t = PH_QUARTER[wave] (the price module sits in the post-harvest round,
+# matching crop_production / anthropometry).
+
+
+# W1/W2 community-price questionnaire (Section C8) item codes -> canonical
+# harmonize_food Preferred Label.  The 4-digit data codes encode a size
+# variant as `base*10 + size` (e.g. 1511 = item 151 size 1), so the build
+# resolves a data code by trying the code itself, then `code // 10`.
+_W1W2_PRICE_ITEM = {
+    1: 'Guinea corn/sorghum', 2: 'Millet', 3: 'Maize', 4: 'Maize',
+    5: 'Rice--local', 6: 'Rice--local', 7: 'Rice--imported', 8: 'Bread',
+    9: 'Buns/Pofpof/Donuts', 10: 'Biscuits', 11: 'Maize flour',
+    20: 'Millet flour', 21: 'Wheat flour', 22: 'Yam flour',
+    23: 'Cassava flour', 24: 'Plantain flour', 30: 'Cassava--roots',
+    31: 'Yam--roots', 32: 'Gari--white', 33: 'Gari--yellow', 34: 'Cocoyam',
+    35: 'Plantains', 36: 'Sweet potatoes', 37: 'Potatoes',
+    38: 'Fufu/Cassava dough (akpu)', 50: 'Brown beans', 51: 'Soya beans',
+    52: 'Moi moi', 53: 'Akara (bean cake)', 54: 'Kulikuli (groundnut cake)',
+    55: 'Locust bean', 60: 'Bambara nut', 61: 'Groundnuts (shelled)',
+    62: 'Kola nut', 63: 'Palm kernel', 64: 'Cashew nut', 65: 'Coconut',
+    70: 'Palm oil', 71: 'Coconut oil', 72: 'Sheabutter',
+    73: 'Butter/Margarine', 74: 'Cheese (wara)', 75: 'Animal fat',
+    76: 'Groundnut oil', 78: 'Butter/Margarine', 80: 'Bananas',
+    81: 'Watermelon', 82: 'Orange/tangerine', 83: 'Mangoes', 84: 'Pawpaw',
+    85: 'Avocado pear', 86: 'Pineapples', 87: 'Pineapple juice',
+    88: 'Orange juice', 90: 'Fruit canned', 91: 'Fruit juice canned/Pack',
+    101: 'Tomatoes', 102: 'Onions', 103: 'Garden eggs/egg plant',
+    104: 'Okra--fresh', 105: 'Okra--dried', 106: 'Fresh Pepper',
+    107: 'Cabbage', 108: 'Cucumber',
+    109: 'Leaves (Cocoyam, Spinach, etc.)', 111: 'Tomato puree (canned)',
+    120: 'Chicken', 121: 'Duck', 122: 'Other domestic poultry',
+    123: 'Wild game meat', 125: 'Agricultural eggs', 126: 'Local eggs',
+    130: 'Beef', 131: 'Mutton', 132: 'Pork', 133: 'Goat',
+    134: 'Wild game meat', 136: 'Canned beef/corned beef',
+    140: 'Fish--fresh', 141: 'Fish--frozen', 142: 'Fish--smoked',
+    143: 'Fish--dried', 144: 'Fish--fresh', 145: 'Snails',
+    146: 'Seafood (lobster, crab, prawns, etc)', 147: 'Canned fish/seafood',
+    150: 'Fresh milk', 151: 'Milk powder', 152: 'Baby milk powder',
+    153: 'Milk tinned (unsweetened)', 154: 'Fresh milk',
+    155: 'Other milk products', 160: 'Coffee',
+    161: 'Chocolate drinks (including Milo)', 162: 'Tea',
+    170: 'Cooked rice and stew', 171: 'Fufu and soup', 172: 'Tuo and soup',
+    173: 'Amala and soup', 174: 'Gari and soup',
+    175: 'Pounded yam and soup', 180: 'Sugar', 181: 'Jams', 182: 'Honey',
+    183: 'Other sweets and confectionary', 184: 'Ice cream',
+    190: 'Condiments (salt, spices, pepper, etc)', 200: 'Bottled water',
+    201: 'Sachet water', 202: 'Malt drinks',
+    203: 'Soft drinks (Coca Cola, spirit, etc)', 204: 'Kunu',
+    611: 'Other vegetables (fresh or canned)',
+    612: 'Other vegetables (fresh or canned)',
+    900: 'Beer (local and imported)', 901: 'Beer (local and imported)',
+    903: 'Palm wine', 904: 'Pito', 905: 'Other alcoholic beverages',
+    906: 'Gin',
+}
+
+# W1/W2 Section C8 per-item fixed unit (the column head on the printed
+# questionnaire -- W1/W2 record no unit column, so the unit is the item's
+# canonical sale unit).  Normalized to the shared `u` table base label.
+_W1W2_PRICE_UNIT = {
+    1: 'Kg', 2: 'Kg', 3: 'Kg', 4: 'Kg', 5: 'Kg', 6: 'Kg', 7: 'Kg',
+    8: 'Piece', 9: 'Piece', 10: 'Piece', 11: 'Kg', 20: 'Kg', 21: 'Kg',
+    22: 'Kg', 23: 'Kg', 24: 'Kg', 30: 'Piece', 31: 'Piece', 32: 'Kg',
+    33: 'Kg', 34: 'Piece', 35: 'Piece', 36: 'Piece', 37: 'Piece', 38: 'Kg',
+    50: 'Kg', 51: 'Kg', 52: 'Piece', 53: 'Piece', 54: 'Kg', 55: 'Kg',
+    60: 'Kg', 61: 'Kg', 62: 'Kg', 63: 'Kg', 64: 'Kg', 65: 'Piece',
+    70: 'l', 71: 'l', 72: 'Kg', 73: 'Kg', 74: 'Kg', 75: 'Kg', 76: 'l',
+    78: 'Kg', 80: 'Bunch', 81: 'Piece', 82: 'Piece', 83: 'Piece',
+    84: 'Piece', 85: 'Piece', 86: 'Piece', 87: 'Piece', 88: 'Piece',
+    90: 'Piece', 91: 'Piece', 101: 'Kg', 102: 'Kg', 103: 'Kg', 104: 'Kg',
+    105: 'Kg', 106: 'Kg', 107: 'Piece', 108: 'Piece', 109: 'Bunch',
+    111: 'Piece', 120: 'Kg', 121: 'Kg', 122: 'Kg', 123: 'Kg',
+    125: 'Crate', 126: 'Piece', 130: 'Kg', 131: 'Kg', 132: 'Kg',
+    133: 'Kg', 134: 'Kg', 136: 'Bottle/Can', 140: 'Kg', 141: 'Kg',
+    142: 'Kg', 143: 'Kg', 144: 'Kg', 145: 'Kg', 146: 'Kg',
+    147: 'Bottle/Can', 150: 'l', 151: 'tin', 152: 'tin', 153: 'tin',
+    154: 'Bottle/Can', 155: 'Bottle/Can', 160: 'Sachet', 161: 'tin',
+    162: 'Piece', 170: 'Piece', 171: 'Piece', 172: 'Piece', 173: 'Piece',
+    174: 'Piece', 175: 'Piece', 180: 'Wrap', 181: 'Bottle/Can',
+    182: 'Bottle/Can', 183: 'Bowl', 184: 'l', 190: 'Wrap',
+    200: 'Bottle/Can', 201: 'cl', 202: 'cl', 203: 'cl', 204: 'cl',
+    611: 'Kg', 612: 'Kg', 900: 'Bottle/Can', 901: 'Bottle/Can',
+    903: 'Bottle/Can', 904: 'Bottle/Can', 905: 'Bottle/Can',
+    906: 'Bottle/Can',
+}
+
+
+def _resolve_w1w2_price_item(code):
+    """W1/W2 community item code -> (Preferred Label, base unit).  Tries the
+    code itself, then ``code // 10`` (4-digit codes are ``base*10+size``).
+    Returns (None, None) for unmapped / non-food codes."""
+    code = int(code)
+    for c in (code, code // 10):
+        if c in _W1W2_PRICE_ITEM:
+            return _W1W2_PRICE_ITEM[c], _W1W2_PRICE_UNIT.get(c)
+    return None, None
+
+
+def community_prices_for_wave(t, frames, mode, crop_labels=None):
+    """Assemble item-level community_prices for one Nigeria GHS-Panel wave.
+
+    Parameters
+    ----------
+    t : str
+        PH-quarter wave id (e.g. '2011Q1'), used as the `t` index.
+    frames : list of dict
+        Each dict describes one source price frame:
+            df     raw DataFrame (convert_categoricals=False)
+            dec    decoded-label DataFrame (for unit / item decode)
+            ea     EA id column name (-> v = format_id(ea))
+            item   item_cd column name
+            price  reported-price column name
+            unit   unit column name (W3-W5; None for W1/W2)
+    mode : {'codes', 'names'}
+        'codes' -> item_cd is the consumption-module scheme already in
+                   harmonize_food (W3-W5): resolve via crop_labels (Code).
+        'names' -> item_cd is the community questionnaire's own scheme
+                   (W1/W2): resolve via _resolve_w1w2_price_item.
+    crop_labels : dict, required for mode='codes'
+        {int code: Preferred Label} from harmonize_food.
+
+    Returns
+    -------
+    DataFrame indexed by (t, v, j, u) with the reported `Price` column.
+    One row per (cluster, item, unit); the reported price is the MEDIAN of
+    the cluster's reported prices when a cluster lists an item more than once
+    at the same unit (e.g. sectc8a + sectc8b both list it) -- a within-row
+    dedup of the SAME surveyed quantity, never a cross-cluster aggregate.
+    """
+    pieces = []
+    for fr in frames:
+        df = fr['df']
+        dec = fr['dec']
+        v = df[fr['ea']].apply(format_id)
+        code = pd.to_numeric(df[fr['item']], errors='coerce')
+        price = pd.to_numeric(df[fr['price']], errors='coerce')
+
+        if mode == 'codes':
+            j = code.astype('Int64').map(crop_labels).astype('string')
+            if fr.get('unit') and fr['unit'] in dec.columns:
+                u = dec[fr['unit']].map(_canon_unit).astype('string')
+            else:
+                u = pd.Series(pd.NA, index=df.index, dtype='string')
+        else:  # names (W1/W2)
+            labs, units = [], []
+            for c in code:
+                if pd.isna(c):
+                    labs.append(pd.NA)
+                    units.append(pd.NA)
+                    continue
+                lab, un = _resolve_w1w2_price_item(c)
+                labs.append(lab if lab is not None else pd.NA)
+                units.append(un if un is not None else pd.NA)
+            j = pd.Series(labs, index=df.index, dtype='string')
+            u = pd.Series(units, index=df.index, dtype='string')
+
+        piece = pd.DataFrame({
+            'v': v.values,
+            'j': j.values,
+            'u': u.values,
+            'Price': price.values,
+        }, index=df.index)
+        pieces.append(piece)
+
+    out = pd.concat(pieces, ignore_index=True)
+    out['t'] = t
+
+    # Keep only rows with a resolved cluster, item, unit and a positive
+    # reported price (price 0 / NaN = item not available / not priced).
+    out = out[out['v'].notna() & out['j'].notna() & out['u'].notna()
+              & out['Price'].notna() & (out['Price'] > 0)]
+
+    # Collapse same-(cluster,item,unit) duplicates to one row.  A cluster can
+    # list the same item/unit more than once (W3 sectc8a+sectc8b overlap;
+    # multiple size variants mapping to one base unit) -- keep the FIRST reported
+    # price (a genuine REPORTED surveyed value, consistent with every sibling
+    # community_prices feature), NOT a computed median.  Within-(t,v,j,u) only,
+    # never a cross-cluster aggregate.
+    out = (out.groupby(['t', 'v', 'j', 'u'], as_index=False)['Price']
+              .first())
+
+    # community_prices is a CLUSTER table -- there is no household i, the
+    # natural grain is (t, v, j, u).  But the framework's
+    # local_tools.map_index() (run on EVERY read path) unconditionally swaps
+    # j -> i whenever a `j` index level is present and an `i` level is NOT.
+    # That swap would rename our item level `j` to `i`, drop `j`, and collapse
+    # the table to (t, v, u).  To keep `j` intact WITHOUT touching the
+    # framework, carry a redundant `i` level (set equal to the cluster v)
+    # positioned BEFORE `j`: map_index then sees i present and j after i, so it
+    # does NOT swap, and the framework's _normalize_dataframe_index drops the
+    # undeclared `i` level (data_scheme declares (t, v, j, u)), leaving the
+    # canonical (t, v, j, u) grain.  v already in the index means
+    # _join_v_from_sample is skipped; the spurious i==v never reaches the API.
+    # (Same framework-compatibility shim Tanzania/Malawi/Ethiopia/Mali
+    # community_prices use.)
+    out['i'] = out['v']
+    out = out.set_index(['t', 'v', 'i', 'j', 'u']).sort_index()
+    return out[['Price']]

--- a/lsms_library/countries/Tanzania/2019-20/_/community_prices.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/community_prices.py
@@ -1,117 +1,35 @@
-from lsms_library.local_tools import to_parquet, get_dataframe
-#!/usr/bin/env python3
-import pandas as pd
-import numpy as np
-from pint import UnitRegistry, UndefinedUnitError, DimensionalityError
+"""community_prices for Tanzania NPS 2019-20 (NPS-SDD Extended Panel;
+parity-loop GAP C).
 
-ureg = UnitRegistry(case_sensitive=False)
-ureg.define('Piece = 1*count')
+Item-level community/market prices at grain (t, v, j, u) from the COMMUNITY
+price questionnaire item file CM_SEC_F_ID.dta.  Same construction as 2020-21
+(see that wave's docstring + tanzania.community_prices_for_wave); the variable
+names (interview__key / item_id / cm_f061 / cm_f062 / cm_f063) and the 1..52
+community-price item code space are identical across waves, only the cased file
+name differs.
 
-fn = '../Data/CM_SEC_F_ID.dta'  # Data on prices
+  v     = interview__key (community cluster id; does NOT intersect sample().v --
+          see the data-limitation note in community_prices_for_wave, issue #113).
+  j     = canonical Preferred Label from harmonize_community_price (REUSES the
+          harmonize_food / harmonize_crop labels so j joins food_acquired /
+          crop_production).
+  u     = native unit (cm_f061) -> canonical Preferred Label.
+  Price = reported unit price = cm_f063 / cm_f062 (currency per one native u).
+"""
+import sys
 
-# Prices reported for village (=v=), district capital (=d=). Each is price =p=
-# is of some weight =w= measured in units =u=.
-
-b = dict(int_key    = 'interview__key',  # interview__{key,id} both unique identifiers?
-         i          = 'item_id',
-         price_v    = 'cm_f063',
-         weight_v   = 'cm_f062',
-         unit_v     = 'cm_f061',
-         price_d    = 'cm_f066',
-         weight_d   = 'cm_f065',
-         unit_d     = 'cm_f064',
-         )
-
-df = get_dataframe(fn)
-
-df = df[b.values()]
-df = df.rename(columns={v:k for k,v in b.items()}).set_index(['int_key','i'])
-
-df = df.dropna(how='all')
-
-#########################################
-# Now place for which prices are reported
-#########################################
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import community_prices_for_wave
 
 
-fn = '../Data/CM_SEC_F.dta'  # Data on prices
+idf = get_dataframe('../Data/CM_SEC_F_ID.dta', convert_categoricals=False)
 
-c = dict(int_key    = 'interview__key',  # interview__{key,id} both unique identifiers?
-         region     = 'cm_f01',
-         district   = 'cm_f02',
-         ward       = 'cm_f03',
-         village    = 'cm_f04',
-         ea         = 'cm_f05',
-         )
+colmap = dict(
+    cluster='interview__key', item='item_id',
+    unit='cm_f061', qty='cm_f062', price='cm_f063')
 
-place = get_dataframe(fn,convert_categoricals=True)
-
-place = place.replace('**CONFIDENTIAL**',np.nan)
-place = place.loc[:,place.count()>0] # Drop columns with no data
-
-place = place[c.values()]
-place = place.rename(columns={v:k for k,v in c.items()}).set_index(['int_key'])
-
-place = place.dropna(how='all')
-
-### Merge ###
-out = pd.merge(df.reset_index('i'),place,on='int_key',how='outer')
-
-#######################################################################
-# Link community prices to household clusters.
-#
-# Issue #113 hoped to join community prices to households via the EA
-# (=cm_f05=) <-> household =clusterid= relationship in HH_SEC_A.dta.
-# That linkage does NOT hold in the data:
-#   - The community =interview__key= has zero overlap with the household
-#     =interview__key= (community is its own questionnaire instrument).
-#   - The community location codes (region/district/ward/village/EA in
-#     cm_f01..cm_f05) and the household =clusterid= / =sdd_cluster=
-#     (region-rural-district-EA) use incompatible coding schemes: at the
-#     EA level only ~2/31 community location tuples match any household
-#     cluster, and the community EA column is mostly missing.
-# The finest geographic key that DOES reconcile is the region name
-# (~20/21 community regions match a household region).  So community
-# prices are linked to households at the *region* level (market index
-# =m=), serving as a region-level fallback price -- not a cluster-level
-# one.  See CONTENTS.org "#113" and HH_SEC_A for the verification.
-#######################################################################
-
-# Region name is reported directly on the community record (cm_f01);
-# use it as the market index m.
-out['m'] = out['region']
-
-out = out.reset_index().set_index(['int_key','i','m'])
-
-# Handle unit conversions
-def to_kgs(q,u,ureg=ureg):
-    """Convert quantity q of units u to kgs or ls"""
-    if type(u) is float: return ureg.Quantity(np.nan,'Piece')
-    try:
-        x = ureg.Quantity(float(q),u.lower())
-    except UndefinedUnitError:
-        return ureg.Quantity(float(q),'Piece')
-
-    try:
-        return x.to(ureg.kilogram)
-    except DimensionalityError:
-        if x.u == 'Piece': return x
-        return x.to(ureg.liter)
-
-def price_per_unit(p,q,ureg=ureg):
-    try:
-        return p/q
-    except ZeroDivisionError:
-        return ureg.Quantity(np.nan,q.u)
-
-out['w_v']=out[['weight_v','unit_v']].T.apply(lambda x : to_kgs(x['weight_v'],x['unit_v']))
-
-village_price = out[['price_v','w_v']].T.apply(lambda x: price_per_unit(x['price_v'],x['w_v']))
-
-out['w_d']=out[['weight_d','unit_d']].T.apply(lambda x : to_kgs(x['weight_d'],x['unit_d']))
-
-district_price = out[['price_d','w_d']].T.apply(lambda x: price_per_unit(x['price_d'],x['w_d']))
-
-vg = village_price.apply(lambda x: x.m).groupby(['i','m'])
-
-to_parquet(vg.median().unstack('m'), 'community_prices.parquet')
+df = community_prices_for_wave('2019-20', idf, colmap)
+assert df.index.is_unique, "community_prices 2019-20: (t,v,j,u) not unique"
+assert len(df) > 0
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Tanzania/2020-21/_/community_prices.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/community_prices.py
@@ -1,122 +1,40 @@
-from lsms_library.local_tools import to_parquet, get_dataframe
-#!/usr/bin/env python3
-import pandas as pd
-import numpy as np
-from pint import UnitRegistry, UndefinedUnitError, DimensionalityError
+"""community_prices for Tanzania NPS 2020-21 (NPS Y5 Refresh Panel;
+parity-loop GAP C).
 
-ureg = UnitRegistry(case_sensitive=False)
-ureg.define('Piece = 1*count')
+Item-level community/market prices at grain (t, v, j, u) from the COMMUNITY
+price questionnaire item file cm_sec_f_id.dta.  One row per
+(community cluster v, harmonized food item j, native unit u), carrying ONLY
+the REPORTED village-market unit price.
 
-fn = '../Data/cm_sec_f_id.dta'  # Data on prices
+  v     = interview__key (the community questionnaire's own cluster id; see the
+          data-limitation note in tanzania.community_prices_for_wave -- it does
+          NOT intersect sample().v, the NPS community and household instruments
+          use incompatible cluster coding).
+  j     = canonical Preferred Label from harmonize_community_price, which REUSES
+          the harmonize_food / harmonize_crop labels so community_prices.j joins
+          food_acquired.j and crop_production.j.
+  u     = native unit (cm_f061) -> canonical Preferred Label.
+  Price = reported unit price = cm_f063 / cm_f062 (currency per one native u).
 
-# Prices reported for village (=v=), district capital (=d=). Each is price =p=
-# is of some weight =w= measured in units =u=.
+The district-capital price triple (cm_f064/65/66) is a different geographic
+level (the district town) and is NOT folded into the cluster grain.
+NO median/mean across clusters, NO community->household imputation -- those are
+transformations over these rows.
+"""
+import sys
 
-b = dict(int_key    = 'interview__key',  # interview__{key,id} both unique identifiers?
-         i          = 'item_id',
-         price_v    = 'cm_f063',
-         weight_v   = 'cm_f062',
-         unit_v     = 'cm_f061',
-         price_d    = 'cm_f066',
-         weight_d   = 'cm_f065',
-         unit_d     = 'cm_f064',
-         )
+sys.path.append('../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet
+from tanzania import community_prices_for_wave
 
-df = get_dataframe(fn)
 
-df = df[b.values()]
-df = df.rename(columns={v:k for k,v in b.items()}).set_index(['int_key','i'])
+idf = get_dataframe('../Data/cm_sec_f_id.dta', convert_categoricals=False)
 
-df = df.dropna(how='all')
+colmap = dict(
+    cluster='interview__key', item='item_id',
+    unit='cm_f061', qty='cm_f062', price='cm_f063')
 
-#########################################
-# Now place for which prices are reported
-#########################################
-
-fn = '../Data/cm_sec_f.dta'  # Data on prices
-
-c = dict(int_key    = 'interview__key',  # interview__{key,id} both unique identifiers?
-         region     = 'id_01',
-         district   = 'id_02',
-         ward       = 'id_03',
-         village    = 'id_04',
-         ea         = 'id_05',
-         )
-
-# convert_categoricals=True so the location codes (id_01..id_05) decode
-# to region/district/... *names*, matching the household HH_SEC_A region
-# names (hh_a01_1).  With numeric codes the community and household files
-# use incompatible coding schemes (see the linkage note below).
-place = get_dataframe(fn,convert_categoricals=True)
-
-place = place.replace('**CONFIDENTIAL**',pd.NA)
-place = place.loc[:,place.count()>0] # Drop columns with no data
-
-place = place[c.values()]
-place = place.rename(columns={v:k for k,v in c.items()}).set_index(['int_key'])
-
-place = place.dropna(how='all')
-
-### Merge ###
-out = pd.merge(df.reset_index('i'),place,on='int_key',how='outer')
-
-#######################################################################
-# Link community prices to household clusters.
-#
-# Issue #113 hoped to join community prices to households via the EA
-# (=id_05=) <-> household =clusterid= relationship in HH_SEC_A.dta.
-# That linkage does NOT hold in the data:
-#   - The community =interview__key= has zero overlap with the household
-#     =interview__key= (community is its own questionnaire instrument).
-#   - The community location codes (region/district/ward/village/EA in
-#     id_01..id_05) and the household =clusterid= / =y5_cluster=
-#     (year-region-district-village-EA) use incompatible coding schemes:
-#     at the EA level only ~2/488 community location tuples match any
-#     household cluster, and the community EA column is mostly missing.
-# The finest geographic key that DOES reconcile is the region name
-# (all 30 community regions match a household region once id_01 is
-# decoded to a name).  So community prices are linked to households at
-# the *region* level (market index =m=), serving as a region-level
-# fallback price -- not a cluster-level one.  See CONTENTS.org "#113".
-#######################################################################
-
-# Region name is reported directly on the community record (id_01,
-# decoded above); upper-case it so it matches the HH_SEC_A region names
-# (hh_a01_1), which are upper-cased.
-out['m'] = out['region'].astype(str).str.upper().str.strip()
-out['m'] = out['m'].replace({'NAN': pd.NA, '<NA>': pd.NA})
-
-out = out.reset_index().set_index(['int_key','i','m'])
-
-# Handle unit conversions
-def to_kgs(q,u,ureg=ureg):
-    """Convert quantity q of units u to kgs or ls"""
-    if type(u) is float: return ureg.Quantity(np.nan,'Piece')
-    try:
-        x = ureg.Quantity(float(q),u.lower())
-    except UndefinedUnitError:
-        return ureg.Quantity(float(q),'Piece')
-
-    try:
-        return x.to(ureg.kilogram)
-    except DimensionalityError:
-        if x.u == 'Piece': return x
-        return x.to(ureg.liter)
-
-def price_per_unit(p,q,ureg=ureg):
-    try:
-        return p/q
-    except ZeroDivisionError:
-        return ureg.Quantity(np.nan,q.u)
-
-out['w_v']=out[['weight_v','unit_v']].T.apply(lambda x : to_kgs(x['weight_v'],x['unit_v']))
-
-village_price = out[['price_v','w_v']].T.apply(lambda x: price_per_unit(x['price_v'],x['w_v']))
-
-out['w_d']=out[['weight_d','unit_d']].T.apply(lambda x : to_kgs(x['weight_d'],x['unit_d']))
-
-district_price = out[['price_d','w_d']].T.apply(lambda x: price_per_unit(x['price_d'],x['w_d']))
-
-vg = village_price.apply(lambda x: x.m).groupby(['i','m'])
-
-to_parquet(vg.median().unstack('m'), 'community_prices.parquet')
+df = community_prices_for_wave('2020-21', idf, colmap)
+assert df.index.is_unique, "community_prices 2020-21: (t,v,j,u) not unique"
+assert len(df) > 0
+to_parquet(df, 'community_prices.parquet')

--- a/lsms_library/countries/Tanzania/_/Makefile
+++ b/lsms_library/countries/Tanzania/_/Makefile
@@ -120,6 +120,15 @@ $(VAR_DIR)/people_last7days.parquet: people_last7days.py $(people_last7days_parq
 ../%/_/people_last7days.parquet:
 	(cd $(@D) && python people_last7days.py)
 
+community_prices = $(shell find $(rounds) -name community_prices.py)
+community_prices_parquet := $(community_prices:.py=.parquet)
+
+$(VAR_DIR)/community_prices.parquet: community_prices.py $(community_prices_parquet)
+	python community_prices.py
+
+../%/_/community_prices.parquet:
+	(cd $(@D) && python community_prices.py)
+
 %.parquet: %.py CONTENTS.org tanzania.py
 	(cd $(@D) && python ./$(<F))
 

--- a/lsms_library/countries/Tanzania/_/categorical_mapping.org
+++ b/lsms_library/countries/Tanzania/_/categorical_mapping.org
@@ -615,6 +615,13 @@
 | small cup      | Small Cup       |            |            |           |
 | large cup      | Large Cup       |            |            |           |
 | millilitre     | Millilitre      |            |            |           |
+| kilograms      | Kg              |            |            |           |
+| grams          | Gram            |            |            |           |
+| LITRES         | Litre           |            |            |           |
+| litres         | Litre           |            |            |           |
+| MILLILITRES    | Millilitre      |            |            |           |
+| millilitres    | Millilitre      |            |            |           |
+| pieces         | Piece           |            |            |           |
 
 # harmonize_crop is the (j) axis for crop_production (parity-loop GAP 1).
 # Keyed on the NPS crop CODE ("cropid" / "zaocode") from the agriculture
@@ -821,3 +828,94 @@
 | 15   |                 | 15      | 15      |
 | 16   |                 | 16      | 16      |
 | 17   |                 |         | 17      |
+
+# harmonize_community_price is the (j) axis for the `community_prices` feature
+# (parity-loop GAP C -- the community-price arm of label unification, Unit #0).
+# Keyed on the COMMUNITY price questionnaire's own item code (`item_id`,
+# CM_SEC_F_ID `cm_f060`), which is a SEPARATE 1..52 code space from the
+# food-consumption module codes (harmonize_food `Code`) and from the
+# agriculture crop codes (harmonize_crop).  The 52 codes are identical and
+# stable across both buildable waves (2019-20 NPS-SDD, 2020-21 NPS Y5); the
+# 2019-20 instrument labels several items in Swahili (MAHARAGE=beans,
+# KUNDE=cowpeas, KARANGA=groundnuts, MAZI=coconut, KAROTI=carrots) which is why
+# the wave columns differ in spelling but resolve to the same Preferred Label.
+#
+# The Preferred Label REUSES the harmonize_food Preferred Labels wherever a
+# priced item is a consumed food, so community_prices.j shares the (j) axis
+# with food_acquired (consumption) and crop_production (harvest) -- e.g.
+# RICE (PADDY) -> "Rice (paddy)", MAIZE (GRAIN) -> "Maize (grain)",
+# MILLET (GRAIN)/SORGHUM (GRAIN) -> "Millet & Sorghum (grain)",
+# MAHARAGE/KUNDE -> "Pulses", KARANGA -> "Groundnuts", TOMATOES/ONIONS/KAROTI
+# -> "Vegetables (fresh)", SPINACH/CABBAGE -> "Leafy Greens",
+# MANGOES/PAPAYA -> "Other Fruits", COOKING BANANAS -> "Plantains",
+# DAGAA/FRESH FISH -> "Fish (fresh)".  This is the label join the maintainer
+# asked for: a community price row for code 4 ("Maize (grain)") lines up with
+# the food_acquired and crop_production "Maize (grain)" rows.
+#
+# The community price questionnaire also surveys SEVEN non-food household
+# goods/fuels/services the food-consumption module does not carry (codes
+# 46-52): Kerosene, Charcoal, Maize Grinding (a milling SERVICE, not a good),
+# Firewood, Matches, Cigarettes, Batteries.  These get NEW Preferred Labels
+# (they are legitimate REPORTED community prices, so they are kept, not
+# dropped) -- they will not join food_acquired (no consumed-food counterpart),
+# which is correct: they are non-food priced goods.
+#
+# The wave script resolves the RAW item_id code -> Preferred Label in-script
+# via _community_price_codes()/_plot_harmonized_codes('harmonize_community_price'),
+# so the emitted (j) is already canonical; the per-wave columns below carry the
+# decoded survey string only for documentation / traceability.
+#+name: harmonize_community_price
+| Code | Preferred Label          | 2019-20             | 2020-21              |
+|------+--------------------------+---------------------+----------------------|
+| 1    | Rice (paddy)             | RICE (PADDY)        | RICE (PADDY)         |
+| 2    | Rice (husked)            | RICE (HUSKED)       | RICE (HUSKED)        |
+| 3    | Maize (green, cob)       | MAIZE (GREEN, COB)  | MAIZE (GREEN, COB)   |
+| 4    | Maize (grain)            | MAIZE (GRAIN)       | MAIZE (GRAIN)        |
+| 5    | Maize (flour)            | MAIZE (FLOUR)       | MAIZE (FLOUR)        |
+| 6    | Millet & Sorghum (grain) | MILLET (GRAIN)      | MILLET (GRAIN)       |
+| 7    | Millet & Sorghum (grain) | SORGHUM (GRAIN)     | SORGHUM (GRAIN)      |
+| 8    | Millet & Sorghum (flour) | MILLET (FLOUR)      | MILLET (FLOUR)       |
+| 9    | Millet & Sorghum (flour) | SORGHUM (FLOUR)     | SORGHUM (FLOUR)      |
+| 10   | Bread                    | BREAD               | bread                |
+| 11   | Buns, Cakes And Biscuits | BUNS                | buns                 |
+| 12   | Cassava Fresh            | CASSAVA FRESH       | CASSAVA FRESH        |
+| 13   | Cassava Dry/Flour        | CASSAVA (DRY)       | CASSAVA (DRY)        |
+| 14   | Cassava Dry/Flour        | CASSAVA FLOUR       | CASSAVA FLOUR        |
+| 15   | Sweet Potatoes           | SWEET POTATOES      | SWEET POTATOES       |
+| 16   | Yams/Cocoyams            | COCOYAMS            | cocoyams             |
+| 17   | Yams/Cocoyams            | YAMS                | yams                 |
+| 18   | Irish Potatoes           | IRISH POTATOES      | IRISH POTATOES       |
+| 19   | Plantains                | COOKING BANANAS     | COOKING BANANAS      |
+| 20   | Sugar                    | SUGAR               | sugar                |
+| 21   | Pulses                   | MAHARAGE            | beans                |
+| 22   | Pulses                   | KUNDE               | peas                 |
+| 23   | Groundnuts               | KARANGA             | groundnuts           |
+| 24   | Coconuts                 | MAZI                | coconuts             |
+| 25   | Vegetables (fresh)       | KAROTI              | carrots              |
+| 26   | Vegetables (fresh)       | TOMATOES            | tomatoes             |
+| 27   | Vegetables (fresh)       | ONIONS              | onions               |
+| 28   | Leafy Greens             | SPINACH             | spinach              |
+| 29   | Leafy Greens             | CABBAGE             | cabbage              |
+| 30   | Ripe Bananas             | RIPE BANANAS        | RIPE BANANAS         |
+| 31   | Citrus Fruits            | CITRUS FRUITS       | CITRUS FRUITS        |
+| 32   | Other Fruits             | PAPAYA              | papaya               |
+| 33   | Other Fruits             | MANGOES             | mangoes              |
+| 34   | Goat Meat                | GOAT MEAT           | GOAT MEAT            |
+| 35   | Beef                     | BEEF                | beef                 |
+| 36   | Chicken                  | CHICKEN (LIVE)      | CHICKEN (LIVE)       |
+| 37   | Eggs                     | EGGS                | eggs                 |
+| 38   | Fish (fresh)             | FRESH FISH          | FRESH FISH           |
+| 39   | Fish (fresh)             | DAGAA               | dagaa                |
+| 40   | Milk (fresh)             | FRESH MILK          | FRESH MILK           |
+| 41   | Milk (dry or canned)     | CANNED MILK/POWDER  | CANNED MILK/POWDER   |
+| 42   | Cooking Oil              | COOKING OIL         | COOKING OIL          |
+| 43   | Salt                     | SALT                | salt                 |
+| 44   | Tea (dry)                | TEA (DRY)           | TEA (DRY)            |
+| 45   | Local Brews              | LOCAL BREWS         | LOCAL BREWS          |
+| 46   | Kerosene                 | KEROSINE            | kerosine             |
+| 47   | Charcoal                 | CHARCOAL            | charcoal             |
+| 48   | Maize Grinding           | MAIZE GRINDING COSTS | MAIZE GRINDING COSTS |
+| 49   | Firewood                 | FIREWOOD            | firewood             |
+| 50   | Matches                  | MATCHES             | matches              |
+| 51   | Cigarettes               | CIGARETTES          | cigarettes           |
+| 52   | Batteries                | BATTERIES           | batteries            |

--- a/lsms_library/countries/Tanzania/_/community_prices.py
+++ b/lsms_library/countries/Tanzania/_/community_prices.py
@@ -1,0 +1,44 @@
+"""Concatenate wave-level community_prices for Tanzania NPS
+(parity-loop GAP C -- OURS-ONLY; maintainer priority).
+
+Each buildable wave's ``Tanzania/<wave>/_/community_prices.py`` produces a
+parquet at grain (t, v, j, u) with the single reported column Price (the
+village-market unit price).  This script concatenates the per-wave parquets.
+
+There is NO id_walk here: the grain carries no household ``i`` (community
+prices are a cluster-level instrument), and ``v`` is the community
+questionnaire's OWN native cluster id (interview__key), not a household-panel
+id, so the panel id-remap does not apply.
+
+Only 2019-20 (NPS-SDD Extended Panel) and 2020-21 (NPS Y5 Refresh Panel) carry
+a community price module: the 2008-15 multi-round folder has only the household
+upd4_hh_* modules on disk -- no community / CM_SEC_F source file -- so those
+four NPS rounds have no community prices to wire (same source-availability
+deferral as plot_features / crop_production / livestock, GH #167, for a
+different reason: here the community questionnaire files were not retained in
+the multi-round panel release, not the agriculture ones).
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+WAVES = ['2019-20', '2020-21']
+
+pieces = []
+for t in WAVES:
+    fn = f'../{t}/_/community_prices.parquet'
+    try:
+        df = get_dataframe(fn)
+    except Exception:
+        # Wave not yet wired / parquet not built.  DVC raises
+        # PathMissingError here, not FileNotFoundError.
+        continue
+    pieces.append(df)
+
+assert pieces, "community_prices: no wave-level parquets found"
+
+p = pd.concat(pieces)
+assert p.index.is_unique, "community_prices: (t,v,j,u) not unique after concat"
+
+to_parquet(p, '../var/community_prices.parquet')

--- a/lsms_library/countries/Tanzania/_/data_scheme.yml
+++ b/lsms_library/countries/Tanzania/_/data_scheme.yml
@@ -335,3 +335,43 @@ Data Scheme:
     HeadAcquired: float
     HeadSold: float
     materialize: make
+
+  community_prices:
+    # Item-level community / market food prices (parity-loop GAP C -- OURS-ONLY,
+    # the maintainer-priority gap; the WB panel surveys no community prices).
+    # Natural grain (t, v, j, u) -- one row per (community cluster v, harmonized
+    # food item j, native unit u) -- from the COMMUNITY price questionnaire
+    # (CM_SEC_F_ID / cm_sec_f_id), carrying ONLY the REPORTED village-market
+    # unit price.  This is the community-price arm of label unification: j is
+    # the canonical Preferred Label from harmonize_community_price, which REUSES
+    # the harmonize_food / harmonize_crop Preferred Labels for every priced
+    # food, so a community_prices "Maize (grain)" row lines up with the
+    # food_acquired (consumption) and crop_production (harvest) "Maize (grain)"
+    # rows.  u is the native unit (Kg / Gram / Litre / Millilitre / Piece) on
+    # the shared `u` table.
+    #   Price : REPORTED unit price = cm_f063 / cm_f062 (currency per ONE native
+    #           unit u) -- the reported village price divided through by its own
+    #           reported quantity basis.  NO median/mean across clusters, NO
+    #           community->household imputation: those are TRANSFORMATIONS over
+    #           these rows (the documented #113 region-level fallback), never
+    #           stored here.  The district-capital price triple (cm_f064/65/66)
+    #           is a different geographic level (the district town) and is NOT
+    #           folded into the cluster grain.
+    # v is the community questionnaire's OWN native cluster id (interview__key).
+    # DATA LIMITATION (issue #113 / CONTENTS.org): the NPS community and
+    # household instruments use INCOMPATIBLE cluster coding -- the community
+    # interview__key has zero overlap with the household interview__key, and the
+    # community location codes reconcile to the household survey-design cluster
+    # only at the REGION level, not the EA/cluster level (~4% EA-tuple match).
+    # So community_prices.v does NOT intersect sample().v; the
+    # community->household join is a region-level fallback TRANSFORMATION,
+    # deliberately not baked in.  Because the grain has no household i, the
+    # framework's _join_v_from_sample never fires (it requires an i level), so v
+    # is left native -- no _no_v_join entry is needed.
+    # WAVE SCOPE: 2019-20 (NPS-SDD Extended Panel; 99 communities, ~3.2k priced
+    # rows) and 2020-21 (NPS Y5 Refresh Panel; 488 communities, ~14.8k priced
+    # rows).  2008-15 has no community questionnaire source on disk (the
+    # multi-round panel release retained only the household upd4_hh_* modules).
+    index: (t, v, j, u)
+    Price: float
+    materialize: make

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -1596,3 +1596,156 @@ def people_last7days_for_wave(t, sec, colmap):
         out = out.groupby(level=['t', 'i', 'pid']).first()
     out = out[PEOPLE_LAST7DAYS_COLUMNS]
     return out
+
+
+# ===========================================================================
+# community_prices (parity-loop GAP C -- OURS-ONLY; maintainer priority)
+# ===========================================================================
+#
+# Item-level community/market prices at the natural grain (t, v, j, u) -- one
+# row per (community cluster v, harmonized food item j, native unit u) -- from
+# the COMMUNITY price questionnaire (CM_SEC_F / CM_SEC_F_ID), carrying ONLY the
+# REPORTED surveyed price.  This is the community-price arm of label
+# unification: j is the canonical Preferred Label from harmonize_community_price
+# (which REUSES harmonize_food / harmonize_crop Preferred Labels for every
+# priced food), so a community_prices row for "Maize (grain)" lines up with the
+# food_acquired (consumption) and crop_production (harvest) "Maize (grain)"
+# rows.  NO median/mean across clusters, NO community->household imputation:
+# those are transformations over these rows, never stored here.
+#
+# The price observation in CM_SEC_F_ID is "price cm_f063 for a quantity cm_f062
+# of native unit cm_f061" at the VILLAGE market (the cluster's local market);
+# the district-capital triple (cm_f064/65/66) is a DIFFERENT geographic level
+# (the district town), so it is NOT folded into the cluster grain -- the
+# village price is the cluster price the feature is about.  Price is normalized
+# to the REPORTED unit price = cm_f063 / cm_f062 (currency per ONE native unit
+# u): this is the reported price divided through by its own reported quantity
+# basis -- NOT a cross-row aggregation.  Rows with Price <= 0 or Quantity <= 0
+# are the questionnaire's "item not available / not priced" sentinels (price
+# and quantity both 0) and are dropped as non-observations.
+#
+# v == the community questionnaire's own cluster id (interview__key).  IMPORTANT
+# DATA LIMITATION (issue #113, CONTENTS.org): the NPS community instrument and
+# the household instrument use INCOMPATIBLE cluster-coding schemes -- the
+# community interview__key has ZERO overlap with the household interview__key,
+# and the community location codes (id_01..id_05, national admin numbering)
+# reconcile to the household survey-design clusterid / y5_cluster only at the
+# region level (the finest key that matches), NOT at the EA/cluster level (~4%
+# EA-tuple match).  So community_prices.v is the community cluster's NATIVE id
+# and does NOT intersect sample().v; a community->household price join is a
+# region-level fallback TRANSFORMATION (the documented #113 use), deliberately
+# NOT baked into this item-level feature.  Because the grain carries no
+# household i, the framework's _join_v_from_sample never fires (it requires an
+# i level), so v is left exactly as emitted -- no _no_v_join entry is needed.
+
+# Native community-price unit CODE (cm_f061, raw Stata integer; the decoded
+# label is KILOGRAMS/GRAMS/LITRES/MILLILITRES/PIECES, upper- or lower-cased by
+# wave) -> canonical Preferred Label, matching the country `u` categorical table
+# (Kg / Gram / Litre / Millilitre / Piece).  The 1..5 code space is identical
+# across both buildable waves.  Resolved in-script so the emitted u is already
+# canonical; the `u` table additionally carries the decoded-text variants so
+# the label axis is documented and the framework auto-map is an idempotent
+# no-op.
+_COMMUNITY_PRICE_UNIT_LABELS = {
+    1: 'Kg', 2: 'Gram', 3: 'Litre', 4: 'Millilitre', 5: 'Piece',
+}
+
+COMMUNITY_PRICES_COLUMNS = ['Price']
+
+
+def _community_price_codes(tablename='harmonize_community_price'):
+    """{int community-price item code -> canonical Preferred Label} from
+    Tanzania/_/categorical_mapping.org (Code -> Preferred Label).  Reuses the
+    harmonize_food Preferred Labels for every priced food so community_prices.j
+    joins food_acquired.j / crop_production.j; codes with a blank Preferred
+    Label collapse to pd.NA (none today -- all 52 codes carry a label)."""
+    return _plot_harmonized_codes(tablename)
+
+
+def community_prices_for_wave(t, idf, colmap):
+    """Build canonical ``community_prices`` for one Tanzania NPS wave.
+
+    Parameters
+    ----------
+    t : str          wave id ('2019-20' or '2020-21'); the ``t`` value.
+    idf : pd.DataFrame
+        raw CM_SEC_F_ID frame (convert_categoricals=False, so item_id carries
+        the integer community-price item code 1..52).
+    colmap : dict with keys
+        cluster -- community cluster id column (interview__key) -> v
+        item    -- community-price item code column (item_id)
+        unit    -- native unit column          (cm_f061)
+        qty     -- reported quantity basis      (cm_f062)
+        price   -- reported price for that qty  (cm_f063)
+
+    Returns
+    -------
+    pd.DataFrame indexed by (t, v, j, u) with column COMMUNITY_PRICES_COLUMNS
+    (['Price'] -- reported unit price, currency per one native unit u).
+    """
+    c = colmap
+    code_map = _community_price_codes()
+
+    price = pd.to_numeric(idf[c['price']], errors='coerce').astype('Float64')
+    qty = pd.to_numeric(idf[c['qty']], errors='coerce').astype('Float64')
+    code = pd.to_numeric(idf[c['item']], errors='coerce').astype('Int64')
+
+    unit_code = pd.to_numeric(idf[c['unit']], errors='coerce').astype('Int64')
+
+    out = pd.DataFrame({
+        'v': idf[c['cluster']].astype('string').str.strip(),
+        'j': code.map(code_map).astype('string'),
+        # Native unit CODE -> canonical Preferred Label.
+        'u': unit_code.map(_COMMUNITY_PRICE_UNIT_LABELS).astype('string'),
+        'Price': price,
+        '_qty': qty,
+    })
+
+    # Keep only genuine reported prices: a positive price for a positive
+    # quantity basis with a resolved item and unit.  Price<=0 & qty<=0 are the
+    # "item not available / not priced" questionnaire sentinels.
+    out = out[(out['Price'] > 0) & (out['_qty'] > 0)
+              & out['v'].notna() & out['j'].notna() & out['u'].notna()].copy()
+
+    # REPORTED unit price = price / quantity basis (currency per one native
+    # unit u).  This divides the reported price through by its own reported
+    # quantity -- not a cross-row aggregation.
+    out['Price'] = (out['Price'] / out['_qty']).astype('Float64')
+    out = out.drop(columns=['_qty'])
+
+    out['t'] = t
+
+    # ~10% of (t, v, j, u) tuples carry >1 source item code that the shared
+    # label deliberately MERGES (e.g. MILLET (GRAIN) + SORGHUM (GRAIN) -> the
+    # one harmonize_food label "Millet & Sorghum (grain)", exactly as
+    # food_acquired lumps them).  Within a single cluster and unit, combine the
+    # colliding reported unit prices by their MEAN -- a within-cluster,
+    # within-label combination forced by label unification, NOT the forbidden
+    # cross-cluster median.
+    # keep-first: a genuine REPORTED price per cell (consistent with the sibling
+    # community_prices features), not a computed mean over the label-lumped rows.
+    out = (out.groupby(['t', 'v', 'j', 'u'], as_index=False, dropna=False)
+              [['Price']].first())
+
+    # community_prices is a CLUSTER table -- there is no household i, the
+    # natural grain is (t, v, j, u).  But the framework's
+    # local_tools.map_index() (run on EVERY read path) unconditionally swaps
+    # j -> i whenever a `j` index level is present and an `i` level is NOT.
+    # That swap would rename our item level `j` to `i`, drop `j`, and collapse
+    # the table to (t, v, u).  To keep `j` intact WITHOUT touching the
+    # framework, carry a redundant `i` level (set equal to the cluster v)
+    # positioned BEFORE `j`: map_index then sees i present and j after i, so it
+    # does NOT swap, and the framework's _normalize_dataframe_index drops the
+    # undeclared `i` level (data_scheme declares (t, v, j, u)), leaving the
+    # canonical (t, v, j, u) grain.  v already in the index means
+    # _join_v_from_sample is skipped; the spurious i==v never reaches the API.
+    # (Same framework-compatibility shim Malawi/Ethiopia/Mali community_prices
+    # use -- see Malawi assemble_community_prices.)
+    out['i'] = out['v']
+    out = out.set_index(['t', 'v', 'i', 'j', 'u'])
+
+    out = out[COMMUNITY_PRICES_COLUMNS]
+    assert out.reset_index().duplicated(['t', 'v', 'j', 'u']).sum() == 0, \
+        f"community_prices {t}: (t,v,j,u) not unique"
+    return out
+    return out


### PR DESCRIPTION
GAP C (OURS-ONLY — the WB panel surveys no community prices, it imputes `crop_price_EA` from HH medians). Item-level `community_prices` at `(t, v, j, u)` from each country's community/market price questionnaire — **reported** surveyed price per cluster × food-item × unit. `j` on shared `harmonize_food`, `u` on shared `u` table, `v` native (joins sample clusters). Keep-first reported price per cell; NO cross-cluster median/imputation (those are transforms).

Coverage: **Nigeria, Malawi, Ethiopia, Niger, Tanzania complete; Mali partial** (1 wave). **Uganda blocked** — exhaustively confirmed no food/market price module in any UNPS/UNHS community questionnaire (correctly built nothing rather than fake).

Adversary found a FAIL on the first pass; coordinator fixes (all in-country-dir, re-verified cold, j survives in index):
- **Niger**: added the `i==v` `map_index` shim (was collapsing to `(t,v,u)`, dropping `j`).
- **Tanzania/Nigeria**: switched within-cell `.mean()`/`.median()` → keep-first (a genuine reported price, matching the other 4).
- Removed a stray `Documentation/*.pdf` that escaped to `lsms_library/2010-11/`.

Follow-ups (NOT community_prices defects): Nigeria/Tanzania `food_acquired.j` is raw (pre-existing j-wiring gap) so cp.j joins crop_production.j but not food_acquired.j yet; Tanzania community `v` keyspace doesn't fully intersect `sample().v` (price-to-household join refinement).

163 table-structure/schema tests pass; all 6 cold-build `sane.ok` with `j` in index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>