### PR TITLE
fix(diagnostics): NaN-safe food_acquired_u_code_leaks (master CI fix)

### DIFF
--- a/lsms_library/diagnostics.py
+++ b/lsms_library/diagnostics.py
@@ -520,9 +520,16 @@ def food_acquired_u_code_leaks(country: str, *,
         df = Country(country, preload_panel_ids=False).food_acquired()
     if not isinstance(df, pd.DataFrame) or "u" not in (df.index.names or []):
         return []
-    u = df.index.get_level_values("u").astype(str)
+    u = df.index.get_level_values("u")
     code = re.compile(r"^\s*\d")  # leading digit => code / code-prefix / item-name
-    return sorted({v for v in u.unique() if code.match(v)})
+    # Coerce per value and skip NaN.  A *categorical* ``u`` level keeps NaN as a
+    # float through ``.astype(str)`` (unlike object dtype, where NaN -> 'nan'),
+    # which fed ``re.match`` a float and raised TypeError (master CI, post-v0.7.3).
+    # A NaN ``u`` means no unit was recorded -- not a leaked code -- so skip it.
+    return sorted({
+        s for v in u.unique()
+        if pd.notna(v) and code.match(s := str(v))
+    })
 
 
 def _check_index_overlap_with_spine(df: pd.DataFrame, country: str) -> Check:

--- a/tests/test_u_code_leak.py
+++ b/tests/test_u_code_leak.py
@@ -66,6 +66,17 @@ def test_leak_detector_no_u_level():
     assert diagnostics.food_acquired_u_code_leaks("X", df=df) == []
 
 
+def test_leak_detector_categorical_u_with_nan():
+    # Regression (master CI, post-v0.7.3): a *categorical* ``u`` level with a
+    # NaN keeps NaN as a float through ``.astype(str)`` (object dtype gives
+    # 'nan'), feeding ``re.match`` a float -> TypeError.  A NaN ``u`` means no
+    # unit was recorded, not a leaked code, so it must be skipped.
+    u_cat = pd.Categorical(["Kg", "Tas", "116", float("nan")])
+    idx = pd.MultiIndex.from_arrays([["x"] * 4, u_cat], names=["i", "u"])
+    df = pd.DataFrame({"Quantity": [1.0] * 4}, index=idx)
+    assert diagnostics.food_acquired_u_code_leaks("X", df=df) == ["116"]
+
+
 # --- cross-country regression (skips when caches/data unavailable) ----------
 
 # Clean per the 2026-06-07 audit; must stay clean.


### PR DESCRIPTION
## What
The `data-tests` CI job failed on the v0.7.3 `master` merge:
```
FAILED tests/test_u_code_leak.py::test_clean_countries_have_no_u_code_leaks
  TypeError: expected string or bytes-like object, got 'float'  (diagnostics.py:525)
```

## Root cause
`food_acquired_u_code_leaks` did `u = ...get_level_values("u").astype(str)` then `re.match` per value. A **categorical** `u` level keeps `NaN` as a **float** through `.astype(str)` (object dtype coerces `NaN -> 'nan'`), so `re.match` got a float → `TypeError`. It only surfaces in `data-tests` (fresh DVC build → categorical `u` with NaN; the job is **skipped on PRs**, runs on push to master), which is why the #447 PR and my local gate (object-dtype `u`) were green.

Reproduced in isolation: `pd.Categorical(['Kg', nan]).astype(str).unique()` → `['Kg', nan(float)]`.

## Fix
Drop the premature `.astype(str)`; skip `NaN` and coerce per value with `str(v)` before the regex. A `NaN` `u` = no unit recorded, not a leaked code → correctly excluded. Adds a categorical-NaN regression test (crashes without the fix). The sibling `.str.match` at `diagnostics.py:770` is the NaN-safe vectorized form (unaffected).

**Already cherry-picked to `master`** (`d981c918`) to green its CI; this PR lands the same fix on `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)