### PR TITLE
feat(#436): LSMS_COUNTRIES_ROOT config-tree override (retire COUNTRIES_ROOT)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -118,8 +118,8 @@ def _purge_country_caches(country_name: str) -> None:
     or import failure shouldn't stop the test session.
     """
     try:
-        from lsms_library.paths import COUNTRIES_ROOT
-        country_dir = COUNTRIES_ROOT / country_name
+        from lsms_library.paths import countries_root
+        country_dir = countries_root() / country_name
         if not (country_dir / "_" / "data_scheme.yml").exists():
             return
         from lsms_library import Country
@@ -163,7 +163,7 @@ def _purge_data_root_caches() -> None:
     or ``dvc-cache`` artefacts — by checking for the canonical
     ``data_scheme.yml`` under ``lsms_library/countries/{name}/_/``.
     """
-    from lsms_library.paths import COUNTRIES_ROOT, data_root
+    from lsms_library.paths import countries_root, data_root
 
     root = data_root()
     if not root.exists():
@@ -173,7 +173,7 @@ def _purge_data_root_caches() -> None:
     for country_dir in sorted(p for p in root.iterdir() if p.is_dir()):
         country_name = country_dir.name
         # Skip directories that aren't real LSMS countries.
-        if not (COUNTRIES_ROOT / country_name / "_" / "data_scheme.yml").exists():
+        if not (countries_root() / country_name / "_" / "data_scheme.yml").exists():
             continue
 
         try:

--- a/lsms_library/catalog.py
+++ b/lsms_library/catalog.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-from .paths import COUNTRIES_ROOT
+from .paths import countries_root
 from .yaml_utils import load_yaml
 
 
@@ -27,7 +27,7 @@ def _country_dirs() -> tuple[str, ...]:
     ``"South Africa"`` survive intact.
     """
     out: list[str] = []
-    for p in sorted(COUNTRIES_ROOT.iterdir()):
+    for p in sorted(countries_root().iterdir()):
         if not p.is_dir() or p.name.startswith("."):
             continue
         if (p / "_" / "data_scheme.yml").exists():
@@ -37,7 +37,7 @@ def _country_dirs() -> tuple[str, ...]:
 
 def _declared_tables(country: str) -> set[str]:
     """The ``Data Scheme`` table names declared in *country*'s data_scheme.yml."""
-    f = COUNTRIES_ROOT / country / "_" / "data_scheme.yml"
+    f = countries_root() / country / "_" / "data_scheme.yml"
     if not f.exists():
         return set()
     with open(f, encoding="utf-8") as fh:

--- a/lsms_library/cli.py
+++ b/lsms_library/cli.py
@@ -15,6 +15,7 @@ import yaml
 
 from .country import Country, _log_issue
 from .local_tools import to_parquet
+from .paths import countries_root
 from .util.generate_dvc_stages import discover_countries as _discover_dvc_countries
 from .util.generate_dvc_stages import generate_country as _generate_dvc_country
 
@@ -61,7 +62,7 @@ def _dump_yaml(data: OrderedDict, path: Path) -> None:
 
 
 def _countries_root() -> Path:
-    return Path(__file__).resolve().parent / "countries"
+    return countries_root()
 
 
 def _dvc_cmd(*args: str) -> List[str]:
@@ -84,10 +85,10 @@ def _collect_dvc_status(target: str, cwd: Path) -> dict:
 
 
 def _available_country_dirs() -> List[str]:
-    countries_root = Path(__file__).resolve().parent / "countries"
+    country_dirs_root = _countries_root()
     names = [
         path.name
-        for path in countries_root.iterdir()
+        for path in country_dirs_root.iterdir()
         if path.is_dir() and not path.name.startswith(".")
     ]
     return sorted(names)
@@ -154,7 +155,7 @@ def cache_list(
 ) -> None:
     """List cached datasets."""
     countries = [country] if country else _available_country_dirs()
-    countries = [c for c in countries if (Path(__file__).resolve().parent / "countries" / c).exists()]
+    countries = [c for c in countries if (_countries_root() / c).exists()]
     for name in countries:
         country_obj = Country(name, preload_panel_ids=False)
         datasets = country_obj.cached_datasets()
@@ -397,7 +398,7 @@ def register(
 ) -> None:
     """Register a DVC materialization stage for a table."""
 
-    base_dir = Path(__file__).resolve().parent / "countries" / country
+    base_dir = _countries_root() / country
     has_wave = bool(wave and wave.lower() not in {"", "all_waves"})
 
     if dvc_file is None:

--- a/lsms_library/config.py
+++ b/lsms_library/config.py
@@ -100,6 +100,18 @@ def data_dir() -> str | None:
     return get("data_dir", env_var="LSMS_DATA_DIR") or None
 
 
+def countries_dir() -> str | None:
+    """Return the country *config* tree override, or None.
+
+    Parallels :func:`data_dir`: lets a git worktree or an alternate config
+    checkout be read by the installed package (whose import location is
+    ``.pth``-pinned), so worktree / parallel-branch development can self-verify.
+    Lookup order: ``LSMS_COUNTRIES_ROOT`` env var -> ``countries_dir`` in
+    config.yml -> None.  See GH #436.
+    """
+    return get("countries_dir", env_var="LSMS_COUNTRIES_ROOT") or None
+
+
 def config_path() -> Path:
     """Return the path to the config file (may not exist yet)."""
     return _config_file()

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -36,7 +36,7 @@ from importlib.resources import files
 import importlib
 from collections import defaultdict
 from .local_tools import df_data_grabber, format_id, get_categorical_mapping, get_dataframe, map_index, get_formatting_functions, panel_ids, id_walk, all_dfs_from_orgfile, to_parquet
-from .paths import data_root
+from .paths import data_root, countries_root
 from .yaml_utils import load_yaml
 import importlib.util
 import logging
@@ -451,7 +451,7 @@ class Wave:
         
     @property
     def file_path(self) -> Path:
-        return files("lsms_library") / "countries" / self.folder
+        return countries_root() / self.folder
 
     @property
     def resources(self) -> dict[str, Any]:
@@ -1027,7 +1027,7 @@ class Country:
 
     def __init__(self, country_name: str, preload_panel_ids: bool = False, verbose: bool = False, assume_cache_fresh: bool = False, trust_cache: bool = False) -> None:
         # Validate country name: reject path traversal attempts
-        countries_dir = Path(__file__).resolve().parent / "countries"
+        countries_dir = countries_root()
         country_dir = (countries_dir / country_name).resolve()
         if not country_dir.is_relative_to(countries_dir):
             raise ValueError(f"Invalid country name {country_name!r}: path traversal not allowed")
@@ -1062,7 +1062,7 @@ class Country:
 
     @property
     def file_path(self) -> Path:
-        return Path(__file__).resolve().parent / "countries" / self.name
+        return countries_root() / self.name
 
     @property
     def resources(self) -> dict[str, Any]:

--- a/lsms_library/data_access.py
+++ b/lsms_library/data_access.py
@@ -59,10 +59,15 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from . import config
+from .paths import countries_root
 
 logger = logging.getLogger(__name__)
 
-_COUNTRIES_DIR = Path(__file__).resolve().parent / "countries"
+# GH #436: countries config-tree root.  Import-time snapshot of
+# ``countries_root()`` -- honors ``LSMS_COUNTRIES_ROOT`` when the env var is set
+# *before* import (the worktree model); it does NOT track a later override +
+# ``countries_root.cache_clear()`` within the same process.
+_COUNTRIES_DIR = countries_root()
 
 # WB LSMS collection: ISO-3166 alpha-3 codes for countries we track.
 # Used by discover_waves() to query the WB Microdata Library catalog.

--- a/lsms_library/diagnostics.py
+++ b/lsms_library/diagnostics.py
@@ -29,7 +29,7 @@ import pandas as pd
 import yaml as _yaml
 from pyarrow.lib import ArrowInvalid
 
-from .paths import data_root, COUNTRIES_ROOT
+from .paths import data_root, countries_root
 from .yaml_utils import load_yaml
 
 
@@ -148,7 +148,7 @@ def _load_scheme(country: str) -> dict:
     represent data that is genuinely unavailable for some countries (e.g.,
     ``panel_weight`` in cross-sectional surveys).
     """
-    yml = COUNTRIES_ROOT / country / "_" / "data_scheme.yml"
+    yml = countries_root() / country / "_" / "data_scheme.yml"
     if not yml.exists():
         return {}
     data = load_yaml(yml)

--- a/lsms_library/dvc_permissions.py
+++ b/lsms_library/dvc_permissions.py
@@ -22,6 +22,8 @@ import getpass
 import pkgutil
 import gnupg
 
+from .paths import countries_root
+
 def is_git_repo(path='.'):
     """
     Check if the specified path is a Git repository.
@@ -58,7 +60,7 @@ def authenticate(gpg_key_file='s3_reader_creds.gpg', max_attempts: int = 3,
     ValueError: If decryption fails due to an incorrect passphrase or other issues.
     """
     # Construct the path to the encrypted file relative to this function's location
-    gpg_path = Path(__file__).resolve().parent / 'countries' / '.dvc'
+    gpg_path = countries_root() / '.dvc'
     encrypted_file = gpg_path / gpg_key_file
 
     # Load the encrypted data

--- a/lsms_library/feature.py
+++ b/lsms_library/feature.py
@@ -11,6 +11,7 @@ import yaml
 from importlib.resources import files
 
 from .yaml_utils import load_yaml
+from .paths import countries_root
 
 
 def _load_global_columns() -> dict[str, dict[str, Any]]:
@@ -110,7 +111,7 @@ def _discover_countries_for_table(table_name: str) -> list[str]:
     # If this is a derived table, look for its source instead
     lookup_name = _DERIVED_SOURCE.get(table_name, table_name)
 
-    countries_dir = files("lsms_library") / "countries"
+    countries_dir = countries_root()
     result = []
     for entry in sorted(Path(countries_dir).iterdir()):
         if not entry.is_dir() or entry.name.startswith("."):

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -82,7 +82,7 @@ from dvc.api import DVCFileSystem
 import pyreadstat
 import inspect
 from typing import Any
-from .paths import data_root, var_path, wave_data_path, COUNTRIES_ROOT
+from .paths import data_root, var_path, wave_data_path, countries_root
 from .config import s3_creds_path as _s3_creds_path
 
 # Initialize DVC filesystem once and reuse it.
@@ -110,7 +110,10 @@ from .config import s3_creds_path as _s3_creds_path
 # ``DVCFileSystem`` construction time.  The auto-unlock pass later in
 # ``lsms_library/__init__.py`` populates it before the first S3 access.
 _PACKAGE_ROOT = Path(__file__).resolve().parent
-_COUNTRIES_DIR = _PACKAGE_ROOT / "countries"
+# GH #436: import-time snapshot of the countries config-tree root.  Honors
+# ``LSMS_COUNTRIES_ROOT`` set *before* import (the worktree model); does not
+# track a later override + ``countries_root.cache_clear()`` in-process.
+_COUNTRIES_DIR = countries_root()
 _DVC_CACHE_DIR = data_root() / "dvc-cache"
 _DVC_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 DVCFS = DVCFileSystem(
@@ -661,7 +664,7 @@ def _resolve_data_path(fn: str, stack_depth: int = 2) -> str:
 
     try:
         caller_file = Path(inspect.stack()[stack_depth].filename).resolve()
-        rel = caller_file.relative_to(COUNTRIES_ROOT)
+        rel = caller_file.relative_to(countries_root())
     except (IndexError, ValueError, TypeError):
         return fn_str
 

--- a/lsms_library/paths.py
+++ b/lsms_library/paths.py
@@ -34,7 +34,30 @@ from functools import lru_cache
 from pathlib import Path
 
 
-COUNTRIES_ROOT = Path(__file__).resolve().parent / "countries"
+@lru_cache(maxsize=None)
+def countries_root() -> Path:
+    """Return the root of the country *config* tree (``countries/{C}/_/...``).
+
+    Resolution order (mirrors :func:`data_root`):
+      1. ``LSMS_COUNTRIES_ROOT`` environment variable
+      2. ``countries_dir`` in ``~/.config/lsms_library/config.yml``
+      3. ``<package>/countries`` (install-relative default)
+
+    Overriding lets a git worktree or an alternate config checkout be read by
+    the installed package -- whose import location is ``.pth``-pinned to the
+    main checkout -- so worktree / parallel-branch development can build and
+    self-verify against its own config tree.  The default is byte-identical to
+    the historical ``Path(__file__).parent / "countries"`` constant, so the
+    common (no-override) case is unchanged.  See GH #436.
+
+    Cached; call ``countries_root.cache_clear()`` after changing the env var or
+    config (e.g. in tests), exactly like :func:`data_root`.
+    """
+    from . import config as _config
+    override = _config.countries_dir()
+    if override:
+        return Path(override).expanduser()
+    return Path(__file__).resolve().parent / "countries"
 
 
 _WHITESPACE_WARNED: set[str] = set()
@@ -104,7 +127,7 @@ def _caller_country_and_wave(stack_depth: int = 2) -> tuple[str | None, str | No
         return None, None
 
     try:
-        rel = caller.relative_to(COUNTRIES_ROOT)
+        rel = caller.relative_to(countries_root())
     except ValueError:
         return None, None
 

--- a/lsms_library/util/generate_dvc_stages.py
+++ b/lsms_library/util/generate_dvc_stages.py
@@ -18,13 +18,14 @@ import sys
 
 from lsms_library.country import _slugify as _country_slugify
 from lsms_library.yaml_utils import load_yaml as load_yaml_with_tags
+from lsms_library.paths import countries_root
 
 import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LSMS_ROOT = REPO_ROOT / "lsms_library"
-COUNTRIES_ROOT = LSMS_ROOT / "countries"
+COUNTRIES_ROOT = countries_root()  # GH #436: honors LSMS_COUNTRIES_ROOT
 
 CORE_DEPS = [
     LSMS_ROOT / "cli.py",

--- a/lsms_library/util/geo_audit.py
+++ b/lsms_library/util/geo_audit.py
@@ -37,6 +37,8 @@ from urllib.parse import urlparse
 
 import yaml
 
+from lsms_library.paths import countries_root
+
 logger = logging.getLogger(__name__)
 
 
@@ -51,7 +53,7 @@ GEO_PATTERNS = [
     "*agri_gps*",
 ]
 
-COUNTRIES_DIR = Path(__file__).resolve().parent.parent / "countries"
+COUNTRIES_DIR = countries_root()  # GH #436: honors LSMS_COUNTRIES_ROOT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_age_dtype_consistency.py
+++ b/tests/test_age_dtype_consistency.py
@@ -18,7 +18,7 @@ import pandas as pd
 import pytest
 import yaml
 
-from lsms_library.paths import COUNTRIES_ROOT
+from lsms_library.paths import countries_root
 
 
 # ---------------------------------------------------------------------------
@@ -36,7 +36,7 @@ _SchemeLoader.add_constructor(
 def _countries_with_household_roster() -> list[str]:
     """Return sorted list of country names that declare household_roster."""
     countries = []
-    for yml in sorted(COUNTRIES_ROOT.glob("*/_/data_scheme.yml")):
+    for yml in sorted(countries_root().glob("*/_/data_scheme.yml")):
         country = yml.parent.parent.name
         with open(yml, "r", encoding="utf-8") as f:
             data = yaml.load(f, Loader=_SchemeLoader)

--- a/tests/test_countries_root_override.py
+++ b/tests/test_countries_root_override.py
@@ -1,0 +1,98 @@
+"""GH #436 Item 1: ``LSMS_COUNTRIES_ROOT`` config-tree override.
+
+The country *config* tree must resolve through ``paths.countries_root()``
+(env -> config.yml -> package-relative default), mirroring ``data_root()``,
+so a git worktree / alternate config checkout can be read by the installed
+(``.pth``-pinned) package and thus self-verify.
+
+Two guarantees:
+  1. **default-preserving** -- no override => the historical package-relative
+     path, byte-identical, so the common case is unchanged;
+  2. **override honored across every layer** -- ``countries_root()``,
+     ``Country.file_path``, and the ``_COUNTRIES_DIR`` snapshots in
+     ``data_access`` / ``local_tools``.  Verified in a subprocess with the env
+     set *before* import (the real worktree model), so the in-process
+     ``lru_cache`` is never polluted.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import lsms_library.paths as paths
+from lsms_library.paths import countries_root
+
+
+def test_default_is_package_countries_dir(monkeypatch):
+    monkeypatch.delenv("LSMS_COUNTRIES_ROOT", raising=False)
+    countries_root.cache_clear()
+    try:
+        default = Path(paths.__file__).resolve().parent / "countries"
+        assert countries_root() == default
+    finally:
+        countries_root.cache_clear()
+
+
+def test_config_resolver_reads_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("LSMS_COUNTRIES_ROOT", str(tmp_path))
+    countries_root.cache_clear()
+    try:
+        from lsms_library import config
+        assert config.countries_dir() == str(tmp_path)
+        assert countries_root() == tmp_path
+    finally:
+        countries_root.cache_clear()  # never leave the override cached
+
+
+def test_subprocess_override_routes_all_layers(tmp_path):
+    """Env set before import => every countries-tree resolver honors it."""
+    ov = tmp_path / "countries"
+    ov.mkdir()
+    script = textwrap.dedent(
+        f"""
+        import warnings; warnings.simplefilter("ignore")
+        from pathlib import Path
+        OV = Path({str(ov)!r})
+        from lsms_library.paths import countries_root
+        import lsms_library.data_access as da
+        import lsms_library.local_tools as lt
+        import lsms_library as ll
+        assert countries_root() == OV, countries_root()
+        assert da._COUNTRIES_DIR == OV, da._COUNTRIES_DIR
+        assert lt._COUNTRIES_DIR == OV, lt._COUNTRIES_DIR
+        assert ll.Country("Uganda").file_path == OV / "Uganda"
+        print("OVERRIDE_OK")
+        """
+    )
+    env = dict(os.environ, LSMS_COUNTRIES_ROOT=str(ov))
+    r = subprocess.run(
+        [sys.executable, "-c", script], env=env, capture_output=True, text=True
+    )
+    assert r.returncode == 0, f"stderr:\n{r.stderr}"
+    assert "OVERRIDE_OK" in r.stdout
+
+
+def test_subprocess_default_unchanged(tmp_path):
+    """No override => package-relative default, byte-identical to history."""
+    script = textwrap.dedent(
+        """
+        import warnings; warnings.simplefilter("ignore")
+        from pathlib import Path
+        import lsms_library.paths as paths
+        from lsms_library.paths import countries_root
+        default = Path(paths.__file__).resolve().parent / "countries"
+        assert countries_root() == default, countries_root()
+        import lsms_library as ll
+        assert ll.Country("Uganda").file_path == default / "Uganda"
+        print("DEFAULT_OK")
+        """
+    )
+    env = {k: v for k, v in os.environ.items() if k != "LSMS_COUNTRIES_ROOT"}
+    r = subprocess.run(
+        [sys.executable, "-c", script], env=env, capture_output=True, text=True
+    )
+    assert r.returncode == 0, f"stderr:\n{r.stderr}"
+    assert "DEFAULT_OK" in r.stdout

--- a/tests/test_global_u_org.py
+++ b/tests/test_global_u_org.py
@@ -36,8 +36,8 @@ def test_global_u_does_not_define_contested_metric_canonicals():
     # (Layer 3), so the global table must not force them.
     import re
     from pathlib import Path
-    from lsms_library.paths import COUNTRIES_ROOT
-    u_org = COUNTRIES_ROOT.parent / "categorical_mapping" / "u.org"
+    from lsms_library.paths import countries_root
+    u_org = countries_root().parent / "categorical_mapping" / "u.org"
     text = u_org.read_text(encoding="utf-8")
     table = [ln for ln in text.splitlines()
              if ln.strip().startswith("|") and "Preferred Label" not in ln

--- a/tests/test_panel_attrition.py
+++ b/tests/test_panel_attrition.py
@@ -8,10 +8,10 @@ from lsms_library.paths import data_root
 
 def _has_cached_table(country_name: str, table: str) -> bool:
     """Check if a table is cached (either data_root or in-tree)."""
-    from lsms_library.paths import COUNTRIES_ROOT
+    from lsms_library.paths import countries_root
     for candidate in [
         data_root(country_name) / "var" / f"{table}.parquet",
-        COUNTRIES_ROOT / country_name / "var" / f"{table}.parquet",
+        countries_root() / country_name / "var" / f"{table}.parquet",
     ]:
         if candidate.exists():
             return True

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -17,14 +17,14 @@ import pandas as pd
 # touching DVC locks.
 
 import lsms_library as ll
-from lsms_library.paths import COUNTRIES_ROOT
+from lsms_library.paths import countries_root
 from lsms_library.yaml_utils import load_yaml
 
 
 def _countries_with_sample() -> list[str]:
     """Discover countries whose data_scheme.yml declares a sample table."""
     countries = []
-    for yml in sorted(COUNTRIES_ROOT.glob("*/_/data_scheme.yml")):
+    for yml in sorted(countries_root().glob("*/_/data_scheme.yml")):
         data = load_yaml(yml)
         if not isinstance(data, dict):
             continue
@@ -49,7 +49,7 @@ NO_WEIGHT_COUNTRIES = {"China", "Kazakhstan", "Pakistan"}
 # tests re-enable automatically with no change here.
 def _countries_without_data() -> set[str]:
     unavailable = set()
-    for yml in sorted(COUNTRIES_ROOT.glob("*/_/data_scheme.yml")):
+    for yml in sorted(countries_root().glob("*/_/data_scheme.yml")):
         data = load_yaml(yml)
         if isinstance(data, dict) and data.get("data_available") is False:
             unavailable.add(yml.parent.parent.name)

--- a/tests/test_schema_consistency.py
+++ b/tests/test_schema_consistency.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from lsms_library.paths import COUNTRIES_ROOT
+from lsms_library.paths import countries_root
 
 # ---------------------------------------------------------------------------
 # Load canonical schema from data_info.yml
@@ -58,7 +58,7 @@ def _load_yaml(path: Path) -> dict:
 
 def _all_data_scheme_paths() -> list[Path]:
     """Return sorted list of all data_scheme.yml paths."""
-    return sorted(COUNTRIES_ROOT.glob("*/_/data_scheme.yml"))
+    return sorted(countries_root().glob("*/_/data_scheme.yml"))
 
 
 def _schemes_with_table(table: str) -> list[tuple[str, Path, dict]]:

--- a/tests/test_table_structure.py
+++ b/tests/test_table_structure.py
@@ -16,7 +16,7 @@ import pandas as pd
 import pytest
 import yaml
 
-from lsms_library.paths import data_root, COUNTRIES_ROOT
+from lsms_library.paths import data_root, countries_root
 from lsms_library.yaml_utils import load_yaml
 
 
@@ -75,7 +75,7 @@ def _load_all_schemes() -> dict[str, dict]:
     set so that ``test_declared_columns_present`` can skip them when absent.
     """
     schemes = {}
-    for yml in sorted(COUNTRIES_ROOT.glob("*/_/data_scheme.yml")):
+    for yml in sorted(countries_root().glob("*/_/data_scheme.yml")):
         country = yml.parent.parent.name
         data = load_yaml(yml)
         if not isinstance(data, dict):
@@ -300,10 +300,10 @@ class TestFeatureSanity:
 
 def _countries_with_housing() -> list[str]:
     """Discover countries whose data_scheme.yml declares a housing table."""
-    from lsms_library.paths import COUNTRIES_ROOT
+    from lsms_library.paths import countries_root
     from lsms_library.yaml_utils import load_yaml
     countries = []
-    for yml in sorted(COUNTRIES_ROOT.glob("*/_/data_scheme.yml")):
+    for yml in sorted(countries_root().glob("*/_/data_scheme.yml")):
         data = load_yaml(yml)
         if not isinstance(data, dict):
             continue

--- a/tests/test_uganda_tables.py
+++ b/tests/test_uganda_tables.py
@@ -5,14 +5,14 @@ from typing import Optional
 import pytest
 
 import lsms_library as ll
-from lsms_library.paths import data_root, COUNTRIES_ROOT
+from lsms_library.paths import data_root, countries_root
 
 
 def _has_cached_table(country_name: str, table: str) -> bool:
     """Check if a table parquet exists at data_root or in-tree."""
     for candidate in [
         data_root(country_name) / "var" / f"{table}.parquet",
-        COUNTRIES_ROOT / country_name / "var" / f"{table}.parquet",
+        countries_root() / country_name / "var" / f"{table}.parquet",
     ]:
         if candidate.exists():
             return True


### PR DESCRIPTION
## What (GH #436 Item 1)

Make the country **config** tree relocatable the way `data_dir` already makes the **data** tree, so a git worktree / alternate config checkout is read by the installed (`.pth`-pinned) package and can **self-verify** — retiring the worktree-can't-build limitation the WB-parity loop worked around.

- `config.countries_dir()` — env `LSMS_COUNTRIES_ROOT` → config.yml `countries_dir` → None (mirrors `data_dir()`).
- `paths.countries_root()` — `lru_cache`d resolver; override → package-relative **default** (byte-identical to the old constant). The `COUNTRIES_ROOT` constant is **removed**.

## Why the issue's 1-line sketch wasn't enough

`COUNTRIES_ROOT` was only used by `catalog`/`diagnostics`. The **load-bearing** resolution — `Country.file_path`, `Wave.file_path` — and the data-access layer (`_COUNTRIES_DIR`, ~35 sites) each resolved `countries/` independently via `files("lsms_library")` / `Path(__file__).parent`, bypassing it. Audited the whole repo and routed **all** of them through the one resolver: country.py (both `file_path`s + the `__init__` traversal check), feature.py, catalog.py, diagnostics.py, cli.py (4 sites + `_countries_root`), data_access.py & local_tools.py `_COUNTRIES_DIR`, dvc_permissions.py, and both utils (geo_audit.py, generate_dvc_stages.py). Migrated 8 test modules + `conftest.py` off the retired constant.

## Adversarial review (3 parallel red-team lenses) — all addressed

- **Completeness**: caught 2 util bypasses (`geo_audit`, `generate_dvc_stages` — the latter reachable from `cli generate-stages`) that the first pass mislabelled "retired/deferred" → now routed.
- **Behavior**: the only semantic delta is symlink-collapse at `Wave.file_path`/`feature` (`files()` → `.resolve()`); **proven inert downstream** and consistent with the sites already `.resolve()`d. Default-preserving confirmed per layer.
- **Import-safety**: no cycle (`config` is a stdlib leaf; `paths` imports it lazily); every module imports standalone, with and without the override.

The full cold gate then caught two more `COUNTRIES_ROOT` importers (7 tests, then `conftest.py`) that static grep/agents missed — fixed; a repo-wide grep now confirms zero importers remain.

## Verification

- Default-preserving: `countries_root()` == package dir; `Uganda.file_path` unchanged (every layer).
- Override honored across config / paths / `Country.file_path` / `_COUNTRIES_DIR` with the env set **before import** (the worktree model) — new subprocess-isolated test `tests/test_countries_root_override.py` (4 cases).
- Full cold gate (`-n 24 --dist=loadfile --rebuild-caches`): _<result on completion>_.

## Scope / deferred

- **Item 2** (declarative per-feature `join_v`/derived in `data_scheme.yml`) — follow-on PR.
- 4 GhanaLSS wave-level `mapping.py` `files()` self-locates — per-country config scripts that re-anchor to the package by design; a separate question.
- `_COUNTRIES_DIR` snapshots resolve at import (worktree model = env before import); documented inline. Fully-dynamic re-pointing mid-process is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
