### PR TITLE
feat(parity): GAP 6 — plot_features attribute audit (+reported item columns) across 7 LSMS-ISA countries

### DIFF
--- a/lsms_library/countries/Ethiopia/2011-12/_/plot_features.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/plot_features.py
@@ -33,6 +33,10 @@ colmap = dict(
     area_unit  = 'pp_s3q02_c',   # farmer-estimate area unit code
     acquire    = 'pp_s2q03',     # how the parcel was acquired -> Tenure
     irrigated  = 'pp_s3q12',     # 1 Yes / 2 No
+    certificate= 'pp_s2q04',     # parcel has a certificate? 1 Yes / 2 No
+    fallow     = 'pp_s3q03',     # field land-status (code 3 == Fallow)
+    erosion    = 'pp_s3q32',     # erosion-control structure?
+    erosion_yes= 2, erosion_no = 1,   # W1-W3 code 2=Yes / 1=No
     # soil_type: not asked in W1 -> SoilType NaN
 )
 

--- a/lsms_library/countries/Ethiopia/2013-14/_/plot_features.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/plot_features.py
@@ -33,6 +33,10 @@ colmap = dict(
     acquire    = 'pp_s2q03',
     soil_type  = 'pp_s2q14',
     irrigated  = 'pp_s3q12',
+    certificate= 'pp_s2q04',     # 1 Yes / 2 No
+    fallow     = 'pp_s3q03',     # field land-status (code 3 == Fallow)
+    erosion    = 'pp_s3q32',     # erosion-control structure?
+    erosion_yes= 2, erosion_no = 1,   # W1-W3 code 2=Yes / 1=No
 )
 
 df = plot_features_for_wave('2013-14', sect2, sect3, colmap)

--- a/lsms_library/countries/Ethiopia/2015-16/_/plot_features.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/plot_features.py
@@ -32,6 +32,10 @@ colmap = dict(
     acquire    = 'pp_s2q03',
     soil_type  = 'pp_s2q14',
     irrigated  = 'pp_s3q12',
+    certificate= 'pp_s2q04',     # 1 Yes / 2 No
+    fallow     = 'pp_s3q03',     # field land-status (code 3 == Fallow)
+    erosion    = 'pp_s3q32',     # erosion-control structure?
+    erosion_yes= 2, erosion_no = 1,   # W1-W3 code 2=Yes / 1=No
 )
 
 df = plot_features_for_wave('2015-16', sect2, sect3, colmap)

--- a/lsms_library/countries/Ethiopia/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Ethiopia/2018-19/_/plot_features.py
@@ -30,6 +30,10 @@ colmap = dict(
     acquire    = 's2q05',    # how acquired -> Tenure
     soil_type  = 's2q16',
     irrigated  = 's3q17',    # 1 Yes / 2 No
+    certificate= 's2q03',    # parcel has a certificate? 1 Yes / 2 No
+    fallow     = 's3q03',    # field land-status (code 3 == Fallow)
+    erosion    = 's3q38',    # erosion-control structure? 1 Yes / 2 No
+    erosion_yes= 1, erosion_no = 2,   # W4-W5 code 1=Yes / 2=No
 )
 
 df = plot_features_for_wave('2018-19', sect2, sect3, colmap)

--- a/lsms_library/countries/Ethiopia/2021-22/_/plot_features.py
+++ b/lsms_library/countries/Ethiopia/2021-22/_/plot_features.py
@@ -28,6 +28,10 @@ colmap = dict(
     acquire    = 's2q05',
     soil_type  = 's2q16',
     irrigated  = 's3q17',
+    certificate= 's2q03',    # parcel has a certificate? 1 Yes / 2 No
+    fallow     = 's3q03',    # field land-status (code 3 == Fallow)
+    erosion    = 's3q38',    # erosion-control structure? 1 Yes / 2 No
+    erosion_yes= 1, erosion_no = 2,   # W4-W5 code 1=Yes / 2=No
 )
 
 df = plot_features_for_wave('2021-22', sect2, sect3, colmap)

--- a/lsms_library/countries/Ethiopia/_/CONTENTS.org
+++ b/lsms_library/countries/Ethiopia/_/CONTENTS.org
@@ -483,6 +483,41 @@ It is declared =optional: true= in =data_scheme.yml= so the all-null
 sanity check exempts it while the canonical column stays declared for
 cross-country alignment.
 
+** Reported item attributes (WB Plot_dataset parity, GAP 6)
+
+Three additional REPORTED Yes/No plot attributes, added at the existing
+=(t, i, plot_id)= grain (row count UNCHANGED at 132694).  All are
+surveyed questions carried verbatim -- nullable =boolean=, with =pd.NA=
+preserved for fields/parcels where the question was not answered (so
+"reported No" is distinguishable from "not asked"):
+  - =Fallow=  : field land-status == "Fallow".  Field-level, =sect3=
+    status code 3 (=pp_s3q03= W1-W3, =s3q03= W4-W5); other reported
+    statuses -> False.
+  - =ErosionProtection= : field has an erosion-control structure.
+    Field-level (=pp_s3q32= W1-W3, =s3q38= W4-W5).  The Yes code FLIPS:
+    W1-W3 code 2 = Yes / 1 = No, W4-W5 code 1 = Yes / 2 = No -- each
+    wave script passes its =erosion_yes= / =erosion_no= via the colmap.
+  - =Certificate= : parcel has a land-use certificate.  Parcel-level
+    (=pp_s2q04= W1-W3, =s2q03= W4-W5; 1 = Yes / 2 = No), broadcast onto
+    the parcel's fields like Tenure / SoilType.  We carry the REPORTED
+    answer only -- NOT the WB's acquire-based override (cert := 0 for
+    rented/borrowed/sharecropped), which is an imputation.
+
+NOT added (deliberately, per the item-level-reported rule):
+  - WB =plot_owned= -- a binary recode of the SAME acquire variable we
+    already carry as =Tenure= (derivable as Tenure in {communal,
+    inherited, owned}); a transform, not an independent question.
+  - WB =plot_slope=, =plot_dist_household=, =elevation=, the
+    soil-quality tags (=nutrient_availability= etc.),
+    =agro_ecological_zone= -- SRTM / HC27 / GAEZ raster joins keyed on
+    EA coordinates, NOT survey-reported plot attributes.
+  - WB =fallow= column is absent for Ethiopia in their panel (they keep
+    only the HH-level count =nb_fallow_plots=, a transform); we recover
+    the item-level reported flag the survey records per field.
+  - WB =farm_size=, =nb_plots=, =nb_fallow_plots=, =soil_fertility_index=
+    -- aggregations / counts / PCA over these item columns; belong in
+    =transformations.py=, not the data layer.
+
 ** Files
 
   - =Ethiopia/_/ethiopia.py:plot_features_for_wave= -- shared helper.

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -89,6 +89,18 @@ Data Scheme:
       optional: true
     SoilType: str
     Irrigated: bool
+    # Reported item-level field/parcel attributes (WB Plot_dataset parity,
+    # GAP 6).  All three are surveyed Yes/No questions carried verbatim
+    # (no aggregation): Fallow = field land-status == "Fallow" (sect3 §3),
+    # ErosionProtection = field has an erosion-control structure (sect3),
+    # Certificate = parcel has a land-use certificate (sect2).  WB
+    # plot_owned is NOT added: it is a binary recode of the same acquire
+    # variable already carried as Tenure (a transform, derivable as
+    # Tenure in {communal, inherited, owned}); plot_slope / plot_dist_*
+    # are SRTM/geospatial raster joins, not survey-reported.
+    Fallow: bool
+    ErosionProtection: bool
+    Certificate: bool
     materialize: make
 
   crop_production:

--- a/lsms_library/countries/Ethiopia/_/ethiopia.py
+++ b/lsms_library/countries/Ethiopia/_/ethiopia.py
@@ -595,6 +595,29 @@ def _map_int_codes(series, code_map):
     return out.astype('string').where(out.notna(), pd.NA)
 
 
+def _yesno_bool_col(df, col, yes, no):
+    """Recode a reported numeric Yes/No code column to nullable boolean.
+
+    ``yes`` / ``no`` are the integer codes for True / False in this wave's
+    questionnaire (they flip between waves for some ESS items).  Codes that
+    are neither (incl. NaN / "don't know") stay ``pd.NA``.  Returns an
+    all-NA ``boolean`` Series indexed like ``df`` when ``col`` is absent.
+
+    Unlike the broader ``_yesno_bool`` (which collapses unrecognized codes to
+    False), this preserves ``pd.NA`` for unanswered rows -- so the plot
+    attribute distinguishes "reported No" from "not asked".  The
+    ``.fillna(False)`` on each condition is what keeps a <NA> code from being
+    masked to True/False (``Series.mask`` treats a <NA> condition as masking).
+    """
+    if not col or col not in df.columns:
+        return pd.Series(pd.NA, index=df.index, dtype='boolean')
+    code = pd.to_numeric(df[col], errors='coerce').astype('Int64')
+    out = pd.Series(pd.NA, index=df.index, dtype='boolean')
+    out = out.mask((code == yes).fillna(False), True)
+    out = out.mask((code == no).fillna(False), False)
+    return out
+
+
 def plot_features_for_wave(t, sect2, sect3, colmap):
     """Build canonical ``plot_features`` for one Ethiopia ESS wave.
 
@@ -621,14 +644,26 @@ def plot_features_for_wave(t, sect2, sect3, colmap):
             area_unit  — sect3 farmer-estimate area-unit code column.
             acquire    — sect2 "how acquired" code column (-> Tenure).
         Optional keys (NaN where omitted / not asked):
-            soil_type  — sect2 soil-type code column (absent in W1).
+            soil_type   — sect2 soil-type code column (absent in W1).
+            certificate — sect2 "parcel has a certificate?" code column
+                          (1=Yes/2=No: pp_s2q04 W1-W3, s2q03 W4-W5).
+            fallow      — sect3 field land-status code column (status
+                          code 3 == Fallow: pp_s3q03 W1-W3, s3q03 W4-W5).
+            erosion     — sect3 "erosion-control structure?" code column
+                          (pp_s3q32 W1-W3, s3q38 W4-W5).
+            erosion_yes / erosion_no — the wave's Yes / No integer codes
+                          for ``erosion`` (default 1 / 2; W1-W3 flip to
+                          2 / 1).
 
     Returns
     -------
     pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
         ``Area`` (hectares, float), ``AreaUnit`` (str), ``Tenure`` (str),
         ``TenureSystem`` (str, always NaN — ESS has no analogue),
-        ``SoilType`` (str), ``Irrigated`` (nullable bool).  GPS
+        ``SoilType`` (str), ``Irrigated`` (nullable bool), ``Fallow``
+        (nullable bool, field land-status == Fallow), ``ErosionProtection``
+        (nullable bool, reported erosion-control structure), ``Certificate``
+        (nullable bool, parcel has a land-use certificate).  GPS
         Latitude / Longitude are NOT emitted (source 100% redacted).
     """
     c = colmap
@@ -649,7 +684,15 @@ def plot_features_for_wave(t, sect2, sect3, colmap):
     else:
         parcel['_SoilType'] = pd.Series(pd.NA, index=parcel.index, dtype='string')
 
