### PR TITLE
feat(#438): EHCVM Tier-1 parity features for 6 West-Africa countries

### DIFF
--- a/lsms_library/countries/Benin/2018-19/_/crop_production.py
+++ b/lsms_library/countries/Benin/2018-19/_/crop_production.py
@@ -1,0 +1,120 @@
+"""Build crop_production for Benin EHCVM 2018-19 (GAP 1, item-level).
+
+Single source file: s16c_me_ben2018.dta (agriculture crop/harvest module).
+One row per reported (field, parcel, crop) harvest record.  Harvest qty +
+unit (s16cq12a / s16cq12b), sold qty + unit (s16cq16a / s16cq16b), sale
+value (s16cq17), and the intercrop flag (s16cq07) are ALL recorded at this
+plot-crop grain in 2018-19, so no cross-file join is needed.
+
+Index = (t, i, plot, crop, u); plot = "{s16cq02}_{s16cq03}" aligns with
+plot_features' plot_id.  `i` is the Benin EHCVM composite household id built
+with ``benin.i()`` from a (grappe, menage) Series, so it matches ``sample().i``
+natively (100% intersection verified).
+
+This script is SELF-CONTAINED: the generic crop-label / unit-label mapping and
+the schema tail (cloned from the Niger EHCVM reference) are inlined below; only
+the load-bearing ``i()`` household-id constructor is imported from Benin's own
+``benin`` module so it cannot drift from ``sample()``.
+
+CROP LABEL NOTE: Niger resolves the crop label through ``harmonize_food``
+(keyed on Original Label).  Benin has no ``harmonize_food`` table, so the
+mapping is loaded if present and otherwise the raw French crop label passes
+through unchanged (Niger's ``_crop_labels`` already passes unmapped labels
+through verbatim) — the native label IS the item identity.  ``u`` likewise
+maps through Benin's ``u`` table with passthrough for the harvest-specific
+units (Sac (100 Kg), Bassine, ...) not in that consumption-unit table.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from benin import i as benin_i
+
+
+def _label_map(tablename):
+    """Load a ``{Original Label -> Preferred Label}`` dict from
+    ``categorical_mapping.org``.  Returns {} if the table is absent so the
+    caller's passthrough leaves labels unchanged."""
+    try:
+        return tools.get_categorical_mapping(
+            tablename=tablename, idxvars='Original Label',
+            **{'Preferred Label': 'Preferred Label'})
+    except Exception:
+        return {}
+
+
+def _crop_labels(source_labels, crop_map):
+    """Map a crop column (string labels from convert_categoricals=True)
+    through ``harmonize_food`` (keyed on Original Label).  Unmapped labels
+    pass through unchanged (kept visible, flagged by the sanity checker)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: crop_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _unit_labels(unit_series, unit_map):
+    """Map a harvest-unit column (string labels) through the ``u`` table.
+    Unmapped labels pass through unchanged."""
+    u = unit_series.astype('string')
+    return u.map(lambda x: unit_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _finish_crop_production(df, t):
+    """Common tail: tag t, build the (t, i, plot, crop, u) index, coerce
+    numeric columns, and guarantee the full schema column set."""
+    for col in ['Quantity', 'Quantity_sold', 'Value_sold']:
+        df[col] = pd.to_numeric(df.get(col), errors='coerce').astype('Float64')
+    if 'harvest_month' not in df.columns:
+        df['harvest_month'] = pd.NA
+    df['harvest_month'] = pd.to_numeric(df['harvest_month'], errors='coerce').astype('Float64')
+    if 'intercropped' not in df.columns:
+        df['intercropped'] = pd.NA
+    df['intercropped'] = df['intercropped'].astype('boolean')
+    df['t'] = t
+    df['crop'] = df['crop'].astype('string')
+    df['u'] = df['u'].astype('string')
+    # Drop placeholder rows with no crop recorded (a parcel listed but no
+    # crop grown / reported on the line).
+    df = df[df['crop'].notna()]
+    keep = ['t', 'i', 'plot', 'crop', 'u', 'Quantity',
+            'Quantity_sold', 'Value_sold', 'harvest_month', 'intercropped']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'plot', 'crop', 'u'])
+    return df
+
+
+# convert_categoricals=True so crop / unit value labels arrive as the
+# strings harmonize_food / the u table key on.
+src = get_dataframe('../Data/s16c_me_ben2018.dta', convert_categoricals=True)
+src_codes = get_dataframe('../Data/s16c_me_ben2018.dta', convert_categoricals=False)
+
+crop_map = _label_map('harmonize_food')
+unit_map = _label_map('u')
+
+hh = src_codes.apply(lambda r: benin_i(pd.Series([r['grappe'], r['menage']])),
+                     axis=1)
+field = src_codes['s16cq02'].apply(format_id)
+parcel = src_codes['s16cq03'].apply(format_id)
+plot = field.astype(str) + '_' + parcel.astype(str)
+
+# intercrop: s16cq07 == 'Association de cultures' -> True, 'Pure' -> False
+intercropped = src['s16cq07'].astype('string').map(
+    {'Association de cultures': True, 'Pure': False})
+
+df = pd.DataFrame({
+    'i':             hh.values,
+    'plot':          plot.values,
+    'crop':          _crop_labels(src['s16cq04'], crop_map).values,
+    'u':             _unit_labels(src['s16cq12b'], unit_map).values,
+    'Quantity':      src['s16cq12a'].values,
+    'Quantity_sold': src['s16cq16a'].values,
+    'Value_sold':    src['s16cq17'].values,
+    'intercropped':  intercropped.values,
+})
+
+df = _finish_crop_production(df, '2018-19')
+
+assert len(df) > 0, 'crop_production 2018-19 produced no rows'
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Benin/2018-19/_/livestock.py
+++ b/lsms_library/countries/Benin/2018-19/_/livestock.py
@@ -1,0 +1,117 @@
+"""Build livestock for Benin EHCVM 2018-19 (GAP 4, item-level).
+
+Single source file: s17_me_ben2018.dta — the EHCVM section-17 livestock
+('Élevage') roster, one row per (household, species).  The roster is
+already restricted to owned species (s17q03 == 1 for every row).
+
+Columns:
+  s17q02  species code (1-11; harmonize_species_ehcvm -> animal)
+  s17q03  owned/raised this species? (1=Oui / 2=Non) — gate (all ==1 here)
+  s17q06  number belonging to the household (HeadCount owned now)
+  s17q08  number bought in the last 12 months (HeadAcquired)
+  s17q10  number sold on the hoof in the last 12 months (HeadSold)
+
+There is NO current herd-value question in EHCVM s17, so Value is not
+emitted.  ``i`` is the Benin EHCVM composite household id built with
+``benin.i()`` from a (grappe, menage) Series, so it matches ``sample().i``
+natively (cf. the GhanaLSS GH #256 key-match).  Grain (t, i, animal); no v
+level (livestock is in the framework's _no_v_join set).
+
+This script is SELF-CONTAINED: the generic ``_map_codes`` /
+``_finish_livestock`` logic (cloned from the Niger EHCVM reference) is
+inlined below; only the load-bearing ``i()`` household-id constructor is
+imported from Benin's own ``benin`` module so it cannot drift from
+``sample()``.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+from benin import i as benin_i
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a ``{int code -> Preferred Label}`` dict from
+    ``categorical_mapping.org`` for a harmonize_* table.  Codes whose
+    Preferred Label is blank / '---' map to NA so the corresponding column
+    stays NaN.  (Inlined from the Niger / Benin EHCVM helper.)"""
+    raw = tools.get_categorical_mapping(tablename=tablename, idxvars=key,
+                                        **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw Stata integer-code) Series through ``code_map``,
+    returning a string Series with NA where the code is unmapped.  Source
+    files must be loaded with ``convert_categoricals=False`` so the codes
+    arrive as integers.  (Inlined from the Niger EHCVM reference.)"""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def _finish_livestock(df, t):
+    """Common tail (inlined from the Niger EHCVM reference): coerce numeric
+    columns, drop unresolved-species placeholder rows, SUM the head counts
+    within (t, i, animal) so each (household, canonical species) is one row,
+    and build the (t, i, animal) index.  HeadCount / HeadAcquired / HeadSold
+    are Float64 (head counts, nullable); the sum uses min_count=1 so an
+    all-NaN group stays NaN rather than becoming 0.  The EHCVM roster already
+    reports one row per species (codes 1-11), so the sum is effectively a
+    no-op; it is kept for parity with the ECVMA sub-type collapse and to
+    guarantee a unique (t, i, animal) index ahead of the framework's
+    canonical-index de-dup collapse."""
+    cols = ['HeadCount', 'HeadAcquired', 'HeadSold']
+    for col in cols:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    df['t'] = t
+    df['animal'] = df['animal'].astype('string')
+    df = df[df['animal'].notna() & df['i'].notna()]
+    df = (df.groupby(['t', 'i', 'animal'], dropna=False)[cols]
+            .sum(min_count=1)
+            .reset_index())
+    keep = ['t', 'i', 'animal'] + cols
+    df = df[keep]
+    df = df.set_index(['t', 'i', 'animal'])
+    return df
+
+
+srcn = get_dataframe('../Data/s17_me_ben2018.dta', convert_categoricals=False)
+
+ehcvm_map = _harmonized_codes('harmonize_species_ehcvm')
+
+# The roster only carries owned species, but keep the gate for parity / safety.
+owned = srcn['s17q03'] == 1
+srcn = srcn[owned.values]
+
+# Household id: EHCVM composite (grappe, menage) via benin.i(), matching
+# sample().i.  benin.i() reads the Series positionally (grappe, menage).
+hh = srcn.apply(lambda r: benin_i(pd.Series([r['grappe'], r['menage']])),
+                axis=1)
+
+df = pd.DataFrame({
+    'i':            hh.values,
+    'animal':       _map_codes(srcn['s17q02'], ehcvm_map).values,
+    'HeadCount':    pd.to_numeric(srcn['s17q06'], errors='coerce').values,
+    'HeadAcquired': pd.to_numeric(srcn['s17q08'], errors='coerce').values,
+    'HeadSold':     pd.to_numeric(srcn['s17q10'], errors='coerce').values,
+})
+
+df = _finish_livestock(df, '2018-19')
+
+assert len(df) > 0, 'livestock 2018-19 produced no rows'
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Benin/2018-19/_/people_last7days.py
+++ b/lsms_library/countries/Benin/2018-19/_/people_last7days.py
@@ -1,0 +1,112 @@
+"""Build people_last7days for Benin EHCVM 2018-19 (GAP 3, item-level).
+
+Two source files:
+  s04_me_ben2018.dta — the 7-day employment module (participation dummies).
+  s01_me_ben2018.dta — the individual roster (age for working_age).
+Merged on (grappe, menage, s01q00a) — the same person key household_roster
+uses.  Grain (t, i, pid); pid = s01q00a; ``i`` = Benin EHCVM composite via
+``benin.i()`` (100% sample intersection verified).
+
+EHCVM's 7-day module records only the three participation DUMMIES in an
+ECVMA-comparable form (s04q06 farm, s04q07 own-business, s04q08 wage) and
+working_age (roster Age >= 6).  It does NOT record productive-work hours or
+the WB 7-day industry section code, so farm_hrs / SB_hrs / wage_hrs and
+Industry are NA (declared for cross-wave schema parity).
+
+This script is SELF-CONTAINED: the build (cloned from the Niger EHCVM
+reference ``people_last7days_ehcvm`` / ``_finish_people_last7days``) is
+inlined; only ``benin.i()`` is imported so the household id cannot drift from
+``sample()``.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+from benin import i as benin_i
+
+
+def _yn_bool(series, yes=1, no=2):
+    """Map a 1=Oui / 2=Non survey item to nullable boolean (other codes ->
+    NA)."""
+    s = pd.to_numeric(series, errors='coerce')
+    out = pd.Series(pd.NA, index=s.index, dtype='boolean')
+    out = out.mask(s == yes, True)
+    out = out.mask(s == no, False)
+    return out
+
+
+def people_last7days_ehcvm(s04, s01, t, pid_col='s01q00a', age_col='s01q04a',
+                           dob_year_col='s01q03c', survey_year=2018):
+    """Build people_last7days from the EHCVM 7-day labor module (s04) merged
+    to the s01 roster for working_age.
+      s04q06 -> farm_work    s04q07 -> SOB_work    s04q08 -> wage_work
+    AGE: prefer reported years (age_col); else survey_year - birth_year
+    (dob_year_col, out-of-range / sentinel -> NA), mirroring household_roster's
+    age_handler.  working_age = Age >= 6.  pid = pid_col."""
+    key = ['grappe', 'menage', pid_col]
+    roster_cols = [age_col, dob_year_col]
+    merged = s04[key + ['s04q06', 's04q07', 's04q08']].merge(
+        s01[key + roster_cols], on=key, how='left')
+
+    hh = merged.apply(lambda r: benin_i(pd.Series([r['grappe'], r['menage']])),
+                      axis=1)
+    pid = merged[pid_col].apply(tools.format_id)
+
+    age = pd.to_numeric(merged[age_col], errors='coerce')
+    if survey_year is not None:
+        birth = pd.to_numeric(merged[dob_year_col], errors='coerce')
+        birth = birth.where((birth >= 1900) & (birth <= survey_year), pd.NA)
+        age_from_dob = survey_year - birth
+        age = age.where(age.notna(), age_from_dob)
+    working_age = (age >= 6)
+    working_age = working_age.where(age.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        'i': hh.values,
+        'pid': pid.values,
+        'farm_work': _yn_bool(merged['s04q06']).values,
+        'SOB_work': _yn_bool(merged['s04q07']).values,
+        'wage_work': _yn_bool(merged['s04q08']).values,
+        'working_age': working_age.values,
+    })
+    return df
+
+
+def _finish_people_last7days(df, t):
+    """Common tail: coerce dtypes, guarantee the full schema column set (NA
+    where this wave lacks a field), drop rows with no individual key, and
+    build the (t, i, pid) index."""
+    df = df.copy()
+    df['t'] = t
+    df['pid'] = df['pid'].astype('string')
+    for col in ['farm_work', 'SOB_work', 'wage_work', 'working_age']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = df[col].astype('boolean')
+    for col in ['farm_hrs', 'SB_hrs', 'wage_hrs']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Industry' not in df.columns:
+        df['Industry'] = pd.NA
+    df['Industry'] = df['Industry'].astype('string')
+    df = df[df['i'].notna() & df['pid'].notna()]
+    keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
+            'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
+    df = df[keep]
+    df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
+    df = df.set_index(['t', 'i', 'pid'])
+    return df
+
+
+s04 = get_dataframe('../Data/s04_me_ben2018.dta', convert_categoricals=False)
+s01 = get_dataframe('../Data/s01_me_ben2018.dta', convert_categoricals=False)
+
+df = people_last7days_ehcvm(s04, s01, '2018-19', survey_year=2018)
+df = _finish_people_last7days(df, '2018-19')
+
+assert len(df) > 0, 'people_last7days 2018-19 produced no rows'
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Benin/2018-19/_/plot_inputs.py
+++ b/lsms_library/countries/Benin/2018-19/_/plot_inputs.py
@@ -1,0 +1,133 @@
+"""Build plot_inputs for Benin EHCVM 2018-19 (GAP 2, item-level).
+
+Single source file: s16b_me_ben2018.dta — the household agricultural-input
+roster, one row per input-type the household was asked about.  Columns:
+  s16bq01   input type (organic / inorganic fert / phyto / seeds-by-crop)
+  s16bq02   USED this input? (Oui / Non) — application gate (all Oui in 2018)
+  s16bq03a / s16bq03b   quantity used + native unit
+  s16bq05   purchased? (Oui / Non)
+  s16bq07a  quantity purchased
+
+We keep s16bq02==1 (applied) rows.  The EHCVM roster has NO crop column — the
+seed's crop is embedded in the input-type label ('Semences de petit mil'),
+resolved to the canonical crop label via harmonize_seed_crop.  Non-seed input
+rows carry crop NaN (filled with the '(not crop-specific)' sentinel in the
+tail).  ``i`` is the Benin EHCVM composite id via ``benin.i()`` (100% sample
+intersection verified).  No plot column; grain is (t, i, input, crop, u).
+
+This script is SELF-CONTAINED: the label mappers and the schema tail (cloned
+from the Niger EHCVM reference) are inlined; only ``benin.i()`` is imported so
+the household id cannot drift from ``sample()``.  harmonize_input and
+harmonize_seed_crop were copied verbatim from Niger into Benin's
+categorical_mapping.org (EHCVM s16b labels are standardized across EHCVM
+countries; every Benin s16bq01 label is covered).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+from benin import i as benin_i
+
+
+# Sentinel for the `crop` index level on input rows that are NOT
+# crop-specific (every fertilizer / pesticide row, and any seed row whose
+# crop could not be resolved).  A non-null token keeps all reported rows and
+# makes "no crop dimension" explicit; it is deliberately not a food/crop label
+# so it never collides with the harmonize_food `crop` values seed rows carry.
+CROP_NA = '(not crop-specific)'
+
+
+def _label_map(tablename):
+    """Load a ``{Original Label -> Preferred Label}`` dict; {} if absent."""
+    try:
+        return tools.get_categorical_mapping(
+            tablename=tablename, idxvars='Original Label',
+            **{'Preferred Label': 'Preferred Label'})
+    except Exception:
+        return {}
+
+
+def _input_labels(source_labels, input_map):
+    """Map an input-type column (string labels) through harmonize_input.
+    Unmapped labels pass through unchanged (kept visible, flagged)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: input_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _seed_crop_labels(source_labels, seed_crop_map):
+    """Resolve the crop embedded in a seed-type label ('Semences de maïs' ->
+    'Maïs en grain') via harmonize_seed_crop.  Returns NA for any label not in
+    the seed-crop table (i.e. non-seed input rows)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: seed_crop_map.get(x, pd.NA) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _unit_labels(unit_series, unit_map):
+    """Map a unit column (string labels) through the ``u`` table; passthrough
+    for units not in the table."""
+    u = unit_series.astype('string')
+    return u.map(lambda x: unit_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _finish_plot_inputs(df, t):
+    """Common tail: coerce numeric columns, guarantee the full schema column
+    set, build the (t, i, input, crop, u) index.  Drops rows with no input
+    identity.  The `crop` and `u` index levels are filled with sentinels
+    wherever absent so the index is fully non-null and no row is lost to the
+    framework's NaN-key duplicate collapse."""
+    for col in ['Quantity', 'Quantity_purchased']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Purchased' not in df.columns:
+        df['Purchased'] = pd.NA
+    df['Purchased'] = df['Purchased'].astype('boolean')
+    df['t'] = t
+    df['input'] = df['input'].astype('string')
+    if 'crop' not in df.columns:
+        df['crop'] = pd.NA
+    df['crop'] = df['crop'].astype('string').fillna(CROP_NA)
+    df['u'] = df['u'].astype('string').fillna('Manquant')
+    df = df[df['input'].notna()]
+    keep = ['t', 'i', 'input', 'crop', 'u',
+            'Quantity', 'Purchased', 'Quantity_purchased']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'input', 'crop', 'u'])
+    return df
+
+
+src = get_dataframe('../Data/s16b_me_ben2018.dta', convert_categoricals=True)
+srcn = get_dataframe('../Data/s16b_me_ben2018.dta', convert_categoricals=False)
+
+input_map = _label_map('harmonize_input')
+seed_crop_map = _label_map('harmonize_seed_crop')
+unit_map = _label_map('u')
+
+# Keep only inputs the household actually applied (s16bq02 == 1 = Oui).
+applied = srcn['s16bq02'] == 1
+src = src[applied.values]
+srcn = srcn[applied.values]
+
+hh = srcn.apply(lambda r: benin_i(pd.Series([r['grappe'], r['menage']])),
+                axis=1)
+
+# purchased: s16bq05 Oui/Non (loaded as labels with convert_categoricals)
+purchased = src['s16bq05'].astype('string').map({'Oui': True, 'Non': False})
+
+df = pd.DataFrame({
+    'i':                  hh.values,
+    'input':              _input_labels(src['s16bq01'], input_map).values,
+    'crop':               _seed_crop_labels(src['s16bq01'], seed_crop_map).values,
+    'u':                  _unit_labels(src['s16bq03b'], unit_map).values,
+    'Quantity':           pd.to_numeric(srcn['s16bq03a'], errors='coerce').values,
+    'Purchased':          purchased.values,
+    'Quantity_purchased': pd.to_numeric(srcn['s16bq07a'], errors='coerce').values,
+})
+
+df = _finish_plot_inputs(df, '2018-19')
+
+assert len(df) > 0, 'plot_inputs 2018-19 produced no rows'
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Benin/2018-19/_/plot_labor.py
+++ b/lsms_library/countries/Benin/2018-19/_/plot_labor.py
@@ -1,0 +1,128 @@
+"""Build plot_labor for Benin EHCVM 2018-19 (GAP 3, item-level).
+
+Single source file: s16a_me_ben2018.dta (agriculture-parcel module — the
+same file plot_features reads, so plot ids align by construction).  EHCVM
+records plot labor at the parcel level, family vs non-family (hired) only
+(NO free/exchange "other" labor):
+
+  Family labor (per family member, member-grid suffix _1.._N, three phases):
+    s16aq33b_*  days each member worked, prep/sowing phase
+    s16aq35b_*  days each member worked, maintenance phase
+    s16aq37b_*  days each member worked, harvest phase
+  -> family PersonDays = Σ over members & phases of those member-day cells.
+
+  Non-family / hired labor (per worker gender category, grid suffix _1.._4,
+  three phases; a = #workers, b = days each, c = wage paid):
+    s16aq39{a,b,c}_*  prep/sowing phase
+    s16aq41{a,b,c}_*  maintenance phase
+    s16aq43{a,b,c}_*  harvest phase
+  -> hired PersonDays = Σ over categories & phases of (a workers × b days);
+     hired Wage       = Σ over categories & phases of c (cash paid).
+
+One row per (plot, source); plot = "{s16aq02}_{s16aq03}" aligns with
+crop_production / plot_features plot_id.  ``i`` = Benin EHCVM composite via
+``benin.i()`` (100% sample intersection verified).
+
+This script is SELF-CONTAINED: the labor-grid reduction (cloned from the Niger
+EHCVM reference ``plot_labor_ehcvm`` / ``_finish_plot_labor``) is inlined; only
+``benin.i()`` is imported so the household id cannot drift from ``sample()``.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+from benin import i as benin_i
+
+
+LABOR_SOURCE_FAMILY = 'family'
+LABOR_SOURCE_HIRED = 'hired'
+
+
+def plot_labor_ehcvm(src, t):
+    """Build plot_labor from the s16a parcel module.  EHCVM records family vs
+    non-family (hired) plot labor only.  Returns the long
+    (i, plot, source, PersonDays, Wage) frame ready for _finish_plot_labor."""
+    cols = list(src.columns)
+
+    def _num(col):
+        return pd.to_numeric(src[col], errors='coerce').astype('Float64')
+
+    hh = src.apply(lambda r: benin_i(pd.Series([r['grappe'], r['menage']])),
+                   axis=1)
+    field = src['s16aq02'].apply(tools.format_id)
+    parcel = src['s16aq03'].apply(tools.format_id)
+    plot = field.astype('string') + '_' + parcel.astype('string')
+
+    # family: sum member-day cells across the three phase grids
+    fam_cols = [c for c in cols
+                if c.startswith('s16aq33b_')
+                or c.startswith('s16aq35b_')
+                or c.startswith('s16aq37b_')]
+    fam_days = sum(_num(c).fillna(0) for c in fam_cols)
+    fam_any = pd.concat([_num(c).notna() for c in fam_cols], axis=1).any(axis=1)
+    fam_days = fam_days.where(fam_any.values, pd.NA)
+    fam = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_FAMILY,
+        'PersonDays': fam_days.values, 'Wage': pd.NA,
+    })
+
+    # hired: Σ(#workers × days) person-days, Σ wage, over phase × category
+    hired_days = pd.Series(0.0, index=src.index, dtype='Float64')
+    hired_wage = pd.Series(0.0, index=src.index, dtype='Float64')
+    any_days = pd.Series(False, index=src.index)
+    any_wage = pd.Series(False, index=src.index)
+    for base in ['s16aq39', 's16aq41', 's16aq43']:
+        for ac in [c for c in cols if c.startswith(base + 'a_')]:
+            suf = ac[len(base + 'a'):]   # e.g. '_1' (keeps the underscore)
+            bc, cc = base + 'b' + suf, base + 'c' + suf
+            workers = _num(ac)
+            days = _num(bc) if bc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            wage = _num(cc) if cc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            pd_cell = workers * days
+            hired_days = hired_days.add(pd_cell.fillna(0))
+            any_days = any_days | pd_cell.notna().values
+            hired_wage = hired_wage.add(wage.fillna(0))
+            any_wage = any_wage | wage.notna().values
+    hired_days = hired_days.where(any_days.values, pd.NA)
+    hired_wage = hired_wage.where(any_wage.values, pd.NA)
+    hired = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_HIRED,
+        'PersonDays': hired_days.values, 'Wage': hired_wage.values,
+    })
+
+    return pd.concat([fam, hired], ignore_index=True)
+
+
+def _finish_plot_labor(df, t):
+    """Common tail: SUM PersonDays / Wage within (t, i, plot, source) so the
+    strata (family members, hired-worker gender categories, phases) collapse
+    onto the natural (plot, source) item grain.  min_count=1 keeps an all-NA
+    group NA.  Rows with no plot, no source, or no labor at all are dropped."""
+    df = df.copy()
+    df['t'] = t
+    df['source'] = df['source'].astype('string')
+    df['plot'] = df['plot'].astype('string')
+    df['PersonDays'] = pd.to_numeric(df.get('PersonDays'), errors='coerce').astype('Float64')
+    if 'Wage' not in df.columns:
+        df['Wage'] = pd.NA
+    df['Wage'] = pd.to_numeric(df['Wage'], errors='coerce').astype('Float64')
+    df = df[df['i'].notna() & df['plot'].notna() & df['source'].notna()]
+    df = (df.groupby(['t', 'i', 'plot', 'source'], dropna=False)[['PersonDays', 'Wage']]
+            .sum(min_count=1)
+            .reset_index())
+    df = df[df['PersonDays'].notna() | df['Wage'].notna()]
+    df = df.set_index(['t', 'i', 'plot', 'source'])
+    return df
+
+
+src = get_dataframe('../Data/s16a_me_ben2018.dta', convert_categoricals=False)
+df = plot_labor_ehcvm(src, '2018-19')
+df = _finish_plot_labor(df, '2018-19')
+
+assert len(df) > 0, 'plot_labor 2018-19 produced no rows'
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Benin/_/categorical_mapping.org
+++ b/lsms_library/countries/Benin/_/categorical_mapping.org
@@ -178,3 +178,84 @@
 |    9 | Chicken         |
 |   10 | Guinea Fowl     |
 |   11 | Other Poultry   |
+
+* Agricultural Inputs (plot_inputs — the input axis)
+
+# harmonize_input (GAP 2 plot_inputs).  Maps each wave's agricultural-input
+# *type* label onto a shared input taxonomy `Preferred Label`.  The reported
+# item-level input feature `plot_inputs` (grain (t, i, input, crop, u)) puts
+# this Preferred Label on its `input` index level.  STRING-KEYED (Original
+# Label) because the integer input-type code is not a stable cross-wave key;
+# the wave script loads convert_categoricals=True and keys on the raw French
+# label.  Copied VERBATIM from the Niger EHCVM reference (the EHCVM s16b
+# input-type labels are standardized across EHCVM countries); every Benin
+# s16bq01 label is covered.  All seed slots collapse to Seed (the seed's crop
+# is carried in the separate `crop` column, resolved by harmonize_seed_crop).
+
+#+NAME: harmonize_input
+| Original Label                            | Preferred Label     |
+|-------------------------------------------+---------------------|
+| engrais organiques-fumure                 | Organic manure      |
+| Engrais organiques-Fumure                 | Organic manure      |
+| Engrais organiques - déchets d'animaux    | Organic manure      |
+| engrais organiques-compost                | Organic compost     |
+| Engrais organiques-Compost                | Organic compost     |
+| Engrais organiques - Ordures ménagères    | Organic compost     |
+| engrais inorganiques - urée               | Urea                |
+| Engrais inorganiques - Urée               | Urea                |
+| engrais inorganiques - dap                | DAP                 |
+| Engrais inorganiques - DAP                | DAP                 |
+| DAP et autres engrais inorganiques        | DAP                 |
+| engrais inorganiques - npk 15/15          | NPK                 |
+| Engrais inorganiques - NPK 15/15          | NPK                 |
+| Engrais inorganiques - NPK/Formule unique | NPK                 |
+| Engrais inorganiques - Phosphates         | Phosphate           |
+| engrais inorganiques - mélange            | Mixed fertilizer    |
+| Engrais inorganiques - Mélange            | Mixed fertilizer    |
+| produits phytosanitaires - pesticides     | Pesticide           |
+| Produits phytosanitaires - Pesticides     | Pesticide           |
+| produits phytosanitaires - herbicides     | Herbicide           |
+| Produits phytosanitaires - Herbicides     | Herbicide           |
+| produits phytosanitaires - fongicides     | Fungicide           |
+| Produits phytosanitaires - Fongicides     | Fungicide           |
+| Produits phytosanitaires-Fongicides       | Fungicide           |
+| Produits phytosanitaires -Fongicides      | Fungicide           |
+| autres produits phytosanitaires           | Other phytosanitary |
+| Autres produits phytosanitaires           | Other phytosanitary |
+| semences                                  | Seed                |
+| Semences                                  | Seed                |
+| Semences de petit mil                     | Seed                |
+| Semences de sorgho                        | Seed                |
+| Semences de maïs                          | Seed                |
+| Semences de riz                           | Seed                |
+| Semences d'autres céréales                | Seed                |
+| Semences de coton                         | Seed                |
+| Semences de sésame                        | Seed                |
+| Semences de césame                        | Seed                |
+| Semences de haricots/niébé                | Seed                |
+| Plants/boutures de tubercules             | Seed                |
+| Autres semences                           | Seed                |
+| 20                                        | Seed                |
+
+# harmonize_seed_crop (GAP 2 plot_inputs).  EHCVM-only helper.  The EHCVM
+# s16b input roster has NO crop column — the crop is encoded in the seed-type
+# label ('Semences de petit mil').  This table resolves each EHCVM seed-type
+# label to the crop's harmonize_food `Preferred Label`, so seed rows carry the
+# SAME `crop` value a grown crop would.  Catch-all seed slots resolve to
+# 'Autre crop'.  Copied VERBATIM from the Niger EHCVM reference.
+
+#+NAME: harmonize_seed_crop
+| Original Label                | Preferred Label     |
+|-------------------------------+---------------------|
+| Semences de petit mil         | Mil                 |
+| Semences de sorgho            | Sorgho              |
+| Semences de maïs              | Maïs en grain       |
+| Semences de riz               | Riz Paddy           |
+| Semences de coton             | Coton               |
+| Semences de sésame            | Sésame              |
+| Semences de césame            | Sésame              |
+| Semences de haricots/niébé    | Niébé/Haricots secs |
+| Semences d'autres céréales    | Autre crop          |
+| Plants/boutures de tubercules | Autre crop          |
+| Autres semences               | Autre crop          |
+| 20                            | Autre crop          |

--- a/lsms_library/countries/Benin/_/categorical_mapping.org
+++ b/lsms_library/countries/Benin/_/categorical_mapping.org
@@ -163,3 +163,18 @@
 |    1 | freehold                   |
 |    2 | granted_right_of_occupancy |
 |    4 | leasehold                  |
+
+#+NAME: harmonize_species_ehcvm
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Cattle          |
+|    2 | Sheep           |
+|    3 | Goats           |
+|    4 | Camels          |
+|    5 | Horses          |
+|    6 | Donkeys         |
+|    7 | Pigs            |
+|    8 | Rabbits         |
+|    9 | Chicken         |
+|   10 | Guinea Fowl     |
+|   11 | Other Poultry   |

--- a/lsms_library/countries/Benin/_/data_scheme.yml
+++ b/lsms_library/countries/Benin/_/data_scheme.yml
@@ -130,3 +130,114 @@ Data Scheme:
     HeadAcquired: float
     HeadSold: float
     materialize: make
+
+  crop_production:
+    # Item-level crop harvest (GAP 1).  One row per REPORTED (field, parcel,
+    # crop) harvest line from the EHCVM agriculture module s16c_me_ben2018.dta
+    # (single 2018-19 wave) — REPORTED values only; harvest_kg / yield /
+    # main_crop / value-shares are transformations, never columns here.  crop
+    # carries the native French crop label (Benin has no harmonize_food crop
+    # table; Niger's passthrough behavior keeps the label as the item
+    # identity); u via the u table (passthrough for harvest-specific units).
+    # ``u`` is in the index (as in food_acquired) because one (plot, crop) can
+    # be reported in several units.  plot = "{field_no}_{parcel_no}" aligns
+    # with plot_features' plot_id.  Quantity_sold / Value_sold recorded at
+    # plot-crop grain (s16cq16a / s16cq17); intercropped from s16cq07.
+    # harvest_month is OMITTED-then-filled NaN (Benin's s16c has no harvest-
+    # month question) but carried for cross-country schema parity with Niger.
+    index: (t, i, plot, crop, u)
+    Quantity: float
+    Quantity_sold: float
+    Value_sold: float
+    harvest_month: float
+    intercropped: bool
+    materialize: make
+
+  plot_inputs:
+    # Item-level agricultural inputs (GAP 2).  One row per REPORTED input
+    # applied by a household from the EHCVM input roster s16b_me_ben2018.dta
+    # (single 2018-19 wave): input identity (Seed / Urea / DAP / NPK /
+    # Phosphate / Organic manure / Organic compost / Pesticide / Herbicide /
+    # Fungicide / Other phytosanitary), reported quantity used + native unit,
+    # purchased flag + reported purchased quantity, and (seed rows) the seed's
+    # crop.  REPORTED values only: seed_kg / nitrogen_kg / fertilizer totals
+    # are TRANSFORMATIONS over these rows, never columns.
+    #
+    # GRAIN NOTE: EHCVM records inputs at the HOUSEHOLD x input grain, NOT
+    # plot x input (the WB plot split is a forbidden fabrication), so `plot`
+    # is NOT in the index; the feature keeps the GAP-2 name `plot_inputs`.
+    # input -> harmonize_input; u -> the u table; crop -> harmonize_seed_crop
+    # on the seed label (the EHCVM s16b roster has no crop column).  Both
+    # tables were copied verbatim from Niger into categorical_mapping.org.
+    # `crop` is in the index; non-crop-specific rows carry the sentinel
+    # '(not crop-specific)' rather than NaN (a NaN index level is dropped by
+    # the framework's canonical NaN-key de-dup collapse).  `u` is in the index
+    # and a missing unit is filled with 'Manquant' for the same non-null
+    # reason.
+    index: (t, i, input, crop, u)
+    Quantity: float
+    Purchased: bool
+    Quantity_purchased: float
+    materialize: make
+
+  plot_labor:
+    # Item-level plot labor (GAP 3).  One row per REPORTED labor SOURCE on a
+    # plot from the EHCVM agriculture-parcel module s16a_me_ben2018.dta (single
+    # 2018-19 wave).  REPORTED person-days; total_labor_days /
+    # total_family_labor_days / total_hired_labor_days / hired_labor_value (a
+    # median-wage valuation) are TRANSFORMATIONS over these rows, never columns.
+    #
+    # GRAIN (t, i, plot, source):
+    #   plot   -- "{field_no}_{parcel_no}", aligned with crop_production's plot
+    #             key and plot_features' plot_id.
+    #   source -- 'family' / 'hired'.  EHCVM s16a records family vs non-family
+    #             (hired) only (no free/exchange 'other' source); small fixed
+    #             vocabulary assigned in code (inline mapping, no table).
+    #
+    # COLUMNS (reported, item-level):
+    #   PersonDays -- within-source sum of the reported day cells (per family
+    #                 member, or per hired-worker gender category, across the
+    #                 prep/maintenance/harvest phases); hired person-days =
+    #                 Σ(#workers × days).  NOT a forbidden cross-source rollup.
+    #   Wage       -- cash PAID to hired labor (CFA francs); NaN for family.
+    # v is NOT baked in (household-linked); the framework joins it from
+    # sample().  units: PersonDays in days; Wage in CFA francs.
+    index: (t, i, plot, source)
+    PersonDays: float
+    Wage: float
+    materialize: make
+
+  people_last7days:
+    # Item-level individual 7-day labor (GAP 3).  One row per individual
+    # carrying the REPORTED last-7-days labor participation, from the EHCVM
+    # 7-day module s04_me_ben2018.dta merged to the s01 roster (single 2018-19
+    # wave).  No rollups: the WB nb_members_working_age HH total is a
+    # transformation, not a column here.
+    #
+    # GRAIN (t, i, pid): pid = s01q00a (matches household_roster).  v
+    # auto-joins from sample() (people_last7days is NOT in the framework
+    # _no_v_join set).
+    #
+    # COLUMNS (reported, per-individual):
+    #   farm_work / SOB_work / wage_work -- worked >=1h on own farm / own
+    #       business / for a wage in the last 7 days (s04q06/07/08; nullable
+    #       bool).
+    #   farm_hrs / SB_hrs / wage_hrs / Industry -- NA in Benin: the EHCVM
+    #       7-day module records hours only for unpaid domestic tasks and the
+    #       industry only as 12-month occupation codes (not the WB 7-day
+    #       section ranges), so these are declared for cross-wave schema parity
+    #       with Niger but left NA.
+    #   working_age -- member is of working age (Age >= 6, the survey
+    #       threshold); Age from s01 (reported years, else survey_year minus
+    #       birth-year s01q03c).
+    # units: hours in hours.
+    index: (t, i, pid)
+    farm_work: bool
+    SOB_work: bool
+    wage_work: bool
+    farm_hrs: float
+    SB_hrs: float
+    wage_hrs: float
+    Industry: str
+    working_age: bool
+    materialize: make

--- a/lsms_library/countries/Benin/_/data_scheme.yml
+++ b/lsms_library/countries/Benin/_/data_scheme.yml
@@ -107,3 +107,26 @@ Data Scheme:
     SoilType: str
     Irrigated: bool
     materialize: make
+
+  livestock:
+    # Item-level livestock roster (GAP 4).  One row per REPORTED
+    # (household, species) the household owns/raises, from the EHCVM
+    # section-17 ('Élevage') module s17_me_ben2018.dta (single 2018-19
+    # wave; roster pre-filtered to owned species, s17q03 == 1).
+    #
+    # GRAIN (t, i, animal) — NO v level: 'livestock' is in the framework's
+    # _no_v_join set, so the household-level rows carry no cluster level and
+    # the framework does NOT join one from sample().  `animal` is the
+    # harmonized species Preferred Label (harmonize_species_ehcvm for the
+    # 1-11 EHCVM codes).  `i` is the EHCVM composite household id built with
+    # benin.i() so it matches sample().i.
+    #
+    # COLUMNS (reported, item-level): HeadCount (owned now), HeadAcquired
+    # (number bought in the last 12 months), HeadSold (number sold on the
+    # hoof in the last 12 months).  A `Value` (herd value) column is
+    # intentionally OMITTED: EHCVM s17 has no current herd-value question.
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    materialize: make

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/crop_production.py
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/crop_production.py
@@ -1,0 +1,105 @@
+"""Build crop_production for Burkina Faso EHCVM 2018-19 (GAP 1, item-level).
+
+Self-contained clone of Niger/2018-19/_/crop_production.py (no
+``import niger``): the helper logic is inlined and the crop / unit maps are
+read from Burkina's own categorical_mapping.org (harmonize_food + u).
+
+Single source file: s16c_me_bfa2018.dta (agriculture crop/harvest module).
+One row per reported (field, parcel, crop) harvest record.  Harvest qty +
+unit (s16cq12a / s16cq12b), sold qty (s16cq16a), sale value (s16cq17), and
+the intercrop flag (s16cq07) are recorded at this plot-crop grain.
+
+ENCODING: loaded with the DEFAULT (utf-8) encoding so the French crop / unit
+labels keep their accents and match the harmonize_food / u table keys.
+
+Index = (t, i, plot, crop, u); plot = "{s16cq02}_{s16cq03}" aligns with
+plot_features' plot_id.  i = EHCVM composite via burkina_faso.ehcvm_i
+(reconciles 100% with sample()).  Unmapped crop / unit labels pass through
+unchanged (kept visible; the GAP-1 reported-only rule).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import (get_dataframe, to_parquet, format_id,
+                                       get_categorical_mapping)
+from burkina_faso import ehcvm_i
+
+
+def _crop_maps():
+    crop_map = get_categorical_mapping(
+        tablename='harmonize_food', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    unit_map = get_categorical_mapping(
+        tablename='u', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    return crop_map, unit_map
+
+
+def _crop_labels(source_labels, crop_map):
+    """Map a crop column (string labels) through harmonize_food.  Unmapped
+    labels pass through unchanged."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: crop_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _unit_labels(unit_series, unit_map):
+    """Map a unit column (string labels) through the u table.  Unmapped
+    labels pass through unchanged."""
+    u = unit_series.astype('string')
+    return u.map(lambda x: unit_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _finish_crop_production(df, t):
+    """Tag t, build the (t, i, plot, crop, u) index, coerce numerics, drop
+    rows with no crop recorded."""
+    for col in ['Quantity', 'Quantity_sold', 'Value_sold']:
+        df[col] = pd.to_numeric(df.get(col), errors='coerce').astype('Float64')
+    if 'harvest_month' not in df.columns:
+        df['harvest_month'] = pd.NA
+    df['harvest_month'] = pd.to_numeric(df['harvest_month'], errors='coerce').astype('Float64')
+    if 'intercropped' not in df.columns:
+        df['intercropped'] = pd.NA
+    df['intercropped'] = df['intercropped'].astype('boolean')
+    df['t'] = t
+    df['crop'] = df['crop'].astype('string')
+    df['u'] = df['u'].astype('string')
+    df = df[df['crop'].notna()]
+    keep = ['t', 'i', 'plot', 'crop', 'u', 'Quantity',
+            'Quantity_sold', 'Value_sold', 'harvest_month', 'intercropped']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'plot', 'crop', 'u'])
+    return df
+
+
+# convert_categoricals=True (default utf-8 encoding) so crop / unit value
+# labels arrive as the accented strings harmonize_food / the u table key on.
+src = get_dataframe('../Data/s16c_me_bfa2018.dta', convert_categoricals=True)
+src_codes = get_dataframe('../Data/s16c_me_bfa2018.dta', convert_categoricals=False)
+
+crop_map, unit_map = _crop_maps()
+
+hh = src_codes.apply(lambda r: ehcvm_i(r['grappe'], r['menage']), axis=1)
+field = src_codes['s16cq02'].apply(format_id)
+parcel = src_codes['s16cq03'].apply(format_id)
+plot = field.astype(str) + '_' + parcel.astype(str)
+
+# intercrop: s16cq07 'Association de cultures' -> True, 'Pure' -> False
+intercropped = src['s16cq07'].map({'Association de cultures': True, 'Pure': False})
+
+df = pd.DataFrame({
+    'i':             hh.values,
+    'plot':          plot.values,
+    'crop':          _crop_labels(src['s16cq04'], crop_map).values,
+    'u':             _unit_labels(src['s16cq12b'], unit_map).values,
+    'Quantity':      src['s16cq12a'].values,
+    'Quantity_sold': src['s16cq16a'].values,
+    'Value_sold':    src['s16cq17'].values,
+    'intercropped':  intercropped.values,
+})
+
+df = _finish_crop_production(df, '2018-19')
+
+assert len(df) > 0, 'crop_production 2018-19 produced no rows'
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/livestock.py
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/livestock.py
@@ -1,0 +1,103 @@
+"""Build livestock for Burkina Faso EHCVM 2018-19 (GAP 4, item-level).
+
+Self-contained clone of Niger/2018-19/_/livestock.py (no ``import niger``):
+the helper logic is inlined and the species code map is read from Burkina's
+own categorical_mapping.org (harmonize_species_ehcvm, copied from Niger).
+
+Single source file: s17_me_bfa2018.dta — the EHCVM section-17 livestock
+('Élevage') roster, one row per (household, species).  The roster is already
+restricted to owned species (s17q03 == 1 for every row).
+
+Columns:
+  s17q02  species code (1-11; harmonize_species_ehcvm -> animal)
+  s17q03  owned/raised this species? (1=Oui / 2=Non) — gate (all ==1 here)
+  s17q06  number belonging to the household (HeadCount owned now)
+  s17q08  number bought in the last 12 months (HeadAcquired)
+  s17q10  number sold on the hoof in the last 12 months (HeadSold)
+
+There is NO current herd-value question in EHCVM s17, so Value is not emitted.
+
+i is the EHCVM composite id reconciling with ``sample()``:
+``format_id(grappe) + '0' + format_id(menage, zeropadding=2)`` via
+``burkina_faso.ehcvm_i`` (NOT the older 3-digit ``i()``, which strands the
+~17% of households with a 3-digit menage off sample — the GAP-4 i-key bug
+this script fixes; verified 100% i-key ∩ sample).  Grain (t, i, animal); no
+v level (livestock is in the framework's _no_v_join set).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, get_categorical_mapping
+from burkina_faso import ehcvm_i
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load an ``{int code -> Preferred Label}`` dict from Burkina's
+    categorical_mapping.org.  Blank / '---' labels map to NA."""
+    raw = get_categorical_mapping(tablename=tablename, idxvars=key,
+                                  **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a raw integer-code Series through ``code_map`` -> string Series,
+    NA where unmapped.  Source loaded convert_categoricals=False."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def _finish_livestock(df, t):
+    """Coerce numeric columns, drop unresolved-species rows, SUM head counts
+    within (t, i, animal) (a within-species sub-type collapse, a no-op for
+    EHCVM which already reports one row per species), build (t, i, animal)."""
+    cols = ['HeadCount', 'HeadAcquired', 'HeadSold']
+    for col in cols:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    df['t'] = t
+    df['animal'] = df['animal'].astype('string')
+    df = df[df['animal'].notna() & df['i'].notna()]
+    df = (df.groupby(['t', 'i', 'animal'], dropna=False)[cols]
+            .sum(min_count=1)
+            .reset_index())
+    keep = ['t', 'i', 'animal'] + cols
+    df = df[keep]
+    df = df.set_index(['t', 'i', 'animal'])
+    return df
+
+
+srcn = get_dataframe('../Data/s17_me_bfa2018.dta', convert_categoricals=False)
+
+ehcvm_map = _harmonized_codes('harmonize_species_ehcvm')
+
+# The roster only carries owned species, but keep the gate for parity / safety.
+owned = srcn['s17q03'] == 1
+srcn = srcn[owned.values]
+
+hh = srcn.apply(lambda r: ehcvm_i(r['grappe'], r['menage']), axis=1)
+
+df = pd.DataFrame({
+    'i':            hh.values,
+    'animal':       _map_codes(srcn['s17q02'], ehcvm_map).values,
+    'HeadCount':    pd.to_numeric(srcn['s17q06'], errors='coerce').values,
+    'HeadAcquired': pd.to_numeric(srcn['s17q08'], errors='coerce').values,
+    'HeadSold':     pd.to_numeric(srcn['s17q10'], errors='coerce').values,
+})
+
+df = _finish_livestock(df, '2018-19')
+
+assert len(df) > 0, 'livestock 2018-19 produced no rows'
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/people_last7days.py
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/people_last7days.py
@@ -1,0 +1,105 @@
+"""Build people_last7days for Burkina Faso EHCVM 2018-19 (GAP 3, item-level).
+
+Self-contained clone of Niger/2018-19/_/people_last7days.py (no ``import
+niger``): the EHCVM 7-day builder and the (t, i, pid) finisher are inlined.
+No categorical maps needed.
+
+Two source files:
+  s04_me_bfa2018.dta — the 7-day employment module (participation dummies).
+  s01_me_bfa2018.dta — the individual roster (age for working_age).
+Merged on (grappe, menage, s01q00a) — the same person key household_roster
+uses.  Grain (t, i, pid); pid = s01q00a; i = EHCVM composite via
+burkina_faso.ehcvm_i (reconciles 100% with sample()).
+
+EHCVM's 7-day module records only the three participation DUMMIES in an
+ECVMA-comparable form (s04q06 farm, s04q07 own-business, s04q08 wage) and
+working_age (roster Age >= 6).  It does NOT record productive-work hours or
+the WB 7-day industry section code, so farm_hrs / SB_hrs / wage_hrs and
+Industry are NA (declared for cross-wave schema parity).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from burkina_faso import ehcvm_i
+
+
+def _yn_bool(series, yes=1, no=2):
+    """Map a 1=Oui / 2=Non item to nullable boolean (other codes -> NA)."""
+    s = pd.to_numeric(series, errors='coerce')
+    out = pd.Series(pd.NA, index=s.index, dtype='boolean')
+    out = out.mask(s == yes, True)
+    out = out.mask(s == no, False)
+    return out
+
+
+def people_last7days_ehcvm(s04, s01, t, pid_col='s01q00a', age_col='s01q04a',
+                           dob_year_col='s01q03c', survey_year=None):
+    """Build the (i, pid, farm_work, SOB_work, wage_work, working_age) frame.
+
+    Age prefers reported years (age_col); else survey_year - birth_year
+    (dob_year_col, 9999 sentinel -> NA).  working_age = Age >= 6."""
+    key = ['grappe', 'menage', pid_col]
+    roster_cols = [age_col, dob_year_col]
+    merged = s04[key + ['s04q06', 's04q07', 's04q08']].merge(
+        s01[key + roster_cols], on=key, how='left')
+
+    hh = merged.apply(lambda r: ehcvm_i(r['grappe'], r['menage']), axis=1)
+    pid = merged[pid_col].apply(format_id)
+
+    age = pd.to_numeric(merged[age_col], errors='coerce')
+    if survey_year is not None:
+        birth = pd.to_numeric(merged[dob_year_col], errors='coerce')
+        birth = birth.where((birth >= 1900) & (birth <= survey_year), pd.NA)
+        age_from_dob = survey_year - birth
+        age = age.where(age.notna(), age_from_dob)
+    working_age = (age >= 6)
+    working_age = working_age.where(age.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        'i': hh.values,
+        'pid': pid.values,
+        'farm_work': _yn_bool(merged['s04q06']).values,
+        'SOB_work': _yn_bool(merged['s04q07']).values,
+        'wage_work': _yn_bool(merged['s04q08']).values,
+        'working_age': working_age.values,
+    })
+    return df
+
+
+def _finish_people_last7days(df, t):
+    """Coerce dtypes, guarantee the full schema, drop rows with no individual
+    key, one row per (t, i, pid), build the (t, i, pid) index."""
+    df = df.copy()
+    df['t'] = t
+    df['pid'] = df['pid'].astype('string')
+    for col in ['farm_work', 'SOB_work', 'wage_work', 'working_age']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = df[col].astype('boolean')
+    for col in ['farm_hrs', 'SB_hrs', 'wage_hrs']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Industry' not in df.columns:
+        df['Industry'] = pd.NA
+    df['Industry'] = df['Industry'].astype('string')
+    df = df[df['i'].notna() & df['pid'].notna()]
+    keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
+            'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
+    df = df[keep]
+    df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
+    df = df.set_index(['t', 'i', 'pid'])
+    return df
+
+
+s04 = get_dataframe('../Data/s04_me_bfa2018.dta', convert_categoricals=False)
+s01 = get_dataframe('../Data/s01_me_bfa2018.dta', convert_categoricals=False)
+
+df = people_last7days_ehcvm(s04, s01, '2018-19', survey_year=2018)
+df = _finish_people_last7days(df, '2018-19')
+
+assert len(df) > 0, 'people_last7days 2018-19 produced no rows'
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/plot_inputs.py
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/plot_inputs.py
@@ -1,0 +1,124 @@
+"""Build plot_inputs for Burkina Faso EHCVM 2018-19 (GAP 2, item-level).
+
+Self-contained clone of Niger/2018-19/_/plot_inputs.py (no ``import
+niger``): helpers inlined; the input / unit / seed-crop maps read from
+Burkina's own categorical_mapping.org (harmonize_input, u,
+harmonize_seed_crop — copied from Niger).
+
+Single source file: s16b_me_bfa2018.dta — the household agricultural-input
+roster, one row per input-type the household was asked about.  Columns:
+  s16bq01   input type (organic / inorganic fert / phyto / seeds-by-crop)
+  s16bq02   USED this input? (1=Oui) — application gate (all Oui in 2018)
+  s16bq03a / s16bq03b   quantity used + native unit
+  s16bq05   purchased? (Oui / Non)
+  s16bq07a  quantity purchased (native unit)
+
+ENCODING: loaded with the DEFAULT (utf-8) encoding so the accented French
+input / unit labels match the harmonize_input / u / harmonize_seed_crop keys.
+
+The EHCVM roster has NO crop column — the seed's crop is embedded in the
+input-type label ('Semences de petit mil'), resolved to the harmonize_food
+crop label via harmonize_seed_crop.  Non-seed input rows carry the CROP_NA
+sentinel.  i = EHCVM composite via burkina_faso.ehcvm_i (reconciles 100%
+with sample()).  No plot column; grain is (t, i, input, crop, u).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import (get_dataframe, to_parquet,
+                                       get_categorical_mapping)
+from burkina_faso import ehcvm_i
+
+
+# Sentinel for the `crop` index level on input rows that are NOT
+# crop-specific.  A non-null token keeps every reported row through the
+# framework's groupby(level=...).first() de-dup (which drops NaN keys).
+CROP_NA = '(not crop-specific)'
+
+
+def _input_maps():
+    input_map = get_categorical_mapping(
+        tablename='harmonize_input', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    unit_map = get_categorical_mapping(
+        tablename='u', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    seed_crop_map = get_categorical_mapping(
+        tablename='harmonize_seed_crop', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    return input_map, unit_map, seed_crop_map
+
+
+def _input_labels(source_labels, input_map):
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: input_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _seed_crop_labels(source_labels, seed_crop_map):
+    """Resolve the crop embedded in a seed-type label ('Semences de petit
+    mil' -> 'Mil') via harmonize_seed_crop.  NA for non-seed input rows."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: seed_crop_map.get(x, pd.NA) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _unit_labels(unit_series, unit_map):
+    u = unit_series.astype('string')
+    return u.map(lambda x: unit_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _finish_plot_inputs(df, t):
+    """Coerce numerics, fill the CROP_NA / 'Manquant' sentinels so the index
+    is fully non-null, drop rows with no input identity, build
+    (t, i, input, crop, u)."""
+    for col in ['Quantity', 'Quantity_purchased']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Purchased' not in df.columns:
+        df['Purchased'] = pd.NA
+    df['Purchased'] = df['Purchased'].astype('boolean')
+    df['t'] = t
+    df['input'] = df['input'].astype('string')
+    if 'crop' not in df.columns:
+        df['crop'] = pd.NA
+    df['crop'] = df['crop'].astype('string').fillna(CROP_NA)
+    df['u'] = df['u'].astype('string').fillna('Manquant')
+    df = df[df['input'].notna()]
+    keep = ['t', 'i', 'input', 'crop', 'u',
+            'Quantity', 'Purchased', 'Quantity_purchased']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'input', 'crop', 'u'])
+    return df
+
+
+src = get_dataframe('../Data/s16b_me_bfa2018.dta', convert_categoricals=True)
+srcn = get_dataframe('../Data/s16b_me_bfa2018.dta', convert_categoricals=False)
+
+input_map, unit_map, seed_crop_map = _input_maps()
+
+# Keep only inputs the household actually applied (s16bq02 == 1 = Oui).
+applied = srcn['s16bq02'] == 1
+src = src[applied.values]
+srcn = srcn[applied.values]
+
+hh = srcn.apply(lambda r: ehcvm_i(r['grappe'], r['menage']), axis=1)
+
+# purchased: s16bq05 Oui/Non (labels with convert_categoricals)
+purchased = src['s16bq05'].map({'Oui': True, 'Non': False})
+
+df = pd.DataFrame({
+    'i':                  hh.values,
+    'input':              _input_labels(src['s16bq01'], input_map).values,
+    'crop':               _seed_crop_labels(src['s16bq01'], seed_crop_map).values,
+    'u':                  _unit_labels(src['s16bq03b'], unit_map).values,
+    'Quantity':           pd.to_numeric(srcn['s16bq03a'], errors='coerce').values,
+    'Purchased':          purchased.values,
+    'Quantity_purchased': pd.to_numeric(srcn['s16bq07a'], errors='coerce').values,
+})
+
+df = _finish_plot_inputs(df, '2018-19')
+
+assert len(df) > 0, 'plot_inputs 2018-19 produced no rows'
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/plot_labor.py
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/plot_labor.py
@@ -1,0 +1,124 @@
+"""Build plot_labor for Burkina Faso EHCVM 2018-19 (GAP 3, item-level).
+
+Self-contained clone of Niger/2018-19/_/plot_labor.py (no ``import niger``):
+the labor-grid reducer and the (t, i, plot, source) finisher are inlined.
+No categorical maps are needed (labor cells are numeric; the `source`
+vocabulary is a tiny fixed in-code set).
+
+Single source file: s16a_me_bfa2018.dta (agriculture-parcel module — the
+same file plot_features reads, so plot ids align by construction).  EHCVM
+records plot labor at the parcel level, family vs non-family (hired) only:
+
+  Family labor (per family member, suffix _1.._N, three phases):
+    s16aq33b_*  days each member worked, prep/sowing phase
+    s16aq35b_*  days each member worked, maintenance phase
+    s16aq37b_*  days each member worked, harvest phase
+  -> family PersonDays = Σ over members & phases.
+
+  Non-family / hired labor (per worker gender category, suffix _1.._N, three
+  phases; a = #workers, b = days each, c = wage paid):
+    s16aq39{a,b,c}_*  prep/sowing phase
+    s16aq41{a,b,c}_*  maintenance phase
+    s16aq43{a,b,c}_*  harvest phase
+  -> hired PersonDays = Σ (a workers × b days); hired Wage = Σ c.
+
+One row per (plot, source); plot = "{s16aq02}_{s16aq03}" aligns with
+crop_production / plot_features plot_id.  i = EHCVM composite via
+burkina_faso.ehcvm_i (reconciles 100% with sample()).  Grain
+(t, i, plot, source); v joined from sample() by the framework.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+from burkina_faso import ehcvm_i
+
+
+LABOR_SOURCE_FAMILY = 'family'
+LABOR_SOURCE_HIRED = 'hired'
+
+
+def plot_labor_ehcvm(src, t):
+    """Reduce the s16a labor grids to one (i, plot, source) row per labor
+    source, returning the long frame [i, plot, source, PersonDays, Wage]."""
+    cols = list(src.columns)
+
+    def _num(col):
+        return pd.to_numeric(src[col], errors='coerce').astype('Float64')
+
+    hh = src.apply(lambda r: ehcvm_i(r['grappe'], r['menage']), axis=1)
+    field = src['s16aq02'].apply(format_id)
+    parcel = src['s16aq03'].apply(format_id)
+    plot = field.astype('string') + '_' + parcel.astype('string')
+
+    # family: sum member-day cells across the three phase grids
+    fam_cols = [c for c in cols
+                if c.startswith('s16aq33b_')
+                or c.startswith('s16aq35b_')
+                or c.startswith('s16aq37b_')]
+    fam_days = sum(_num(c).fillna(0) for c in fam_cols)
+    fam_any = pd.concat([_num(c).notna() for c in fam_cols], axis=1).any(axis=1)
+    fam_days = fam_days.where(fam_any.values, pd.NA)
+    fam = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_FAMILY,
+        'PersonDays': fam_days.values, 'Wage': pd.NA,
+    })
+
+    # hired: Σ(#workers × days) person-days, Σ wage, over phase × category
+    hired_days = pd.Series(0.0, index=src.index, dtype='Float64')
+    hired_wage = pd.Series(0.0, index=src.index, dtype='Float64')
+    any_days = pd.Series(False, index=src.index)
+    any_wage = pd.Series(False, index=src.index)
+    for base in ['s16aq39', 's16aq41', 's16aq43']:
+        for ac in [c for c in cols if c.startswith(base + 'a_')]:
+            suf = ac[len(base + 'a'):]   # e.g. '_1' (keeps the underscore)
+            bc, cc = base + 'b' + suf, base + 'c' + suf
+            workers = _num(ac)
+            days = _num(bc) if bc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            wage = _num(cc) if cc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            pd_cell = workers * days
+            hired_days = hired_days.add(pd_cell.fillna(0))
+            any_days = any_days | pd_cell.notna().values
+            hired_wage = hired_wage.add(wage.fillna(0))
+            any_wage = any_wage | wage.notna().values
+    hired_days = hired_days.where(any_days.values, pd.NA)
+    hired_wage = hired_wage.where(any_wage.values, pd.NA)
+    hired = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_HIRED,
+        'PersonDays': hired_days.values, 'Wage': hired_wage.values,
+    })
+
+    return pd.concat([fam, hired], ignore_index=True)
+
+
+def _finish_plot_labor(df, t):
+    """Sum PersonDays / Wage within (t, i, plot, source) (a within-source
+    collapse of the member / category / phase strata), drop rows with no
+    plot / source / reported labor, build (t, i, plot, source)."""
+    df = df.copy()
+    df['t'] = t
+    df['source'] = df['source'].astype('string')
+    df['plot'] = df['plot'].astype('string')
+    df['PersonDays'] = pd.to_numeric(df.get('PersonDays'), errors='coerce').astype('Float64')
+    if 'Wage' not in df.columns:
+        df['Wage'] = pd.NA
+    df['Wage'] = pd.to_numeric(df['Wage'], errors='coerce').astype('Float64')
+    df = df[df['i'].notna() & df['plot'].notna() & df['source'].notna()]
+    df = (df.groupby(['t', 'i', 'plot', 'source'], dropna=False)[['PersonDays', 'Wage']]
+            .sum(min_count=1)
+            .reset_index())
+    df = df[df['PersonDays'].notna() | df['Wage'].notna()]
+    df = df.set_index(['t', 'i', 'plot', 'source'])
+    return df
+
+
+src = get_dataframe('../Data/s16a_me_bfa2018.dta', convert_categoricals=False)
+df = plot_labor_ehcvm(src, '2018-19')
+df = _finish_plot_labor(df, '2018-19')
+
+assert len(df) > 0, 'plot_labor 2018-19 produced no rows'
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Burkina_Faso/_/burkina_faso.py
+++ b/lsms_library/countries/Burkina_Faso/_/burkina_faso.py
@@ -14,6 +14,36 @@ def i(value):
     '''
     return tools.format_id(value.iloc[0]) + tools.format_id(value.iloc[1], zeropadding=3)
 
+
+def ehcvm_i(grappe, menage):
+    '''Canonical EHCVM household id reconciling with ``sample()``.
+
+    The Burkina EHCVM 2018-19 ``sample`` table builds ``i`` as
+    ``format_id(grappe) + '0' + format_id(menage, zeropadding=2)`` —
+    grappe, a literal ``'0'`` separator, then the menage zero-padded to
+    TWO digits.  (Verified empirically: this gives a 100% i-key
+    intersection with ``sample().i`` across s00/s01/s04/s16a/s16b/s16c/s17.)
+
+    This deliberately differs from the older :func:`i` above, which uses
+    ``format_id(grappe) + format_id(menage, zeropadding=3)`` (no separator,
+    3-digit menage).  The two AGREE only for two-digit menage; for the
+    ~17% of households with a three-digit menage (100-527) they diverge —
+    e.g. grappe=472, menage=141 -> :func:`i` makes ``'472141'`` but
+    ``sample()`` (and this helper) make ``'4720141'``.  Using :func:`i`
+    for the agriculture/livestock rosters therefore stranded ~17% of
+    households off ``sample()`` (the GAP-4 livestock i-key bug).  New
+    EHCVM features (livestock, crop_production, plot_inputs, plot_labor,
+    people_last7days) MUST use this helper.  ``i`` is left untouched
+    because ``food_acquired`` / ``plot_features`` already depend on it.
+
+    Returns None if either component is missing.
+    '''
+    g = tools.format_id(grappe)
+    m = tools.format_id(menage, zeropadding=2)
+    if g is None or m is None:
+        return None
+    return g + '0' + m
+
 def _household_roster_from_df(df, sex, age, HHID, sex_converter=None, age_converter=None,
                                months_spent='months_spent', Age_ints=None):
     """Inline replacement for lsms.tools.get_household_roster(fn_type=None)."""

--- a/lsms_library/countries/Burkina_Faso/_/categorical_mapping.org
+++ b/lsms_library/countries/Burkina_Faso/_/categorical_mapping.org
@@ -459,3 +459,109 @@
 |    1 | freehold                   |
 |    2 | granted_right_of_occupancy |
 |    4 | leasehold                  |
+
+* Agriculture input / seed-crop / livestock-species harmonization
+#  (GAP 1-4 EHCVM parity, parity-loop 2026-06-15).  Copied from the Niger
+#  EHCVM reference (Niger/_/categorical_mapping.org).  These tables back the
+#  self-contained crop_production / plot_inputs / livestock wave scripts.
+#
+#  ENCODING NOTE: the Burkina EHCVM agriculture files (s16b/s16c) must be
+#  read with the DEFAULT (utf-8) encoding so the French value labels arrive
+#  with their accents intact ('Engrais inorganiques - Urée', 'Semences de
+#  maïs') — these are the keys below.  Reading with encoding='iso-8859-1'
+#  (as food_acquired.py does) STRIPS the accents ('Ure', 'mas') and would
+#  break every string match here.
+
+# harmonize_input — s16bq01 input-type label -> canonical input identity.
+# Keyed on the utf-8 value label (Original Label).  Burkina's trailing seed
+# slot whose label text was not stored is the bare '21' (the Niger sibling
+# uses '20'); it is the 'Autres semences' code -> Seed.
+
+#+NAME: harmonize_input
+| Original Label                            | Preferred Label     |
+|-------------------------------------------+---------------------|
+| engrais organiques-fumure                 | Organic manure      |
+| Engrais organiques-Fumure                 | Organic manure      |
+| Engrais organiques - déchets d'animaux    | Organic manure      |
+| engrais organiques-compost                | Organic compost     |
+| Engrais organiques-Compost                | Organic compost     |
+| Engrais organiques - Ordures ménagères    | Organic compost     |
+| engrais inorganiques - urée               | Urea                |
+| Engrais inorganiques - Urée               | Urea                |
+| engrais inorganiques - dap                | DAP                 |
+| Engrais inorganiques - DAP                | DAP                 |
+| DAP et autres engrais inorganiques        | DAP                 |
+| engrais inorganiques - npk 15/15          | NPK                 |
+| Engrais inorganiques - NPK 15/15          | NPK                 |
+| Engrais inorganiques - NPK/Formule unique | NPK                 |
+| Engrais inorganiques - Phosphates         | Phosphate           |
+| engrais inorganiques - mélange            | Mixed fertilizer    |
+| Engrais inorganiques - Mélange            | Mixed fertilizer    |
+| produits phytosanitaires - pesticides     | Pesticide           |
+| Produits phytosanitaires - Pesticides     | Pesticide           |
+| produits phytosanitaires - herbicides     | Herbicide           |
+| Produits phytosanitaires - Herbicides     | Herbicide           |
+| produits phytosanitaires - fongicides     | Fungicide           |
+| Produits phytosanitaires - Fongicides     | Fungicide           |
+| Produits phytosanitaires-Fongicides       | Fungicide           |
+| Produits phytosanitaires -Fongicides      | Fungicide           |
+| autres produits phytosanitaires           | Other phytosanitary |
+| Autres produits phytosanitaires           | Other phytosanitary |
+| semences                                  | Seed                |
+| Semences                                  | Seed                |
+| Semences de petit mil                     | Seed                |
+| Semences de sorgho                        | Seed                |
+| Semences de maïs                          | Seed                |
+| Semences de riz                           | Seed                |
+| Semences d'autres céréales                | Seed                |
+| Semences de coton                         | Seed                |
+| Semences de sésame                        | Seed                |
+| Semences de césame                        | Seed                |
+| Semences de haricots/niébé                | Seed                |
+| Plants/boutures de tubercules             | Seed                |
+| Autres semences                           | Seed                |
+| 20                                        | Seed                |
+| 21                                        | Seed                |
+
+# harmonize_seed_crop — EHCVM-only.  The s16b roster has NO crop column;
+# the crop is encoded in the seed-type label.  Resolves each seed label to
+# the crop's harmonize_food Preferred Label.  Catch-all seed slots ->
+# 'Autre crop'.  '21' is Burkina's trailing 'Autres semences' slot.
+
+#+NAME: harmonize_seed_crop
+| Original Label                | Preferred Label     |
+|-------------------------------+---------------------|
+| Semences de petit mil         | Mil                 |
+| Semences de sorgho            | Sorgho              |
+| Semences de maïs              | Maïs en grain       |
+| Semences de riz               | Riz Paddy           |
+| Semences de coton             | Coton               |
+| Semences de sésame            | Sésame              |
+| Semences de césame            | Sésame              |
+| Semences de haricots/niébé    | Niébé/Haricots secs |
+| Semences d'autres céréales    | Autre crop          |
+| Plants/boutures de tubercules | Autre crop          |
+| Autres semences               | Autre crop          |
+| 20                            | Autre crop          |
+| 21                            | Autre crop          |
+
+# harmonize_species_ehcvm — s17q02 livestock species CODE (1-11) ->
+# canonical species Preferred Label.  Code-keyed (load s17 with
+# convert_categoricals=False).  Codes are the elevage__id value labels:
+# 1 Bovins, 2 Ovins, 3 Caprins, 4 Camelins, 5 Equins, 6 Asins,
+# 7 Porcins, 8 Lapins, 9 Poules, 10 Pintades, 11 Autres volailles.
+
+#+NAME: harmonize_species_ehcvm
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Cattle          |
+|    2 | Sheep           |
+|    3 | Goats           |
+|    4 | Camels          |
+|    5 | Horses          |
+|    6 | Donkeys         |
+|    7 | Pigs            |
+|    8 | Rabbits         |
+|    9 | Chicken         |
+|   10 | Guinea Fowl     |
+|   11 | Other Poultry   |

--- a/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
+++ b/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
@@ -170,6 +170,121 @@ Data Scheme:
     index: (t, i)
     Int_t: datetime
 
+  crop_production:
+    # Item-level crop harvest (GAP 1; EHCVM parity loop 2026-06-15, cloned
+    # self-contained from Niger).  One row per REPORTED (field, parcel,
+    # crop) harvest line — REPORTED values only (harvest_kg / yield /
+    # main_crop are transformations, never columns).  2018-19 only: s16c
+    # records harvest qty+unit (s16cq12a/b), sold qty (s16cq16a), sale
+    # value (s16cq17) and the intercrop flag (s16cq07) at this plot-crop
+    # grain.  crop joins food via harmonize_food Preferred Labels; u via
+    # the u table; unmapped labels pass through unchanged.  u is in the
+    # index because one (plot, crop) can be reported in several units.
+    # plot = "{field_no}_{parcel_no}" aligns with plot_features' plot_id.
+    # i is the canonical EHCVM id (burkina_faso.ehcvm_i: grappe + '0' +
+    # 2-digit menage) reconciling 100% with sample().  harvest_month NA
+    # (no planting/harvest-date question in s16c); intercropped from
+    # s16cq07.
+    index: (t, i, plot, crop, u)
+    Quantity: float
+    Quantity_sold: float
+    Value_sold: float
+    harvest_month: float
+    intercropped: bool
+    materialize: make
+
+  plot_inputs:
+    # Item-level agricultural inputs (GAP 2; EHCVM parity loop 2026-06-15,
+    # cloned self-contained from Niger).  One row per REPORTED input
+    # applied: input identity (Seed / Urea / DAP / NPK / Phosphate / Mixed
+    # fertilizer / Organic manure / Organic compost / Pesticide / Herbicide
+    # / Fungicide / Other phytosanitary), reported quantity used + native
+    # unit, purchased flag + reported purchased quantity, and (seed rows)
+    # the seed's crop on the shared harmonize_food labels.  REPORTED values
+    # only.  Source s16b (2018-19) records inputs at the HOUSEHOLD x input
+    # grain, NOT plot x input (no parcel-level input data); the GAP-2 name
+    # `plot_inputs` is kept but `plot` is NOT in the index.  input ->
+    # harmonize_input; u -> the u table; the EHCVM roster has no crop
+    # column so seed crop is resolved from the seed label via
+    # harmonize_seed_crop.  Non-crop-specific rows carry the sentinel
+    # '(not crop-specific)' and a missing unit carries 'Manquant' — a NaN
+    # index level would be dropped by the framework's canonical NaN-key
+    # de-dup collapse.  i via burkina_faso.ehcvm_i (100% sample reconcile).
+    # ENCODING: s16b read default (utf-8) so accented labels match the maps.
+    index: (t, i, input, crop, u)
+    Quantity: float
+    Purchased: bool
+    Quantity_purchased: float
+    materialize: make
+
+  livestock:
+    # Item-level livestock roster (GAP 4; EHCVM parity loop 2026-06-15,
+    # cloned self-contained from Niger).  One row per REPORTED (household,
+    # species) owned — the pre-collapse roster (the WB engaged-in-livestock
+    # binary is groupby(['t','i']).any() over these rows; TLU is a
+    # Σ(head × factor) transform — neither is a column here).  GRAIN
+    # (t, i, animal) — NO v level ('livestock' is in the framework
+    # _no_v_join set).  `animal` is the harmonize_species_ehcvm Preferred
+    # Label (s17q02 codes 1-11 -> Cattle / Sheep / Goats / Camels / Horses
+    # / Donkeys / Pigs / Rabbits / Chicken / Guinea Fowl / Other Poultry).
+    # 2018-19 only: s17q06 head owned, s17q08 bought (HeadAcquired), s17q10
+    # sold; roster pre-filtered to owned species (s17q03==1).  No herd
+    # Value column (s17 records only purchase/sale FLOW values).
+    #
+    # I-KEY FIX (2026-06-15): the original (un-merged) livestock draft used
+    # the older burkina_faso.i() (grappe + 3-digit menage) which collides
+    # for the ~17% of households with a 3-digit menage, stranding them off
+    # sample() (83.4% i-key).  This build uses burkina_faso.ehcvm_i
+    # (grappe + '0' + 2-digit menage) — the SAME format sample() uses —
+    # giving 100% i-key ∩ sample.
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    materialize: make
+
+  plot_labor:
+    # Item-level plot labor (GAP 3; EHCVM parity loop 2026-06-15, cloned
+    # self-contained from Niger).  One row per REPORTED labor SOURCE on a
+    # plot (the WB total_*_labor_days / hired_labor_value sums are
+    # transformations, never columns).  GRAIN (t, i, plot, source):
+    # plot = "{field_no}_{parcel_no}" aligned with crop_production /
+    # plot_features; source 'family' / 'hired' (EHCVM s16a records family
+    # vs non-family only — no free/exchange 'other').  PersonDays is the
+    # within-source sum of the member / gender-category / phase day cells
+    # (EHCVM hired = Σ #workers × days); Wage is the cash paid to hired
+    # labor (NaN for family).  i via burkina_faso.ehcvm_i (100% reconcile);
+    # v joins from sample().  2018-19 only (s16a family grids s16aq33/35/37b
+    # + hired grids s16aq39/41/43{a,b,c}).
+    index: (t, i, plot, source)
+    PersonDays: float
+    Wage: float
+    materialize: make
+
+  people_last7days:
+    # Item-level individual 7-day labor (GAP 3; EHCVM parity loop
+    # 2026-06-15, cloned self-contained from Niger).  One row per
+    # individual with the REPORTED last-7-days labor participation (this is
+    # the (t, i, pid) per-individual feature, NOT Uganda's legacy HH-level
+    # count).  GRAIN (t, i, pid): pid = s01q00a (matches household_roster);
+    # i via burkina_faso.ehcvm_i (100% reconcile); v auto-joins from
+    # sample().  COLUMNS: farm_work / SOB_work / wage_work (s04q06/07/08
+    # 1=Oui/2=Non -> bool) and working_age (roster Age >= 6, Age from
+    # s01q04a else 2018 - s01q03c birth year).  EHCVM's 7-day module
+    # records no productive-work hours nor the WB 7-day industry section
+    # code, so farm_hrs / SB_hrs / wage_hrs / Industry are NA (declared for
+    # cross-country schema parity).  2018-19 only.
+    index: (t, i, pid)
+    farm_work: bool
+    SOB_work: bool
+    wage_work: bool
+    farm_hrs: float
+    SB_hrs: float
+    wage_hrs: float
+    Industry: str
+    working_age: bool
+    materialize: make
+
   food_expenditures: !make
   food_prices: !make
   food_quantities: !make

--- a/lsms_library/countries/CotedIvoire/2018-19/_/crop_production.py
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/crop_production.py
@@ -1,0 +1,123 @@
+"""Build crop_production for CotedIvoire EHCVM 2018-19 (GAP 1, item-level).
+
+Single source file: ../Data/Menage/s16c_me_CIV2018.dta (agriculture
+crop/harvest module).  One row per reported (field, parcel, crop) harvest
+record.  Harvest qty + unit (s16cq12a / s16cq12b), sold qty (s16cq16a), sale
+value (s16cq17), and the intercrop flag (s16cq07) are ALL recorded at this
+plot-crop grain in 2018-19, so no cross-file join is needed.  This is the
+CotedIvoire analogue of Niger's EHCVM 2018-19 s16c crop module; the column
+scheme verified identical.
+
+Index = (t, i, plot, crop, u); plot = "{s16cq02}_{s16cq03}" aligns with
+plot_features' plot_id.
+
+i is CotedIvoire's EHCVM composite household id.  CotedIvoire PREDATES the
+standard EHCVM list (CLAUDE.md) and uses a DIFFERENT id scheme from the
+Niger / Senegal / Mali EHCVM siblings: NO 'E_' prefix and NO '0' separator —
+just ``format_id(grappe) + format_id(menage, zeropadding=3)`` (e.g.
+grappe=1, menage=3 -> '1003'), matching sample().i.  Inlined here (NOT
+imported from niger / cotedivoire) to keep this wave script self-contained.
+
+CROP LABELS: CotedIvoire has NO harmonize_food table (its food harmonization
+is code-keyed via food_items, not a string label table; and its forest/cash
+crops — Cacao, Anacarde, Hévéa, Café — are absent from the Sahelian Niger
+table).  So crop labels pass through UNCHANGED (the harmonized French label,
+kept visible and flagged by the sanity checker) where no map applies — the
+same pass-through behavior Niger's _crop_labels uses for unmapped labels.
+If a country-level harmonize_food is added later it is picked up
+automatically.  Units map through the existing CotedIvoire `u` table.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id, get_categorical_mapping
+
+
+def _i(grappe, menage):
+    """CotedIvoire EHCVM household id: format_id(grappe) +
+    format_id(menage, zeropadding=3).  Inlined copy of cotedivoire.i() so
+    this wave script is self-contained.  Returns None if either part is
+    missing so the _finish gate drops the row."""
+    g = format_id(grappe)
+    m = format_id(menage, zeropadding=3)
+    if g is None or m is None:
+        return None
+    return g + m
+
+
+def _label_map(tablename):
+    """Load a {Original Label -> Preferred Label} dict from
+    categorical_mapping.org, returning {} (pass-through) if the table is
+    absent.  Mirrors niger.py:_crop_maps but tolerant of a missing table."""
+    try:
+        return get_categorical_mapping(
+            tablename=tablename, idxvars='Original Label',
+            **{'Preferred Label': 'Preferred Label'})
+    except (FileNotFoundError, KeyError):
+        return {}
+
+
+def _map_labels(source_labels, label_map):
+    """Map a string-label column through ``label_map``.  Unmapped labels pass
+    through unchanged (kept visible, flagged by the sanity checker)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: label_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _finish_crop_production(df, t):
+    """Common tail: tag t, build the (t, i, plot, crop, u) index, coerce
+    numeric columns, guarantee the schema column set.  Mirrors
+    niger.py:_finish_crop_production."""
+    for col in ['Quantity', 'Quantity_sold', 'Value_sold']:
+        df[col] = pd.to_numeric(df.get(col), errors='coerce').astype('Float64')
+    if 'harvest_month' not in df.columns:
+        df['harvest_month'] = pd.NA
+    df['harvest_month'] = pd.to_numeric(df['harvest_month'], errors='coerce').astype('Float64')
+    if 'intercropped' not in df.columns:
+        df['intercropped'] = pd.NA
+    df['intercropped'] = df['intercropped'].astype('boolean')
+    df['t'] = t
+    df['crop'] = df['crop'].astype('string')
+    df['u'] = df['u'].astype('string')
+    # Drop placeholder rows with no crop recorded (a parcel listed but no
+    # crop grown / reported on the line).
+    df = df[df['crop'].notna() & df['i'].notna()]
+    keep = ['t', 'i', 'plot', 'crop', 'u', 'Quantity',
+            'Quantity_sold', 'Value_sold', 'harvest_month', 'intercropped']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'plot', 'crop', 'u'])
+    return df
+
+
+# convert_categoricals=True so crop / unit value labels arrive as the strings
+# harmonize_food (if present) / the u table key on.  Codes file for the
+# field/parcel ids and the (numeric) intercrop fallback.
+src = get_dataframe('../Data/Menage/s16c_me_CIV2018.dta', convert_categoricals=True)
+src_codes = get_dataframe('../Data/Menage/s16c_me_CIV2018.dta', convert_categoricals=False)
+
+crop_map = _label_map('harmonize_food')
+unit_map = _label_map('u')
+
+hh = src_codes.apply(lambda r: _i(r['grappe'], r['menage']), axis=1)
+field = src_codes['s16cq02'].apply(format_id)
+parcel = src_codes['s16cq03'].apply(format_id)
+plot = field.astype(str) + '_' + parcel.astype(str)
+
+# intercrop: s16cq07 == 'Association de cultures' -> True, 'Pure' -> False
+intercropped = src['s16cq07'].astype('string').map(
+    {'Association de cultures': True, 'Pure': False})
+
+df = pd.DataFrame({
+    'i':             hh.values,
+    'plot':          plot.values,
+    'crop':          _map_labels(src['s16cq04'], crop_map).values,
+    'u':             _map_labels(src['s16cq12b'], unit_map).values,
+    'Quantity':      pd.to_numeric(src_codes['s16cq12a'], errors='coerce').values,
+    'Quantity_sold': pd.to_numeric(src_codes['s16cq16a'], errors='coerce').values,
+    'Value_sold':    pd.to_numeric(src_codes['s16cq17'], errors='coerce').values,
+    'intercropped':  intercropped.values,
+})
+
+df = _finish_crop_production(df, '2018-19')
+
+assert len(df) > 0, 'crop_production 2018-19 produced no rows'
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/CotedIvoire/2018-19/_/livestock.py
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/livestock.py
@@ -1,0 +1,119 @@
+"""Build livestock for CotedIvoire EHCVM 2018-19 (GAP 4, item-level).
+
+Single source file: s17_me_CIV2018.dta — the EHCVM section-17 livestock
+('Élevage') roster, one row per (household, species).  The roster is
+already restricted to owned species (s17q03 == 1 for every row).  This is
+the CotedIvoire analogue of the Niger EHCVM 2018-19 s17 roster.
+
+Columns:
+  s17q02  species code (1-11, elevage__id; harmonize_species_ehcvm -> animal)
+  s17q03  owned/raised this species? (1=Oui / 2=Non) — gate (all ==1 here)
+  s17q06  number belonging to the household (HeadCount owned now)
+  s17q08  number bought in the last 12 months (HeadAcquired)
+  s17q10  number sold on the hoof in the last 12 months (HeadSold)
+
+There is NO current herd-value question in EHCVM s17 (s17q05/q06 are head
+counts; s17q09/q13 are purchase/sale FLOW values), so Value is not emitted.
+
+i is CotedIvoire's EHCVM composite household id.  CotedIvoire PREDATES the
+standard EHCVM list (per CLAUDE.md) and uses a DIFFERENT id scheme from the
+Niger / Senegal / Mali EHCVM siblings: NO 'E_' prefix and NO '0' separator —
+just ``format_id(grappe) + format_id(menage, zeropadding=3)`` (e.g.
+grappe=1, menage=3 -> '1003'), matching sample().i.  The logic is inlined
+here (NOT imported from cotedivoire.py) to keep this wave script
+self-contained.  Grain (t, i, animal); no v level (livestock is in the
+framework _no_v_join set).
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, get_categorical_mapping, format_id
+
+
+def _i(grappe, menage):
+    """CotedIvoire EHCVM household id: format_id(grappe) +
+    format_id(menage, zeropadding=3).  Inlined copy of cotedivoire.i()
+    so this wave script is self-contained.  Returns None if either part
+    is missing, so the _finish gate can drop the row."""
+    g = format_id(grappe)
+    m = format_id(menage, zeropadding=3)
+    if g is None or m is None:
+        return None
+    return g + m
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw Stata integer-code) Series through ``code_map``,
+    returning a string Series with NA where the code is unmapped.  Source
+    files are loaded with ``convert_categoricals=False`` so the codes
+    arrive as integers.  Generic helper mirrored from niger.py:_map_codes."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a ``{int code -> Preferred Label}`` dict from
+    categorical_mapping.org.  Codes whose Preferred Label is blank / '---'
+    map to NA.  Generic helper mirrored from niger.py:_harmonized_codes."""
+    raw = get_categorical_mapping(tablename=tablename, idxvars=key,
+                                  **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _finish_livestock(df, t):
+    """Coerce numeric columns, drop unresolved-species / no-id placeholder
+    rows, SUM head counts within (t, i, animal) so each (household,
+    canonical species) is one row, and build the (t, i, animal) index.
+    The EHCVM roster already reports one row per species (codes 1-11), so
+    the sum is effectively a no-op here, but it guarantees a unique index.
+    min_count=1 keeps an all-NaN group NaN.  Value is NOT a column: EHCVM
+    s17 records no current herd value (only purchase / sale flow values).
+    Generic logic mirrored from niger.py:_finish_livestock."""
+    cols = ['HeadCount', 'HeadAcquired', 'HeadSold']
+    for col in cols:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    df['t'] = t
+    df['animal'] = df['animal'].astype('string')
+    df = df[df['animal'].notna() & df['i'].notna()]
+    df = (df.groupby(['t', 'i', 'animal'], dropna=False)[cols]
+            .sum(min_count=1)
+            .reset_index())
+    keep = ['t', 'i', 'animal'] + cols
+    df = df[keep]
+    df = df.set_index(['t', 'i', 'animal'])
+    return df
+
+
+srcn = get_dataframe('../Data/Menage/s17_me_CIV2018.dta', convert_categoricals=False)
+
+ehcvm_map = _harmonized_codes('harmonize_species_ehcvm')
+
+# The roster only carries owned species, but keep the gate for parity / safety.
+owned = srcn['s17q03'] == 1
+srcn = srcn[owned.values]
+
+hh = srcn.apply(lambda r: _i(r['grappe'], r['menage']), axis=1)
+
+df = pd.DataFrame({
+    'i':            hh.values,
+    'animal':       _map_codes(srcn['s17q02'], ehcvm_map).values,
+    'HeadCount':    pd.to_numeric(srcn['s17q06'], errors='coerce').values,
+    'HeadAcquired': pd.to_numeric(srcn['s17q08'], errors='coerce').values,
+    'HeadSold':     pd.to_numeric(srcn['s17q10'], errors='coerce').values,
+})
+
+df = _finish_livestock(df, '2018-19')
+
+assert len(df) > 0, 'livestock 2018-19 produced no rows'
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/CotedIvoire/2018-19/_/people_last7days.py
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/people_last7days.py
@@ -1,0 +1,111 @@
+"""Build people_last7days for CotedIvoire EHCVM 2018-19 (GAP 3, item-level).
+
+Two source files (verified to match Niger's EHCVM 2018-19 layout):
+  ../Data/Menage/s04_me_CIV2018.dta — the 7-day employment module
+                                      (participation dummies s04q06/07/08).
+  ../Data/Menage/s01_me_CIV2018.dta — the individual roster (age for
+                                      working_age).
+Merged on (grappe, menage, s01q00a) — the same person key household_roster
+uses.  Grain (t, i, pid); pid = s01q00a.
+
+EHCVM's 7-day module records only the three participation DUMMIES in an
+ECVMA-comparable form (s04q06 farm, s04q07 own-business, s04q08 wage) and
+working_age (roster Age >= 6).  It does NOT record productive-work hours or
+the WB 7-day industry section code, so farm_hrs / SB_hrs / wage_hrs and
+Industry are NA (declared for cross-wave schema parity).
+
+i is CotedIvoire's EHCVM composite id (grappe + zero-padded(3) menage; NO
+'E_' prefix — CotedIvoire predates the standard EHCVM list), inlined here so
+this wave script is self-contained.  The EHCVM build is an inlined copy of
+niger.py:people_last7days_ehcvm / _finish_people_last7days.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+
+
+def _i(grappe, menage):
+    g = format_id(grappe)
+    m = format_id(menage, zeropadding=3)
+    if g is None or m is None:
+        return None
+    return g + m
+
+
+def _yn_bool(series, yes=1, no=2):
+    """Map a 1=Oui / 2=Non item to nullable boolean (other codes -> NA)."""
+    s = pd.to_numeric(series, errors='coerce')
+    out = pd.Series(pd.NA, index=s.index, dtype='boolean')
+    out = out.mask(s == yes, True)
+    out = out.mask(s == no, False)
+    return out
+
+
+def people_last7days_ehcvm(s04, s01, t, pid_col='s01q00a', age_col='s01q04a',
+                           dob_year_col='s01q03c', survey_year=None):
+    """Build people_last7days for the EHCVM 2018-19 wave.  Inlined copy of
+    niger.py:people_last7days_ehcvm: prefer reported years, else
+    survey_year - birth_year; working_age = Age >= 6."""
+    key = ['grappe', 'menage', pid_col]
+    roster_cols = [age_col, dob_year_col]
+    merged = s04[key + ['s04q06', 's04q07', 's04q08']].merge(
+        s01[key + roster_cols], on=key, how='left')
+
+    hh = merged.apply(lambda r: _i(r['grappe'], r['menage']), axis=1)
+    pid = merged[pid_col].apply(format_id)
+
+    age = pd.to_numeric(merged[age_col], errors='coerce')
+    if survey_year is not None:
+        birth = pd.to_numeric(merged[dob_year_col], errors='coerce')
+        birth = birth.where((birth >= 1900) & (birth <= survey_year), pd.NA)
+        age_from_dob = survey_year - birth
+        age = age.where(age.notna(), age_from_dob)
+    working_age = (age >= 6)
+    working_age = working_age.where(age.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        'i': hh.values,
+        'pid': pid.values,
+        'farm_work': _yn_bool(merged['s04q06']).values,
+        'SOB_work': _yn_bool(merged['s04q07']).values,
+        'wage_work': _yn_bool(merged['s04q08']).values,
+        'working_age': working_age.values,
+    })
+    return df
+
+
+def _finish_people_last7days(df, t):
+    """Coerce dtypes, guarantee the full schema (NA where absent), drop rows
+    with no individual key, build the (t, i, pid) index.  Inlined copy of
+    niger.py:_finish_people_last7days."""
+    df = df.copy()
+    df['t'] = t
+    df['pid'] = df['pid'].astype('string')
+    for col in ['farm_work', 'SOB_work', 'wage_work', 'working_age']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = df[col].astype('boolean')
+    for col in ['farm_hrs', 'SB_hrs', 'wage_hrs']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Industry' not in df.columns:
+        df['Industry'] = pd.NA
+    df['Industry'] = df['Industry'].astype('string')
+    df = df[df['i'].notna() & df['pid'].notna()]
+    keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
+            'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
+    df = df[keep]
+    df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
+    df = df.set_index(['t', 'i', 'pid'])
+    return df
+
+
+s04 = get_dataframe('../Data/Menage/s04_me_CIV2018.dta', convert_categoricals=False)
+s01 = get_dataframe('../Data/Menage/s01_me_CIV2018.dta', convert_categoricals=False)
+
+df = people_last7days_ehcvm(s04, s01, '2018-19', survey_year=2018)
+df = _finish_people_last7days(df, '2018-19')
+
+assert len(df) > 0, 'people_last7days 2018-19 produced no rows'
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/CotedIvoire/2018-19/_/plot_features.py
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/plot_features.py
@@ -1,0 +1,179 @@
+"""Build plot_features for CotedIvoire EHCVM 2018-19 (GH #167; EHCVM cluster).
+
+CotedIvoire is the one EHCVM country that was missing plot_features.  This
+clones the Niger/Mali EHCVM reference (niger.py:plot_features_for_wave,
+PR #284) inline so the wave script is self-contained.
+
+Single source file: ../Data/Menage/s16a_me_CIV2018.dta (agriculture-parcel
+module).  plot_id = "{field_no}_{parcel_no}" (s16aq02 _ s16aq03); unique
+within each (grappe, menage).  The s16a code schemes (tenure s16aq10,
+tenure_system / certificate s16aq13, soil s16aq18, water s16aq17, fertility
+s16aq20, area est s16aq09a/b, GPS area s16aq47 / flag s16aq45) verified to
+match the Niger EHCVM 2018-19 reference; the harmonize_* code tables were
+cloned into CotedIvoire's categorical_mapping.org.
+
+i is CotedIvoire's EHCVM composite id (grappe + zero-padded(3) menage; NO
+'E_' prefix — CotedIvoire predates the standard EHCVM list), inlined here.
+Returns a DataFrame indexed by (t, i, plot_id) with the same canonical
+columns as the Niger reference: Area (ha float), AreaUnit, AreaSelfReported,
+Tenure, TenureSystem, PlotCertificate (nullable bool), SoilType,
+SoilFertility, Irrigated (nullable bool).
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id, get_categorical_mapping
+
+
+def _i(grappe, menage):
+    g = format_id(grappe)
+    m = format_id(menage, zeropadding=3)
+    if g is None or m is None:
+        return None
+    return g + m
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a {int code -> Preferred Label} dict; blank / '---' map to NA.
+    Inlined copy of niger.py:_harmonized_codes."""
+    raw = get_categorical_mapping(tablename=tablename, idxvars=key,
+                                  **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a raw integer-code Series through code_map -> string Series with
+    NA where unmapped.  Inlined copy of niger.py:_map_codes."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def plot_features_for_wave(t, source, colmap):
+    """Build canonical plot_features for one EHCVM wave.  Inlined copy of
+    niger.py:plot_features_for_wave (the Mali sibling contract)."""
+    tenure_map = _harmonized_codes('harmonize_tenure')
+    tenure_system_map = _harmonized_codes('harmonize_tenure_system')
+    soil_map = _harmonized_codes('harmonize_soil')
+    water_map = _harmonized_codes('harmonize_water')
+
+    c = colmap
+
+    # Drop placeholder rows for non-farming households (no field/parcel).
+    src = source[source[c['field_no']].notna() & source[c['parcel_no']].notna()].copy()
+
+    g_col, m_col = c['grappe'], c['menage']
+    hh = src.apply(lambda r: _i(r[g_col], r[m_col]), axis=1)
+
+    field = src[c['field_no']].apply(format_id)
+    parcel = src[c['parcel_no']].apply(format_id)
+    plot_id = field.astype(str) + '_' + parcel.astype(str)
+
+    # Area in hectares.  GPS where measured, else farmer estimate converted
+    # from its declared unit (1=Hectare ->x1, 2=m^2 ->/10000).
+    area_gps = pd.to_numeric(src[c['area_gps']], errors='coerce').astype('Float64')
+    gps_flag = src[c['gps_measured']].astype('Int64')
+
+    est_raw = pd.to_numeric(src[c['area_est']], errors='coerce').astype('Float64')
+    est_unit = src[c['area_est_unit']].astype('Int64')
+    est_ha = est_raw.where(est_unit != 2, est_raw / 10000)
+
+    area_ha = est_ha.copy()
+    use_gps = (gps_flag == 1) & area_gps.notna()
+    area_ha = area_gps.where(use_gps, area_ha)
+
+    # Plausibility clamp (GH #327): NaN out implausible areas (>1000 ha or
+    # non-positive); rows are kept, only the Area value is dropped.
+    area_ha = area_ha.where(((area_ha > 0) & (area_ha <= 1000)) | area_ha.isna(), pd.NA)
+
+    area_unit = pd.Series(['hectares'] * len(src), index=src.index, dtype='string')
+    area_unit = area_unit.where(area_ha.notna(), pd.NA)
+
+    tenure = _map_codes(src[c['tenure']], tenure_map) \
+        if c.get('tenure') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    tenure_system = _map_codes(src[c['tenure_system']], tenure_system_map) \
+        if c.get('tenure_system') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+    soil_type = _map_codes(src[c['soil_type']], soil_map) \
+        if c.get('soil_type') in src.columns else pd.Series(pd.NA, index=src.index, dtype='string')
+
+    irrigated = pd.Series(pd.NA, index=src.index, dtype='boolean')
+    if c.get('water_source') in src.columns:
+        water_label = _map_codes(src[c['water_source']], water_map)
+        irrigated = (water_label == 'Irrigated').astype('boolean')
+        irrigated = irrigated.where(water_label.notna(), pd.NA)
+
+    # AreaSelfReported (WB parity): the reported farmer-estimate parcel area
+    # in hectares, carried distinct from GPS-preferred Area.
+    area_self = est_ha.where(((est_ha > 0) & (est_ha <= 1000)) | est_ha.isna(), pd.NA)
+
+    # PlotCertificate (WB parity): s16aq13 codes 1-5 = a formal land document
+    # -> True; code 7 (Aucun) -> False; code 6 (Autre) and missing -> NA.
+    plot_certificate = pd.Series(pd.NA, index=src.index, dtype='boolean')
+    if c.get('certificate') in src.columns:
+        cert_code = src[c['certificate']].astype('Int64')
+        has_doc = cert_code.isin([1, 2, 3, 4, 5])
+        plot_certificate = has_doc.astype('boolean')
+        plot_certificate = plot_certificate.where(cert_code.isin([1, 2, 3, 4, 5, 7]), pd.NA)
+
+    # SoilFertility (WB parity): s16aq20 1=Bonne -> good, 2=Moyenne -> medium,
+    # 3=Faible -> poor (verified identical labels in CotedIvoire).
+    fertility_map = {1: 'good', 2: 'medium', 3: 'poor'}
+    soil_fertility = pd.Series(pd.NA, index=src.index, dtype='string')
+    if c.get('fertility') in src.columns:
+        soil_fertility = _map_codes(src[c['fertility']], fertility_map)
+
+    df = pd.DataFrame({
+        't':                t,
+        'i':                hh.values,
+        'plot_id':          plot_id.values,
+        'Area':             area_ha.values,
+        'AreaUnit':         area_unit.values,
+        'AreaSelfReported': area_self.values,
+        'Tenure':           tenure.values,
+        'TenureSystem':     tenure_system.values,
+        'PlotCertificate':  plot_certificate.values,
+        'SoilType':         soil_type.values,
+        'SoilFertility':    soil_fertility.values,
+        'Irrigated':        irrigated.values,
+    })
+    # Drop rows with no valid household id before indexing.
+    df = df[df['i'].notna()]
+    df = df.set_index(['t', 'i', 'plot_id'])
+    return df
+
+
+# convert_categoricals=False keeps the integer s16a codes the harmonize_*
+# tables key on.
+src = get_dataframe('../Data/Menage/s16a_me_CIV2018.dta', convert_categoricals=False)
+
+colmap = dict(
+    grappe        = 'grappe',
+    menage        = 'menage',
+    field_no      = 's16aq02',
+    parcel_no     = 's16aq03',
+    area_gps      = 's16aq47',
+    gps_measured  = 's16aq45',
+    area_est      = 's16aq09a',
+    area_est_unit = 's16aq09b',
+    tenure        = 's16aq10',
+    tenure_system = 's16aq13',
+    certificate   = 's16aq13',  # WB plot_certificate: has-any-legal-document bool
+    soil_type     = 's16aq18',
+    water_source  = 's16aq17',
+    fertility     = 's16aq20',  # WB soil-quality tag: reported good/medium/poor
+)
+
+df = plot_features_for_wave('2018-19', src, colmap)
+
+assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2018-19"
+assert len(df) > 0, "plot_features 2018-19 produced no rows"
+
+to_parquet(df, 'plot_features.parquet')

--- a/lsms_library/countries/CotedIvoire/2018-19/_/plot_inputs.py
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/plot_inputs.py
@@ -1,0 +1,124 @@
+"""Build plot_inputs for CotedIvoire EHCVM 2018-19 (GAP 2, item-level).
+
+Single source file: ../Data/Menage/s16b_me_CIV2018.dta — the household
+agricultural-input roster, one row per input-type the household used.
+Columns (verified identical to Niger's EHCVM 2018-19 s16b):
+  s16bq01   input type (organic / inorganic fert / phyto / seeds-by-crop)
+  s16bq02   USED this input? (1=Oui) — application gate (all 1 here)
+  s16bq03a / s16bq03b   quantity used + native unit
+  s16bq05   purchased? (Oui / Non)
+  s16bq07a  quantity purchased (native unit)
+
+We keep s16bq02==1 (applied) rows.  The EHCVM roster has NO crop column —
+the seed's crop is embedded in the input-type label ('Semences de riz'),
+resolved to the crop label via harmonize_seed_crop (cloned from Niger into
+CotedIvoire's categorical_mapping.org).  Non-seed input rows carry the
+CROP_NA sentinel.  Grain (t, i, input, crop, u).
+
+i is CotedIvoire's EHCVM composite id (grappe + zero-padded(3) menage; NO
+'E_' prefix — CotedIvoire predates the standard EHCVM list), inlined here so
+this wave script is self-contained.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id, get_categorical_mapping
+
+
+# Sentinel for the `crop` index level on non-crop-specific input rows.  A
+# partly-null index level would be silently dropped by the framework's
+# canonical-index de-dup (groupby().first() drops NaN keys); a non-null token
+# keeps every reported row.  Mirrors niger.py:CROP_NA.
+CROP_NA = '(not crop-specific)'
+
+
+def _i(grappe, menage):
+    g = format_id(grappe)
+    m = format_id(menage, zeropadding=3)
+    if g is None or m is None:
+        return None
+    return g + m
+
+
+def _label_map(tablename):
+    """Load a {Original Label -> Preferred Label} dict, returning {} if the
+    table is absent (pass-through)."""
+    try:
+        return get_categorical_mapping(
+            tablename=tablename, idxvars='Original Label',
+            **{'Preferred Label': 'Preferred Label'})
+    except (FileNotFoundError, KeyError):
+        return {}
+
+
+def _input_labels(source_labels, input_map):
+    """Map an input-type column through harmonize_input.  Unmapped labels
+    pass through unchanged."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: input_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _seed_crop_labels(source_labels, seed_crop_map):
+    """Resolve the crop embedded in a seed-type label ('Semences de riz' ->
+    'Riz Paddy') via harmonize_seed_crop.  Returns NA for any non-seed label
+    (not in the seed-crop table)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: seed_crop_map.get(x, pd.NA) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _finish_plot_inputs(df, t):
+    """Common tail: coerce numeric columns, guarantee the full schema set,
+    fill the crop / u index levels with sentinels so no row is lost to the
+    framework's NaN-key collapse, build the (t, i, input, crop, u) index.
+    Mirrors niger.py:_finish_plot_inputs."""
+    for col in ['Quantity', 'Quantity_purchased']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Purchased' not in df.columns:
+        df['Purchased'] = pd.NA
+    df['Purchased'] = df['Purchased'].astype('boolean')
+    df['t'] = t
+    df['input'] = df['input'].astype('string')
+    if 'crop' not in df.columns:
+        df['crop'] = pd.NA
+    df['crop'] = df['crop'].astype('string').fillna(CROP_NA)
+    df['u'] = df['u'].astype('string').fillna('Manquant')
+    df = df[df['input'].notna() & df['i'].notna()]
+    keep = ['t', 'i', 'input', 'crop', 'u',
+            'Quantity', 'Purchased', 'Quantity_purchased']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'input', 'crop', 'u'])
+    return df
+
+
+src = get_dataframe('../Data/Menage/s16b_me_CIV2018.dta', convert_categoricals=True)
+srcn = get_dataframe('../Data/Menage/s16b_me_CIV2018.dta', convert_categoricals=False)
+
+input_map = _label_map('harmonize_input')
+unit_map = _label_map('u')
+seed_crop_map = _label_map('harmonize_seed_crop')
+
+# Keep only inputs the household actually applied (s16bq02 == 1 = Oui).
+applied = srcn['s16bq02'] == 1
+src = src[applied.values]
+srcn = srcn[applied.values]
+
+hh = srcn.apply(lambda r: _i(r['grappe'], r['menage']), axis=1)
+
+# purchased: s16bq05 Oui/Non (labels with convert_categoricals)
+purchased = src['s16bq05'].astype('string').map({'Oui': True, 'Non': False})
+
+df = pd.DataFrame({
+    'i':                  hh.values,
+    'input':              _input_labels(src['s16bq01'], input_map).values,
+    'crop':               _seed_crop_labels(src['s16bq01'], seed_crop_map).values,
+    'u':                  _input_labels(src['s16bq03b'], unit_map).values,
+    'Quantity':           pd.to_numeric(srcn['s16bq03a'], errors='coerce').values,
+    'Purchased':          purchased.values,
+    'Quantity_purchased': pd.to_numeric(srcn['s16bq07a'], errors='coerce').values,
+})
+
+df = _finish_plot_inputs(df, '2018-19')
+
+assert len(df) > 0, 'plot_inputs 2018-19 produced no rows'
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/CotedIvoire/2018-19/_/plot_labor.py
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/plot_labor.py
@@ -1,0 +1,129 @@
+"""Build plot_labor for CotedIvoire EHCVM 2018-19 (GAP 3, item-level).
+
+Single source file: ../Data/Menage/s16a_me_CIV2018.dta (agriculture-parcel
+module — the same file plot_features reads, so plot ids align by
+construction).  Column scheme verified identical to Niger's EHCVM 2018-19
+s16a.  EHCVM records plot labor at the parcel level, family vs non-family
+(hired) only (NO free/exchange "other" labor):
+
+  Family labor (per family member, member-grid suffix _1.._N, three phases):
+    s16aq33b_*  days each member worked, prep/sowing phase
+    s16aq35b_*  days each member worked, maintenance phase
+    s16aq37b_*  days each member worked, harvest phase
+  -> family PersonDays = Σ over members & phases of those member-day cells.
+
+  Non-family / hired labor (per worker gender category, grid suffix _1.._4,
+  three phases; a = #workers, b = days each, c = wage paid):
+    s16aq39{a,b,c}_*  prep/sowing phase
+    s16aq41{a,b,c}_*  maintenance phase
+    s16aq43{a,b,c}_*  harvest phase
+  -> hired PersonDays = Σ over categories & phases of (a workers × b days);
+     hired Wage       = Σ over categories & phases of c (cash paid).
+
+One row per (plot, source); plot = "{s16aq02}_{s16aq03}" aligns with
+crop_production / plot_features plot_id.  Grain (t, i, plot, source).
+
+i is CotedIvoire's EHCVM composite id (grappe + zero-padded(3) menage; NO
+'E_' prefix — CotedIvoire predates the standard EHCVM list), inlined here so
+this wave script is self-contained.  The plot_labor_ehcvm reshape and the
+_finish_plot_labor tail are inlined copies of niger.py's shared helpers.
+"""
+import pandas as pd
+
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+
+
+LABOR_SOURCE_FAMILY = 'family'
+LABOR_SOURCE_HIRED = 'hired'
+
+
+def _i(grappe, menage):
+    g = format_id(grappe)
+    m = format_id(menage, zeropadding=3)
+    if g is None or m is None:
+        return None
+    return g + m
+
+
+def plot_labor_ehcvm(src, t):
+    """Reshape an EHCVM s16a parcel module into long (i, plot, source,
+    PersonDays, Wage) rows.  Inlined copy of niger.py:plot_labor_ehcvm."""
+    cols = list(src.columns)
+
+    def _num(col):
+        return pd.to_numeric(src[col], errors='coerce').astype('Float64')
+
+    hh = src.apply(lambda r: _i(r['grappe'], r['menage']), axis=1)
+    field = src['s16aq02'].apply(format_id)
+    parcel = src['s16aq03'].apply(format_id)
+    plot = field.astype('string') + '_' + parcel.astype('string')
+
+    # family: sum member-day cells across the three phase grids
+    fam_cols = [c for c in cols
+                if c.startswith('s16aq33b_')
+                or c.startswith('s16aq35b_')
+                or c.startswith('s16aq37b_')]
+    fam_days = sum(_num(c).fillna(0) for c in fam_cols)
+    fam_any = pd.concat([_num(c).notna() for c in fam_cols], axis=1).any(axis=1)
+    fam_days = fam_days.where(fam_any.values, pd.NA)
+    fam = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_FAMILY,
+        'PersonDays': fam_days.values, 'Wage': pd.NA,
+    })
+
+    # hired: Σ(#workers × days) person-days, Σ wage, over phase × category
+    hired_days = pd.Series(0.0, index=src.index, dtype='Float64')
+    hired_wage = pd.Series(0.0, index=src.index, dtype='Float64')
+    any_days = pd.Series(False, index=src.index)
+    any_wage = pd.Series(False, index=src.index)
+    for base in ['s16aq39', 's16aq41', 's16aq43']:
+        for ac in [c for c in cols if c.startswith(base + 'a_')]:
+            suf = ac[len(base + 'a'):]   # e.g. '_1' (keeps the underscore)
+            bc, cc = base + 'b' + suf, base + 'c' + suf
+            workers = _num(ac)
+            days = _num(bc) if bc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            wage = _num(cc) if cc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            pd_cell = workers * days
+            hired_days = hired_days.add(pd_cell.fillna(0))
+            any_days = any_days | pd_cell.notna().values
+            hired_wage = hired_wage.add(wage.fillna(0))
+            any_wage = any_wage | wage.notna().values
+    hired_days = hired_days.where(any_days.values, pd.NA)
+    hired_wage = hired_wage.where(any_wage.values, pd.NA)
+    hired = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_HIRED,
+        'PersonDays': hired_days.values, 'Wage': hired_wage.values,
+    })
+
+    return pd.concat([fam, hired], ignore_index=True)
+
+
+def _finish_plot_labor(df, t):
+    """Sum PersonDays / Wage within (t, i, plot, source) and build the index.
+    Inlined copy of niger.py:_finish_plot_labor."""
+    df = df.copy()
+    df['t'] = t
+    df['source'] = df['source'].astype('string')
+    df['plot'] = df['plot'].astype('string')
+    df['PersonDays'] = pd.to_numeric(df.get('PersonDays'), errors='coerce').astype('Float64')
+    if 'Wage' not in df.columns:
+        df['Wage'] = pd.NA
+    df['Wage'] = pd.to_numeric(df['Wage'], errors='coerce').astype('Float64')
+    df = df[df['i'].notna() & df['plot'].notna() & df['source'].notna()]
+    df = (df.groupby(['t', 'i', 'plot', 'source'], dropna=False)[['PersonDays', 'Wage']]
+            .sum(min_count=1)
+            .reset_index())
+    # Drop (plot, source) rows with no reported labor at all.
+    df = df[df['PersonDays'].notna() | df['Wage'].notna()]
+    df = df.set_index(['t', 'i', 'plot', 'source'])
+    return df
+
+
+src = get_dataframe('../Data/Menage/s16a_me_CIV2018.dta', convert_categoricals=False)
+df = plot_labor_ehcvm(src, '2018-19')
+df = _finish_plot_labor(df, '2018-19')
+
+assert len(df) > 0, 'plot_labor 2018-19 produced no rows'
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/CotedIvoire/_/Makefile
+++ b/lsms_library/countries/CotedIvoire/_/Makefile
@@ -42,6 +42,27 @@ $(VAR_DIR)/shocks.parquet: shocks.py $(shocks_parquet)
 ../%/_/livestock.parquet: ../%/_/livestock.py categorical_mapping.org
 	(cd $(@D) && python livestock.py)
 
+# EHCVM parity features (plot_features / crop_production / plot_inputs /
+# plot_labor / people_last7days).  Script-path wave tables like livestock:
+# each wave's _/<feature>.py reads its EHCVM source module(s) under
+# ../Data/Menage/ and writes the wave-level parquet via to_parquet().  The
+# wave-level grab_data() has no script fallback, so the per-feature pattern
+# rule runs the wave script (one rule per feature, mirroring livestock).
+../%/_/plot_features.parquet: ../%/_/plot_features.py categorical_mapping.org
+	(cd $(@D) && python plot_features.py)
+
+../%/_/crop_production.parquet: ../%/_/crop_production.py categorical_mapping.org
+	(cd $(@D) && python crop_production.py)
+
+../%/_/plot_inputs.parquet: ../%/_/plot_inputs.py categorical_mapping.org
+	(cd $(@D) && python plot_inputs.py)
+
+../%/_/plot_labor.parquet: ../%/_/plot_labor.py categorical_mapping.org
+	(cd $(@D) && python plot_labor.py)
+
+../%/_/people_last7days.parquet: ../%/_/people_last7days.py
+	(cd $(@D) && python people_last7days.py)
+
 %.parquet: %.py CONTENTS.org tanzania.py
 	(cd $(@D) && python ./$(<F))
 

--- a/lsms_library/countries/CotedIvoire/_/Makefile
+++ b/lsms_library/countries/CotedIvoire/_/Makefile
@@ -35,6 +35,13 @@ $(VAR_DIR)/shocks.parquet: shocks.py $(shocks_parquet)
 ../%/_/shocks.parquet:
 	(cd $(@D) && python shocks.py)
 
+# livestock (GAP 4, item-level).  Script-path wave table: each wave's
+# _/livestock.py reads its s17 roster and writes the wave-level parquet via
+# to_parquet().  The wave-level grab_data() invokes
+# `make ../<wave>/_/livestock.parquet`, so this rule runs that wave script.
+../%/_/livestock.parquet: ../%/_/livestock.py categorical_mapping.org
+	(cd $(@D) && python livestock.py)
+
 %.parquet: %.py CONTENTS.org tanzania.py
 	(cd $(@D) && python ./$(<F))
 

--- a/lsms_library/countries/CotedIvoire/_/categorical_mapping.org
+++ b/lsms_library/countries/CotedIvoire/_/categorical_mapping.org
@@ -79,3 +79,29 @@
 | Tiles              | Tiles           |
 | Dung               | Earth with Dung |
 | Other              | Other           |
+
+* Livestock Species
+
+# harmonize_species_ehcvm — EHCVM s17 livestock species codes (s17q02).
+# Codes are the elevage__id value labels: 1 Bovins, 2 Ovins, 3 Caprins,
+# 4 Camelins, 5 Equins, 6 Asins, 7 Porcins, 8 Lapins, 9 Poules,
+# 10 Pintades, 11 Autres volailles.  The Preferred Label vocabulary is the
+# shared EHCVM/ECVMA `animal` axis (Cattle / Sheep / Goats / Camels /
+# Horses / Donkeys / Pigs / Rabbits / Chicken / Guinea Fowl / Other
+# Poultry).  Referenced from 2018-19/_/livestock.py via
+# get_categorical_mapping('harmonize_species_ehcvm', 'Code', 'Preferred Label').
+
+#+NAME: harmonize_species_ehcvm
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Cattle          |
+|    2 | Sheep           |
+|    3 | Goats           |
+|    4 | Camels          |
+|    5 | Horses          |
+|    6 | Donkeys         |
+|    7 | Pigs            |
+|    8 | Rabbits         |
+|    9 | Chicken         |
+|   10 | Guinea Fowl     |
+|   11 | Other Poultry   |

--- a/lsms_library/countries/CotedIvoire/_/categorical_mapping.org
+++ b/lsms_library/countries/CotedIvoire/_/categorical_mapping.org
@@ -105,3 +105,135 @@
 |    9 | Chicken         |
 |   10 | Guinea Fowl     |
 |   11 | Other Poultry   |
+
+* Plot Features (the plot_id axis)
+
+# EHCVM-standard code-keyed harmonize tables for the agriculture-parcel
+# module s16a_me_CIV2018.dta, cloned verbatim from Niger/_/
+# categorical_mapping.org (PR #284 / #167 EHCVM cluster).  The EHCVM s16a
+# code schemes are uniform across the program, and the CotedIvoire 2018-19
+# s16a codes verified to match exactly:
+#   s16aq10 tenure        codes 1-6 (1 Propriétaire, 2 Prêt gratuit,
+#                         3 Fermage, 4 Métayage, 5 Gage, 6 Autre).
+#   s16aq13 tenure_system codes 1-7 (1 Titre foncier ... 7 Aucun).
+#   s16aq18 soil_type     codes 1-5 (1 Sableux, 2 Limoneux, 3 Argileux,
+#                         4 Glacis, 5 Autre).
+#   s16aq17 water_source  codes 1-6 (1-3 Irrigation*, 4 Pluviale,
+#                         5 Marais/wetlands, 6 Autre -> NA, irrigated NA).
+# Because the mapping is on the integer code (not a country-specific
+# string label), it transfers cleanly; CotedIvoire's code 6 water_source
+# ('Autre') has no Niger entry and falls through to NA (Irrigated NA),
+# which is the intended behavior.  Referenced from
+# 2018-19/_/plot_features.py via get_categorical_mapping(<table>, 'Code',
+# 'Preferred Label').
+
+#+name: harmonize_tenure
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | owned           |
+|    2 | use_right       |
+|    3 | rented_in       |
+|    4 | sharecropped_in |
+|    5 | other_tenure    |
+|    6 | other_tenure    |
+|    7 | owned           |
+
+#+name: harmonize_soil
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | sandy           |
+|    2 | loam            |
+|    3 | clay            |
+|    4 | hardpan         |
+|    5 | other           |
+
+#+name: harmonize_water
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Irrigated       |
+|    2 | Irrigated       |
+|    3 | Irrigated       |
+|    4 | Rain-fed        |
+|    5 | Wetland         |
+
+#+name: harmonize_tenure_system
+| Code | Preferred Label            |
+|------+----------------------------|
+|    1 | freehold                   |
+|    2 | granted_right_of_occupancy |
+|    4 | leasehold                  |
+
+* Agricultural Inputs (plot_inputs — the input axis)
+
+# EHCVM-standard string-keyed input tables for the household
+# agricultural-input roster s16b_me_CIV2018.dta, cloned from Niger/_/
+# categorical_mapping.org (GAP 2, 2026-06-14).  The EHCVM s16bq01 input
+# value labels are program-standard French strings; every CotedIvoire
+# 2018-19 s16bq01 label verified present here (Engrais inorganiques -
+# NPK/Formule unique, Produits phytosanitaires - Herbicides, Semences de
+# riz, DAP et autres engrais inorganiques, ...).  harmonize_seed_crop
+# resolves the crop embedded in each seed-type label onto a crop label
+# (the s16b roster has no crop column).  Referenced from
+# 2018-19/_/plot_inputs.py via get_categorical_mapping(<table>,
+# 'Original Label', 'Preferred Label').
+
+#+NAME: harmonize_input
+| Original Label                            | Preferred Label     |
+|-------------------------------------------+---------------------|
+| engrais organiques-fumure                 | Organic manure      |
+| Engrais organiques-Fumure                 | Organic manure      |
+| Engrais organiques - déchets d'animaux    | Organic manure      |
+| engrais organiques-compost                | Organic compost     |
+| Engrais organiques-Compost                | Organic compost     |
+| Engrais organiques - Ordures ménagères    | Organic compost     |
+| engrais inorganiques - urée               | Urea                |
+| Engrais inorganiques - Urée               | Urea                |
+| engrais inorganiques - dap                | DAP                 |
+| Engrais inorganiques - DAP                | DAP                 |
+| DAP et autres engrais inorganiques        | DAP                 |
+| engrais inorganiques - npk 15/15          | NPK                 |
+| Engrais inorganiques - NPK 15/15          | NPK                 |
+| Engrais inorganiques - NPK/Formule unique | NPK                 |
+| Engrais inorganiques - Phosphates         | Phosphate           |
+| engrais inorganiques - mélange            | Mixed fertilizer    |
+| Engrais inorganiques - Mélange            | Mixed fertilizer    |
+| produits phytosanitaires - pesticides     | Pesticide           |
+| Produits phytosanitaires - Pesticides     | Pesticide           |
+| produits phytosanitaires - herbicides     | Herbicide           |
+| Produits phytosanitaires - Herbicides     | Herbicide           |
+| produits phytosanitaires - fongicides     | Fungicide           |
+| Produits phytosanitaires - Fongicides     | Fungicide           |
+| Produits phytosanitaires-Fongicides       | Fungicide           |
+| Produits phytosanitaires -Fongicides      | Fungicide           |
+| autres produits phytosanitaires           | Other phytosanitary |
+| Autres produits phytosanitaires           | Other phytosanitary |
+| semences                                  | Seed                |
+| Semences                                  | Seed                |
+| Semences de petit mil                     | Seed                |
+| Semences de sorgho                        | Seed                |
+| Semences de maïs                          | Seed                |
+| Semences de riz                           | Seed                |
+| Semences d'autres céréales                | Seed                |
+| Semences de coton                         | Seed                |
+| Semences de sésame                        | Seed                |
+| Semences de césame                        | Seed                |
+| Semences de haricots/niébé                | Seed                |
+| Plants/boutures de tubercules             | Seed                |
+| Autres semences                           | Seed                |
+| 20                                        | Seed                |
+
+#+NAME: harmonize_seed_crop
+| Original Label                | Preferred Label     |
+|-------------------------------+---------------------|
+| Semences de petit mil         | Mil                 |
+| Semences de sorgho            | Sorgho              |
+| Semences de maïs              | Maïs en grain       |
+| Semences de riz               | Riz Paddy           |
+| Semences de coton             | Coton               |
+| Semences de sésame            | Sésame              |
+| Semences de césame            | Sésame              |
+| Semences de haricots/niébé    | Niébé/Haricots secs |
+| Semences d'autres céréales    | Autre crop          |
+| Plants/boutures de tubercules | Autre crop          |
+| Autres semences               | Autre crop          |
+| 20                            | Autre crop          |

--- a/lsms_library/countries/CotedIvoire/_/data_scheme.yml
+++ b/lsms_library/countries/CotedIvoire/_/data_scheme.yml
@@ -119,3 +119,131 @@ Data Scheme:
     HeadAcquired: float
     HeadSold: float
     materialize: make
+
+  plot_features:
+    # Lasting parcel-level characteristics from the EHCVM agriculture
+    # module s16a (GH #167).  CotedIvoire was the one EHCVM country missing
+    # plot_features; this clones the Niger / Mali EHCVM reference (PR #284),
+    # inlined self-contained in 2018-19/_/plot_features.py.  EHCVM 2018-19
+    # only.  plot_id = "{field_no}_{parcel_no}" (s16aq02_s16aq03).
+    #
+    # CotedIvoire predates the standard EHCVM list (CLAUDE.md): household id
+    # is format_id(grappe) + format_id(menage, zeropadding=3) (e.g. '1003'),
+    # NOT the 'E_'+grappe+'0'+menage scheme of the Niger/Mali/Senegal EHCVM
+    # siblings.  Source files live under ../Data/Menage/ (the Menage subdir),
+    # with the UPPERCASE country code in the filename (s16a_me_CIV2018.dta)
+    # but lowercase sNNqNN columns.  The s16a code schemes (tenure s16aq10,
+    # tenure_system / certificate s16aq13, soil s16aq18, water s16aq17,
+    # fertility s16aq20) verified to match the EHCVM reference; the
+    # harmonize_* code tables were cloned into categorical_mapping.org.
+    # Latitude / Longitude are NOT emitted (no decimal-degree parcel GPS).
+    index: (t, i, plot_id)
+    Area: float
+    AreaUnit: str
+    AreaSelfReported: float
+    Tenure: str
+    TenureSystem: str
+    PlotCertificate: bool
+    SoilType: str
+    SoilFertility: str
+    Irrigated: bool
+    materialize: make
+
+  crop_production:
+    # Item-level crop harvest (GAP 1).  One row per REPORTED (field, parcel,
+    # crop) harvest line from s16c_me_CIV2018.dta — REPORTED values only;
+    # harvest_kg / yield / main_crop / value-shares are transformations,
+    # never columns here.  EHCVM 2018-19 (s16c): harvest qty+unit
+    # (s16cq12a/b), sold qty (s16cq16a), sale value (s16cq17), intercrop
+    # (s16cq07) all at this plot-crop grain — no cross-file join.
+    #
+    # CROP LABELS: CotedIvoire has NO harmonize_food string table (its food
+    # harmonization is code-keyed via food_items; and its cash/forest crops
+    # — Cacao, Anacarde, Hévéa, Café — are absent from the Sahelian Niger
+    # table), so crop labels PASS THROUGH unchanged (the harmonized French
+    # label, kept visible) where no map applies — the same pass-through
+    # behavior Niger uses for unmapped labels.  u maps through the existing
+    # CotedIvoire `u` table.  plot = "{field_no}_{parcel_no}" aligns with
+    # plot_features' plot_id; u is in the index (one (plot, crop) can be
+    # reported in several units).  harvest_month is all-NA (not recorded in
+    # 2018-19); carried for cross-wave schema parity.
+    index: (t, i, plot, crop, u)
+    Quantity: float
+    Quantity_sold: float
+    Value_sold: float
+    harvest_month: float
+    intercropped: bool
+    materialize: make
+
+  plot_inputs:
+    # Item-level agricultural inputs (GAP 2).  One row per REPORTED applied
+    # input from s16b_me_CIV2018.dta: input identity (Seed / Urea / DAP / NPK
+    # / Phosphate / Mixed fertilizer / Organic manure / Organic compost /
+    # Pesticide / Herbicide / Fungicide / Other phytosanitary), reported
+    # quantity used + native unit, purchased flag + reported purchased
+    # quantity, and (seed rows) the seed's crop.  REPORTED values only:
+    # seed_kg / nitrogen_kg / any-use flags are transformations, never here.
+    #
+    # GRAIN NOTE: EHCVM records inputs at HOUSEHOLD x input grain, NOT plot x
+    # input (the WB plot split is a fabricated allocation; reported-only rule
+    # forbids it), so `plot` is NOT in the index.  input -> harmonize_input;
+    # u -> the u table; crop (seed rows) via harmonize_seed_crop on the seed
+    # label.  Both harmonize_input and harmonize_seed_crop are EHCVM-standard
+    # string tables cloned from Niger into categorical_mapping.org (every
+    # CotedIvoire s16bq01 label verified present).  Non-crop-specific rows
+    # carry the sentinel '(not crop-specific)'; a missing unit carries
+    # 'Manquant' — non-null index levels so no row is lost to the framework's
+    # NaN-key de-dup collapse.  Same i / path quirks as plot_features.
+    index: (t, i, input, crop, u)
+    Quantity: float
+    Purchased: bool
+    Quantity_purchased: float
+    materialize: make
+
+  plot_labor:
+    # Item-level plot labor (GAP 3).  One row per REPORTED labor SOURCE on a
+    # plot from s16a_me_CIV2018.dta -- the reported person-days the WB .do
+    # collapses to total_labor_days / total_family_labor_days /
+    # total_hired_labor_days / hired_labor_value; all those sums / valuations
+    # are TRANSFORMATIONS over these rows, never columns here.
+    #
+    # GRAIN (t, i, plot, source): source in {family, hired}.  EHCVM s16a
+    # records family (member-day grids s16aq33b_/35b_/37b_) vs non-family /
+    # hired (s16aq39/41/43 {a=#workers, b=days, c=wage}) only -- no free /
+    # exchange 'other' labor.  PersonDays is the within-source sum of the day
+    # cells (strata of the same (plot, source) item, NOT a cross-source
+    # rollup); hired person-days = Σ(#workers × days).  Wage = cash PAID to
+    # hired labor (CFA francs), NaN for family.  plot = "{field_no}_
+    # {parcel_no}" aligns with crop_production / plot_features.  v auto-joins
+    # from sample().  Same i / path quirks as plot_features.
+    index: (t, i, plot, source)
+    PersonDays: float
+    Wage: float
+    materialize: make
+
+  people_last7days:
+    # Item-level individual 7-day labor (GAP 3).  One row per individual,
+    # carrying REPORTED last-7-days labor participation -- the per-individual
+    # activity feature the GAP ranking targets.  Two source files merged on
+    # (grappe, menage, s01q00a): s04_me_CIV2018.dta (7-day dummies) and
+    # s01_me_CIV2018.dta (roster age for working_age).
+    #
+    # GRAIN (t, i, pid): pid = s01q00a (matches household_roster).  v
+    # auto-joins from sample().  COLUMNS: farm_work / SOB_work / wage_work
+    # (worked >=1h on own farm / own business / for a wage in the last 7
+    # days, nullable bool, from s04q06/07/08); working_age (Age >= 6, the
+    # survey threshold).  EHCVM 7-day module records hours only for unpaid
+    # domestic tasks and industry only as 12-month occupation codes (not the
+    # WB 7-day section ranges), so farm_hrs / SB_hrs / wage_hrs / Industry
+    # are NA (declared for cross-wave schema parity with the ECVMA waves of
+    # the sibling countries).  Same i / path quirks as plot_features.
+    index: (t, i, pid)
+    farm_work: bool
+    SOB_work: bool
+    wage_work: bool
+    farm_hrs: float
+    SB_hrs: float
+    wage_hrs: float
+    Industry: str
+    working_age: bool
+    materialize: make

--- a/lsms_library/countries/CotedIvoire/_/data_scheme.yml
+++ b/lsms_library/countries/CotedIvoire/_/data_scheme.yml
@@ -86,3 +86,36 @@ Data Scheme:
   interview_date:
     index: (t, i)
     Int_t: datetime
+
+  livestock:
+    # Item-level livestock roster (GAP 4).  One row per REPORTED
+    # (household, species) the household owns/raises, from EHCVM §17
+    # 'Élevage' (s17_me_CIV2018.dta).  The roster is pre-filtered to owned
+    # species (s17q03 == 1).  An engaged-in-livestock HH binary is
+    # recoverable as groupby(['t','i']).any(); TLU is a Σ(head × factor)
+    # transformation — neither is a column here (item-level / reported
+    # discipline).
+    #
+    # GRAIN (t, i, animal) — NO v level: 'livestock' is in the framework's
+    # _no_v_join set, so the household-level rows carry no cluster level and
+    # the framework does NOT join one from sample().  `animal` is the
+    # harmonized species Preferred Label (harmonize_species_ehcvm: codes
+    # 1-11 -> Cattle / Sheep / Goats / Camels / Horses / Donkeys / Pigs /
+    # Rabbits / Chicken / Guinea Fowl / Other Poultry).
+    #
+    # CotedIvoire predates the standard EHCVM list (CLAUDE.md): its
+    # household id is format_id(grappe) + format_id(menage, zeropadding=3)
+    # (e.g. '1003'), NOT the 'E_'+grappe+'0'+menage scheme the Niger/Mali/
+    # Senegal EHCVM siblings use.  2018-19/_/livestock.py inlines that id
+    # construction to match sample().i.
+    #
+    # COLUMNS (reported, item-level): HeadCount (owned now, s17q06),
+    # HeadAcquired (number bought in the last 12 months, s17q08), HeadSold
+    # (number sold on the hoof in the last 12 months, s17q10).  A `Value`
+    # (herd value) column is OMITTED: EHCVM s17 records no current herd
+    # value (only purchase / sale FLOW values).
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    materialize: make

--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/crop_production.py
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/crop_production.py
@@ -1,0 +1,147 @@
+"""Build crop_production for Guinea-Bissau EHCVM 2018-19 (GAP 1, item-level).
+
+Cloned from Niger/2018-19/_/crop_production.py but SELF-CONTAINED: the
+label maps, the i() builder, and the (t, i, plot, crop, u) finish tail are
+inlined here so this script does not import the niger module.
+
+Single source file: s16c_me_gnb2018.dta (agriculture crop/harvest module).
+One row per reported (field, parcel, crop) harvest record.  Harvest qty +
+unit (s16cq12a / s16cq12b), sold qty + unit (s16cq16a / s16cq16b), sale
+value (s16cq17), and the intercrop flag (s16cq07) are ALL recorded at this
+plot-crop grain in 2018-19, so no cross-file join is needed.
+
+Index = (t, i, plot, crop, u); plot = "{s16cq02}_{s16cq03}" aligns with
+plot_features' plot_id.  i = EHCVM composite via the Guinea-Bissau helper
+(grappe + '0' + zero-padded menage, NO 'E_' prefix).
+
+LABEL NOTE (silent-failure gotcha): Guinea-Bissau's categorical_mapping.org
+has NO harmonize_food table (the EHCVM crop value labels are Portuguese:
+'Cajueiro', 'Arroz paddy', 'Mancarra', ...).  A bare get_categorical_mapping
+on a missing table silently returns the FIRST org table (here `u`), which
+would mis-map crops to unit labels.  We guard with _table_exists(): if the
+named table is absent the map is empty and the raw (Portuguese) crop label
+passes through unchanged — visible and flagged by the sanity checker, never
+silently corrupted.  The `u` table DOES exist for Guinea-Bissau (Portuguese
+units: Kg / Saco grande / Bacia / ...), so units harmonize normally.  The
+intercrop labels are Portuguese ('Associação de culturas' / 'Pura').
+"""
+import os
+
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+
+
+_ORG = os.path.join(os.path.dirname(__file__), '..', '..', '_',
+                    'categorical_mapping.org')
+
+
+def _table_exists(tablename):
+    """True iff categorical_mapping.org declares a ``#+name:`` /
+    ``#+NAME:`` header for ``tablename``.  Guards against
+    get_categorical_mapping's silent fall-through to the first org table
+    when the requested table is absent."""
+    target = ('#+name: ' + tablename).lower()
+    try:
+        with open(_ORG, encoding='utf-8') as fh:
+            for line in fh:
+                if line.strip().lower() == target:
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+def i(value):
+    """Guinea-Bissau EHCVM household id from (grappe, menage).  No 'E_'
+    prefix (single EHCVM wave).  Inlined for self-containment."""
+    if isinstance(value, pd.Series):
+        grappe = tools.format_id(value.iloc[0])
+        menage = tools.format_id(value.iloc[1], zeropadding=2)
+        if grappe is None or menage is None:
+            return None
+        return grappe + '0' + menage
+    return tools.format_id(value)
+
+
+def _safe_map(tablename):
+    """Load a {Original Label -> Preferred Label} dict only if the table
+    really exists; otherwise return {} (identity passthrough)."""
+    if not _table_exists(tablename):
+        return {}
+    return tools.get_categorical_mapping(
+        tablename=tablename, idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+
+
+def _crop_labels(source_labels, crop_map):
+    """Map a crop column (string labels) through crop_map.  Unmapped labels
+    pass through unchanged (kept visible, flagged by the sanity checker)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: crop_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _unit_labels(unit_series, unit_map):
+    """Map a unit column (string labels) through the u table.  Unmapped
+    labels pass through unchanged."""
+    u = unit_series.astype('string')
+    return u.map(lambda x: unit_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _finish_crop_production(df, t):
+    """Tag t, build the (t, i, plot, crop, u) index, coerce numeric columns,
+    guarantee the schema column set, drop rows with no crop recorded."""
+    for col in ['Quantity', 'Quantity_sold', 'Value_sold']:
+        df[col] = pd.to_numeric(df.get(col), errors='coerce').astype('Float64')
+    if 'harvest_month' not in df.columns:
+        df['harvest_month'] = pd.NA
+    df['harvest_month'] = pd.to_numeric(df['harvest_month'], errors='coerce').astype('Float64')
+    if 'intercropped' not in df.columns:
+        df['intercropped'] = pd.NA
+    df['intercropped'] = df['intercropped'].astype('boolean')
+    df['t'] = t
+    df['crop'] = df['crop'].astype('string')
+    df['u'] = df['u'].astype('string')
+    df = df[df['crop'].notna()]
+    keep = ['t', 'i', 'plot', 'crop', 'u', 'Quantity',
+            'Quantity_sold', 'Value_sold', 'harvest_month', 'intercropped']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'plot', 'crop', 'u'])
+    return df
+
+
+# convert_categoricals=True so crop / unit value labels arrive as the
+# strings the (Portuguese) label tables key on; codes for plot ids come from
+# the convert_categoricals=False frame so format_id sees integers.
+src = get_dataframe('../Data/s16c_me_gnb2018.dta', convert_categoricals=True)
+src_codes = get_dataframe('../Data/s16c_me_gnb2018.dta', convert_categoricals=False)
+
+crop_map = _safe_map('harmonize_food')   # absent in GNB -> identity passthrough
+unit_map = _safe_map('u')                # present in GNB
+
+hh = src.apply(lambda r: i(pd.Series([r['grappe'], r['menage']],
+                                     index=['grappe', 'menage'])), axis=1)
+field = src_codes['s16cq02'].apply(format_id)
+parcel = src_codes['s16cq03'].apply(format_id)
+plot = field.astype(str) + '_' + parcel.astype(str)
+
+# intercrop: 'Associação de culturas' (code 2) -> True, 'Pura' (code 1) -> False
+intercropped = src['s16cq07'].astype('string').map(
+    {'Associação de culturas': True, 'Pura': False})
+
+df = pd.DataFrame({
+    'i':             hh.values,
+    'plot':          plot.values,
+    'crop':          _crop_labels(src['s16cq04'], crop_map).values,
+    'u':             _unit_labels(src['s16cq12b'], unit_map).values,
+    'Quantity':      src['s16cq12a'].values,
+    'Quantity_sold': src['s16cq16a'].values,
+    'Value_sold':    src['s16cq17'].values,
+    'intercropped':  intercropped.values,
+})
+
+df = _finish_crop_production(df, '2018-19')
+
+assert len(df) > 0, 'crop_production 2018-19 produced no rows'
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/livestock.py
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/livestock.py
@@ -1,0 +1,127 @@
+"""Build livestock for Guinea-Bissau EHCVM 2018-19 (GAP 4, item-level).
+
+Cloned from Niger/2018-19/_/livestock.py but SELF-CONTAINED: the map /
+finish helpers and the household-id builder are inlined here so this
+script does not import the niger module.
+
+Single source file: s17_me_gnb2018.dta — the EHCVM section-17 livestock
+('Élevage') roster, one row per (household, species).  The roster is
+already restricted to owned species (s17q03 == 1 for every row).
+
+Columns:
+  s17q02  species code (1-11, elevage__id; harmonize_species_ehcvm -> animal)
+  s17q03  owned/raised this species? (1=Oui / 2=Non) — gate (all ==1 here)
+  s17q06  number belonging to the household (HeadCount owned now)
+  s17q08  number bought in the last 12 months (HeadAcquired)
+  s17q10  number sold on the hoof in the last 12 months (HeadSold)
+
+There is NO current herd-value question in EHCVM s17 (s17q05/q06 are head
+counts; s17q09/q13 are purchase/sale FLOW values), so Value is not emitted.
+
+Guinea-Bissau note: the s17 species value LABELS are French/Portuguese,
+but s17q02 carries the same integer 1-11 code scheme as the other EHCVM
+countries, so keying harmonize_species_ehcvm on the integer code is
+language-proof (the file is loaded convert_categoricals=False).
+
+`i` is the EHCVM composite id built with Guinea-Bissau's own formatter
+(format_id(grappe) + '0' + zero-padded format_id(menage)) — NOTE: unlike
+Niger, Guinea-Bissau does NOT prepend the 'E_' panel-namespace prefix, so
+this matches sample().i natively.  Grain (t, i, animal); no v level
+(livestock is in the framework _no_v_join set).
+"""
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+def i(value):
+    """Guinea-Bissau EHCVM household id from (grappe, menage).
+
+    Inlined from Guinea-Bissau/_/guinea_bissau.py so this script is
+    self-contained.  No 'E_' prefix (Guinea-Bissau has a single EHCVM
+    wave, no panel namespace collision to guard against)."""
+    if isinstance(value, pd.Series):
+        grappe = tools.format_id(value.iloc[0])
+        menage = tools.format_id(value.iloc[1], zeropadding=2)
+        if grappe is None or menage is None:
+            return None
+        return grappe + '0' + menage
+    return tools.format_id(value)
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw Stata integer-code) Series through ``code_map``,
+    returning a string Series with NA where the code is unmapped.  The
+    source file is loaded convert_categoricals=False so the codes arrive
+    as integers."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def _species_map():
+    """Load the EHCVM species code->Preferred Label dict (codes 1-11) from
+    categorical_mapping.org.  Keyed on the integer Code."""
+    raw = tools.get_categorical_mapping(tablename='harmonize_species_ehcvm',
+                                        idxvars='Code',
+                                        **{'Preferred Label': 'Preferred Label'})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _finish_livestock(df, t):
+    """Tag t, coerce numeric columns, drop unresolved-species rows, sum head
+    counts within (t, i, animal) so each (household, canonical species) is
+    one row, and build the (t, i, animal) index.  The EHCVM roster already
+    reports one row per species (codes 1-11), so the sum is a no-op here;
+    it is kept for parity with the Niger template.  min_count=1 keeps an
+    all-NaN group NaN rather than 0."""
+    cols = ['HeadCount', 'HeadAcquired', 'HeadSold']
+    for col in cols:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    df['t'] = t
+    df['animal'] = df['animal'].astype('string')
+    df = df[df['animal'].notna() & df['i'].notna()]
+    df = (df.groupby(['t', 'i', 'animal'], dropna=False)[cols]
+            .sum(min_count=1)
+            .reset_index())
+    keep = ['t', 'i', 'animal'] + cols
+    df = df[keep]
+    df = df.set_index(['t', 'i', 'animal'])
+    return df
+
+
+srcn = get_dataframe('../Data/s17_me_gnb2018.dta', convert_categoricals=False)
+
+ehcvm_map = _species_map()
+
+# The roster only carries owned species, but keep the gate for parity / safety.
+owned = srcn['s17q03'] == 1
+srcn = srcn[owned.values]
+
+hh = srcn.apply(lambda r: i(pd.Series([r['grappe'], r['menage']],
+                                       index=['grappe', 'menage'])), axis=1)
+
+df = pd.DataFrame({
+    'i':            hh.values,
+    'animal':       _map_codes(srcn['s17q02'], ehcvm_map).values,
+    'HeadCount':    pd.to_numeric(srcn['s17q06'], errors='coerce').values,
+    'HeadAcquired': pd.to_numeric(srcn['s17q08'], errors='coerce').values,
+    'HeadSold':     pd.to_numeric(srcn['s17q10'], errors='coerce').values,
+})
+
+df = _finish_livestock(df, '2018-19')
+
+assert len(df) > 0, 'livestock 2018-19 produced no rows'
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/people_last7days.py
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/people_last7days.py
@@ -1,0 +1,121 @@
+"""Build people_last7days for Guinea-Bissau EHCVM 2018-19 (GAP 3, item-level).
+
+Cloned from Niger/2018-19/_/people_last7days.py but SELF-CONTAINED: the
+EHCVM 7-day reducer and the (t, i, pid) finish tail are inlined here so
+this script does not import the niger module.
+
+Two source files:
+  s04_me_gnb2018.dta — the 7-day employment module (participation dummies).
+  s01_me_gnb2018.dta — the individual roster (age for working_age).
+Merged on (grappe, menage, s01q00a) — the same person key household_roster
+uses.  Grain (t, i, pid); pid = s01q00a; i = EHCVM composite via the
+Guinea-Bissau helper (grappe + '0' + zero-padded menage, NO 'E_' prefix).
+
+EHCVM's 7-day module records only the three participation DUMMIES in an
+ECVMA-comparable form (s04q06 farm, s04q07 own-business, s04q08 wage) and
+working_age (roster Age >= 6).  It does NOT record productive-work hours or
+the WB 7-day industry section code, so farm_hrs / SB_hrs / wage_hrs and
+Industry are NA (declared for cross-wave schema parity).  No categorical
+tables are needed: the dummies are integer-coded (1=yes / 2=no) and age is
+numeric, so the Portuguese value labels are irrelevant (loaded
+convert_categoricals=False).
+"""
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+def i(value):
+    """Guinea-Bissau EHCVM household id from (grappe, menage).  No 'E_'
+    prefix (single EHCVM wave).  Inlined for self-containment."""
+    if isinstance(value, pd.Series):
+        grappe = tools.format_id(value.iloc[0])
+        menage = tools.format_id(value.iloc[1], zeropadding=2)
+        if grappe is None or menage is None:
+            return None
+        return grappe + '0' + menage
+    return tools.format_id(value)
+
+
+def _yn_bool(series, yes=1, no=2):
+    """Map a 1=Oui/Sim / 2=Non/Não survey item to nullable boolean (other
+    codes, e.g. 9 'no answer', -> NA).  Keyed on the integer code, so the
+    Portuguese labels do not matter."""
+    s = pd.to_numeric(series, errors='coerce')
+    out = pd.Series(pd.NA, index=s.index, dtype='boolean')
+    out = out.mask(s == yes, True)
+    out = out.mask(s == no, False)
+    return out
+
+
+def people_last7days_ehcvm(s04, s01, t, pid_col='s01q00a', age_col='s01q04a',
+                           dob_year_col='s01q03c', survey_year=None):
+    """Build people_last7days for the EHCVM wave from its s04 (7-day dummies)
+    and s01 (roster age) modules.  working_age = Age >= 6, with Age preferring
+    reported years (s01q04a) else survey_year - birth_year (s01q03c)."""
+    key = ['grappe', 'menage', pid_col]
+    roster_cols = [age_col, dob_year_col]
+    merged = s04[key + ['s04q06', 's04q07', 's04q08']].merge(
+        s01[key + roster_cols], on=key, how='left')
+
+    hh = merged.apply(lambda r: i(pd.Series([r['grappe'], r['menage']],
+                                            index=['grappe', 'menage'])),
+                      axis=1)
+    pid = merged[pid_col].apply(tools.format_id)
+
+    age = pd.to_numeric(merged[age_col], errors='coerce')
+    if survey_year is not None:
+        birth = pd.to_numeric(merged[dob_year_col], errors='coerce')
+        birth = birth.where((birth >= 1900) & (birth <= survey_year), pd.NA)
+        age_from_dob = survey_year - birth
+        age = age.where(age.notna(), age_from_dob)
+    working_age = (age >= 6)
+    working_age = working_age.where(age.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        'i': hh.values,
+        'pid': pid.values,
+        'farm_work': _yn_bool(merged['s04q06']).values,
+        'SOB_work': _yn_bool(merged['s04q07']).values,
+        'wage_work': _yn_bool(merged['s04q08']).values,
+        'working_age': working_age.values,
+    })
+    return df
+
+
+def _finish_people_last7days(df, t):
+    """Coerce dtypes, guarantee the full schema column set (NA where the wave
+    lacks a field), drop rows with no individual key, build the (t, i, pid)
+    index keeping the first reported line per individual."""
+    df = df.copy()
+    df['t'] = t
+    df['pid'] = df['pid'].astype('string')
+    for col in ['farm_work', 'SOB_work', 'wage_work', 'working_age']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = df[col].astype('boolean')
+    for col in ['farm_hrs', 'SB_hrs', 'wage_hrs']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Industry' not in df.columns:
+        df['Industry'] = pd.NA
+    df['Industry'] = df['Industry'].astype('string')
+    df = df[df['i'].notna() & df['pid'].notna()]
+    keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
+            'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
+    df = df[keep]
+    df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
+    df = df.set_index(['t', 'i', 'pid'])
+    return df
+
+
+s04 = get_dataframe('../Data/s04_me_gnb2018.dta', convert_categoricals=False)
+s01 = get_dataframe('../Data/s01_me_gnb2018.dta', convert_categoricals=False)
+
+df = people_last7days_ehcvm(s04, s01, '2018-19', survey_year=2018)
+df = _finish_people_last7days(df, '2018-19')
+
+assert len(df) > 0, 'people_last7days 2018-19 produced no rows'
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/plot_inputs.py
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/plot_inputs.py
@@ -1,0 +1,166 @@
+"""Build plot_inputs for Guinea-Bissau EHCVM 2018-19 (GAP 2, item-level).
+
+Cloned from Niger/2018-19/_/plot_inputs.py but SELF-CONTAINED: the label
+maps, the i() builder, the CROP_NA sentinel, and the
+(t, i, input, crop, u) finish tail are inlined here so this script does
+not import the niger module.
+
+Single source file: s16b_me_gnb2018.dta — the household agricultural-input
+roster, one row per input-type the household was asked about.  Columns:
+  s16bq01   input type (organic / inorganic fert / phyto / seeds-by-crop)
+  s16bq02   USED this input? (1=Sim / 2=Não) — application gate
+  s16bq03a / s16bq03b   quantity used + native unit
+  s16bq05   purchased? (Sim / Não)
+  s16bq07a  quantity purchased (native unit)
+
+We keep s16bq02==1 (applied) rows.  The EHCVM roster has NO crop column —
+the seed's crop is embedded in the input-type label ('Sementes de arroz'),
+resolved via harmonize_seed_crop where that table exists.  Non-seed input
+rows carry the CROP_NA sentinel.  i = EHCVM composite via the Guinea-Bissau
+helper (grappe + '0' + zero-padded menage, NO 'E_' prefix).  No plot
+column; grain is (t, i, input, crop, u).
+
+LABEL NOTE (silent-failure gotcha): Guinea-Bissau's categorical_mapping.org
+has NEITHER harmonize_input NOR harmonize_seed_crop (the input value labels
+are Portuguese: 'Sementes de arroz', 'Adubos inorgânicos - ureia', ...).  A
+bare get_categorical_mapping on a missing table silently returns the FIRST
+org table (`u`), which would mis-map inputs to unit labels.  We guard with
+_table_exists(): if the named table is absent the map is empty, so input
+labels pass through unchanged (raw Portuguese, visible / flagged) and seed
+crops resolve to the CROP_NA sentinel.  The `u` table DOES exist for
+Guinea-Bissau, so units harmonize normally.  Purchased labels are
+Portuguese ('Sim' / 'Não').
+"""
+import os
+
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+# Sentinel for the `crop` index level on input rows that are NOT
+# crop-specific.  A non-null token keeps all reported rows through the
+# framework's NaN-key de-dup collapse (groupby().first() drops NaN keys).
+CROP_NA = '(not crop-specific)'
+
+_ORG = os.path.join(os.path.dirname(__file__), '..', '..', '_',
+                    'categorical_mapping.org')
+
+
+def _table_exists(tablename):
+    """True iff categorical_mapping.org declares a ``#+name:`` /
+    ``#+NAME:`` header for ``tablename``.  Guards against
+    get_categorical_mapping's silent fall-through to the first org table."""
+    target = ('#+name: ' + tablename).lower()
+    try:
+        with open(_ORG, encoding='utf-8') as fh:
+            for line in fh:
+                if line.strip().lower() == target:
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+def i(value):
+    """Guinea-Bissau EHCVM household id from (grappe, menage).  No 'E_'
+    prefix (single EHCVM wave).  Inlined for self-containment."""
+    if isinstance(value, pd.Series):
+        grappe = tools.format_id(value.iloc[0])
+        menage = tools.format_id(value.iloc[1], zeropadding=2)
+        if grappe is None or menage is None:
+            return None
+        return grappe + '0' + menage
+    return tools.format_id(value)
+
+
+def _safe_map(tablename):
+    """Load a {Original Label -> Preferred Label} dict only if the table
+    really exists; otherwise return {} (identity passthrough)."""
+    if not _table_exists(tablename):
+        return {}
+    return tools.get_categorical_mapping(
+        tablename=tablename, idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+
+
+def _input_labels(source_labels, input_map):
+    """Map an input-type column through input_map.  Unmapped labels pass
+    through unchanged (kept visible, flagged by the sanity checker)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: input_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _seed_crop_labels(source_labels, seed_crop_map):
+    """Resolve the crop embedded in a seed-type label via seed_crop_map.
+    Returns NA for any label not in the table (non-seed rows / unresolved
+    seed crops); _finish fills those with the CROP_NA sentinel."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: seed_crop_map.get(x, pd.NA) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _unit_labels(unit_series, unit_map):
+    """Map a unit column through the u table.  Unmapped labels pass
+    through unchanged."""
+    u = unit_series.astype('string')
+    return u.map(lambda x: unit_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _finish_plot_inputs(df, t):
+    """Coerce numeric columns, guarantee the schema column set, fill the
+    crop / u index levels with non-null tokens where absent, drop rows with
+    no input identity, build the (t, i, input, crop, u) index."""
+    for col in ['Quantity', 'Quantity_purchased']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Purchased' not in df.columns:
+        df['Purchased'] = pd.NA
+    df['Purchased'] = df['Purchased'].astype('boolean')
+    df['t'] = t
+    df['input'] = df['input'].astype('string')
+    if 'crop' not in df.columns:
+        df['crop'] = pd.NA
+    df['crop'] = df['crop'].astype('string').fillna(CROP_NA)
+    df['u'] = df['u'].astype('string').fillna('Manquant')
+    df = df[df['input'].notna()]
+    keep = ['t', 'i', 'input', 'crop', 'u',
+            'Quantity', 'Purchased', 'Quantity_purchased']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'input', 'crop', 'u'])
+    return df
+
+
+src = get_dataframe('../Data/s16b_me_gnb2018.dta', convert_categoricals=True)
+srcn = get_dataframe('../Data/s16b_me_gnb2018.dta', convert_categoricals=False)
+
+input_map = _safe_map('harmonize_input')        # absent in GNB -> passthrough
+unit_map = _safe_map('u')                        # present in GNB
+seed_crop_map = _safe_map('harmonize_seed_crop')  # absent in GNB -> sentinel
+
+# Keep only inputs the household actually applied (s16bq02 == 1 = Sim).
+applied = srcn['s16bq02'] == 1
+src = src[applied.values]
+srcn = srcn[applied.values]
+
+hh = src.apply(lambda r: i(pd.Series([r['grappe'], r['menage']],
+                                     index=['grappe', 'menage'])), axis=1)
+
+# purchased: 'Sim' / 'Não' (loaded as labels with convert_categoricals)
+purchased = src['s16bq05'].astype('string').map({'Sim': True, 'Não': False})
+
+df = pd.DataFrame({
+    'i':                  hh.values,
+    'input':              _input_labels(src['s16bq01'], input_map).values,
+    'crop':               _seed_crop_labels(src['s16bq01'], seed_crop_map).values,
+    'u':                  _unit_labels(src['s16bq03b'], unit_map).values,
+    'Quantity':           pd.to_numeric(srcn['s16bq03a'], errors='coerce').values,
+    'Purchased':          purchased.values,
+    'Quantity_purchased': pd.to_numeric(srcn['s16bq07a'], errors='coerce').values,
+})
+
+df = _finish_plot_inputs(df, '2018-19')
+
+assert len(df) > 0, 'plot_inputs 2018-19 produced no rows'
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/plot_labor.py
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/plot_labor.py
@@ -1,0 +1,144 @@
+"""Build plot_labor for Guinea-Bissau EHCVM 2018-19 (GAP 3, item-level).
+
+Cloned from Niger/2018-19/_/plot_labor.py but SELF-CONTAINED: the EHCVM
+s16a labor-grid reducer and the (t, i, plot, source) finish tail are
+inlined here so this script does not import the niger module.
+
+Single source file: s16a_me_gnb2018.dta (agriculture-parcel module — the
+same file plot_features reads, so plot ids align by construction).  EHCVM
+records plot labor at the parcel level, family vs non-family (hired) only
+(NO free/exchange "other" labor):
+
+  Family labor (per family member, member-grid suffix _1.._N, three phases):
+    s16aq33b_*  days each member worked, prep/sowing phase
+    s16aq35b_*  days each member worked, maintenance phase
+    s16aq37b_*  days each member worked, harvest phase
+  -> family PersonDays = Σ over members & phases of those member-day cells.
+
+  Non-family / hired labor (per worker gender category, grid suffix _1.._4,
+  three phases; a = #workers, b = days each, c = wage paid):
+    s16aq39{a,b,c}_*  prep/sowing phase
+    s16aq41{a,b,c}_*  maintenance phase
+    s16aq43{a,b,c}_*  harvest phase
+  -> hired PersonDays = Σ over categories & phases of (a workers × b days);
+     hired Wage       = Σ over categories & phases of c (cash paid).
+
+One row per (plot, source); plot = "{s16aq02}_{s16aq03}" aligns with
+crop_production / plot_features plot_id.  i = EHCVM composite via the
+Guinea-Bissau helper (grappe + '0' + zero-padded menage, NO 'E_' prefix —
+single EHCVM wave, no panel-namespace collision).  No categorical tables
+are needed: the labor grids are pure numeric day / worker / wage cells, so
+the Portuguese value labels of the other s16a columns are irrelevant here.
+"""
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+# Canonical labor-source Preferred Labels (the `source` index level).  Tiny
+# fixed vocabulary assigned in code (not read from a raw label column).
+LABOR_SOURCE_FAMILY = 'family'
+LABOR_SOURCE_HIRED = 'hired'
+
+
+def i(value):
+    """Guinea-Bissau EHCVM household id from (grappe, menage).
+
+    Inlined from Guinea-Bissau/_/guinea_bissau.py so this script is
+    self-contained.  No 'E_' prefix (single EHCVM wave)."""
+    if isinstance(value, pd.Series):
+        grappe = tools.format_id(value.iloc[0])
+        menage = tools.format_id(value.iloc[1], zeropadding=2)
+        if grappe is None or menage is None:
+            return None
+        return grappe + '0' + menage
+    return tools.format_id(value)
+
+
+def plot_labor_ehcvm(src, t):
+    """Build the long (i, plot, source, PersonDays, Wage) frame from one
+    EHCVM wave's s16a parcel module.  family PersonDays = Σ member-day cells;
+    hired PersonDays = Σ(#workers × days); hired Wage = Σ cash paid."""
+    cols = list(src.columns)
+
+    def _num(col):
+        return pd.to_numeric(src[col], errors='coerce').astype('Float64')
+
+    hh = src.apply(lambda r: i(pd.Series([r['grappe'], r['menage']],
+                                         index=['grappe', 'menage'])),
+                   axis=1)
+    field = src['s16aq02'].apply(tools.format_id)
+    parcel = src['s16aq03'].apply(tools.format_id)
+    plot = field.astype('string') + '_' + parcel.astype('string')
+
+    # family: sum member-day cells across the three phase grids
+    fam_cols = [c for c in cols
+                if c.startswith('s16aq33b_')
+                or c.startswith('s16aq35b_')
+                or c.startswith('s16aq37b_')]
+    fam_days = sum(_num(c).fillna(0) for c in fam_cols)
+    fam_any = pd.concat([_num(c).notna() for c in fam_cols], axis=1).any(axis=1)
+    fam_days = fam_days.where(fam_any.values, pd.NA)
+    fam = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_FAMILY,
+        'PersonDays': fam_days.values, 'Wage': pd.NA,
+    })
+
+    # hired: Σ(#workers × days) person-days, Σ wage, over phase × category
+    hired_days = pd.Series(0.0, index=src.index, dtype='Float64')
+    hired_wage = pd.Series(0.0, index=src.index, dtype='Float64')
+    any_days = pd.Series(False, index=src.index)
+    any_wage = pd.Series(False, index=src.index)
+    for base in ['s16aq39', 's16aq41', 's16aq43']:
+        for ac in [c for c in cols if c.startswith(base + 'a_')]:
+            suf = ac[len(base + 'a'):]   # e.g. '_1' (keeps the underscore)
+            bc, cc = base + 'b' + suf, base + 'c' + suf
+            workers = _num(ac)
+            days = _num(bc) if bc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            wage = _num(cc) if cc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            pd_cell = workers * days
+            hired_days = hired_days.add(pd_cell.fillna(0))
+            any_days = any_days | pd_cell.notna().values
+            hired_wage = hired_wage.add(wage.fillna(0))
+            any_wage = any_wage | wage.notna().values
+    hired_days = hired_days.where(any_days.values, pd.NA)
+    hired_wage = hired_wage.where(any_wage.values, pd.NA)
+    hired = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_HIRED,
+        'PersonDays': hired_days.values, 'Wage': hired_wage.values,
+    })
+
+    return pd.concat([fam, hired], ignore_index=True)
+
+
+def _finish_plot_labor(df, t):
+    """Tag t, sum PersonDays / Wage within (t, i, plot, source) so the strata
+    (family members, hired-worker categories, phases) collapse onto the
+    natural (plot, source) item grain, drop placeholder rows, build the index.
+    min_count=1 keeps an all-NA group NA rather than 0."""
+    df = df.copy()
+    df['t'] = t
+    df['source'] = df['source'].astype('string')
+    df['plot'] = df['plot'].astype('string')
+    df['PersonDays'] = pd.to_numeric(df.get('PersonDays'), errors='coerce').astype('Float64')
+    if 'Wage' not in df.columns:
+        df['Wage'] = pd.NA
+    df['Wage'] = pd.to_numeric(df['Wage'], errors='coerce').astype('Float64')
+    df = df[df['i'].notna() & df['plot'].notna() & df['source'].notna()]
+    df = (df.groupby(['t', 'i', 'plot', 'source'], dropna=False)[['PersonDays', 'Wage']]
+            .sum(min_count=1)
+            .reset_index())
+    df = df[df['PersonDays'].notna() | df['Wage'].notna()]
+    df = df.set_index(['t', 'i', 'plot', 'source'])
+    return df
+
+
+src = get_dataframe('../Data/s16a_me_gnb2018.dta', convert_categoricals=False)
+df = plot_labor_ehcvm(src, '2018-19')
+df = _finish_plot_labor(df, '2018-19')
+
+assert len(df) > 0, 'plot_labor 2018-19 produced no rows'
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Guinea-Bissau/_/categorical_mapping.org
+++ b/lsms_library/countries/Guinea-Bissau/_/categorical_mapping.org
@@ -125,3 +125,31 @@
 |    1 | freehold                   |
 |    2 | granted_right_of_occupancy |
 |    4 | leasehold                  |
