### PR TITLE
feat(#438): EthiopiaRHS crop_production (t,i,j); retire area_output

### DIFF
--- a/lsms_library/countries/EthiopiaRHS/1994a/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1994a/Data/.gitignore
@@ -1,3 +1,4 @@
 /*.dta
 /land1all.tab
 /Anthropometry_R1-R4.tab
+/area_output_94.tab

--- a/lsms_library/countries/EthiopiaRHS/1994a/Data/area_output_94.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1994a/Data/area_output_94.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 186bbdef6ec69fa8c469b3fd3031d675
+  size: 333313
+  hash: md5
+  path: area_output_94.tab

--- a/lsms_library/countries/EthiopiaRHS/1994a/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1994a/_/data_info.yml
@@ -223,3 +223,40 @@ anthropometry:
         Sex:
             - sex
             - mappings: ['erhs_sex', 'Code', 'Preferred Label']
+
+# crop_production (#438): R1 (1994a) HH x crop production (kg) + area (ha).
+# Source: area_output_94.tab (WIDE HH x crop aggregate, already summed over
+# plots -> reduced (t,i,j) grain).  9 crops: white/black teff, barley,
+# wheat, maize, sorghum, coffee, chat, enset.  Per-crop source columns
+# {stub}prd94 (production, kg) and {stub}ha94 (area, hectares), declared as
+# {stub}_kg / {stub}_ha myvars; the crop_production df_edit hook in
+# _/ethiopiarhs.py melts them to long (i, j), sets u='Kg'.
+# i-KEY: i = [q1c, hhid] -- peasant-association code + HH-no-within-village,
+# the SAME composite the 1994a roster uses (q1c+hhid; this file carries both
+# q1c+hhid and q5+paid -- all four ID cols present and verified).
+crop_production:
+    file: area_output_94.tab
+    converted_categoricals: False
+    idxvars:
+        i:
+            - q1c
+            - hhid
+    myvars:
+        wtef_kg: wtefprd94
+        wtef_ha: wtefha94
+        btef_kg: btefprd94
+        btef_ha: btefha94
+        barl_kg: barlprd94
+        barl_ha: barlha94
+        wht_kg: whtprd94
+        wht_ha: whtha94
+        maiz_kg: maizprd94
+        maiz_ha: maizha94
+        sorg_kg: sorgprd94
+        sorg_ha: sorgha94
+        coff_kg: coffprd94
+        coff_ha: coffha94
+        chat_kg: chatprd94
+        chat_ha: chatha94
+        enset_kg: ensetprd94
+        enset_ha: ensetha94

--- a/lsms_library/countries/EthiopiaRHS/1994b/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1994b/Data/.gitignore
@@ -1,2 +1,3 @@
 /*.dta
 /Anthropometry_R1-R4.tab
+/area_output_r2r3rev.tab

--- a/lsms_library/countries/EthiopiaRHS/1994b/Data/area_output_r2r3rev.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1994b/Data/area_output_r2r3rev.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 7290b60443c574813c5dbc4ad5413ccc
+  size: 506378
+  hash: md5
+  path: area_output_r2r3rev.tab

--- a/lsms_library/countries/EthiopiaRHS/1994b/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1994b/_/data_info.yml
@@ -118,3 +118,28 @@ anthropometry:
         Sex:
             - sex
             - mappings: ['erhs_sex', 'Code', 'Preferred Label']
+
+# crop_production (#438): R2 (1994b) HH x crop production (kg) -- PRODUCTION
+# ONLY.  The pooled R2/R3 area_output_r2r3rev.tab carries the R2 production
+# columns {stub}prd94_2 but NO R2 area columns (area exists only for R3:
+# {stub}ha95).  So only the {stub}_kg myvars are declared; the
+# crop_production hook leaves Area_ha NaN for this wave (documented in
+# data_scheme.yml).  9 crops.  i = [paid, hhid] -- paid (= q1c PA code) +
+# HH-no-within-village; this file keys on paid/hhid/q1b (verified present).
+crop_production:
+    file: area_output_r2r3rev.tab
+    converted_categoricals: False
+    idxvars:
+        i:
+            - paid
+            - hhid
+    myvars:
+        wtef_kg: wtefprd94_2
+        btef_kg: btefprd94_2
+        barl_kg: barlprd94_2
+        wht_kg: whtprd94_2
+        maiz_kg: maizprd94_2
+        sorg_kg: sorgprd94_2
+        coff_kg: coffprd94_2
+        chat_kg: chatprd94_2
+        enset_kg: ensetprd94_2

--- a/lsms_library/countries/EthiopiaRHS/1995/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1995/Data/.gitignore
@@ -1,2 +1,3 @@
 /*.dta
 /Anthropometry_R1-R4.tab
+/area_output_r2r3rev.tab

--- a/lsms_library/countries/EthiopiaRHS/1995/Data/area_output_r2r3rev.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1995/Data/area_output_r2r3rev.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 7290b60443c574813c5dbc4ad5413ccc
+  size: 506378
+  hash: md5
+  path: area_output_r2r3rev.tab

--- a/lsms_library/countries/EthiopiaRHS/1995/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1995/_/data_info.yml
@@ -119,3 +119,35 @@ anthropometry:
         Sex:
             - sex
             - mappings: ['erhs_sex', 'Code', 'Preferred Label']
+
+# crop_production (#438): R3 (1995) HH x crop production (kg) + area (ha).
+# Source: the pooled R2/R3 area_output_r2r3rev.tab, R3 columns {stub}prd95
+# (production, kg) and {stub}ha95 (area, hectares), declared as {stub}_kg /
+# {stub}_ha myvars.  9 crops.  i = [paid, hhid] -- paid (= q1c PA code) +
+# HH-no-within-village (this file keys on paid/hhid/q1b, verified present).
+crop_production:
+    file: area_output_r2r3rev.tab
+    converted_categoricals: False
+    idxvars:
+        i:
+            - paid
+            - hhid
+    myvars:
+        wtef_kg: wtefprd95
+        wtef_ha: wtefha95
+        btef_kg: btefprd95
+        btef_ha: btefha95
+        barl_kg: barlprd95
+        barl_ha: barlha95
+        wht_kg: whtprd95
+        wht_ha: whtha95
+        maiz_kg: maizprd95
+        maiz_ha: maizha95
+        sorg_kg: sorgprd95
+        sorg_ha: sorgha95
+        coff_kg: coffprd95
+        coff_ha: coffha95
+        chat_kg: chatprd95
+        chat_ha: chatha95
+        enset_kg: ensetprd95
+        enset_ha: ensetha95

--- a/lsms_library/countries/EthiopiaRHS/1997/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1997/Data/.gitignore
@@ -1,2 +1,3 @@
 /*.dta
 /Anthropometry_R1-R4.tab
+/area_output_97.tab

--- a/lsms_library/countries/EthiopiaRHS/1997/Data/area_output_97.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1997/Data/area_output_97.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 1d614f7b8e6e875b6b810061faf251f9
+  size: 408496
+  hash: md5
+  path: area_output_97.tab

--- a/lsms_library/countries/EthiopiaRHS/1997/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1997/_/data_info.yml
@@ -128,3 +128,37 @@ anthropometry:
         Sex:
             - sex
             - mappings: ['erhs_sex', 'Code', 'Preferred Label']
+
+# crop_production (#438): R4 (1997) HH x crop production (kg) + area (ha).
+# Source: area_output_97.tab (9 crops).  NOTE the R4 production columns are
+# named {stub}prd_97 (with an UNDERSCORE before 97), while area is {stub}ha97
+# (no underscore).  Declared as {stub}_kg / {stub}_ha myvars.  The file also
+# carries a per-crop VALUE column ({stub}v_97) which is NOT extracted (#438
+# keeps Quantity + Area_ha only).  i = [q1c, hhid] -- the SAME composite the
+# 1994a roster uses (this file carries q1c/hhid/q5/paid, all verified).
+crop_production:
+    file: area_output_97.tab
+    converted_categoricals: False
+    idxvars:
+        i:
+            - q1c
+            - hhid
+    myvars:
+        wtef_kg: wtefprd_97
+        wtef_ha: wtefha97
+        btef_kg: btefprd_97
+        btef_ha: btefha97
+        barl_kg: barlprd_97
+        barl_ha: barlha97
+        wht_kg: whtprd_97
+        wht_ha: whtha97
+        maiz_kg: maizprd_97
+        maiz_ha: maizha97
+        sorg_kg: sorgprd_97
+        sorg_ha: sorgha97
+        coff_kg: coffprd_97
+        coff_ha: coffha97
+        chat_kg: chatprd_97
+        chat_ha: chatha97
+        enset_kg: ensetprd_97
+        enset_ha: ensetha97

--- a/lsms_library/countries/EthiopiaRHS/2004/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/2004/_/data_info.yml
@@ -54,9 +54,15 @@ livestock:
         LivestockValue: livval6
         TLU: lsu6
 
-# area_output: HH x crop AREA (ha) + PRODUCTION (kg) totals, 2004 = 9 crops.
-# Source columns {crop}ha04 / {crop}prd04.
-area_output:
+# crop_production (#438): R6 (2004) HH x crop production (kg) + area (ha).
+# Source: area_output_04rev.tab (9 crops: white/black teff, barley, wheat,
+# maize, sorghum, coffee, chat, enset).  Per-crop source columns
+# {stub}prd04 (production, kg) and {stub}ha04 (area, hectares), declared as
+# {stub}_kg / {stub}_ha myvars; the crop_production df_edit hook in
+# _/ethiopiarhs.py melts them to long (i, j).  i = composite (paid, hhid)
+# via the shared ethiopiarhs.i formatter (statically verified, same
+# keyspace as the 1994+ panel).
+crop_production:
     file: area_output_04rev.tab
     converted_categoricals: False
     idxvars:
@@ -64,24 +70,24 @@ area_output:
             - paid
             - hhid
     myvars:
-        WhiteTeff_ha: wtefha04
-        WhiteTeff_kg: wtefprd04
-        BlackTeff_ha: btefha04
-        BlackTeff_kg: btefprd04
-        Barley_ha: barlha04
-        Barley_kg: barlprd04
-        Wheat_ha: whtha04
-        Wheat_kg: whtprd04
-        Maize_ha: maizha04
-        Maize_kg: maizprd04
-        Sorghum_ha: sorgha04
-        Sorghum_kg: sorgprd04
-        Coffee_ha: coffha04
-        Coffee_kg: coffprd04
-        Chat_ha: chatha04
-        Chat_kg: chatprd04
-        Enset_ha: ensetha04
-        Enset_kg: ensetprd04
+        wtef_kg: wtefprd04
+        wtef_ha: wtefha04
+        btef_kg: btefprd04
+        btef_ha: btefha04
+        barl_kg: barlprd04
+        barl_ha: barlha04
+        wht_kg: whtprd04
+        wht_ha: whtha04
+        maiz_kg: maizprd04
+        maiz_ha: maizha04
+        sorg_kg: sorgprd04
+        sorg_ha: sorgha04
+        coff_kg: coffprd04
+        coff_ha: coffha04
+        chat_kg: chatprd04
+        chat_ha: chatha04
+        enset_kg: ensetprd04
+        enset_ha: ensetha04
 
 # Sampling design + cluster geography.  Extracted from the consumption
 # aggregate file (richest HH coverage); v = paid (numeric PA code 1..20).

--- a/lsms_library/countries/EthiopiaRHS/2009/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/2009/_/data_info.yml
@@ -7,8 +7,9 @@
 # pattern), NOT household_roster/food_acquired.
 #
 # i-KEY (statically verified).  i = composite (pa, hhid) for the
-# consumption/hhsize/livestock files, and (paid, hhid) for the area_output
-# file -- `pa`/`paid` are the SAME numeric peasant-association code 1..20
+# consumption/hhsize/livestock files, and (paid, hhid) for the
+# crop_production source file -- `pa`/`paid` are the SAME numeric
+# peasant-association code 1..20
 # as q1c; `hhid` is the HH-number-within-PA (NOT unique within the wave:
 # 265 distinct vs 1357 rows), so the composite is mandatory.  Same keyspace
 # as the 1994+ panel -> joins the main panel + gets a real v from the 2009
@@ -16,7 +17,7 @@
 # False): pa/paid/hhid and the value columns are stable numeric scalars.
 #
 # The 2009 files are SINGLE-ROUND (not pooled), so the all-NaN-row drop in
-# the consumption/hhsize/area_output hooks is effectively a no-op here.
+# the consumption/hhsize hooks is effectively a no-op here.
 
 # consumption: HH-level R7 consumption scalars.  Poor uses poorpc7 (the
 # per-capita poverty indicator; 2009 has no plain `poor7`).  aeu absent.
@@ -60,13 +61,14 @@ livestock:
         LivestockValue: lvs_val7
         TLU: tlu7
 
-# area_output: HH x cereal AREA (ha) + PRODUCTION (kg), 2009 = 6 cereals
-# (white/black teff, barley, wheat, maize, sorghum).  Coffee/chat/enset are
-# NOT in the 2009 cereals file, so they are simply omitted here; the
-# country-level cross-wave concat unions columns, leaving 2009's
-# Coffee/Chat/Enset_ha/_kg NaN (the data_scheme declares the 2004+2009
-# union).  This file keys on `paid` (not `pa`).
-area_output:
+# crop_production (#438): R7 (2009) HH x cereal production (kg) + area (ha),
+# 6 CEREALS ONLY (white/black teff, barley, wheat, maize, sorghum).
+# Coffee/chat/enset are NOT in the 2009 cereals file, so only those 6 crop
+# stubs are declared here; the crop_production hook simply emits 6 crop rows
+# per HH (no NaN coffee/chat/enset rows).  Source: erhs7_meher_area_output_
+# cereals_2009.tab; per-crop columns {stub}prd09 / {stub}ha09 declared as
+# {stub}_kg / {stub}_ha myvars.  This file keys on `paid` (not `pa`).
+crop_production:
     file: erhs7_meher_area_output_cereals_2009.tab
     converted_categoricals: False
     idxvars:
@@ -74,18 +76,18 @@ area_output:
             - paid
             - hhid
     myvars:
-        WhiteTeff_ha: wtefha09
-        WhiteTeff_kg: wtefprd09
-        BlackTeff_ha: btefha09
-        BlackTeff_kg: btefprd09
-        Barley_ha: barlha09
-        Barley_kg: barlprd09
-        Wheat_ha: whtha09
-        Wheat_kg: whtprd09
-        Maize_ha: maizha09
-        Maize_kg: maizprd09
-        Sorghum_ha: sorgha09
-        Sorghum_kg: sorgprd09
+        wtef_kg: wtefprd09
+        wtef_ha: wtefha09
+        btef_kg: btefprd09
+        btef_ha: btefha09
+        barl_kg: barlprd09
+        barl_ha: barlha09
+        wht_kg: whtprd09
+        wht_ha: whtha09
+        maiz_kg: maizprd09
+        maiz_ha: maizha09
+        sorg_kg: sorgprd09
+        sorg_ha: sorgha09
 
 # Sampling design + cluster geography.  Extracted from the consumption
 # aggregate file; v = pa (numeric PA code 1..20).  Region/Woreda mapped

--- a/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
+++ b/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
@@ -15,12 +15,15 @@ Country: EthiopiaRHS
 #    auto-derive household_characteristics, food_expenditures/food_quantities.
 #  - sample + cluster_features (all 8 waves where geography exists).
 #  - plot_features (1994a R1).
+#  - anthropometry (t,i,pid) 1994-1997 (R1-R4) + crop_production (t,i,j)
+#    1994-1997/2004/2009 (R1-R4,R6,R7) -- item-level parity features (#438).
 #  - bespoke HH-level (t,i) VALUE/aggregate tables where the IFPRI archive
 #    ships only pre-aggregated household scalars (no roster/item-level food):
 #    assets (1989 R1), livestock (1999 R5 + 2004 R6 + 2009 R7),
-#    income (1999 R5), consumption (2004 R6 + 2009 R7), hhsize (2009 R7),
-#    area_output (2004 R6 + 2009 R7).  These follow the documented
-#    _no_v_join (t,i) pattern (see country.py _no_v_join + CLAUDE.md).
+#    income (1999 R5), consumption (2004 R6 + 2009 R7), hhsize (2009 R7).
+#    These follow the documented _no_v_join (t,i) pattern (see CLAUDE.md).
+#    (The former HH-level `area_output` (t,i) table is RETIRED -- subsumed by
+#    the item-level crop_production above; #438.)
 #  - panel_ids (!make).
 
 Data Scheme:
@@ -99,35 +102,28 @@ Data Scheme:
     HouseholdSize: float    # hhsize
     MaleHead: float         # malehead (1 = male-headed)
 
-  # area_output (#277): HH x crop pre-aggregated AREA (ha) + PRODUCTION (kg)
-  # totals for 2004 (R6) and 2009 (R7).  NOT plot_features (no per-plot rows;
-  # this is the HH-level constructed crop summary).  Documented HH-level
-  # (t,i) variant.  Columns are the UNION of 2004 (9 crops: white/black teff,
-  # barley, wheat, maize, sorghum, coffee, chat, enset) and 2009 (6 cereals:
-  # white/black teff, barley, wheat, maize, sorghum); 2009 leaves
-  # coffee/chat/enset NaN (missing_ok column union).  Per-crop column
-  # naming: {Crop}_ha (hectares), {Crop}_kg (production).  i = composite
-  # (paid, hhid) via the shared ethiopiarhs.i formatter.  Added to _no_v_join.
-  area_output:
-    index: (t, i)
-    WhiteTeff_ha: float
-    WhiteTeff_kg: float
-    BlackTeff_ha: float
-    BlackTeff_kg: float
-    Barley_ha: float
-    Barley_kg: float
-    Wheat_ha: float
-    Wheat_kg: float
-    Maize_ha: float
-    Maize_kg: float
-    Sorghum_ha: float
-    Sorghum_kg: float
-    Coffee_ha: float        # 2004 only
-    Coffee_kg: float        # 2004 only
-    Chat_ha: float          # 2004 only
-    Chat_kg: float          # 2004 only
-    Enset_ha: float         # 2004 only
-    Enset_kg: float         # 2004 only
+  # crop_production (#438, Tier-2): item-level HH x crop production.  The
+  # ERHS area_output_* files are WIDE HH x crop AGGREGATES -- already summed
+  # across plots, so there is NO plot dimension; this is the documented ERHS
+  # reduced-grain variant ((t,i,j), not the canonical (t,i,plot,j)).  Per-
+  # wave data_info extracts each round's {stub}_kg (production, kg) and
+  # {stub}_ha (area, hectares) myvars; the `crop_production` df_edit hook in
+  # _/ethiopiarhs.py melts them to long (i, j), maps the 9 crop stubs to
+  # Preferred Labels (White/Black Teff, Barley, Wheat, Maize, Sorghum,
+  # Coffee, Chat, Enset), sets u='Kg', and drops rows with neither metric.
+  # The framework prepends t and joins v from sample() -> returned grain
+  # (i, t, v, j, u).  SUBSUMES the retired (t,i) wide `area_output` table.
+  #
+  # WAVE COVERAGE: 1994a (R1), 1994b (R2, PRODUCTION ONLY -- no area in the
+  # r2r3rev R2 columns), 1995 (R3), 1997 (R4), 2004 (R6), 2009 (R7, 6
+  # CEREALS only -- no coffee/chat/enset).  1999 (R5) is DEFERRED: its
+  # area_output_99 uses a packed-hhid keyspace with ~0.000 overlap vs the
+  # 1999 composite sample (documented follow-up; do NOT wire it here).
+  crop_production:
+    index: (t, i, j)
+    Quantity: float        # production, kg harvested
+    Area_ha: float         # area planted, hectares (NaN for 1994b R2)
+    u: str                 # constant 'Kg' (production unit)
 
   # anthropometry (#438 Tier-2): individual (t, i, pid) body measures for
   # the four 1994-1997 rounds (R1-R4), from the pooled wide

--- a/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
+++ b/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
@@ -266,18 +266,6 @@ def hhsize(df):
     return _drop_all_nan_value_rows(df)
 
 
-def area_output(df):
-    """R6/R7 HH x crop area(ha)+production(kg): drop all-NaN-crop rows.
-
-    The 2004 source carries 9 crops (white/black teff, barley, wheat,
-    maize, sorghum, coffee, chat, enset); 2009 carries 6 cereals (the
-    teff/barley/wheat/maize/sorghum subset) and leaves coffee/chat/enset
-    absent (filled NaN by the wave data_info's missing_ok myvars).  A row
-    with no crop area or production at all carries no information -> drop.
-    """
-    return _drop_all_nan_value_rows(df)
-
-
 def anthropometry(df):
     """Individual (t, i, pid) body measures, one round-slice per wave (#438).
 
@@ -315,3 +303,46 @@ def anthropometry(df):
                     & (flat[k].astype('string').str.strip() != '')]
 
     return flat.set_index(idx)
+
+
+_CROP_LABELS = {
+    'wtef': 'White Teff', 'btef': 'Black Teff', 'barl': 'Barley',
+    'wht': 'Wheat', 'maiz': 'Maize', 'sorg': 'Sorghum',
+    'coff': 'Coffee', 'chat': 'Chat', 'enset': 'Enset',
+}
+
+
+def crop_production(df):
+    """Melt the wide ERHS HH x crop area_output_* slice to long (t,i,j) (#438).
+
+    Each wave's data_info extracts that round's per-crop production (kg) and
+    area (ha) as {stub}_kg / {stub}_ha myvars over an (i,) index.  Reshape to
+    one row per (i, j) crop: Quantity (kg), Area_ha, u='Kg'.  ERHS aggregates
+    are HH x crop (already summed over plots) -> reduced (t,i,j) grain, no
+    plot dimension.  Framework prepends t and joins v from sample().
+    """
+    idx = list(df.index.names)            # ('i',)
+    flat = df.reset_index()
+    parts = []
+    for stub, label in _CROP_LABELS.items():
+        kg, ha = f'{stub}_kg', f'{stub}_ha'
+        if kg not in flat.columns and ha not in flat.columns:
+            continue
+        part = flat[idx].copy()
+        part['j'] = label
+        part['Quantity'] = (pd.to_numeric(flat[kg], errors='coerce')
+                            if kg in flat.columns
+                            else pd.Series(np.nan, index=flat.index))
+        part['Area_ha'] = (pd.to_numeric(flat[ha], errors='coerce')
+                           if ha in flat.columns
+                           else pd.Series(np.nan, index=flat.index))
+        parts.append(part)
+    out = pd.concat(parts, ignore_index=True)
+    out = out[out['Quantity'].notna() | out['Area_ha'].notna()]
+    out['u'] = 'Kg'
+    out = out[out['j'].notna()]
+    for k in idx:
+        out = out[out[k].notna() & (out[k].astype('string').str.strip() != '')]
+    out = out.set_index(idx + ['j'])
+    out = out.groupby(level=out.index.names).first()   # defensive de-dupe
+    return out

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -3079,6 +3079,17 @@ class Country:
             "    loc = legacy_locality(Country('Uganda'))\n\n"
             "See docs/migration/locality.md for details."
         ),
+        'area_output': (
+            "Country('EthiopiaRHS').area_output() is deprecated and will be "
+            "removed in a future release. The HH-level (t, i) wide crop table "
+            "is subsumed by the item-level crop_production (t, i, j) feature "
+            "(GH #438), which covers more waves (R1-R4 + R6 + R7):\n\n"
+            "    Country('EthiopiaRHS').crop_production()  # (t, i, v, j, u)\n\n"
+            "For callers who need the legacy wide (t, i) shape, a compatibility "
+            "shim is available:\n\n"
+            "    from lsms_library.transformations import legacy_area_output\n"
+            "    ao = legacy_area_output(Country('EthiopiaRHS'))"
+        ),
     }
 
     def __getattr__(self, name):
@@ -3105,8 +3116,9 @@ class Country:
 
             def method(*args, **kwargs):
                 warnings.warn(dep_msg, DeprecationWarning, stacklevel=2)
-                from .transformations import legacy_locality
-                _shims = {'locality': legacy_locality}
+                from .transformations import legacy_locality, legacy_area_output
+                _shims = {'locality': legacy_locality,
+                          'area_output': legacy_area_output}
                 return _shims[name](self)
 
             method.__name__ = name

--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -1185,6 +1185,45 @@ def food_prices_from_acquired(df, units='kgvalue', *, volume_as_mass=True):
     return v
 
 
+def legacy_area_output(country):
+    """Reproduce the retired EthiopiaRHS Country(X).area_output() (t,i) table.
+
+    The HH-level wide ``area_output`` table (#277) was retired in favour of the
+    item-level ``crop_production`` (t, i, j) feature (#438), which subsumes it.
+    This shim re-widens ``crop_production`` back to the old (t, i) shape with
+    per-crop ``{Crop}_kg`` (production) and ``{Crop}_ha`` (area) columns, so
+    callers migrating off ``area_output()`` keep working.
+
+    Note: ``crop_production`` covers MORE waves than the original ``area_output``
+    (R1-R4 + R6 + R7, not just R6/R7), so this shim now returns those extra
+    waves too.  New code should use ``crop_production()`` directly.
+
+    Parameters
+    ----------
+    country : Country
+        The Country instance (e.g., ``ll.Country('EthiopiaRHS')``).
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame indexed by (t, i) with ``{Crop}_kg`` / ``{Crop}_ha`` columns
+        (crop label spaces removed, e.g. ``WhiteTeff_kg``).
+    """
+    cp = country.crop_production().reset_index()
+    idx = [c for c in ('t', 'i') if c in cp.columns]
+    # crop label -> compact column stem ('White Teff' -> 'WhiteTeff')
+    cp['stem'] = cp['j'].astype(str).str.replace(' ', '', regex=False)
+    kg = cp.pivot_table(index=idx, columns='stem', values='Quantity',
+                        aggfunc='first')
+    ha = cp.pivot_table(index=idx, columns='stem', values='Area_ha',
+                        aggfunc='first')
+    kg.columns = [f'{c}_kg' for c in kg.columns]
+    ha.columns = [f'{c}_ha' for c in ha.columns]
+    out = kg.join(ha, how='outer').sort_index(axis=1)
+    out.columns.name = None
+    return out
+
+
 def legacy_locality(country):
     """Reproduce the pre-deprecation output of Country(X).locality().
 


### PR DESCRIPTION
Second **Tier-2** parity feature (#438). Item-level HH×crop production, melted from the wide ERHS `area_output_*` aggregates into canonical long `(t, i, j)`. **Subsumes and retires** the former HH-level `(t, i)` wide `area_output` table.

## What
- **6 wave `data_info.yml` `crop_production` blocks** (1994a/1994b/1995/1997/2004/2009) declare each round's `{stub}_kg` (production) / `{stub}_ha` (area) myvars over an `(i,)` index. Per-wave keyspaces statically verified vs `sample()` (i-key **1.000**); 1994b is production-only (no R2 area).
- **`crop_production(df)` df_edit hook** melts the wide crop columns to long `(i,j)`, maps 9 crop stubs → Preferred Labels (White/Black Teff, Barley, Wheat, Maize, Sorghum, Coffee, Chat, Enset), sets `u='Kg'`, drops crop-cells with neither metric. Framework prepends `t` + joins `v` → returned grain `(i,t,v,j,u)`.
- **`data_scheme.yml`** registers `(t,i,j)` `Quantity/Area_ha/u`. Reduced grain (the source files are HH×crop, already summed over plots — no plot dimension), the documented ERHS reduced-grain pattern.
- **1999 (R5) deferred**: `area_output_99` uses a packed-hhid keyspace (~0.000 overlap vs the 1999 composite sample); documented follow-up.

## Retire area_output
- Removed from `data_scheme.yml` + 2004/2009 `data_info.yml` + the `area_output(df)` hook (kept `_drop_all_nan_value_rows`).
- `Country._DEPRECATED` gains `area_output` (message → crop_production) + `transformations.legacy_area_output`, a re-widen shim back to the old wide `(t,i)` `{Crop}_kg/_ha` shape for external callers. (No in-repo callers existed.)

## Verification
- **Cold build**: 17,523 rows × 6 waves; grain `(i,t,v,j)`; i-key **1.000**, v-null **0.032** (2009 Movers), **0 dup tuples**. Quantity [0,68288]kg, Area_ha [0,625]ha, 0 negatives, u=Kg. `is_this_feature_sane` all PASS except 2 benign WARNs (auto-joined `v`; constant `u`).
- **Adversarial**: 4 melted cells exact-match the raw `{stub}prd/{stub}ha`; re-widen round-trip exact (Maize 1994a 100.0 → legacy `Maize_kg` 100.0).
- **area_output retired**: not in data_scheme; `.area_output()` emits `DeprecationWarning` and returns the `legacy_area_output` re-widen.
- Source `dvc add` + `push` (4 files; remote in sync).
- **Tests**: schema + catalog + deprecation + EthiopiaRHS/crop_production table_structure → **233 passed**.

Design doc: `slurm_logs/2026-06-15_ehcvm_parity/TIER2_CROP_PRODUCTION_DESIGN.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)