### PR TITLE
docs(Tanzania): document community_prices↔household link limitation (#113)

### DIFF
--- a/lsms_library/countries/Tanzania/_/CONTENTS.org
+++ b/lsms_library/countries/Tanzania/_/CONTENTS.org
@@ -81,10 +81,15 @@ The community questionnaire price data appears decent for 2019-20.
    directory).
 2. Match community prices to households via EA/cluster identifiers.
    - Blocker :: Linking the /places/ where community prices are
-     observed to household locations is not straightforward.  The
-     =clusterid= in =HH_SEC_A.dta= should in principle match the
-     community survey’s EA identifier, but this linkage has not been
-     verified.
+     observed to household locations is /not possible at the EA/cluster
+     level/.  The community survey's =v= (=interview__key=) is a
+     per-interview token with zero overlap with =sample().v=
+     (=clusterid= / =y5_cluster=); the only shared geography is the
+     national admin tuple, which is many-to-many with the survey
+     cluster and (in 2020-21) uses an irreconcilable district
+     numbering.  See *Why the community-price ↔ household link cannot be
+     made cleanly* below for the full diagnosis and match rates.  A
+     region-level fallback is the most that can be done.
 3. Use community prices as a fallback when household-level unit values
    cannot be constructed (i.e., when =quant_purchase= is missing).
 4. Merge with existing =food_prices_quantities_and_expenditures.py=
@@ -97,6 +102,80 @@ The community questionnaire price data appears decent for 2019-20.
 - =Tanzania/2020-21/Data/= --- community questionnaire files (DVC-tracked)
 - =Tanzania/_/food_prices_quantities_and_expenditures.py= --- current price pipeline
 - =Tanzania/_/food_acquired.py= --- country-level aggregation
