### PR TITLE
feat(#438): EHCVM label foundation — harmonize_food for Benin/CotedIvoire/Togo/Guinea-Bissau

### DIFF
--- a/lsms_library/countries/Benin/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Benin/2018-19/_/data_info.yml
@@ -196,7 +196,9 @@ food_acquired:
         i:
             - grappe
             - menage
-        j: s07bq01
+        j:
+            - s07bq01
+            - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
         u: s07bq03b
     myvars:
         Quantity: s07bq03a

--- a/lsms_library/countries/Benin/_/categorical_mapping.org
+++ b/lsms_library/countries/Benin/_/categorical_mapping.org
@@ -259,3 +259,179 @@
 | Plants/boutures de tubercules | Autre crop          |
 | Autres semences               | Autre crop          |
 | 20                            | Autre crop          |
+
+* Food / Crop Labels (the j and crop axes)
+
+# harmonize_food (EHCVM label foundation, finalized 2026-06-15 from the
+# accepted DRAFT propagated from Niger).  A SINGLE shared taxonomy maps
+# BOTH food_acquired.j (s07bq01 value labels) and crop_production.crop
+# (s16cq04) onto canonical Preferred Labels (the Niger design).  Consumed
+# by crop_production.py via get_categorical_mapping('harmonize_food', ...)
+# and by food_acquired's j-index mappings: clause in the wave data_info.yml.
+# Rows whose draft Preferred Label was blank (undecodable bare numeric
+# codes / unresolved items) are DROPPED so those Original Labels pass
+# through raw instead of mapping to ''.
+
+#+NAME: harmonize_food
+| Original Label                                                            | Preferred Label                                                                      |
+|---------------------------------------------------------------------------+--------------------------------------------------------------------------------------|
+| Abats et tripes (foie, rognon, etc.)                                      | Abats et tripes (foie, rognon, etc.)                                                 |
+| AdÃ©mÃ¨ / Ninnouwi (Feuilles crin-crin)                                   | Autres légumes en feuilles                                                           |
+| Afintin (Moutarde africaine)                                              | Soumbala (moutarde africaine)                                                        |
+| Ail                                                                       | Ail                                                                                  |
+| Ananas                                                                    | Ananas                                                                               |
+| Arachide grillÃ©e                                                         | Arachide grillée                                                                     |
+| Arachides dÃ©cortiquÃ©es ou pilÃ©es                                       | Arachides décortiquées                                                               |
+| Arachides fraÃ®ches en coques                                             | Arachides fraîches en coques                                                         |
+| Arachides sÃ©chÃ©es en coques                                             | Arachides séchées en coques                                                          |
+| ArÃ´me (Maggi, Jumbo, etc.)                                               | Arôme (Maggi, Jumbo, etc.)                                                           |
+| AttiÃ©ke                                                                  | Attiéke                                                                              |
+| Aubergine, Courge/Courgette                                               | Aubergine, Courge/Courgette                                                          |
+| Autre lÃ©gumes frais n.d.a                                                | Autre légumes frais n.d.a                                                            |
+| Autres agrumes                                                            | Autres agrumes                                                                       |
+| Autres condiments (poivre etc.)                                           | Autres condiments (poivre etc.)                                                      |
+| Autres cÃ©rÃ©ales                                                         | Autres céréales                                                                      |
+| Autres farines de cÃ©rÃ©ales                                              | Autres farines de céréales                                                           |
+| Autres fruits (pommes, raisin, etc.)                                      | Autres fruits (pommes, raisin, etc.)                                                 |
+| Autres huiles n.d.a. (maÃ¯s, huile palmiste, etc.)                        | Autres huiles n.d.a. (maïs, huile palmiste, etc.)                                    |
+| Autres lÃ©gumes secs n.d.a                                                | Autres légumes secs n.d.a                                                            |
+| Autres produits alimentaires                                              | Autres produits alimentaires                                                         |
+| Autres produits laitiers                                                  | Autres produits laitiers                                                             |
+| Autres tisanes et infusions n.d.a. (quinquelibat, citronelle, etc.)       | Autres tisanes et infusions n.d.a. (quinquelibat, citronelle, etc.)                  |
+| Autres tubercules n.d.a                                                   | Autres tubercules n.d.a                                                              |
+| Autres viandes n.d.a                                                      | Autres viandes n.d.a                                                                 |
+| Avocats                                                                   | Avocats                                                                              |
+| Banane douce                                                              | Banane douce                                                                         |
+| Bar frais                                                                 | Autres poissons frais                                                                |
+| Beignets, galettes                                                        | Beignets, galettes                                                                   |
+| Beurre                                                                    | Beurre                                                                               |
+| Beurre de karitÃ©                                                         | Beurre de karité                                                                     |
+| Biscuits                                                                  | Biscuits                                                                             |
+| BiÃ¨res et vins traditionnels (Tchappalo, Tchoucoutou, vin de palme etc.) | Bières et vins traditionnels (dolo, vin de palme, vin de raphia, vin de cajou, etc.) |
+| BiÃ¨res industrielles                                                     | Bières industrielles                                                                 |
+| Boissons gazeuses (coca, etc.)                                            | Boissons gazeuses (coca, etc.)                                                       |
+| CafÃ©                                                                     | Café                                                                                 |
+| Canne Ã  sucre                                                            | Canne à sucre                                                                        |
+| Caramel, bonbons, confiseries, etc                                        | Caramel, bonbons, confiseries, etc                                                   |
+| Carotte                                                                   | Carotte                                                                              |
+| Carpe fraÃ®che                                                            | Carpes fraîches                                                                      |
+| Charcuterie (jambon, saucisson), conserves de viandes                     | Charcuterie (jambon, saucisson), conserves de viandes                                |
+| Chinchard frais (Silivi)                                                  | Autres poissons frais                                                                |
+| Chinchard fumÃ©                                                           | Autres poissons fumés                                                                |
+| Chocolat en poudre                                                        | Chocolat en poudre                                                                   |
+| Chocolat Ã  croquer, pÃ¢te Ã  tartiner                                    | Chocolat à croquer, pâte à tartiner                                                  |
+| Choux                                                                     | Choux                                                                                |
+| Citrons                                                                   | Citrons                                                                              |
+| ConcentrÃ© de tomate                                                      | Concentré de tomate                                                                  |
+| Concombre                                                                 | Concombre                                                                            |
+| Conserves de poisson                                                      | Conserves de poisson                                                                 |
+| Crabes, crevettes et autres fruits de mer                                 | Crabes, crevettes et autres fruits de mer                                            |
+| Croissants                                                                | Croissants                                                                           |
+| Cube alimentaire (Maggi, Jumbo, )                                         | Cube alimentaire (Maggi, Jumbo, )                                                    |
+| Dattes                                                                    | Dattes                                                                               |
+| Eau minÃ©rale/ filtrÃ©e                                                   | Eau minérale/ filtrée                                                                |
+| Farine de blÃ© local ou importÃ©                                          | Farine de blé local ou importé                                                       |
+| Farine de maÃ¯s                                                           | Farine de maïs                                                                       |
+| Farine de mil                                                             | Farine de mil                                                                        |
+| Farines de manioc                                                         | Farines de manioc                                                                    |
+| Feuilles d'oseille (bissap)                                               | Feuilles d'oseille                                                                   |
+| Feuilles de baobab                                                        | Feuilles de baobab                                                                   |
+| Feuilles de manioc, moringa, fonman, feuilles de taro et autres feuilles  | Feuilles de manioc, feuilles de taro et, autres feuilles                             |
+| Fonio                                                                     | Fonio                                                                                |
+| Fromage local (Amon)                                                      | Fromage                                                                              |
+| Gari, tapioca                                                             | Gari, tapioca                                                                        |
+| Gboman                                                                    | Autres légumes en feuilles                                                           |
+| Gibiers                                                                   | Gibiers                                                                              |
+| Gingembre                                                                 | Gingembre                                                                            |
+| Gombo frais                                                               | Gombo frais                                                                          |
+| Gombo sec                                                                 | Gombo sec                                                                            |
+| GÃ¢teaux                                                                  | Gâteaux                                                                              |
+| Haricot vert                                                              | Haricot vert                                                                         |
+| Huile d'arachide                                                          | Huile d'arachide                                                                     |
+| Huile de coton                                                            | Huile de coton                                                                       |
+| Huile de palme rouge                                                      | Huile de palme rouge                                                                 |
+| Huile de soja                                                             | Huile de soja                                                                        |
+| Igname                                                                    | Igname                                                                               |
+| Jus de fruits (orange, bissap, gingembre, jus de cajou,etc.)              | Jus de fruits (orange, bissap, gingembre, jus de cajou,etc.)                         |
+| Jus en poudre                                                             | Jus en poudre                                                                        |
+| Lait caillÃ©, yaourt                                                      | Lait caillé, yaourt                                                                  |
+| Lait concentrÃ© non-sucrÃ©                                                | Lait concentré non-sucré                                                             |
+| Lait concentrÃ© sucrÃ©                                                    | Lait concentré sucré                                                                 |
+| Lait en poudre                                                            | Lait en poudre                                                                       |
+| Lait et farines pour bÃ©bÃ©                                               | Lait et farines pour bébé                                                            |
+| Lait frais                                                                | Lait frais                                                                           |
+| Mangue                                                                    | Mangue                                                                               |
+| Manioc                                                                    | Manioc                                                                               |
+| Marquereau (salomon) fumÃ©                                                | Autres poissons fumés                                                                |
+| Marquereau frais (Saloumon)                                               | Maquereau (poisson de mer)                                                           |
+| Mayonnaise                                                                | Mayonnaise                                                                           |
+| MaÃ¯s en grain                                                            | Maïs en grain                                                                        |
+| MaÃ¯s en Ã©pi                                                             | Maïs en épi                                                                          |
+| Miel                                                                      | Miel                                                                                 |
+| Mil                                                                       | Mil                                                                                  |
+| NiÃ©bÃ©/Haricots secs                                                     | Niébé/Haricots secs                                                                  |
+| Noix de cajou                                                             | Noix de cajou                                                                        |
+| Noix de coco                                                              | Noix de coco                                                                         |
+| Noix de cola                                                              | Noix de cola                                                                         |
+| Noix de karitÃ©                                                           | Noix de karité                                                                       |
+| Oeufs                                                                     | Œufs                                                                                 |
+| Oignon frais                                                              | Oignon frais                                                                         |
+| Orange                                                                    | Orange                                                                               |
+| Pain moderne                                                              | Pain moderne                                                                         |
+| Pain traditionnel                                                         | Pain traditionnel                                                                    |
+| PastÃ¨que, Melon                                                          | Pastèque, Melon                                                                      |
+| Patate douce                                                              | Patate douce                                                                         |
+| Petit pois secs                                                           | Petit pois secs                                                                      |
+| Petits pois                                                               | Petits pois                                                                          |
+| Piment                                                                    | Piment frais                                                                         |
+| Plantain                                                                  | Plantain                                                                             |
+| Poissons sÃ©chÃ©s / frits                                                 | Poisson séché                                                                        |
+| Poivron frais                                                             | Poivron frais                                                                        |
+| Pomme de terre                                                            | Pomme de terre                                                                       |
+| Poulet sur pied                                                           | Poulet sur pied                                                                      |
+| PÃ¢te d'arachide                                                          | Pâte d'arachide                                                                      |
+| PÃ¢tes alimentaires                                                       | Pâtes alimentaires                                                                   |
+| Riz ImportÃ© grains brisÃ©s                                               | Riz importé non parfumé                                                              |
+| Riz importÃ© longs grains                                                 | Riz importé non parfumé                                                              |
+| Riz local NÃ©rica                                                         | Autre Riz local                                                                      |
+| Riz local parfumÃ©, 841 (wannon)                                          | Autre Riz local                                                                      |
+| Salade (laitue)                                                           | Salade (laitue)                                                                      |
+| Sel                                                                       | Sel                                                                                  |
+| Sorgho                                                                    | Sorgho                                                                               |
+| Sucre (poudre ou morceaux)                                                | Sucre (poudre ou morceaux)                                                           |
+| SÃ©same                                                                   | Sésame                                                                               |
+| Taro, macabo                                                              | Taro, macabo                                                                         |
+| ThÃ©                                                                      | Thé                                                                                  |
+| Tomate fraÃ®che                                                           | Tomate fraîche                                                                       |
+| Tomate sÃ©chÃ©e                                                           | Tomate séchée                                                                        |
+| Viande d'autres volailles domestiques                                     | Viande d'autres volailles domestiques                                                |
+| Viande de bÅ__uf                                                          | Viande de bœuf                                                                       |
+| Viande de chameau                                                         | Viande de chameau                                                                    |
+| Viande de chÃ¨vre                                                         | Viande de chèvre                                                                     |
+| Viande de mouton                                                          | Viande de mouton                                                                     |
+| Viande de porc                                                            | Viande de porc                                                                       |
+| Viande de poulet                                                          | Viande de poulet                                                                     |
+| Vinaigre /moutarde                                                        | Vinaigre /moutarde                                                                   |
+| Agrume                                                                    | Agrume                                                                               |
+| Amarante (Tchapata)                                                       | Amarante                                                                             |
+| Arachide                                                                  | Arachide                                                                             |
+| Aubergine                                                                 | Aubergine,                                                                           |
+| Autre (à préciser)                                                        | Autre crop                                                                           |
+| Betterave                                                                 | Betterave                                                                            |
+| Chou                                                                      | Chou                                                                                 |
+| Coton                                                                     | Coton                                                                                |
+| Gombo                                                                     | Gombo frais                                                                          |
+| Laitue                                                                    | Salade (laitue)                                                                      |
+| Maïs                                                                      | Maïs en grain                                                                        |
+| Menthe                                                                    | Menthe                                                                               |
+| Niébé                                                                     | Niébé/Haricots secs                                                                  |
+| Oignon                                                                    | Oignon frais                                                                         |
+| Oseille                                                                   | Oseille                                                                              |
+| Pastèque                                                                  | Pastèque                                                                             |
+| Persil                                                                    | Persil                                                                               |
+| Poivron                                                                   | Poivron frais                                                                        |
+| Riz Paddy                                                                 | Riz Paddy                                                                            |
+| Sésame                                                                    | Sésame                                                                               |
+| Taro                                                                      | Taro, macabo                                                                         |
+| Tomate                                                                    | Tomate fraîche                                                                       |
+| Voandzou                                                                  | Voandzou                                                                             |

--- a/lsms_library/countries/CotedIvoire/2018-19/_/data_info.yml
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/data_info.yml
@@ -284,7 +284,9 @@ food_acquired:
         i:
             - grappe
             - menage
-        j: s07bq01
+        j:
+            - s07bq01
+            - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
         u: s07bq03b
     myvars:
         Quantity: s07bq03a

--- a/lsms_library/countries/CotedIvoire/_/categorical_mapping.org
+++ b/lsms_library/countries/CotedIvoire/_/categorical_mapping.org
@@ -237,3 +237,187 @@
 | Plants/boutures de tubercules | Autre crop          |
 | Autres semences               | Autre crop          |
 | 20                            | Autre crop          |
+
+* Food / Crop Labels (the j and crop axes)
+
+# harmonize_food (EHCVM label foundation, finalized 2026-06-15 from the
+# accepted DRAFT propagated from Niger).  A SINGLE shared taxonomy maps
+# BOTH food_acquired.j (s07bq01 value labels) and crop_production.crop
+# (s16cq04) onto canonical Preferred Labels (the Niger design).  Consumed
+# by crop_production.py via get_categorical_mapping('harmonize_food', ...)
+# and by food_acquired's j-index mappings: clause in the wave data_info.yml.
+# Rows whose draft Preferred Label was blank (undecodable bare numeric
+# codes / unresolved items) are DROPPED so those Original Labels pass
+# through raw instead of mapping to ''.
+# MERGED from the draft's two tables (harmonize_food crops +
+# harmonize_food_acquired foods), deduped by Original Label; the
+# separate harmonize_food_acquired table is retired.
+
+#+NAME: harmonize_food
+| Original Label                                                         | Preferred Label                                                                      |
+|------------------------------------------------------------------------+--------------------------------------------------------------------------------------|
+| Agrume                                                                 | Agrume                                                                               |
+| Anacarde                                                               | Cashew                                                                               |
+| Arachide                                                               | Arachide                                                                             |
+| Aubergine                                                              | Aubergine,                                                                           |
+| Autre                                                                  | Autre crop                                                                           |
+| Betterave                                                              | Betterave                                                                            |
+| Cacao                                                                  | Cocoa                                                                                |
+| Café                                                                   | Coffee                                                                               |
+| Calebassier                                                            | Calebassier                                                                          |
+| Carotte                                                                | Carotte                                                                              |
+| Chou                                                                   | Chou                                                                                 |
+| Concombre                                                              | Concombre                                                                            |
+| Coton                                                                  | Coton                                                                                |
+| Courge                                                                 | Courge/Courgette                                                                     |
+| Epinard                                                                | Épinard                                                                              |
+| Fonio                                                                  | Fonio                                                                                |
+| Gingembre                                                              | Gingembre                                                                            |
+| Girofle                                                                | Clove                                                                                |
+| Gombo                                                                  | Gombo frais                                                                          |
+| Haricot vert                                                           | Haricot vert                                                                         |
+| Hévéa                                                                  | Rubber                                                                               |
+| Igname                                                                 | Igname                                                                               |
+| Jaxatu                                                                 | Jaxatu                                                                               |
+| Laitue                                                                 | Salade (laitue)                                                                      |
+| Manguier                                                               | Mangue                                                                               |
+| Manioc                                                                 | Manioc                                                                               |
+| Maïs                                                                   | Maïs en grain                                                                        |
+| Mil                                                                    | Mil                                                                                  |
+| Niébé                                                                  | Niébé/Haricots secs                                                                  |
+| Oignon                                                                 | Oignon frais                                                                         |
+| Oseille                                                                | Oseille                                                                              |
+| Palmier à huile                                                        | Oil palm                                                                             |
+| Pastèque                                                               | Pastèque                                                                             |
+| Patate douce                                                           | Patate douce                                                                         |
+| Persil                                                                 | Persil                                                                               |
+| Piment                                                                 | Piment frais                                                                         |
+| Poivron                                                                | Poivron frais                                                                        |
+| Pomme de terre                                                         | Pomme de terre                                                                       |
+| Radis                                                                  | Radis                                                                                |
+| Riz Paddy                                                              | Riz Paddy                                                                            |
+| Sorgho                                                                 | Sorgho                                                                               |
+| Sésame                                                                 | Sésame                                                                               |
+| Taro                                                                   | Taro, macabo                                                                         |
+| Thé                                                                    | Thé                                                                                  |
+| Tomate                                                                 | Tomate fraîche                                                                       |
+| Abats et tripes (foie, rognon, etc.)                                   | Abats et tripes (foie, rognon, etc.)                                                 |
+| Ail                                                                    | Ail                                                                                  |
+| Ananas                                                                 | Ananas                                                                               |
+| Appolo frais (Chinchards)                                              | Appolo frais (Chinchards)                                                            |
+| Arachide grillée                                                       | Arachide grillée                                                                     |
+| Arachides décortiquées ou pilées                                       | Arachides décortiquées ou pilées                                                     |
+| Arachides fraîches en coques                                           | Arachides fraîches en coques                                                         |
+| Arachides séchées en coques                                            | Arachides séchées en coques                                                          |
+| Arôme (Maggi, Jumbo, etc.)                                             | Arôme (Maggi, Jumbo, etc.)                                                           |
+| Attiéke                                                                | Attiéke                                                                              |
+| Aubergine, Courge/Courgette                                            | Aubergine, Courge/Courgette                                                          |
+| Autres Poissons fumés                                                  | Autres poissons fumés                                                                |
+| Autres agrumes                                                         | Autres agrumes                                                                       |
+| Autres condiments (poivre etc.)                                        | Autres condiments (poivre etc.)                                                      |
+| Autres céréales                                                        | Autres céréales                                                                      |
+| Autres farines de céréales                                             | Autres farines de céréales                                                           |
+| Autres feuilles (manioc, taro, baobab, haricot)                        | Feuilles de manioc, feuilles de taro et, autres feuilles                             |
+| Autres fruits (pommes, raisin, etc.)                                   | Autres fruits (pommes, raisin, etc.)                                                 |
+| Autres huiles n.d.a. (maïs, palmiste, soja, etc.)                      | Autres huiles n.d.a. (maïs, huile palmiste, soja etc.)                               |
+| Autres légumes frais n.d.a                                             | Autre légumes frais n.d.a                                                            |
+| Autres légumes secs n.d.a                                              | Autres légumes secs n.d.a                                                            |
+| Autres poissons frais                                                  | Autres poissons frais                                                                |
+| Autres produits alimentaires                                           | Autres produits alimentaires                                                         |
+| Autres produits laitiers                                               | Autres produits laitiers                                                             |
+| Autres tisanes et infusions n.d.a. (quinquelibat, citronelle, etc.)    | Autres tisanes et infusions n.d.a. (quinquelibat, citronelle, etc.)                  |
+| Autres tubercules n.d.a                                                | Autres tubercules n.d.a                                                              |
+| Autres viandes n.d.a                                                   | Autres viandes n.d.a                                                                 |
+| Avocats                                                                | Avocats                                                                              |
+| Banane douce                                                           | Banane douce                                                                         |
+| Beignets, galettes                                                     | Beignets, galettes                                                                   |
+| Beurre                                                                 | Beurre                                                                               |
+| Beurre de karité                                                       | Beurre de karité                                                                     |
+| Biscuits                                                               | Biscuits                                                                             |
+| Bières et vins traditionnels (dolo, vin de palme, vin de raphia, etc.) | Bières et vins traditionnels (dolo, vin de palme, vin de raphia, vin de cajou, etc.) |
+| Bières industrielles                                                   | Bières industrielles                                                                 |
+| Boissons gazeuses (coca, etc.)                                         | Boissons gazeuses (coca, etc.)                                                       |
+| Canne à sucre                                                          | Canne à sucre                                                                        |
+| Caramel, bonbons, confiseries, etc                                     | Caramel, bonbons, confiseries, etc                                                   |
+| Charcuterie (jambon, saucisson), conserves de viandes                  | Charcuterie (jambon, saucisson), conserves de viandes                                |
+| Chocolat en poudre                                                     | Chocolat en poudre                                                                   |
+| Chocolat à croquer, pâte à tartiner                                    | Chocolat à croquer, pâte à tartiner                                                  |
+| Citrons                                                                | Citrons                                                                              |
+| Concentré de tomate                                                    | Concentré de tomate                                                                  |
+| Conserves de poisson                                                   | Conserves de poisson                                                                 |
+| Crabes, crevettes et autres fruits de mer                              | Crabes, crevettes et autres fruits de mer                                            |
+| Croissants                                                             | Croissants                                                                           |
+| Cube alimentaire (Maggi, Jumbo, )                                      | Cube alimentaire (Maggi, Jumbo, )                                                    |
+| Dattes                                                                 | Dattes                                                                               |
+| Eau minérale/ filtrée                                                  | Eau minérale/ filtrée                                                                |
+| Epinards                                                               | Épinard                                                                              |
+| Farine de blé local ou importé                                         | Farine de blé local ou importé                                                       |
+| Farine de maïs                                                         | Farine de maïs                                                                       |
+| Farine de mil                                                          | Farine de mil                                                                        |
+| Farines de manioc                                                      | Farines de manioc                                                                    |
+| Feuilles d'oseille (dah)                                               | Feuilles d'oseille                                                                   |
+| Feuilles de patate                                                     | Feuilles de patate                                                                   |
+| Fromage                                                                | Fromage                                                                              |
+| Gari, tapioca                                                          | Gari, tapioca                                                                        |
+| Gibiers                                                                | Gibiers                                                                              |
+| Gombo frais                                                            | Gombo frais                                                                          |
+| Gombo sec                                                              | Gombo sec                                                                            |
+| Gâteaux                                                                | Gâteaux                                                                              |
+| Huile d'arachide                                                       | Huile d'arachide                                                                     |
+| Huile de coton                                                         | Huile de coton                                                                       |
+| Huile de palme raffiné                                                 | Huile de palme raffinée                                                              |
+| Huile de palme rouge                                                   | Huile de palme rouge                                                                 |
+| Jus de fruits (orange, bissap, gingembre, jus de cajou,etc.)           | Jus de fruits (orange, bissap, gingembre, jus de cajou,etc.)                         |
+| Jus en poudre                                                          | Jus en poudre                                                                        |
+| Kplala                                                                 | Kplala                                                                               |
+| Lait caillé, yaourt                                                    | Lait caillé, yaourt                                                                  |
+| Lait concentré non-sucré                                               | Lait concentré non-sucré                                                             |
+| Lait concentré sucré                                                   | Lait concentré sucré                                                                 |
+| Lait en poudre                                                         | Lait en poudre                                                                       |
+| Lait et farines pour bébé                                              | Lait et farines pour bébé                                                            |
+| Lait frais                                                             | Lait frais                                                                           |
+| Mangue                                                                 | Mangue                                                                               |
+| Mayonnaise                                                             | Mayonnaise                                                                           |
+| Maïs en grain                                                          | Maïs en grain                                                                        |
+| Maïs en épi                                                            | Maïs en épi                                                                          |
+| Miel                                                                   | Miel                                                                                 |
+| Niébé/Haricots secs                                                    | Niébé/Haricots secs                                                                  |
+| Noix de cajou                                                          | Noix de cajou                                                                        |
+| Noix de coco                                                           | Noix de coco                                                                         |
+| Noix de cola                                                           | Noix de cola                                                                         |
+| Noix de karité                                                         | Noix de karité                                                                       |
+| Oignon frais                                                           | Oignon frais                                                                         |
+| Orange                                                                 | Orange                                                                               |
+| Pain moderne                                                           | Pain moderne                                                                         |
+| Pain traditionnel                                                      | Pain traditionnel                                                                    |
+| Pastèque, Melon                                                        | Pastèque, Melon                                                                      |
+| Petit pois secs                                                        | Petit pois secs                                                                      |
+| Petits pois                                                            | Petits pois                                                                          |
+| Plantain                                                               | Plantain                                                                             |
+| Poisson fumé mangni                                                    | Poisson fumé mangni                                                                  |
+| Poisson séché                                                          | Poisson séché                                                                        |
+| Poivron frais                                                          | Poivron frais                                                                        |
+| Poulet sur pied                                                        | Poulet sur pied                                                                      |
+| Pâte d'arachide                                                        | Pâte d'arachide                                                                      |
+| Pâtes alimentaires                                                     | Pâtes alimentaires                                                                   |
+| Riz importé Denicachia                                                 | Riz importé Denicachia                                                               |
+| Riz importé de Luxe                                                    | Riz importé de Luxe                                                                  |
+| Riz local  gros grain court                                            | Riz local gros grain court                                                           |
+| Riz local Danané petit grain long                                      | Riz local Danané petit grain long                                                    |
+| Salade (laitue)                                                        | Salade (laitue)                                                                      |
+| Sardinelles fraiches                                                   | Sardinelles fraiches                                                                 |
+| Sel                                                                    | Sel                                                                                  |
+| Soumbala (moutarde africaine)                                          | Soumbala (moutarde africaine)                                                        |
+| Sucre (poudre ou morceaux)                                             | Sucre (poudre ou morceaux)                                                           |
+| Taro, macabo                                                           | Taro, macabo                                                                         |
+| Tilapia frais (carpe grise importée)                                   | Tilapia frais (carpe grise importée)                                                 |
+| Tomate fraîche                                                         | Tomate fraîche                                                                       |
+| Tomate séchée                                                          | Tomate séchée                                                                        |
+| Viande d'autres volailles domestiques                                  | Viande d'autres volailles domestiques                                                |
+| Viande de bœuf                                                         | Viande de bœuf                                                                       |
+| Viande de chèvre                                                       | Viande de chèvre                                                                     |
+| Viande de mouton                                                       | Viande de mouton                                                                     |
+| Viande de porc                                                         | Viande de porc                                                                       |
+| Viande de poulet                                                       | Viande de poulet                                                                     |
+| Vinaigre /moutarde                                                     | Vinaigre /moutarde                                                                   |
+| Œufs                                                                   | Œufs                                                                                 |

--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/data_info.yml
@@ -76,7 +76,9 @@ food_acquired:
         i:
             - grappe
             - menage
-        j: s07bq01
+        j:
+            - s07bq01
+            - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
         u: s07bq03b
     myvars:
         Quantity: s07bq03a

--- a/lsms_library/countries/Guinea-Bissau/_/categorical_mapping.org
+++ b/lsms_library/countries/Guinea-Bissau/_/categorical_mapping.org
@@ -153,3 +153,182 @@
 |    9 | Chicken         |
 |   10 | Guinea Fowl     |
 |   11 | Other Poultry   |
+
+* Food / Crop Labels (the j and crop axes)
+
+# harmonize_food (EHCVM label foundation, finalized 2026-06-15 from the
+# accepted DRAFT propagated from Niger).  A SINGLE shared taxonomy maps
+# BOTH food_acquired.j (s07bq01 value labels) and crop_production.crop
+# (s16cq04) onto canonical Preferred Labels (the Niger design).  Consumed
+# by crop_production.py via get_categorical_mapping('harmonize_food', ...)
+# and by food_acquired's j-index mappings: clause in the wave data_info.yml.
+# Rows whose draft Preferred Label was blank (undecodable bare numeric
+# codes / unresolved items) are DROPPED so those Original Labels pass
+# through raw instead of mapping to ''.
+
+#+NAME: harmonize_food
+| Original Label                                                 | Preferred Label                                                                      |
+|----------------------------------------------------------------+--------------------------------------------------------------------------------------|
+| Abacate                                                        | Avocats                                                                              |
+| Alho                                                           | Ail                                                                                  |
+| AnanÃ¡s                                                        | Ananas                                                                               |
+| Aroma (Maggi, Jumbo, etc.)                                     | Arôme (Maggi, Jumbo, etc.)                                                           |
+| Arroz importado perfumado                                      | Riz importé parfumé                                                                  |
+| Arroz importado simples                                        | Riz importé non parfumé                                                              |
+| Arroz local de Npampam                                         | Riz du Niger                                                                         |
+| Arroz local de bolanha                                         | Autre Riz local                                                                      |
+| AttiÃ©ke                                                       | Attiéké                                                                              |
+| AÃ§Ãºcar (em pÃ³ ou cubos)                                     | Sucre (poudre ou morceaux)                                                           |
+| Bagre fresco                                                   | Mâchoiron frais (guiguiri)                                                           |
+| Bagre fumado                                                   | Sillure fumé                                                                         |
+| Banana doce                                                    | Banane douce                                                                         |
+| Banana plantain                                                | Plantain                                                                             |
+| Batata inglesa                                                 | Pomme de terre                                                                       |
+| Batata-doce                                                    | Patate douce                                                                         |
+| Bebidas com gÃ¡s (coca-cola, etc.)                             | Boissons gazeuses (coca, etc.)                                                       |
+| Beringela, abÃ³bora/curgete                                    | Aubergine, Courge/Courgette                                                          |
+| Bolachas                                                       | Biscuits                                                                             |
+| Bolos                                                          | Gâteaux                                                                              |
+| Cabaceira                                                      | Fruit de baobab                                                                      |
+| CafÃ©                                                          | Café                                                                                 |
+| Candja fresco                                                  | Gombo frais                                                                          |
+| Candja seco                                                    | Gombo sec                                                                            |
+| Caramelo, bombons, pastÃ©is, etc                               | Caramel, bonbons, confiseries, etc                                                   |
+| Caranguejos, camarÃ£o e outros mariscos                        | Crabes, crevettes et autres fruits de mer                                            |
+| Carne de cabra                                                 | Viande de chèvre                                                                     |
+| Carne de carneiro                                              | Viande de mouton                                                                     |
+| Carne de galinha                                               | Viande de poulet                                                                     |
+| Carne de outras aves                                           | Viande d'autres volailles                                                            |
+| Carne de porco                                                 | Viande de porc                                                                       |
+| Carne de vaca                                                  | Viande de bœuf                                                                       |
+| Castanha de cajÃº                                              | Noix de cajou                                                                        |
+| CaÃ§a                                                          | Gibiers                                                                              |
+| Cebola fresca                                                  | Oignon frais                                                                         |
+| Cenoura                                                        | Carotte                                                                              |
+| Cervejas e Vinhos tradicional ( Vinho de caju)                 | Bières et vins traditionnels (dolo, vin de palme, vin de raphia, vin de cajou, etc.) |
+| Cervejas industriais                                           | Bières industrielles                                                                 |
+| Chabeu                                                         | Huile de palme rouge                                                                 |
+| Charcutaria (fiambre, chouriÃ§o), conservas de carne           | Charcuterie (jambon, saucisson), conserves de viandes                                |
+| Chocolate em pÃ³                                               | Chocolat en poudre                                                                   |
+| Chocolate para comer, pasta para barrar                        | Chocolat à croquer, pâte à tartiner                                                  |
+| ChÃ¡                                                           | Thé                                                                                  |
+| Concentrado de tomate                                          | Concentré de tomate                                                                  |
+| Conservas de peixe                                             | Conserves de poisson                                                                 |
+| Croissants                                                     | Croissants                                                                           |
+| Cubos de caldo (Maggi, Jumbo)                                  | Cube alimentaire (Maggi, Jumbo, )                                                    |
+| Djagatu                                                        | Aubergine,                                                                           |
+| Donetes/panguetes, panquecas                                   | Beignets, galettes                                                                   |
+| Ervilhas                                                       | Petits pois                                                                          |
+| Ervilhas secas                                                 | Petit pois secs                                                                      |
+| Farinha de milho bacil                                         | Farine de maïs                                                                       |
+| Farinha de milho preto                                         | Farine de mil                                                                        |
+| Farinha de trigo local ou importado                            | Farine de blé local ou importé                                                       |
+| Farinhas de mandioca                                           | Farines de manioc                                                                    |
+| FeijÃ£o verde                                                  | Haricot vert                                                                         |
+| FeijÃ£o-frade, feijÃ£o seco                                    | Niébé/Haricots secs                                                                  |
+| Folhas de azeda (badjique)                                     | Feuilles d'oseille                                                                   |
+| Folhas de cabaceira                                            | Feuilles de baobab                                                                   |
+| Folhas de mandioca, folhas de taro e outras folhas             | Feuilles de manioc, feuilles de taro et, autres feuilles                             |
+| Folhas locais                                                  | Autres légumes en feuilles                                                           |
+| Fundo                                                          | Fonio                                                                                |
+| Galinha vivo                                                   | Poulet sur pied                                                                      |
+| Gengibre                                                       | Gingembre                                                                            |
+| Inhame                                                         | Igname                                                                               |
+| Laranja                                                        | Orange                                                                               |
+| Leite coalhado, iogurte                                        | Lait caillé, yaourt                                                                  |
+| Leite condensado com aÃ§Ãºcar                                  | Lait concentré sucré                                                                 |
+| Leite condensado sem aÃ§Ãºcar                                  | Lait concentré non-sucré                                                             |
+| Leite e farinhas para bebÃ©                                    | Lait et farines pour bébé                                                            |
+| Leite em pÃ³                                                   | Lait en poudre                                                                       |
+| Leite fresco                                                   | Lait frais                                                                           |
+| LimÃ£o                                                         | Citrons                                                                              |
+| Maionese                                                       | Mayonnaise                                                                           |
+| Malagueta,  suculbembe                                         | Piment frais                                                                         |
+| Mancarra frescos com casca                                     | Arachides fraîches en coques                                                         |
+| Mancarra ralada                                                | Arachides pilées                                                                     |
+| Mancarra secos com casca                                       | Arachides séchées en coques                                                          |
+| Mancarra sem casca ou pilada                                   | Arachides décortiquées                                                               |
+| Mancarra torrada                                               | Arachide grillée                                                                     |
+| Mandioca                                                       | Manioc                                                                               |
+| Manga                                                          | Mangue                                                                               |
+| Manteiga                                                       | Beurre                                                                               |
+| Manteiga de karite                                             | Beurre de karité                                                                     |
+| Massas alimentÃ­cias                                           | Pâtes alimentaires                                                                   |
+| Mel                                                            | Miel                                                                                 |
+| Melancia, melÃ£o                                               | Pastèque, Melon                                                                      |
+| Milho bacil em espiga                                          | Maïs en épi                                                                          |
+| Milho bacil em grÃ£o                                           | Maïs en grain                                                                        |
+| Milho cavalo/Sorgo                                             | Sorgho                                                                               |
+| Milho preto                                                    | Mil                                                                                  |
+| Miudezas e tripas (fÃ­gado, rins, etc.)                        | Abats et tripes (foie, rognon, etc.)                                                 |
+| Neteto                                                         | Soumbala (moutarde africaine)                                                        |
+| Noz de coco                                                    | Noix de coco                                                                         |
+| Noz de cola                                                    | Noix de cola                                                                         |
+| Outras carnes n.e                                              | Autres viandes n.d.a                                                                 |
+| Outras farinhas de cereais                                     | Autres farines de céréales                                                           |
+| Outras tisanas e infusÃµes n.e. (quinqueliba, citronela, etc.) | Autres tisanes et infusions n.d.a. (quinquelibat, citronelle, etc.)                  |
+| Outros cereais                                                 | Autres céréales                                                                      |
+| Outros citrinos                                                | Autres agrumes (mandarine, pamplemousse, etc.)                                       |
+| Outros condimentos (pimenta, etc.)                             | Autres condiments (poivre etc.)                                                      |
+| Outros legumes frescos n.e                                     | Autre légumes frais n.d.a                                                            |
+| Outros produtos lÃ¡cteos                                       | Autres produits laitiers                                                             |
+| Outros tubÃ©rculos n.e                                         | Autres tubercules n.d.a                                                              |
+| Outros Ã³leos n.e. (milho, oleo de misto, etc.)                | Autres huiles n.d.a. (maïs, huile palmiste, etc.)                                    |
+| Ovos                                                           | Œufs                                                                                 |
+| Papaia                                                         | Papaye                                                                               |
+| Peixe seco                                                     | Poisson séché                                                                        |
+| Pepino                                                         | Concombre                                                                            |
+| Pimento fresco                                                 | Poivron frais                                                                        |
+| PÃ£o moderno                                                   | Pain moderne                                                                         |
+| PÃ£o tradicional                                               | Pain traditionnel                                                                    |
+| Queijo                                                         | Fromage                                                                              |
+| Repolho                                                        | Choux                                                                                |
+| Sal                                                            | Sel                                                                                  |
+| Salada (alface)                                                | Salade (laitue)                                                                      |
+| Sumos de fruta (laranja, hibisco, cajÃº, etc.)                 | Jus de fruits (orange, bissap, gingembre, jus de cajou,etc.)                         |
+| Sumos em pÃ³                                                   | Jus en poudre                                                                        |
+| SÃ©samo                                                        | Sésame                                                                               |
+| Tainha fresco                                                  | Autres poissons frais                                                                |
+| Taro, manfafa                                                  | Taro, macabo                                                                         |
+| Tomate fresco                                                  | Tomate fraîche                                                                       |
+| Tomate seco                                                    | Tomate séchée                                                                        |
+| TÃ¢maras                                                       | Dattes                                                                               |
+| Vinagre de limÃ£o                                              | Vinaigre de citron                                                                   |
+| Vinagre/mostrada                                               | Vinaigre /moutarde                                                                   |
+| Ã__gua filtrada                                                | Eau minérale/ filtrée                                                                |
+| Ã__leo de mancarra                                             | Huile d'arachide                                                                     |
+| Ã__leo de palma                                                | Huile de palme raffinée                                                              |
+| Ã__leo de soja                                                 | Huile de soja                                                                        |
+| Abóbora                                                        | Courge/Courgette                                                                     |
+| Alface                                                         | Salade (laitue)                                                                      |
+| Algodão                                                        | Coton                                                                                |
+| Ananas                                                         | Ananas                                                                               |
+| Arroz Mpampam                                                  | Riz du Niger                                                                         |
+| Arroz paddy                                                    | Riz Paddy                                                                            |
+| Badjiqui                                                       | Feuilles d'oseille                                                                   |
+| Beringela                                                      | Aubergine,                                                                           |
+| Beterraba                                                      | Betterave                                                                            |
+| Cajueiro                                                       | Noix de cajou                                                                        |
+| Cana-de-açucar                                                 | Canne à sucre                                                                        |
+| Candja                                                         | Gombo frais                                                                          |
+| Cebola                                                         | Oignon frais                                                                         |
+| Citrinos                                                       | Autres agrumes (mandarine, pamplemousse, etc.)                                       |
+| Coconete                                                       | Noix de coco                                                                         |
+| Feijão                                                         | Niébé/Haricots secs                                                                  |
+| Feijão verde                                                   | Haricot vert                                                                         |
+| Hortelã-pimenta                                                | Menthe                                                                               |
+| Malagueta                                                      | Piment frais                                                                         |
+| Mancarra                                                       | Arachide                                                                             |
+| Mangueira                                                      | Mangue                                                                               |
+| Melancia                                                       | Pastèque                                                                             |
+| Melão                                                          | Melon                                                                                |
+| Milho bacil                                                    | Maïs en grain                                                                        |
+| Milho cavalo                                                   | Sorgho                                                                               |
+| Outro (especificar)                                            | Autre crop                                                                           |
+| Papaeira                                                       | Papaye                                                                               |
+| Pimento                                                        | Poivron frais                                                                        |
+| Pinha                                                          | Ananas                                                                               |
+| Salsa                                                          | Persil                                                                               |
+| Sésamo                                                         | Sésame                                                                               |
+| Taro/Manfafa                                                   | Taro, macabo                                                                         |
+| Tomate                                                         | Tomate fraîche                                                                       |

--- a/lsms_library/countries/Togo/2018/_/data_info.yml
+++ b/lsms_library/countries/Togo/2018/_/data_info.yml
@@ -225,7 +225,9 @@ food_acquired:
         i:
             - grappe
             - menage
-        j: s07bq01
+        j:
+            - s07bq01
+            - mappings: ['harmonize_food', 'Original Label', 'Preferred Label']
         u:
             - s07bq03b
             - mappings: ['ehcvm_units', 'Code', 'Preferred Label']

--- a/lsms_library/countries/Togo/_/categorical_mapping.org
+++ b/lsms_library/countries/Togo/_/categorical_mapping.org
@@ -191,3 +191,181 @@
 | Plants/boutures de tubercules | Autre crop          |
 | Autres semences               | Autre crop          |
 | 20                            | Autre crop          |
+
+* Food / Crop Labels (the j and crop axes)
+
+# harmonize_food (EHCVM label foundation, finalized 2026-06-15 from the
+# accepted DRAFT propagated from Niger).  A SINGLE shared taxonomy maps
+# BOTH food_acquired.j (s07bq01 value labels) and crop_production.crop
+# (s16cq04) onto canonical Preferred Labels (the Niger design).  Consumed
+# by crop_production.py via get_categorical_mapping('harmonize_food', ...)
+# and by food_acquired's j-index mappings: clause in the wave data_info.yml.
+# Rows whose draft Preferred Label was blank (undecodable bare numeric
+# codes / unresolved items) are DROPPED so those Original Labels pass
+# through raw instead of mapping to ''.
+
+#+NAME: harmonize_food
+| Original Label                                                          | Preferred Label                                                                      |
+|-------------------------------------------------------------------------+--------------------------------------------------------------------------------------|
+| Abats et tripes (foie, rognon, etc.)                                    | Abats et tripes (foie, rognon, etc.)                                                 |
+| AdÃ©mÃ¨ (Feuilles crin-crin)                                            | Autres légumes en feuilles                                                           |
+| Afintin (Moutarde africaine)                                            | Soumbala (moutarde africaine)                                                        |
+| Ail                                                                     | Ail                                                                                  |
+| Ananas                                                                  | Ananas                                                                               |
+| Anchois fumÃ©                                                           | Autres poissons fumés                                                                |
+| Arachide grillÃ©e                                                       | Arachide grillée                                                                     |
+| Arachides dÃ©cortiquÃ©es ou pilÃ©es                                     | Arachides décortiquées                                                               |
+| Arachides fraÃ®ches en coques                                           | Arachides fraîches en coques                                                         |
+| Arachides sÃ©chÃ©es en coques                                           | Arachides séchées en coques                                                          |
+| ArÃ´me (Maggi, Jumbo, etc.)                                             | Arôme (Maggi, Jumbo, etc.)                                                           |
+| AttiÃ©ke                                                                | Attiéke                                                                              |
+| Aubergine, Courge/Courgette                                             | Aubergine, Courge/Courgette                                                          |
+| Autre lÃ©gumes frais n.d.a                                              | Autre légumes frais n.d.a                                                            |
+| Autres agrumes                                                          | Autres agrumes                                                                       |
+| Autres condiments (poivre etc.)                                         | Autres condiments (poivre etc.)                                                      |
+| Autres fruits (pommes, raisin, etc.)                                    | Autres fruits (pommes, raisin, etc.)                                                 |
+| Autres huiles n.d.a. (maÃ¯s, soja, huile palmiste, etc.)                | Autres huiles n.d.a. (maïs, huile palmiste, etc.)                                    |
+| Autres lÃ©gumes secs n.d.a                                              | Autres légumes secs n.d.a                                                            |
+| Autres produits alimentaires                                            | Autres produits alimentaires                                                         |
+| Autres produits laitiers                                                | Autres produits laitiers                                                             |
+| Autres tisanes et infusions n.d.a. (quinquelibat, citronelle, etc.)     | Autres tisanes et infusions n.d.a. (quinquelibat, citronelle, etc.)                  |
+| Autres tubercules n.d.a                                                 | Autres tubercules n.d.a                                                              |
+| Autres viandes n.d.a                                                    | Autres viandes n.d.a                                                                 |
+| Avocats                                                                 | Avocats                                                                              |
+| Banane douce                                                            | Banane douce                                                                         |
+| Beignets, galettes                                                      | Beignets, galettes                                                                   |
+| Beurre                                                                  | Beurre                                                                               |
+| Beurre de karitÃ©                                                       | Beurre de karité                                                                     |
+| Biscuits                                                                | Biscuits                                                                             |
+| BiÃ¨res et vins traditionnels (dolo, vin de palme, vin de raphia, etc.) | Bières et vins traditionnels (dolo, vin de palme, vin de raphia, vin de cajou, etc.) |
+| BiÃ¨res industrielles                                                   | Bières industrielles                                                                 |
+| BlÃ©                                                                    | Blé                                                                                  |
+| Boissons gazeuses (coca, etc.)                                          | Boissons gazeuses (coca, etc.)                                                       |
+| CafÃ©                                                                   | Café                                                                                 |
+| Canne Ã  sucre                                                          | Canne à sucre                                                                        |
+| Caramel, bonbons, confiseries, etc                                      | Caramel, bonbons, confiseries, etc                                                   |
+| Carotte                                                                 | Carotte                                                                              |
+| Carpe fraÃ®che                                                          | Carpes fraîches                                                                      |
+| Charcuterie (jambon, saucisson), conserves de viandes                   | Charcuterie (jambon, saucisson), conserves de viandes                                |
+| Chinchard frais                                                         | Autres poissons frais                                                                |
+| Chinchard fumÃ©                                                         | Autres poissons fumés                                                                |
+| Chocolat en poudre                                                      | Chocolat en poudre                                                                   |
+| Chocolat Ã  croquer, pÃ¢te Ã  tartiner                                  | Chocolat à croquer, pâte à tartiner                                                  |
+| Choux                                                                   | Choux                                                                                |
+| Citrons                                                                 | Citrons                                                                              |
+| ConcentrÃ© de tomate                                                    | Concentré de tomate                                                                  |
+| Concombre                                                               | Concombre                                                                            |
+| Conserves de poisson                                                    | Conserves de poisson                                                                 |
+| Crabes, crevettes et autres fruits de mer                               | Crabes, crevettes et autres fruits de mer                                            |
+| Croissants                                                              | Croissants                                                                           |
+| Cube alimentaire (Maggi, Jumbo, )                                       | Cube alimentaire (Maggi, Jumbo, )                                                    |
+| Dattes                                                                  | Dattes                                                                               |
+| Dorade fraiche                                                          | Autres poissons frais                                                                |
+| Eau minÃ©rale/ filtrÃ©e                                                 | Eau minérale/ filtrée                                                                |
+| Farine de blÃ© local ou importÃ©                                        | Farine de blé local ou importé                                                       |
+| Farine de maÃ¯s                                                         | Farine de maïs                                                                       |
+| Farine de mil                                                           | Farine de mil                                                                        |
+| Farines de manioc                                                       | Farines de manioc                                                                    |
+| Feuilles d'oseille (dakoumou, bissap/floerÃ¨)                           | Feuilles d'oseille                                                                   |
+| Feuilles de baobab                                                      | Feuilles de baobab                                                                   |
+| Fonio                                                                   | Fonio                                                                                |
+| Fromage local                                                           | Fromage                                                                              |
+| Gari, tapioca                                                           | Gari, tapioca                                                                        |
+| Gboma                                                                   | Autres légumes en feuilles                                                           |
+| Gibiers                                                                 | Gibiers                                                                              |
+| Gingembre                                                               | Gingembre                                                                            |
+| Gombo frais                                                             | Gombo frais                                                                          |
+| Gombo sec                                                               | Gombo sec                                                                            |
+| GÃ¢teaux                                                                | Gâteaux                                                                              |
+| Haricot vert                                                            | Haricot vert                                                                         |
+| Huile d'arachide                                                        | Huile d'arachide                                                                     |
+| Huile de coton                                                          | Huile de coton                                                                       |
+| Huile de palme raffinÃ©e                                                | Huile de palme raffinée                                                              |
+| Huile de palme rouge                                                    | Huile de palme rouge                                                                 |
+| Igname                                                                  | Igname                                                                               |
+| Jus de fruits (orange, bissap, gingembre, jus de cajou,etc.)            | Jus de fruits (orange, bissap, gingembre, jus de cajou,etc.)                         |
+| Jus en poudre                                                           | Jus en poudre                                                                        |
+| Lait caillÃ©, yaourt                                                    | Lait caillé, yaourt                                                                  |
+| Lait concentrÃ© non-sucrÃ©                                              | Lait concentré non-sucré                                                             |
+| Lait concentrÃ© sucrÃ©                                                  | Lait concentré sucré                                                                 |
+| Lait en poudre                                                          | Lait en poudre                                                                       |
+| Lait et farines pour bÃ©bÃ©                                             | Lait et farines pour bébé                                                            |
+| Lait frais                                                              | Lait frais                                                                           |
+| Mangue                                                                  | Mangue                                                                               |
+| Manioc                                                                  | Manioc                                                                               |
+| Maquereau frais                                                         | Maquereau (poisson de mer)                                                           |
+| Mayonnaise                                                              | Mayonnaise                                                                           |
+| MaÃ¯s en grains                                                         | Maïs en grain                                                                        |
+| MaÃ¯s en Ã©pis                                                          | Maïs en épi                                                                          |
+| Miel                                                                    | Miel                                                                                 |
+| Mil                                                                     | Mil                                                                                  |
+| Moringa, feuilles de manioc, feuilles de taro et autres feuilles        | Feuilles de manioc, feuilles de taro et, autres feuilles                             |
+| NiÃ©bÃ©/Haricots secs                                                   | Niébé/Haricots secs                                                                  |
+| Noix de cajou                                                           | Noix de cajou                                                                        |
+| Noix de coco                                                            | Noix de coco                                                                         |
+| Noix de cola                                                            | Noix de cola                                                                         |
+| Noix de karitÃ©                                                         | Noix de karité                                                                       |
+| Oeufs                                                                   | Œufs                                                                                 |
+| Oignon frais                                                            | Oignon frais                                                                         |
+| Orange                                                                  | Orange                                                                               |
+| Pain moderne                                                            | Pain moderne                                                                         |
+| Pain traditionnel                                                       | Pain traditionnel                                                                    |
+| PastÃ¨que, Melon                                                        | Pastèque, Melon                                                                      |
+| Patate douce                                                            | Patate douce                                                                         |
+| Petit pois secs                                                         | Petit pois secs                                                                      |
+| Petits pois                                                             | Petits pois                                                                          |
+| Piment                                                                  | Piment frais                                                                         |
+| Plantain                                                                | Plantain                                                                             |
+| Poisson sÃ©chÃ©                                                         | Poisson séché                                                                        |
+| Poivron frais                                                           | Poivron frais                                                                        |
+| Pomme de terre                                                          | Pomme de terre                                                                       |
+| Poulet sur pied                                                         | Poulet sur pied                                                                      |
+| PÃ¢te d'arachide                                                        | Pâte d'arachide                                                                      |
+| PÃ¢tes alimentaires                                                     | Pâtes alimentaires                                                                   |
+| Riz importÃ© brisÃ©                                                     | Riz importé non parfumé                                                              |
+| Riz importÃ© longs grains                                               | Riz importé non parfumé                                                              |
+| Riz local (KoviÃ©)                                                      | Autre Riz local                                                                      |
+| Riz local longs grains                                                  | Autre Riz local                                                                      |
+| Salade (laitue)                                                         | Salade (laitue)                                                                      |
+| Sel                                                                     | Sel                                                                                  |
+| Sorgho                                                                  | Sorgho                                                                               |
+| Sucre (poudre ou morceaux)                                              | Sucre (poudre ou morceaux)                                                           |
+| SÃ©same                                                                 | Sésame                                                                               |
+| Taro, macabo                                                            | Taro, macabo                                                                         |
+| ThÃ©                                                                    | Thé                                                                                  |
+| Tomate fraÃ®che                                                         | Tomate fraîche                                                                       |
+| Tomate sÃ©chÃ©e                                                         | Tomate séchée                                                                        |
+| Viande d'autres volailles domestiques                                   | Viande d'autres volailles domestiques                                                |
+| Viande de bÅ__uf                                                        | Viande de bœuf                                                                       |
+| Viande de chameau                                                       | Viande de chameau                                                                    |
+| Viande de chÃ¨vre                                                       | Viande de chèvre                                                                     |
+| Viande de mouton                                                        | Viande de mouton                                                                     |
+| Viande de porc                                                          | Viande de porc                                                                       |
+| Viande de poulet                                                        | Viande de poulet                                                                     |
+| Vinaigre /moutarde                                                      | Vinaigre /moutarde                                                                   |
+| Agrume                                                                  | Agrume                                                                               |
+| Amarante (Tchapata)                                                     | Amarante                                                                             |
+| Arachide                                                                | Arachide                                                                             |
+| Aubergine                                                               | Aubergine,                                                                           |
+| Autre (à préciser)                                                      | Autre crop                                                                           |
+| Blé                                                                     | Blé                                                                                  |
+| Café                                                                    | Café                                                                                 |
+| Calebassier                                                             | Calebassier                                                                          |
+| Chou                                                                    | Chou                                                                                 |
+| Coton                                                                   | Coton                                                                                |
+| Epinard                                                                 | Épinard                                                                              |
+| Gombo                                                                   | Gombo frais                                                                          |
+| Laitue                                                                  | Salade (laitue)                                                                      |
+| Manguier                                                                | Mangue                                                                               |
+| Maïs                                                                    | Maïs en grain                                                                        |
+| Melon                                                                   | Melon                                                                                |
+| Niébé                                                                   | Niébé/Haricots secs                                                                  |
+| Oignon                                                                  | Oignon frais                                                                         |
+| Oseille                                                                 | Oseille                                                                              |
+| Riz Paddy                                                               | Riz Paddy                                                                            |
+| Souchet                                                                 | Souchet                                                                              |
+| Sésame                                                                  | Sésame                                                                               |
+| Taro                                                                    | Taro, macabo                                                                         |
+| Thé                                                                     | Thé                                                                                  |
+| Tomate                                                                  | Tomate fraîche                                                                       |
+| Voandzou                                                                | Voandzou                                                                             |


### PR DESCRIPTION
## Summary

Builds the `harmonize_food` label foundation for the 4 EHCVM countries that lacked it (Benin, CôtedIvoire, Togo, Guinea-Bissau), so `crop_production.crop` and `food_acquired.j` map to the **shared Niger canonical taxonomy** — the GH #438 cross-join (foods ↔ crops ↔ prices on one axis).

- One `harmonize_food` table per country (`Original Label → Preferred Label`), serving **both** crop (via `crop_production.py`'s `get_categorical_mapping`) **and** food (via a `data_info.yml` `mappings:` clause on `j`, matching Niger).
- **French** (Benin/CIV/Togo): propagated from Niger's vocabulary (reused verbatim; no new canonical labels coined except CIV cash/forest crops — Cocoa/Cashew/Rubber/Coffee/Oil palm/Clove).
- **Guinea-Bissau** (Portuguese): translated to the same canonical labels (reviewed — incl. `Milho preto`→millet, `Cajueiro`→cashew).
- CôtedIvoire's two draft tables folded into one (cross-join); undecodable bare-code rows dropped → pass through raw, never `''`.

## Verification (committed tree, fresh cache)
20/20 build PASS across the 4 countries × {food_acquired, crop_production, food_expenditures, food_prices, food_quantities}:
- **0 `''` leakage** in `j` and `crop` everywhere.
- Harmonized to ~130 canonical food labels / ~40 crop labels per country; derived food tables re-bucket cleanly.
- `test_schema_consistency`: 207 passed.

Config-only change (4 countries' `categorical_mapping.org` + wave `data_info.yml`); no framework / other-country impact.

Advances #438 (label foundation done for Tier-1; Tier-2 EthiopiaRHS / Tier-3 + the GNB 13 untranslated locals remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)