+
+# livestock species (GAP 4; EHCVM cluster).
+#
+# harmonize_species_ehcvm — EHCVM s17 livestock roster species code
+# (Guinea-Bissau 2018-19 s17q02).  The integer 1-11 value scheme is shared
+# across the EHCVM countries (the value LABELS localize — French / Portuguese
+# — but the codes do not), so this table keys on the integer Code and is
+# reused verbatim from the Niger reference.  The wave-level _/livestock.py
+# loads s17 with convert_categoricals=False and maps the integer code here.
+# Codes are the elevage__id value labels: 1 Bovins, 2 Ovins, 3 Caprins,
+# 4 Camelins, 5 Equins, 6 Asins, 7 Porcins, 8 Lapins, 9 Poules, 10 Pintades,
+# 11 Autres volailles.  Preferred Label vocabulary: Cattle, Sheep, Goats,
+# Camels, Horses, Donkeys, Pigs, Rabbits, Chicken, Guinea Fowl, Other Poultry.
+
+#+NAME: harmonize_species_ehcvm
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Cattle          |
+|    2 | Sheep           |
+|    3 | Goats           |
+|    4 | Camels          |
+|    5 | Horses          |
+|    6 | Donkeys         |
+|    7 | Pigs            |
+|    8 | Rabbits         |
+|    9 | Chicken         |
+|   10 | Guinea Fowl     |
+|   11 | Other Poultry   |

