### PR TITLE
fix(Mali): container u labels as names, not digit-leading metric (#223 leak)

### DIFF
--- a/lsms_library/countries/Mali/_/categorical_mapping.org
+++ b/lsms_library/countries/Mali/_/categorical_mapping.org
@@ -45,12 +45,12 @@
 | Panier                       | Panier          | ---     | x       | x       |
 | Paquet                       | Paquet          | x       | x       | x       |
 | Piece                        | Piece           | ---     | x       | x       |
-| Sac (25 Kg)                  | 25 Kg           | ---     | x       | ---     |
+| Sac (25 Kg)                  | Sac (25 Kg)     | ---     | x       | ---     |
 | Sans os au Kg                | Kg              | ---     | x       | x       |
 | Sans os au tas               | Tas             | ---     | x       | x       |
-| Seau (10 Kg)                 | 10 Kg           | ---     | x       | x       |
-| Seau (25 Kg)                 | 25 Kg           | ---     | x       | ---     |
-| Seau (5 Kg )                 | 5 Kg            | ---     | x       | x       |
+| Seau (10 Kg)                 | Seau (10 Kg)    | ---     | x       | x       |
+| Seau (25 Kg)                 | Seau (25 Kg)    | ---     | x       | ---     |
+| Seau (5 Kg )                 | Seau (5 Kg)     | ---     | x       | x       |
 | Tas                          | Tas             | x       | x       | x       |
 | Tranche                      | Tranche         | ---     | x       | x       |
 | boite                        | Boite           | ---     | x       | x       |


### PR DESCRIPTION
Release-gate caught it: Unit #0 collapsed Mali's container units (`Sac (25 Kg)`, `Seau (10|25|5 Kg)`) to **digit-leading** metric Preferred Labels, which the #223 Layer-2 leak audit flags (any `u` beginning with a digit) and Mali is in the test's `_KNOWN_CLEAN` list. Fixed per the **EthiopiaRHS convention** (container/local units → their unit *name*, non-digit-leading; price-ratio inference recovers kg). Mali `food_acquired` unchanged (430188 rows, sane.ok); u-code leaks 3→0; `test_u_code_leak` green (8 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>