+
+*** Why the community-price ↔ household link cannot be made cleanly (diagnosis 2026-06-14)
+
+The item-level =community_prices= feature (grain =(t, v, j, u)=, built from
+=CM_SEC_F_ID.dta= / =cm_sec_f_id.dta=) is wired and sane (cold-build 15,831
+rows over 2019-20 + 2020-21, =is_this_feature_sane().ok == True=).  But its
+=v= does **not** intersect =sample().v=, and the proposed step 2 above ---
+matching community prices to households via a shared EA/cluster id --- has been
+investigated and found **infeasible without a lossy, unverifiable crosswalk**.
+The =v= keyspaces are genuinely different identifiers of different things, not
+two encodings of the same EA.  Concrete evidence below; the data limitation is
+recorded so the price-fallback work (#113) is not blocked on a key that does
+not exist.
+
+**The id columns on each side.**
+
+| side                 | =v= source column | format                | example          |
+|----------------------+--------------------+-----------------------+------------------|
+| community_prices     | =interview__key=   | 11-char =XX-XX-XX-XX=  | =00-38-24-76=    |
+| sample() 2019-20     | =clusterid=        | 8--9 digit integer    | =11014002=       |
+| sample() 2020-21     | =y5_cluster=       | 16-char =RR-DD-WWW-EE-CCC= | =02-02-033-04-004= |
+
+=interview__key= is a Survey-Solutions per-*interview* token, **unique per
+questionnaire instance**, NOT a cluster id: the community file's 99 (2019-20) /
+488 (2020-21) keys have **zero** overlap with the household file's own
+=interview__key= column (1,184 / 4,709 keys) --- by construction, because each
+is a distinct interview.  So =interview__key= can never be the join key.
+
+**The only shared geography is the national admin tuple, and it does not
+resolve to a survey cluster.**  The community cover page (=CM_SEC_A=) carries
+admin location codes =id_01..id_05= (region / district / ward / village / ...);
+the household cover page carries the parallel national-admin =t0_region /
+t0_district / t0_ward_code / t0_ea_codee=.  Domains overlap at the coarse
+levels (2019-20: region 27/27, district 53/57, ward 53/58 of community codes
+present on the household side), so in principle one could match on
+=(region, district, ward)=.  But:
+
+1. *The national admin tuple is not 1:1 with the survey cluster, even within
+   the household file.*  The survey-design =clusterid= / =y5_cluster= is a
+   sampling cluster, not an admin unit.  35 of 165 household ward-tuples
+   (2019-20) hold 2--3 distinct =clusterid=; the tracking design also pins
+   moved households to their *baseline* cluster while recording a *new* admin
+   location, so the same =clusterid= appears under several admin tuples.  The
+   admin→cluster map is many-to-many on the household side.
+
+2. *2019-20 best case: 38 of 99 communities (38%) resolve to a unique
+   cluster.*  Matching community =(id_01,id_02,id_03)= to the household
+   ward-tuple: 55/99 match a ward at all (44 communities sit in wards with no
+   surviving tracked household), and of those 55 only 38 map to a single
+   =clusterid= (17 are ambiguous, ward holds >1 cluster).  Adding the village
+   code =id_04= makes it *worse* (15 matches) --- =id_04= is the village number
+   in a different numbering than the survey =t0_ea_codee=.
+
+3. *2020-21: the district numbering is irreconcilable, so no honest match
+   exists.*  Community =id_02= is the 2--3-digit national district code
+   (=128, 71, 97...=); the =y5_cluster= "DD" field is a 1--2-digit
+   within-region district index (domain ≈ =1..9=).  Region+district+ward match
+   = **0/488**.  Dropping district to match on =(region, ward)= "recovers"
+   475/488 --- but ward numbers repeat across districts within a region
+   (58 region+ward pairs already collide onto ≥2 clusters in the household
+   file alone), so those matches conflate wards in different districts and
+   cannot be validated.  That is precisely a lossy many-to-many crosswalk.
+
+**Conclusion.**  There is no shared, lossless EA/cluster key between the
+community-price instrument and =sample()=.  The finest reliably shared key is
+the national *region* (and, for 2019-20 only, partially the ward), not the EA.
+A community→household price join is therefore a deliberate *region-level
+fallback transformation* (the documented #113 use), and must be implemented as
+such by the maintainer --- it is **not** a clean key join and is intentionally
+NOT baked into the item-level =community_prices= feature, whose =v= is left as
+the community's native =interview__key=.  Reproduce the numbers above from
+=Tanzania/2019-20/Data/CM_SEC_A.dta= + =HH_SEC_A.dta= and
+=Tanzania/2020-21/Data/cm_sec_a.dta= + =hh_sec_a.dta= (=get_dataframe(...,
+convert_categoricals=False)=).
 
 ** DONE Link  2019-20 and 2020-21 to panel
 CLOSED: [2026-03-29 Sat]

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -1681,16 +1681,20 @@ def people_last7days_for_wave(t, sec, colmap):
 # and quantity both 0) and are dropped as non-observations.
 #
 # v == the community questionnaire's own cluster id (interview__key).  IMPORTANT
-# DATA LIMITATION (issue #113, CONTENTS.org): the NPS community instrument and
-# the household instrument use INCOMPATIBLE cluster-coding schemes -- the
-# community interview__key has ZERO overlap with the household interview__key,
-# and the community location codes (id_01..id_05, national admin numbering)
-# reconcile to the household survey-design clusterid / y5_cluster only at the
-# region level (the finest key that matches), NOT at the EA/cluster level (~4%
-# EA-tuple match).  So community_prices.v is the community cluster's NATIVE id
-# and does NOT intersect sample().v; a community->household price join is a
-# region-level fallback TRANSFORMATION (the documented #113 use), deliberately
-# NOT baked into this item-level feature.  Because the grain carries no
+# DATA LIMITATION (issue #113; full diagnosis + match rates in CONTENTS.org,
+# "Why the community-price <-> household link cannot be made cleanly"): the NPS
+# community instrument and the household instrument use INCOMPATIBLE cluster
+# coding -- v == interview__key is a per-INTERVIEW token (NOT a cluster id) with
+# ZERO overlap with sample().v (clusterid / y5_cluster).  The only shared
+# geography is the national admin tuple (community id_01..id_05 vs household
+# t0_region/district/ward); but it is many-to-many with the survey cluster even
+# within the household file (tracking design), so the best-case match is 38/99
+# communities -> a unique cluster in 2019-20, and for 2020-21 the district
+# numbering is irreconcilable (region+district+ward match == 0/488).  So
+# community_prices.v is the community cluster's NATIVE id and does NOT intersect
+# sample().v; a community->household price join is at best a REGION-level
+# fallback TRANSFORMATION (the documented #113 use), deliberately NOT baked into
+# this item-level feature.  Because the grain carries no
 # household i, the framework's _join_v_from_sample never fires (it requires an
 # i level), so v is left exactly as emitted -- no _no_v_join entry is needed.
 


### PR DESCRIPTION
Investigation outcome for #113 (the Tanzania community-price ↔ household link). **Documented limitation, no forced fix** —  is a per-interview Survey-Solutions token, not a cluster id; no faithful join to `sample().v` exists (only region-level, and even that is many-to-many by the panel tracking design). `community_prices` is unchanged (15,831 rows, sane.ok). Evidence added to `Tanzania/_/CONTENTS.org`; stale match-rate comment in `tanzania.py` corrected. Closes the *investigation* of #113; the issue stays open for the (separate) quantity-fallback usage decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>