--- a/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
+++ b/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
@@ -141,3 +141,127 @@ Data Scheme:
     HeadAcquired: float
     HeadSold: float
     materialize: make
+
+  crop_production:
+    # Item-level crop harvest (GAP 1), cloned from the Niger EHCVM
+    # reference.  One row per REPORTED (field, parcel, crop) harvest line
+    # from s16c_me_gnb2018.dta — REPORTED values only; harvest_kg / yield /
+    # main_crop / value-shares are transformations, never columns here.
+    # Single EHCVM wave: 2018-19 (script-path).  crop joins food via the
+    # harmonize_food Preferred Labels where that table exists; Guinea-Bissau
+    # has NO harmonize_food table, so the raw Portuguese crop labels
+    # ('Cajueiro', 'Arroz paddy', 'Mancarra', ...) pass through unchanged
+    # (visible / flagged), never silently mis-mapped to the `u` fallback.
+    # u via the Portuguese `u` table.  ``u`` is in the index (as in
+    # food_acquired) because one (plot, crop) can be reported in several
+    # units.  plot = "{field_no}_{parcel_no}" aligns with plot_features'
+    # plot_id.  intercropped from s16cq07 ('Associação de culturas' / 'Pura').
+    # harvest_month / perennial are not recorded by s16c, so harvest_month is
+    # NaN and a perennial flag is omitted entirely.
+    index: (t, i, plot, crop, u)
+    Quantity: float
+    Quantity_sold: float
+    Value_sold: float
+    harvest_month: float
+    intercropped: bool
+    materialize: make
+
+  plot_inputs:
+    # Item-level agricultural inputs (GAP 2), cloned from the Niger EHCVM
+    # reference.  One row per REPORTED input applied by a household from
+    # s16b_me_gnb2018.dta: input identity, reported quantity used + native
+    # unit, purchased flag + reported purchased quantity, and (seed rows) the
+    # seed's crop.  REPORTED values only: seed_kg / nitrogen_kg / fertilizer
+    # totals are transformations, never columns.  Single EHCVM wave: 2018-19
+    # (script-path).
+    #
+    # GRAIN NOTE: EHCVM records inputs at the HOUSEHOLD x input grain, NOT
+    # plot x input (no parcel-level input question); the WB plot-level
+    # seed_kg / nitrogen_kg fabricates a plot split, which the reported-only
+    # rule forbids.  So `plot` is NOT in the index; the feature keeps the
+    # GAP-2 name `plot_inputs`.
+    #
+    # LABEL NOTE: Guinea-Bissau has NEITHER harmonize_input NOR
+    # harmonize_seed_crop, so the raw Portuguese input labels ('Sementes de
+    # arroz', 'Adubos inorgânicos - ureia', ...) pass through unchanged
+    # (visible / flagged) and seed crops resolve to the '(not crop-specific)'
+    # sentinel — never silently mis-mapped to the `u` fallback.  Non-crop-
+    # specific rows carry the sentinel rather than NaN so the index level is
+    # non-null and survives the framework's canonical NaN-key de-dup collapse.
+    # `u` via the Portuguese `u` table; a missing unit is filled with
+    # 'Manquant' for the same non-null reason.  Purchased from s16bq05
+    # ('Sim' / 'Não').
+    index: (t, i, input, crop, u)
+    Quantity: float
+    Purchased: bool
+    Quantity_purchased: float
+    materialize: make
+
+  plot_labor:
+    # Item-level plot labor (GAP 3), cloned from the Niger EHCVM reference.
+    # One row per REPORTED labor SOURCE on a plot from s16a_me_gnb2018.dta —
+    # the reported person-days the WB .do collapses to total_labor_days /
+    # total_family_labor_days / total_hired_labor_days / hired_labor_value
+    # (a median-wage valuation).  ALL of those are TRANSFORMATIONS over these
+    # rows, never columns here.  Single EHCVM wave: 2018-19 (script-path).
+    #
+    # GRAIN (t, i, plot, source):
+    #   plot   -- "{field_no}_{parcel_no}", aligned with crop_production's
+    #             plot key and plot_features' plot_id.
+    #   source -- 'family' / 'hired'.  EHCVM s16a records family vs non-family
+    #             (hired) labor only (NO free/exchange 'other' source).  Small
+    #             fixed vocabulary assigned in code (no categorical table).
+    #
+    # COLUMNS (reported, item-level):
+    #   PersonDays -- reported person-days of that source on the plot.  The
+    #                 survey reports a source as several day cells (per family
+    #                 member, or per hired-worker gender category, across the
+    #                 prep / maintenance / harvest phases); these are strata of
+    #                 the SAME (plot, source) item, so PersonDays is their
+    #                 within-source sum (NOT a forbidden cross-source rollup).
+    #                 EHCVM hired person-days = Σ(#workers × days).
+    #   Wage       -- cash PAID to hired labor where the survey records it.
+    #                 NaN for family (no cash paid).
+    # No categorical tables are needed (pure numeric grids).  v is NOT baked
+    # in (household-linked); the framework joins it from sample().
+    # units: PersonDays in days; Wage in CFA francs.
+    index: (t, i, plot, source)
+    PersonDays: float
+    Wage: float
+    materialize: make
+
+  people_last7days:
+    # Item-level individual 7-day labor (GAP 3), cloned from the Niger EHCVM
+    # reference.  One row per individual, carrying the REPORTED last-7-days
+    # labor participation — the per-individual activity feature the GAP
+    # ranking targets.  No rollups: the WB nb_members_working_age HH total is
+    # a transformation, not a column here.  Single EHCVM wave: 2018-19
+    # (script-path); two source files s04 (7-day dummies) + s01 (roster age),
+    # merged on (grappe, menage, s01q00a).
+    #
+    # GRAIN (t, i, pid): pid = s01q00a (matches household_roster).  v
+    # auto-joins from sample().
+    #
+    # COLUMNS (reported, per-individual):
+    #   farm_work / SOB_work / wage_work -- worked >=1h on own farm /
+    #       own business / for a wage in the last 7 days (nullable bool;
+    #       s04q06 / s04q07 / s04q08, integer-coded 1=yes / 2=no).
+    #   farm_hrs / SB_hrs / wage_hrs / Industry -- NA: the EHCVM 7-day module
+    #       records hours only for unpaid domestic tasks and the industry only
+    #       as 12-month occupation codes (not the WB 7-day section ranges), so
+    #       these are declared for cross-country schema parity but left NA.
+    #   working_age -- member is of working age (Age >= 6, the survey
+    #       threshold).  Age prefers reported years (s01q04a) else
+    #       survey_year - birth_year (s01q03c), mirroring household_roster.
+    # No categorical tables are needed (integer dummies + numeric age).
+    # units: hours in hours.
+    index: (t, i, pid)
+    farm_work: bool
+    SOB_work: bool
+    wage_work: bool
+    farm_hrs: float
+    SB_hrs: float
+    wage_hrs: float
+    Industry: str
+    working_age: bool
+    materialize: make

