### PR TITLE
EHCVM interview_date per-visit visit index + source-wiring/regression fixes (#438, #474, #475, #476)

### DIFF
--- a/lsms_library/countries/Albania/2002/_/data_info.yml
+++ b/lsms_library/countries/Albania/2002/_/data_info.yml
@@ -63,18 +63,39 @@ household_roster:
         MonthsAway: m1_q11
 
 interview_date:
-    # Cover page metadata_cl.dta; m0_date is int YYYYMMDD parsed by
-    # mapping.py:Int_t. i=[psu,hh] -> composite via mapping.py:i() to match
-    # sample()'s household identity ('psu-hh'); `hh` alone is only the
-    # within-cluster number (14 unique). See CONTENTS.org re: the roster's
-    # i=hh issue.
+    # Cover page metadata_cl.dta.  GH #474: previously wired Int_t to
+    # m0_date, which the source labels "Date of last modification" -- a
+    # data-entry timestamp, NOT the fieldwork interview date.  The real
+    # interview date is the "Day / Month / Year of Interview" question:
+    # Visit 1 = m0_q08d/m/y, Visit 2 = m0_q08d2/m2/y2 (Albania 2002 is a
+    # genuine two-visit survey; the *2 columns are empty in this file, so the
+    # country-level albania.interview_date melt yields no visit=2 rows -- NaT
+    # rows are dropped, never fabricated).  Columns are given year, month, day
+    # order and combined into a Timestamp by albania.albania_date_ymd, then
+    # melted onto a `visit` index level by the country-level
+    # albania.interview_date df_edit hook.
+    # i=[psu,hh] -> composite via mapping.py:i() to match sample()'s household
+    # identity ('psu-hh'); `hh` alone is only the within-cluster number (14
+    # unique). See CONTENTS.org re: the roster's i=hh issue.
+    # converted_categoricals: False -- the Year-of-Interview column carries a
+    # Stata value label that decodes every cell to '***Undefined Label'; read
+    # the underlying numeric code so albania_date_ymd sees 2002, not a label.
     file:
         - ../Data/metadata_cl.dta
+    converted_categoricals: False
     idxvars:
         i: [psu, hh]
     myvars:
-        Int_t:
-            - m0_date
+        int_t:
+            - m0_q08y
+            - m0_q08m
+            - m0_q08d
+            - mapping: albania_date_ymd
+        int_t_v2:
+            - m0_q08y2
+            - m0_q08m2
+            - m0_q08d2
+            - mapping: albania_date_ymd
 
 subjective_well_being:
     # Module 9 "Subjective Poverty" (subjpov_cl.dta).  m09_q09 "Economic status"

--- a/lsms_library/countries/Albania/2004/_/data_info.yml
+++ b/lsms_library/countries/Albania/2004/_/data_info.yml
@@ -52,12 +52,22 @@ household_roster:
         MonthsAway: m1_q08
 
 interview_date:
-    # Cover page w3_hh_basic.dta; m0_date is int YYYYMMDD parsed by
-    # mapping.py:Int_t. i=chid matches the roster.
+    # Cover page w3_hh_basic.dta.  GH #474: previously wired Int_t to
+    # m0_date, which the source labels "data entry date" -- a data-entry
+    # timestamp, NOT the fieldwork interview date.  The real interview date
+    # is "date of enumeration (day/month/year)" = m0_q04d/m/y (single visit;
+    # the 2004 panel cover records no second enumerator visit).  Columns are
+    # given year, month, day order and combined into a Timestamp by
+    # albania.albania_date_ymd, then melted onto a `visit` index level
+    # (visit=1 only here) by the country-level albania.interview_date df_edit
+    # hook.  i=chid matches the roster.
     file:
         - ../Data/w3_hh_basic.dta
     idxvars:
         i: chid
     myvars:
-        Int_t:
-            - m0_date
+        int_t:
+            - m0_q04y
+            - m0_q04m
+            - m0_q04d
+            - mapping: albania_date_ymd

--- a/lsms_library/countries/Albania/2005/_/data_info.yml
+++ b/lsms_library/countries/Albania/2005/_/data_info.yml
@@ -92,16 +92,26 @@ housing:
         Rooms: m13a_q08
 
 interview_date:
-    # Cover page identification_cl.dta; m0_date is int YYYYMMDD parsed by
-    # mapping.py:Int_t. i=[m0_q00,m0_q01] uses the composite i() to match the
+    # Cover page identification_cl.dta.  GH #474: previously wired Int_t to
+    # m0_date, which the source labels "Date of last modification" -- a
+    # data-entry timestamp, NOT the fieldwork interview date.  The real
+    # interview date is the "Day / Month / Year of Interview" question =
+    # m0_q8d/m/y (single visit; the cover records no second enumerator
+    # visit).  Columns are given year, month, day order and combined into a
+    # Timestamp by albania.albania_date_ymd, then melted onto a `visit` index
+    # level (visit=1 only here) by the country-level albania.interview_date
+    # df_edit hook.  i=[m0_q00,m0_q01] uses the composite i() to match the
     # household identity built by sample.py (so _join_v_from_sample resolves v).
     file:
         - ../Data/identification_cl.dta
     idxvars:
         i: [m0_q00, m0_q01]
     myvars:
-        Int_t:
-            - m0_date
+        int_t:
+            - m0_q8y
+            - m0_q8m
+            - m0_q8d
+            - mapping: albania_date_ymd
 
 subjective_well_being:
     # Module 7 "Subjective Poverty" (subjective_poverty_cl.dta).  Two

--- a/lsms_library/countries/Albania/_/albania.py
+++ b/lsms_library/countries/Albania/_/albania.py
@@ -95,6 +95,101 @@ _SOIL = {
 }
 
 
+def albania_date_ymd(row):
+    """Combine a [year, month, day] row into a Timestamp.
+
+    Used by the ``interview_date`` table.  Albania's cover files record the
+    fieldwork interview date as three separate numeric columns -- "Day /
+    Month / Year of Interview" (2002 ``m0_q08d/m/y``, 2005 ``m0_q8d/m/y``)
+    or "date of enumeration (day/month/year)" (2004 ``m0_q04d/m/y``).
+    Declare the columns in **year, month, day** order in the wave's
+    data_info.yml ``int_t`` myvar with a trailing
+    ``mapping: albania_date_ymd``.
+
+    The month component is numeric (e.g. ``5``); it is handled by building a
+    'DAY MONTH YEAR' string and letting ``pd.to_datetime`` parse it (a name
+    like 'MAY' would also work).  Returns ``pd.NaT`` when any part is missing
+    or the date is unparseable -- so households with no recorded interview
+    date (e.g. an empty Visit-2 column) drop out rather than being fabricated.
+
+    The cover files load with ``convert_categoricals=True``, so a numeric
+    cell with no Stata value label can arrive as the sentinel string
+    ``'***Undefined Label'`` (and day/year as label-typed objects); each
+    component is therefore coerced with ``pd.to_numeric`` and any
+    non-numeric / undefined value yields ``pd.NaT`` rather than raising.
+
+    Mirrors :func:`lsms_library.countries.Malawi._.malawi.malawi_date_ymd`.
+    """
+    y, m, d = row.iloc[0], row.iloc[1], row.iloc[2]
+    if pd.isna(y) or pd.isna(m) or pd.isna(d):
+        return pd.NaT
+    # Year and day are always numeric calendar components; coerce defensively
+    # (categorical-label objects / '***Undefined Label' sentinels -> NaT).
+    y_num = pd.to_numeric(y, errors='coerce')
+    d_num = pd.to_numeric(d, errors='coerce')
+    if pd.isna(y_num) or pd.isna(d_num):
+        return pd.NaT
+    # Month may be a numeric code (5 / 5.0) or an English name ('MAY').
+    # A numeric month is parsed with an explicit %Y-%m-%d format so a string
+    # like '4 5 2002' is never mis-read as April-5 (the day/month order of a
+    # bare 'D M Y' string is ambiguous to pd.to_datetime); a month *name*
+    # ('MAY') is unambiguous and is parsed without a format.
+    m_num = pd.to_numeric(m, errors='coerce')
+    if pd.notna(m_num):
+        month = int(m_num)
+        return pd.to_datetime(
+            f"{int(y_num):04d}-{month:02d}-{int(d_num):02d}",
+            format="%Y-%m-%d", errors='coerce')
+    if isinstance(m, str) and m.strip():
+        return pd.to_datetime(
+            f"{int(d_num)} {m.strip()} {int(y_num)}", errors='coerce')
+    return pd.NaT
+
+
+def interview_date(df):
+    """Melt Albania's per-visit interview dates onto a ``visit`` index level.
+
+    Country-level ``df_edit`` hook for the ``interview_date`` table
+    (auto-dispatched by table name; see country.py ``grab_data`` ->
+    ``formatting_functions.get(request)``).  Mirrors
+    :func:`lsms_library.countries.Malawi._.malawi.interview_date`.
+
+    Per GH #474 the Albania waves previously wired ``Int_t`` to ``m0_date``,
+    which the source labels as "Date of last modification" / "data entry
+    date" -- a data-entry timestamp, NOT the fieldwork interview date.  The
+    real interview date lives in the "Day / Month / Year of Interview"
+    question columns, combined by :func:`albania_date_ymd` into ``Int_t``
+    (Visit 1) and -- where the wave's cover records a second enumerator visit
+    (2002 ``m0_q08*2``) -- ``Int_t_v2`` (Visit 2).
+
+    Input
+    -----
+    df : pd.DataFrame
+        Indexed per the wave's ``idxvars`` (after the framework prepends
+        ``t``, i.e. ``(t, i)``), carrying the Visit-1 interview date in a
+        ``int_t`` / ``Int_t`` column and -- where the wave records a second
+        visit -- the Visit-2 date in ``int_t_v2`` / ``Int_t_v2``.  Both
+        casings are accepted defensively (the ``int_t -> Int_t``
+        rejected-spelling rewrite has NOT run at this wave-level hook stage).
+
+    Output
+    ------
+    pd.DataFrame indexed ``(<original idx>, visit)`` -- i.e. ``(t, i,
+    visit)`` -- with a single ``Int_t`` datetime column.  ``visit`` is an
+    ordinal Int64 level: ``1`` carries the Visit-1 date, ``2`` the Visit-2
+    date.  Visit rows whose date is NaT are DROPPED -- never fabricated -- so
+    a single-visit wave (2004, 2005) yields only ``visit=1`` rows, and the
+    2002 Visit-2 columns (present in the questionnaire but empty in this data
+    file) yield no ``visit=2`` rows.
+
+    Delegates to the shared
+    :func:`lsms_library.local_tools.melt_visit_intervals` helper with
+    ``start_base='int_t'`` and the legacy ``Int_t`` output column (Albania
+    records only an interview *date* per visit, no separate start/end).
+    """
+    return tools.melt_visit_intervals(df, start_base='int_t', out_start='Int_t')
+
+
 def _clean_label(series):
     """Lower-case, whitespace-collapse a string/categorical label Series for
     case-insensitive mapping; NA stays NA."""

--- a/lsms_library/countries/Albania/_/data_scheme.yml
+++ b/lsms_library/countries/Albania/_/data_scheme.yml
@@ -66,8 +66,22 @@ Data Scheme:
     Own Step: int
 
   interview_date:
-    index: (t, i)
+    # GH #474: Int_t now comes from the "Day / Month / Year of Interview"
+    # question (Visit 1 = m0_q08*/m0_q04*/m0_q8*, Visit 2 = m0_q08*2 in
+    # 2002), NOT the m0_date last-modification / data-entry stamp.  Albania
+    # 2002 is a genuine two-visit survey, so -- following the Malawi pattern
+    # -- both visit dates are preserved on an ordinal `visit` index level
+    # (1 = first visit, 2 = second visit), melted by the country-level
+    # albania.interview_date df_edit hook (visit rows with a NaT date are
+    # dropped there).  2004 / 2005 are single-visit -> visit = 1 only; the
+    # 2002 *2 columns are empty in this data file -> no visit = 2 rows.
+    # `v` auto-joins from sample() at API time, so the returned grain is
+    # (t, v, i, visit).  Collapsing `visit` with the declared `first`
+    # aggregation reproduces the legacy Visit-1-only table.
+    index: (t, i, visit)
     Int_t: datetime
+    aggregation:
+      visit: first
 
   # Occurrence-only shocks module (2012 wave only; earlier waves have no
   # shocks module).  No impact (Affected*) or coping (HowCoped*) detail in

--- a/lsms_library/countries/Benin/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Benin/2018-19/_/data_info.yml
@@ -263,7 +263,13 @@ interview_date:
             - grappe
             - menage
     myvars:
-        int_t: s00q23a
+        # q23/q24/q25 a/b = visits 1/2/3 start/end
+        int_start:    s00q23a
+        int_end:      s00q23b
+        int_start_v2: s00q24a
+        int_end_v2:   s00q24b
+        int_start_v3: s00q25a
+        int_end_v3:   s00q25b
 
 shocks:
     file: s14_me_ben2018.dta

--- a/lsms_library/countries/Benin/_/benin.py
+++ b/lsms_library/countries/Benin/_/benin.py
@@ -169,3 +169,12 @@ def plot_features_for_wave(t, source, colmap):
     })
     df = df.set_index(['t', 'i', 'plot_id'])
     return df