-    parcel_attrs = (parcel[key + ['_Tenure', '_SoilType']]
+    # Certificate: reported parcel-level question "does this parcel have a
+    # certificate?" (pp_s2q04 W1-W3, s2q03 W4-W5), coded 1=Yes / 2=No in
+    # every wave.  REPORTED value only -- we do NOT apply the WB's
+    # acquire-based override (cert:=0 for rented/borrowed/sharecropped),
+    # which is an imputation, not the surveyed answer.
+    parcel['_Certificate'] = _yesno_bool_col(parcel, c.get('certificate'),
+                                             yes=1, no=2)
+
+    parcel_attrs = (parcel[key + ['_Tenure', '_SoilType', '_Certificate']]
                     .drop_duplicates(subset=key))
 
     # --- Field-level rows (sect3) ---
@@ -675,6 +718,28 @@ def plot_features_for_wave(t, sect2, sect3, colmap):
     irrigated = irrigated.mask(irr == 1, True)
     irrigated = irrigated.mask(irr == 2, False)
 
+    # Fallow: reported field-level land-status question (pp_s3q03 W1-W3,
+    # s3q03 W4-W5); status code 3 == "Fallow" in every wave.  True for the
+    # fallow status, False for any other reported status, NA if unanswered.
+    fal = pd.to_numeric(field.get(c.get('fallow')), errors='coerce').astype('Int64') \
+        if c.get('fallow') and c['fallow'] in field.columns \
+        else pd.Series(pd.NA, index=field.index, dtype='Int64')
+    # True iff status == 3 (Fallow), False for any other reported status,
+    # NA where the status was not recorded.  (Note: a comparison against a
+    # masked Int64 yields <NA> for missing codes, and Series.mask treats a
+    # <NA> condition as "mask" -- so guard each mask with .fillna(False).)
+    fallow = pd.Series(pd.NA, index=field.index, dtype='boolean')
+    fallow = fallow.mask(fal.notna(), False)
+    fallow = fallow.mask((fal == 3).fillna(False), True)
+
+    # ErosionProtection: reported field-level question "is there an erosion-
+    # control structure on this field?" (pp_s3q32 W1-W3 coded 2=Yes/1=No;
+    # s3q38 W4-W5 coded 1=Yes/2=No -- the Yes code flips, so the wave script
+    # passes the wave's yes/no codes via the colmap).
+    erosion = _yesno_bool_col(field, c.get('erosion'),
+                              yes=c.get('erosion_yes', 1),
+                              no=c.get('erosion_no', 2))
+
     # Join parcel attributes onto field rows (LEFT, on the holder-aware key).
     field = field.merge(parcel_attrs, on=key, how='left')
 
@@ -684,15 +749,18 @@ def plot_features_for_wave(t, sect2, sect3, colmap):
                + field[c['field_id']].apply(format_id).astype(str))
 
     out = pd.DataFrame({
-        't':            t,
-        'i':            hh.values,
-        'plot_id':      plot_id.values,
-        'Area':         area_ha.values,
-        'AreaUnit':     area_unit.values,
-        'Tenure':       field['_Tenure'].astype('string').values,
-        'TenureSystem': pd.Series(pd.NA, index=field.index, dtype='string').values,
-        'SoilType':     field['_SoilType'].astype('string').values,
-        'Irrigated':    irrigated.values,
+        't':                 t,
+        'i':                 hh.values,
+        'plot_id':           plot_id.values,
+        'Area':              area_ha.values,
+        'AreaUnit':          area_unit.values,
+        'Tenure':            field['_Tenure'].astype('string').values,
+        'TenureSystem':      pd.Series(pd.NA, index=field.index, dtype='string').values,
+        'SoilType':          field['_SoilType'].astype('string').values,
+        'Irrigated':         irrigated.values,
+        'Fallow':            fallow.values,
+        'ErosionProtection': erosion.values,
+        'Certificate':       field['_Certificate'].astype('boolean').values,
     })
     out = out.dropna(subset=['i', 'plot_id'])
     out = out.set_index(['t', 'i', 'plot_id'])

--- a/lsms_library/countries/Malawi/2010-11/_/plot_features.py
+++ b/lsms_library/countries/Malawi/2010-11/_/plot_features.py
@@ -35,6 +35,8 @@ colmap = dict(
     soil_type    = 'ag_d21',
     water_source = 'ag_d28a',
     acquire      = 'ag_d03',
+    fallow       = 'ag_d14',
+    erosion      = 'ag_d25a',
 )
 
 df = plot_features_for_wave(WAVE, df_c, df_d, colmap)

--- a/lsms_library/countries/Malawi/2013-14/_/plot_features.py
+++ b/lsms_library/countries/Malawi/2013-14/_/plot_features.py
@@ -31,6 +31,8 @@ colmap = dict(
     soil_type    = 'ag_d21',
     water_source = 'ag_d28a',
     acquire      = 'ag_d03',
+    fallow       = 'ag_d14',
+    erosion      = 'ag_d25a',
 )
 
 df = plot_features_for_wave(WAVE, df_c, df_d, colmap)

--- a/lsms_library/countries/Malawi/2016-17/_/plot_features.py
+++ b/lsms_library/countries/Malawi/2016-17/_/plot_features.py
@@ -74,7 +74,11 @@ colmap = dict(
     area_gps     = 'ag_c04c',
     soil_type    = 'ag_d21',
     water_source = 'ag_d28a',
-    # acquire omitted: ag_d03 absent in IHS4 -> Tenure NaN.
+    fallow       = 'ag_d14',
+    erosion      = 'ag_d25a',
+    # acquire omitted: ag_d03 absent in IHS4 -> Tenure / PlotOwned NaN
+    # (the WB derives plot_owned from the Module B2 parcel roster here,
+    # a different grain; left NaN rather than cross-grain joined).
 )
 
 pieces = []
@@ -85,7 +89,7 @@ c_xs = get_dataframe('../Data/Cross_Sectional/ag_mod_c.dta',
 d_xs = _read_usecols(
     'Malawi/2016-17/Data/Cross_Sectional/ag_mod_d.dta',
     usecols=['case_id', 'hhid', 'gardenid', 'plotid',
-             'ag_d02', 'ag_d21', 'ag_d28a'])
+             'ag_d02', 'ag_d21', 'ag_d28a', 'ag_d14', 'ag_d25a'])
 
 c_xs['hhid'] = 'cs-17-' + c_xs['case_id'].apply(format_id)
 c_xs['plotkey'] = _plotkey(c_xs)

--- a/lsms_library/countries/Malawi/2019-20/_/plot_features.py
+++ b/lsms_library/countries/Malawi/2019-20/_/plot_features.py
@@ -35,7 +35,11 @@ colmap = dict(
     area_gps     = 'ag_c04c',
     soil_type    = 'ag_d21',
     water_source = 'ag_d28a',
-    # acquire omitted: ag_d03 absent in IHS5 -> Tenure NaN.
+    fallow       = 'ag_d14',
+    erosion      = 'ag_d25a',
+    # acquire omitted: ag_d03 absent in IHS5 -> Tenure / PlotOwned NaN
+    # (the WB derives plot_owned from the Module B2 parcel roster here,
+    # a different grain; left NaN rather than cross-grain joined).
 )
 
 pieces = []

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -97,16 +97,41 @@ Data Scheme:
     # in each wave's plot_features.py.  Tenure is derived from the labeled
     # acquire question ag_d03 in 2010-11 & 2013-14 ONLY; ag_d03 is absent
     # from IHS4/IHS5 ag_mod_d (where ag_d02 is "ID of Respondent", not
-    # tenure), so Tenure / TenureSystem are NaN for 2016-17 & 2019-20.
-    # Latitude / Longitude are deferred: Malawi plot GPS is offset /
-    # redacted in the public release.
+    # tenure), so Tenure / TenureSystem / PlotOwned are NaN for 2016-17 &
+    # 2019-20.  Latitude / Longitude are deferred: Malawi plot GPS is
+    # offset / redacted in the public release.
+    #
+    # GAP-6 audit (parity-plot-audit) added the missing WB Plot_dataset
+    # item-level plot attributes at the existing (t, i, plot_id) grain:
+    #   AreaSelfReported  -- the farmer-estimate plot area in hectares (the
+    #     WB area_self_reported), distinct from the GPS-preferred Area
+    #     above (Area falls back to it when GPS is missing); ag_c04a/b.
+    #   PlotOwned (bool)  -- the WB plot_owned: acquire codes 1-5 (granted/
+    #     inherited/bride price/purchased) = owned, 6-11 = not owned, from
+    #     the same ag_d03 that drives Tenure -> populated 2010-11 & 2013-14
+    #     only (NaN for IHS4/IHS5, where the WB uses a parcel-grain Module
+    #     B2 roster, out of this plot-grain feature's scope).
+    #   Fallow (bool)     -- per-plot fallow flag, ag_d14 == 4 "Fallow"; all
+    #     four waves.  The WB nb_fallow_plots is a COUNT transform over this
+    #     item flag (NOT stored here).
+    #   ErosionProtection (bool) -- the WB erosion_protection: 1st erosion-
+    #     control facility code ag_d25a != 1 (1 = "No erosion control");
+    #     all four waves.
+    # plot_certificate and plot_slope are NOT added: Malawi Module D has no
+    # land-certificate question (the WB plot_certificate comes from a
+    # parcel-grain Module B2 roster in IHS4/IHS5 only), and plot_slope is a
+    # geospatial raster covariate (SRTM slope), not a survey-reported item.
     index: (t, i, plot_id)
     Area: float
     AreaUnit: str
+    AreaSelfReported: float
     Tenure: str
     TenureSystem: str
+    PlotOwned: bool
     SoilType: str
     Irrigated: bool
+    Fallow: bool
+    ErosionProtection: bool
     materialize: make
   food_coping:
     # rCSI coping-strategy day counts (GH #332).  Module H question H02

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -625,15 +625,30 @@ def plot_features_for_wave(t, df_c, df_d, colmap):
             soil_type  — soil-type code column in df_d (ag_d21)
             water_source — water-source code column in df_d (ag_d28a)
             acquire    — tenure/acquire code column in df_d (ag_d03);
-                         omit (or absent) -> Tenure NaN (2016-17/2019-20)
+                         omit (or absent) -> Tenure / PlotOwned NaN
+                         (2016-17/2019-20)
+            fallow     — cultivation-status code column in df_d (ag_d14);
+                         omit (or absent) -> Fallow NaN
+            erosion    — 1st erosion-control facility code column in df_d
+                         (ag_d25a); omit (or absent) -> ErosionProtection NaN
 
     Returns
     -------
     pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
