### PR TITLE
feat(#438): EthiopiaRHS anthropometry (t,i,pid) — Tier-2 pilot

### DIFF
--- a/lsms_library/countries/EthiopiaRHS/1994a/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1994a/Data/.gitignore
@@ -1,2 +1,3 @@
 /*.dta
 /land1all.tab
+/Anthropometry_R1-R4.tab

--- a/lsms_library/countries/EthiopiaRHS/1994a/Data/Anthropometry_R1-R4.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1994a/Data/Anthropometry_R1-R4.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: c25caca1c5bfd211bb2c4bfcaecef24c
+  size: 4096463
+  hash: md5
+  path: Anthropometry_R1-R4.tab

--- a/lsms_library/countries/EthiopiaRHS/1994a/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1994a/_/data_info.yml
@@ -196,3 +196,30 @@ plot_features:
             - mapping:
                 1: True       # Yes
                 2: False      # No
+
+# anthropometry (#438 Tier-2): individual (t, i, pid) body measures.
+# Source Anthropometry_R1-R4.tab is a POOLED wide file -- every measured
+# person across rounds 1-4 in round-suffixed columns (height{r}/weight{r}/
+# age{r}); 1994a is ROUND 1.  Keys (q1c, q1d, pid) sit in the roster
+# keyspace (q1c, hhid==q1d, ind==pid; statically verified 1.000 HH/person
+# overlap vs demo123), so (i, pid) joins household_roster and v auto-joins
+# from sample().  Sex 1/2 -> M/F via erhs_sex (same as the roster).  The
+# `anthropometry` df_edit hook in _/ethiopiarhs.py drops out-of-round
+# all-NaN-measure rows and converts age (years) -> Age_months (the
+# cross-country anthropometry convention; ERHS-shipped z-scores haz/waz/whz
+# are query-time transforms, NOT stored).
+anthropometry:
+    file: Anthropometry_R1-R4.tab
+    converted_categoricals: False
+    idxvars:
+        i:
+            - q1c
+            - q1d
+        pid: pid
+    myvars:
+        Height: height1
+        Weight: weight1
+        Age_months: age1     # raw YEARS; df_edit hook multiplies by 12
+        Sex:
+            - sex
+            - mappings: ['erhs_sex', 'Code', 'Preferred Label']

--- a/lsms_library/countries/EthiopiaRHS/1994b/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1994b/Data/.gitignore
@@ -1,1 +1,2 @@
 /*.dta
+/Anthropometry_R1-R4.tab

--- a/lsms_library/countries/EthiopiaRHS/1994b/Data/Anthropometry_R1-R4.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1994b/Data/Anthropometry_R1-R4.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: c25caca1c5bfd211bb2c4bfcaecef24c
+  size: 4096463
+  hash: md5
+  path: Anthropometry_R1-R4.tab

--- a/lsms_library/countries/EthiopiaRHS/1994b/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1994b/_/data_info.yml
@@ -96,3 +96,25 @@ cluster_features:
         Woreda:
             - q1c
             - mappings: ['erhs_village_woreda', 'Code', 'Woreda']
+
+# anthropometry (#438 Tier-2): individual (t, i, pid) body measures.
+# 1994b is ROUND 2 of the pooled Anthropometry_R1-R4.tab (height2/weight2/
+# age2).  Keys (q1c, q1d, pid) join the roster keyspace (verified 1.000 HH/
+# person overlap); v auto-joins from sample().  See the 1994a block for the
+# full rationale; the `anthropometry` df_edit hook drops out-of-round
+# all-NaN-measure rows and converts age (years) -> Age_months.
+anthropometry:
+    file: Anthropometry_R1-R4.tab
+    converted_categoricals: False
+    idxvars:
+        i:
+            - q1c
+            - q1d
+        pid: pid
+    myvars:
+        Height: height2
+        Weight: weight2
+        Age_months: age2     # raw YEARS; df_edit hook multiplies by 12
+        Sex:
+            - sex
+            - mappings: ['erhs_sex', 'Code', 'Preferred Label']

--- a/lsms_library/countries/EthiopiaRHS/1995/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1995/Data/.gitignore
@@ -1,1 +1,2 @@
 /*.dta
+/Anthropometry_R1-R4.tab

--- a/lsms_library/countries/EthiopiaRHS/1995/Data/Anthropometry_R1-R4.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1995/Data/Anthropometry_R1-R4.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: c25caca1c5bfd211bb2c4bfcaecef24c
+  size: 4096463
+  hash: md5
+  path: Anthropometry_R1-R4.tab

--- a/lsms_library/countries/EthiopiaRHS/1995/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1995/_/data_info.yml
@@ -97,3 +97,25 @@ cluster_features:
         Woreda:
             - q1c
             - mappings: ['erhs_village_woreda', 'Code', 'Woreda']
+
+# anthropometry (#438 Tier-2): individual (t, i, pid) body measures.
+# 1995 is ROUND 3 of the pooled Anthropometry_R1-R4.tab (height3/weight3/
+# age3).  Keys (q1c, q1d, pid) join the roster keyspace (verified 1.000 HH/
+# person overlap); v auto-joins from sample().  See the 1994a block for the
+# full rationale; the `anthropometry` df_edit hook drops out-of-round
+# all-NaN-measure rows and converts age (years) -> Age_months.
+anthropometry:
+    file: Anthropometry_R1-R4.tab
+    converted_categoricals: False
+    idxvars:
+        i:
+            - q1c
+            - q1d
+        pid: pid
+    myvars:
+        Height: height3
+        Weight: weight3
+        Age_months: age3     # raw YEARS; df_edit hook multiplies by 12
+        Sex:
+            - sex
+            - mappings: ['erhs_sex', 'Code', 'Preferred Label']

--- a/lsms_library/countries/EthiopiaRHS/1997/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1997/Data/.gitignore
@@ -1,1 +1,2 @@
 /*.dta
+/Anthropometry_R1-R4.tab

--- a/lsms_library/countries/EthiopiaRHS/1997/Data/Anthropometry_R1-R4.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1997/Data/Anthropometry_R1-R4.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: c25caca1c5bfd211bb2c4bfcaecef24c
+  size: 4096463
+  hash: md5
+  path: Anthropometry_R1-R4.tab

--- a/lsms_library/countries/EthiopiaRHS/1997/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1997/_/data_info.yml
@@ -105,3 +105,26 @@ cluster_features:
         Woreda:
             - q1c
             - mappings: ['erhs_village_woreda', 'Code', 'Woreda']
+
+# anthropometry (#438 Tier-2): individual (t, i, pid) body measures.
+# 1997 is ROUND 4 of the pooled Anthropometry_R1-R4.tab (height4/weight4/
+# age4).  Keys (q1c, q1d, pid) join the 1997 roster keyspace -- here the
+# roster source is age_sex_r4.dta, which itself keys on (q1c, q1d, pid)
+# (verified 1.000 person overlap).  v auto-joins from sample().  See the
+# 1994a block for the full rationale; the `anthropometry` df_edit hook
+# drops out-of-round all-NaN-measure rows and converts age -> Age_months.
+anthropometry:
+    file: Anthropometry_R1-R4.tab
+    converted_categoricals: False
+    idxvars:
+        i:
+            - q1c
+            - q1d
+        pid: pid
+    myvars:
+        Height: height4
+        Weight: weight4
+        Age_months: age4     # raw YEARS; df_edit hook multiplies by 12
+        Sex:
+            - sex
+            - mappings: ['erhs_sex', 'Code', 'Preferred Label']

--- a/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
+++ b/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
@@ -129,6 +129,27 @@ Data Scheme:
     Enset_ha: float         # 2004 only
     Enset_kg: float         # 2004 only
 
+  # anthropometry (#438 Tier-2): individual (t, i, pid) body measures for
+  # the four 1994-1997 rounds (R1-R4), from the pooled wide
+  # Anthropometry_R1-R4.tab (each wave slices its round's height{r}/weight{r}/
+  # age{r} columns; the `anthropometry` df_edit hook in _/ethiopiarhs.py drops
+  # out-of-round all-NaN rows and converts age years -> Age_months).  Matches
+  # the cross-country anthropometry schema (Ethiopia ESS / Malawi / Uganda):
+  #   Weight (kg), Height (cm), Age_months, Sex (M/F via erhs_sex).
+  # NO MUAC (ERHS records no mid-upper-arm circumference); the WHO z-scores
+  # the source ships (haz/waz/whz) are query-time TRANSFORMS, never stored.
+  # Grain (t, i, pid) aligns with household_roster's (i, pid); v auto-joins
+  # from sample() at API time -> returned grain (t, i, v, pid).  Built via
+  # the ERHS YAML + df_edit path (no materialize: make), like the rest of
+  # this country's features.  DEFERRED: 1989 (no body-measure module) and
+  # 1999/2004/2009 (R5-R7 not in Anthropometry_R1-R4.tab).
+  anthropometry:
+    index: (t, i, pid)
+    Weight: float
+    Height: float
+    Age_months: float
+    Sex: str
+
   # Mali-style clean YAML: extract wide per-source columns; the
   # `food_acquired` df_edit hook in _/ethiopiarhs.py melts them to
   # canonical long form on s. Price is API-derived (food_prices).

--- a/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
+++ b/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
@@ -276,3 +276,42 @@ def area_output(df):
     with no crop area or production at all carries no information -> drop.
     """
     return _drop_all_nan_value_rows(df)
+
+
+def anthropometry(df):
+    """Individual (t, i, pid) body measures, one round-slice per wave (#438).
+
+    Source Anthropometry_R1-R4.tab is a POOLED wide file carrying every
+    measured person across rounds 1-4 in round-suffixed columns; each wave's
+    data_info extracts THAT round's height/weight/age (+ roster sex), so the
+    framework hands this hook a frame indexed (i, pid) with columns
+    [Height, Weight, Age_months, Sex] in which the out-of-round persons (not
+    measured in this round) are all-NaN on the measures.  Two fixes:
+
+    1. Drop the out-of-round rows -- those with NO height/weight/age at all
+       (Sex is roster-sourced and present for everyone, so an all-value-cols
+       drop would keep them; restrict the all-NaN test to the MEASURES).
+    2. ``Age_months`` arrives as raw AGE IN YEARS (the source ``age{r}``
+       column); multiply by 12 to match the cross-country anthropometry
+       convention (Ethiopia ESS / Malawi / Uganda).  ERHS-shipped WHO
+       z-scores (haz/waz/whz) are query-time transforms and are NOT carried.
+
+    NA-index rows (a person with no q1c/q1d/pid) cannot be placed in a
+    household -> dropped (they would fail the sanity no-null-index check).
+    """
+    idx = list(df.index.names)
+    flat = df.reset_index()
+
+    measures = [c for c in ('Height', 'Weight', 'Age_months') if c in flat.columns]
+    flat = flat.dropna(subset=measures, how='all')
+
+    # Age years -> months (cross-country convention).
+    if 'Age_months' in flat.columns:
+        flat['Age_months'] = pd.to_numeric(flat['Age_months'], errors='coerce') * 12
+
+    # Drop rows that cannot be assigned to a (i, pid) cell.
+    for k in idx:
+        flat = flat[flat[k].notna()
+                    & (flat[k].astype('string').str.strip() != '')]
+
+    return flat.set_index(idx)


### PR DESCRIPTION
First **Tier-2** parity feature (#438) and the **first non-ISA anthropometry** — the EHCVM Tier-1 pass dropped anthropometry because those surveys field no body measures; the IFPRI ERHS does.

## What
Wires the ERHS body-measurement module for the four 1994–1997 rounds (R1–R4) from the pooled wide file `Anthropometry_R1-R4.tab`, producing the canonical `(t, i, pid)` anthropometry table (v auto-joins from `sample()` → returned grain `(t, i, v, pid)`).

- 4 wave `data_info.yml` blocks each slice that round's `height{r}/weight{r}/age{r}` (+ roster `sex` via `erhs_sex`); `i=[q1c,q1d]`, `pid=pid`.
- `anthropometry(df)` df_edit hook in `_/ethiopiarhs.py`: drops out-of-round all-NaN-measure rows; converts age (years) → `Age_months`.
- `data_scheme.yml` registers `(t,i,pid)` with `Weight/Height/Age_months/Sex`, matching the cross-country schema (Ethiopia ESS / Malawi / Uganda). No MUAC (ERHS records none); WHO z-scores the source ships (`haz/waz/whz`) are query-time transforms, not stored.
- Source copied into each wave's `Data/` + `dvc add` + `dvc push` (one blob, `md5 c25caca…`; remote in sync). Built via the ERHS YAML + df_edit path (no `materialize: make`), like the rest of this country's features.

## Verification
- **Cold build**: 36,433 rows across 1994a/1994b/1995/1997; i-key **1.000**, v-null **0.000**, **0 duplicate tuples**.
- **Sane ranges**: Height [35,190]cm, Weight [1,93]kg, Age_months ≤1254.5; Sex balanced F/M, 0 NaN. `is_this_feature_sane`: all PASS (one expected benign WARN — the auto-joined `v` level).
- **Keyspace** verified 1.000: roster `(i,pid)` overlap 10424/10425; per-round slicing checked exact against the raw file (heights `[148,145,150,159]` → 1994a..1997; `age×12` → Age_months `[424,430,432,458]`).
- **Tests**: EthiopiaRHS/anthropometry 6/6 (`test_table_structure`); schema + catalog 216 passed.

## Context
Tier-2 discovery + plan for the remaining features (crop_production, community_prices, plot_inputs/labor) in `slurm_logs/2026-06-15_ehcvm_parity/TIER2_ETHIOPIARHS_DISCOVERY.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)