+
+
+def interview_date(df):
+    """Melt EHCVM per-visit interview start/end timestamps onto a `visit`
+    index. q23/q24/q25 a/b = visit 1/2/3 start/end -> int_start/int_end[_v2/_v3].
+    Delegates to local_tools.melt_visit_intervals -> 'Interview start' /
+    'Interview end'; collapsing `visit` with `first` reproduces the legacy
+    single-date table."""
+    return tools.melt_visit_intervals(df)

--- a/lsms_library/countries/Benin/_/data_scheme.yml
+++ b/lsms_library/countries/Benin/_/data_scheme.yml
@@ -80,8 +80,11 @@ Data Scheme:
     Floor: str
 
   interview_date:
-    index: (t, i)
-    Int_t: datetime
+    index: (t, i, visit)
+    Interview start: datetime
+    Interview end: datetime
+    aggregation:
+      visit: first
   shocks:
     index: (t, i, Shock)
     AffectedIncome: bool

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/data_info.yml
@@ -262,7 +262,13 @@ interview_date:
             - grappe
             - menage
     myvars:
-        Int_t: s00q23a
+        # q23/q24/q25 a/b = visits 1/2/3 start/end
+        int_start:    s00q23a
+        int_end:      s00q23b
+        int_start_v2: s00q24a
+        int_end_v2:   s00q24b
+        int_start_v3: s00q25a
+        int_end_v3:   s00q25b
 
 food_security:
     # FAO 8-item FIES, EHCVM §8A.  s08aq01..08 -> Worried..WholeDay in

