### PR TITLE
fix(#461): df_from_orgfile raises on a missing named table (no silent first-table fallback)

### DIFF
--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -1223,9 +1223,19 @@ def df_from_orgfile(orgfn: str | Path, name: str | None = None, set_columns: boo
     # Get indices of #+name: lines:
     names = [i for i,s in enumerate(contents) if f'#+name: {name}'.lower()==s.strip().lower()]
 
-    if len(names)==0:
-        #warnings.warn(f'No table {name} in {orgfn}.')
+    if name is None:
+        # No table requested: the table is assumed to be the first thing in the
+        # file (modulo leading #+ option lines).  This is the documented
+        # default and the only case in which a missing #+name header is OK.
         start = 0
+    elif len(names)==0:
+        # A specific table was requested but does not exist.  Do NOT silently
+        # fall back to the first table in the file (GH #461): that silently
+        # mis-maps (e.g. an absent harmonize_seed_crop returning the `u` units
+        # table -> every crop labelled with a unit).  Raise a clear KeyError;
+        # both df_data_grabber and get_categorical_mapping already catch it and
+        # continue their search-path / add a contextual note.
+        raise KeyError(f'No table named {name!r} in {orgfn}.')
     elif len(names)>1:
         start = names[0]
         warnings.warn(f'More than one table with {name} in {orgfn}.  Reading first one at line {start}.')

--- a/tests/test_orgfile_missing_table.py
+++ b/tests/test_orgfile_missing_table.py
@@ -1,0 +1,112 @@
+"""GH #461: df_from_orgfile / get_categorical_mapping must not silently fall
+back to the FIRST org table when a *named* table is absent.
+
+Before the fix, requesting a table that did not exist returned the first table
+in the file (e.g. an absent ``harmonize_seed_crop`` silently returned the ``u``
+units map -> every crop labelled with a unit).  The fix raises a clear
+``KeyError`` for a missing *named* table while preserving the documented
+``name=None`` "first table in the file" behaviour.
+
+These tests parse small temp org files only -- no microdata, CI-safe.
+"""
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from lsms_library.local_tools import df_from_orgfile, get_categorical_mapping
+
+
+# Two named tables, realistic spacing (blank lines between tables).
+ORG = textwrap.dedent(
+    """\
+    #+title: fixture
+
+    #+name: u
+    | Original Label | Preferred Label |
+    |----------------+-----------------|
+    | kg             | Kg              |
+    | litre          | Litre           |
+
+    #+name: harmonize_food
+    | Original Label | Preferred Label |
+    |----------------+-----------------|
+    | maize          | Maize           |
+    | rice           | Rice            |
+    """
+)
+
+# A bare pipe-table file with no #+name header (e.g. Ethiopia nonfood_items.org,
+# Panama food_items.org) -- the only legitimate name=None use.
+BARE_ORG = textwrap.dedent(
+    """\
+    | Original Label | Preferred Label |
+    |----------------+-----------------|
+    | maize          | Maize           |
+    | rice           | Rice            |
+    """
+)
+
+
+@pytest.fixture()
+def orgfile(tmp_path):
+    p = tmp_path / "categorical_mapping.org"
+    p.write_text(ORG, encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def barefile(tmp_path):
+    p = tmp_path / "food_items.org"
+    p.write_text(BARE_ORG, encoding="utf-8")
+    return p
+
+
+def test_named_table_returns_that_table(orgfile):
+    # Sanity: the SECOND table is selected by name, not the first.
+    df = df_from_orgfile(orgfile, name="harmonize_food")
+    assert list(df.columns) == ["Original Label", "Preferred Label"]
+    assert set(df["Preferred Label"]) == {"Maize", "Rice"}
+
+
+def test_missing_named_table_raises(orgfile):
+    # The regression: an absent named table must NOT silently return the
+    # first table (``u``); it must raise a clear KeyError naming the table.
+    with pytest.raises(KeyError, match="harmonize_seed_crop"):
+        df_from_orgfile(orgfile, name="harmonize_seed_crop")
+
+
+def test_name_none_still_reads_first_table(barefile):
+    # Documented default preserved: name=None -> first table in a bare file.
+    df = df_from_orgfile(barefile, name=None)
+    assert list(df.columns) == ["Original Label", "Preferred Label"]
+    assert set(df["Preferred Label"]) == {"Maize", "Rice"}
+
+
+def test_get_categorical_mapping_missing_table_raises(orgfile, monkeypatch):
+    # End-to-end through get_categorical_mapping: a missing tablename must
+    # surface a clear error, not the first table's contents.
+    monkeypatch.chdir(orgfile.parent)
+    with pytest.raises((KeyError, FileNotFoundError)):
+        get_categorical_mapping(
+            "categorical_mapping.org",
+            tablename="harmonize_seed_crop",
+            idxvars="Original Label",
+            dirs=["./"],
+            **{"Preferred Label": "Preferred Label"},
+        )
+
+
+def test_get_categorical_mapping_present_table_ok(orgfile, monkeypatch):
+    # And a present table still resolves to its own contents (mirrors the
+    # real crop_production.py call shape).
+    monkeypatch.chdir(orgfile.parent)
+    d = get_categorical_mapping(
+        "categorical_mapping.org",
+        tablename="harmonize_food",
+        idxvars="Original Label",
+        dirs=["./"],
+        **{"Preferred Label": "Preferred Label"},
+    )
+    assert d == {"maize": "Maize", "rice": "Rice"}


### PR DESCRIPTION
Closes #461.

## Problem
`df_from_orgfile(name=<absent>)` silently fell back to `start = 0` and returned the **first** table in the file. So requesting an absent `harmonize_seed_crop` returned the `u` units map — labelling every crop with a unit (surfaced during the #438 EHCVM Tier-1 Guinea-Bissau clone). Routed through `get_categorical_mapping` / `df_data_grabber`, the `shape[0]==0` guard never caught it because the first table is non-empty.

## Fix
Distinguish the two cases in `df_from_orgfile`:
- `name=None` → first table in the file (documented default; bare pipe-table files like Ethiopia's `nonfood_items.org`). **Preserved.**
- `name=<specific>` and absent → raise a clear `KeyError` naming the table + file. Both `df_data_grabber` and `get_categorical_mapping` already catch `KeyError`, so the search-path fallback and contextual `add_note` are intact.

## Verification
- **New regression test** `tests/test_orgfile_missing_table.py` (5 cases): named-table selection, missing-table raises, `name=None` first-table preserved, end-to-end `get_categorical_mapping` raises-on-missing / resolves-on-present.
- **Full suite**: 1802 passed, 87 skipped, 10 xfailed, 1 xpassed.
- **Rebuild gate** (Senegal + Niger `crop_production`/`plot_inputs`/`plot_labor`/`livestock`, cleared cache, normal backend re-running the wave scripts): 8/8 PASS, i-key=1.000 — confirms legitimate `harmonize_*` reads still resolve.
- **Adversarial**: no caller combines `orgtbl=` with `missing_ok=True` (`missing_ok` governs missing *columns*, not a missing *table*), so no NaN-tolerance path is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)