### PR TITLE
docs: fix caching/config documentation staleness (post v0.8.0 + #436)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ The returned DataFrame prepends a `country` index level.
 - `scrum-master-hpc` (shared sucoder skill at `~/.sucoder/skills/scrum-master-hpc/SKILL.md`) — dispatching subagents, worktrees, DVC lock hygiene. Read this before using the Agent tool for multi-country work. Library-specific addenda:
   1. Subagents share the parquet cache at `~/.local/share/lsms_library/`, so concurrent agents building different countries don't conflict.
   2. The venv is at `{repo_root}/.venv/bin/python` (not in worktrees) — set `PYTHONPATH` to the worktree so development-branch code is picked up.
-  3. **`.venv/lib/python3.11/site-packages/lsms_library.pth` hardcodes the main-repo path** — `PYTHONPATH` alone does NOT redirect imports of `lsms_library` to a worktree.  Worker agents that rebuild a feature to verify a YAML edit will silently run the main checkout's code.  Either (a) verify via static diff only, or (b) have the agent install a fresh venv inside its worktree.  See the `.pth`-pinned package imports pitfall in the scrum-master-hpc skill for detection and mitigations.
+  3. **`.venv/lib/python3.11/site-packages/lsms_library.pth` hardcodes the main-repo path** — `PYTHONPATH` alone does NOT redirect imports of `lsms_library` to a worktree.  Worker agents that rebuild a feature to verify a YAML edit will silently run the main checkout's code.  For **config** edits (`countries/{C}/_/...` — YAML/scripts/`.org`, the common case), set **`LSMS_COUNTRIES_ROOT=<worktree>/lsms_library/countries`** so the live package reads the worktree's config tree (GH #436); this is the clean fix and needs no fresh venv.  For **library-code** edits (`country.py`, `local_tools.py`, …) the `.pth` still pins to the main checkout, so either (a) verify via static diff only, or (b) have the agent install a fresh venv inside its worktree.  See the `.pth`-pinned package imports pitfall in the scrum-master-hpc skill for detection and mitigations.
   4. *Savio compute nodes only*: `.venv` is typically a symlink to `/local/jobNNN/venv` (node-local SSD) and goes stale whenever you land on a different node.  Recovery recipe lives in `.venv.lustre/README_WHY_THIS_EXISTS.md` at the repo root.  **Do not just grab `.venv.lustre/bin/python`** — every import will round-trip through Lustre.  Follow the README's **adopt-or-build recipe** (adopt any importable `/local/job*/venv` already on the node → tar-pipe build only if none → reclaim the stale ones), which gives cross-job persistence without root.  Note: a stable `/local/$USER/<repo>` path is NOT creatable by us (`/local` is `root:root`); a genuinely persistent path needs an HPC-support ticket (README "Admin endgame").  **Opt-in fast path**: `bin/savio_venv.sh` packages the venv as a single squashfs image (`.venv.sqfs`, ~255 MB / one Lustre inode vs ~33k files) and mounts it per job via apptainer's `squashfuse_ll` (`mount`/`umount`/`update` subcommands) — kills the Lustre-MDS load and sidesteps the per-job reaper; see `docs/savio_venv.md` for the model + how to rebuild the image when deps change.  This guidance is Savio-specific; other environments (login nodes, laptops, non-HPC clusters) use a normal in-tree `.venv/` and this paragraph doesn't apply.
 
 ## Repository Layout
@@ -55,7 +55,7 @@ Override the data root with `data_dir` in `~/.config/lsms_library/config.yml` or
     3. `pytest --rebuild-caches` (or `make test-full`) — same as the CLI above for *every* country under `data_root()`, run before the test session, then sets `LSMS_NO_CACHE=1`. Use when verifying a wave-script fix in CI; previously a stale L2-wave parquet could pass a test the source-only fix would have failed (Nigeria/Senegal age sentinels, 2026-04-25).
     4. `LSMS_BUILD_BACKEND=make` — bypasses both parquet tiers entirely; see below.
 - **`LSMS_BUILD_BACKEND=make`** bypasses both parquet tiers — every call rebuilds from source, with no L2-country or L2-wave writes or reads. (L1 still serves blobs; the bypass is over the harmonized parquet layer only.)
-- **`assume_cache_fresh=True`** is a narrower in-process short-circuit at the top of `_aggregate_wave_data` that still calls `_finalize_result` (so kinship expansion, spelling normalization, and `_join_v_from_sample` still apply). Use when L2-country is known fresh to skip all DVC / existence checks. It ignores `LSMS_NO_CACHE`. (`trust_cache=True` is a deprecated alias; removed in v0.8.0.)
+- **`assume_cache_fresh=True`** is a narrower in-process short-circuit at the top of `_aggregate_wave_data` that still calls `_finalize_result` (so kinship expansion, spelling normalization, and `_join_v_from_sample` still apply). Use when L2-country is known fresh to skip all DVC / existence checks. It ignores `LSMS_NO_CACHE`. (`trust_cache=True` is a deprecated alias for `assume_cache_fresh=True` — still accepted, emits `DeprecationWarning`; slated for removal in a future release.)
 - **Cache vs. API**: cached parquets store pre-transformation data. Kinship expansion, canonical spelling enforcement, and dtype coercion happen in `_finalize_result()` on every read — not at cache write time. So `pd.read_parquet(cache_path)` shows raw `Relationship` strings; the Country API shows decomposed `(Sex, Generation, Distance, Affinity)`.
 - **DVC stage layer is retired (v0.7.0).** Country-level `dvc.yaml` files are now `stages: {}`. All data loading goes through the cache + `load_from_waves` path. The `reproduce()` code path in `country.py` is dead code pending removal. See `SkunkWorks/dvc_object_management.org`.
 - **L2-wave cache for YAML-path tables (added 2026-04-15).** `Wave.grab_data()` now caches its result at `data_root()/{Country}/{wave}/_/{table}.parquet` on first call, for YAML-path tables only (script-path tables already wrote L2-wave parquets via their `to_parquet()` calls). This eliminates the per-wave DVC metadata lookup that previously made `_market_lookup` (and any other wave-iterating code) hit DVC SQLite on every call. Measured speedup: 408s → 0.02s per wave on Uganda `cluster_features`. Same staleness semantics as L2-country (no auto-invalidation; `LSMS_NO_CACHE=1` forces rebuild). The `to_parquet()` function gains an `absolute_path=True` kwarg to skip call-stack inference when the caller builds an absolute path itself.
@@ -79,9 +79,22 @@ Microdata must be obtained from the [World Bank Microdata Library](https://micro
 **User config** lives at `~/.config/lsms_library/config.yml`:
 ```yaml
 microdata_api_key: your_key_here
-# data_dir: /path/to/override   # same as LSMS_DATA_DIR env var
+# data_dir: /path/to/override        # same as LSMS_DATA_DIR env var
+# countries_dir: /path/to/config     # same as LSMS_COUNTRIES_ROOT env var
 ```
 Lookup order for each setting: environment variable → config file → None.
+
+**Two independent roots (GH #436 — code/config separation).** `data_dir` /
+`LSMS_DATA_DIR` overrides where the *derived caches + DVC blobs* live (see
+`docs/guide/caching.md`). `countries_dir` / `LSMS_COUNTRIES_ROOT` overrides
+where the *config tree* (`countries/{C}/_/data_info.yml`, `data_scheme.yml`,
+`*.org`, per-country `.py`) is read from — default is package-relative
+(`files("lsms_library")/"countries"`, via `paths.countries_root()`). Keeping
+them independent lets a pip-install or a git worktree point at a config tree
+under development while sharing the warm cache. **Resolve config paths via
+`countries_root()` / `Wave.file_path` / `Country.file_path`, never via a
+hardcoded `files("lsms_library")/"countries"`** — the latter ignores the
+override.
 
 **Always read files with `get_dataframe()` from `local_tools`.** It handles `.dta` / `.csv` / `.parquet` via a fallback chain: local file on disk → DVC filesystem (`DVCFileSystem`) → WB NADA download via `data_access.get_data_file()`. A script written as `get_dataframe('../Data/file.dta')` works whether the file is local, DVC-cached, or has never been downloaded.
 
@@ -159,7 +172,7 @@ Auto-unlock decrypts `s3_reader_creds.gpg` with an obfuscated passphrase at impo
 
 ## `sample()` and Cluster Identity
 
-The `sample` table (index `(i, t)`, columns `v`, `weight`, `panel_weight`, `strata`, `Rural`) is the single source of truth for mapping households to their sampling cluster. **As of 2026-04-10, `v` is joined from `sample()` at API time** by `_join_v_from_sample()` in `country.py`, called from `_finalize_result()` for any household-level table when the country has `sample` in its `data_scheme` and `v` isn't already present.
+The `sample` table (index `(i, t)`, columns `v`, `weight`, `panel_weight`, `strata`, `Rural`) is the single source of truth for mapping households to their sampling cluster. **As of 2026-04-10, `v` is joined from `sample()` at API time** by `_join_v_from_sample()` in `country.py`, called from `_finalize_result()` for any household-level table when the country has `sample` in its `data_scheme` and `v` isn't already present. **A feature can opt out of the v-join declaratively** (GH #436/#455 — the old hardcoded `_no_v_join` set in `country.py` is gone): in the canonical `lsms_library/data_info.yml`, either declare the table's index *without* `v` under `Index Info > index_info` (auto-exempts, e.g. `shocks`/`assets`), or add the feature to the `Join v from sample > skip_extra` list (e.g. `livestock`/`income`). No `country.py` edit. See `.claude/skills/add-feature/SKILL.md`.
 
 Rules:
 - Do NOT put `v` in feature `data_scheme.yml` indexes other than `cluster_features` (which owns it).

--- a/docs/guide/caching.md
+++ b/docs/guide/caching.md
@@ -29,9 +29,9 @@ The library maintains three independent caches, all rooted under
 
 | Tier | Path | Content | Populated by | Read by |
 |---|---|---|---|---|
-| **L2-country (parquet)** | `~/.local/share/lsms_library/{Country}/var/{table}.parquet` | Per-country, per-table harmonized output (waves concatenated, ready for analysis) | `Country.{table}()` after building from waves | The v0.7.0 top-of-function cache read in `load_dataframe_with_dvc` (`country.py:1611-1652`) |
+| **L2-country (parquet)** | `~/.local/share/lsms_library/{Country}/var/{table}.parquet` | Per-country, per-table harmonized output (waves concatenated, ready for analysis) | `Country.{table}()` after building from waves | The v0.7.0 top-of-function cache read in `load_dataframe_with_dvc` (hash-gated since v0.8.0) |
 | **L2-wave (parquet)** | `~/.local/share/lsms_library/{Country}/{wave}/_/{table}.parquet` | Per-wave harmonized output (one wave's portion of the table) | `Wave.grab_data()` on first call (YAML path, since 2026-04-15) or `_/{table}.py` scripts via `to_parquet()` (script path, always) | `Wave.grab_data()` on subsequent calls; `run_make_target` for script-path tables |
-| **L1 (DVC blobs)** | `~/.local/share/lsms_library/dvc-cache/{md5[:2]}/{md5[2:]}` | Content-addressed copies of the raw `.dta` files (and other DVC-tracked sources) | `_ensure_dvc_pulled()` in `local_tools.py` calls `Repo.fetch` on first read of any DVC-tracked file | `DVCFS.open()` via `DataFileSystem._get_fs_path`'s `typ == "cache"` branch |
+| **L1 (DVC blobs)** | `~/.local/share/lsms_library/dvc-cache/{md5[:2]}/{md5[2:]}` | Content-addressed copies of the raw `.dta` files (and other DVC-tracked sources) | `_ensure_dvc_pulled()` in `local_tools.py` downloads the blob **directly from S3** (sidecar md5 + the active DVC remote's fsspec backend) on first read, bypassing the DVC CLI / `Repo.fetch` (v0.7.3) | `DVCFS.open()` via `DataFileSystem._get_fs_path`'s `typ == "cache"` branch |
 
 All three tiers live under the same root, so a single `LSMS_DATA_DIR`
 environment variable moves them together. On a shared cluster, set
@@ -49,8 +49,9 @@ the parquet cache), the library re-runs wave aggregation. For each wave
 in turn, `Wave.grab_data()` checks L2-wave first and reads it directly
 on a hit. On an L2-wave miss the wave script calls `get_dataframe()` for
 its raw `.dta` files; on an L1 hit the file is served from the local
-blob cache via `DVCFS.open()`, on an L1 miss `_ensure_dvc_pulled` runs
-`Repo.fetch` to populate the cache and then `DVCFS.open` reads from it.
+blob cache via `DVCFS.open()`, on an L1 miss `_ensure_dvc_pulled`
+downloads the blob directly from S3 (via the sidecar md5, bypassing
+`Repo.fetch`) and then `DVCFS.open` reads from it.
 After the first cold rebuild, L1 and L2-wave both stay warm across
 sessions, so the next L2-country rebuild doesn't need any S3 traffic
 or repeated DVC SQLite lookups.
@@ -61,12 +62,18 @@ Empirical numbers on a Linux workstation, Niger `household_roster`
 | Scenario | Time | What's running |
 |---|---|---|
 | Truly cold (no caches) | ~600 s | First-ever fetch, every blob from S3, full DVC index build |
-| Cold-cold (L1 + L2-country both empty) | 460-510 s | Per-file `Repo.fetch` (~11 s each) + harmonization + parquet write |
+| Cold-cold (L1 + L2-country both empty) | 460-510 s | Per-file blob fetch + harmonization + parquet write |
 | **L2-country cold, L1 warm** | **~70 s** | Sidecar pre-check finds blobs in cache, no S3 traffic, harmonization + parquet write only |
 | All-warm (L2-country hit) | ~0.5 s | v0.7.0 top read returns the parquet directly |
 
-The interesting row is "L2-country cold, L1 warm": ~7× faster than
-cold-cold, because the per-file `Repo.fetch` overhead and the S3
+> **Note (v0.7.3+):** the two cold rows were measured in the
+> `Repo.fetch` era (~11 s/blob). The direct-S3 bypass now fetches each
+> blob in ~0.1 s and lock-free, so cold builds are dominated by
+> harmonization, not fetching — the absolute cold numbers are lower than
+> shown. The relative ordering still holds.
+
+The interesting row is "L2-country cold, L1 warm": much faster than
+cold-cold, because the per-file fetch overhead and the S3
 round-trips are both gone. Adding the L2-wave tier (2026-04-15) further
 removes the per-wave DVC SQLite metadata lookup on cold L2-country
 rebuilds (Uganda `cluster_features`: 408 s → 0.02 s per wave).
@@ -74,18 +81,22 @@ rebuilds (Uganda `cluster_features`: 408 s → 0.02 s per wave).
 ## Cross-Session Behavior
 
 As of v0.7.0, the library reads `{data_root}/{Country}/var/{table}.parquet`
-unconditionally at the top of `load_dataframe_with_dvc`
-(`lsms_library/country.py:1611-1652`) when the file exists. Every country
+at the top of `load_dataframe_with_dvc` when the file exists **and its
+embedded content hash is fresh (or absent)** — the v0.8.0 staleness check
+described next; before v0.8.0 this read was unconditional. Every country
 benefits from this; there is no longer a special-case for the seven
 DVC-stage countries.
 
 **Automatic content-hash staleness (v0.8.0).** Each cached parquet
 carries an embedded content hash (in its pyarrow schema metadata) that
 covers everything determining its *pre-finalize* contents: the
-`LSMS_CACHE_SCHEMA` version, the wave's `data_info.yml`, the wave and
-country modules (`{wave_folder}.py`, `{country}.py`, `mapping.py`), any
-`_/{table}.py` script, and the **DVC sidecar md5** of each declared
-source file (the `.dta` itself is never hashed or downloaded). On read,
+`LSMS_CACHE_SCHEMA` version, the wave's `data_info.yml`, the country's
+`data_scheme.yml` and `Makefile`, the wave and country modules
+(`{wave_folder}.py`, `{country}.py`, `mapping.py`), any `_/{table}.py`
+script, the build-time `*.org` inputs in `_/` (`food_items.org`,
+`categorical_mapping.org`, … — `CONTENTS.org` excluded), and the **DVC
+sidecar md5** of each declared source file (the `.dta` itself is never
+hashed or downloaded). On read,
 the hash is recomputed from the current sources and compared:
 
 - **match** → the cached parquet is served (fast path preserved);
@@ -132,6 +143,12 @@ All three tiers are under the user data directory:
 Override with the `LSMS_DATA_DIR` environment variable or the `data_dir`
 key in `~/.config/lsms_library/config.yml`. The env var takes precedence.
 
+This controls only the **data** root (caches + DVC blobs). The **config
+tree** (`countries/{C}/_/...`) is separately overridable via
+`LSMS_COUNTRIES_ROOT` / `countries_dir` (GH #436) — see CLAUDE.md "Data
+Access". Keeping the two independent is what lets a git worktree read its
+own config while sharing the warm cache.
+
 The library handles both DVC cache layouts because legacy `.dvc` sidecars
 in the `countries/` repo carry `md5-dos2unix` hashes from before the DVC
 3.0 cutover and write to the flat layout, while newer sidecars use the
@@ -145,8 +162,9 @@ This is a hard architectural rule: the package source tree
 only. Tracked data files live in the L1 cache under `data_root()`,
 not in the workspace.
 
-`_ensure_dvc_pulled` calls `Repo.fetch` (not `Repo.pull`) to populate
-the cache without checking files out into the package tree. And
+`_ensure_dvc_pulled` downloads blobs directly from S3 (via the sidecar
+md5, bypassing the DVC CLI / `Repo.fetch`) to populate the cache without
+checking files out into the package tree. And
 `local_file()` inside `get_dataframe` refuses to use any workspace copy
 of a file that has a sister `.dvc` sidecar — if it finds one, it emits
 a `UserWarning` with a cleanup command and falls through to the DVC
@@ -159,8 +177,8 @@ If you see warnings like:
 > through to the DVC cache path. Clean up with: `find lsms_library/countries -type f -name '*.dta' -execdir test -e '{}.dvc' \; -print -delete`
 
 it means your dev checkout has leftover `.dta` files from a prior
-`dvc pull` (or from an older version of the library that did
-`Repo.pull` instead of `Repo.fetch`). Run the cleanup command to
+`dvc pull` (or from an older version of the library that checked files
+out via `Repo.pull`). Run the cleanup command to
 remove them. The cache under `data_root()` already has the same
 content; the warnings will stop and reads will use the canonical
 cache path.

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -1202,8 +1202,8 @@ class Country:
         self.wave_folder_map = {}
         if trust_cache:
             warnings.warn(
-                "trust_cache is deprecated and will be removed in v0.8.0. "
-                "Use assume_cache_fresh=True instead.",
+                "trust_cache is deprecated and will be removed in a future "
+                "release. Use assume_cache_fresh=True instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
## What

A documentation audit after the recent caching + config work (v0.8.0
content-hash invalidation #454, #436 config-tree separation #452,
declarative no-v-join #455) found prose that had drifted from the code.
This fixes the verified discrepancies. Docs-only, plus one stale warning
string.

## Findings fixed

**docs/guide/caching.md**
- **L1 described as `Repo.fetch`** — the code has used the lock-free
  direct-S3 bypass since v0.7.3 (`local_tools.py:_ensure_dvc_pulled`,
  ~0.1 s/blob, ~850× faster). Fixed the L1 tier row, the "how they
  interact" prose, and the package-tree note; annotated the cold-path
  perf table as pre-bypass (Repo.fetch-era) numbers.
- **Self-contradiction from the v0.8.0 edit** — it still said the parquet
  is read "unconditionally … when the file exists" immediately above the
  new hash-staleness block. Now: read if present **and** hash-fresh/absent.
- **Incomplete hash-inputs list** — added `data_scheme.yml`, `Makefile`,
  and `*.org`.
- Replaced stale hardcoded `country.py:1611-1652` line refs with names;
  added a note on the data-root vs config-tree (`LSMS_COUNTRIES_ROOT`) split.

**CLAUDE.md**
- **`LSMS_COUNTRIES_ROOT` / `countries_dir` (#436) was undocumented in prose**
  (only in code docstrings) — added to "Data Access".
- **Worktree addendum was misleading** — `LSMS_COUNTRIES_ROOT` now lets a
  worktree self-verify *config* edits without a fresh venv (code edits
  still need it, since the `.pth` pins the code).
- **"trust_cache removed in v0.8.0" was wrong** — it's still a live
  deprecated alias that warns; corrected.
- **#455's declarative v-join opt-out** (index-without-`v` / `skip_extra`
  in `data_info.yml`; the hardcoded `_no_v_join` set is gone) — noted in
  the canonical v-join section.

**lsms_library/country.py** (one line)
- `trust_cache` `DeprecationWarning` said "will be removed in v0.8.0"
  (which shipped without removing it) → "in a future release".

## Verification

Every claim was checked against the code on current `development`
(`_ensure_dvc_pulled` bypass, `Country.__init__` still accepts
`trust_cache`, the declarative `_no_v_join_tables()` machinery,
`countries_root()` / `LSMS_COUNTRIES_ROOT`). Import + syntax check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