--- a/lsms_library/countries/Burkina_Faso/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2021-22/_/data_info.yml
@@ -240,7 +240,13 @@ interview_date:
             - grappe
             - menage
     myvars:
-        Int_t: s00q23a
+        # q23/q24/q25 a/b = visits 1/2/3 start/end
+        int_start:    s00q23a
+        int_end:      s00q23b
+        int_start_v2: s00q24a
+        int_end_v2:   s00q24b
+        int_start_v3: s00q25a
+        int_end_v3:   s00q25b
 
 food_security:
     # FAO 8-item FIES, EHCVM §8A.  s08aq01..08 -> Worried..WholeDay in

--- a/lsms_library/countries/Burkina_Faso/_/burkina_faso.py
+++ b/lsms_library/countries/Burkina_Faso/_/burkina_faso.py
@@ -252,3 +252,12 @@ def plot_features_for_wave(t, source, colmap, id_fn=None):
     })
     df = df.set_index(['t', 'i', 'plot_id'])
     return df
+
+
+def interview_date(df):
+    """Melt EHCVM per-visit interview start/end timestamps onto a `visit`
+    index. q23/q24/q25 a/b = visit 1/2/3 start/end -> int_start/int_end[_v2/_v3].
+    Delegates to local_tools.melt_visit_intervals -> 'Interview start' /
+    'Interview end'; collapsing `visit` with `first` reproduces the legacy
+    single-date table."""
+    return tools.melt_visit_intervals(df)

--- a/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
+++ b/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
@@ -167,8 +167,11 @@ Data Scheme:
     materialize: make
 
   interview_date:
-    index: (t, i)
-    Int_t: datetime
+    index: (t, i, visit)
+    Interview start: datetime
+    Interview end: datetime
+    aggregation:
+      visit: first
 
   crop_production:
     # Item-level crop harvest (GAP 1; EHCVM parity loop 2026-06-15, cloned

--- a/lsms_library/countries/CotedIvoire/2018-19/_/data_info.yml
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/data_info.yml
@@ -327,4 +327,10 @@ interview_date:
             - grappe
             - menage
     myvars:
-        Int_t: s00q23a
+        # q23/q24/q25 a/b = visits 1/2/3 start/end
+        int_start:    s00q23a
+        int_end:      s00q23b
+        int_start_v2: s00q24a
+        int_end_v2:   s00q24b
+        int_start_v3: s00q25a
+        int_end_v3:   s00q25b

--- a/lsms_library/countries/CotedIvoire/_/cotedivoire.py
+++ b/lsms_library/countries/CotedIvoire/_/cotedivoire.py
@@ -81,3 +81,12 @@ def shocks(df):
         df['HowCoped2'] = hc2
     df = df.drop(columns=cope_cols)
     return df
+
+
+def interview_date(df):
+    """Melt EHCVM per-visit interview start/end timestamps onto a `visit`
+    index. q23/q24/q25 a/b = visit 1/2/3 start/end -> int_start/int_end[_v2/_v3].
+    Delegates to local_tools.melt_visit_intervals -> 'Interview start' /
+    'Interview end'; collapsing `visit` with `first` reproduces the legacy
+    single-date table."""
+    return tools.melt_visit_intervals(df)

--- a/lsms_library/countries/CotedIvoire/_/data_scheme.yml
+++ b/lsms_library/countries/CotedIvoire/_/data_scheme.yml
@@ -84,8 +84,11 @@ Data Scheme:
     Floor: str
 
   interview_date:
-    index: (t, i)
-    Int_t: datetime
+    index: (t, i, visit)
+    Interview start: datetime
+    Interview end: datetime
+    aggregation:
+      visit: first
 
   livestock:
     # Item-level livestock roster (GAP 4).  One row per REPORTED

--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/data_info.yml
@@ -275,7 +275,13 @@ interview_date:
             - grappe
             - menage
     myvars:
-        Int_t: s00q23a
+        # q23/q24/q25 a/b = visits 1/2/3 start/end timestamps
+        int_start:    s00q23a
+        int_end:      s00q23b
+        int_start_v2: s00q24a
+        int_end_v2:   s00q24b
+        int_start_v3: s00q25a
+        int_end_v3:   s00q25b
 
 food_security:
     # FAO 8-item Food Insecurity Experience Scale (FIES), EHCVM Section 8A