--- a/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
+++ b/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
@@ -109,3 +109,35 @@ Data Scheme:
     SoilType: str
     Irrigated: bool
     materialize: make
+
+  livestock:
+    # Item-level livestock roster (GAP 4), cloned from the Niger EHCVM
+    # reference.  One row per REPORTED (household, species) the household
+    # owns/raises, from EHCVM Section 17 'Élevage' (s17_me_gnb2018.dta, one
+    # row per (household, species), pre-filtered to owned species
+    # s17q03 == 1).  The WB engaged-in-livestock y/n binary is recoverable
+    # as groupby(['t','i']).any() over these rows; TLU is a
+    # Σ(head × species-factor) transformation — neither is a column here
+    # (item-level / reported-values discipline).
+    #
+    # GRAIN (t, i, animal) — NO v level: 'livestock' is in the framework's
+    # _no_v_join set, so the household-level rows carry no cluster level and
+    # the framework does NOT join one from sample().  `animal` is the
+    # harmonized species Preferred Label (harmonize_species_ehcvm maps the
+    # 1-11 EHCVM species code s17q02 -> Cattle / Sheep / Goats / Camels /
+    # Horses / Donkeys / Pigs / Rabbits / Chicken / Guinea Fowl / Other
+    # Poultry).  The species value labels are French / Portuguese but the
+    # integer codes match the other EHCVM countries, so the mapping keys on
+    # the code (s17 loaded convert_categoricals=False).  Single EHCVM wave:
+    # 2018-19.
+    #
+    # COLUMNS (reported, item-level): HeadCount (owned now, s17q06),
+    # HeadAcquired (number bought in the last 12 months, s17q08), HeadSold
+    # (number sold on the hoof in the last 12 months, s17q10).  A `Value`
+    # (herd value) column is intentionally OMITTED: EHCVM s17 records only
+    # purchase / sale FLOW values, no current herd value.
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    materialize: make

