### PR TITLE
feat(interview_date): visit index for Malawi (both visit dates; default-agg first)

### DIFF
--- a/SkunkWorks/grain_aggregation_policy.org
+++ b/SkunkWorks/grain_aggregation_policy.org
@@ -200,7 +200,37 @@ footguns; they become lossless union+sentinel.
 - Geographic hierarchy (=woreda > v > i=) for the =<broadcast>= sentinel:
   worth it, or keep community_prices' explicit broadcast indefinitely?
 
+* Reality check (2026-06-16): visit values, and what plot_labor actually drops
+
+We checked the two multi-visit cases against the raw data before designing
+the =visit= level's VALUES.  Findings:
+
+- *=visit= = date is unsupported by our current data.*  The only multi-visit
+  feature today (GhanaLSS =food_acquired=, GLSS4/5/7) stores visits as WIDE
+  COLUMN ORDINALS (=s9bq{1..6}=, =s8hq{3..8}=, up to ~10 in 1991-92/2005-06);
+  the date of each visit is NOT recorded anywhere in the wave -- only a single
+  household interview date (=g7sec0.ddate/mdate/ydate=) plus an =hhstatus=
+  "all 7 visits" flag.  So =visit= stays an ORDINAL + =<sum>= sentinel; do NOT
+  build date-valued-visit machinery speculatively -- it waits for a feature
+  whose multi-visit data actually carries per-visit dates.
+- *Where per-visit DATES do exist:* the =interview_date= table.  Malawi's
+  household cover records two interview-visit dates (=hh_a23_1/_2= in 2010-11;
+  =interviewdate_v1/_v2= in 2016-17/2019-20 Panel), of which the table
+  currently keeps only Visit 1.  -> Give =interview_date= a =visit= index
+  (ordinal) carrying both dates, default aggregation =first= (= Visit 1).
+  Isolated change: age computation reads the roster's own date columns via
+  =age_handler=, NOT the =interview_date= table, so no consumer breaks.
+- *plot_labor correction (for the parked LSMS+ thread).*  =ag_d47*=/=ag_d48*=
+  are NOT two enumeration visits -- the raw labels are =ag_d47= = non-harvest
+  activities, =ag_d48= = harvesting (an ACTIVITY split; the "two visit columns"
+  comment in =malawi.py= is a misnomer to fix).  So =plot_labor='s =PersonDays=
+  sums over *man/woman/child* x *(non-harvest, harvest)* -- no visit axis.  The
+  detail being discarded is the gendered =man/woman/child= split (the #439
+  LSMS+ data, summed into oblivion) and the activity split.  When we pick up
+  plot_labor/LSMS+, frame it around THOSE axes, not visits.
+
 * Status
 