--- a/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
+++ b/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
@@ -72,8 +72,11 @@ Data Scheme:
     Floor: str
 
   interview_date:
-    index: (t, i)
-    Int_t: datetime
+    index: (t, i, visit)
+    Interview start: datetime
+    Interview end: datetime
+    aggregation:
+      visit: first
 
   food_security:
     # FAO 8-item Food Insecurity Experience Scale (FIES), EHCVM Section

--- a/lsms_library/countries/Guinea-Bissau/_/guinea-bissau.py
+++ b/lsms_library/countries/Guinea-Bissau/_/guinea-bissau.py
@@ -9,3 +9,12 @@ def i(value):
     if isinstance(value, (pd.Series, np.ndarray, list, tuple)):
         return tools.format_id(value.iloc[0]) + '0' + tools.format_id(value.iloc[1], zeropadding=2)
     return tools.format_id(value)
+
+
+def interview_date(df):
+    """Melt EHCVM per-visit interview start/end timestamps onto a `visit`
+    index. q23/q24/q25 a/b = visit 1/2/3 start/end -> int_start/int_end[_v2/_v3].
+    Delegates to local_tools.melt_visit_intervals -> 'Interview start' /
+    'Interview end'; collapsing `visit` with `first` reproduces the legacy
+    single-date table."""
+    return tools.melt_visit_intervals(df)

--- a/lsms_library/countries/Kosovo/2000/_/interview_date.py
+++ b/lsms_library/countries/Kosovo/2000/_/interview_date.py
@@ -3,15 +3,28 @@ import sys
 sys.path.append('../../../_/')
 from lsms_library.local_tools import df_data_grabber, to_parquet
 
