### PR TITLE
fix(#460): Burkina_Faso plot_features i() matches sample per-wave (0.846 → 1.0)

### DIFF
--- a/lsms_library/countries/Burkina_Faso/2018-19/_/plot_features.py
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/plot_features.py
@@ -6,12 +6,19 @@ each (grappe, menage).  See
 lsms_library/countries/Burkina_Faso/_/burkina_faso.py:plot_features_for_wave
 for the harmonization shared across both EHCVM waves (copied from the
 Mali EHCVM reference, PR #284).
+
+Household id (GH #460): the 2018-19 wave's mapping.py overrides i() to
+the canonical EHCVM form (grappe + '0' + 2-digit menage), so sample() /
+household_roster carry 7-char ids for 3-digit menage.  This script must
+build plot_features' i with the SAME formatter, so it passes ehcvm_i.
+The previous default (the country-level 3-digit i()) stranded ~30% of
+2018-19 plot_features households off sample() (the #460 i-key bug).
 """
 import sys
 
 sys.path.append('../../_/')
 from lsms_library.local_tools import get_dataframe, to_parquet
-from burkina_faso import plot_features_for_wave
+from burkina_faso import plot_features_for_wave, ehcvm_i
 
 
 # convert_categoricals=False keeps the integer s16a codes that the
@@ -33,7 +40,7 @@ colmap = dict(
     water_source  = 's16aq17',
 )
 
-df = plot_features_for_wave('2018-19', src, colmap)
+df = plot_features_for_wave('2018-19', src, colmap, id_fn=ehcvm_i)
 
 assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2018-19"
 assert len(df) > 0, "plot_features 2018-19 produced no rows"

--- a/lsms_library/countries/Burkina_Faso/2021-22/_/plot_features.py
+++ b/lsms_library/countries/Burkina_Faso/2021-22/_/plot_features.py
@@ -6,12 +6,29 @@ each (grappe, menage).  See
 lsms_library/countries/Burkina_Faso/_/burkina_faso.py:plot_features_for_wave
 for the harmonization shared across both EHCVM waves (copied from the
 Mali EHCVM reference, PR #284).
+
+Household id (GH #460): UNLIKE 2018-19, the 2021-22 wave's mapping.py
+does NOT override i(), so its sample() / household_roster fall back to
+the country-level i() (grappe + 3-digit menage, no '0' separator).
+Verified empirically: sample 2021-22 carries old-form ids (e.g. '9120'
+for grappe=9, menage=120), NOT the canonical '90120'.  This script must
+build plot_features' i with the SAME formatter, so it passes the
+country i() (wrapped to ehcvm_i's (grappe, menage) signature).  Using
+ehcvm_i here would instead strand every 3-digit-menage household off
+sample().  (plot_features 2021-22 already reconciled 100% before #460;
+this keeps it so while #460 fixes the 2018-19 mismatch.)
 """
 import sys
+import pandas as pd
 
 sys.path.append('../../_/')
 from lsms_library.local_tools import get_dataframe, to_parquet
-from burkina_faso import plot_features_for_wave
+from burkina_faso import plot_features_for_wave, i as country_i
+
+
+def _old_i(grappe, menage):
+    """Country-level i() exposed with ehcvm_i's (grappe, menage) signature."""
+    return country_i(pd.Series([grappe, menage]))
 
 
 # convert_categoricals=False keeps the integer s16a codes that the
@@ -33,7 +50,7 @@ colmap = dict(
     water_source  = 's16aq17',
 )
 
-df = plot_features_for_wave('2021-22', src, colmap)
+df = plot_features_for_wave('2021-22', src, colmap, id_fn=_old_i)
 
 assert df.index.is_unique, "Non-unique (t, i, plot_id) index in plot_features 2021-22"
 assert len(df) > 0, "plot_features 2021-22 produced no rows"

--- a/lsms_library/countries/Burkina_Faso/_/burkina_faso.py
+++ b/lsms_library/countries/Burkina_Faso/_/burkina_faso.py
@@ -108,10 +108,18 @@ def panel_ids(df):
 # Burkina Faso copies the Mali EHCVM reference implementation (PR #284):
 # a single per-wave agriculture-parcel file s16a_me_bfa{year} with a
 # uniform column scheme.  The only country-specific piece is the
-# household-id formatter ``i()`` above — Burkina uses
-# ``format_id(grappe) + format_id(menage, zeropadding=3)`` (no extra '0'
-# separators), which is what ``sample()`` and ``panel_ids`` use, so the
-# emitted ``i`` matches ``sample().i`` natively.
+# household-id formatter, which MUST match the one the wave's ``sample()``
+# uses (GH #460) — and that DIFFERS BY WAVE:
+#   * 2018-19: mapping.py overrides ``i()`` to ``ehcvm_i`` (grappe + '0' +
+#     2-digit menage), so sample() / household_roster carry 7-char ids for
+#     3-digit menage.  plot_features 2018-19 passes ``ehcvm_i``.
+#   * 2021-22: mapping.py has NO ``i()`` override, so sample() / roster fall
+#     back to the country-level ``i()`` (grappe + 3-digit menage, no '0'
+#     separator).  plot_features 2021-22 passes that old formatter.
+# ``plot_features_for_wave`` takes ``id_fn`` so each wave's plot_features.py
+# selects the formatter matching its own sample().  Hardcoding the old
+# ``i()`` (the pre-#460 behavior) stranded ~30% of 2018-19 plot_features
+# households (3-digit menage) off sample() — the #460 i-key 0.846 bug.
 
 
 def _harmonized_codes(tablename, key='Code', value='Preferred Label'):
@@ -143,22 +151,36 @@ def _map_codes(series, code_map):
     return out.astype('string').where(out.notna(), pd.NA)
 
 
-def plot_features_for_wave(t, source, colmap):
+def plot_features_for_wave(t, source, colmap, id_fn=None):
     """Build canonical ``plot_features`` for one Burkina Faso EHCVM wave.
 
-    Mirrors ``Mali/_/mali.py:plot_features_for_wave`` exactly except it
-    uses Burkina's ``i()`` household-id formatter.  Returns a DataFrame
-    indexed by ``(t, i, plot_id)`` with columns ``Area`` (hectares
-    float), ``AreaUnit`` ('hectares'), ``Tenure``, ``TenureSystem``,
+    Mirrors ``Mali/_/mali.py:plot_features_for_wave`` exactly except for
+    the household-id formatter.  Returns a DataFrame indexed by
+    ``(t, i, plot_id)`` with columns ``Area`` (hectares float),
+    ``AreaUnit`` ('hectares'), ``Tenure``, ``TenureSystem``,
     ``SoilType`` (str), and ``Irrigated`` (nullable bool).
 
     Required ``colmap`` keys: grappe, menage, field_no, parcel_no,
     area_gps, gps_measured, area_est, area_est_unit, tenure,
     tenure_system, soil_type, water_source.
 
+    ``id_fn(grappe, menage) -> str`` selects the household-id formatter,
+    which MUST match the one the wave's ``sample()`` uses (GH #460).
+    The 2018-19 wave's ``mapping.py`` overrides ``i()`` to the canonical
+    ``ehcvm_i`` form (``grappe + '0' + 2-digit menage``), so its sample /
+    roster carry 7-char ids for 3-digit menage; the 2021-22 wave has no
+    such override, so its sample / roster fall back to the country-level
+    :func:`i` (``grappe + 3-digit menage``, no separator).  Hardcoding
+    :func:`i` here therefore stranded ~30% of 2018-19 plot_features
+    households off ``sample()`` (the #460 plot_features 0.846 i-key bug).
+    Each wave's ``plot_features.py`` passes the formatter matching its own
+    ``sample()``; the default is :func:`ehcvm_i` (the canonical EHCVM id).
+
     Latitude / Longitude are deferred — EHCVM s16a has no decimal-degree
     parcel GPS (s16aq47 is an area, not a coordinate).
     """
+    if id_fn is None:
+        id_fn = ehcvm_i
     tenure_map = _harmonized_codes('harmonize_tenure')
     tenure_system_map = _harmonized_codes('harmonize_tenure_system')
     soil_map = _harmonized_codes('harmonize_soil')
@@ -171,9 +193,9 @@ def plot_features_for_wave(t, source, colmap):
     # blank.  Keeping them would emit a content-free "nan_nan" plot_id.
     src = source[source[c['field_no']].notna() & source[c['parcel_no']].notna()].copy()
 
-    # Household id: EHCVM composite (grappe, menage) via burkina i().
-    hh = src.apply(lambda r: i(pd.Series([r[c['grappe']], r[c['menage']]])),
-                   axis=1)
+    # Household id: composite (grappe, menage) via the wave-supplied
+    # formatter (must match the wave's sample(); see docstring, GH #460).
+    hh = src.apply(lambda r: id_fn(r[c['grappe']], r[c['menage']]), axis=1)
 
     field = src[c['field_no']].apply(tools.format_id)
     parcel = src[c['parcel_no']].apply(tools.format_id)


### PR DESCRIPTION
Fixes #460 (the plot_features half).

`plot_features_for_wave` hardcoded the country `i()` (`grappe + menage.zfill(3)`), but 2018-19's `mapping.py` overrides `i()` to the canonical `grappe + '0' + menage.zfill(2)` (=`ehcvm_i`) that `sample()`/`household_roster` use — so 3-digit-menage households were stranded (`plot_features` ∩ sample = 0.704 for 2018-19, 0.846 overall). Parameterized `plot_features_for_wave(id_fn=)`; each wave passes the formatter matching its own `sample` (2018-19 → `ehcvm_i`; 2021-22 → old country `i()`, since 2021-22 has no `mapping.py` override and its sample uses the old form). Country `i()` left untouched (sample/roster/panel_ids/2014/2021-22 depend on it).

**Result (gate, fresh cache):** plot_features ∩ sample **0.846 → 1.0**; sample 1.0, roster/food_acquired/food_expenditures steady at 0.980. No regression.

Note: `food_acquired`'s 0.98 is a SEPARATE 2014 weights-file coverage gap (382 consumption HHs absent from weights; same id form both sides) — not the i()-form bug, left as-is. If we want it tracked, it's a small data-coverage follow-up distinct from #460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)