--- a/lsms_library/countries/Senegal/2018-19/_/crop_production.py
+++ b/lsms_library/countries/Senegal/2018-19/_/crop_production.py
@@ -1,0 +1,125 @@
+"""Build crop_production for Senegal EHCVM 2018-19 (GAP 1, item-level).
+
+Cloned from the Niger EHCVM template (Niger/2018-19/_/crop_production.py).
+Single source file: s16c_me_sen2018.dta (agriculture crop/harvest module).
+One row per reported (field, parcel, crop) harvest record.  Harvest qty +
+unit (s16cq12a / s16cq12b), sold qty (s16cq16a), sale value (s16cq17), and
+the intercrop flag (s16cq07) are ALL recorded at this plot-crop grain in
+2018-19, so no cross-file join is needed.
+
+Index = (t, i, plot, crop, u); plot = "{s16cq02}_{s16cq03}" aligns with
+plot_features' plot_id.  REPORTED values only — harvest_kg / yield /
+main_crop / value-shares are transformations, never columns here.
+
+This script is SELF-CONTAINED — it inlines the Senegal household-id
+formatter (matching sample() / livestock.py: grappe + '0' + zero-padded
+menage, NO 'E_' prefix), the crop / unit label mappers, and the finishing
+tail rather than importing them, so it has no cross-country / wave-module
+import coupling.
+
+`crop` joins food via harmonize_food Preferred Labels (so a crop that is
+also a consumed food shares food_acquired's Preferred Label); `u` via the u
+table.  Both mappers PASS UNMAPPED LABELS THROUGH unchanged (kept visible,
+flagged by the sanity checker) — exactly the Niger template behavior;
+Senegal's harmonize_food / u tables cover only a subset of the s16c crop /
+unit labels, so the rest surface in raw French.
+"""
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+
+
+def i(value):
+    """Senegal EHCVM household id from (grappe, menage): grappe + '0' +
+    zero-padded (2-digit) menage.  Matches sample().i / mapping.i /
+    livestock.py (NO 'E_' prefix).  Built positionally (``.iloc``)."""
+    g = tools.format_id(value.iloc[0])
+    m = tools.format_id(value.iloc[1], zeropadding=2)
+    if g is None or m is None:
+        return None
+    return g + '0' + m
+
+
+def _crop_maps():
+    crop_map = tools.get_categorical_mapping(
+        tablename='harmonize_food', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    unit_map = tools.get_categorical_mapping(
+        tablename='u', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    return crop_map, unit_map
+
+
+def _crop_labels(source_labels, crop_map):
+    """Map a crop column (string labels from convert_categoricals=True)
+    through ``harmonize_food`` (keyed on Original Label).  Unmapped labels
+    pass through unchanged (kept visible, flagged by the sanity checker)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: crop_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _unit_labels(unit_series, unit_map):
+    """Map a harvest-unit column (string labels) through the ``u`` table.
+    Unmapped labels pass through unchanged."""
+    u = unit_series.astype('string')
+    return u.map(lambda x: unit_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _finish_crop_production(df, t):
+    """Common tail: tag t, build the (t, i, plot, crop, u) index, coerce
+    numeric columns, and guarantee the full schema column set.  Drops
+    placeholder rows with no crop recorded."""
+    for col in ['Quantity', 'Quantity_sold', 'Value_sold']:
+        df[col] = pd.to_numeric(df.get(col), errors='coerce').astype('Float64')
+    # harvest_month: not recorded in the EHCVM s16c module; NaN here (carried
+    # for cross-wave schema parity).
+    if 'harvest_month' not in df.columns:
+        df['harvest_month'] = pd.NA
+    df['harvest_month'] = pd.to_numeric(df['harvest_month'], errors='coerce').astype('Float64')
+    if 'intercropped' not in df.columns:
+        df['intercropped'] = pd.NA
+    df['intercropped'] = df['intercropped'].astype('boolean')
+    df['t'] = t
+    df['crop'] = df['crop'].astype('string')
+    df['u'] = df['u'].astype('string')
+    df = df[df['crop'].notna()]
+    keep = ['t', 'i', 'plot', 'crop', 'u', 'Quantity',
+            'Quantity_sold', 'Value_sold', 'harvest_month', 'intercropped']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'plot', 'crop', 'u'])
+    return df
+
+
+# convert_categoricals=True so crop / unit value labels arrive as the strings
+# that harmonize_food / the u table key on; the *_codes view keeps the integer
+# field / parcel ids that format_id zero-pads.
+src = get_dataframe('../Data/s16c_me_sen2018.dta', convert_categoricals=True)
+src_codes = get_dataframe('../Data/s16c_me_sen2018.dta', convert_categoricals=False)
+
+crop_map, unit_map = _crop_maps()
+
+hh = src_codes.apply(lambda r: i(pd.Series([r['grappe'], r['menage']])), axis=1)
+field = src_codes['s16cq02'].apply(format_id)
+parcel = src_codes['s16cq03'].apply(format_id)
+plot = field.astype(str) + '_' + parcel.astype(str)
+
+# intercrop: s16cq07 == 'Association de cultures' -> True, 'Pure' -> False
+intercropped = src['s16cq07'].astype('string').map(
+    {'Association de cultures': True, 'Pure': False})
+
+df = pd.DataFrame({
+    'i':             hh.values,
+    'plot':          plot.values,
+    'crop':          _crop_labels(src['s16cq04'], crop_map).values,
+    'u':             _unit_labels(src['s16cq12b'], unit_map).values,
+    'Quantity':      src_codes['s16cq12a'].values,
+    'Quantity_sold': src_codes['s16cq16a'].values,
+    'Value_sold':    src_codes['s16cq17'].values,
+    'intercropped':  intercropped.values,
+})
+
+df = _finish_crop_production(df, '2018-19')
+
+assert len(df) > 0, 'crop_production 2018-19 produced no rows'
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Senegal/2018-19/_/livestock.py
+++ b/lsms_library/countries/Senegal/2018-19/_/livestock.py
@@ -1,0 +1,118 @@
+"""Build livestock for Senegal EHCVM 2018-19 (GAP 4, item-level).
+
+Single source file: s17_me_sen2018.dta — the EHCVM section-17 livestock
+('Élevage') roster, one row per (household, species).  The roster is
+already restricted to owned species (s17q03 == 1 for every row).
+
+Columns:
+  s17q02  species code (1-11, elevage__id; harmonize_species_ehcvm -> animal)
+  s17q03  owned/raised this species? (1=Oui / 2=Non) — gate (all ==1 here)
+  s17q06  number belonging to the household (HeadCount owned now)
+  s17q08  number bought in the last 12 months (HeadAcquired)
+  s17q10  number sold on the hoof in the last 12 months (HeadSold)
+
+There is NO current herd-value question in EHCVM s17 (s17q05/q06 are head
+counts; s17q09/q13 are purchase/sale FLOW values), so Value is not emitted.
+``i`` is the Senegal EHCVM composite id (grappe + '0' + zero-padded menage)
+matching sample().  Grain (t, i, animal); no v level (livestock is in the
+framework _no_v_join set).
+
+This script is SELF-CONTAINED — it inlines the Senegal household-id
+formatter, the integer-code mapper, and the finishing tail rather than
+importing them, so it has no cross-country / wave-module import coupling.
+"""
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+def i(value):
+    """Senegal EHCVM household id from (grappe, menage): grappe + '0' +
+    zero-padded (2-digit) menage.  Matches sample().i / mapping.i.  Built
+    positionally (``.iloc``) so a bare ``pd.Series([grappe, menage])``
+    works, mirroring senegal.py's formatter."""
+    g = tools.format_id(value.iloc[0])
+    m = tools.format_id(value.iloc[1], zeropadding=2)
+    if g is None or m is None:
+        return None
+    return g + '0' + m
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a ``{int code -> Preferred Label}`` dict from
+    ``categorical_mapping.org``.  Codes whose Preferred Label is blank /
+    '---' map to NA so the corresponding row stays NaN."""
+    raw = tools.get_categorical_mapping(tablename=tablename, idxvars=key,
+                                        **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a numeric (raw Stata integer-code) Series through ``code_map``,
+    returning a string Series with NA where the code is unmapped.  Source
+    files must be loaded with ``convert_categoricals=False``."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def _finish_livestock(df, t):
+    """Coerce numeric columns, drop unresolved-species placeholder rows, SUM
+    the head counts within (t, i, animal) so each (household, canonical
+    species) is one row, and build the (t, i, animal) index.  The EHCVM
+    roster already reports one row per species (codes 1-11), so the sum is a
+    no-op here, but it keeps the (t, i, animal) index unique for safety.
+    HeadCount / HeadAcquired / HeadSold are Float64 (nullable head counts);
+    min_count=1 keeps an all-NaN group NaN rather than 0.  Value is NOT a
+    column: EHCVM s17 records no current herd value."""
+    cols = ['HeadCount', 'HeadAcquired', 'HeadSold']
+    for col in cols:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    df['t'] = t
+    df['animal'] = df['animal'].astype('string')
+    df = df[df['animal'].notna() & df['i'].notna()]
+    df = (df.groupby(['t', 'i', 'animal'], dropna=False)[cols]
+            .sum(min_count=1)
+            .reset_index())
+    keep = ['t', 'i', 'animal'] + cols
+    df = df[keep]
+    df = df.set_index(['t', 'i', 'animal'])
+    return df
+
+
+# convert_categoricals=False keeps the integer s17 codes that the
+# harmonize_species_ehcvm table keys on.
+srcn = get_dataframe('../Data/s17_me_sen2018.dta', convert_categoricals=False)
+
+ehcvm_map = _harmonized_codes('harmonize_species_ehcvm')
+
+# The roster only carries owned species, but keep the gate for parity / safety.
+owned = srcn['s17q03'] == 1
+srcn = srcn[owned.values]
+
+hh = srcn.apply(lambda r: i(pd.Series([r['grappe'], r['menage']])), axis=1)
+
+df = pd.DataFrame({
+    'i':            hh.values,
+    'animal':       _map_codes(srcn['s17q02'], ehcvm_map).values,
+    'HeadCount':    pd.to_numeric(srcn['s17q06'], errors='coerce').values,
+    'HeadAcquired': pd.to_numeric(srcn['s17q08'], errors='coerce').values,
+    'HeadSold':     pd.to_numeric(srcn['s17q10'], errors='coerce').values,
+})
+
+df = _finish_livestock(df, '2018-19')
+
+assert len(df) > 0, 'livestock 2018-19 produced no rows'
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Senegal/2018-19/_/people_last7days.py
+++ b/lsms_library/countries/Senegal/2018-19/_/people_last7days.py
@@ -1,0 +1,118 @@
+"""Build people_last7days for Senegal EHCVM 2018-19 (GAP 3, item-level).
+
+Cloned from the Niger EHCVM template (Niger/2018-19/_/people_last7days.py).
+Two source files:
+  s04_me_sen2018.dta — the 7-day employment module (participation dummies).
+  s01_me_sen2018.dta — the individual roster (age for working_age).
+Merged on (grappe, menage, s01q00a) — the same person key household_roster
+uses.  Grain (t, i, pid); pid = s01q00a.
+
+EHCVM's 7-day module records only the three participation DUMMIES in an
+ECVMA-comparable form (s04q06 farm, s04q07 own-business, s04q08 wage) and
+working_age (roster Age >= 6).  It does NOT record productive-work hours or
+the WB 7-day industry section code, so farm_hrs / SB_hrs / wage_hrs and
+Industry are NA (declared for cross-wave schema parity).
+
+This script is SELF-CONTAINED — it inlines the Senegal household-id
+formatter (matching sample() / livestock.py: grappe + '0' + zero-padded
+menage, NO 'E_' prefix), the Oui/Non -> bool mapper, and the finishing
+tail.  AGE: prefer reported years (s01q04a), else survey_year (2018) -
+birth_year (s01q03c; 9999 / out-of-range sentinel -> NA), mirroring
+household_roster's age_handler.  working_age = Age >= 6.
+"""
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+def i(value):
+    """Senegal EHCVM household id from (grappe, menage): grappe + '0' +
+    zero-padded (2-digit) menage.  Matches sample() / livestock.py (NO
+    'E_' prefix).  Built positionally (``.iloc``)."""
+    g = tools.format_id(value.iloc[0])
+    m = tools.format_id(value.iloc[1], zeropadding=2)
+    if g is None or m is None:
+        return None
+    return g + '0' + m
+
+
+def _yn_bool(series, yes=1, no=2):
+    """Map a 1=Oui / 2=Non survey item to nullable boolean (other codes,
+    e.g. 9 'no answer', -> NA)."""
+    s = pd.to_numeric(series, errors='coerce')
+    out = pd.Series(pd.NA, index=s.index, dtype='boolean')
+    out = out.mask(s == yes, True)
+    out = out.mask(s == no, False)
+    return out
+
+
+def people_last7days_ehcvm(s04, s01, t, pid_col='s01q00a', age_col='s01q04a',
+                           dob_year_col='s01q03c', survey_year=None):
+    """Build the (i, pid, farm_work, SOB_work, wage_work, working_age) frame.
+    The 7-day dummies come from s04 (s04q06/07/08); Age is merged from the
+    s01 roster on (grappe, menage, pid_col)."""
+    key = ['grappe', 'menage', pid_col]
+    roster_cols = [age_col, dob_year_col]
+    merged = s04[key + ['s04q06', 's04q07', 's04q08']].merge(
+        s01[key + roster_cols], on=key, how='left')
+
+    hh = merged.apply(lambda r: i(pd.Series([r['grappe'], r['menage']])), axis=1)
+    pid = merged[pid_col].apply(tools.format_id)
+
+    age = pd.to_numeric(merged[age_col], errors='coerce')
+    if survey_year is not None:
+        birth = pd.to_numeric(merged[dob_year_col], errors='coerce')
+        birth = birth.where((birth >= 1900) & (birth <= survey_year), pd.NA)
+        age_from_dob = survey_year - birth
+        age = age.where(age.notna(), age_from_dob)
+    working_age = (age >= 6)
+    # Keep working_age NA where age is entirely unknown (rather than False).
+    working_age = working_age.where(age.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        'i': hh.values,
+        'pid': pid.values,
+        'farm_work': _yn_bool(merged['s04q06']).values,
+        'SOB_work': _yn_bool(merged['s04q07']).values,
+        'wage_work': _yn_bool(merged['s04q08']).values,
+        'working_age': working_age.values,
+    })
+    return df
+
+
+def _finish_people_last7days(df, t):
+    """Common tail: coerce dtypes, guarantee the full schema column set (NA
+    where the wave lacks a field), drop rows with no individual key, build
+    the (t, i, pid) index (one row per person)."""
+    df = df.copy()
+    df['t'] = t
+    df['pid'] = df['pid'].astype('string')
+    for col in ['farm_work', 'SOB_work', 'wage_work', 'working_age']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = df[col].astype('boolean')
+    for col in ['farm_hrs', 'SB_hrs', 'wage_hrs']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Industry' not in df.columns:
+        df['Industry'] = pd.NA
+    df['Industry'] = df['Industry'].astype('string')
+    df = df[df['i'].notna() & df['pid'].notna()]
+    keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
+            'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
+    df = df[keep]
+    df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
+    df = df.set_index(['t', 'i', 'pid'])
+    return df
+
+
+s04 = get_dataframe('../Data/s04_me_sen2018.dta', convert_categoricals=False)
+s01 = get_dataframe('../Data/s01_me_sen2018.dta', convert_categoricals=False)
+
+df = people_last7days_ehcvm(s04, s01, '2018-19', survey_year=2018)
+df = _finish_people_last7days(df, '2018-19')
+
+assert len(df) > 0, 'people_last7days 2018-19 produced no rows'
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Senegal/2018-19/_/plot_inputs.py
+++ b/lsms_library/countries/Senegal/2018-19/_/plot_inputs.py
@@ -1,0 +1,141 @@
+"""Build plot_inputs for Senegal EHCVM 2018-19 (GAP 2, item-level).
+
+Cloned from the Niger EHCVM template (Niger/2018-19/_/plot_inputs.py).
+Single source file: s16b_me_sen2018.dta — the household agricultural-input
+roster, one row per input-type the household was asked about.  Columns:
+  s16bq01   input type (organic / inorganic fert / phyto / seeds-by-crop)
+  s16bq02   USED this input? (1=Oui) — application gate (all 1 in 2018)
+  s16bq03a / s16bq03b   quantity used + native unit
+  s16bq05   purchased? (Oui / Non)
+  s16bq07a  quantity purchased (native unit)
+
+We keep s16bq02==1 (applied) rows.  The EHCVM roster has NO crop column —
+the seed's crop is embedded in the input-type label ('Semences de petit
+mil'), resolved to the harmonize_food crop label via harmonize_seed_crop.
+Non-seed input rows carry the CROP_NA sentinel.  Grain (t, i, input, crop,
+u); no plot column (EHCVM records inputs at the household x input grain).
+
+This script is SELF-CONTAINED — it inlines the Senegal household-id
+formatter (matching sample() / livestock.py: grappe + '0' + zero-padded
+menage, NO 'E_' prefix), the input / seed-crop / unit label mappers, and
+the finishing tail.  The harmonize_input / harmonize_seed_crop tables were
+copied from Niger into Senegal's categorical_mapping.org (with the
+Senegal-specific 'Semences d'arachide' -> Arachide seed slot added).
+"""
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+# See _finish_plot_inputs: a non-null token keeps non-crop-specific rows from
+# being silently dropped by the framework's NaN-key duplicate collapse.
+CROP_NA = '(not crop-specific)'
+
+
+def i(value):
+    """Senegal EHCVM household id from (grappe, menage): grappe + '0' +
+    zero-padded (2-digit) menage.  Matches sample() / livestock.py (NO
+    'E_' prefix).  Built positionally (``.iloc``)."""
+    g = tools.format_id(value.iloc[0])
+    m = tools.format_id(value.iloc[1], zeropadding=2)
+    if g is None or m is None:
+        return None
+    return g + '0' + m
+
+
+def _input_maps():
+    """Load the harmonize_input (input-type) and u (unit) string->label maps,
+    plus the harmonize_seed_crop map (EHCVM seed-label -> crop).  Keyed on
+    Original Label."""
+    input_map = tools.get_categorical_mapping(
+        tablename='harmonize_input', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    unit_map = tools.get_categorical_mapping(
+        tablename='u', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    seed_crop_map = tools.get_categorical_mapping(
+        tablename='harmonize_seed_crop', idxvars='Original Label',
+        **{'Preferred Label': 'Preferred Label'})
+    return input_map, unit_map, seed_crop_map
+
+
+def _input_labels(source_labels, input_map):
+    """Map an input-type column through harmonize_input.  Unmapped labels
+    pass through unchanged (kept visible, flagged by the sanity checker)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: input_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _unit_labels(unit_series, unit_map):
+    """Map a native-unit column through the ``u`` table.  Unmapped labels
+    pass through unchanged."""
+    u = unit_series.astype('string')
+    return u.map(lambda x: unit_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _seed_crop_labels(source_labels, seed_crop_map):
+    """Resolve the crop embedded in a seed-type label ('Semences de petit
+    mil' -> 'Mil') via harmonize_seed_crop.  Returns NA for any label not in
+    the seed-crop table (i.e. non-seed input rows)."""
+    lab = source_labels.astype('string')
+    return lab.map(lambda x: seed_crop_map.get(x, pd.NA) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _finish_plot_inputs(df, t):
+    """Common tail: coerce numeric columns, guarantee the full schema column
+    set, build the (t, i, input, crop, u) index.  Drops rows with no input
+    identity.  The `crop` index level is filled with the CROP_NA sentinel
+    wherever no crop applies; the native unit `u` with the 'Manquant' label —
+    so neither index level is null and no row is lost to the framework's
+    NaN-key duplicate collapse."""
+    for col in ['Quantity', 'Quantity_purchased']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Purchased' not in df.columns:
+        df['Purchased'] = pd.NA
+    df['Purchased'] = df['Purchased'].astype('boolean')
+    df['t'] = t
+    df['input'] = df['input'].astype('string')
+    if 'crop' not in df.columns:
+        df['crop'] = pd.NA
+    df['crop'] = df['crop'].astype('string').fillna(CROP_NA)
+    df['u'] = df['u'].astype('string').fillna('Manquant')
+    df = df[df['input'].notna()]
+    keep = ['t', 'i', 'input', 'crop', 'u',
+            'Quantity', 'Purchased', 'Quantity_purchased']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'input', 'crop', 'u'])
+    return df
+
+
+src = get_dataframe('../Data/s16b_me_sen2018.dta', convert_categoricals=True)
+srcn = get_dataframe('../Data/s16b_me_sen2018.dta', convert_categoricals=False)
+
+input_map, unit_map, seed_crop_map = _input_maps()
+
+# Keep only inputs the household actually applied (s16bq02 == 1 = Oui).
+applied = srcn['s16bq02'] == 1
+src = src[applied.values]
+srcn = srcn[applied.values]
+
+hh = srcn.apply(lambda r: i(pd.Series([r['grappe'], r['menage']])), axis=1)
+
+# purchased: s16bq05 Oui/Non (loaded as labels with convert_categoricals)
+purchased = src['s16bq05'].astype('string').map({'Oui': True, 'Non': False})
+
+df = pd.DataFrame({
+    'i':                  hh.values,
+    'input':              _input_labels(src['s16bq01'], input_map).values,
+    'crop':               _seed_crop_labels(src['s16bq01'], seed_crop_map).values,
+    'u':                  _unit_labels(src['s16bq03b'], unit_map).values,
+    'Quantity':           pd.to_numeric(srcn['s16bq03a'], errors='coerce').values,
+    'Purchased':          purchased.values,
+    'Quantity_purchased': pd.to_numeric(srcn['s16bq07a'], errors='coerce').values,
+})
+
+df = _finish_plot_inputs(df, '2018-19')
+
+assert len(df) > 0, 'plot_inputs 2018-19 produced no rows'
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Senegal/2018-19/_/plot_labor.py
+++ b/lsms_library/countries/Senegal/2018-19/_/plot_labor.py
@@ -1,0 +1,136 @@
+"""Build plot_labor for Senegal EHCVM 2018-19 (GAP 3, item-level).
+
+Cloned from the Niger EHCVM template (Niger/2018-19/_/plot_labor.py).
+Single source file: s16a_me_sen2018.dta (agriculture-parcel module — the
+same file plot_features reads, so plot ids align by construction).  EHCVM
+records plot labor at the parcel level, family vs non-family (hired) only
+(NO free/exchange "other" labor):
+
+  Family labor (per family member, member-grid suffix _1.._N, three phases):
+    s16aq33b_*  days each member worked, prep/sowing phase
+    s16aq35b_*  days each member worked, maintenance phase
+    s16aq37b_*  days each member worked, harvest phase
+  -> family PersonDays = Σ over members & phases of those member-day cells.
+
+  Non-family / hired labor (per worker gender category, grid suffix _1.._4,
+  three phases; a = #workers, b = days each, c = wage paid):
+    s16aq39{a,b,c}_*  prep/sowing phase
+    s16aq41{a,b,c}_*  maintenance phase
+    s16aq43{a,b,c}_*  harvest phase
+  -> hired PersonDays = Σ over categories & phases of (a workers × b days);
+     hired Wage       = Σ over categories & phases of c (cash paid).
+
+One row per (plot, source); plot = "{s16aq02}_{s16aq03}" aligns with
+crop_production / plot_features plot_id.  Grain (t, i, plot, source).
+
+This script is SELF-CONTAINED — it inlines the Senegal household-id
+formatter (matching sample() / livestock.py: grappe + '0' + zero-padded
+menage, NO 'E_' prefix), the EHCVM s16a labor-grid reducer, and the
+finishing tail.  units: PersonDays in days; Wage in CFA francs.
+"""
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+LABOR_SOURCE_FAMILY = 'family'
+LABOR_SOURCE_HIRED = 'hired'
+
+
+def i(value):
+    """Senegal EHCVM household id from (grappe, menage): grappe + '0' +
+    zero-padded (2-digit) menage.  Matches sample() / livestock.py (NO
+    'E_' prefix).  Built positionally (``.iloc``)."""
+    g = tools.format_id(value.iloc[0])
+    m = tools.format_id(value.iloc[1], zeropadding=2)
+    if g is None or m is None:
+        return None
+    return g + '0' + m
+
+
+def plot_labor_ehcvm(src, t):
+    """Build the long (i, plot, source, PersonDays, Wage) frame from the
+    s16a parcel module.  EHCVM records family vs non-family (hired) plot
+    labor only.  family = Σ member-day cells across the three phase grids;
+    hired = Σ(#workers × days) and Σ wage over phase × worker category."""
+    cols = list(src.columns)
+
+    def _num(col):
+        return pd.to_numeric(src[col], errors='coerce').astype('Float64')
+
+    hh = src.apply(lambda r: i(pd.Series([r['grappe'], r['menage']])), axis=1)
+    field = src['s16aq02'].apply(tools.format_id)
+    parcel = src['s16aq03'].apply(tools.format_id)
+    plot = field.astype('string') + '_' + parcel.astype('string')
+
+    # family: sum member-day cells across the three phase grids
+    fam_cols = [c for c in cols
+                if c.startswith('s16aq33b_')
+                or c.startswith('s16aq35b_')
+                or c.startswith('s16aq37b_')]
+    fam_days = sum(_num(c).fillna(0) for c in fam_cols)
+    fam_any = pd.concat([_num(c).notna() for c in fam_cols], axis=1).any(axis=1)
+    fam_days = fam_days.where(fam_any.values, pd.NA)
+    fam = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_FAMILY,
+        'PersonDays': fam_days.values, 'Wage': pd.NA,
+    })
+
+    # hired: Σ(#workers × days) person-days, Σ wage, over phase × category
+    hired_days = pd.Series(0.0, index=src.index, dtype='Float64')
+    hired_wage = pd.Series(0.0, index=src.index, dtype='Float64')
+    any_days = pd.Series(False, index=src.index)
+    any_wage = pd.Series(False, index=src.index)
+    for base in ['s16aq39', 's16aq41', 's16aq43']:
+        for ac in [c for c in cols if c.startswith(base + 'a_')]:
+            suf = ac[len(base + 'a'):]   # e.g. '_1' (keeps the underscore)
+            bc, cc = base + 'b' + suf, base + 'c' + suf
+            workers = _num(ac)
+            days = _num(bc) if bc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            wage = _num(cc) if cc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            pd_cell = workers * days
+            hired_days = hired_days.add(pd_cell.fillna(0))
+            any_days = any_days | pd_cell.notna().values
+            hired_wage = hired_wage.add(wage.fillna(0))
+            any_wage = any_wage | wage.notna().values
+    hired_days = hired_days.where(any_days.values, pd.NA)
+    hired_wage = hired_wage.where(any_wage.values, pd.NA)
+    hired = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_HIRED,
+        'PersonDays': hired_days.values, 'Wage': hired_wage.values,
+    })
+
+    return pd.concat([fam, hired], ignore_index=True)
+
+
+def _finish_plot_labor(df, t):
+    """Common tail: SUM PersonDays / Wage within (t, i, plot, source) so the
+    strata (family members, hired-worker categories, phases) collapse onto
+    the natural (plot, source) item grain.  min_count=1 keeps an all-NA group
+    NA.  Rows with no plot / source / person-days are dropped."""
+    df = df.copy()
+    df['t'] = t
+    df['source'] = df['source'].astype('string')
+    df['plot'] = df['plot'].astype('string')
+    df['PersonDays'] = pd.to_numeric(df.get('PersonDays'), errors='coerce').astype('Float64')
+    if 'Wage' not in df.columns:
+        df['Wage'] = pd.NA
+    df['Wage'] = pd.to_numeric(df['Wage'], errors='coerce').astype('Float64')
+    df = df[df['i'].notna() & df['plot'].notna() & df['source'].notna()]
+    df = (df.groupby(['t', 'i', 'plot', 'source'], dropna=False)[['PersonDays', 'Wage']]
+            .sum(min_count=1)
+            .reset_index())
+    df = df[df['PersonDays'].notna() | df['Wage'].notna()]
+    df = df.set_index(['t', 'i', 'plot', 'source'])
+    return df
+
+
+src = get_dataframe('../Data/s16a_me_sen2018.dta', convert_categoricals=False)
+df = plot_labor_ehcvm(src, '2018-19')
+df = _finish_plot_labor(df, '2018-19')
+
+assert len(df) > 0, 'plot_labor 2018-19 produced no rows'
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Senegal/_/categorical_mapping.org
+++ b/lsms_library/countries/Senegal/_/categorical_mapping.org
@@ -545,3 +545,93 @@
 |    9 | Chicken         |
 |   10 | Guinea Fowl     |
 |   11 | Other Poultry   |