-idxvars = dict(t=('s0i_dat0', lambda x: "2000"),
+# Issue #475: s0i_dat0/s0i_dat1 are a CSPro case open/close MACHINE timestamp
+# (the two are ~identical), NOT the fieldwork interview date.  The genuine
+# questionnaire interview date is field s0i_q22, recorded as day (s0i_q22a),
+# month (s0i_q22b) and year (s0i_q22c is the constant literal "Year"; the
+# survey is single-round 2000, so the year is fixed at 2000).  The packed
+# s0i_q22 integer (DDMMYYYY) drops a digit for a couple of records, so we
+# build Int_t from the separate day/month components instead.
+idxvars = dict(t=('s0i_q22a', lambda x: "2000"),
                i='hhid')
-myvars = dict(s0i_dat0='s0i_dat0')
+myvars = dict(s0i_q22a='s0i_q22a', s0i_q22b='s0i_q22b')
 
 df = df_data_grabber('../Data/ID.dta', idxvars, **myvars)
-# A handful of records carry impossible calendar dates (e.g. 20001032,
-# 20001200, 20001100 -- day/month out of range). Coerce those to NaT.
-df['Int_t'] = pd.to_datetime(df['s0i_dat0'].astype('Int64').astype(str),
-                             format='%Y%m%d', errors='coerce')
-df = df.drop(columns=['s0i_dat0'])
+# Out-of-range day/month components (day > 31, month > 12) coerce to NaT.
+# A few records carry an in-range but implausible date (e.g. January in a
+# Sep-Dec fieldwork survey -- a likely data-entry typo); these are VALID
+# calendar dates, so they are preserved as recorded -- we never fabricate or
+# silently "repair" a date.
+df['Int_t'] = pd.to_datetime(
+    dict(year=2000,
+         month=df['s0i_q22b'].astype('Int64'),
+         day=df['s0i_q22a'].astype('Int64')),
+    errors='coerce')
+df = df.drop(columns=['s0i_q22a', 's0i_q22b'])
 
 to_parquet(df, 'interview_date.parquet')

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -14,7 +14,7 @@ import numpy as np
 import re
 import sys
 sys.path.append('../../../_/')
-from lsms_library.local_tools import conversion_table_matching_global, format_id
+from lsms_library.local_tools import conversion_table_matching_global, format_id, melt_visit_dates
 
 
 def _extract_kg_conversion(series):
@@ -266,42 +266,13 @@ def interview_date(df):
     from ``sample()`` at API time, giving the returned grain
     ``(t, v, i, visit)``.  Collapsing ``visit`` with the declared ``first``
     aggregation (data_scheme.yml) reproduces the legacy Visit-1-only table.
+
+    Implementation delegates to the shared
+    :func:`lsms_library.local_tools.melt_visit_dates` helper (the EHCVM
+    family reuses the same melt via its own one-line hooks); the prior
+    inline v1/v2 logic was equivalent for Malawi's two-visit data.
     """
-    def _pick(*names):
-        for n in names:
-            if n in df.columns:
-                return n
-        return None
-
-    v1_col = _pick('int_t', 'Int_t')
-    v2_col = _pick('int_t_v2', 'Int_t_v2')
-
-    if v1_col is None:
-        # Nothing to melt (defensive): hand back unchanged.
-        return df
-
-    idx_names = list(df.index.names)
-    flat = df.reset_index()
-
-    pieces = []
-    v1 = flat[idx_names].copy()
-    v1['visit'] = 1
-    v1['Int_t'] = pd.to_datetime(flat[v1_col], errors='coerce')
-    pieces.append(v1)
-
-    if v2_col is not None:
-        v2 = flat[idx_names].copy()
-        v2['visit'] = 2
-        v2['Int_t'] = pd.to_datetime(flat[v2_col], errors='coerce')
-        # Drop households not revisited (no Visit-2 date) -- reported only,
-        # no fabricated visits.
-        v2 = v2[v2['Int_t'].notna()]
-        pieces.append(v2)
-
-    out = pd.concat(pieces, ignore_index=True)
-    out['visit'] = out['visit'].astype('Int64')
-    out = out.set_index(idx_names + ['visit'])
-    return out
+    return melt_visit_dates(df)
 
 
 def harmonize_food_labels(df, level='i'):

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -14,7 +14,7 @@ import numpy as np
 import re
 import sys
 sys.path.append('../../../_/')
-from lsms_library.local_tools import conversion_table_matching_global, format_id, melt_visit_dates
+from lsms_library.local_tools import conversion_table_matching_global, format_id, melt_visit_intervals
 
 
 def _extract_kg_conversion(series):
@@ -268,11 +268,12 @@ def interview_date(df):
     aggregation (data_scheme.yml) reproduces the legacy Visit-1-only table.
 
     Implementation delegates to the shared
-    :func:`lsms_library.local_tools.melt_visit_dates` helper (the EHCVM
-    family reuses the same melt via its own one-line hooks); the prior
-    inline v1/v2 logic was equivalent for Malawi's two-visit data.
+    :func:`lsms_library.local_tools.melt_visit_intervals` helper.  Malawi
+    records only an interview *date* per visit (no separate start/end), so we
+    pass ``start_base='int_t'`` and keep the legacy ``Int_t`` output column;
+    the EHCVM family reuses the same helper with start/end timestamps.
     """
-    return melt_visit_dates(df)
+    return melt_visit_intervals(df, start_base='int_t', out_start='Int_t')
 
 
 def harmonize_food_labels(df, level='i'):

--- a/lsms_library/countries/Niger/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Niger/2018-19/_/data_info.yml
@@ -268,7 +268,13 @@ interview_date:
             - grappe
             - menage
     myvars:
-        int_t: s00q23a
+        # q23/q24/q25 a/b = visits 1/2/3 start/end
+        int_start:    s00q23a
+        int_end:      s00q23b
+        int_start_v2: s00q24a
+        int_end_v2:   s00q24b
+        int_start_v3: s00q25a
+        int_end_v3:   s00q25b
 
 food_security:
     # FAO Food Insecurity Experience Scale (FIES), EHCVM Section 8A

--- a/lsms_library/countries/Niger/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Niger/2021-22/_/data_info.yml
@@ -261,7 +261,13 @@ interview_date:
             - grappe
             - menage
     myvars:
-        int_t: s00q23a
+        # q23/q24/q25 a/b = visits 1/2/3 start/end
+        int_start:    s00q23a
+        int_end:      s00q23b
+        int_start_v2: s00q24a
+        int_end_v2:   s00q24b
+        int_start_v3: s00q25a
+        int_end_v3:   s00q25b
 
 food_security:
     # FAO Food Insecurity Experience Scale (FIES), EHCVM Section 8A

--- a/lsms_library/countries/Niger/_/data_scheme.yml
+++ b/lsms_library/countries/Niger/_/data_scheme.yml
@@ -108,8 +108,11 @@ Data Scheme:
     Own Step: int
 
   interview_date:
-    index: (t, i)
-    Int_t: datetime
+    index: (t, i, visit)
+    Interview start: datetime
+    Interview end: datetime
+    aggregation:
+      visit: first
 
   plot_features:
     # Lasting parcel-level characteristics from the EHCVM agriculture

--- a/lsms_library/countries/Niger/_/niger.py
+++ b/lsms_library/countries/Niger/_/niger.py
@@ -1238,3 +1238,12 @@ def _finish_community_prices(df, t):
     df = df[keep]
     df = df.set_index(['t', 'v', 'i', 'j', 'u']).sort_index()
     return df
+
+
+def interview_date(df):
+    """Melt EHCVM per-visit interview start/end timestamps onto a `visit`
+    index. q23/q24/q25 a/b = visit 1/2/3 start/end -> int_start/int_end[_v2/_v3].
+    Delegates to local_tools.melt_visit_intervals -> 'Interview start' /
+    'Interview end'; collapsing `visit` with `first` reproduces the legacy
+    single-date table."""
+    return tools.melt_visit_intervals(df)

--- a/lsms_library/countries/Senegal/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Senegal/2018-19/_/data_info.yml
@@ -265,7 +265,26 @@ interview_date:
             - grappe
             - menage
     myvars:
-        Int_t: s00q23a
+        # EHCVM cover records start+end timestamps for up to THREE enumerator
+        # visits needed to administer the questionnaire (cf. s00q22): q23a/b =
+        # visit 1 start/end, q24a/b = visit 2, q25a/b = visit 3.  Melted onto a
+        # `visit` index by senegal.interview_date.  (Do NOT confuse q23b =
+        # visit-1 END with a later visit.)
+        #
+        # DATA CAVEAT (2018-19 only): ~half of this wave's households have
+        # inconsistently-entered visit timestamps -- consecutive visits collapse
+        # to the same day and the labelled q24a/q24b "visit 2" duration is
+        # implausible (median ~19h).  Only ~12% show 3 distinct visit days vs
+        # ~93% in the clean waves (Benin/Mali/Niger/...).  Carried exactly as
+        # recorded (no repair -- we can't reliably tell which records are
+        # mis-entered); treat 2018-19 Interview end and visit durations
+        # skeptically.  The other 11 EHCVM waves are cleanly sequential.
+        int_start:    s00q23a
+        int_end:      s00q23b
+        int_start_v2: s00q24a
+        int_end_v2:   s00q24b
+        int_start_v3: s00q25a
+        int_end_v3:   s00q25b
 
 food_security:
     # FAO FIES 8-item scale, EHCVM §8A 'Sécurité alimentaire'.

--- a/lsms_library/countries/Senegal/2021-22/_/data_info.yml
+++ b/lsms_library/countries/Senegal/2021-22/_/data_info.yml
@@ -254,7 +254,17 @@ interview_date:
             - grappe
             - menage
     myvars:
-        Int_t: s00q23a
+        # EHCVM cover records start+end timestamps for up to THREE enumerator
+        # visits needed to administer the questionnaire (cf. s00q22): q23a/b =
+        # visit 1 start/end, q24a/b = visit 2, q25a/b = visit 3.  Melted onto a
+        # `visit` index by senegal.interview_date.  (Do NOT confuse q23b =
+        # visit-1 END with a later visit.)
+        int_start:    s00q23a
+        int_end:      s00q23b
+        int_start_v2: s00q24a
+        int_end_v2:   s00q24b
+        int_start_v3: s00q25a
+        int_end_v3:   s00q25b
 
 food_security:
     # FAO FIES 8-item scale, EHCVM §8A 'Sécurité alimentaire'.

--- a/lsms_library/countries/Senegal/_/data_scheme.yml
+++ b/lsms_library/countries/Senegal/_/data_scheme.yml
@@ -88,8 +88,17 @@ Data Scheme:
     Floor: str
 
   interview_date:
-    index: (t, i)
-    Int_t: datetime
+    # EHCVM records start+end timestamps for each enumerator visit needed to
+    # complete the questionnaire (distinct from the survey round, which `t`
+    # carries).  Both visits are preserved on an ordinal `visit` level, melted
+    # by senegal.interview_date; v auto-joins from sample() -> grain
+    # (t, v, i, visit).  Collapsing `visit` with `first` reproduces the legacy
+    # visit-1-start single-date table.
+    index: (t, i, visit)
+    Interview start: datetime
+    Interview end: datetime
+    aggregation:
+      visit: first
 
   sample:
     index: (i, t)

--- a/lsms_library/countries/Senegal/_/senegal.py
+++ b/lsms_library/countries/Senegal/_/senegal.py
@@ -246,3 +246,20 @@ def plot_features_for_wave(t, source, colmap):
     })
     df = df.set_index(['t', 'i', 'plot_id'])
     return df
