### PR TITLE
feat(#438/#275): EthiopiaRHS community_prices (t,v,j,u); fix map_index j-drop for cluster features

### DIFF
--- a/lsms_library/countries/EthiopiaRHS/1994a/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/1994a/Data/.gitignore
@@ -2,3 +2,4 @@
 /land1all.tab
 /Anthropometry_R1-R4.tab
 /area_output_94.tab
+/price1234_rev.tab

--- a/lsms_library/countries/EthiopiaRHS/1994a/Data/price1234_rev.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/1994a/Data/price1234_rev.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 3af5147a95724518021799faa3f2c565
+  size: 47038
+  hash: md5
+  path: price1234_rev.tab

--- a/lsms_library/countries/EthiopiaRHS/2004/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/2004/Data/.gitignore
@@ -1,3 +1,4 @@
 /consumptionaggregates_123456.tab
 /livestockaggregates_123456.tab
 /area_output_04rev.tab
+/rd6_kgpr_Mkt.tab

--- a/lsms_library/countries/EthiopiaRHS/2004/Data/rd6_kgpr_Mkt.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/2004/Data/rd6_kgpr_Mkt.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 2073f2300df55e2ddf6539f80cd62bb4
+  size: 12988
+  hash: md5
+  path: rd6_kgpr_Mkt.tab

--- a/lsms_library/countries/EthiopiaRHS/2009/Data/.gitignore
+++ b/lsms_library/countries/EthiopiaRHS/2009/Data/.gitignore
@@ -2,3 +2,4 @@
 /hhsize_round7.tab
 /livestock_agg_round7.tab
 /erhs7_meher_area_output_cereals_2009.tab
+/price2009.tab

--- a/lsms_library/countries/EthiopiaRHS/2009/Data/price2009.tab.dvc
+++ b/lsms_library/countries/EthiopiaRHS/2009/Data/price2009.tab.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: b77aa0b1a85853a02687680d46064aaf
+  size: 69366
+  hash: md5
+  path: price2009.tab

--- a/lsms_library/countries/EthiopiaRHS/_/Makefile
+++ b/lsms_library/countries/EthiopiaRHS/_/Makefile
@@ -1,0 +1,19 @@
+COUNTRY := $(shell basename "$$(cd .. && pwd)")
+LSMS_DATA_ROOT ?= $(if $(LSMS_DATA_DIR),$(LSMS_DATA_DIR),$(if $(XDG_DATA_HOME),$(XDG_DATA_HOME),$(HOME)/.local/share)/lsms_library)
+VAR_DIR ?= $(LSMS_DATA_ROOT)/$(COUNTRY)/var
+
+all: panel_ids.json
+
+# Panel IDs (constructed from the ERHS cover sheets; see panel_ids.py).
+panel_ids.json updated_ids.json: panel_ids.py ethiopiarhs.py
+	python panel_ids.py
+
+# community_prices (#438 / #275): PA-level surveyed food prices.  Country-level
+# script reads the three dedicated price files (price1234_rev R1-R4 broadcast
+# Woreda->PA, rd6_kgpr_Mkt R6, price2009 R7), maps item codes -> Preferred
+# Labels via harmonize_community_food, and writes the (t,v,j,u) parquet.
+$(VAR_DIR)/community_prices.parquet: community_prices.py ethiopiarhs.py categorical_mapping.org
+	python community_prices.py
+
+clean:
+	rm -f panel_ids.json updated_ids.json

--- a/lsms_library/countries/EthiopiaRHS/_/categorical_mapping.org
+++ b/lsms_library/countries/EthiopiaRHS/_/categorical_mapping.org
@@ -428,3 +428,67 @@ distinction) pending Codeunit1.SPS.
 | 100 | Minilik |
 | 102 | Mezo |
 | 103 | Finala |