+
+* Agricultural Inputs (plot_inputs — the input axis)
+
+# harmonize_input (GAP 2 plot_inputs).  Cloned from Niger's harmonize_input
+# (the EHCVM s16b input-type labels are identical across the two EHCVM
+# countries).  Maps each wave's agricultural-input *type* label onto a
+# shared input taxonomy `Preferred Label`; the reported item-level
+# plot_inputs feature (grain (t, i, input, crop, u)) puts this Preferred
+# Label on its `input` index level.  STRING-KEYED on Original Label (the
+# integer code is not a stable key): the wave script loads
+# convert_categoricals=True and keys on the raw French label.  SENEGAL
+# DELTA: the s16b roster carries 'Semences d'arachide' (groundnut seed,
+# the largest seed slot — 1610 rows) which Niger's data does not; added
+# here mapping to Seed (its crop is resolved by harmonize_seed_crop below).
+# Referenced via tools.get_categorical_mapping('harmonize_input',
+# 'Original Label','Preferred Label').
+
+#+NAME: harmonize_input
+| Original Label                            | Preferred Label     |
+|-------------------------------------------+---------------------|
+| engrais organiques-fumure                 | Organic manure      |
+| Engrais organiques-Fumure                 | Organic manure      |
+| Engrais organiques - déchets d'animaux    | Organic manure      |
+| engrais organiques-compost                | Organic compost     |
+| Engrais organiques-Compost                | Organic compost     |
+| Engrais organiques - Ordures ménagères    | Organic compost     |
+| engrais inorganiques - urée               | Urea                |
+| Engrais inorganiques - Urée               | Urea                |
+| engrais inorganiques - dap                | DAP                 |
+| Engrais inorganiques - DAP                | DAP                 |
+| DAP et autres engrais inorganiques        | DAP                 |
+| engrais inorganiques - npk 15/15          | NPK                 |
+| Engrais inorganiques - NPK 15/15          | NPK                 |
+| Engrais inorganiques - NPK/Formule unique | NPK                 |
+| Engrais inorganiques - Phosphates         | Phosphate           |
+| engrais inorganiques - mélange            | Mixed fertilizer    |
+| Engrais inorganiques - Mélange            | Mixed fertilizer    |
+| produits phytosanitaires - pesticides     | Pesticide           |
+| Produits phytosanitaires - Pesticides     | Pesticide           |
+| produits phytosanitaires - herbicides     | Herbicide           |
+| Produits phytosanitaires - Herbicides     | Herbicide           |
+| produits phytosanitaires - fongicides     | Fungicide           |
+| Produits phytosanitaires - Fongicides     | Fungicide           |
+| Produits phytosanitaires-Fongicides       | Fungicide           |
+| Produits phytosanitaires -Fongicides      | Fungicide           |
+| autres produits phytosanitaires           | Other phytosanitary |
+| Autres produits phytosanitaires           | Other phytosanitary |
+| semences                                  | Seed                |
+| Semences                                  | Seed                |
+| Semences d'arachide                       | Seed                |
+| Semences de petit mil                     | Seed                |
+| Semences de sorgho                        | Seed                |
+| Semences de maïs                          | Seed                |
+| Semences de riz                           | Seed                |
+| Semences d'autres céréales                | Seed                |
+| Semences de coton                         | Seed                |
+| Semences de sésame                        | Seed                |
+| Semences de césame                        | Seed                |
+| Semences de haricots/niébé                | Seed                |
+| Plants/boutures de tubercules             | Seed                |
+| Autres semences                           | Seed                |
+| 20                                        | Seed                |
+
+# harmonize_seed_crop (GAP 2 plot_inputs).  EHCVM-only helper, cloned from
+# Niger's harmonize_seed_crop.  The s16b roster has NO crop column — the
+# crop is encoded in the seed-type label ('Semences de petit mil') — so
+# this table resolves each EHCVM seed-type label to a crop Preferred Label.
+# The catch-all seed slots ('Semences d'autres céréales', 'Autres
+# semences', 'Plants/boutures de tubercules', '20') resolve to 'Autre
+# crop'.  Non-seed input labels are absent here (the wave script consults
+# this table only for rows whose input resolved to 'Seed').  SENEGAL DELTA:
+# 'Semences d'arachide' -> 'Arachide' (the dominant Senegal seed crop, not
+# present in the Niger data).
+
+#+NAME: harmonize_seed_crop
+| Original Label                | Preferred Label     |
+|-------------------------------+---------------------|
+| Semences d'arachide           | Arachide            |
+| Semences de petit mil         | Mil                 |
+| Semences de sorgho            | Sorgho              |
+| Semences de maïs              | Maïs en grain       |
+| Semences de riz               | Riz Paddy           |
+| Semences de coton             | Coton               |
+| Semences de sésame            | Sésame              |
+| Semences de césame            | Sésame              |
+| Semences de haricots/niébé    | Niébé/Haricots secs |
+| Semences d'autres céréales    | Autre crop          |
+| Plants/boutures de tubercules | Autre crop          |
+| Autres semences               | Autre crop          |
+| 20                            | Autre crop          |

