### PR TITLE
docs+fix: grain aggregation policy note; u in crop_production index (Malawi, EthiopiaRHS)

### DIFF
--- a/SkunkWorks/grain_aggregation_policy.org
+++ b/SkunkWorks/grain_aggregation_policy.org
@@ -1,0 +1,205 @@
+#+TITLE: Grain Aggregation Policy (Design, Not Yet Implemented)
+#+DATE: 2026-06-16
+#+AUTHOR: Sue
+
+* Context
+
+Surveys collect the same concept at different granularities.  One
+country records crop output per /plot/; another reports it per
+/household x crop/ (already summed over plots).  One records food
+acquisition per /visit/ within a wave; another records a single
+recall.  One prices food at the /peasant association/; another only at
+the /woreda/.  If each feature is to compose across countries via
+=ll.Feature(name)()=, these grains must reconcile to a common
+denominator -- WITHOUT discarding the finer detail a richer survey
+actually carries.
+
+The GhanaLSS =food_acquired= work solved one instance of this
+elegantly: the raw/wave parquet keeps a country-local =visit= index
+level, and the derived food tables (=food_expenditures=,
+=food_prices=, =food_quantities=) collapse over it so they compose
+with countries that have no =visit=.  The detail survives in the raw
+artifact; the aggregation is imposed only at the composing layer.
+
+This note generalizes that pattern into an explicit, per-column
+*grain aggregation policy*:
+
+#+BEGIN_QUOTE
+Raw (wave/country) parquets encode the MAXIMAL grain the survey
+supports.  The canonical (composable) grain is the cross-country
+common denominator declared in =data_info.yml=.  Composition collapses
+the extra raw levels to the canonical grain via a DECLARED per-column
+aggregation -- never via a silent drop.
+#+END_QUOTE
+
+This file is a design sketch.  Nothing here is implemented yet.
+
+* The keystone: the current generic collapse is lossy
+
+Two different collapse mechanisms exist today, and only one is safe:
+
+- *Generic (unsafe)* :: =country._normalize_dataframe_index= drops an
+  undeclared index level and resolves the resulting duplicates with
+  =groupby().first()= (=country.py= ~3817, the GH #323 path).  This
+  keeps one row per canonical tuple and SILENTLY DISCARDS the rest.
+- *Food-derived (safe)* :: =visit=/=s=/=u= are collapsed in the
+  =_FOOD_DERIVED= transform with an explicit *sum* (=reaggregate=True=).
+
+So "automatically summed over when composed" describes the bespoke
+food path, not a general facility.  The generic behavior is a
+=.first()= footgun.  Observed twice recently:
+
+- =community_prices= collapsed 2691 -> 108 rows (one price per cluster)
+  before the v0.8.x =map_index= fix.
+- The original =food_acquired= duplicate-tuple warning (GH #323).
+
+*The prerequisite for generalizing "max detail in raw" is replacing the
+silent =.first()= with a declared per-column aggregation, and making an
+UNDECLARED extra level loud (warn/refuse) rather than quiet.*  Without
+that, "encode maximal detail" merely multiplies the silent-loss surface.
+
+* Per-column aggregation policy
+
+The collapse function is, in spirit:
+
+#+BEGIN_SRC python
+result = raw.groupby(canonical_index_levels).agg(per_column_policy)
+#+END_SRC
+
+where =canonical_index_levels= INCLUDES =u= (see next section), and the
+policy is per measure:
+
+- =sum=    :: additive measures -- Quantity, Expenditure, Area,
+  PersonDays, counts.
+- =median= :: prices.  House practice elsewhere aggregates prices by
+  median; summing prices is meaningless and the mean is less robust.
+- =first=  :: invariants that are constant within the finer level --
+  labels, Tenure, SoilType, etc.
+- (no policy) :: an extra raw level with NO declared policy WARNS (or
+  refuses), instead of =.first()=-dropping.
+
+** Units need no commensurability -- keep =u= in the group key
+
+Because =u= is itself a grouping key, =groupby([... , 'u']).sum()= sums
+the additive measures WITHIN each unit.  Heterogeneous units survive as
+SEPARATE rows; nothing is ever summed across incompatible units.  A
+household that harvested maize in =kg= on one plot and in =bags= on
+another collapses to two rows -- =(.., Maize, kg)= and
+=(.., Maize, bags)= -- which is correct and lossless.
+
+Consequently kg-conversion is NOT a precondition for composition.  It
+is a separate, OPT-IN projection for when the caller explicitly wants a
+single-unit basis -- exactly the existing =units== kwarg family
+(=food_quantities(units='kgs')=, =food_prices(units='kgvalue')=).
+Aggregation is always unit-safe; commensurability is a deliberate
+downstream ask.
+
+* =u= belongs in the canonical index
+
+For =groupby([..., 'u']).agg()= to preserve units, =u= must be a
+grouping key, i.e. an INDEX level -- not a free column.  The codebase
+is currently inconsistent here, and the inconsistencies are bugs:
+
+- =Ethiopia= (ESS) =crop_production= :: =(t, i, plot_id, j, u)= -- u in
+  the index.  Correct.
+- =Malawi= =crop_production= :: =(t, i, plot, crop)= with =u= as a
+  COLUMN.  *Bug.*
+- =EthiopiaRHS= =crop_production= :: declared =(t, i, j)= with =u= a
+  constant ='Kg'= column (PR #467).  *Bug* (degenerate today since u is
+  always Kg, but wrong in principle).
+- =community_prices= (all countries) :: =(t, v, j, u)=.  Correct --
+  already the target shape.
+
+Fixing the two =crop_production= cases to put =u= in the index is a
+concrete, low-risk cleanup that this policy needs anyway.
+
+* Taxonomy of grain differences
+
+Not every cross-country mismatch is an aggregation problem.
+
+- *Nested (this policy applies)* :: the coarser survey's grain is the
+  finer survey's grain summed over one extra level.  =crop_production=:
+  ISA =(t, i, plot, j, u)= vs EthiopiaRHS =(t, i, j, u)= -- =plot= is
+  the new =visit=.  Sum Quantity/Area over =plot= (keeping =u=) and the
+  two compose.  This is the highest-value first application.
+- *Orthogonal (policy does NOT apply)* :: the surveys differ in the
+  KIND of dimension, not the depth.  =plot_inputs=/=plot_labor= (#469):
+  ISA is =(plot, input|source)=; EthiopiaRHS is =(activity, source)= at
+  household grain (plough/weed/harvest), inputs by =crop=.  No
+  aggregation reconciles =plot= with =activity=; this is a genuine
+  schema divergence, documented as blocked.
+- *Coarser source (needs the INVERSE)* :: a survey collected at a
+  grain coarser than canonical.  =community_prices= R1-R4: prices at
+  =woreda=, canonical is =v= (PA).  There is no detail to aggregate
+  down -- it must be BROADCAST (woreda -> its PAs), an imputation, and
+  should arguably be flagged as imputed rather than presented as
+  observed.  Out of scope for the aggregation policy; noted for
+  completeness.
+
+* Proposed schema surface
+
+Declare the policy alongside the canonical index in =data_info.yml=:
+
+#+BEGIN_SRC yaml
+crop_production:
+  Index Info:
+    index_info: (t, v, i, j, u)     # canonical (composable) grain; u IS a level
+  aggregation:                       # how to collapse EXTRA raw levels
+    Quantity: sum
+    Area: sum
+    Price: median
+    # invariants -> first; anything with no policy WARNS on collapse
+  # raw parquets may carry extra levels (plot, season, visit, obs);
+  # they are summed/median'd to index_info on read.
+#+END_SRC
+
+Collapse rule (replacing the =.first()= block in
+=_normalize_dataframe_index=):
+
+#+BEGIN_SRC python
+extra = [lvl for lvl in df.index.names if lvl not in canonical]
+if extra:
+    policy = aggregation_policy(method_name)      # from data_info.yml
+    unpoliced = [c for c in df.columns if c not in policy]
+    if unpoliced:
+        warnings.warn(f"{method_name}: collapsing over {extra} with no "
+                      f"aggregation policy for {unpoliced}; refusing to "
+                      f".first()-drop (GH #323).")
+    df = df.groupby(level=canonical, observed=True).agg(policy)
+#+END_SRC
+
+The =labels=/=reaggregate== kwarg family is already a prototype of this
+on the =j= axis (collapsing food items to =Aggregate=).  This lifts the
+same idea to ANY extra index level, driven by declaration rather than
+bespoke per-feature code.
+
+* Applications / first targets
+
+1. *Fix =u= placement* in =Malawi= and =EthiopiaRHS= =crop_production=
+   (move =u= into the index).  Low-risk; needed regardless.
+2. *crop_production plot grain* :: carry =plot= in the ISA raw parquets;
+   declare =sum= over =plot=; ERHS (no plot) and ISA then compose at
+   =(t, v, i, j, u)= with no special-casing.
+3. *Generalize the collapse* in =_normalize_dataframe_index= per the
+   rule above; retire the silent =.first()=.
+4. *Audit existing features* for undeclared extra levels currently being
+   =.first()=-dropped (the warning from step 3 surfaces them).
+
+* Open questions
+
+- Where does the aggregation run -- per-country =_finalize_result=, or
+  at =Feature= assembly after the =country= level is prepended?  The
+  food-derived path runs per-country; cross-country composition then
+  concatenates.  A single declared policy should serve both, but the
+  call site needs to be pinned so it runs exactly once.
+- Median over an even count: define the convention (interpolate vs
+  lower) so results are reproducible across pandas versions.
+- Interaction with =cache_hash=: the aggregation policy is a
+  post-read transform (like spellings/kinship), so it should NOT enter
+  the L2 content hash -- the raw parquet is what's cached.  Confirm.
+
+* Status
+
+Design sketch.  Not implemented.  Depends on no other open work; the
+=u=-placement fixes (target 1) are independently shippable and are the
+natural first step.

--- a/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
+++ b/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
@@ -120,10 +120,12 @@ Data Scheme:
   # area_output_99 uses a packed-hhid keyspace with ~0.000 overlap vs the
   # 1999 composite sample (documented follow-up; do NOT wire it here).
   crop_production:
-    index: (t, i, j)
+    # u is an INDEX level (grouping key), not a column -- see
+    # SkunkWorks/grain_aggregation_policy.org.  Degenerate here (always 'Kg'),
+    # but the canonical shape carries u in the index uniformly.
+    index: (t, i, j, u)
     Quantity: float        # production, kg harvested
     Area_ha: float         # area planted, hectares (NaN for 1994b R2)
-    u: str                 # constant 'Kg' (production unit)
 
   # anthropometry (#438 Tier-2): individual (t, i, pid) body measures for
   # the four 1994-1997 rounds (R1-R4), from the pooled wide

--- a/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
+++ b/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
@@ -343,6 +343,6 @@ def crop_production(df):
     out = out[out['j'].notna()]
     for k in idx:
         out = out[out[k].notna() & (out[k].astype('string').str.strip() != '')]
-    out = out.set_index(idx + ['j'])
+    out = out.set_index(idx + ['j', 'u'])   # u is a grouping key, not a column
     out = out.groupby(level=out.index.names).first()   # defensive de-dupe
     return out

--- a/lsms_library/countries/Malawi/_/crop_production.py
+++ b/lsms_library/countries/Malawi/_/crop_production.py
@@ -34,4 +34,13 @@ assert pieces, "crop_production: no wave-level parquets found"
 
 p = pd.concat(pieces)
 
+# Move u into the index (canonical (t, i, plot, crop, u)).  u is a grouping
+# key, not a free column: a plot-crop measured in two units must be two
+# distinct rows, not one survivor of a .first() collapse.  See
+# SkunkWorks/grain_aggregation_policy.org.  Wave parquets carry u as a
+# column; append it here so the country parquet's on-disk index matches the
+# declared schema.
+if 'u' in p.columns:
+    p = p.set_index('u', append=True)
+
 to_parquet(p, '../var/crop_production.parquet')

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -174,9 +174,12 @@ Data Scheme:
     # main_crop / value-shares) are transformations, NOT stored columns.
     # 2004-05 (IHS2) deferred: household-level aggregated ag file, no
     # plot-crop roster.  See _/malawi.py:assemble_crop_production.
-    index: (t, i, plot, crop)
+    # u is an INDEX level (a grouping key), so collapsing an extra raw level
+    # sums Quantity WITHIN each unit and heterogeneous units survive as
+    # distinct rows (SkunkWorks/grain_aggregation_policy.org).  Was a column
+    # (a bug: a plot-crop measured in two units collapsed via .first()).
+    index: (t, i, plot, crop, u)
     Quantity: float
-    u: str
     Quantity_sold: float
     Value_sold: float
     planting_month: int


### PR DESCRIPTION
Design note + its first down payment.

## `SkunkWorks/grain_aggregation_policy.org`
Generalizes the GhanaLSS `visit` pattern into an explicit **grain aggregation policy**: raw parquets encode the *maximal* grain; the canonical (composable) grain is the cross-country common denominator; composition collapses extra levels via a **declared per-column aggregation** (`sum` for additive measures, **`median`** for prices, `first` for invariants) — never a silent `groupby().first()` (GH #323). Keeping `u` in the group key makes the collapse **unit-safe with no commensurability precondition**; kg-conversion stays an opt-in `units=` projection. Taxonomy: *nested* (applies — `plot` is the next `visit`), *orthogonal* (plot_inputs/labor #469), *coarser-source* (needs broadcast — community_prices woreda→PA).

## Target 1 — `u` in the canonical index
`u` is a grouping key, not a free column. Two `crop_production` declarations had it as a column (bugs):
- **Malawi**: `(t,i,plot,crop)` + `u` column → `(t,i,plot,crop,u)`; concatenator appends `u` to the index. Also **recovers** plot-crops measured in two units that the old non-unique-index `.first()` collapse silently dropped.
- **EthiopiaRHS**: `(t,i,j)` + constant `u='Kg'` column → `(t,i,j,u)`; the df_edit hook sets `u` in the index.

(Ethiopia ESS already had `u` in the index; `community_prices` already `(t,v,j,u)`.)

## Verification (cold rebuild)
- EthiopiaRHS crop_production: API `(i,t,v,j,u)`, on-disk `(t,i,j,u)`, **17,523 rows** (unchanged).
- Malawi crop_production: API `(i,t,v,plot,crop,u)`, on-disk `(t,i,plot,crop,u)`, **128,006 rows**.
- Gate: schema + catalog + EthiopiaRHS/Malawi crop_production table_structure → **231 passed**.

Config-only (data_scheme + scripts); no library-code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)