-Design sketch.  Prerequisite (1) implemented (PR #471); (2)-(5) pending.
-No code beyond (1) yet.
+Design sketch.  Prerequisites: (1) =u=-in-index implemented (PR #471);
+=interview_date= =visit= index in progress (the one place per-visit dates
+exist).  (2)-(5) pending.

--- a/lsms_library/countries/Malawi/2010-11/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2010-11/_/data_info.yml
@@ -60,8 +60,13 @@ interview_date:
         i: case_id
     myvars:
         # hh_a23_1 = "Interview Date [MDY] (Visit 1)", a Stata %td date that
-        # get_dataframe returns as datetime64.  Visit 2 (hh_a23_2) is dropped.
+        # get_dataframe returns as datetime64.  hh_a23_2 = the Visit 2 date
+        # (same %td datetime; populated for the ~3247 panel HH revisited at
+        # post-harvest).  Both are melted to the `visit` index level by the
+        # country-level malawi.interview_date df_edit hook (visit 2 rows with
+        # a NaT date are dropped there).
         int_t: hh_a23_1
+        int_t_v2: hh_a23_2
 
 cluster_features:
     dfs:

--- a/lsms_library/countries/Malawi/2013-14/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2013-14/_/data_info.yml
@@ -33,6 +33,18 @@ interview_date:
             - hh_a23a_2
             - hh_a23a_1
             - mapping: malawi_date_ymd
+        # Visit 2, Attempt 1 interview date -- same Day/Month-name/Year
+        # triplet layout one block later in Module A (labelled "Visit 2 -
+        # Interview Date ..." in the source).  hh_a37a_1 = Day, hh_a37a_2 =
+        # Month name, hh_a37a_3 = Year; ~3974 of 4000 panel HH revisited.
+        # Melted to the `visit` index level by malawi.interview_date.
+        # NB the hh_a23b_*/hh_a23c_* columns are Visit-1 re-attempts (NOT
+        # Visit 2), so the Visit-2 date lives in the hh_a37a_* block.
+        int_t_v2:
+            - hh_a37a_3
+            - hh_a37a_2
+            - hh_a37a_1
+            - mapping: malawi_date_ymd
 
 cluster_features:
     dfs:

--- a/lsms_library/countries/Malawi/2016-17/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2016-17/_/data_info.yml
@@ -29,14 +29,20 @@ interview_date:
         - Panel/hh_mod_a_filt_16.dta:
             i: y3_hhid
             int_t: interviewdate_v1
+            int_t_v2: interviewdate_v2
     idxvars:
         i:
             - case_id
             - mapping: cs_i
     myvars:
-        # Cross_Sectional names the date column 'interviewDate'; the Panel
-        # file uses 'interviewdate_v1' (Visit 1), overridden per-file above.
-        # Both are 'YYYY-MM-DD' strings -> datetime via the Int_t coercion.
+        # Cross_Sectional names the date column 'interviewDate' (single
+        # visit); the Panel file uses 'interviewdate_v1' (Visit 1) +
+        # 'interviewdate_v2' (Visit 2), overridden per-file above.  Both are
+        # 'YYYY-MM-DD' strings -> datetime via the Int_t coercion.  The
+        # cross-sectional half has no Visit 2, so int_t_v2 is requested only
+        # from the Panel file (NaN-filled on concat for the CS rows).  Both
+        # date columns are melted to the `visit` index level by the
+        # country-level malawi.interview_date df_edit hook.
         int_t: interviewDate
 
 cluster_features:

--- a/lsms_library/countries/Malawi/2019-20/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2019-20/_/data_info.yml
@@ -29,14 +29,20 @@ interview_date:
         - Panel/hh_mod_a_filt_19.dta:
             i: y4_hhid
             int_t: interviewdate_v1
+            int_t_v2: interviewdate_v2
     idxvars:
         i:
             - case_id
             - function: cs_i
     myvars:
-        # Cross_Sectional names the date column 'interviewDate'; the Panel
-        # file uses 'interviewdate_v1' (Visit 1), overridden per-file above.
-        # Both are 'YYYY-MM-DD' strings -> datetime via the Int_t coercion.
+        # Cross_Sectional names the date column 'interviewDate' (single
+        # visit); the Panel file uses 'interviewdate_v1' (Visit 1) +
+        # 'interviewdate_v2' (Visit 2), overridden per-file above.  Both are
+        # 'YYYY-MM-DD' strings -> datetime via the Int_t coercion.  The
+        # cross-sectional half has no Visit 2, so int_t_v2 is requested only
+        # from the Panel file (NaN-filled on concat for the CS rows).  Both
+        # date columns are melted to the `visit` index level by the
+        # country-level malawi.interview_date df_edit hook.
         int_t: interviewDate
 
 cluster_features:

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -71,8 +71,28 @@ Data Scheme:
     Expenditure: float
     materialize: make
   interview_date:
-    index: (t, i)
+    # Malawi's panel cover files record TWO interview-visit dates per
+    # household (Visit 1 + a post-harvest Visit 2).  Rather than keep only
+    # Visit 1, both dates are preserved on an ordinal `visit` index level
+    # (1 = first visit, 2 = second visit), melted by the country-level
+    # malawi.interview_date df_edit hook.  This is the first application of
+    # the grain-aggregation-policy design (SkunkWorks/
+    # grain_aggregation_policy.org): preserve the richer survey detail,
+    # aggregate only when the analyst explicitly asks.
+    #   - 2010-11, 2016-17 (Panel), 2019-20 (Panel): visit in {1, 2}.
+    #   - 2004-05 (IHS2, single visit) and the 2016-17 / 2019-20
+    #     Cross_Sectional halves: visit = 1 only (no Visit-2 date recorded).
+    # `visit` is a Malawi-specific extra level on top of the canonical
+    # (t, v, i) grain; v auto-joins from sample() at API time, so the
+    # returned grain is (t, v, i, visit).
+    index: (t, i, visit)
     Int_t: datetime
+    # Forward-looking grain-aggregation policy (nothing reads this yet -- it
+    # documents the intended reduction).  Collapsing the `visit` level takes
+    # the FIRST (Visit-1) date, reproducing the legacy single-date table:
+    #   df.groupby(level=['t','v','i']).first()  ==  visit==1 rows.
+    aggregation:
+      visit: first
   shocks:
     index: (t, i, Shock)
     AffectedIncome: bool

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -230,6 +230,80 @@ def malawi_date_ymd(row):
     return pd.to_datetime(f"{int(d)} {month} {int(y)}", errors='coerce')
 
 
+def interview_date(df):
+    """Melt Malawi's per-visit interview dates onto a ``visit`` index level.
+
+    Country-level ``df_edit`` hook for the ``interview_date`` table
+    (auto-dispatched by table name; see country.py ``grab_data`` ->
+    ``formatting_functions.get(request)``).  This is the first application
+    of the grain-aggregation-policy design (SkunkWorks/
+    grain_aggregation_policy.org): the raw cover files of Malawi's panel
+    waves record TWO interview-visit dates per household, and we preserve
+    BOTH on an ordinal ``visit`` level rather than discarding Visit 2.
+
+    Input
+    -----
+    df : pd.DataFrame
+        Indexed per the wave's ``idxvars`` (after the framework prepends
+        ``t``, i.e. ``(t, i)``), carrying the Visit-1 interview date in a
+        ``int_t`` / ``Int_t`` column and -- where the wave records a second
+        visit -- the Visit-2 date in ``int_t_v2`` / ``Int_t_v2``.  The
+        column casing depends on whether the canonical ``int_t -> Int_t``
+        rejected-spelling rewrite has run yet (it has NOT at this wave-level
+        hook stage), so both spellings are accepted defensively.
+
+    Output
+    ------
+    pd.DataFrame indexed ``(<original idx>, visit)`` -- i.e. ``(t, i,
+    visit)`` -- with a single ``Int_t`` datetime column.  ``visit`` is an
+    ordinal Int64 level: ``1`` carries the Visit-1 date, ``2`` the Visit-2
+    date.  Visit-2 rows whose date is NaT (households not revisited, the
+    single-visit IHS2 wave, and the IHS4/IHS5 cross-sectional halves which
+    have no Visit 2) are DROPPED -- never fabricated.  A wave with no
+    Visit-2 column simply yields ``visit=1`` rows.
+
+    The framework then prepends ``t`` (already present) and joins ``v``
+    from ``sample()`` at API time, giving the returned grain
+    ``(t, v, i, visit)``.  Collapsing ``visit`` with the declared ``first``
+    aggregation (data_scheme.yml) reproduces the legacy Visit-1-only table.
+    """
+    def _pick(*names):
+        for n in names:
+            if n in df.columns:
+                return n
+        return None
+
+    v1_col = _pick('int_t', 'Int_t')
+    v2_col = _pick('int_t_v2', 'Int_t_v2')
+
+    if v1_col is None:
+        # Nothing to melt (defensive): hand back unchanged.
+        return df
+
+    idx_names = list(df.index.names)
+    flat = df.reset_index()
+
+    pieces = []
+    v1 = flat[idx_names].copy()
+    v1['visit'] = 1
+    v1['Int_t'] = pd.to_datetime(flat[v1_col], errors='coerce')
+    pieces.append(v1)
+
+    if v2_col is not None:
+        v2 = flat[idx_names].copy()
+        v2['visit'] = 2
+        v2['Int_t'] = pd.to_datetime(flat[v2_col], errors='coerce')
+        # Drop households not revisited (no Visit-2 date) -- reported only,
+        # no fabricated visits.
+        v2 = v2[v2['Int_t'].notna()]
+        pieces.append(v2)
+
+    out = pd.concat(pieces, ignore_index=True)
+    out['visit'] = out['visit'].astype('Int64')
+    out = out.set_index(idx_names + ['visit'])
+    return out
+
+
 def harmonize_food_labels(df, level='i'):
     """Apply the cross-wave union of Malawi's harmonize_food map to ``df``.
 

--- a/lsms_library/diagnostics.py
+++ b/lsms_library/diagnostics.py
@@ -166,7 +166,12 @@ def _load_scheme(country: str) -> dict:
             continue
         idx_raw = spec.get("index", "")
         idx = [s.strip() for s in str(idx_raw).strip("()").split(",") if s.strip()] if idx_raw else []
-        skip = {"index", "materialize", "backend"}
+        # Scheme meta-keys (not columns).  `aggregation` is the
+        # grain-aggregation-policy block (SkunkWorks/
+        # grain_aggregation_policy.org): a {level: reducer} map declaring how
+        # an extra index level collapses; documentary/forward-looking, not a
+        # data column.
+        skip = {"index", "materialize", "backend", "aggregation"}
         cols = {}
         optional_cols: set[str] = set()
         for k, v in spec.items():

--- a/tests/test_table_structure.py
+++ b/tests/test_table_structure.py
@@ -97,8 +97,10 @@ def _load_all_schemes() -> dict[str, dict]:
                 continue
             idx_raw = spec.get("index", "")
             idx = _parse_index_tuple(str(idx_raw)) if idx_raw else []
-            # Skip non-column keys: 'index', 'materialize' (from !make tag), etc.
-            skip_keys = {"index", "materialize", "backend"}
+            # Skip non-column keys: 'index', 'materialize' (from !make tag),
+            # 'aggregation' (the grain-aggregation-policy {level: reducer} block;
+            # see SkunkWorks/grain_aggregation_policy.org), etc.
+            skip_keys = {"index", "materialize", "backend", "aggregation"}
             columns = {}
             optional_cols: set[str] = set()
             for k, v in spec.items():


### PR DESCRIPTION
First application of the grain-aggregation-policy (`SkunkWorks/grain_aggregation_policy.org`). Malawi `interview_date` kept only Visit 1 though the raw cover records two visit dates; now it carries a `visit` ordinal index preserving both, with a declared default aggregation `first` (= Visit 1 = prior behavior when collapsed).

## Changes
- **4 wave `data_info.yml`** source the Visit-2 date where present: 2010-11 `hh_a23_2`; 2013-14 `hh_a37a_*` (the real Visit-2 block — *not* `hh_a23b_*`, which are Visit-1 re-attempts; verified by labels); 2016-17/2019-20 Panel `interviewdate_v2`. 2004-05 + Cross_Sectional halves are single-visit.
- **`malawi.py`**: `interview_date(df)` df_edit hook melts v1/v2 → `(t,i,visit)`, one `Int_t` datetime per visit, NaT visit-2 rows dropped.
- **`data_scheme.yml`**: index `(t,i)` → `(t,i,visit)` + `aggregation: {visit: first}` (forward-looking policy declaration).
- **`diagnostics.py` + `tests/test_table_structure.py`**: teach both scheme parsers that `aggregation` is a meta-key, not a column (`country.py` already tolerant). No assertion weakened.
- **grain note** addendum: visit=date is unsupported by current multi-visit *data* (GhanaLSS food = wide ordinals) → `visit` stays ordinal+sentinel, dates live in `interview_date`; plus the `plot_labor` correction (`ag_d47/d48` = non-harvest/harvest activities, not visits — discarded axes are man/woman/child #439 + activity).

## Verification (cold rebuild)
- grain `(i,t,v,visit)`, **69,378 rows, 0 dups, 0 NaT**, visit∈{1,2}.
- per-wave v1/v2: 2004-05 11280/0; 2010-11 12271/3247; 2013-14 3996/3971; 2016-17 14788/2481; 2019-20 14248/3096.
- **backward-compat**: `groupby(t,v,i).first()` == Visit-1 date for all **56,583** HH with a Visit-1 date (Visit-1 unchanged); **+475** HH that had a *NaT* Visit-1 (silently dropped by the old single-date API) now surface via visit==2.
- age path unaffected (`interview_date` is a leaf; age reads the roster's own date cols).
- Tests: schema + catalog + Malawi/interview_date table_structure → **230 passed**.

Part of a broader, pervasive pattern (see PR discussion / the cross-country survey): ~14 countries record per-visit dates currently collapsed to visit-1. This is the Malawi-first increment; EHCVM family (uniform) is the natural next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)