--- a/lsms_library/countries/Senegal/_/categorical_mapping.org
+++ b/lsms_library/countries/Senegal/_/categorical_mapping.org
@@ -524,3 +524,24 @@
 |    1 | freehold                   |
 |    2 | granted_right_of_occupancy |
 |    4 | leasehold                  |
+
+# harmonize_species_ehcvm — EHCVM s17 livestock species code (s17q02 in
+#    2018-19, s17q01 in 2021-22 — the column moves but the 1-11 value
+#    scheme is identical).  Codes are the elevage__id value labels:
+#    1 Bovins, 2 Ovins, 3 Caprins, 4 Camelins, 5 Equins, 6 Asins,
+#    7 Porcins, 8 Lapins, 9 Poules, 10 Pintades, 11 Autres volailles.
+#    (Cloned verbatim from Niger's harmonize_species_ehcvm.)
+#+NAME: harmonize_species_ehcvm
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Cattle          |
+|    2 | Sheep           |
+|    3 | Goats           |
+|    4 | Camels          |
+|    5 | Horses          |
+|    6 | Donkeys         |
+|    7 | Pigs            |
+|    8 | Rabbits         |
+|    9 | Chicken         |
+|   10 | Guinea Fowl     |
+|   11 | Other Poultry   |

--- a/lsms_library/countries/Senegal/_/data_scheme.yml
+++ b/lsms_library/countries/Senegal/_/data_scheme.yml
@@ -120,3 +120,28 @@ Data Scheme:
     SoilType: str
     Irrigated: bool
     materialize: make
+
+  livestock:
+    # Item-level livestock roster (GAP 4), cloned from the Niger EHCVM
+    # template.  One row per REPORTED (household, species) the household
+    # owns/raises, from the EHCVM Section 17 'Élevage' roster
+    # (s17_me_sen2018.dta).  The WB .do collapses this to a single
+    # engaged-in-livestock y/n binary (recoverable as
+    # groupby(['t','i']).any() over these rows); TLU is a Σ(head × factor)
+    # transformation — neither is a column here (item-level discipline).
+    #
+    # GRAIN (t, i, animal) — NO v level: 'livestock' is in the framework's
+    # _no_v_join set, so the household-level rows carry no cluster level and
+    # the framework does NOT join one from sample().  `animal` is the
+    # harmonized species Preferred Label (harmonize_species_ehcvm; codes
+    # 1-11).  EHCVM 2018-19 only (the 2021-22 round lacks this section).
+    #
+    # COLUMNS (reported, item-level): HeadCount (owned now), HeadAcquired
+    # (number bought in the last 12 months), HeadSold (number sold on the
+    # hoof in the last 12 months).  A `Value` (herd value) column is
+    # intentionally OMITTED: EHCVM s17 records no current herd value.
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    materialize: make

--- a/lsms_library/countries/Senegal/_/data_scheme.yml
+++ b/lsms_library/countries/Senegal/_/data_scheme.yml
@@ -145,3 +145,113 @@ Data Scheme:
     HeadAcquired: float
     HeadSold: float
     materialize: make
+
+  crop_production:
+    # Item-level crop harvest (GAP 1), cloned from the Niger EHCVM template.
+    # One row per REPORTED (field, parcel, crop) harvest line from the EHCVM
+    # agriculture module s16c (s16c_me_sen2018.dta) — REPORTED values only;
+    # harvest_kg / yield / main_crop / value-shares are transformations,
+    # never columns here.  EHCVM 2018-19 only.  crop joins food via
+    # harmonize_food Preferred Labels; u via the u table (both label-
+    # preserving — Senegal's tables cover a subset of the s16c labels, the
+    # rest surface in raw French and are flagged by the sanity checker).
+    # plot = "{s16cq02}_{s16cq03}" aligns with plot_features' plot_id.  `u`
+    # is in the index (as in food_acquired): one (plot, crop) can be reported
+    # in several units.  Quantity_sold / Value_sold are at plot-crop grain
+    # (s16cq16a / s16cq17).  harvest_month is NA (the EHCVM s16c module has
+    # no planting/harvest-date question); intercropped from s16cq07.
+    index: (t, i, plot, crop, u)
+    Quantity: float
+    Quantity_sold: float
+    Value_sold: float
+    harvest_month: float
+    intercropped: bool
+    materialize: make
+
+  plot_inputs:
+    # Item-level agricultural inputs (GAP 2), cloned from the Niger EHCVM
+    # template.  One row per REPORTED input applied by a household from the
+    # EHCVM s16b roster (s16b_me_sen2018.dta): input identity, reported
+    # quantity used + native unit, purchased flag + reported purchased
+    # quantity, and (seed rows) the seed's crop on the shared harmonize_food
+    # labels.  REPORTED values only: seed_kg / nitrogen_kg / fertilizer
+    # totals are transformations, never columns.  EHCVM 2018-19 only.
+    #
+    # GRAIN (t, i, input, crop, u): Senegal (like Niger) records inputs at
+    # the HOUSEHOLD x input grain, NOT plot x input, so `plot` is NOT in the
+    # index (the feature keeps the GAP-2 name).  input -> harmonize_input;
+    # u -> the u table; crop -> harmonize_seed_crop on the seed label (both
+    # copied from Niger, with the Senegal-specific 'Semences d'arachide' ->
+    # Arachide seed slot added).  Non-crop-specific rows (every fertilizer /
+    # pesticide; unresolved seed crops) carry the sentinel
+    # '(not crop-specific)' rather than NaN — a NaN index level would be
+    # silently dropped by the framework's canonical NaN-key de-dup collapse.
+    # A missing unit is filled with the 'Manquant' u label for the same
+    # non-null reason.
+    index: (t, i, input, crop, u)
+    Quantity: float
+    Purchased: bool
+    Quantity_purchased: float
+    materialize: make
+
+  plot_labor:
+    # Item-level plot labor (GAP 3), cloned from the Niger EHCVM template.
+    # One row per REPORTED labor SOURCE on a plot, from the EHCVM s16a parcel
+    # module (s16a_me_sen2018.dta — the same file plot_features reads).
+    # EHCVM records family vs non-family (hired) only (NO free/exchange
+    # 'other').  The WB .do collapses these to total_labor_days /
+    # total_family_labor_days / total_hired_labor_days / hired_labor_value —
+    # all TRANSFORMATIONS over these rows, never columns here.  EHCVM 2018-19
+    # only.
+    #
+    # GRAIN (t, i, plot, source):
+    #   plot   -- "{field_no}_{parcel_no}", aligned with crop_production's
+    #             plot key and plot_features' plot_id.
+    #   source -- 'family' / 'hired' (EHCVM s16a has no 'other' source).
+    #             Small fixed vocabulary assigned in code (no categorical
+    #             table).
+    # COLUMNS (reported): PersonDays -- reported person-days of that source on
+    #   the plot (family = Σ member-day cells across the three phase grids;
+    #   hired = Σ(#workers × days) over the non-family grids — a within-source
+    #   sum of strata, NOT a cross-source rollup).  Wage -- cash PAID to hired
+    #   labor (CFA francs); NaN for family.  v auto-joins from sample().
+    #   units: PersonDays in days; Wage in CFA francs.
+    index: (t, i, plot, source)
+    PersonDays: float
+    Wage: float
+    materialize: make
+
+  people_last7days:
+    # Item-level individual 7-day labor (GAP 3), cloned from the Niger EHCVM
+    # template.  One row per individual carrying the REPORTED last-7-days
+    # labor participation, from the EHCVM s04 7-day module
+    # (s04_me_sen2018.dta) merged to the s01 roster (s01_me_sen2018.dta) for
+    # working_age.  This is the per-individual activity feature the GAP
+    # ranking targets (distinct from Uganda's legacy HH-level count).  No
+    # rollups: the WB nb_members_working_age HH total is a transformation.
+    # EHCVM 2018-19 only.
+    #
+    # GRAIN (t, i, pid): pid = s01q00a (matches household_roster).  v
+    # auto-joins from sample().
+    #
+    # COLUMNS (reported, per-individual):
+    #   farm_work / SOB_work / wage_work -- worked >=1h on own farm / own
+    #       business / for a wage in the last 7 days (nullable bool; s04q06 /
+    #       s04q07 / s04q08).
+    #   working_age -- member is of working age (Age >= 6, the survey
+    #       threshold).
+    # The EHCVM 7-day module records hours only for unpaid domestic tasks and
+    # the industry only as 12-month occupation codes (not the WB 7-day
+    # section ranges), so farm_hrs / SB_hrs / wage_hrs / Industry are NA
+    # (declared for cross-wave / cross-country schema parity).
+    # units: hours in hours.
+    index: (t, i, pid)
+    farm_work: bool
+    SOB_work: bool
+    wage_work: bool
+    farm_hrs: float
+    SB_hrs: float
+    wage_hrs: float
+    Industry: str
+    working_age: bool
+    materialize: make

