### PR TITLE
fix(parity): route food_acquired.j through harmonize_food for Nigeria + Tanzania (#443)

### DIFF
--- a/lsms_library/countries/Nigeria/2010-11/_/food_acquired.py
+++ b/lsms_library/countries/Nigeria/2010-11/_/food_acquired.py
@@ -16,9 +16,22 @@ sys.path.append('../../../_/')
 from lsms_library.local_tools import to_parquet, get_categorical_mapping, get_dataframe
 from lsms_library.transformations import food_acquired_to_canonical
 
-food_labels = get_categorical_mapping(tablename='harmonize_food',
-                                       idxvars='Code',
-                                       **{'Preferred Label': 'Preferred Label'})
+_food_labels_raw = get_categorical_mapping(tablename='harmonize_food',
+                                           idxvars='Code',
+                                           **{'Preferred Label': 'Preferred Label'})
+# Re-key harmonize_food on INT codes so the numeric item_cd (int64 in the
+# source CSV) resolves to its Preferred Label.  The Code column is
+# string-keyed, so a raw int j would otherwise never match and stay numeric
+# (GH #443).  Codes with a blank / '---' label legitimately stay raw.
+food_labels = {}
+for _k, _v in _food_labels_raw.items():
+    try:
+        _ik = int(_k)
+    except (TypeError, ValueError):
+        continue
+    if pd.isna(_v) or str(_v).strip() in ('', '---'):
+        continue
+    food_labels[_ik] = str(_v).strip()
 
 _unit_raw = get_categorical_mapping(tablename='u',
                                      idxvars='Code',

--- a/lsms_library/countries/Nigeria/2012-13/_/food_acquired.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/food_acquired.py
@@ -13,9 +13,22 @@ sys.path.append('../../../_/')
 from lsms_library.local_tools import to_parquet, get_categorical_mapping, get_dataframe
 from lsms_library.transformations import food_acquired_to_canonical
 
-food_labels = get_categorical_mapping(tablename='harmonize_food',
-                                       idxvars='Code',
-                                       **{'Preferred Label': 'Preferred Label'})
+_food_labels_raw = get_categorical_mapping(tablename='harmonize_food',
+                                           idxvars='Code',
+                                           **{'Preferred Label': 'Preferred Label'})
+# Re-key harmonize_food on INT codes so the numeric item_cd (int64 in the
+# source CSV) resolves to its Preferred Label.  The Code column is
+# string-keyed, so a raw int j would otherwise never match and stay numeric
+# (GH #443).  Codes with a blank / '---' label legitimately stay raw.
+food_labels = {}
+for _k, _v in _food_labels_raw.items():
+    try:
+        _ik = int(_k)
+    except (TypeError, ValueError):
+        continue
+    if pd.isna(_v) or str(_v).strip() in ('', '---'):
+        continue
+    food_labels[_ik] = str(_v).strip()
 
 _unit_raw = get_categorical_mapping(tablename='u',
                                      idxvars='Code',

--- a/lsms_library/countries/Nigeria/2015-16/_/food_acquired.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/food_acquired.py
@@ -13,9 +13,22 @@ sys.path.append('../../../_/')
 from lsms_library.local_tools import to_parquet, get_categorical_mapping, get_dataframe
 from lsms_library.transformations import food_acquired_to_canonical
 
-food_labels = get_categorical_mapping(tablename='harmonize_food',
-                                       idxvars='Code',
-                                       **{'Preferred Label': 'Preferred Label'})
+_food_labels_raw = get_categorical_mapping(tablename='harmonize_food',
+                                           idxvars='Code',
+                                           **{'Preferred Label': 'Preferred Label'})
+# Re-key harmonize_food on INT codes so the numeric item_cd (int64 in the
+# source CSV) resolves to its Preferred Label.  The Code column is
+# string-keyed, so a raw int j would otherwise never match and stay numeric
+# (GH #443).  Codes with a blank / '---' label legitimately stay raw.
+food_labels = {}
+for _k, _v in _food_labels_raw.items():
+    try:
+        _ik = int(_k)
+    except (TypeError, ValueError):
+        continue
+    if pd.isna(_v) or str(_v).strip() in ('', '---'):
+        continue
+    food_labels[_ik] = str(_v).strip()
 
 _unit_raw = get_categorical_mapping(tablename='u',
                                      idxvars='Code',

--- a/lsms_library/countries/Nigeria/2018-19/_/food_acquired.py
+++ b/lsms_library/countries/Nigeria/2018-19/_/food_acquired.py
@@ -17,9 +17,22 @@ sys.path.append('../../../_/')
 from lsms_library.local_tools import to_parquet, get_categorical_mapping, get_dataframe
 from lsms_library.transformations import food_acquired_to_canonical
 
-food_labels = get_categorical_mapping(tablename='harmonize_food',
-                                       idxvars='Code',
-                                       **{'Preferred Label': 'Preferred Label'})
+_food_labels_raw = get_categorical_mapping(tablename='harmonize_food',
+                                           idxvars='Code',
+                                           **{'Preferred Label': 'Preferred Label'})
+# Re-key harmonize_food on INT codes so the numeric item_cd (int64 in the
+# source CSV) resolves to its Preferred Label.  The Code column is
+# string-keyed, so a raw int j would otherwise never match and stay numeric
+# (GH #443).  Codes with a blank / '---' label legitimately stay raw.
+food_labels = {}
+for _k, _v in _food_labels_raw.items():
+    try:
+        _ik = int(_k)
+    except (TypeError, ValueError):
+        continue
+    if pd.isna(_v) or str(_v).strip() in ('', '---'):
+        continue
+    food_labels[_ik] = str(_v).strip()
 
 _unit_raw = get_categorical_mapping(tablename='u',
                                      idxvars='Code',

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -83,9 +83,17 @@ PH_QUARTER = {
 # Preferred Label registered in the `u` table.
 
 
-def _crop_labels():
-    """{int cropcode: Preferred Label} from harmonize_food (shared with
-    food_acquired)."""
+def harmonized_food_labels():
+    """{int itemcode: Preferred Label} from the Code-keyed harmonize_food
+    table.  This is the SAME resolver crop_production uses (see
+    ``_crop_labels``), exposed for food_acquired so its ``j`` resolves to
+    the shared Preferred Label and joins crop_production.crop (GH #443).
+
+    The food itemcodes in the GHS consumption modules are read as integers
+    (``item_cd`` is int64 in the source CSVs), while harmonize_food's Code
+    column is string-keyed; this returns an INT-keyed dict so a numeric
+    ``j`` matches.  Codes with a blank / '---' Preferred Label are dropped
+    (they legitimately stay raw)."""
     from lsms_library.local_tools import get_categorical_mapping
     raw = get_categorical_mapping(tablename='harmonize_food', idxvars='Code',
                                   **{'Preferred Label': 'Preferred Label'})
@@ -99,6 +107,12 @@ def _crop_labels():
             continue
         out[ik] = str(v).strip()
     return out
+
+
+def _crop_labels():
+    """{int cropcode: Preferred Label} from harmonize_food (shared with
+    food_acquired)."""
+    return harmonized_food_labels()
 
 
 def _strip_code_prefix(s):

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -532,6 +532,18 @@ def food_acquired_to_canonical(df):
     work = work.rename(columns={'j': 'i_canon', 'i': 'j_canon'})
     work = work.rename(columns={'i_canon': 'i', 'j_canon': 'j'})
 
+    # Route the canonical item axis (j) through harmonize_food so it carries
+    # the shared Preferred Label rather than the raw UPPERCASE survey label
+    # (GH #443).  This is the SAME {raw label -> Preferred Label} resolver
+    # used by prices_and_units / food_expenditures / food_quantities and by
+    # crop_production, so food_acquired.j now joins crop_production.j.  Items
+    # with no harmonize_food entry keep their raw label (no fabrication); the
+    # row count is unchanged -- only the j *labels* change.
+    _food_labels = harmonized_food_labels()
+    _jcol = work['j'].astype('object')
+    work['j'] = _jcol.map(lambda s: _food_labels.get(s.strip(), s)
+                          if isinstance(s, str) else s)
+
     def _make(source_label, quant_col, unit_col, value_col=None):
         out = pd.DataFrame({
             't': work['t'].values,


### PR DESCRIPTION
Closes the food↔crop↔price label-unification gap for the two countries where `food_acquired.j` stayed raw. Root cause: Nigeria's `item_cd` is int64 but `harmonize_food` Code keys are strings (the `.replace` was a silent no-op); Tanzania's script-path `j` was never routed through `harmonized_food_labels`. Fix uses the **existing resolvers** (the same ones `crop_production`/`food_expenditures` use). Label-preserving (rows unchanged: 1,005,656 / 251,613); `j` 0%→100% resolved; `food_acquired.j ∩ crop_production.j` 0→40 (Nigeria) / 0→21 (Tanzania); sane.ok; 18 scoped tests pass (incl. u_code_leak). No framework edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>