+
+* harmonize_community_food (#438 / #275 -- DRAFT, labels for review)
+
+Item-code -> Preferred Label for the ERHS community/market PRICE
+instruments (price1234_rev R1-R4, rd6_kgpr_Mkt R6, price2009 R7).  =Code=
+is the consistent low =item1234= scheme (1=white teff, 2=black teff, ...),
+which is stable across R1-R7.  =Original Label= is the R7 (price2009)
+=foodtype= text (the cleanest in-data label).  =Preferred Label= is the
+harmonized j, ALIGNED with the existing =harmonize_food= vocabulary where
+the item overlaps (so a priced food joins food_acquired / crop_production
+on j) -- e.g. Teff (white)/(black), Barley, Coffee, Enset, Araqi/Katikala,
+Coffee leaf/Tea match harmonize_food exactly.
+
+DRAFT -- the items flagged below are judgement calls (local Amharic names);
+Preferred Labels are the maintainer's curation domain.  Items NOT in this
+table (the high =code= 100+/300+/500+ aggregate codes, ~11% of R1-R4 price
+rows) are dropped by the community_prices script with a logged count.
+
+#+NAME: harmonize_community_food
+| Code | Original Label             | Preferred Label       |
+|------+----------------------------+-----------------------|
+|    1 | Teff (white)               | Teff (white)          |
+|    2 | Teff (black)               | Teff (black)          |
+|    3 | Barley (Gebis)             | Barley                |
+|    4 | Wheat/ Durahh (Sinde)      | Wheat                 |
+|    5 | Maize (Bekolo/Bahismashla) | Maize                 |
+|    6 | Sorghum (Mashila)          | Sorghum               |
+|    7 | Millet (Zengada)           | Millet                |
+|    9 | Horse Beans (Bakela)       | Horse Beans           |
+|   14 | Lentils (Misir)            | Lentils               |
+|   16 | Coffee                     | Coffee                |
+|   17 | Chat                       | Chat                  |
+|   18 | Enset                      | Enset                 |
+|   21 | Gesho                      | Gesho                 |
+|   26 | Potatoes                   | Potatoes              |
+|   28 | Salata                     | Lettuce (Salata)      |
+|   31 | Onions                     | Onions                |
+|   33 | Nech Shinkuri (garlic)     | Garlic                |
+|   35 | Fasolia                    | Haricot Beans (Fasolia) |
+|   40 | Chick Peas (Shimbra)       | Chick Peas            |
+|   41 | Cow Peas (Ater)            | Cow Peas              |
+|   46 | Tomatoes                   | Tomatoes              |
+|   47 | Vetch                      | Vetch                 |
+|   48 | Nueg                       | Noug                  |
+|   49 | Gommen                     | Kale (Gomen)          |
+|   53 | Field Peas                 | Field Peas            |
+|   54 | Fenugreek (abish)          | Fenugreek             |
+|   57 | Jinjibel (ginger)          | Ginger                |
+|   59 | Tikl Gommen (cabbage)      | Cabbage               |
+|   61 | Beef (yekebit siga)        | Beef                  |
+|   62 | Goat Meat (yefiyel siga)   | Goat Meat             |
+|   64 | Butter                     | Butter                |
+|   65 | Milk                       | Milk                  |
+|   67 | Chicken                    | Chicken               |
+|   68 | Eggs                       | Eggs                  |
+|   71 | Tej                        | Tej                   |
+|   73 | Araqi/Kathikala            | Araqi/Katikala        |
+|   75 | Sugar                      | Sugar                 |
+|   81 | Salt                       | Salt                  |
+|   82 | Cooking Oil                | Cooking Oil           |
+|   84 | Karia                      | Chili Pepper (Karia)  |
+|   85 | Berbere                    | Berbere               |
+|   86 | Bread (dabo)               | Bread (Dabo)          |
+|   90 | Coffee leag                | Coffee leaf/Tea       |

--- a/lsms_library/countries/EthiopiaRHS/_/community_prices.py
+++ b/lsms_library/countries/EthiopiaRHS/_/community_prices.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+"""EthiopiaRHS community / market prices -> (t, v, j, u) Price  (#438 / #275).
+
+PA-level SURVEYED food prices from the ERHS dedicated price instruments (NOT
+the household food_acquired unit values).  Three sources, one per price design;
+the low ``item1234`` food-code scheme is consistent across all of them:
+
+  price1234_rev.tab : R1-R4 (1994a/1994b/1995/1997).  WOREDA-level (q1b),
+                      price-per-kg in p_r1..p_r4.  Broadcast to each PA in the
+                      Woreda via the q1c->q1b crosswalk (demo123).
+  rd6_kgpr_Mkt.tab  : R6 (2004).  PA-level (paid), kg_pr6 = avg of 3 markets.
+  price2009.tab     : R7 (2009).  PA-level (paid), price_r7.
+
+Grain (t, v, j, u='Kg') Price.  v = PA, formatted into the sample()/
+cluster_features v keyspace.  Cluster-level feature: v IS in the index, there
+is NO household i, so the framework does NOT join v from sample().
+
+j = harmonize_community_food Preferred Label (categorical_mapping.org; DRAFT,
+maintainer-curated), aligned with harmonize_food so a priced food joins
+food_acquired / crop_production on j.  Items absent from that table (high
+aggregate codes 100+/300+/500+, ~11% of R1-R4 price rows) are dropped with a
+logged count -- REPORTED prices only, no imputation.
+"""
+import sys
+import numpy as np
+import pandas as pd
+
+sys.path.append('../../../_/')
+from lsms_library.local_tools import get_dataframe, to_parquet, df_from_orgfile, format_id
+
+# round column (price1234_rev) -> wave label
+R_TO_T = {'p_r1': '1994a', 'p_r2': '1994b', 'p_r3': '1995', 'p_r4': '1997'}
+
+U = 'Kg'   # ERHS price instruments are all price-per-kilogram
+
+
+def _item_label_map():
+    """item1234 code -> Preferred Label (DRAFT harmonize_community_food)."""
+    t = df_from_orgfile('./categorical_mapping.org',
+                        name='harmonize_community_food', to_numeric=False)
+    t.columns = [c.strip() for c in t.columns]
+    t['Code'] = pd.to_numeric(t['Code'], errors='coerce').astype('Int64')
+    t = t.dropna(subset=['Code'])
+    return {int(k): str(v).strip()
+            for k, v in zip(t['Code'], t['Preferred Label']) if str(v).strip()}
+
+
+def _woreda_to_pas():
+    """q1b (Woreda code) -> [q1c (PA code), ...], from the demo123 crosswalk."""
+    ros = get_dataframe('../1994a/Data/demo123.dta', convert_categoricals=False)
+    xw = ros[['q1c', 'q1b']].dropna().drop_duplicates()
+    out = {}
+    for q1b, grp in xw.groupby('q1b'):
+        out[int(q1b)] = sorted({int(x) for x in grp['q1c']})
+    return out
+
+
+def _finish(df, t):
+    """Common tail: code->j, u, t, drop unmapped/zero, return (t,v,j,u) Price."""
+    labels = _item_label_map()
+    df = df.copy()
+    df['j'] = df['code'].astype('Int64').map(labels)
+    df['Price'] = pd.to_numeric(df['Price'], errors='coerce')
+    n0 = len(df)
+    df = df[df['j'].notna() & df['Price'].notna() & (df['Price'] > 0)]
+    dropped = n0 - len(df)
+    if dropped:
+        print(f"  {t}: dropped {dropped}/{n0} rows (unmapped item code or "
+              f"non-positive price)")
+    df['t'] = t
+    df['u'] = U
+    df['v'] = df['v'].apply(format_id)
+    out = df[['t', 'v', 'j', 'u', 'Price']]
+    # one reported price per (t, v, j, u): average if a Preferred Label
+    # collapses >1 raw code at a cluster (rare; distinct codes -> distinct j)
+    out = out.groupby(['t', 'v', 'j', 'u'], as_index=False)['Price'].mean()
+    return out.set_index(['t', 'v', 'j', 'u'])
+
+
+pieces = []
+
+# --- R1-R4: price1234_rev, Woreda-level, broadcast to PAs ---------------
+w2p = _woreda_to_pas()
+p1 = get_dataframe('../1994a/Data/price1234_rev.tab', convert_categoricals=False)
+# price1234_rev ships BOTH a 100+ 'code' column and the low 'item1234' scheme;
+# harmonize_community_food keys on the low scheme, so drop the 100+ 'code'
+# and use item1234 as our 'code'.
+p1 = p1.drop(columns=['code']).rename(columns={'item1234': 'code'})
+for rcol, t in R_TO_T.items():
+    sub = p1[['q1b', 'code', rcol]].dropna(subset=['q1b', 'code']).copy()
+    sub = sub.rename(columns={rcol: 'Price'})
+    # broadcast each Woreda row to its PAs
+    rows = []
+    for _, r in sub.iterrows():
+        for pa in w2p.get(int(r['q1b']), []):
+            rows.append({'v': pa, 'code': r['code'], 'Price': r['Price']})
+    if rows:
+        pieces.append(_finish(pd.DataFrame(rows), t))
+
+# --- R6 (2004): rd6_kgpr_Mkt, PA-level ----------------------------------
+rd6 = get_dataframe('../2004/Data/rd6_kgpr_Mkt.tab', convert_categoricals=False)
+rd6 = rd6.rename(columns={'item1234': 'code', 'paid': 'v', 'kg_pr6': 'Price'})
+pieces.append(_finish(rd6[['v', 'code', 'Price']].dropna(subset=['v', 'code']), '2004'))
+
+# --- R7 (2009): price2009, PA-level -------------------------------------
+p9 = get_dataframe('../2009/Data/price2009.tab', convert_categoricals=False)
+p9 = p9.rename(columns={'item': 'code', 'paid': 'v', 'price_r7': 'Price'})
+pieces.append(_finish(p9[['v', 'code', 'Price']].dropna(subset=['v', 'code']), '2009'))
+
+prices = pd.concat(pieces)
+print(f"community_prices: {len(prices)} rows, "
+      f"{prices.index.get_level_values('t').nunique()} waves, "
+      f"{prices.index.get_level_values('j').nunique()} items")
+
+to_parquet(prices, '../var/community_prices.parquet')

--- a/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
+++ b/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
@@ -205,4 +205,21 @@ Data Scheme:
     Woreda: str
     Rural: str
 
+  # community_prices (#438 / #275): PA-level SURVEYED food prices (an
+  # independent price series, distinct from the household food_acquired unit
+  # values).  Cluster-level (t, v, j, u) -- v IS in the index (no household i,
+  # no _join_v_from_sample).  Script-path (materialize: make): the country
+  # _/community_prices.py reads the three dedicated ERHS price instruments and
+  # writes var/community_prices.parquet:
+  #   price1234_rev (R1-R4, WOREDA-level p_r1..p_r4, broadcast to PAs),
+  #   rd6_kgpr_Mkt (R6/2004, PA-level kg_pr6), price2009 (R7/2009, price_r7).
+  # All price-per-KG -> u='Kg'.  j = harmonize_community_food Preferred Label
+  # (DRAFT; aligned with harmonize_food so prices join food_acquired /
+  # crop_production on j).  REPORTED prices only -- unmapped item codes
+  # (high aggregate codes) and non-positive prices are dropped.  Resolves #275.
+  community_prices:
+    index: (t, v, j, u)
+    Price: float
+    materialize: make
+
   panel_ids: !make

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -3772,6 +3772,21 @@ def _normalize_dataframe_index(
 
     current_names = list(df.index.names)
 
+    # Undo map_index()'s legacy j->i swap when the schema actually declares 'j'.
+    # map_index() renames a 'j' index level to 'i' whenever a table has no
+    # household 'i' level (a legacy old-parquet convention).  For a cluster-
+    # level item feature (e.g. community_prices, index (t, v, j, u) with no
+    # household i), that rename turns the declared 'j' into an *undeclared* 'i',
+    # which the level-drop + duplicate-collapse below then discards entirely --
+    # silent data loss (the food item collapses, leaving one price per cluster).
+    # When the schema wants 'j' (not 'i') and the frame carries the swapped 'i'
+    # but no 'j', restore the name so the level survives.  Household tables
+    # (declared 'i') and tables declaring both i and j are untouched.
+    if ('j' in declared and 'i' not in declared
+            and 'i' in current_names and 'j' not in current_names):
+        df = df.rename_axis(index={'i': 'j'})
+        current_names = list(df.index.names)
+
     # Add synthetic levels when declared but missing (e.g., 't' for wave outputs)
     missing_levels = [lvl for lvl in declared if lvl not in current_names]
     if missing_levels:

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -2052,7 +2052,14 @@ def map_index(df: pd.DataFrame) -> pd.DataFrame:
     needs_swap = False
     if 'j' in index_names:
         if 'i' not in index_names:
-            needs_swap = True
+            # The legacy j->i swap rescues OLD household parquets that stored
+            # the household id under 'j'.  A cluster-level item feature
+            # (e.g. community_prices, indexed by the cluster 'v' with NO
+            # household 'i') legitimately uses 'j' for the food item -- swapping
+            # it to 'i' makes 'j' undeclared and the food item gets dropped +
+            # collapsed away downstream (silent data loss).  Detect that shape
+            # by the presence of 'v' without 'i' and leave 'j' intact.
+            needs_swap = 'v' not in index_names
         else:
             try:
                 needs_swap = index_names.index('j') < index_names.index('i')

--- a/tests/test_normalize_index_j_preserved.py
+++ b/tests/test_normalize_index_j_preserved.py
@@ -1,0 +1,50 @@
+"""GH #438/#275: _normalize_dataframe_index must restore a map_index()-swapped
+j->i for cluster-level item features (community_prices), so the food item is
+NOT dropped + collapsed away (silent data loss).
+
+map_index() renames a 'j' index level to 'i' when a table has no household 'i'.
+For a (t, v, j, u) feature that swap makes 'j' undeclared, and the old
+level-drop + duplicate-collapse discarded the item entirely (one price per
+cluster).  These tests pin the restore + that household 'i' is untouched.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from lsms_library.country import _normalize_dataframe_index
+
+
+def test_restores_swapped_j_for_cluster_item_feature():
+    # community_prices AFTER map_index swapped j->i: index (t, v, i, u) where
+    # 'i' is really the food item (no household i).
+    idx = pd.MultiIndex.from_tuples(
+        [('2009', '1', 'Teff', 'Kg'),
+         ('2009', '1', 'Barley', 'Kg'),
+         ('2009', '2', 'Teff', 'Kg')],
+        names=['t', 'v', 'i', 'u'],
+    )
+    df = pd.DataFrame({'Price': [9.5, 3.0, 9.6]}, index=idx)
+    out = _normalize_dataframe_index(df, {'index': '(t, v, j, u)'}, None)
+    assert list(out.index.names) == ['t', 'v', 'j', 'u'], "i must be restored to j"
+    assert len(out) == 3, "no collapse: all (t,v,j,u) rows survive"
+
+
+def test_household_i_is_not_renamed():
+    # A household table that genuinely declares 'i' must keep its 'i' level.
+    idx = pd.MultiIndex.from_tuples(
+        [('2009', 'h1'), ('2009', 'h2')], names=['t', 'i'])
+    df = pd.DataFrame({'x': [1, 2]}, index=idx)
+    out = _normalize_dataframe_index(df, {'index': '(t, i)'}, None)
+    assert list(out.index.names) == ['t', 'i']
+    assert len(out) == 2
+
+
+def test_table_declaring_both_i_and_j_untouched():
+    # crop_production-like (t, i, j): both present, no rename.
+    idx = pd.MultiIndex.from_tuples(
+        [('2009', 'h1', 'Maize'), ('2009', 'h1', 'Teff')],
+        names=['t', 'i', 'j'])
+    df = pd.DataFrame({'Quantity': [10, 20]}, index=idx)
+    out = _normalize_dataframe_index(df, {'index': '(t, i, j)'}, None)
+    assert set(out.index.names) == {'t', 'i', 'j'}
+    assert len(out) == 2


### PR DESCRIPTION
Third **Tier-2** parity feature + the framework bug it surfaced. **Closes #275.**

## community_prices
PA-level **surveyed** food prices (an independent price series, distinct from the household `food_acquired` unit values). Cluster-level `(t, v, j, u)` — `v` in the index, no household `i`. Script-path (ERHS's first `materialize: make` feature): `_/community_prices.py` reads the three dedicated price instruments → `var/community_prices.parquet`:
- `price1234_rev.tab` — R1–R4 (1994a/b/1995/1997), **Woreda-level** `p_r1..p_r4`, **broadcast to each PA** in the Woreda via the demo123 `q1c→q1b` crosswalk;
- `rd6_kgpr_Mkt.tab` — R6 (2004), PA-level `kg_pr6` (avg of 3 markets);
- `price2009.tab` — R7 (2009), PA-level `price_r7`.

All price-per-kg → `u='Kg'`. `j` = `harmonize_community_food` Preferred Label (new table, aligned with `harmonize_food` so prices join `food_acquired`/`crop_production` on `j`). Reported prices only — unmapped high aggregate codes + non-positive prices dropped (logged). Adds `_/Makefile`.

> ⚠️ **`harmonize_community_food` Preferred Labels are a draft** — a few are local-name judgement calls (Salata, Gomen/Kale, Karia/Chili, Fasolia). Curate freely.

## Framework fix (the headline bug)
`map_index()` unconditionally renamed a `j` index level to `i` when a table lacked household `i` (a legacy *old-household-parquet* convention). For a cluster-level item feature (community_prices: indexed by `v`, no `i`), that turned the declared `j` into an undeclared `i`, which `_normalize_dataframe_index` then **dropped + collapsed** → one price per cluster (**2691 → 108 rows, silent data loss**). Two guards:
- `local_tools.map_index`: don't swap j→i when `v` present + `i` absent (cluster shape) — root fix, keeps the on-disk parquet aligned with the schema.
- `country._normalize_dataframe_index`: restore swapped i→j when the schema declares `j` but the frame has `i` — heals any pre-existing `i`-stamped cache. Household tables untouched.
- `tests/test_normalize_index_j_preserved.py` (3 cases).

## Verification
- **Cold build**: 2,691 rows × 6 waves; grain `(t,v,j,u)`; 0 dup tuples; Price [0.01,140] median 2.50, 0 neg, u=Kg. **v matches cluster_features 18/18 = 1.000**. `is_this_feature_sane` all PASS (only the expected "no household i" warn). **Composes with crop_production on j** (Barley/Chat/Coffee/Enset/Maize/Sorghum/Wheat).
- On-disk var/ parquet keeps `(t,v,j,u)` across cold rebuild (fix verified).
- **Niger community_prices unchanged: 15,423 rows** — no regression.
- **Full suite: 1845 passed** (the 2 Senegal/crop_production failures are the pre-existing all-null `harvest_month` issue #466, unrelated; CI-skipped).
- Source `dvc add` + `push` (3 files; remote in sync).

Design: `slurm_logs/2026-06-15_ehcvm_parity/TIER2_COMMUNITY_PRICES_GRAIN.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)