+
+
+def interview_date(df):
+    """Melt EHCVM per-visit interview start/end timestamps onto a `visit` index.
+
+    Country-level df_edit hook for the interview_date table (dispatched by
+    table name via country.py grab_data).  EHCVM cover files record a start
+    and end datetime for each of the (up to two) enumerator visits needed to
+    complete the household questionnaire -- distinct from the survey round,
+    which `t` carries.  The wave data_info.yml maps q23a/q23b = visit-1
+    start/end and q24a/q24b = visit-2 start/end to int_start/int_end[_v2].
+    Delegates to the shared local_tools.melt_visit_intervals helper, producing
+    columns 'Interview start' / 'Interview end' on an ordinal `visit` index.
+    Collapsing `visit` with the declared `first` aggregation reproduces the
+    legacy visit-1-start single-date table.
+    """
+    return tools.melt_visit_intervals(df)

--- a/lsms_library/countries/Togo/2018/_/data_info.yml
+++ b/lsms_library/countries/Togo/2018/_/data_info.yml
@@ -270,7 +270,13 @@ interview_date:
             - grappe
             - menage
     myvars:
-        Int_t: s00q23a
+        # q23/q24/q25 a/b = visits 1/2/3 start/end
+        int_start:    s00q23a
+        int_end:      s00q23b
+        int_start_v2: s00q24a
+        int_end_v2:   s00q24b
+        int_start_v3: s00q25a
+        int_end_v3:   s00q25b
 
 food_security:
     # FAO Food Insecurity Experience Scale (FIES), EHCVM §8A

--- a/lsms_library/countries/Togo/_/data_scheme.yml
+++ b/lsms_library/countries/Togo/_/data_scheme.yml
@@ -85,8 +85,11 @@ Data Scheme:
     Floor: str
 
   interview_date:
-    index: (t, i)
-    Int_t: datetime
+    index: (t, i, visit)
+    Interview start: datetime
+    Interview end: datetime
+    aggregation:
+      visit: first
 
   plot_features:
     # Lasting parcel-level characteristics from the EHCVM agriculture

--- a/lsms_library/countries/Togo/_/togo.py
+++ b/lsms_library/countries/Togo/_/togo.py
@@ -332,3 +332,12 @@ def plot_features_for_wave(t, source, colmap):
     })
     df = df.set_index(['t', 'i', 'plot_id'])
     return df
+
+
+def interview_date(df):
+    """Melt EHCVM per-visit interview start/end timestamps onto a `visit`
+    index. q23/q24/q25 a/b = visit 1/2/3 start/end -> int_start/int_end[_v2/_v3].
+    Delegates to local_tools.melt_visit_intervals -> 'Interview start' /
+    'Interview end'; collapsing `visit` with `first` reproduces the legacy
+    single-date table."""
+    return tools.melt_visit_intervals(df)

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -657,6 +657,23 @@ class Wave:
         
         formatting_functions = self.formatting_functions
 
+        # A function whose name matches a declared data_scheme table is that
+        # table's df_edit hook (dispatched per-table as
+        # ``final_mapping['df_edit']`` below), NOT a per-cell column formatter.
+        # Guard against a myvar that happens to share a name with such a table
+        # hook -- e.g. the legacy ``interview_date`` cover-page myvar inside an
+        # EHCVM ``household_roster`` colliding with the country-module
+        # ``interview_date(df)`` visit-melt hook.  Auto-binding the df-level
+        # hook as a per-cell formatter applies it to a scalar string and raises
+        # ``AttributeError`` (masked downstream as a misleading ``KeyError``),
+        # breaking the roster build / silently dropping waves (GH #476).  Such
+        # a myvar is treated as a plain column rename, exactly as it was before
+        # the table hook existed; the table's own df_edit dispatch is
+        # unaffected.
+        declared_tables = set(
+            ((self.country.resources or {}).get('Data Scheme') or {}).keys()
+        )
+
         def map_formatting_function(var_name, value, format_id_function = False):
             """Applies formatting functions if available, otherwise uses defaults."""
             if isinstance(value, list) and isinstance(value[-1], dict):
@@ -694,7 +711,7 @@ class Wave:
                         return (value[:-1], mapping)    
                 else:
                     return tuple(value)
-            if var_name in formatting_functions:
+            if var_name in formatting_functions and var_name not in declared_tables:
                 # Named formatting functions for idxvars (e.g., Benin's `i()`)
                 # expect composite keys (list values like [grappe, menage]).
                 # When the value is a simple string (single column), use

--- a/lsms_library/data_info.yml
+++ b/lsms_library/data_info.yml
@@ -206,7 +206,16 @@ Columns:
     HowCoped2:
       type: str
   interview_date:
+    # Int_t: legacy single interview datetime (most countries).  EHCVM
+    # records a start (and end) timestamp per enumerator visit, melted onto
+    # an ordinal `visit` index (local_tools.melt_visit_intervals) into
+    # Interview start / Interview end.  None required: a country emits
+    # whichever columns its source records (start-only -> Interview start).
     Int_t:
+      type: datetime
+    Interview start:
+      type: datetime
+    Interview end:
       type: datetime
   individual_education:
     Educational Attainment:

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -1036,12 +1036,22 @@ def df_data_grabber(fn: str | Path, idxvars: dict[str, Any] | str, convert_categ
         try:
             for k,v in kwargs.items():
                 out[k] = grabber(df,v)
-        except AttributeError:
-            if isinstance(kwargs,str):
-                out[k] = df[k]
-            else: # A list?
-                for k in kwargs:
+        except AttributeError as exc:
+            # Legacy fallback: a myvar whose value is a literal source-column
+            # name can be copied straight across when ``grabber`` cannot parse
+            # it.  But when a ``(column, function)`` myvar's *function* raised
+            # the AttributeError internally, this fallback instead masks it as
+            # a misleading ``KeyError`` on the renamed target key -- which cost
+            # real debugging time on GH #476.  Chain the original error so the
+            # genuine cause survives when the fallback itself fails.
+            try:
+                if isinstance(kwargs,str):
                     out[k] = df[k]
+                else: # A list?
+                    for k in kwargs:
+                        out[k] = df[k]
+            except Exception as fallback_exc:
+                raise fallback_exc from exc
     # When ``kwargs`` (myvars) is empty, ``out`` already holds just
     # the renamed idxvars frame (built above from the ``idxvars`` dict)
     # which is what ``set_index(list(idxvars.keys()))`` needs.  An

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -2078,58 +2078,79 @@ def map_index(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def melt_visit_dates(df: pd.DataFrame, col_base: str = 'int_t',
-                     out_col: str = 'Int_t', visit_level: str = 'visit') -> pd.DataFrame:
-    """Melt per-visit interview-date columns onto an ordinal ``visit`` index.
+def melt_visit_intervals(df: pd.DataFrame,
+                         start_base: str = 'int_start', end_base: str = 'int_end',
+                         out_start: str = 'Interview start', out_end: str = 'Interview end',
+                         visit_level: str = 'visit') -> pd.DataFrame:
+    """Melt per-visit interview ``(start[, end])`` timestamps onto a ``visit`` index.
 
-    Shared ``df_edit``-hook helper for the ``interview_date`` table (the first
+    Shared ``df_edit``-hook helper for the ``interview_date`` table (an
     application of the grain-aggregation-policy, SkunkWorks/
-    grain_aggregation_policy.org).  Surveys that visit a household more than
-    once record a date per visit; we preserve them all on an ordinal ``visit``
-    level rather than collapsing to the first.
+    grain_aggregation_policy.org).  The number of enumerator visits needed to
+    complete a household questionnaire is distinct from the survey *round*
+    (post-planting / post-harvest, already carried by ``t``); some surveys
+    record a start (and end) timestamp per such visit.  We preserve every
+    visit on an ordinal ``visit`` level rather than keeping only the first.
 
-    Input: ``df`` indexed by the table's idxvars (e.g. ``(i,)`` or ``(t, i)``,
-    ``t`` is prepended by the framework later), carrying the visit dates in
-    columns named ``int_t`` (visit 1), ``int_t_v2`` (visit 2), ``int_t_v3``
-    (visit 3), ...  Both lower- and ``Int_t``-cased spellings are accepted,
-    since the canonical ``int_t -> Int_t`` rewrite has not run at hook stage.
+    Input columns (target names produced by the wave ``myvars``; both lower-
+    and capitalised first-letter spellings accepted):
 
-    Output: indexed ``(<original idx>, visit)`` with a single ``out_col``
-    datetime column; ``visit`` is an ordinal ``Int64`` (1, 2, 3, ...).  Rows
-    whose date is NaT (a household not visited that many times, a single-visit
-    wave) are DROPPED -- never fabricated -- so a household with only a later
-    visit's date surfaces at that visit number, and a wave with only visit 1
-    yields ``visit=1`` rows.  Collapsing ``visit`` with the declared ``first``
-    aggregation reproduces the legacy first-visit-only table.
+    - visit 1 start = ``start_base`` (default ``int_start``); end = ``end_base``
+      (default ``int_end``);
+    - visit n>=2 start = ``{start_base}_v{n}``; end = ``{end_base}_v{n}``.
+
+    The END columns are OPTIONAL: a survey that records only a start timestamp
+    (e.g. a single interview *date*) supplies just the start columns, and the
+    output then carries only ``out_start`` -- the all-NaT ``out_end`` column is
+    dropped.  Set ``out_start='Int_t'`` (with no end columns present) to
+    reproduce the legacy single-datetime-per-visit shape.
+
+    Output: indexed ``(<original idx>, visit)`` with columns ``out_start`` and
+    (where any end is recorded) ``out_end``; ``visit`` is an ordinal ``Int64``
+    (1, 2, 3, ...).  A visit whose start AND end are both NaT is DROPPED --
+    never fabricated -- so a household not visited that many times does not
+    surface at that visit number.  Collapsing ``visit`` with the declared
+    ``first`` aggregation reproduces the legacy first-visit-only table.
     """
     def _pick(*names):
         return next((n for n in names if n in df.columns), None)
 
+    def _col(base, n):
+        cap = base[:1].upper() + base[1:]
+        if n == 1:
+            return _pick(base, cap)
+        return _pick(f'{base}_v{n}', f'{cap}_v{n}')
+
+    # Discover visits 1..N: stop at the first ordinal with neither a start nor
+    # an end column declared.
     specs = []
-    v1 = _pick(col_base, out_col)
-    if v1 is None:
-        return df  # nothing to melt; hand back unchanged (defensive)
-    specs.append((1, v1))
-    n = 2
+    n = 1
     while True:
-        c = _pick(f'{col_base}_v{n}', f'{out_col}_v{n}')
-        if c is None:
+        s, e = _col(start_base, n), _col(end_base, n)
+        if s is None and e is None:
             break
-        specs.append((n, c))
+        specs.append((n, s, e))
         n += 1
+    if not specs:
+        return df  # nothing to melt; hand back unchanged (defensive)
 
     idx_names = list(df.index.names)
     flat = df.reset_index()
     pieces = []
-    for vnum, col in specs:
+    for vnum, s, e in specs:
         part = flat[idx_names].copy()
         part[visit_level] = vnum
-        part[out_col] = pd.to_datetime(flat[col], errors='coerce')
+        part[out_start] = pd.to_datetime(flat[s], errors='coerce') if s else pd.NaT
+        part[out_end] = pd.to_datetime(flat[e], errors='coerce') if e else pd.NaT
         pieces.append(part)
 
     out = pd.concat(pieces, ignore_index=True)
-    out = out[out[out_col].notna()]                 # drop NaT (un-made) visits
+    # Drop un-made visits (both start and end NaT); never fabricate a visit.
+    out = out[out[out_start].notna() | out[out_end].notna()]
     out[visit_level] = out[visit_level].astype('Int64')
+    # Start-only surveys: drop the all-NaT end column entirely.
+    if out_end in out.columns and out[out_end].isna().all():
+        out = out.drop(columns=[out_end])
     return out.set_index(idx_names + [visit_level])
 
 

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -2078,6 +2078,61 @@ def map_index(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def melt_visit_dates(df: pd.DataFrame, col_base: str = 'int_t',
+                     out_col: str = 'Int_t', visit_level: str = 'visit') -> pd.DataFrame:
+    """Melt per-visit interview-date columns onto an ordinal ``visit`` index.
+
+    Shared ``df_edit``-hook helper for the ``interview_date`` table (the first
+    application of the grain-aggregation-policy, SkunkWorks/
+    grain_aggregation_policy.org).  Surveys that visit a household more than
+    once record a date per visit; we preserve them all on an ordinal ``visit``
+    level rather than collapsing to the first.
+
+    Input: ``df`` indexed by the table's idxvars (e.g. ``(i,)`` or ``(t, i)``,
+    ``t`` is prepended by the framework later), carrying the visit dates in
+    columns named ``int_t`` (visit 1), ``int_t_v2`` (visit 2), ``int_t_v3``
+    (visit 3), ...  Both lower- and ``Int_t``-cased spellings are accepted,
+    since the canonical ``int_t -> Int_t`` rewrite has not run at hook stage.
+
+    Output: indexed ``(<original idx>, visit)`` with a single ``out_col``
+    datetime column; ``visit`` is an ordinal ``Int64`` (1, 2, 3, ...).  Rows
+    whose date is NaT (a household not visited that many times, a single-visit
+    wave) are DROPPED -- never fabricated -- so a household with only a later
+    visit's date surfaces at that visit number, and a wave with only visit 1
+    yields ``visit=1`` rows.  Collapsing ``visit`` with the declared ``first``
+    aggregation reproduces the legacy first-visit-only table.
+    """
+    def _pick(*names):
+        return next((n for n in names if n in df.columns), None)
+
+    specs = []
+    v1 = _pick(col_base, out_col)
+    if v1 is None:
+        return df  # nothing to melt; hand back unchanged (defensive)
+    specs.append((1, v1))
+    n = 2
+    while True:
+        c = _pick(f'{col_base}_v{n}', f'{out_col}_v{n}')
+        if c is None:
+            break
+        specs.append((n, c))
+        n += 1
+
+    idx_names = list(df.index.names)
+    flat = df.reset_index()
+    pieces = []
+    for vnum, col in specs:
+        part = flat[idx_names].copy()
+        part[visit_level] = vnum
+        part[out_col] = pd.to_datetime(flat[col], errors='coerce')
+        pieces.append(part)
+
+    out = pd.concat(pieces, ignore_index=True)
+    out = out[out[out_col].notna()]                 # drop NaT (un-made) visits
+    out[visit_level] = out[visit_level].astype('Int64')
+    return out.set_index(idx_names + [visit_level])
+
+
 import importlib.util
 def get_formatting_functions(mod_path: Path, name: str, general_formatting_functions: dict[str, Any] = {}) -> dict[str, Any]:
     formatting_function = general_formatting_functions.copy()


### PR DESCRIPTION
## Summary

Builds out the EHCVM `interview_date` per-visit **visit index** (part of #438) and
fixes three bugs surfaced by the cross-country visit-date survey.

### Feature (part of #438)
- Generalize the shared melt helper to per-visit **start/end intervals**
  (`local_tools.melt_visit_intervals`); retrofit Malawi onto it.
- Wire EHCVM `interview_date` for Senegal + the six other EHCVM countries:
  per-visit start/end timestamps melted onto an ordinal `visit` index
  (`(t, v, i, visit)`), collapsible to the legacy first-visit table.

### Bug fixes
- **Closes #475 (Kosovo):** the `interview_date` script sourced `Int_t` from
  `s0i_dat0`, a CSPro case open/close **machine timestamp**. Now sourced from
  the questionnaire date `s0i_q22a/b` (day/month, year fixed to the single 2000
  round). New dates land in the Sep–Dec 2000 fieldwork window and precede the
  old data-entry stamps (2866/2880 rows changed).
- **Closes #474 (Albania):** 2002/2004/2005 wired `Int_t` to `m0_date`, which
  the source labels "Date of last modification" / "data entry date" — not the
  interview date. Now wired to the real "Day/Month/Year of Interview" question
  (2002 `m0_q08*` incl. a 2nd visit; 2004 `m0_q04*`; 2005 `m0_q8*`), combined
  via `albania_date_ymd` and melted onto the `visit` index. (Also: a
  `converted_categoricals: False` override for 2002's mislabeled year column,
  and numeric-month date parsing.)
- **Closes #476 (EHCVM roster regression):** the new country-module
  `interview_date(df)` table hook collided with the cover-page `interview_date`
  myvar in each EHCVM `household_roster` — `map_formatting_function` auto-bound
  the **DataFrame-level hook as a per-cell formatter**, raising `AttributeError`
  (masked as a misleading `KeyError`). On a cold cache this was a hard failure
  (Benin/Guinea-Bissau/Togo) or a **silent drop of entire EHCVM waves**
  (Niger/Burkina_Faso/CotedIvoire).

  **Root-cause fix (framework, not config):** a function whose name matches a
  declared `data_scheme` table is that table's `df_edit` hook, never a per-cell
  column formatter — `map_formatting_function` now skips the auto-bind for such
  names, so the `interview_date` myvar reverts to a plain column rename (it is
  load-bearing: `mapping.py::household_roster(df)` feeds it to `age_handler`
  for DOB-derived Age, then drops it) while the `interview_date` **table** melt
  is untouched. Static audit confirmed `interview_date` is the **only**
  myvar/table-name collision in the repo, so the blast radius is exactly this
  bug. Also narrowed `df_data_grabber`'s masking `except AttributeError` so the
  genuine error survives.

## Validation
Cold rebuild (`LSMS_NO_CACHE=1`):
- 8/8 EHCVM `household_roster` build with **full wave sets** restored and no
  `interview_date` column leak.
- 8/8 `interview_date` tables build (7 melt → `visit` index; Mali keeps its
  plain `Int_t` design).
- Malawi/Uganda/Ethiopia/Tanzania rosters + Malawi `interview_date` melt
  unaffected.
- 207 schema-consistency tests pass.

> Note: the full `pytest --rebuild-caches` suite was **not** run (cluster
> compute cost); validation relied on targeted cold rebuilds + a static
> collision audit + the structural tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)