--- a/lsms_library/countries/Togo/2018/_/crop_production.py
+++ b/lsms_library/countries/Togo/2018/_/crop_production.py
@@ -1,0 +1,121 @@
+"""Build crop_production for Togo EHCVM 2018 (item-level), cloned from the
+Niger 2018-19 EHCVM template.  SELF-CONTAINED: the map/finish helpers are
+inlined here, so this script does NOT import togo or niger.
+
+Single source file: ../Data1/s16c_me_tgo2018.dta (agriculture crop/harvest
+module).  One row per reported (field, parcel, crop) harvest record.
+Harvest qty + unit (s16cq12a / s16cq12b), sold qty + unit (s16cq16a /
+s16cq16b), sale value (s16cq17), and the intercrop flag (s16cq07) are ALL
+recorded at this plot-crop grain in 2018, so no cross-file join is needed.
+
+*** TOGO PATH / WAVE QUIRKS: the EHCVM agriculture module lives in
+2018/Data1/ (NOT 2018/Data/, which holds only _forEthan extracts); the
+wave dir is named 2018 (NOT 2018-19); the code suffix is tgo2018; t='2018'.
+Togo also ships bespoke Togo_survey2018_* files — DO NOT use those; this
+uses the standardized EHCVM module s16c_me_tgo2018.dta. ***
+
+Index = (t, i, plot, crop, u); plot = "{s16cq02}_{s16cq03}" aligns with
+plot_features' plot_id.  `i` is Togo's composite household id (grappe + '0'
++ zero-padded menage, inlined verbatim from togo.i() / 2018/_/livestock.py —
+NO 'E_' prefix), matching sample() and plot_features (t='2018').
+
+MAPPING NOTE: Togo has NO `harmonize_food` table (its food labels live in
+food_items.org keyed on Code, not Original Label), so the crop labels pass
+through as their raw French Preferred Labels ('Maïs', 'Sorgho', ...) — the
+same identity-passthrough the Niger helper applies to any unmapped label.
+The `u` unit table resolves at the library level (../../../_/), so units are
+harmonized through it where present.  perennial / planting_month are not
+recorded by EHCVM s16c, so they are omitted (parity with Niger).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet, format_id
+
+
+def i(value):
+    """Composite household id from (grappe, menage), matching Togo's
+    sample().  Inlined VERBATIM from togo.i() / 2018/_/livestock.py: grappe
+    + '0' separator + zero-padded (2-digit) menage.  NO 'E_' prefix."""
+    return tools.format_id(value.iloc[0]) + '0' + tools.format_id(value.iloc[1], zeropadding=2)
+
+
+def _maybe_map(tablename):
+    """Load a {Original Label -> Preferred Label} dict, or return {} (identity
+    passthrough) if the table is absent for Togo.  harmonize_food is absent
+    here, so its labels stay raw; `u` resolves at the library level."""
+    try:
+        return tools.get_categorical_mapping(
+            tablename=tablename, idxvars='Original Label',
+            **{'Preferred Label': 'Preferred Label'})
+    except (FileNotFoundError, KeyError):
+        return {}
+
+
+def _label_map(series, label_map):
+    """Map a string-label Series through label_map; unmapped labels pass
+    through unchanged (kept visible)."""
+    lab = series.astype('string')
+    return lab.map(lambda x: label_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _finish_crop_production(df, t):
+    """Common tail (inlined from niger._finish_crop_production): coerce
+    numeric columns, build the (t, i, plot, crop, u) index, drop rows with no
+    crop recorded."""
+    for col in ['Quantity', 'Quantity_sold', 'Value_sold']:
+        df[col] = pd.to_numeric(df.get(col), errors='coerce').astype('Float64')
+    if 'harvest_month' not in df.columns:
+        df['harvest_month'] = pd.NA
+    df['harvest_month'] = pd.to_numeric(df['harvest_month'], errors='coerce').astype('Float64')
+    if 'intercropped' not in df.columns:
+        df['intercropped'] = pd.NA
+    df['intercropped'] = df['intercropped'].astype('boolean')
+    df['t'] = t
+    df['crop'] = df['crop'].astype('string')
+    df['u'] = df['u'].astype('string')
+    df = df[df['crop'].notna()]
+    keep = ['t', 'i', 'plot', 'crop', 'u', 'Quantity',
+            'Quantity_sold', 'Value_sold', 'harvest_month', 'intercropped']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'plot', 'crop', 'u'])
+    return df
+
+
+# convert_categoricals=True so crop / unit value labels arrive as the strings
+# the harmonize_food / u tables key on; the codes view is used for the
+# plot/parcel sequence numbers (so format_id sees integers, not labels).
+src = get_dataframe('../Data1/s16c_me_tgo2018.dta', convert_categoricals=True)
+src_codes = get_dataframe('../Data1/s16c_me_tgo2018.dta', convert_categoricals=False)
+
+crop_map = _maybe_map('harmonize_food')
+unit_map = _maybe_map('u')
+
+hh = src.apply(lambda r: i(pd.Series([r['grappe'], r['menage']],
+                                     index=['grappe', 'menage'])), axis=1)
+field = src_codes['s16cq02'].apply(format_id)
+parcel = src_codes['s16cq03'].apply(format_id)
+plot = field.astype(str) + '_' + parcel.astype(str)
+
+# intercrop: s16cq07 == 'Association de cultures' -> True, 'Pure' -> False
+intercropped = src['s16cq07'].astype('string').map(
+    {'Association de cultures': True, 'Pure': False})
+
+df = pd.DataFrame({
+    'i':             hh.values,
+    'plot':          plot.values,
+    'crop':          _label_map(src['s16cq04'], crop_map).values,
+    'u':             _label_map(src['s16cq12b'], unit_map).values,
+    'Quantity':      src['s16cq12a'].values,
+    'Quantity_sold': src['s16cq16a'].values,
+    'Value_sold':    src['s16cq17'].values,
+    'intercropped':  intercropped.values,
+})
+
+df = _finish_crop_production(df, '2018')
+
+assert len(df) > 0, 'crop_production 2018 produced no rows'
+to_parquet(df, 'crop_production.parquet')

--- a/lsms_library/countries/Togo/2018/_/livestock.py
+++ b/lsms_library/countries/Togo/2018/_/livestock.py
@@ -1,0 +1,118 @@
+"""Build livestock for Togo EHCVM 2018 (item-level), cloned from the
+Niger 2018-19 EHCVM template.  SELF-CONTAINED: the map/finish helpers
+are inlined here, so this script does NOT import togo or niger.
+
+Single source file: ../Data1/s17_me_tgo2018.dta — the EHCVM section-17
+livestock ('Élevage') roster, one row per (household, species).  The
+roster is already restricted to owned species (s17q03 == 1 for every
+row); the gate is kept for parity / safety.
+
+*** SOURCE LOCATION: the EHCVM livestock module lives in 2018/Data1/
+(NOT 2018/Data/, which holds only _forEthan extracts) and the wave dir
+is named 2018 (NOT 2018-19).  Togo's repo also ships bespoke
+Togo_survey2018_* files — DO NOT use those; this uses the standardized
+EHCVM module s17_me_tgo2018.dta. ***
+
+Columns:
+  s17q02  species code (1-11, elevage__id; harmonize_species_ehcvm -> animal)
+  s17q03  owned/raised this species? (1=Oui / 2=Non) — gate (all ==1 here)
+  s17q06  number belonging to the household (HeadCount owned now)
+  s17q08  number bought in the last 12 months (HeadAcquired)
+  s17q10  number sold on the hoof in the last 12 months (HeadSold)
+
+There is NO current herd-value question in EHCVM s17, so Value is not
+emitted.  i is Togo's composite id (grappe + '0' + zero-padded menage,
+inlined verbatim from togo.i() — NO 'E_' prefix), matching Togo's
+sample() and plot_features (which use t='2018').  Grain (t, i, animal);
+no v level (livestock is in the framework's _no_v_join set).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+def i(value):
+    """Composite household id from (grappe, menage), matching Togo's
+    sample().  Inlined VERBATIM from togo.i() (Togo/_/togo.py): grappe +
+    '0' separator + zero-padded (2-digit) menage.  Togo's sample() and
+    plot_features() use this exact form (NO 'E_' prefix), so livestock i
+    matches sample() 1:1 (verified: 100% intersection)."""
+    return tools.format_id(value.iloc[0]) + '0' + tools.format_id(value.iloc[1], zeropadding=2)
+
+
+def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
+    """Load a {int code -> Preferred Label} dict from categorical_mapping.org.
+    Blank / '---' Preferred Labels map to NA.  (Inlined from togo._/.)"""
+    raw = tools.get_categorical_mapping(tablename=tablename, idxvars=key,
+                                        **{value: value})
+    out = {}
+    for k, v in raw.items():
+        try:
+            int_k = int(k)
+        except (TypeError, ValueError):
+            int_k = k
+        if pd.isna(v) or str(v).strip() in ('---', ''):
+            out[int_k] = pd.NA
+        else:
+            out[int_k] = str(v).strip()
+    return out
+
+
+def _map_codes(series, code_map):
+    """Map a numeric raw Stata integer-code Series through code_map, returning
+    a string Series with NA where unmapped.  Source loaded with
+    convert_categoricals=False so codes arrive as integers."""
+    out = series.astype('Int64').map(code_map)
+    return out.astype('string').where(out.notna(), pd.NA)
+
+
+def _finish_livestock(df, t):
+    """Coerce numeric columns, drop unresolved-species placeholder rows, SUM
+    head counts within (t, i, animal), build the (t, i, animal) index.
+    HeadCount / HeadAcquired / HeadSold are Float64 (nullable); min_count=1
+    keeps an all-NaN group NaN.  No Value column (EHCVM records no herd
+    value)."""
+    cols = ['HeadCount', 'HeadAcquired', 'HeadSold']
+    for col in cols:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    df['t'] = t
+    df['animal'] = df['animal'].astype('string')
+    df = df[df['animal'].notna() & df['i'].notna()]
+    df = (df.groupby(['t', 'i', 'animal'], dropna=False)[cols]
+            .sum(min_count=1)
+            .reset_index())
+    keep = ['t', 'i', 'animal'] + cols
+    df = df[keep]
+    df = df.set_index(['t', 'i', 'animal'])
+    return df
+
+
+srcn = get_dataframe('../Data1/s17_me_tgo2018.dta', convert_categoricals=False)
+
+ehcvm_map = _harmonized_codes('harmonize_species_ehcvm')
+
+# The roster only carries owned species, but keep the gate for parity / safety.
+owned = srcn['s17q03'] == 1
+srcn = srcn[owned.values]
+
+hh = srcn.apply(lambda r: i(pd.Series([r['grappe'], r['menage']],
+                                      index=['grappe', 'menage'])), axis=1)
+
+df = pd.DataFrame({
+    'i':            hh.values,
+    'animal':       _map_codes(srcn['s17q02'], ehcvm_map).values,
+    'HeadCount':    pd.to_numeric(srcn['s17q06'], errors='coerce').values,
+    'HeadAcquired': pd.to_numeric(srcn['s17q08'], errors='coerce').values,
+    'HeadSold':     pd.to_numeric(srcn['s17q10'], errors='coerce').values,
+})
+
+df = _finish_livestock(df, '2018')
+
+assert len(df) > 0, 'livestock 2018 produced no rows'
+to_parquet(df, 'livestock.parquet')

--- a/lsms_library/countries/Togo/2018/_/people_last7days.py
+++ b/lsms_library/countries/Togo/2018/_/people_last7days.py
@@ -1,0 +1,122 @@
+"""Build people_last7days for Togo EHCVM 2018 (individual 7-day activity),
+cloned from the Niger 2018-19 EHCVM template.  SELF-CONTAINED: the
+build/finish helpers are inlined here, so this script does NOT import togo
+or niger.
+
+Two source files:
+  s04_me_tgo2018.dta — the 7-day employment module (participation dummies).
+  s01_me_tgo2018.dta — the individual roster (age for working_age).
+Merged on (grappe, menage, s01q00a) — the same person key household_roster
+uses.  Grain (t, i, pid); pid = s01q00a; `i` is Togo's composite household
+id (grappe + '0' + zero-padded menage; NO 'E_' prefix), matching sample()
+(t='2018').
+
+*** TOGO PATH / WAVE QUIRKS: sources in 2018/Data1/; wave dir 2018; code
+suffix tgo2018; t='2018'; standardized modules (NOT Togo_survey2018_*). ***
+
+EHCVM's 7-day module records only the three participation DUMMIES in an
+ECVMA-comparable form (s04q06 farm, s04q07 own-business, s04q08 wage) and
+working_age (roster Age >= 6).  It does NOT record productive-work hours or
+the WB 7-day industry section code, so farm_hrs / SB_hrs / wage_hrs and
+Industry are NA (declared for cross-wave schema parity).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+def i(value):
+    """Composite household id from (grappe, menage), matching Togo's
+    sample().  Inlined VERBATIM from togo.i() / 2018/_/livestock.py: grappe
+    + '0' separator + zero-padded (2-digit) menage.  NO 'E_' prefix."""
+    return tools.format_id(value.iloc[0]) + '0' + tools.format_id(value.iloc[1], zeropadding=2)
+
+
+def _yn_bool(series, yes=1, no=2):
+    """Map a 1=Oui / 2=Non survey item to nullable boolean (other codes ->
+    NA).  Inlined from niger._yn_bool."""
+    s = pd.to_numeric(series, errors='coerce')
+    out = pd.Series(pd.NA, index=s.index, dtype='boolean')
+    out = out.mask(s == yes, True)
+    out = out.mask(s == no, False)
+    return out
+
+
+def people_last7days_ehcvm(s04, s01, t, pid_col='s01q00a', age_col='s01q04a',
+                           dob_year_col='s01q03c', survey_year=None):
+    """Build people_last7days from the EHCVM s04 (7-day) + s01 (roster)
+    modules.  Inlined from niger.people_last7days_ehcvm, but uses Togo's i().
+
+    farm_work/SOB_work/wage_work from s04q06/07/08 (1=Oui / 2=Non).  Age:
+    prefer reported years (age_col), else survey_year - birth_year
+    (dob_year_col, with a 1900..survey_year sanity window).  working_age =
+    Age >= 6.  Returns the (i, pid, farm_work, SOB_work, wage_work,
+    working_age) frame ready for _finish_people_last7days."""
+    key = ['grappe', 'menage', pid_col]
+    roster_cols = [age_col, dob_year_col]
+    merged = s04[key + ['s04q06', 's04q07', 's04q08']].merge(
+        s01[key + roster_cols], on=key, how='left')
+
+    hh = merged.apply(lambda r: i(pd.Series([r['grappe'], r['menage']],
+                                            index=['grappe', 'menage'])), axis=1)
+    pid = merged[pid_col].apply(tools.format_id)
+
+    age = pd.to_numeric(merged[age_col], errors='coerce')
+    if survey_year is not None:
+        birth = pd.to_numeric(merged[dob_year_col], errors='coerce')
+        birth = birth.where((birth >= 1900) & (birth <= survey_year), pd.NA)
+        age_from_dob = survey_year - birth
+        age = age.where(age.notna(), age_from_dob)
+    working_age = (age >= 6)
+    working_age = working_age.where(age.notna(), pd.NA)
+
+    df = pd.DataFrame({
+        'i': hh.values,
+        'pid': pid.values,
+        'farm_work': _yn_bool(merged['s04q06']).values,
+        'SOB_work': _yn_bool(merged['s04q07']).values,
+        'wage_work': _yn_bool(merged['s04q08']).values,
+        'working_age': working_age.values,
+    })
+    return df
+
+
+def _finish_people_last7days(df, t):
+    """Common tail (inlined from niger._finish_people_last7days): coerce
+    dtypes, guarantee the full schema column set (NA where the wave lacks a
+    field), drop rows with no individual key, build the (t, i, pid) index."""
+    df = df.copy()
+    df['t'] = t
+    df['pid'] = df['pid'].astype('string')
+    for col in ['farm_work', 'SOB_work', 'wage_work', 'working_age']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = df[col].astype('boolean')
+    for col in ['farm_hrs', 'SB_hrs', 'wage_hrs']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Industry' not in df.columns:
+        df['Industry'] = pd.NA
+    df['Industry'] = df['Industry'].astype('string')
+    df = df[df['i'].notna() & df['pid'].notna()]
+    keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
+            'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
+    df = df[keep]
+    df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
+    df = df.set_index(['t', 'i', 'pid'])
+    return df
+
+
+s04 = get_dataframe('../Data1/s04_me_tgo2018.dta', convert_categoricals=False)
+s01 = get_dataframe('../Data1/s01_me_tgo2018.dta', convert_categoricals=False)
+
+df = people_last7days_ehcvm(s04, s01, '2018', survey_year=2018)
+df = _finish_people_last7days(df, '2018')
+
+assert len(df) > 0, 'people_last7days 2018 produced no rows'
+to_parquet(df, 'people_last7days.parquet')

--- a/lsms_library/countries/Togo/2018/_/plot_inputs.py
+++ b/lsms_library/countries/Togo/2018/_/plot_inputs.py
@@ -1,0 +1,146 @@
+"""Build plot_inputs for Togo EHCVM 2018 (item-level), cloned from the Niger
+2018-19 EHCVM template.  SELF-CONTAINED: the map/finish helpers are inlined
+here, so this script does NOT import togo or niger.
+
+Single source file: ../Data1/s16b_me_tgo2018.dta — the household
+agricultural-input roster, one row per input-type the household was asked
+about.  Columns:
+  s16bq01   input type (organic / inorganic fert / phyto / seeds-by-crop)
+  s16bq02   USED this input? (1=Oui / 2=Non) — application gate
+  s16bq03a / s16bq03b   quantity used + native unit
+  s16bq05   purchased? (Oui / Non)
+  s16bq07a  quantity purchased (native unit)
+
+*** TOGO PATH / WAVE QUIRKS: source in 2018/Data1/; wave dir 2018; code
+suffix tgo2018; t='2018'; standardized module (NOT Togo_survey2018_*). ***
+
+We keep s16bq02==1 (applied) rows.  The EHCVM roster has NO crop column —
+the seed's crop is embedded in the input-type label ('Semences de petit
+mil'), resolved to a crop label via harmonize_seed_crop (copied from Niger
+into Togo's categorical_mapping.org).  Non-seed input rows carry the CROP_NA
+sentinel.  `i` is Togo's composite household id (grappe + '0' + zero-padded
+menage; NO 'E_' prefix), matching sample() (t='2018').  No plot column;
+grain is (t, i, input, crop, u).
+
+MAPPING: harmonize_input + harmonize_seed_crop were copied verbatim from
+Niger into Togo/_/categorical_mapping.org (the EHCVM s16b labels are
+identical across EHCVM countries; every Togo input label is covered).  `u`
+resolves at the library level.
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+# Sentinel for the `crop` index level on input rows that are NOT
+# crop-specific (every fertilizer / pesticide row, and any seed row whose
+# crop could not be resolved).  A non-null token keeps every reported row
+# through the framework's NaN-key duplicate collapse (groupby().first()
+# drops NaN grouping keys).  Inlined verbatim from niger.CROP_NA.
+CROP_NA = '(not crop-specific)'
+# Missing-unit fill (a reported input may lack a recorded unit, e.g. a count
+# of bags); keeps the `u` index level non-null.  Matches niger's 'Manquant'.
+UNIT_NA = 'Manquant'
+
+
+def i(value):
+    """Composite household id from (grappe, menage), matching Togo's
+    sample().  Inlined VERBATIM from togo.i() / 2018/_/livestock.py: grappe
+    + '0' separator + zero-padded (2-digit) menage.  NO 'E_' prefix."""
+    return tools.format_id(value.iloc[0]) + '0' + tools.format_id(value.iloc[1], zeropadding=2)
+
+
+def _maybe_map(tablename):
+    """Load a {Original Label -> Preferred Label} dict, or {} (identity) if
+    the table is absent for Togo."""
+    try:
+        return tools.get_categorical_mapping(
+            tablename=tablename, idxvars='Original Label',
+            **{'Preferred Label': 'Preferred Label'})
+    except (FileNotFoundError, KeyError):
+        return {}
+
+
+def _input_labels(series, input_map):
+    """Map an input-type column through harmonize_input; unmapped labels pass
+    through unchanged (kept visible)."""
+    lab = series.astype('string')
+    return lab.map(lambda x: input_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _seed_crop_labels(series, seed_crop_map):
+    """Resolve the crop embedded in a seed-type label via harmonize_seed_crop.
+    Returns NA for any label not in the seed-crop table (non-seed rows)."""
+    lab = series.astype('string')
+    return lab.map(lambda x: seed_crop_map.get(x, pd.NA) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _unit_labels(series, unit_map):
+    """Map a native-unit column through the `u` table; unmapped labels pass
+    through unchanged."""
+    u = series.astype('string')
+    return u.map(lambda x: unit_map.get(x, x) if pd.notna(x) else pd.NA).astype('string')
+
+
+def _finish_plot_inputs(df, t):
+    """Common tail (inlined from niger._finish_plot_inputs): coerce numeric
+    columns, fill the CROP_NA / UNIT_NA sentinels so every index level is
+    non-null, drop rows with no input identity, build the
+    (t, i, input, crop, u) index."""
+    for col in ['Quantity', 'Quantity_purchased']:
+        if col not in df.columns:
+            df[col] = pd.NA
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Float64')
+    if 'Purchased' not in df.columns:
+        df['Purchased'] = pd.NA
+    df['Purchased'] = df['Purchased'].astype('boolean')
+    df['t'] = t
+    df['input'] = df['input'].astype('string')
+    if 'crop' not in df.columns:
+        df['crop'] = pd.NA
+    df['crop'] = df['crop'].astype('string').fillna(CROP_NA)
+    df['u'] = df['u'].astype('string').fillna(UNIT_NA)
+    df = df[df['input'].notna()]
+    keep = ['t', 'i', 'input', 'crop', 'u',
+            'Quantity', 'Purchased', 'Quantity_purchased']
+    df = df[[c for c in keep if c in df.columns]]
+    df = df.set_index(['t', 'i', 'input', 'crop', 'u'])
+    return df
+
+
+src = get_dataframe('../Data1/s16b_me_tgo2018.dta', convert_categoricals=True)
+srcn = get_dataframe('../Data1/s16b_me_tgo2018.dta', convert_categoricals=False)
+
+input_map = _maybe_map('harmonize_input')
+unit_map = _maybe_map('u')
+seed_crop_map = _maybe_map('harmonize_seed_crop')
+
+# Keep only inputs the household actually applied (s16bq02 == 1 = Oui).
+applied = srcn['s16bq02'] == 1
+src = src[applied.values]
+srcn = srcn[applied.values]
+
+hh = src.apply(lambda r: i(pd.Series([r['grappe'], r['menage']],
+                                     index=['grappe', 'menage'])), axis=1)
+
+# purchased: s16bq05 Oui/Non (labels via convert_categoricals)
+purchased = src['s16bq05'].astype('string').map({'Oui': True, 'Non': False})
+
+df = pd.DataFrame({
+    'i':                  hh.values,
+    'input':              _input_labels(src['s16bq01'], input_map).values,
+    'crop':               _seed_crop_labels(src['s16bq01'], seed_crop_map).values,
+    'u':                  _unit_labels(src['s16bq03b'], unit_map).values,
+    'Quantity':           pd.to_numeric(srcn['s16bq03a'], errors='coerce').values,
+    'Purchased':          purchased.values,
+    'Quantity_purchased': pd.to_numeric(srcn['s16bq07a'], errors='coerce').values,
+})
+
+df = _finish_plot_inputs(df, '2018')
+
+assert len(df) > 0, 'plot_inputs 2018 produced no rows'
+to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Togo/2018/_/plot_labor.py
+++ b/lsms_library/countries/Togo/2018/_/plot_labor.py
@@ -1,0 +1,137 @@
+"""Build plot_labor for Togo EHCVM 2018 (item-level), cloned from the Niger
+2018-19 EHCVM template.  SELF-CONTAINED: the build/finish helpers are
+inlined here, so this script does NOT import togo or niger.
+
+Single source file: ../Data1/s16a_me_tgo2018.dta (agriculture-parcel module
+— the same file plot_features reads, so plot ids align by construction).
+EHCVM records plot labor at the parcel level, family vs non-family (hired)
+only (NO free/exchange "other" labor):
+
+  Family labor (per family member, member-grid suffix _1.._N, three phases):
+    s16aq33b_*  days each member worked, prep/sowing phase
+    s16aq35b_*  days each member worked, maintenance phase
+    s16aq37b_*  days each member worked, harvest phase
+  -> family PersonDays = Σ over members & phases of those member-day cells.
+
+  Non-family / hired labor (per worker gender category, grid suffix _1.._4,
+  three phases; a = #workers, b = days each, c = wage paid):
+    s16aq39{a,b,c}_*  prep/sowing phase
+    s16aq41{a,b,c}_*  maintenance phase
+    s16aq43{a,b,c}_*  harvest phase
+  -> hired PersonDays = Σ over categories & phases of (a workers × b days);
+     hired Wage       = Σ over categories & phases of c (cash paid).
+
+*** TOGO PATH / WAVE QUIRKS: source in 2018/Data1/; wave dir 2018; code
+suffix tgo2018; t='2018'; standardized module (NOT Togo_survey2018_*). ***
+
+One row per (plot, source); plot = "{s16aq02}_{s16aq03}" aligns with
+crop_production / plot_features plot_id.  `i` is Togo's composite household
+id (grappe + '0' + zero-padded menage; NO 'E_' prefix), matching sample()
+(t='2018').  Grain (t, i, plot, source).
+"""
+import sys
+
+sys.path.append('../../_/')
+import pandas as pd
+
+import lsms_library.local_tools as tools
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+LABOR_SOURCE_FAMILY = 'family'
+LABOR_SOURCE_HIRED = 'hired'
+
+
+def i(value):
+    """Composite household id from (grappe, menage), matching Togo's
+    sample().  Inlined VERBATIM from togo.i() / 2018/_/livestock.py: grappe
+    + '0' separator + zero-padded (2-digit) menage.  NO 'E_' prefix."""
+    return tools.format_id(value.iloc[0]) + '0' + tools.format_id(value.iloc[1], zeropadding=2)
+
+
+def plot_labor_ehcvm(src, t):
+    """Build plot_labor from the s16a parcel module (inlined from
+    niger.plot_labor_ehcvm, but uses Togo's i()).  EHCVM records family vs
+    non-family (hired) plot labor only.  Returns the long
+    (i, plot, source, PersonDays, Wage) frame ready for _finish_plot_labor."""
+    cols = list(src.columns)
+
+    def _num(col):
+        return pd.to_numeric(src[col], errors='coerce').astype('Float64')
+
+    hh = src.apply(lambda r: i(pd.Series([r['grappe'], r['menage']],
+                                         index=['grappe', 'menage'])), axis=1)
+    field = src['s16aq02'].apply(tools.format_id)
+    parcel = src['s16aq03'].apply(tools.format_id)
+    plot = field.astype('string') + '_' + parcel.astype('string')
+
+    # family: sum member-day cells across the three phase grids
+    fam_cols = [c for c in cols
+                if c.startswith('s16aq33b_')
+                or c.startswith('s16aq35b_')
+                or c.startswith('s16aq37b_')]
+    fam_days = sum(_num(c).fillna(0) for c in fam_cols)
+    fam_any = pd.concat([_num(c).notna() for c in fam_cols], axis=1).any(axis=1)
+    fam_days = fam_days.where(fam_any.values, pd.NA)
+    fam = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_FAMILY,
+        'PersonDays': fam_days.values, 'Wage': pd.NA,
+    })
+
+    # hired: Σ(#workers × days) person-days, Σ wage, over phase × category
+    hired_days = pd.Series(0.0, index=src.index, dtype='Float64')
+    hired_wage = pd.Series(0.0, index=src.index, dtype='Float64')
+    any_days = pd.Series(False, index=src.index)
+    any_wage = pd.Series(False, index=src.index)
+    for base in ['s16aq39', 's16aq41', 's16aq43']:
+        for ac in [c for c in cols if c.startswith(base + 'a_')]:
+            suf = ac[len(base + 'a'):]   # e.g. '_1' (keeps the underscore)
+            bc, cc = base + 'b' + suf, base + 'c' + suf
+            workers = _num(ac)
+            days = _num(bc) if bc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            wage = _num(cc) if cc in cols else pd.Series(pd.NA, index=src.index, dtype='Float64')
+            pd_cell = workers * days
+            hired_days = hired_days.add(pd_cell.fillna(0))
+            any_days = any_days | pd_cell.notna().values
+            hired_wage = hired_wage.add(wage.fillna(0))
+            any_wage = any_wage | wage.notna().values
+    hired_days = hired_days.where(any_days.values, pd.NA)
+    hired_wage = hired_wage.where(any_wage.values, pd.NA)
+    hired = pd.DataFrame({
+        'i': hh.values, 'plot': plot.values,
+        'source': LABOR_SOURCE_HIRED,
+        'PersonDays': hired_days.values, 'Wage': hired_wage.values,
+    })
+
+    return pd.concat([fam, hired], ignore_index=True)
+
+
+def _finish_plot_labor(df, t):
+    """Common tail (inlined from niger._finish_plot_labor): SUM PersonDays /
+    Wage within (t, i, plot, source) so the member / category / phase strata
+    collapse onto the (plot, source) item grain.  Drops rows with no plot, no
+    source, or no reported labor at all."""
+    df = df.copy()
+    df['t'] = t
+    df['source'] = df['source'].astype('string')
+    df['plot'] = df['plot'].astype('string')
+    df['PersonDays'] = pd.to_numeric(df.get('PersonDays'), errors='coerce').astype('Float64')
+    if 'Wage' not in df.columns:
+        df['Wage'] = pd.NA
+    df['Wage'] = pd.to_numeric(df['Wage'], errors='coerce').astype('Float64')
+    df = df[df['i'].notna() & df['plot'].notna() & df['source'].notna()]
+    df = (df.groupby(['t', 'i', 'plot', 'source'], dropna=False)[['PersonDays', 'Wage']]
+            .sum(min_count=1)
+            .reset_index())
+    df = df[df['PersonDays'].notna() | df['Wage'].notna()]
+    df = df.set_index(['t', 'i', 'plot', 'source'])
+    return df
+
+
+src = get_dataframe('../Data1/s16a_me_tgo2018.dta', convert_categoricals=False)
+df = plot_labor_ehcvm(src, '2018')
+df = _finish_plot_labor(df, '2018')
+
+assert len(df) > 0, 'plot_labor 2018 produced no rows'
+to_parquet(df, 'plot_labor.parquet')

--- a/lsms_library/countries/Togo/_/Makefile
+++ b/lsms_library/countries/Togo/_/Makefile
@@ -31,6 +31,13 @@ $(VAR_DIR)/food_acquired.parquet: food_acquired.py $(food_acquired_parquet)
 ../%/_/plot_features.parquet: ../%/_/plot_features.py
 	(cd $(@D) && python plot_features.py)
 
+# Wave-level livestock (EHCVM cluster; cloned from Niger).  Same gap as
+# plot_features above: the generic %.parquet rule never fires for it
+# because its food_items.org/malawi.py prereqs are absent, so give it an
+# explicit pattern rule.
+../%/_/livestock.parquet: ../%/_/livestock.py
+	(cd $(@D) && python livestock.py)
+
 %.parquet: %.py food_items.org malawi.py
 	(cd $(@D) && python ./$(<F))
 

--- a/lsms_library/countries/Togo/_/Makefile
+++ b/lsms_library/countries/Togo/_/Makefile
@@ -38,6 +38,22 @@ $(VAR_DIR)/food_acquired.parquet: food_acquired.py $(food_acquired_parquet)
 ../%/_/livestock.parquet: ../%/_/livestock.py
 	(cd $(@D) && python livestock.py)
 
+# Wave-level EHCVM parity features (cloned from Niger 2018-19).  Same gap as
+# plot_features / livestock above: the generic %.parquet rule never fires
+# for them (the food_items.org/malawi.py prereqs are absent), so each gets
+# an explicit pattern rule that runs its self-contained wave script.
+../%/_/crop_production.parquet: ../%/_/crop_production.py
+	(cd $(@D) && python crop_production.py)
+
+../%/_/plot_inputs.parquet: ../%/_/plot_inputs.py
+	(cd $(@D) && python plot_inputs.py)
+
+../%/_/plot_labor.parquet: ../%/_/plot_labor.py
+	(cd $(@D) && python plot_labor.py)
+
+../%/_/people_last7days.parquet: ../%/_/people_last7days.py
+	(cd $(@D) && python people_last7days.py)
+
 %.parquet: %.py food_items.org malawi.py
 	(cd $(@D) && python ./$(<F))
 

--- a/lsms_library/countries/Togo/_/categorical_mapping.org
+++ b/lsms_library/countries/Togo/_/categorical_mapping.org
@@ -93,3 +93,25 @@
 |    1 | freehold                   |
 |    2 | granted_right_of_occupancy |
 |    4 | leasehold                  |
+
+# livestock harmonize table (EHCVM cluster; cloned from Niger 2018-19,
+# PR for GAP 4).  s17q02 species code (elevage__id, 1-11) -> canonical
+# `animal`.  Shared EHCVM vocabulary so the animal axis matches the
+# other EHCVM countries.  Referenced from 2018/_/livestock.py via
+# tools.get_categorical_mapping('harmonize_species_ehcvm','Code',
+# 'Preferred Label').
+
+#+NAME: harmonize_species_ehcvm
+| Code | Preferred Label |
+|------+-----------------|
+|    1 | Cattle          |
+|    2 | Sheep           |
+|    3 | Goats           |
+|    4 | Camels          |
+|    5 | Horses          |
+|    6 | Donkeys         |
+|    7 | Pigs            |
+|    8 | Rabbits         |
+|    9 | Chicken         |
+|   10 | Guinea Fowl     |
+|   11 | Other Poultry   |

--- a/lsms_library/countries/Togo/_/categorical_mapping.org
+++ b/lsms_library/countries/Togo/_/categorical_mapping.org
@@ -115,3 +115,79 @@
 |    9 | Chicken         |
 |   10 | Guinea Fowl     |
 |   11 | Other Poultry   |
+
+# plot_inputs harmonize tables (EHCVM cluster; cloned VERBATIM from Niger
+# 2018-19 GAP 2, parity loop 2026-06-15).  The EHCVM s16b input roster is
+# identical across the EHCVM countries (same French value labels), so the
+# Niger Original Labels match Togo's s16bq01 1:1 (verified: every Togo
+# input label is covered).  Referenced from 2018/_/plot_inputs.py via
+# tools.get_categorical_mapping('harmonize_input'/'harmonize_seed_crop',
+# 'Original Label', 'Preferred Label').
+#
+# harmonize_input — s16bq01 input-type label -> canonical input identity.
+# harmonize_seed_crop — EHCVM seed-type label -> the seed's crop.  The
+#   s16b roster has NO crop column; the crop is embedded in the seed-type
+#   label ('Semences de petit mil'), resolved here.  Catch-all seed slots
+#   ('Semences d'autres céréales', 'Autres semences', 'Plants/boutures de
+#   tubercules', the bare '20' slot) -> 'Autre crop'.
+
+#+NAME: harmonize_input
+| Original Label                            | Preferred Label     |
+|-------------------------------------------+---------------------|
+| engrais organiques-fumure                 | Organic manure      |
+| Engrais organiques-Fumure                 | Organic manure      |
+| Engrais organiques - déchets d'animaux    | Organic manure      |
+| engrais organiques-compost                | Organic compost     |
+| Engrais organiques-Compost                | Organic compost     |
+| Engrais organiques - Ordures ménagères    | Organic compost     |
+| engrais inorganiques - urée               | Urea                |
+| Engrais inorganiques - Urée               | Urea                |
+| engrais inorganiques - dap                | DAP                 |
+| Engrais inorganiques - DAP                | DAP                 |
+| DAP et autres engrais inorganiques        | DAP                 |
+| engrais inorganiques - npk 15/15          | NPK                 |
+| Engrais inorganiques - NPK 15/15          | NPK                 |
+| Engrais inorganiques - NPK/Formule unique | NPK                 |
+| Engrais inorganiques - Phosphates         | Phosphate           |
+| engrais inorganiques - mélange            | Mixed fertilizer    |
+| Engrais inorganiques - Mélange            | Mixed fertilizer    |
+| produits phytosanitaires - pesticides     | Pesticide           |
+| Produits phytosanitaires - Pesticides     | Pesticide           |
+| produits phytosanitaires - herbicides     | Herbicide           |
+| Produits phytosanitaires - Herbicides     | Herbicide           |
+| produits phytosanitaires - fongicides     | Fungicide           |
+| Produits phytosanitaires - Fongicides     | Fungicide           |
+| Produits phytosanitaires-Fongicides       | Fungicide           |
+| Produits phytosanitaires -Fongicides      | Fungicide           |
+| autres produits phytosanitaires           | Other phytosanitary |
+| Autres produits phytosanitaires           | Other phytosanitary |
+| semences                                  | Seed                |
+| Semences                                  | Seed                |
+| Semences de petit mil                     | Seed                |
+| Semences de sorgho                        | Seed                |
+| Semences de maïs                          | Seed                |
+| Semences de riz                           | Seed                |
+| Semences d'autres céréales                | Seed                |
+| Semences de coton                         | Seed                |
+| Semences de sésame                        | Seed                |
+| Semences de césame                        | Seed                |
+| Semences de haricots/niébé                | Seed                |
+| Plants/boutures de tubercules             | Seed                |
+| Autres semences                           | Seed                |
+| 20                                        | Seed                |
+
+#+NAME: harmonize_seed_crop
+| Original Label                | Preferred Label     |
+|-------------------------------+---------------------|
+| Semences de petit mil         | Mil                 |
+| Semences de sorgho            | Sorgho              |
+| Semences de maïs              | Maïs en grain       |
+| Semences de riz               | Riz Paddy           |
+| Semences de coton             | Coton               |
+| Semences de sésame            | Sésame              |
+| Semences de césame            | Sésame              |
+| Semences de haricots/niébé    | Niébé/Haricots secs |
+| Semences d'autres céréales    | Autre crop          |
+| Plants/boutures de tubercules | Autre crop          |
+| Autres semences               | Autre crop          |
+| 20                            | Autre crop          |

--- a/lsms_library/countries/Togo/_/data_scheme.yml
+++ b/lsms_library/countries/Togo/_/data_scheme.yml
@@ -131,3 +131,82 @@ Data Scheme:
     HeadAcquired: float
     HeadSold: float
     materialize: make
+
+  crop_production:
+    # Item-level crop harvest (EHCVM cluster; cloned from Niger 2018-19,
+    # GAP 1).  One row per REPORTED (field, parcel, crop) harvest line from
+    # the EHCVM agriculture module (2018/Data1/s16c_me_tgo2018.dta, NOT the
+    # bespoke Togo_survey2018_* files).  REPORTED values only; harvest_kg /
+    # yield / main_crop / value-shares are transformations, never columns.
+    # crop labels pass through as raw French (Togo has no harmonize_food
+    # table); u via the library-level u table.  plot = "{s16cq02}_{s16cq03}"
+    # aligns with plot_features' plot_id.  `u` is in the index (as in
+    # food_acquired) because one (plot, crop) can be reported in several
+    # units.  planting_month / perennial omitted (not recorded by EHCVM
+    # s16c); harvest_month all-NaN here (only 2014-15 ECVMA recorded it) but
+    # carried for cross-wave schema parity; intercropped from s16cq07.
+    index: (t, i, plot, crop, u)
+    Quantity: float
+    Quantity_sold: float
+    Value_sold: float
+    harvest_month: float
+    intercropped: bool
+    materialize: make
+
+  plot_inputs:
+    # Item-level agricultural inputs (EHCVM cluster; cloned from Niger
+    # 2018-19, GAP 2).  One row per REPORTED input applied by a household
+    # (2018/Data1/s16b_me_tgo2018.dta).  REPORTED values only; seed_kg /
+    # nitrogen_kg / fertilizer totals are transformations, never columns.
+    # GRAIN NOTE: EHCVM records inputs at the HOUSEHOLD x input grain, NOT
+    # plot x input (no parcel-level input question), so `plot` is NOT in the
+    # index; the feature keeps the GAP-2 name `plot_inputs`.  input ->
+    # harmonize_input, crop -> harmonize_seed_crop (both copied from Niger
+    # into Togo/_/categorical_mapping.org — the EHCVM s16b labels are
+    # identical across EHCVM countries); u via the library-level u table.
+    # Non-crop-specific rows carry the sentinel '(not crop-specific)' and a
+    # missing unit the 'Manquant' u label, both non-null so the framework's
+    # canonical NaN-key de-dup collapse does not silently drop them.
+    index: (t, i, input, crop, u)
+    Quantity: float
+    Purchased: bool
+    Quantity_purchased: float
+    materialize: make
+
+  plot_labor:
+    # Item-level plot labor (EHCVM cluster; cloned from Niger 2018-19,
+    # GAP 3).  One row per REPORTED labor SOURCE on a plot from the EHCVM
+    # agriculture-parcel module (2018/Data1/s16a_me_tgo2018.dta — the same
+    # file plot_features reads, so plot ids align).  REPORTED values only;
+    # total_labor_days / hired_labor_value are transformations, never
+    # columns.  GRAIN (t, i, plot, source): source is 'family' / 'hired'
+    # (EHCVM s16a records family vs non-family only — no free/exchange
+    # 'other').  PersonDays = within-source sum over the member / gender-
+    # category / phase strata (NOT a cross-source rollup); EHCVM hired
+    # person-days = Σ(#workers × days).  Wage = cash paid to hired labor
+    # (CFA francs); NaN for family.  plot = "{s16aq02}_{s16aq03}".
+    index: (t, i, plot, source)
+    PersonDays: float
+    Wage: float
+    materialize: make
+
+  people_last7days:
+    # Individual 7-day activity (EHCVM cluster; cloned from Niger 2018-19,
+    # GAP 3).  One row per individual from the EHCVM 7-day employment module
+    # (2018/Data1/s04_me_tgo2018.dta) merged to the s01 roster for age.
+    # GRAIN (t, i, pid); pid = s01q00a (matches household_roster).  EHCVM
+    # records only the three participation DUMMIES (s04q06 farm -> farm_work,
+    # s04q07 own-business -> SOB_work, s04q08 wage -> wage_work) and
+    # working_age (roster Age >= 6).  It does NOT record productive-work
+    # hours or the WB 7-day industry section code, so farm_hrs / SB_hrs /
+    # wage_hrs and Industry are NA (declared for cross-wave schema parity).
+    index: (t, i, pid)
+    farm_work: bool
+    SOB_work: bool
+    wage_work: bool
+    farm_hrs: float
+    SB_hrs: float
+    wage_hrs: float
+    Industry: str
+    working_age: bool
+    materialize: make

--- a/lsms_library/countries/Togo/_/data_scheme.yml
+++ b/lsms_library/countries/Togo/_/data_scheme.yml
@@ -104,3 +104,30 @@ Data Scheme:
     SoilType: str
     Irrigated: bool
     materialize: make
+
+  livestock:
+    # Item-level livestock roster (EHCVM cluster; cloned from Niger
+    # 2018-19, GAP 4).  One row per REPORTED (household, species) the
+    # household owns/raises, from the EHCVM §17 'Élevage' roster
+    # (2018/Data1/s17_me_tgo2018.dta, NOT the bespoke Togo_survey2018_*
+    # files).  Source: s17q02 species (1-11, harmonize_species_ehcvm),
+    # s17q06 head, s17q08 bought, s17q10 sold; s17q03==1 owned gate
+    # (roster is pre-filtered to owned).
+    #
+    # GRAIN (t, i, animal) — NO v level: 'livestock' is in the
+    # framework's _no_v_join set, so the household-level rows carry no
+    # cluster level and the framework does NOT join one from sample().
+    # `animal` is the harmonized species Preferred Label
+    # (harmonize_species_ehcvm).
+    #
+    # COLUMNS (reported, item-level): HeadCount (owned now), HeadAcquired
+    # (number bought in the last 12 months), HeadSold (number sold on the
+    # hoof in the last 12 months).  A `Value` (herd value) column is
+    # intentionally OMITTED: EHCVM s17 asks no current herd value (only
+    # purchase / sale FLOW values), so an all-NaN Value column would only
+    # trip the sanity checker.
+    index: (t, i, animal)
+    HeadCount: float
+    HeadAcquired: float
+    HeadSold: float
+    materialize: make


### PR DESCRIPTION
## Summary

Extends the WB-parity item-feature stack (GH #438) to the **6 EHCVM West-Africa countries** — Benin, Burkina_Faso, CôtedIvoire, Guinea-Bissau, Senegal, Togo — by cloning the **Niger 2018-19 EHCVM template** (EHCVM is one standardized instrument, so the section codes are shared). Built by 12 isolated per-country worktree agents (enabled by the #436 `LSMS_COUNTRIES_ROOT` override).

### Features added (all grain-canonical, i-key ∩ sample = 1.0)
- **livestock** `(t,i,animal)` ← `s17` — all 6
- **crop_production** `(t,i,plot,crop,u)` ← `s16c` — all 6
- **plot_inputs** `(t,i,input,crop,u)` ← `s16b` — all 6
- **plot_labor** `(t,i,plot,source)` ← `s16a` — all 6
- **people_last7days** `(t,i,pid)` ← `s04`+`s01` — all 6
- **plot_features** — added for CôtedIvoire (the one country missing it)

Each wave script is self-contained (own per-country `i()` helper, inline `_finish_*`, shared `harmonize_*` tables copied from Niger). **Crucially, each country's `i()` differs** (prefix / separator / menage zero-pad width all vary) and was derived from that country's own `sample`/`food_acquired` — a hard i-key≈1.0 gate per feature.

### Burkina livestock fix (the pilot's payoff)
Burkina livestock initially hit 83.4% i-key. Root cause: `sample` uses `grappe + '0' + menage.zfill(2)`, the old `burkina_faso.i()` uses `grappe + menage.zfill(3)` (no separator) — they diverge for 3-digit-menage households. Added `ehcvm_i()` (matches sample) → **1.0**.

## Verification
- **Integrated gate (committed tree, fresh cache): 42/42 PASS** — 30 new features (i-key 1.0) + 12 existing (food_acquired/plot_features, no regression).
- **Full suite: 1677 passed, 0 failed** — no regression to the rest of the library; `data_scheme` schema-valid.

## Known follow-ons (NOT blockers — filed separately)
1. **EHCVM label foundation**: `harmonize_food`/`harmonize_input`/`harmonize_seed_crop` are uneven per country (Senegal has food; Benin/Togo/CIV/GNB don't) → some crop/input labels pass through raw French/Portuguese; GNB `plot_inputs.crop` is all-sentinel. Structural grain is canonical regardless.
2. **Pre-existing Burkina `i()` bug**: existing `food_acquired` (0.98) / `plot_features` (0.846) under-join sample (old `i()`); not introduced here (new features use `ehcvm_i`).
3. **`get_categorical_mapping` missing-table fragility**: silently returns the first org table when the named table is absent (cwd-dependent).

Advances #438 (Tier-1 structural pass; label foundation + Tier-2 EthiopiaRHS / Tier-3 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)