-        ``Area`` (hectares, float), ``AreaUnit`` (str, always 'acres'),
-        ``Tenure`` (str), ``TenureSystem`` (str), ``SoilType`` (str),
-        and ``Irrigated`` (nullable bool).  Latitude / Longitude are
-        deferred (Malawi plot GPS is offset / redacted; GH #167).
+        ``Area`` (hectares, float — GPS-preferred), ``AreaUnit`` (str,
+        always 'acres'), ``AreaSelfReported`` (hectares, float — the
+        farmer-estimate area, NOT GPS-overridden, the WB
+        ``area_self_reported``), ``Tenure`` (str), ``TenureSystem`` (str),
+        ``PlotOwned`` (nullable bool — the WB ``plot_owned``, acquire codes
+        1-5 = owned, 6-11 = not owned, from the same ag_d03 that drives
+        Tenure; NaN where acquire is absent), ``SoilType`` (str),
+        ``Irrigated`` (nullable bool), ``Fallow`` (nullable bool — the WB
+        per-plot fallow flag, ag_d14 == 4 "Fallow"; the WB nb_fallow_plots
+        is a count transform over this), and ``ErosionProtection``
+        (nullable bool — the WB ``erosion_protection``, ag_d25a != 1
+        i.e. any facility other than "No erosion control").  Latitude /
+        Longitude are deferred (Malawi plot GPS is offset / redacted;
+        GH #167).
     """
     c = colmap
 
@@ -644,7 +659,9 @@ def plot_features_for_wave(t, df_c, df_d, colmap):
         d_cols = ['hhid', 'plotkey'] + [
             df_d_col for df_d_col in (c.get('soil_type'),
                                       c.get('water_source'),
-                                      c.get('acquire'))
+                                      c.get('acquire'),
+                                      c.get('fallow'),
+                                      c.get('erosion'))
             if df_d_col and df_d_col in df_d.columns]
         df = df.merge(df_d[d_cols].drop_duplicates(['hhid', 'plotkey']),
                       on=['hhid', 'plotkey'], how='left')
@@ -666,6 +683,11 @@ def plot_features_for_wave(t, df_c, df_d, colmap):
         gps_acres = gps_acres.where((gps_acres <= 2500) | gps_acres.isna(), pd.NA)
         area_ha = gps_acres * ACRES_TO_HECTARES
 
+    # AreaSelfReported: the farmer-estimate area in hectares, kept as its
+    # OWN column (the WB ``area_self_reported``), distinct from the
+    # GPS-preferred ``Area`` above.  Reported item attribute, never
+    # GPS-overridden.
+    est_ha = pd.Series(pd.NA, index=df.index, dtype='Float64')
     est_col = c.get('area_est')
     unit_col = c.get('area_unit')
     if est_col and est_col in df.columns:
@@ -674,13 +696,15 @@ def plot_features_for_wave(t, df_c, df_d, colmap):
                 if unit_col and unit_col in df.columns
                 else pd.Series(pd.NA, index=df.index, dtype='Int64'))
         # acre -> ha, hectare -> ha, sq metre -> ha; OTHER (4) / 0 -> NaN
-        est_ha = pd.Series(pd.NA, index=df.index, dtype='Float64')
         est_ha = est_ha.where(unit != 1, est * ACRES_TO_HECTARES)
         est_ha = est_ha.where(unit != 2, est)
         est_ha = est_ha.where(unit != 3, est / 10000.0)
         # Clamp implausible estimates too (>1000 ha)
         est_ha = est_ha.where((est_ha <= 1000) | est_ha.isna(), pd.NA)
+        # GPS-preferred Area falls back to the self-reported estimate.
         area_ha = area_ha.where(area_ha.notna(), est_ha)
+
+    area_self_reported = est_ha
 
     area_unit = pd.Series(['acres'] * n, index=df.index, dtype='string')
     area_unit = area_unit.where(area_ha.notna(), pd.NA)
@@ -701,10 +725,14 @@ def plot_features_for_wave(t, df_c, df_d, colmap):
         irrigated = (wcode != 7).astype('boolean')
         irrigated = irrigated.where(wcode.notna(), pd.NA)
 
-    # Tenure / TenureSystem from the acquire code (ag_d03), present in
-    # 2010-11 & 2013-14 only.  Absent -> all NaN (2016-17 / 2019-20).
+    # Tenure / TenureSystem / PlotOwned from the acquire code (ag_d03),
+    # present in 2010-11 & 2013-14 only.  Absent -> all NaN (2016-17 /
+    # 2019-20: the WB derives plot_owned from the Module B2 parcel-tenure
+    # roster there, a different grain -- left NaN here rather than joined,
+    # matching how Tenure already behaves for those waves).
     tenure = pd.Series(pd.NA, index=df.index, dtype='string')
     tenure_system = pd.Series(pd.NA, index=df.index, dtype='string')
+    plot_owned = pd.Series(pd.NA, index=df.index, dtype='boolean')
     acq_col = c.get('acquire')
     if acq_col and acq_col in df.columns:
         acode = pd.to_numeric(df[acq_col], errors='coerce').astype('Int64')
@@ -712,17 +740,52 @@ def plot_features_for_wave(t, df_c, df_d, colmap):
         # Leasehold acquire code (6) -> TenureSystem 'leasehold'.
         tenure_system = pd.Series(pd.NA, index=df.index, dtype='string')
         tenure_system = tenure_system.where(acode != 6, 'leasehold')
+        # PlotOwned: the WB plot_owned recode of ag_d03 -- codes 1-5
+        # (granted / inherited / bride price / purchased with or without
+        # title) = owned; 6-11 (leasehold / rent / tenant / borrowed /
+        # squatter / other) = not owned.  NaN where the acquire code is
+        # itself missing.
+        plot_owned = ((acode >= 1) & (acode <= 5)).astype('boolean')
+        plot_owned = plot_owned.where(acode.notna(), pd.NA)
+
+    # Fallow: the WB per-plot fallow flag -- cultivation-status code
+    # ag_d14 == 4 ("Fallow").  Any other recorded status (cultivated,
+    # rented/given out, forest, pasture, other) = not fallow; NaN where
+    # the status is unrecorded.  The WB nb_fallow_plots is a count
+    # transform over this item flag (NOT stored here).
+    fallow = pd.Series(pd.NA, index=df.index, dtype='boolean')
+    fallow_col = c.get('fallow')
+    if fallow_col and fallow_col in df.columns:
+        fcode = pd.to_numeric(df[fallow_col], errors='coerce').astype('Int64')
+        fallow = (fcode == 4).astype('boolean')
+        fallow = fallow.where(fcode.notna(), pd.NA)
+
+    # ErosionProtection: the WB erosion_protection recode of the 1st
+    # erosion-control facility code ag_d25a -- code 1 = "No erosion
+    # control" -> False; any other recorded facility (terraces, bunds,
+    # gabions, vetiver, tree belts, drainage, ...) -> True.  NaN where
+    # unrecorded.
+    erosion_protection = pd.Series(pd.NA, index=df.index, dtype='boolean')
+    ero_col = c.get('erosion')
+    if ero_col and ero_col in df.columns:
+        ecode = pd.to_numeric(df[ero_col], errors='coerce').astype('Int64')
+        erosion_protection = (ecode != 1).astype('boolean')
+        erosion_protection = erosion_protection.where(ecode.notna(), pd.NA)
 
     out = pd.DataFrame({
-        't':            t,
-        'i':            idx_i.values,
-        'plot_id':      plot_id.values,
-        'Area':         area_ha.values,
-        'AreaUnit':     area_unit.values,
-        'Tenure':       tenure.values,
-        'TenureSystem': tenure_system.values,
-        'SoilType':     soil_type.values,
-        'Irrigated':    irrigated.values,
+        't':                t,
+        'i':                idx_i.values,
+        'plot_id':          plot_id.values,
+        'Area':             area_ha.values,
+        'AreaUnit':         area_unit.values,
+        'AreaSelfReported': area_self_reported.values,
+        'Tenure':           tenure.values,
+        'TenureSystem':     tenure_system.values,
+        'PlotOwned':        plot_owned.values,
+        'SoilType':         soil_type.values,
+        'Irrigated':        irrigated.values,
+        'Fallow':           fallow.values,
+        'ErosionProtection': erosion_protection.values,
     })
     # Collapse any duplicate (hhid, plotkey) area rows defensively
     # (Module C should be one row per plot; first-wins keeps it unique).

--- a/lsms_library/countries/Mali/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Mali/2018-19/_/plot_features.py
@@ -31,6 +31,8 @@ colmap = dict(
     tenure_system = 's16aq13',
     soil_type     = 's16aq18',
     water_source  = 's16aq17',
+    topography    = 's16aq19',
+    soil_fertility= 's16aq20',
 )
 
 df = plot_features_for_wave('2018-19', src, colmap)

--- a/lsms_library/countries/Mali/2021-22/_/plot_features.py
+++ b/lsms_library/countries/Mali/2021-22/_/plot_features.py
@@ -28,6 +28,8 @@ colmap = dict(
     tenure_system = 's16aq13',
     soil_type     = 's16aq18',
     water_source  = 's16aq17',
+    topography    = 's16aq19',
+    soil_fertility= 's16aq20',
 )
 
 df = plot_features_for_wave('2021-22', src, colmap)

--- a/lsms_library/countries/Mali/_/categorical_mapping.org
+++ b/lsms_library/countries/Mali/_/categorical_mapping.org
@@ -513,6 +513,32 @@
 |    2 | granted_right_of_occupancy |
 |    4 | leasehold                  |
 
+# harmonize_topography — s16aq19 reported per-plot topography/slope class
+# (the survey-REPORTED analogue of the WB harmonised panel's GAEZ-raster
+# `plot_slope`, which is a geospatial join — not reported — and out of the
+# item-attribute scope here).  Codes are identical across both EHCVM waves
+# (2021-22 merely prefixes "N. ").  Free-form str labels, English.
+#+name: harmonize_topography
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | hill            |
+|    2 | plain           |
+|    3 | gentle slope    |
+|    4 | steep slope     |
+|    5 | valley          |
+|    6 | other           |
+
+# harmonize_soil_fertility — s16aq20 farmer's REPORTED fertility assessment
+# of the plot.  This is the surveyed soil-quality tag, NOT the WB panel's
+# `soil_fertility_index` (a PCA over GAEZ rasters — a forbidden transform).
+# Codes identical across both EHCVM waves.
+#+name: harmonize_soil_fertility
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | good            |
+|    2 | medium          |
+|    3 | poor            |
+
 # harmonize_input — the input-identity (`input` index level) taxonomy for
 # plot_inputs (GAP 2, parity loop).  Unlike the other harmonize_* tables,
 # the inputs are NOT a decoded label column in the source: each input type

--- a/lsms_library/countries/Mali/_/data_scheme.yml
+++ b/lsms_library/countries/Mali/_/data_scheme.yml
@@ -115,12 +115,29 @@ Data Scheme:
     # plot_id = "{field_no}_{parcel_no}".  Latitude / Longitude are NOT
     # emitted — EHCVM s16a has no decimal-degree parcel GPS (s16aq47 is
     # an area, not a coordinate); deferred as in Uganda.
+    #
+    # Item-attribute audit vs the WB harmonised Plot_dataset (parity GAP 6):
+    # the WB EACI panel carries irrigated / plot_owned / plot_certificate
+    # (already our Irrigated / Tenure / TenureSystem) plus self_reported_area
+    # and the GAEZ-raster plot_slope / soil_fertility_index (geospatial / PCA
+    # transforms — NOT reported, out of scope).  erosion_protection and the
+    # per-plot fallow flag are EACI-instrument items absent from the EHCVM
+    # s16a module these two waves use, so they are not in the source.  Added
+    # the REPORTED s16a item attributes the audit surfaced: SelfReportedArea
+    # (farmer estimate, kept distinct from the GPS-preferred Area) and the
+    # surveyed slope/fertility tags Topography (s16aq19) / SoilFertility
+    # (s16aq20) — the reported analogues of the WB's GAEZ plot_slope /
+    # soil_fertility_index.  No farm_size / nb_plots / nb_fallow_plots /
+    # soil_fertility_index columns — those are transformations.py rollups.
     index: (t, i, plot_id)
     Area: float
     AreaUnit: str
+    SelfReportedArea: float
     Tenure: str
     TenureSystem: str
     SoilType: str
+    Topography: str
+    SoilFertility: str
     Irrigated: bool
     materialize: make
   crop_production:

--- a/lsms_library/countries/Mali/_/mali.py
+++ b/lsms_library/countries/Mali/_/mali.py
@@ -125,12 +125,17 @@ def plot_features_for_wave(t, source, colmap):
             tenure_system — land-document question    -> TenureSystem
             soil_type     — soil-type question        -> SoilType
             water_source  — water-source question     -> Irrigated
+            topography    — topography/slope question -> Topography  (optional)
+            soil_fertility— fertility-rating question -> SoilFertility (optional)
 
     Returns
     -------
     pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
         ``Area`` (hectares float), ``AreaUnit`` (always 'hectares'),
-        ``Tenure``, ``TenureSystem``, ``SoilType`` (str), and
+        ``SelfReportedArea`` (hectares float — the farmer estimate, kept
+        distinct from the GPS-preferred ``Area``), ``Tenure``,
+        ``TenureSystem``, ``SoilType`` (str), ``Topography`` (str reported
+        slope class), ``SoilFertility`` (str reported fertility rating), and
         ``Irrigated`` (nullable bool).
 
     Notes
@@ -149,6 +154,8 @@ def plot_features_for_wave(t, source, colmap):
     tenure_system_map = _harmonized_codes('harmonize_tenure_system')
     soil_map = _harmonized_codes('harmonize_soil')
     water_map = _harmonized_codes('harmonize_water')
+    topo_map = _harmonized_codes('harmonize_topography')
+    fert_map = _harmonized_codes('harmonize_soil_fertility')
 
     c = colmap
 
@@ -193,12 +200,29 @@ def plot_features_for_wave(t, source, colmap):
     area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
     area_unit = area_unit.where(area_ha.notna(), pd.NA)
 
+    # Farmer-self-reported parcel area (hectares).  The WB harmonised panel
+    # carries `self_reported_area` distinctly from the GPS measure; we keep it
+    # as its own REPORTED column rather than only as the GPS fallback folded
+    # into Area above.  Same unit conversion (1=Hectare, 2=m^2) and the same
+    # plausibility clamp (GH #327) as Area.
+    self_area = est_ha.where(((est_ha > 0) & (est_ha <= 1000)) | est_ha.isna(), pd.NA)
+
     tenure = _map_codes(src[c['tenure']], tenure_map) \
         if c.get('tenure') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
     tenure_system = _map_codes(src[c['tenure_system']], tenure_system_map) \
         if c.get('tenure_system') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
     soil_type = _map_codes(src[c['soil_type']], soil_map) \
         if c.get('soil_type') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+
+    # Reported per-plot topography/slope class (s16aq19) and the farmer's
+    # reported soil-fertility assessment (s16aq20).  These are SURVEYED item
+    # attributes — the reported analogues of the WB panel's GAEZ-raster
+    # `plot_slope` / `soil_fertility_index` (which are geospatial/PCA
+    # transforms, out of scope).  Both columns are optional in the colmap.
+    topography = _map_codes(src[c['topography']], topo_map) \
+        if c.get('topography') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    soil_fertility = _map_codes(src[c['soil_fertility']], fert_map) \
+        if c.get('soil_fertility') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
 
     irrigated = pd.Series(pd.NA, index=src.index, dtype='boolean')
     if c.get('water_source') in src.columns:
@@ -207,15 +231,18 @@ def plot_features_for_wave(t, source, colmap):
         irrigated = irrigated.where(water_label.notna(), pd.NA)
 
     df = pd.DataFrame({
-        't':            t,
-        'i':            hh.values,
-        'plot_id':      plot_id.values,
-        'Area':         area_ha.values,
-        'AreaUnit':     area_unit.values,
-        'Tenure':       tenure.values,
-        'TenureSystem': tenure_system.values,
-        'SoilType':     soil_type.values,
-        'Irrigated':    irrigated.values,
+        't':                t,
+        'i':                hh.values,
+        'plot_id':          plot_id.values,
+        'Area':             area_ha.values,
+        'AreaUnit':         area_unit.values,
+        'SelfReportedArea': self_area.values,
+        'Tenure':           tenure.values,
+        'TenureSystem':     tenure_system.values,
+        'SoilType':         soil_type.values,
+        'Topography':       topography.values,
+        'SoilFertility':    soil_fertility.values,
+        'Irrigated':        irrigated.values,
     })
     df = df.set_index(['t', 'i', 'plot_id'])
     return df

--- a/lsms_library/countries/Niger/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Niger/2018-19/_/plot_features.py
@@ -28,8 +28,10 @@ colmap = dict(
     area_est_unit = 's16aq09b',
     tenure        = 's16aq10',
     tenure_system = 's16aq13',
+    certificate   = 's16aq13',  # WB plot_certificate: has-any-legal-document bool
     soil_type     = 's16aq18',
     water_source  = 's16aq17',
+    fertility     = 's16aq20',  # WB soil-quality tag: reported good/medium/poor
 )
 
 df = plot_features_for_wave('2018-19', src, colmap)

--- a/lsms_library/countries/Niger/2021-22/_/plot_features.py
+++ b/lsms_library/countries/Niger/2021-22/_/plot_features.py
@@ -26,8 +26,10 @@ colmap = dict(
     area_est_unit = 's16aq09b',
     tenure        = 's16aq10',
     tenure_system = 's16aq13',
+    certificate   = 's16aq13',  # WB plot_certificate: has-any-legal-document bool
     soil_type     = 's16aq18',
     water_source  = 's16aq17',
+    fertility     = 's16aq20',  # WB soil-quality tag: reported good/medium/poor
 )
 
 df = plot_features_for_wave('2021-22', src, colmap)

--- a/lsms_library/countries/Niger/_/data_scheme.yml
+++ b/lsms_library/countries/Niger/_/data_scheme.yml
@@ -121,12 +121,34 @@ Data Scheme:
     # owned.  Latitude / Longitude are NOT emitted — EHCVM s16a has no
     # decimal-degree parcel GPS (s16aq47 is an area, not a coordinate);
     # deferred as in Uganda.
+    #
+    # WB-parity audit (GAP 6, 2026-06-14): added three REPORTED item
+    # columns at the existing (t, i, plot_id) grain, all from the same
+    # s16a parcel module the feature already reads (label-preserving — the
+    # six original columns and the row count are unchanged):
+    #   AreaSelfReported (s16aq09a/b) — WB area_self_reported: the farmer
+    #     estimate in hectares, kept distinct from GPS-preferred Area.
+    #   PlotCertificate  (s16aq13)    — WB plot_certificate: bool, holds a
+    #     formal land document (codes 1-5) vs none (7); Autre/missing NA.
+    #   SoilFertility    (s16aq20)    — WB soil-quality tag: reported
+    #     good/medium/poor (WB's soil_fertility_index PCA is a transform,
+    #     NOT stored).
+    # WB item attrs NOT in the EHCVM s16a source, hence skipped (no fake
+    # all-NA columns): fallow / erosion_protection (no s16a question;
+    # WB derives them from the ECVMA as01q module, which is the pre-EHCVM
+    # 2011-12/2014-15 instrument — out of scope for this feature) and
+    # plot_slope (WB plot_slope is SRTM geospatial, not survey-reported;
+    # the reported topography s16aq19 is a distinct construct left for a
+    # future Topography column with its own harmonize table).
     index: (t, i, plot_id)
     Area: float
     AreaUnit: str
+    AreaSelfReported: float
     Tenure: str
     TenureSystem: str
+    PlotCertificate: bool
     SoilType: str
+    SoilFertility: str
     Irrigated: bool
     materialize: make
 

--- a/lsms_library/countries/Niger/_/niger.py
+++ b/lsms_library/countries/Niger/_/niger.py
@@ -260,8 +260,19 @@ def plot_features_for_wave(t, source, colmap):
     See ``Mali/_/mali.py:plot_features_for_wave`` for the full contract
     (this is a direct sibling).  Returns a DataFrame indexed by
     ``(t, i, plot_id)`` with columns ``Area`` (hectares float),
-    ``AreaUnit`` (always 'hectares'), ``Tenure``, ``TenureSystem``,
-    ``SoilType`` (str), and ``Irrigated`` (nullable bool).
+    ``AreaUnit`` (always 'hectares'), ``AreaSelfReported`` (reported
+    farmer-estimate area in hectares, distinct from the GPS-preferred
+    ``Area``), ``Tenure``, ``TenureSystem``, ``PlotCertificate``
+    (nullable bool: has a formal land document), ``SoilType`` (str),
+    ``SoilFertility`` (reported good/medium/poor str), and ``Irrigated``
+    (nullable bool).
+
+    The three reported item attributes added in the 2026-06-14 WB-parity
+    audit (GAP 6) — ``AreaSelfReported`` (s16aq09a/b), ``PlotCertificate``
+    (s16aq13), ``SoilFertility`` (s16aq20) — are emitted only when the
+    matching ``colmap`` keys (``area_est``/``area_est_unit``,
+    ``certificate``, ``fertility``) are supplied; otherwise they fall back
+    to all-NA so the schema stays stable across waves that lack them.
 
     Niger note: ``i`` is built with Niger's ``i()`` formatter from a
     lowercase-named (grappe, menage) Series so the EHCVM 'E_' prefix
@@ -333,16 +344,59 @@ def plot_features_for_wave(t, source, colmap):
         irrigated = (water_label == 'Irrigated').astype('boolean')
         irrigated = irrigated.where(water_label.notna(), pd.NA)
 
+    # AreaSelfReported (WB parity: area_self_reported / self_reported_area).
+    # The REPORTED farmer-estimate parcel area (s16aq09a), in hectares,
+    # carried distinct from ``Area`` (which prefers GPS where measured).
+    # WB keeps the self-reported estimate as its own variable rather than
+    # folding it into the GPS-preferred area; we mirror that here so the
+    # reported estimate survives even on plots where GPS was used.  Same
+    # unit conversion (1=Ha, 2=m^2 -> /10000) and plausibility clamp
+    # (GH #327) as ``Area``.  ``est_ha`` was already computed above.
+    area_self = est_ha.where(((est_ha > 0) & (est_ha <= 1000)) | est_ha.isna(), pd.NA)
+
+    # PlotCertificate (WB parity: plot_certificate).  Reported bool from
+    # s16aq13 "Avez-vous un document légal qui affirme votre possession de
+    # cette parcelle?" — codes 1-5 are a formal land document (Titre
+    # foncier / Permis d'exploiter / Procès-verbal / Bail / Convention de
+    # vente) -> True; code 7 (Aucun) -> False; code 6 (Autre) and missing
+    # -> NA.  This is a SECOND, complementary projection of s16aq13: the
+    # existing ``TenureSystem`` maps only the three codes (1,2,4) that
+    # imply a clear tenure regime, whereas WB's plot_certificate is the
+    # binary has-any-document fact over the same question.  Not a transform
+    # (no sum/count/PCA) — a direct reported recode of one source column.
+    plot_certificate = pd.Series(pd.NA, index=src.index, dtype='boolean')
+    if c.get('certificate') in src.columns:
+        cert_code = src[c['certificate']].astype('Int64')
+        has_doc = cert_code.isin([1, 2, 3, 4, 5])
+        plot_certificate = has_doc.astype('boolean')
+        # code 7 = Aucun -> False (already via isin); code 6 = Autre and
+        # any missing -> NA (not a defensible yes/no).
+        plot_certificate = plot_certificate.where(cert_code.isin([1, 2, 3, 4, 5, 7]), pd.NA)
+
+    # SoilFertility (WB parity: a reported soil-quality tag; WB's
+    # soil_fertility_index is a banned PCA transform, but s16aq20 records
+    # the farmer's REPORTED fertility rating directly).  s16aq20 codes
+    # 1=Bonne -> good, 2=Moyenne -> medium, 3=Faible -> poor.  Emitted as
+    # a normalized English ordinal string; no parallel categorical table
+    # (the three labels are identical across both EHCVM waves).
+    fertility_map = {1: 'good', 2: 'medium', 3: 'poor'}
+    soil_fertility = pd.Series(pd.NA, index=src.index, dtype='string')
+    if c.get('fertility') in src.columns:
+        soil_fertility = _map_codes(src[c['fertility']], fertility_map)
+
     df = pd.DataFrame({
-        't':            t,
-        'i':            hh.values,
-        'plot_id':      plot_id.values,
-        'Area':         area_ha.values,
-        'AreaUnit':     area_unit.values,
-        'Tenure':       tenure.values,
-        'TenureSystem': tenure_system.values,
-        'SoilType':     soil_type.values,
-        'Irrigated':    irrigated.values,
+        't':                t,
+        'i':                hh.values,
+        'plot_id':          plot_id.values,
+        'Area':             area_ha.values,
+        'AreaUnit':         area_unit.values,
+        'AreaSelfReported': area_self.values,
+        'Tenure':           tenure.values,
+        'TenureSystem':     tenure_system.values,
+        'PlotCertificate':  plot_certificate.values,
+        'SoilType':         soil_type.values,
+        'SoilFertility':    soil_fertility.values,
+        'Irrigated':        irrigated.values,
     })
     df = df.set_index(['t', 'i', 'plot_id'])
     return df

--- a/lsms_library/countries/Nigeria/2010-11/_/plot_features.py
+++ b/lsms_library/countries/Nigeria/2010-11/_/plot_features.py
@@ -2,8 +2,12 @@
 
 Post-planting only -> single t = 2010Q3.  Area (sect11a1) joined onto
 plot detail (sect11b) on (hhid, plotid).  Wave 1's sect11b stops at q28,
-so it carries NO soil type, irrigation, or separate tenure-system
-question; SoilType / Irrigated / TenureSystem are NaN this wave.
+so it carries NO soil type, irrigation, separate tenure-system, land
+certificate, or erosion-protection question; SoilType / Irrigated /
+TenureSystem / PlotCertificate / ErosionProtection are NaN this wave.
+Fallow comes from s11bq17 ("left fallow"), with s11bq16 ("cultivated?")
+forcing not-fallow.  PlotSlope from the plot-geovariables file
+(srtmslp_nga, degrees), joined on (hhid, plotid).
 """
 import sys
 
@@ -17,15 +21,20 @@ area = get_dataframe('../Data/Post Planting Wave 1/Agriculture/'
                      'sect11a1_plantingw1.dta', convert_categoricals=False)
 detail = get_dataframe('../Data/Post Planting Wave 1/Agriculture/'
                        'sect11b_plantingw1.dta', convert_categoricals=False)
+geovar = get_dataframe('../Data/nga_plotgeovariables_y1.csv',
+                       convert_categoricals=False)
 
 colmap = dict(
     hhid='hhid', plot_id='plotid',
     area_est='s11aq4a', area_unit='s11aq4b', area_gps='s11aq4d',
     acquire='s11bq4',          # tenure
-    # no soil / irrigation / tenure-system questions in W1
+    fallow='s11bq17',          # 1 = "left fallow"
+    fallow_cultivated='s11bq16',   # 1 = cultivated -> not fallow
+    slope='srtmslp_nga',
+    # no soil / irrigation / tenure-system / certificate / erosion in W1
 )
 
-df = plot_features_for_wave(t, area, detail, colmap)
+df = plot_features_for_wave(t, area, detail, colmap, geovar=geovar)
 
 assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2010-11"
 assert len(df) > 0, "plot_features 2010-11 produced no rows"

--- a/lsms_library/countries/Nigeria/2012-13/_/plot_features.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/plot_features.py
@@ -1,7 +1,9 @@
 """Build plot_features for Nigeria GHS-Panel wave 2 (2012-13; GH #167).
 
 Post-planting only -> single t = 2012Q3.  Area (sect11a1) joined onto
-plot detail (sect11b1) on (hhid, plotid).
+plot detail (sect11b1) on (hhid, plotid).  Erosion protection is absent
+this wave (ErosionProtection NaN).  PlotSlope from the plot-geovariables
+file (srtmslp_nga, degrees), joined on (hhid, plotid).
 """
 import sys
 
@@ -15,6 +17,8 @@ area = get_dataframe('../Data/Post Planting Wave 2/Agriculture/'
                      'sect11a1_plantingw2.dta', convert_categoricals=False)
 detail = get_dataframe('../Data/Post Planting Wave 2/Agriculture/'
                        'sect11b1_plantingw2.dta', convert_categoricals=False)
+geovar = get_dataframe('../Data/nga_plotgeovariables_y2.csv',
+                       convert_categoricals=False)
 
 colmap = dict(
     hhid='hhid', plot_id='plotid',
@@ -22,10 +26,13 @@ colmap = dict(
     acquire='s11b1q4',          # tenure
     soil_type='s11b1q44',
     irrigated='s11b1q39',
-    # no separate tenure-system question pre-W5
+    certificate='s11b1q7',      # land-ownership certificate
+    fallow='s11b1q28',          # main-use code 1 = fallow
+    slope='srtmslp_nga',
+    # no separate tenure-system question pre-W5; erosion absent in W2
 )
 
-df = plot_features_for_wave(t, area, detail, colmap)
+df = plot_features_for_wave(t, area, detail, colmap, geovar=geovar)
 
 assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2012-13"
 assert len(df) > 0, "plot_features 2012-13 produced no rows"

--- a/lsms_library/countries/Nigeria/2015-16/_/plot_features.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/plot_features.py
@@ -2,7 +2,9 @@
 
 Post-planting only -> single t = 2015Q3.  Area (sect11a1) joined onto
 plot detail (sect11b1) on (hhid, plotid).  W3 acquire scheme has 6 codes
-(adds family inheritance = 5, sharecropped = 6).
+(adds family inheritance = 5, sharecropped = 6).  Erosion protection
+(s11b1q49) first appears this wave.  PlotSlope from the plot-geovariables
+file (srtmslp_nga, degrees), joined on (hhid, plotid).
 """
 import sys
 
@@ -16,6 +18,8 @@ area = get_dataframe('../Data/sect11a1_plantingw3.dta',
                      convert_categoricals=False)
 detail = get_dataframe('../Data/sect11b1_plantingw3.dta',
                        convert_categoricals=False)
+geovar = get_dataframe('../Data/nga_plotgeovariables_y3.csv',
+                       convert_categoricals=False)
 
 colmap = dict(
     hhid='hhid', plot_id='plotid',
@@ -23,9 +27,13 @@ colmap = dict(
     acquire='s11b1q4',          # tenure
     soil_type='s11b1q44',
     irrigated='s11b1q39',
+    certificate='s11b1q7',      # land-ownership certificate
+    erosion='s11b1q49',         # erosion-protection measure
+    fallow='s11b1q28',          # main-use code 1 = fallow
+    slope='srtmslp_nga',
 )
 
-df = plot_features_for_wave(t, area, detail, colmap)
+df = plot_features_for_wave(t, area, detail, colmap, geovar=geovar)
 
 assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2015-16"
 assert len(df) > 0, "plot_features 2015-16 produced no rows"

--- a/lsms_library/countries/Nigeria/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Nigeria/2018-19/_/plot_features.py
@@ -5,6 +5,9 @@ plot detail (sect11b1) on (hhid, plotid).
 
 TRAP (recon): in W4 the AREA NUMBER is s11aq4aa.  s11aq4a is a GPS
 yes/no FLAG (1/2), NOT the area -- do not use it.
+
+PlotSlope from the plot-geovariables file (srtmslp_nga, degrees), joined
+on (hhid, plotid).
 """
 import sys
 
@@ -18,6 +21,8 @@ area = get_dataframe('../Data/sect11a1_plantingw4.dta',
                      convert_categoricals=False)
 detail = get_dataframe('../Data/sect11b1_plantingw4.dta',
                        convert_categoricals=False)
+geovar = get_dataframe('../Data/nga_plotgeovariables_y4.dta',
+                       convert_categoricals=False)
 
 colmap = dict(
     hhid='hhid', plot_id='plotid',
@@ -26,9 +31,13 @@ colmap = dict(
     acquire='s11b1q4',          # tenure (7 codes)
     soil_type='s11b1q44',
     irrigated='s11b1q39',
+    certificate='s11b1q7',      # land-ownership certificate
+    erosion='s11b1q49',         # erosion-protection measure
+    fallow='s11b1q28',          # main-use code 1 = fallow
+    slope='srtmslp_nga',
 )
 
-df = plot_features_for_wave(t, area, detail, colmap)
+df = plot_features_for_wave(t, area, detail, colmap, geovar=geovar)
 
 assert df.index.is_unique, "Non-unique (t, i, plot_id) in plot_features 2018-19"
 assert len(df) > 0, "plot_features 2018-19 produced no rows"

--- a/lsms_library/countries/Nigeria/2023-24/_/plot_features.py
+++ b/lsms_library/countries/Nigeria/2023-24/_/plot_features.py
@@ -9,6 +9,10 @@ field 10).  GPS area is s11mq3.  Tenure acquire is s11b1q4 (9 codes);
 the separate tenure-SYSTEM question s11b1q4b appears ONLY in W5.
 Soil = s11b1q61, irrigation = s11b1q56.  Beware: s11b1q39 here is
 "right to bequeath" and s11b1q44 is "main use" -- NOT soil/irrigation.
+Land certificate is s11b1q8 (was s11b1q7 in W2-W4); erosion protection
+is s11b1q66 (was s11b1q49); Fallow reads the main-use question s11b1q44
+(code 1 = fallow).  No plot-geovariables file was released for W5, so
+PlotSlope is NaN this wave.
 """
 import sys
 
@@ -30,6 +34,10 @@ colmap = dict(
     tenure_system='s11b1q4b',   # W5 only
     soil_type='s11b1q61',       # NOT s11b1q44 (= main use in W5)
     irrigated='s11b1q56',       # NOT s11b1q39 (= right to bequeath in W5)
+    certificate='s11b1q8',      # land-ownership certificate (renumbered)
+    erosion='s11b1q66',         # erosion-protection measure (renumbered)
+    fallow='s11b1q44',          # main-use code 1 = fallow
+    # no plot-geovariables file for W5 -> PlotSlope NaN
 )
 
 df = plot_features_for_wave(t, area, detail, colmap)

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -973,7 +973,7 @@ def _map_codes(series, code_map):
     return out.astype('string').where(out.notna(), pd.NA)
 
 
-def plot_features_for_wave(t, area, detail, colmap):
+def plot_features_for_wave(t, area, detail, colmap, geovar=None):
     """Build canonical ``plot_features`` for one Nigeria GHS-Panel wave.
 
     Nigeria is a post-planting / post-harvest survey; lasting plot
@@ -1001,16 +1001,33 @@ def plot_features_for_wave(t, area, detail, colmap):
             tenure_system                  (in `detail`; W5 only)
             soil_type                      (in `detail`; W2+ only)
             irrigated                      (in `detail`; W2+ only)
+            certificate                    (in `detail`; W2+ -> PlotCertificate)
+            erosion                        (in `detail`; W3+ -> ErosionProtection)
+            fallow                         (in `detail`; -> Fallow, code 1=fallow)
+            fallow_cultivated              (in `detail`; W1 only override:
+                                            value 1 forces Fallow=False)
+            slope                          (in `geovar`; -> PlotSlope, degrees)
         Omitted / absent columns yield NaN for the corresponding output.
+    geovar : pd.DataFrame | None
+        Raw plot-geovariables frame (``nga_plotgeovariables_y*``), loaded
+        with ``get_dataframe(..., convert_categoricals=False)``, joined on
+        (hhid, plotid) to attach ``PlotSlope`` (``srtmslp_nga``).  Absent
+        in W5 (no plot-geovariables file released) -> PlotSlope NaN.
 
     Returns
     -------
     pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
         ``Area`` (hectares float), ``AreaUnit`` (native unit label),
-        ``Tenure``, ``TenureSystem``, ``SoilType`` (str) and
-        ``Irrigated`` (nullable boolean).  Latitude / Longitude are
+        ``Tenure``, ``TenureSystem``, ``SoilType`` (str),
+        ``Irrigated`` (nullable boolean), ``PlotCertificate`` (nullable
+        boolean: holds a land-ownership certificate), ``ErosionProtection``
+        (nullable boolean: erosion-control measure present), ``Fallow``
+        (nullable boolean: plot left fallow this season) and ``PlotSlope``
+        (float, SRTM-derived slope in degrees).  Latitude / Longitude are
         deferred (Nigeria has no decimal-degree parcel coordinates;
-        only GPS area in m^2).
+        only GPS area in m^2).  ``PlotCertificate`` / ``ErosionProtection``
+        / ``Fallow`` are the *reported* per-plot item flags; the HH-level
+        ``nb_fallow_plots`` count is a downstream transform, never stored.
     """
     c = colmap
     wave_label = wave_folder_map.get(t, t)   # PP quarter -> 'YYYY-YY'
@@ -1064,6 +1081,17 @@ def plot_features_for_wave(t, area, detail, colmap):
     soil_type = pd.Series(pd.NA, index=a.index, dtype='string')
     irrigated = pd.Series(pd.NA, index=a.index, dtype='boolean')
 
+    def _yes_no_bool(series):
+        """Map a 1=Yes / 2=No reported flag to nullable boolean.
+
+        Anything else (3 = "don't know", sentinels, missing) -> NA.
+        """
+        num = pd.to_numeric(series, errors='coerce')
+        out = pd.Series(pd.NA, index=series.index, dtype='boolean')
+        out = out.where(~(num == 1), True)
+        out = out.where(~(num == 2), False)
+        return out
+
     if detail is not None and not detail.empty:
         d = detail.copy()
         d_hh = d[c['hhid']].apply(format_id)
@@ -1088,19 +1116,64 @@ def plot_features_for_wave(t, area, detail, colmap):
             irr_bool = irr_bool.where(~(irr == 2), False)
             det['Irrigated'] = irr_bool.values
 
+        # PlotCertificate: holds a land-ownership certificate (s11b1q7 /
+        # s11b1q8).  1 = Yes, 2 = No, 3 ("don't know") -> NA.
+        if c.get('certificate') in d.columns:
+            det['PlotCertificate'] = _yes_no_bool(d[c['certificate']]).values
+
+        # ErosionProtection: erosion-control measure on the plot (s11b1q49 /
+        # s11b1q66).  1 = Yes, 2 = No.
+        if c.get('erosion') in d.columns:
+            det['ErosionProtection'] = _yes_no_bool(d[c['erosion']]).values
+
+        # Fallow: plot left fallow this season.  Reported as a per-plot
+        # item flag with code 1 = fallow (s11bq17 "left fallow" in W1;
+        # s11b1q28 / s11b1q44 main-use code 1 in W2-W5).  Anything else
+        # observed -> not fallow; missing -> NA.  In W1 a separate
+        # "cultivated this plot?" question (s11bq16, value 1 = yes) takes
+        # precedence and forces Fallow = False, matching the WB .do logic
+        # (`replace fallow_plot = 0 if s11bq16 == 1`).
+        if c.get('fallow') in d.columns:
+            fal = pd.to_numeric(d[c['fallow']], errors='coerce')
+            fal_bool = pd.Series(pd.NA, index=d.index, dtype='boolean')
+            fal_bool = fal_bool.where(fal.isna(), False)   # observed -> False
+            fal_bool = fal_bool.where(~(fal == 1), True)    # code 1 -> fallow
+            if c.get('fallow_cultivated') in d.columns:
+                cult = pd.to_numeric(d[c['fallow_cultivated']],
+                                     errors='coerce')
+                fal_bool = fal_bool.where(~(cult == 1), False)
+            det['Fallow'] = fal_bool.values
+
         # Detail is unique on (i, plot_id); drop dup detail rows defensively.
         det = det.drop_duplicates(subset=['i', 'plot_id'])
         pieces = pieces.merge(det, on=['i', 'plot_id'], how='left')
 
+    # --- PlotSlope from plot-geovariables (joined on (hhid, plotid)) ---
+    if (geovar is not None and not geovar.empty
+            and c.get('slope') in geovar.columns):
+        g = geovar.copy()
+        g_hh = g[c['hhid']].apply(format_id)
+        g_plot = g[c['plot_id']].apply(format_id)
+        slope = pd.to_numeric(g[c['slope']], errors='coerce').astype('Float64')
+        gv = pd.DataFrame({'i': g_hh.values, 'plot_id': g_plot.values,
+                           'PlotSlope': slope.values})
+        gv = gv.drop_duplicates(subset=['i', 'plot_id'])
+        pieces = pieces.merge(gv, on=['i', 'plot_id'], how='left')
+
     # Ensure all canonical columns exist.
     for col, dtype in (('Tenure', 'string'), ('TenureSystem', 'string'),
-                       ('SoilType', 'string'), ('Irrigated', 'boolean')):
+                       ('SoilType', 'string'), ('Irrigated', 'boolean'),
+                       ('PlotCertificate', 'boolean'),
+                       ('ErosionProtection', 'boolean'),
+                       ('Fallow', 'boolean'), ('PlotSlope', 'Float64')):
         if col not in pieces.columns:
             pieces[col] = pd.Series(pd.NA, index=pieces.index, dtype=dtype)
 
     pieces['t'] = t
     pieces = pieces[['t', 'i', 'plot_id', 'Area', 'AreaUnit', 'Tenure',
-                     'TenureSystem', 'SoilType', 'Irrigated']]
+                     'TenureSystem', 'SoilType', 'Irrigated',
+                     'PlotCertificate', 'ErosionProtection', 'Fallow',
+                     'PlotSlope']]
     pieces = pieces.set_index(['t', 'i', 'plot_id'])
     return pieces
 

--- a/lsms_library/countries/Tanzania/2019-20/_/plot_features.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/plot_features.py
@@ -24,8 +24,10 @@ colmap = dict(
     use        = 'ag3a_03',
     soil_type  = 'ag3a_10',
     irrigated  = 'ag3a_18',
+    erosion    = 'ag3a_15',
     acquire    = 'ag3a_25',
     legal_cert = 'ag3a_28a',
+    cert_other = 'ag3a_28d',
 )
 
 df = plot_features_for_wave('2019-20', sec02, sec3a, colmap)

--- a/lsms_library/countries/Tanzania/2020-21/_/plot_features.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/plot_features.py
@@ -25,8 +25,10 @@ colmap = dict(
     use        = 'ag3a_03',
     soil_type  = 'ag3a_10',
     irrigated  = 'ag3a_18',
+    erosion    = 'ag3a_15',
     acquire    = 'ag3a_25',
     legal_cert = 'ag3a_28a',
+    cert_other = 'ag3a_28d',
 )
 
 df = plot_features_for_wave('2020-21', sec02, sec3a, colmap)

--- a/lsms_library/countries/Tanzania/_/data_scheme.yml
+++ b/lsms_library/countries/Tanzania/_/data_scheme.yml
@@ -140,10 +140,23 @@ Data Scheme:
     index: (t, i, plot_id)
     Area: float
     AreaUnit: str
+    # SelfReportedArea: farmer-estimated plot area (ha) from ag2a_04, kept
+    # distinct from the GPS-preferred Area (WB area_self_reported).
+    SelfReportedArea: float
     Tenure: str
     TenureSystem: str
     SoilType: str
     Irrigated: bool
+    # Reported item attributes mirroring the WB Plot_dataset plot block
+    # (TZA_NPS*.do): Owned (plot_owned, ag3a_25), Certificate
+    # (plot_certificate, ag3a_28a/28d), ErosionProtection (ag3a_15),
+    # Fallow (ag3a_03==4).  Per-HH rollups (farm_size, nb_plots,
+    # nb_fallow_plots, soil_fertility_index) are transformations over these
+    # item columns, NOT stored here.
+    Owned: bool
+    Certificate: bool
+    ErosionProtection: bool
+    Fallow: bool
     materialize: make
 
   crop_production:

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -759,16 +759,33 @@ def plot_features_for_wave(t, sec02, sec3a, colmap):
         use        — plot use status            (ag3a_03)
         soil_type  — soil type                  (ag3a_10)
         irrigated  — irrigated y/n              (ag3a_18)
+        erosion    — erosion-protection y/n     (ag3a_15)  [optional]
         acquire    — how acquired               (ag3a_25)
         legal_cert — certificate of occupancy   (ag3a_28a)
+        cert_other — other ownership document   (ag3a_28d) [optional]
 
     Returns
     -------
     pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
-        Area (hectares, float), AreaUnit (str, 'acres'), Tenure (str),
-        TenureSystem (str), SoilType (str), Irrigated (bool nullable).
+        Area (hectares, float), AreaUnit (str, 'acres'),
+        SelfReportedArea (hectares, float — farmer estimate before the
+        GPS-preference merge), Tenure (str), TenureSystem (str),
+        SoilType (str), Irrigated (bool nullable), Owned (bool nullable),
+        Certificate (bool nullable), ErosionProtection (bool nullable),
+        Fallow (bool nullable).
+
+    The five reported item attributes beyond the original area/tenure/soil
+    set (SelfReportedArea, Owned, Certificate, ErosionProtection, Fallow)
+    mirror the WB LSMS-ISA Plot_dataset item fields (TZA_NPS*.do plot
+    block); each is a value the questionnaire records PER PLOT.  Per-HH
+    rollups (farm_size, nb_plots, nb_fallow_plots, soil_fertility_index)
+    are transformations over these item columns, NOT stored here.
+
     GPS coordinates (ag2a_07__Latitude/Longitude) are CONFIDENTIAL /
-    redacted in the source and are deliberately NOT emitted.
+    redacted in the source and are deliberately NOT emitted.  plot_slope /
+    plot_elevation are ABSENT from the NPS instrument (the WB cleaning code
+    notes "plot slope (absent)" / "plot elevation (absent)"; they come from
+    external geospatial layers, not the survey) and are likewise omitted.
     """
     c = colmap
     tenure_map = _plot_harmonized_codes('harmonize_tenure')
@@ -792,7 +809,11 @@ def plot_features_for_wave(t, sec02, sec3a, colmap):
     a['Area'] = (area_acres * HECTARES_PER_ACRE).values
     area_unit = pd.Series(['acres'] * len(sec02), index=sec02.index, dtype='string')
     a['AreaUnit'] = area_unit.where(area_acres.notna(), pd.NA).values
-    area = a[['_hh', '_plot', 'Area', 'AreaUnit']]
+    # SelfReportedArea: the farmer estimate alone (ha), kept distinct from
+    # the GPS-preferred Area (WB Plot_dataset carries area_self_reported as
+    # its own item field).  Same plausibility clamp already applied above.
+    a['SelfReportedArea'] = (area_est * HECTARES_PER_ACRE).values
+    area = a[['_hh', '_plot', 'Area', 'AreaUnit', 'SelfReportedArea']]
 
     # --- AG_SEC_3A: detail ---------------------------------------------
     d = pd.DataFrame(index=sec3a.index)
@@ -815,6 +836,39 @@ def plot_features_for_wave(t, sec02, sec3a, colmap):
     irrigated = irr.map({1: True, 2: False}).astype('boolean')
     d['Irrigated'] = irrigated.values
 
+    # --- reported item attributes (WB Plot_dataset parity, GAP 6) -------
+    # Owned: WB plot_owned recode of how-acquired ag3a_25 -- codes
+    # {1,2,5,9} (purchased / granted-titled / inherited / allocated as
+    # owner) -> True, any other acquisition mode -> False.  NaN where
+    # acquisition is unrecorded.  (TZA_NPS*.do plot block.)
+    owned = acq.map(lambda v: pd.NA if pd.isna(v)
+                    else (True if v in (1, 2, 5, 9) else False)).astype('boolean')
+    d['Owned'] = owned.values
+
+    # Certificate: WB plot_certificate.  Base from ag3a_28a (1,2 -> Yes;
+    # 3 -> No), promoted to True when any other ownership document
+    # ag3a_28d is in 1..5, and forced False when the plot is not Owned.
+    cert_a = pd.to_numeric(sec3a[c['legal_cert']], errors='coerce').astype('Int64')
+    cert = cert_a.map({1: True, 2: True, 3: False}).astype('boolean')
+    if c.get('cert_other') is not None and c['cert_other'] in sec3a.columns:
+        cert_d = pd.to_numeric(sec3a[c['cert_other']], errors='coerce').astype('Int64')
+        cert = cert.where(~cert_d.isin([1, 2, 3, 4, 5]), True)
+    cert = cert.where(~(owned == False), False)
+    d['Certificate'] = cert.values
+
+    # ErosionProtection: ag3a_15 1=YES->True, 2=NO->False, else NaN.
+    if c.get('erosion') is not None and c['erosion'] in sec3a.columns:
+        ero = pd.to_numeric(sec3a[c['erosion']], errors='coerce').astype('Int64')
+        d['ErosionProtection'] = ero.map({1: True, 2: False}).astype('boolean').values
+    else:
+        d['ErosionProtection'] = pd.array([pd.NA] * len(sec3a), dtype='boolean')
+
+    # Fallow: WB fallow_plot from use status ag3a_03 == 4 (left fallow);
+    # any other recorded use -> False; NaN where use is unrecorded.
+    fallow = use.map(lambda v: pd.NA if pd.isna(v)
+                     else (True if v == 4 else False)).astype('boolean')
+    d['Fallow'] = fallow.values
+
     # --- merge (1:1 on hhid, plot) -------------------------------------
     df = area.merge(d, on=['_hh', '_plot'], how='outer', indicator=True)
     n_unmatched = int((df['_merge'] != 'both').sum())
@@ -827,7 +881,9 @@ def plot_features_for_wave(t, sec02, sec3a, colmap):
     df['t'] = t
     df = df.rename(columns={'_hh': 'i', '_plot': 'plot_id'})
     df = df.set_index(['t', 'i', 'plot_id'])
-    df = df[['Area', 'AreaUnit', 'Tenure', 'TenureSystem', 'SoilType', 'Irrigated']]
+    df = df[['Area', 'AreaUnit', 'SelfReportedArea', 'Tenure', 'TenureSystem',
+             'SoilType', 'Irrigated', 'Owned', 'Certificate',
+             'ErosionProtection', 'Fallow']]
     return df
 
 

--- a/lsms_library/countries/Uganda/2009-10/_/plot_features.py
+++ b/lsms_library/countries/Uganda/2009-10/_/plot_features.py
@@ -29,6 +29,8 @@ colmap_2a = dict(
     acquire       = 'a2aq8',
     # soil_type intentionally omitted — Stata label bug.
     water_source  = 'a2aq20',
+    certificate   = 'a2aq25',   # formal certificate of title (1-3=Yes, 4=No)
+    erosion       = 'a2aq24',   # erosion-control facility (free-text method string)
 )
 colmap_2b = dict(
     hhid          = 'HHID',
@@ -39,6 +41,8 @@ colmap_2b = dict(
     acquire       = 'a2bq8',
     soil_type     = 'a2bq17',
     water_source  = 'a2bq19',
+    # No certificate question for use-rights (AGSEC2B) parcels.
+    erosion       = 'a2bq23',   # erosion-control facility (free-text method string)
 )
 
 df_a = plot_features_for_wave('2009-10', df_2a, None, colmap_2a)

--- a/lsms_library/countries/Uganda/2010-11/_/plot_features.py
+++ b/lsms_library/countries/Uganda/2010-11/_/plot_features.py
@@ -27,6 +27,8 @@ colmap_2a = dict(
     tenure_system = 'a2aq7',
     acquire       = 'a2aq8',
     water_source  = 'a2aq20',
+    certificate   = 'a2aq25',   # formal certificate of title (1-3=Yes, 4=No)
+    erosion       = 'a2aq24a',  # erosion-control facility (free-text method string)
 )
 colmap_2b = dict(
     hhid          = 'HHID',
@@ -37,6 +39,8 @@ colmap_2b = dict(
     acquire       = 'a2bq8',
     soil_type     = 'a2bq17',
     water_source  = 'a2bq19',
+    # No certificate question for use-rights (AGSEC2B) parcels.
+    erosion       = 'a2bq23a',  # erosion-control facility (free-text method string)
 )
 
 df_a = plot_features_for_wave('2010-11', df_2a, None, colmap_2a)

--- a/lsms_library/countries/Uganda/2011-12/_/plot_features.py
+++ b/lsms_library/countries/Uganda/2011-12/_/plot_features.py
@@ -29,6 +29,8 @@ colmap_2a = dict(
     soil_type     = 'a2aq16',
     # water_source intentionally omitted — a2aq18 Stata label is
     # "main water source" but values are soil-type codes (label bug).
+    certificate   = 'a2aq23',   # formal certificate of title (1-3=Yes, 4=No)
+    erosion       = 'a2aq22a',  # erosion-control facility (method code; 8=None)
 )
 colmap_2b = dict(
     hhid          = 'HHID',
@@ -39,6 +41,8 @@ colmap_2b = dict(
     acquire       = 'a2bq8',
     # 2011-12 AGSEC2B uses different numbering — check questionnaire
     # before declaring soil/water columns here.
+    # No certificate question for use-rights (AGSEC2B) parcels.
+    erosion       = 'a2bq20a',  # erosion-control facility (method code; 8=None)
 )
 
 df_a = plot_features_for_wave('2011-12', df_2a, None, colmap_2a)

--- a/lsms_library/countries/Uganda/2013-14/_/plot_features.py
+++ b/lsms_library/countries/Uganda/2013-14/_/plot_features.py
@@ -36,6 +36,8 @@ colmap = dict(
     acquire       = 'a2aq8',
     soil_type     = 'a2aq16',
     water_source  = 'a2aq18',
+    certificate   = 'a2aq23',   # formal certificate of title (1-3=Yes, 4=No)
+    erosion       = 'a2aq22a',  # erosion-control facility (method code; 8=None)
 )
 
 # AGSEC2B uses a2bq* numbering (vs AGSEC2A's a2aq*), so we call the
@@ -49,6 +51,8 @@ colmap_2b = dict(
     acquire       = 'a2bq8',
     soil_type     = 'a2bq14',
     water_source  = 'a2bq16',
+    # No certificate question for use-rights (AGSEC2B) parcels.
+    erosion       = 'a2bq20a',  # erosion-control facility (method code; 8=None)
 )
 
 # Call helper twice (once per source) so each source uses its own

--- a/lsms_library/countries/Uganda/2015-16/_/plot_features.py
+++ b/lsms_library/countries/Uganda/2015-16/_/plot_features.py
@@ -25,6 +25,8 @@ colmap_2a = dict(
     acquire       = 'a2aq8',
     soil_type     = 'a2aq16',
     water_source  = 'a2aq18',
+    certificate   = 'a2aq23',   # formal certificate of title (1-3=Yes, 4=No)
+    erosion       = 'a2aq22a',  # erosion-control facility (method code; 8=None)
 )
 colmap_2b = dict(
     hhid          = 'HHID',
@@ -35,6 +37,8 @@ colmap_2b = dict(
     acquire       = 'a2bq8',
     soil_type     = 'a2bq14',
     water_source  = 'a2bq16',
+    # No certificate question for use-rights (AGSEC2B) parcels.
+    erosion       = 'a2bq20a',  # erosion-control facility (method code; 8=None)
 )
 
 df_a = plot_features_for_wave('2015-16', df_2a, None, colmap_2a)

--- a/lsms_library/countries/Uganda/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Uganda/2018-19/_/plot_features.py
@@ -26,6 +26,8 @@ colmap_2a = dict(
     acquire       = 's2aq8',
     soil_type     = 's2aq16',
     water_source  = 'a2aq18',
+    certificate   = 's2aq23',   # formal certificate of title (1-3=Yes, 4=No)
+    erosion       = 's2aq22a',  # erosion-control facility (method code; 8=None)
 )
 colmap_2b = dict(
     hhid          = 'hhid',
@@ -36,6 +38,8 @@ colmap_2b = dict(
     acquire       = 's2aq08',
     soil_type     = 's2aq16',
     water_source  = 'a2aq18',
+    # No certificate question for use-rights (AGSEC2B) parcels.
+    erosion       = 's2aq22a',  # erosion-control facility (method code; 8=None)
 )
 
 df_a = plot_features_for_wave('2018-19', df_2a, None, colmap_2a)

--- a/lsms_library/countries/Uganda/2019-20/_/plot_features.py
+++ b/lsms_library/countries/Uganda/2019-20/_/plot_features.py
@@ -25,6 +25,8 @@ colmap_2a = dict(
     # soil_type column appears absent from the 2019-20 AGSEC2A keyword
     # grep — to verify on a follow-up.  Omitting for v1.
     water_source  = 'a2aq18',
+    certificate   = 's2aq23',   # formal certificate of title (1-3=Yes, 4=No)
+    erosion       = 's2aq22a',  # erosion-control facility (method code; 8=None)
 )
 colmap_2b = dict(
     hhid          = 'hhid',
@@ -34,6 +36,8 @@ colmap_2b = dict(
     tenure_system = 's2aq07',
     acquire       = 's2aq08',
     water_source  = 'a2aq18',
+    # No certificate question for use-rights (AGSEC2B) parcels.
+    erosion       = 's2aq22a',  # erosion-control facility (method code; 8=None)
 )
 
 df_a = plot_features_for_wave('2019-20', df_2a, None, colmap_2a)

--- a/lsms_library/countries/Uganda/_/data_scheme.yml
+++ b/lsms_library/countries/Uganda/_/data_scheme.yml
@@ -99,6 +99,19 @@ Data Scheme:
     # in a non-standard DMS encoding (Latitude_Minutes range 0-99 etc.)
     # and is mostly NaN.  Adding GPS is a documented follow-up; for v1
     # Uganda emits the six lasting-attribute columns only.
+    #
+    # GAP-6 parity audit (2026-06-14): added the REPORTED per-parcel
+    # item attributes the WB LSMS-ISA harmonised Plot_dataset carries
+    # (self_reported_area / plot_owned / plot_certificate /
+    # erosion_protection; UGA_UNPS1.do:396-650).  SelfReportedArea is
+    # the farmer estimate kept distinct from Area (which prefers GPS).
+    # PlotOwned / PlotCertificate / ErosionProtection are reported
+    # booleans.  The WB aggregates farm_size / nb_plots / nb_fallow_plots
+    # (sums/counts) and soil_fertility_index (PCA over geospatial
+    # soil-quality rasters) are transformations, NOT stored here; the WB
+    # plot_slope / soil-quality tags come from the GPS geovars raster
+    # keyed on the household, not the parcel questionnaire, so they are
+    # not survey-reported plot attributes and are excluded.
     index: (t, i, plot_id)
     Area: float
     AreaUnit: str
@@ -106,6 +119,10 @@ Data Scheme:
     TenureSystem: str
     SoilType: str
     Irrigated: bool
+    SelfReportedArea: float
+    PlotOwned: bool
+    PlotCertificate: bool
+    ErosionProtection: bool
     materialize: make
   crop_production:
     # Item-level post-harvest crop module (GAP 1 parity build).  One row

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -597,6 +597,17 @@ def plot_features_for_wave(t, source_2a, source_2b, colmap):
             acquire        — How-acquired question (a2aq8 / s2aq8 / ...)
             soil_type      — Soil-type question
             water_source   — Main-water-source question
+            certificate    — Formal certificate-of-title question
+                             (a2aq25 / a2aq23 / s2aq23; AGSEC2A only —
+                             use-rights parcels in AGSEC2B are never
+                             titled, so the question isn't asked there).
+            erosion        — Erosion-control / water-harvesting-facility
+                             question (a2aq24 / a2aq22a / s2aq22a in
+                             AGSEC2A; a2bq23 / a2bq20a / s2aq22a in
+                             AGSEC2B).  May be a numeric method code
+                             (8/'None' -> no facility, other -> facility)
+                             or, in 2009-10, a free-text method string
+                             (empty -> NA, any non-empty code -> facility).
         Each value is the column name in the corresponding source df.
 
     Returns
@@ -604,10 +615,27 @@ def plot_features_for_wave(t, source_2a, source_2b, colmap):
     pd.DataFrame indexed by ``(t, i, plot_id)`` with columns
         ``Area`` (hectares, float), ``AreaUnit`` (str, always 'acres'),
         ``Tenure`` (str), ``TenureSystem`` (str), ``SoilType`` (str),
-        and ``Irrigated`` (bool nullable).  GPS columns (Latitude /
-        Longitude) are reserved in the canonical Columns block but not
-        emitted here — Uganda's DMS encoding in AGSEC2A is
-        non-standard and mostly NaN; revisit in a follow-up.
+        ``Irrigated`` (bool nullable), and the GAP-6 parity item columns
+        ``SelfReportedArea`` (hectares, float — the *reported* farmer
+        estimate, distinct from ``Area`` which prefers the GPS measure),
+        ``PlotOwned`` (bool nullable), ``PlotCertificate`` (bool
+        nullable), and ``ErosionProtection`` (bool nullable).  GPS
+        columns (Latitude / Longitude) are reserved in the canonical
+        Columns block but not emitted here — Uganda's DMS encoding in
+        AGSEC2A is non-standard and mostly NaN; revisit in a follow-up.
+
+    Notes on the GAP-6 reported item columns (audit add, 2026-06-14)
+    ----------------------------------------------------------------
+    These are REPORTED per-parcel attributes the UNPS questionnaire
+    records, mirroring the WB LSMS-ISA harmonised Plot_dataset item
+    fields ``self_reported_area`` / ``plot_owned`` / ``plot_certificate``
+    / ``erosion_protection`` (UGA_UNPS1.do:396-650).  We store the
+    reported booleans only; the WB aggregates ``farm_size`` (Σ area),
+    ``nb_plots`` / ``nb_fallow_plots`` (counts) and ``soil_fertility_index``
+    (PCA over geospatial soil-quality rasters) are transformations and are
+    NOT stored.  ``plot_slope`` and the soil-quality tags are dropped
+    entirely: they come from the GPS ``geovars`` raster file keyed on the
+    household (not the parcel) and are not survey-reported plot attributes.
     """
     tenure_system_map = _harmonized_codes('harmonize_tenure_system')
     soil_map = _harmonized_codes('harmonize_soil')
@@ -642,6 +670,17 @@ def plot_features_for_wave(t, source_2a, source_2b, colmap):
         area_unit = pd.Series(['acres'] * len(src), index=src.index, dtype='string')
         # Where area is NaN, leave AreaUnit NaN too (no measurement = no unit).
         area_unit = area_unit.where(area_acres.notna(), pd.NA)
+
+        # SelfReportedArea (GAP-6 parity): the farmer-estimated parcel
+        # size, kept as its own REPORTED column in hectares.  Distinct
+        # from Area, which prefers the GPS measure and only falls back to
+        # this estimate.  WB: area_self_reported = A2aq5 * 0.404686.
+        self_reported_ha = pd.Series(pd.NA, index=src.index, dtype='Float64')
+        if c.get('area_est') in src.columns:
+            sr_acres = pd.to_numeric(src[c['area_est']], errors='coerce').astype('Float64')
+            # Same plausibility clamp as Area (drop > 2500 acres).
+            sr_acres = sr_acres.where((sr_acres <= 2500) | sr_acres.isna(), pd.NA)
+            self_reported_ha = sr_acres * HECTARES_PER_ACRE
 
         # TenureSystem (Freehold/Leasehold/Mailo/Customary/...)
         tenure_system = pd.Series(pd.NA, index=src.index, dtype='string')
@@ -678,6 +717,85 @@ def plot_features_for_wave(t, source_2a, source_2b, colmap):
             # Where water_label is NaN, leave irrigated as NaN too
             irrigated = irrigated.where(water_label.notna(), pd.NA)
 
+        # PlotCertificate (GAP-6 parity): reported formal/customary
+        # certificate-of-title flag.  Source codes 1-3 = a certificate
+        # type (title / customary / occupancy) -> True; 4 = 'No document'
+        # -> False; anything else / missing -> NA.  Only AGSEC2A (owned
+        # parcels) asks this — use-rights AGSEC2B parcels are never
+        # titled, so the column is absent there and stays NA.
+        # WB: recode A2aq25 (1/3 = 1 "Yes") (4 = 0 "No").
+        plot_certificate = pd.Series(pd.NA, index=src.index, dtype='boolean')
+        cert_col = c.get('certificate')
+        if cert_col and cert_col in src.columns:
+            cert = pd.to_numeric(src[cert_col], errors='coerce').astype('Int64')
+            plot_certificate = pd.Series(pd.NA, index=src.index, dtype='boolean')
+            plot_certificate = plot_certificate.mask(cert.isin([1, 2, 3]), True)
+            plot_certificate = plot_certificate.mask(cert == 4, False)
+
+        # PlotOwned (GAP-6 parity): reported ownership flag derived from
+        # the how-acquired question.  AGSEC2A acquire codes 1 (Purchased)
+        # / 2 (Inherited/gift) -> owned (True); 3 (Leased-in) / 4 (Just
+        # walked in) -> not owned (False); 5 (Do not know) / 6 (Other) ->
+        # NA.  In the 2018-19+ merged code list, 6/7 (given by local
+        # authorities / government) are treated as owned and 8/9
+        # (agreement / without agreement) as use-rights (not owned).
+        # AGSEC2B parcels are use-rights by construction -> False.
+        # A parcel with a certificate is owned regardless of acquire
+        # mode (WB: replace plot_owned = 1 if plot_certificate==1).
+        plot_owned = pd.Series(pd.NA, index=src.index, dtype='boolean')
+        acq_owned_codes = [1, 2, 6, 7]
+        acq_notowned_codes = [3, 4, 8, 9]
+        if letter == 'B':
+            # Use-rights parcels: never owned (acquire codes are
+            # agreement / without-agreement / other).
+            plot_owned = pd.Series(False, index=src.index, dtype='boolean')
+            # But leave NA where the source row carries no acquire info
+            # at all (defensive — keeps parity with the 2A path).
+            if acq_col and acq_col in src.columns:
+                acq_b = src[acq_col].astype('Int64')
+                plot_owned = plot_owned.where(acq_b.notna(), pd.NA)
+        elif acq_col and acq_col in src.columns:
+            acq_a = src[acq_col].astype('Int64')
+            plot_owned = pd.Series(pd.NA, index=src.index, dtype='boolean')
+            plot_owned = plot_owned.mask(acq_a.isin(acq_owned_codes), True)
+            plot_owned = plot_owned.mask(acq_a.isin(acq_notowned_codes), False)
+        # Certificate implies ownership.
+        plot_owned = plot_owned.mask(plot_certificate == True, True)
+
+        # ErosionProtection (GAP-6 parity): reported presence of an
+        # erosion-control / water-harvesting facility on the parcel.
+        # The source column is either a numeric method code (later
+        # waves: 8 / 'none' -> no facility -> False, any other listed
+        # method -> True) or, in 2009-10, a free-text multi-method
+        # string (empty -> NA, any non-empty code -> a facility is
+        # present -> True).  WB: encode then recode 'None' levels -> 0,
+        # else -> 1 (UGA_UNPS1.do:644-648).
+        erosion_protection = pd.Series(pd.NA, index=src.index, dtype='boolean')
+        erosion_col = c.get('erosion')
+        if erosion_col and erosion_col in src.columns:
+            es = src[erosion_col]
+            if pd.api.types.is_numeric_dtype(es):
+                en = pd.to_numeric(es, errors='coerce').astype('Int64')
+                erosion_protection = pd.Series(pd.NA, index=src.index, dtype='boolean')
+                # 8 == 'None' in the method codelist.
+                erosion_protection = erosion_protection.mask(en == 8, False)
+                erosion_protection = erosion_protection.mask(
+                    en.notna() & (en != 8), True)
+            else:
+                # Free-text multi-method string (2009-10 / 2010-11).  The
+                # column holds concatenated method-letter codes; a genuine
+                # method present -> a facility exists (True).  Placeholder
+                # non-answers ('', '0', '-', '.', 'none') carry no
+                # facility information and stay NA.  We deliberately do
+                # NOT reproduce the WB encode-then-recode-by-level logic
+                # (UGA_UNPS2.do:641-648), which is brittle to the
+                # alphabetical encode order.
+                es_str = es.astype('string').str.strip()
+                placeholder = {'', '0', '-', '.', 'none'}
+                is_placeholder = es_str.isna() | es_str.str.lower().isin(placeholder)
+                erosion_protection = pd.Series(pd.NA, index=src.index, dtype='boolean')
+                erosion_protection = erosion_protection.mask(~is_placeholder, True)
+
         # GPS deferred for v1.  Uganda's DMS encoding in AGSEC2A is
         # non-standard (Minutes ranges 0-99, Seconds 0-999) and the
         # columns are mostly NaN; revisit when a maintainer with
@@ -687,22 +805,27 @@ def plot_features_for_wave(t, source_2a, source_2b, colmap):
         # have decimal-degree plot GPS.
 
         piece = pd.DataFrame({
-            't':            t,
-            'i':            hh.values,
-            'plot_id':      plot_id.values,
-            'Area':         area_ha.values,
-            'AreaUnit':     area_unit.values,
-            'Tenure':       tenure.values,
-            'TenureSystem': tenure_system.values,
-            'SoilType':     soil_type.values,
-            'Irrigated':    irrigated.values,
+            't':                t,
+            'i':                hh.values,
+            'plot_id':          plot_id.values,
+            'Area':             area_ha.values,
+            'AreaUnit':         area_unit.values,
+            'Tenure':           tenure.values,
+            'TenureSystem':     tenure_system.values,
+            'SoilType':         soil_type.values,
+            'Irrigated':        irrigated.values,
+            'SelfReportedArea': self_reported_ha.values,
+            'PlotOwned':        plot_owned.values,
+            'PlotCertificate':  plot_certificate.values,
+            'ErosionProtection': erosion_protection.values,
         })
         pieces.append(piece)
 
     if not pieces:
         return pd.DataFrame(
             columns=['Area','AreaUnit','Tenure','TenureSystem',
-                     'SoilType','Irrigated'])
+                     'SoilType','Irrigated','SelfReportedArea',
+                     'PlotOwned','PlotCertificate','ErosionProtection'])
 
     df = pd.concat(pieces, ignore_index=True)
     df = df.set_index(['t', 'i', 'plot_id'])


### PR DESCRIPTION
GAP 6: audit each country's existing `plot_features` against the WB `Plot_dataset` item attributes and ADD the missing **reported** per-plot columns at the existing `(t,i,plot)` grain — fallow, erosion-protection, certificate, ownership, self-reported-area, topography/slope, soil-fertility tag (where the source records them). Reused existing categorical tables (only Mali added two genuinely-new construct tables: `harmonize_topography`, `harmonize_soil_fertility`). NO aggregates (`farm_size`/`nb_plots`/`soil_fertility_index` are transforms — deliberately excluded).

- **Label-preserving**: existing 6 columns byte-identical, 0 baseline rows lost (verified by adversary stash-baseline comparison + independent re-check). Small row increases (Uganda +248, Nigeria/Malawi +3) are previously-all-NaN plots now **surfaced** because a new reported column populates them — 0 spurious rows, more completeness not corruption.
- `v` auto-joins; **no framework edits**; scope confined to the 7 country dirs.
- Note: gaps that add columns to an existing feature require a **cache rewarm** of its `var/parquet` before the test gate (the stale parquet predates the new schema) — first hit here; 160 tests pass after rewarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>