### PR TITLE
fix(#445): clear pre-existing cold-gate failures (Uganda baselines, Albania waves)

### DIFF
--- a/lsms_library/countries/Albania/_/albania.py
+++ b/lsms_library/countries/Albania/_/albania.py
@@ -25,6 +25,17 @@ import pandas as pd
 import lsms_library.local_tools as tools
 
 
+# Authoritative wave list.  Mirrors the ``Waves:`` block in this folder's
+# ``data_scheme.yml`` and, crucially, EXCLUDES 1996 (Employment & Welfare
+# Survey -- not LSMS; the ``1996/`` dir carries only Documentation).  This
+# attribute is required because ``Country.waves`` (country.py) consults a
+# ``_/{country}.py`` module's ``waves`` BEFORE the data_scheme ``Waves:`` list;
+# when the module exists but defines no ``waves``, the property falls through to
+# a directory glob that silently re-includes ``1996/`` (it has
+# Documentation/SOURCE.org), reviving the documented exclusion.  See GH #445.
+waves = ['2002', '2003', '2004', '2005', '2008', '2012']
+
+
 # --- canonical-value maps ----------------------------------------------------
 #
 # Tenure: how the household came to hold the plot.  Albania's land was almost

--- a/tests/fixtures/uganda_baseline.json
+++ b/tests/fixtures/uganda_baseline.json
@@ -67,11 +67,11 @@
   },
   "2005-06/_/interview_date.parquet": {
     "columns": [
-      "date"
+      "Int_t"
     ],
     "content_hash": "74c6bdba442651cf4aef26d338f6b69123d83c5228d871f7577c78af9831623d",
     "dtypes": {
-      "date": "datetime64[us]"
+      "Int_t": "datetime64[us]"
     },
     "index_names": [
       "j",
@@ -102,9 +102,9 @@
       "AffectedIncome": "float64",
       "AffectedProduction": "float64",
       "Duration": "float64",
-      "HowCoped0": "object",
-      "HowCoped1": "object",
-      "HowCoped2": "object",
+      "HowCoped0": "str",
+      "HowCoped1": "str",
+      "HowCoped2": "str",
       "Onset": "float64",
       "Year": "float64"
     },
@@ -186,11 +186,11 @@
   },
   "2009-10/_/interview_date.parquet": {
     "columns": [
-      "date"
+      "Int_t"
     ],
     "content_hash": "129f3f1d69eb639afac4e94fe36490e8705af5a824a48c42a32c69f6a1ef8061",
     "dtypes": {
-      "date": "datetime64[us]"
+      "Int_t": "datetime64[us]"
     },
     "index_names": [
       "j",
@@ -305,11 +305,11 @@
   },
   "2010-11/_/interview_date.parquet": {
     "columns": [
-      "date"
+      "Int_t"
     ],
     "content_hash": "9de8b45ca42ecbda0d5ca7979407ae03c7942d966bd4c6a54bcc38a569af03ca",
     "dtypes": {
-      "date": "datetime64[us]"
+      "Int_t": "datetime64[us]"
     },
     "index_names": [
       "j",
@@ -424,11 +424,11 @@
   },
   "2011-12/_/interview_date.parquet": {
     "columns": [
-      "date"
+      "Int_t"
     ],
     "content_hash": "0d8b25cc6e9fe530c02cf69a42a8df409a1c3a352a07a3ebbc6379b2c065b722",
     "dtypes": {
-      "date": "datetime64[us]"
+      "Int_t": "datetime64[us]"
     },
     "index_names": [
       "j",
@@ -543,11 +543,11 @@
   },
   "2013-14/_/interview_date.parquet": {
     "columns": [
-      "date"
+      "Int_t"
     ],
     "content_hash": "d211e3d4ce558199f69d2202c8da8e38880141a361ae84a74a79cb900488fc53",
     "dtypes": {
-      "date": "datetime64[us]"
+      "Int_t": "datetime64[us]"
     },
     "index_names": [
       "j",
@@ -662,11 +662,11 @@
   },
   "2015-16/_/interview_date.parquet": {
     "columns": [
-      "date"
+      "Int_t"
     ],
     "content_hash": "5b548b5731f30008220185de11bf6203ee9f64df5cd93dc9875126a993c694e4",
     "dtypes": {
-      "date": "datetime64[us]"
+      "Int_t": "datetime64[us]"
     },
     "index_names": [
       "j",
@@ -781,11 +781,11 @@
   },
   "2018-19/_/interview_date.parquet": {
     "columns": [
-      "date"
+      "Int_t"
     ],
     "content_hash": "3253f8884dc0560b05679ee0cd022026e83205b0d1fed74e748eb239d204c81b",
     "dtypes": {
-      "date": "datetime64[us]"
+      "Int_t": "datetime64[us]"
     },
     "index_names": [
       "j",
@@ -900,11 +900,11 @@
   },
   "2019-20/_/interview_date.parquet": {
     "columns": [
-      "date"
+      "Int_t"
     ],
     "content_hash": "e4378281a5f351bef2fe154ee67e00f8c57fdf848aedcee16ade6d261a317907",
     "dtypes": {
-      "date": "datetime64[us]"
+      "Int_t": "datetime64[us]"
     },
     "index_names": [
       "j",
@@ -959,11 +959,11 @@
       "Region",
       "Rural"
     ],
-    "content_hash": "1d6fcaba9606ce0d00ee340a0cb141475e2a05d67db9e654692bbfdfb852a982",
+    "content_hash": "fd9f5655ab2ee408840c499061bc1639f7d73fa9b1c09daed4c0e31d8c9f78fa",
     "dtypes": {
       "District": "str",
-      "Latitude": "float32",
-      "Longitude": "float32",
+      "Latitude": "float64",
+      "Longitude": "float64",
       "Region": "string",
       "Rural": "string"
     },
@@ -1348,11 +1348,11 @@
   },
   "var/interview_date.parquet": {
     "columns": [
-      "date"
+      "Int_t"
     ],
     "content_hash": "f60e9b7fd205ecbf352d6f7d1e978867e6790d9719d1b21010cb318f9f9f5166",
     "dtypes": {
-      "date": "datetime64[us]"
+      "Int_t": "datetime64[us]"
     },
     "index_names": [
       "i",
@@ -1381,7 +1381,7 @@
       "Vitamin C",
       "Zinc"
     ],
-    "content_hash": "7575d77349c031fcd72ec80613eb62eea5ce9426dc72af47e7663b87fd4d10e8",
+    "content_hash": "fc85fc2e2046f3c034d77b1b56da52dbafb9f38bd24f6f63331846677b6eee44",
     "dtypes": {
       "Calcium": "float64",
       "Carbohydrate": "float64",
@@ -1471,17 +1471,17 @@
       "Onset",
       "Year"
     ],
-    "content_hash": "b011252b14589f6339de4151baebbaa9365cd2c033eb685c6b0e4888a4cc0623",
+    "content_hash": "53c53cb3645f4bfbf5d56ae33e6140258aaa2f8b3d84cd40e2d039761a96b4f1",
     "dtypes": {
-      "AffectedAssets": "boolean",
-      "AffectedConsumption": "boolean",
-      "AffectedIncome": "boolean",
-      "AffectedProduction": "boolean",
+      "AffectedAssets": "string",
+      "AffectedConsumption": "string",
+      "AffectedIncome": "string",
+      "AffectedProduction": "string",
       "Duration": "float64",
-      "HowCoped0": "object",
-      "HowCoped1": "object",
-      "HowCoped2": "object",
-      "Onset": "Int64",
+      "HowCoped0": "str",
+      "HowCoped1": "str",
+      "HowCoped2": "str",
+      "Onset": "Float64",
       "Year": "Float64"
     },
     "index_names": [

--- a/tests/test_uganda_api_vs_replication.py
+++ b/tests/test_uganda_api_vs_replication.py
@@ -544,6 +544,24 @@ def test_api_matches_replication(spec: FeatureSpec) -> None:
             "replication should regenerate or the bridge extended."
         )
 
+    # ``interview_date`` was harmonized cross-country in commit ``4192eb06``
+    # (closes #325): every declarer now emits a single canonical ``Int_t``
+    # datetime column instead of the old per-country ``date``.  The Uganda
+    # replication baseline (``interview_date.parquet``) predates that change
+    # and still carries ``date``, so the API↔replication merge finds no shared
+    # data column (API cols ``['Int_t']`` vs repl cols ``['date']``).  The
+    # library output is correct; the replication baseline should regenerate.
+    # Same class as the food_acquired / nutrition drift above.  Keeping xfail
+    # (not skip) so we notice when the replication baseline is regenerated.
+    # Surfaced by the 2026-06-14 full cold gate (GH #445).
+    if spec.name == "interview_date":
+        pytest.xfail(
+            "interview_date: API moved to canonical 'Int_t' (#325, commit "
+            "4192eb06); replication baseline still carries 'date', so no "
+            "shared data column after merge.  Library output is correct; "
+            "replication should regenerate."
+        )
+
     repl = _load_replication(spec.name)
 
     try:


### PR DESCRIPTION
## What

Clears the pre-existing failures GH #445 surfaced in the 2026-06-14 full cold
`pytest --rebuild-caches` gate. None were introduced by the WB-parity loop;
four are stale baselines tracking intentional, already-shipped schema evolution,
and one is a framework footgun. Investigated read-only first, then fixed.

## The 5 failures and what each turned out to be

| Failure | Diagnosis | This PR |
|---|---|---|
| `test_sample[Albania]` "missing 1996" | **Framework footgun**: `Country.waves` reads a `_/{country}.py` module's `waves` attr *before* the data_scheme `Waves:` list, then falls through to a directory glob when the module defines none. `albania.py` had no `waves`, so the glob re-included `1996/` (has `Documentation/SOURCE.org`) despite data_scheme documenting it excluded (EWS, not LSMS). | Add authoritative `waves` to `albania.py` |
| `invariance[interview_date]` (×9 wave/var) | `date`→`Int_t` — intentional (`4192eb06`, closes #325) | Regenerate baseline |
| `invariance[cluster_features]` | Lat/Lon float32→float64 + GPS now populated (coords in Uganda's bbox, #161) | Regenerate baseline |
| `invariance[shocks]` | pandas-3.0 dtype migration (boolean→string, Int64→Float64; values preserved) | Regenerate baseline |
| `api_vs_replication[interview_date]` | replication baseline predates #325 (`date` vs `Int_t`) | `xfail` (matches existing food_acquired/nutrition) |
| `api_vs_replication[food_quantities]` | **Not a stale baseline** — passes deterministically warm AND cold in isolation. Its gate failure is the pre-existing **#330** parallel-cold cache-race flake. | **Left alone** (xfail would XPASS) |

## How the baseline was regenerated (defensively)

- Canonical `tests/generate_baseline.py` against a **fresh cold build** (cleared cache → built all 13 baseline tables from empty), then **restricted to the original 53-key set** so the test surface does not expand to newly-built tables.
- 13 entries changed; all three *content_hash* changes (cluster_features, shocks, nutrition) **verified deterministic across two independent cold builds** before pinning. (nutrition's hash had drifted from food-chain evolution but was masked in the gate by skip/ordering — it is reproducible.)
- 40 entries kept byte-identical.

## Verification

- Albania: `test_sample[Albania]` passes (`Albania.waves` no longer lists 1996).
- `interview_date` api → XFAIL (documented); `food_quantities` api → passes.
- Uganda invariance: **53/53 pass** against a clean cold build (run with `--no-purge` serially; conftest purges the Uganda cache at session start in default mode, so a plain run skips — `conftest.py:96-109`).
- Full cold all-country gate (`-n 24 --dist=loadfile --rebuild-caches`, all 40 countries, commit `f840977c`): **`1117 passed, 137 skipped, 11 xfailed, 1 xpassed, 0 failed, 0 errors`** (exit 0, 21m). Down from the prior gate's **5 failed**. (The extra skips vs. that gate are the read-only Uganda invariance tests skipping when no other test rebuilt the cache first — the #330 timing fragility — which is why they were verified separately via `--no-purge` above. The 1 xpassed is a pre-existing replication xfail that happened to pass under this run's cache timing; not introduced here.)

## Not in scope (maintainer follow-ups)

- **#330** — the parallel-cold cache-race flake that makes `food_quantities` (and the read-only invariance tests) timing-dependent under xdist. The invariance tests only *read* parquets, so they pass/skip depending on whether another test rebuilt Uganda's cache first. Not a correctness issue.
- The broader `Country.waves` footgun (data_scheme `Waves:` silently ignored whenever a country `_/` module exists). Albania is the only country currently affected; a framework fix would make the data_scheme list authoritative.
- Regenerating the external **replication** parquets (would let the two `interview_date`/`food_acquired`/`nutrition` xfails flip back to real comparisons).

Refs #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
