### PR TITLE
feat(currency): label monetary tables with ISO 4217 (phase 1)

### DIFF
--- a/lsms_library/__init__.py
+++ b/lsms_library/__init__.py
@@ -119,6 +119,7 @@ from . import country
 from .country import Country, Wave
 from .feature import Feature
 from .catalog import countries, features
+from .currency import currency_for
 from . import local_tools as tools
 from . import transformations
 from .dvc_permissions import authenticate

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -48,6 +48,7 @@ from .local_tools import (
 )
 from .paths import data_root, countries_root
 from .yaml_utils import load_yaml
+from .currency import attach_currency, is_monetary_table
 import importlib.util
 import hashlib
 import logging
@@ -1985,10 +1986,17 @@ class Country:
         result.attrs = dict(df.attrs)
         return result
 
-    def _finalize_result(self, df: Any, scheme_entry: dict[str, Any], method_name: str) -> pd.DataFrame | dict[str, Any]:
+    def _finalize_result(self, df: Any, scheme_entry: dict[str, Any], method_name: str,
+                         currency: str | None = None) -> pd.DataFrame | dict[str, Any]:
         """
         Apply final harmonization steps (index augmentation, normalization, id walk)
         before returning a dataset to callers.
+
+        ``currency`` (``'index'`` / ``'column'`` / ``None``) optionally attaches
+        the ISO 4217 currency label to monetary tables; see
+        :func:`lsms_library.currency.attach_currency`.  Applied last so it sits
+        on the fully-finalized frame and is preserved by the downstream
+        ``_relabel_j`` / ``_add_market_index`` steps in the caller.
         """
         if isinstance(df, dict):
             return df
@@ -2099,6 +2107,11 @@ class Country:
             # the universal safety-net.
             df = df.dropna(how='all')
 
+            # Attach the ISO 4217 currency label (last, so it rides through the
+            # caller's _relabel_j / _add_market_index without being dropped).
+            if currency is not None and method_name and not df.empty:
+                df = attach_currency(df, self.name, method_name, mode=currency)
+
         return df
 
     def _table_cache_hash(self, method_name: str, waves: list[str]) -> str | None:
@@ -2200,11 +2213,15 @@ class Country:
             except OSError:
                 pass
 
-    def _aggregate_wave_data(self, waves: list[str] | None = None, method_name: str | None = None) -> pd.DataFrame | dict[str, Any]:
+    def _aggregate_wave_data(self, waves: list[str] | None = None, method_name: str | None = None,
+                             currency: str | None = None) -> pd.DataFrame | dict[str, Any]:
         """Aggregates data across multiple waves using a single dataset method.
 
         If the required `.parquet` file is missing, it requests `Makefile` to
         generate only that file.
+
+        ``currency`` is forwarded to :meth:`_finalize_result` to optionally
+        attach the ISO 4217 currency label (monetary tables only).
         """
         if method_name not in self.data_scheme+['other_features', 'food_prices_quantities_and_expenditures', 'updated_ids']:
             warnings.warn(f"Data scheme does not contain {method_name} for {self.name}")
@@ -2226,7 +2243,7 @@ class Country:
             if parquet_path.exists():
                 df_cached = get_dataframe(parquet_path)
                 df_cached = map_index(df_cached)
-                return self._finalize_result(df_cached, scheme_entry, method_name)
+                return self._finalize_result(df_cached, scheme_entry, method_name, currency=currency)
 
         if (
             not self._panel_ids_attempted
@@ -2836,7 +2853,7 @@ class Country:
                 # the issues tracker before the exception propagates.
                 _log_issue(self.name, method_name, waves, error)
                 raise
-        return self._finalize_result(df, scheme_entry, method_name)
+        return self._finalize_result(df, scheme_entry, method_name, currency=currency)
 
     def _compute_panel_ids(self) -> None:
         """
@@ -3136,7 +3153,7 @@ class Country:
 
         if name in self.data_scheme or name in self._FOOD_DERIVED or name in self._ROSTER_DERIVED:
             def method(waves=None, market=None, labels='Preferred', age_cuts=None,
-                       units=None, volume_as_mass=True):
+                       units=None, volume_as_mass=True, currency=None):
                 if age_cuts is not None and name not in self._ROSTER_DERIVED:
                     raise TypeError(
                         f"{name}() got an unexpected keyword argument 'age_cuts'; "
@@ -3154,6 +3171,17 @@ class Country:
                         f"{name}() got an unexpected keyword argument 'volume_as_mass'; "
                         "only 'food_prices' and 'food_quantities' accept it."
                     )
+                if currency is not None:
+                    if currency not in {'index', 'column'}:
+                        raise ValueError(
+                            f"{name}() currency= must be 'index', 'column', or None; "
+                            f"got {currency!r}"
+                        )
+                    if not is_monetary_table(name, self.name):
+                        raise TypeError(
+                            f"{name}() got an unexpected keyword argument 'currency'; "
+                            "only tables with monetary columns accept it."
+                        )
                 # For derived food tables, try deriving from food_acquired first
                 # before falling back to wave-level scripts / make
                 if (name in self._FOOD_DERIVED
@@ -3177,7 +3205,8 @@ class Country:
                         if isinstance(fa, pd.DataFrame) and not fa.empty:
                             derived = transform_fn(fa, **transform_kwargs)
                             scheme_entry = self._materialization_entry(name)
-                            derived = self._finalize_result(derived, scheme_entry, name)
+                            derived = self._finalize_result(derived, scheme_entry, name,
+                                                            currency=currency)
                     except (FileNotFoundError, KeyError, ValueError, RuntimeError) as exc:
                         if units is not None:
                             # Caller explicitly asked for canonical units= behaviour;
@@ -3223,7 +3252,7 @@ class Country:
                             "Deriving %s from household_roster failed (%s); "
                             "falling back to legacy aggregation", name, exc)
 
-                result = self._aggregate_wave_data(waves, name)
+                result = self._aggregate_wave_data(waves, name, currency=currency)
                 # Apply relabeling to any table with a j index level
                 if (isinstance(result, pd.DataFrame) and not result.empty
                         and 'j' in (result.index.names or [])):
@@ -3296,6 +3325,17 @@ class Country:
                     "    compact labels ``00-03``, ``04-08``, …, ``51+``.\n"
                     "    Fractional breakpoints (e.g. ``(0.5, 1, 5)``) are\n"
                     "    allowed and trigger explicit ``[lo, hi)`` labels.\n"
+                )
+            if is_monetary_table(name, self.name):
+                doc_parts.append(
+                    "currency : {'index', 'column'}, optional\n"
+                    "    Attach the ISO 4217 currency code (resolved per wave,\n"
+                    "    e.g. UGX, NGN, XOF; GhanaLSS 2005-06 -> GHC vs 2016-17\n"
+                    "    -> GHS) to this monetary table.  ``'index'`` appends a\n"
+                    "    ``currency`` index level; ``'column'`` adds a column.\n"
+                    "    Defaults to ``None`` (omit) for single-country calls;\n"
+                    "    ``Feature(...)`` defaults to ``'index'``.  See\n"
+                    "    :func:`lsms_library.currency.attach_currency`.\n"
                 )
             method.__doc__ = "".join(doc_parts)
             method.__name__ = name

--- a/lsms_library/currency.py
+++ b/lsms_library/currency.py
@@ -1,0 +1,214 @@
+"""(country, wave) -> ISO 4217 currency labeling for monetary tables.
+
+Phase 1 ("label only") of the currency story.  Monetary columns in the
+harmonized tables (``food_expenditures.Expenditure``, ``food_prices.Price``,
+``assets.Value``, ``plot_labor.Wage``, ...) are in nominal local currency
+units.  Within a single country they are commensurable; across countries
+(``ll.Feature('food_expenditures')``) they are not -- NGN, UGX, XOF, ... at
+wildly different scales with no label.  This module is the single read-time
+mechanism that attaches an ISO 4217 alpha-3 code, and the join key for the
+planned FX / PPP / CPI conversion layer (NOT built yet).
+
+Source of truth: the ``Currency:`` section of ``lsms_library/data_info.yml``.
+Currency is keyed on **(country, wave)**, not country alone -- two in-sample
+redenominations (GhanaLSS GHC->GHS at 2007, Tajikistan TJR->TJS at 2000)
+changed both the scale and the ISO code mid-survey -- and is **not injective**
+with country (the 8 EHCVM/WAEMU countries all share XOF).
+
+Design notes
+------------
+- Applied at API read time (in ``Country._finalize_result``), *after* the
+  parquet cache read, so cached parquet shapes are never rewritten and no cache
+  invalidation is needed.
+- Off by default for single-country ``Country(...)`` calls (backward compatible
+  -- adding an index level would change the grain the CFE demand estimator
+  merges/reorders on); on (``'index'``) by default for ``Feature(...)``.
+- The set of monetary columns is the union of a built-in seed
+  (:data:`_DEFAULT_MONETARY`) and any ``monetary:`` flags declared in
+  ``data_info.yml``'s ``Columns`` section or a country's ``data_scheme.yml`` --
+  declarative and extensible without editing this module.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+from importlib.resources import files
+
+import pandas as pd
+import yaml
+
+from .paths import countries_root
+from .yaml_utils import load_yaml
+
+#: Name of the currency index level / column attached to monetary tables.
+CURRENCY_LEVEL = "currency"
+
+#: Accepted ``currency=`` representation modes (``None`` means "omit").
+_VALID_MODES = frozenset({"index", "column"})
+
+#: Built-in seed of monetary columns per table, denominated in local currency.
+#: Unioned at runtime with ``monetary: true`` flags in ``data_info.yml``'s
+#: ``Columns`` section and each country's ``data_scheme.yml``.  The derived food
+#: tables (``food_expenditures`` / ``food_prices``) are not in any
+#: ``data_scheme.yml``, so the seed is the only place they can be declared
+#: monetary.  Deflated / real columns are deliberately omitted (e.g.
+#: EthiopiaRHS ``consumption.RealConsumptionPC``).
+_DEFAULT_MONETARY: dict[str, frozenset[str]] = {
+    "food_acquired": frozenset({"Expenditure", "Price"}),
+    "food_expenditures": frozenset({"Expenditure"}),
+    "food_prices": frozenset({"Price"}),
+    "community_prices": frozenset({"Price"}),
+    "assets": frozenset({"Value", "Purchase Price"}),
+    "livestock": frozenset({"Value", "Purchase Price"}),
+    "crop_production": frozenset({"Value_sold"}),
+    "plot_labor": frozenset({"Wage"}),
+    "earnings": frozenset({"Earnings"}),
+    "income": frozenset({"income", "TotalIncome", "CropIncome",
+                         "LivestockIncome", "OffFarmIncome", "WageIncome"}),
+}
+
+
+@lru_cache(maxsize=1)
+def _load_data_info() -> dict:
+    """Parse the global ``data_info.yml`` once."""
+    info_path = files("lsms_library") / "data_info.yml"
+    with open(info_path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+@lru_cache(maxsize=None)
+def _load_country_scheme(country: str) -> dict:
+    """The ``Data Scheme`` mapping from *country*'s ``data_scheme.yml``."""
+    path = countries_root() / country / "_" / "data_scheme.yml"
+    if not path.exists():
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        data = load_yaml(f)
+    if not isinstance(data, dict):
+        return {}
+    scheme = data.get("Data Scheme", {})
+    return scheme if isinstance(scheme, dict) else {}
+
+
+def currency_for(country: str, wave: str | None = None):
+    """ISO 4217 alpha-3 code for *country* (and optional *wave*).
+
+    Resolves the ``Currency:`` section of ``data_info.yml``.  A scalar entry is
+    constant across waves; a ``{default, overrides}`` mapping applies the
+    per-wave ``overrides[wave]`` when it matches, else ``default``.
+
+    Returns :data:`pandas.NA` when the country is unknown (or, for a mapping
+    with no ``default``, the wave is unknown).
+
+    >>> currency_for('Uganda')            # doctest: +SKIP
+    'UGX'
+    >>> currency_for('GhanaLSS', '2005-06')   # doctest: +SKIP
+    'GHC'
+    >>> currency_for('GhanaLSS', '2016-17')   # doctest: +SKIP
+    'GHS'
+    """
+    spec = _load_data_info().get("Currency", {}).get(country)
+    if isinstance(spec, str):
+        return spec
+    if isinstance(spec, dict):
+        overrides = spec.get("overrides") or {}
+        if wave is not None and wave in overrides:
+            return overrides[wave]
+        return spec.get("default", pd.NA)
+    return pd.NA
+
+
+@lru_cache(maxsize=None)
+def _monetary_columns(table: str, country: str | None = None) -> frozenset[str]:
+    """Column names in *table* denominated in local currency.
+
+    Union of the built-in seed (:data:`_DEFAULT_MONETARY`), ``monetary: true``
+    flags in ``data_info.yml``'s ``Columns`` section, and (when *country* is
+    given) the country's ``data_scheme.yml``.  A column may set
+    ``monetary: false`` in either YAML source to opt out (e.g. a real / deflated
+    column); an explicit ``false`` wins.
+    """
+    cols: set[str] = set(_DEFAULT_MONETARY.get(table, frozenset()))
+    opt_out: set[str] = set()
+
+    def _scan(columns_dict) -> None:
+        if not isinstance(columns_dict, dict):
+            return
+        for col, meta in columns_dict.items():
+            if not isinstance(meta, dict):
+                continue
+            flag = meta.get("monetary")
+            if flag is True:
+                cols.add(col)
+            elif flag is False:
+                opt_out.add(col)
+
+    _scan(_load_data_info().get("Columns", {}).get(table))
+    if country:
+        _scan(_load_country_scheme(country).get(table))
+
+    return frozenset(cols - opt_out)
+
+
+def is_monetary_table(table: str, country: str | None = None) -> bool:
+    """Whether *table* carries any local-currency column (for *country*)."""
+    return bool(_monetary_columns(table, country))
+
+
+def attach_currency(df: pd.DataFrame, country: str, table: str,
+                    mode: str) -> pd.DataFrame:
+    """Attach the ISO 4217 currency label to *df* for *country* / *table*.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        A finalized table frame.  Returned unchanged if empty.
+    country, table : str
+        Used to resolve the currency and to decide whether *table* is monetary
+        (a no-op for non-monetary tables).
+    mode : {'index', 'column'}
+        ``'index'`` appends a ``currency`` index level (placed last);
+        ``'column'`` adds a ``currency`` column.
+
+    Notes
+    -----
+    The currency is resolved **per row** from the ``t`` (wave) index level, so
+    within-country redenominations (Ghana, Tajikistan) are labeled correctly;
+    when there is no ``t`` level the country default is used for every row.
+
+    pandas-3.0 / CoW safe: returns a new frame, never mutates *df* in place,
+    uses the nullable ``string`` dtype (``pd.NA`` for unknowns), and preserves
+    ``df.attrs`` (notably ``id_converted``) across the ``set_index`` mutation.
+    Idempotent: a frame already carrying a ``currency`` level/column is returned
+    unchanged.
+    """
+    if mode not in _VALID_MODES:
+        raise ValueError(
+            f"currency mode must be one of {sorted(_VALID_MODES)} or None; "
+            f"got {mode!r}"
+        )
+    if not isinstance(df, pd.DataFrame) or df.empty:
+        return df
+    if not _monetary_columns(table, country):
+        return df
+
+    names = list(df.index.names)
+    if CURRENCY_LEVEL in names or CURRENCY_LEVEL in df.columns:
+        return df  # already labeled; don't double-apply
+
+    saved_attrs = dict(df.attrs)
+
+    # Resolve per-row currency from the wave (`t`) level.
+    if "t" in names:
+        tvals = df.index.get_level_values("t")
+        uniq = {t: currency_for(country, t) for t in pd.unique(tvals)}
+        codes = [uniq[t] for t in tvals]
+    else:
+        codes = [currency_for(country, None)] * len(df)
+    currency_series = pd.Series(pd.array(codes, dtype="string"), index=df.index)
+
+    out = df.copy()
+    out[CURRENCY_LEVEL] = currency_series
+    if mode == "index":
+        out = out.set_index(CURRENCY_LEVEL, append=True)
+    out.attrs = saved_attrs
+    return out

--- a/lsms_library/data_info.yml
+++ b/lsms_library/data_info.yml
@@ -225,12 +225,14 @@ Columns:
       note: amount acquired in unit u, per acquisition source s
     Expenditure:
       type: float
+      monetary: true
       note: monetary value of the acquisition; primarily for
         s=purchased, also for s=inkind where the survey records an
         imputed value
     Price:
       type: float
       api_derived: true
+      monetary: true
       note: |
         Value per unit at the relevant point of acquisition.  Market
         price for s=purchased (Expenditure / Quantity, back-calculated
@@ -249,3 +251,78 @@ Rejected Spellings:
   # scan).  Substring rewrite is case-sensitive, so this matches 'int_t'
   # exactly without touching 'Int_t' or unrelated columns.
   int_t: Int_t
+
+# Per-country currency for monetary columns (ISO 4217 alpha-3).
+#
+# Monetary values in the harmonized tables (food_expenditures.Expenditure,
+# food_prices.Price, assets.Value, plot_labor.Wage, ...) are in nominal local
+# currency units.  Within a single country they are commensurable; across
+# countries (ll.Feature('food_expenditures')) they are not.  This section is the
+# single source of truth mapping (country, wave) -> ISO 4217 code, consumed by
+# lsms_library.currency.currency_for() and attached to monetary tables at API
+# time when the caller passes currency='index'/'column' (see currency.py).
+#
+# It is also the JOIN KEY for the planned conversion layer (FX / PPP / CPI ->
+# USD / international$ / real); that layer is NOT built yet.
+#
+# A value is either a scalar ISO code (constant across all of a country's waves)
+# or a mapping {default: CODE, overrides: {'<wave>': CODE, ...}}.  Wave keys MUST
+# be quoted strings -- they are matched against the string-valued `t` index level
+# (e.g. '2005-06', '1999'), so an unquoted 1999 (YAML int) would never match.
+#
+# Currency is a function of (country, wave), NOT country alone: two in-sample
+# redenominations changed both the SCALE and the ISO code mid-survey --
+#   * GhanaLSS: old cedi GHC -> Ghana cedi GHS at 2007 (1 GHS = 10,000 GHC).
+#   * Tajikistan: Tajikistani ruble TJR -> somoni TJS at 2000 (1 TJS = 1000 TJR).
+# Currency is also NOT injective with country: the 8 EHCVM/WAEMU countries all
+# share XOF.  Lines tagged `# VERIFY` are best-effort and should be confirmed
+# against the questionnaire/codebook before relying on them downstream.
+Currency:
+  Albania: ALL
+  Armenia: AMD
+  Azerbaijan:                       # only the 1995 wave is present (pre-2006
+    default: AZN                    # manat redenomination, 1 AZN = 5000 AZM)
+    overrides: {'1995': AZM}
+  Benin: XOF
+  Burkina_Faso: XOF
+  Cambodia: KHR
+  China: CNY
+  CotedIvoire: XOF
+  Ethiopia: ETB
+  EthiopiaRHS: ETB
+  GhanaLSS:                         # 2007 redenomination, 1 GHS = 10,000 GHC
+    default: GHS                    # (2012-13, 2016-17 -> GHS via default)
+    overrides:
+      '1987-88': GHC
+      '1988-89': GHC
+      '1991-92': GHC
+      '1998-99': GHC
+      '2005-06': GHC
+  GhanaSPS: GHS                     # waves 2009-10/2013-14/2017-18, all post-reform
+  Guatemala: GTQ
+  Guinea-Bissau: XOF
+  Guyana: GYD
+  India: INR
+  Iraq: IQD
+  Kazakhstan: KZT
+  Kosovo: EUR
+  Liberia: LRD                      # VERIFY: HIES may report USD (dual currency)
+  Malawi: MWK
+  Mali: XOF
+  Nepal: NPR
+  Niger: XOF
+  Nigeria: NGN
+  Pakistan: PKR
+  Senegal: XOF
+  Serbia: RSD                       # 2007 wave (RSD since 2006)
+  'Serbia and Montenegro':          # 2002, 2003 waves
+    default: CSD                    # Serbian dinar (CSD) from 2003
+    overrides: {'2002': YUM}        # VERIFY: Yugoslav dinar (YUM) in 2002
+  South Africa: ZAR
+  Tajikistan:                       # 2000 somoni reform, 1 TJS = 1000 TJR
+    default: TJS                    # (2003, 2007, 2009 -> TJS via default)
+    overrides: {'1999': TJR}
+  Tanzania: TZS
+  Timor-Leste: USD                  # USD official since 2000
+  Togo: XOF
+  Uganda: UGX

--- a/lsms_library/feature.py
+++ b/lsms_library/feature.py
@@ -11,6 +11,7 @@ import yaml
 from importlib.resources import files
 
 from .yaml_utils import load_yaml
+from .currency import CURRENCY_LEVEL, is_monetary_table
 from .paths import countries_root
 
 
@@ -175,7 +176,8 @@ class Feature:
             if isinstance(meta, dict) and meta.get("required", False)
         ]
 
-    def __call__(self, countries: list[str] | None = None, trust_cache: bool | None = None) -> pd.DataFrame:
+    def __call__(self, countries: list[str] | None = None, trust_cache: bool | None = None,
+                 currency: str | None = 'index') -> pd.DataFrame:
         """Load and concatenate data across countries.
 
         Parameters
@@ -185,6 +187,13 @@ class Feature:
         trust_cache : bool, optional
             If *True*, read existing cached parquets without validation.
             Defaults to the instance-level setting from ``__init__``.
+        currency : {'index', 'column', None}, optional
+            Attach the ISO 4217 currency code to monetary tables.  Defaults to
+            ``'index'`` here (cross-country stacking is exactly where mixed
+            currencies are silently incommensurable) -- unlike single-country
+            ``Country(...)`` calls, which default to ``None``.  A no-op for
+            non-monetary tables (there is nothing to label).  See
+            :func:`lsms_library.currency.attach_currency`.
 
         Returns
         -------
@@ -193,16 +202,29 @@ class Feature:
         """
         from . import Country
 
+        if currency is not None and currency not in {'index', 'column'}:
+            raise ValueError(
+                f"currency must be 'index', 'column', or None; got {currency!r}"
+            )
         effective_trust_cache = trust_cache if trust_cache is not None else self.trust_cache
         targets = countries if countries is not None else self.countries
         frames: list[pd.DataFrame] = []
         canonical_levels = _canonical_index_levels(self.table_name)
 
+        # Currency is a no-op for non-monetary tables; only pass it through (and
+        # widen the canonical index so _harmonize_country_frame keeps the level)
+        # when this feature actually has monetary columns.
+        pass_currency = currency if is_monetary_table(self.table_name) else None
+        if pass_currency == 'index' and canonical_levels:
+            canonical_levels = canonical_levels + [CURRENCY_LEVEL]
+
         for name in targets:
             try:
                 c = Country(name, trust_cache=effective_trust_cache)
                 method = getattr(c, self.table_name)
-                df = method()
+                # Only pass currency= for monetary tables (it's the generated
+                # method that accepts it); preserve the bare call otherwise.
+                df = method(currency=pass_currency) if pass_currency is not None else method()
                 if not isinstance(df, pd.DataFrame) or df.empty:
                     warnings.warn(
                         f"No data for {self.table_name} in {name}"

--- a/tests/test_currency.py
+++ b/tests/test_currency.py
@@ -1,0 +1,238 @@
+"""Tests for (country, wave) -> ISO 4217 currency labeling.
+
+Covers the data-free module logic (resolution, monetary-column detection,
+attach_currency representation modes) plus guards on the Country API; the
+cross-country Feature checks are skipped when microdata isn't available.
+
+See lsms_library/currency.py and the Currency: section of data_info.yml.
+"""
+import re
+
+import pandas as pd
+import pytest
+
+from lsms_library import currency_for, Country, Feature
+from lsms_library.catalog import _country_dirs
+from lsms_library.currency import (
+    CURRENCY_LEVEL,
+    attach_currency,
+    is_monetary_table,
+    _monetary_columns,
+)
+
+_ISO_4217 = re.compile(r"[A-Z]{3}")
+
+# The 8 EHCVM / WAEMU countries that all share the West African CFA franc.
+_XOF_COUNTRIES = [
+    "Benin", "Burkina_Faso", "CotedIvoire", "Guinea-Bissau",
+    "Mali", "Niger", "Senegal", "Togo",
+]
+
+
+# ---------------------------------------------------------------------------
+# Completeness: every country resolves to a well-formed ISO 4217 code
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("country", _country_dirs())
+def test_every_country_has_currency(country):
+    """No country may be omitted from data_info.yml's Currency: section."""
+    code = currency_for(country)
+    assert code is not pd.NA, f"{country} missing from Currency: section"
+    assert isinstance(code, str) and _ISO_4217.fullmatch(code), (
+        f"{country} default currency {code!r} is not ISO 4217 alpha-3"
+    )
+
+
+def test_unknown_country_returns_na():
+    assert currency_for("Atlantis") is pd.NA
+
+
+# ---------------------------------------------------------------------------
+# Per-wave overrides: the in-sample redenominations
+# ---------------------------------------------------------------------------
+
+def test_ghana_redenomination_per_wave():
+    # Old cedi (GHC) before the 2007 reform ...
+    for wave in ["1987-88", "1998-99", "2005-06"]:
+        assert currency_for("GhanaLSS", wave) == "GHC"
+    # ... new Ghana cedi (GHS) after, incl. the default.
+    for wave in ["2012-13", "2016-17"]:
+        assert currency_for("GhanaLSS", wave) == "GHS"
+    assert currency_for("GhanaLSS") == "GHS"
+    # GhanaSPS is entirely post-reform.
+    assert currency_for("GhanaSPS") == "GHS"
+
+
+def test_tajikistan_redenomination_per_wave():
+    assert currency_for("Tajikistan", "1999") == "TJR"   # ruble, pre-2000
+    for wave in ["2003", "2007", "2009"]:
+        assert currency_for("Tajikistan", wave) == "TJS"  # somoni
+
+
+def test_unknown_wave_falls_back_to_default():
+    assert currency_for("GhanaLSS", "2099-00") == "GHS"
+
+
+# ---------------------------------------------------------------------------
+# Currency is NOT injective with country (shared XOF)
+# ---------------------------------------------------------------------------
+
+def test_xof_shared_across_ehcvm_countries():
+    codes = {c: currency_for(c) for c in _XOF_COUNTRIES}
+    assert set(codes.values()) == {"XOF"}, codes
+
+
+# ---------------------------------------------------------------------------
+# Monetary-column detection
+# ---------------------------------------------------------------------------
+
+def test_monetary_columns_detection():
+    assert _monetary_columns("food_acquired") >= {"Expenditure", "Price"}
+    assert _monetary_columns("food_expenditures") == {"Expenditure"}
+    assert _monetary_columns("food_prices") == {"Price"}
+    assert _monetary_columns("household_roster") == frozenset()
+    assert is_monetary_table("food_expenditures")
+    assert not is_monetary_table("household_roster")
+
+
+# ---------------------------------------------------------------------------
+# attach_currency: representation modes (synthetic frame, no microdata)
+# ---------------------------------------------------------------------------
+
+def _ghana_frame():
+    """Two-row food_expenditures-shaped frame spanning the redenomination."""
+    idx = pd.MultiIndex.from_tuples(
+        [("h1", "2005-06", "rice"), ("h2", "2016-17", "rice")],
+        names=["i", "t", "j"],
+    )
+    df = pd.DataFrame({"Expenditure": [10.0, 20.0]}, index=idx)
+    df.attrs["id_converted"] = True
+    return df
+
+
+def test_attach_currency_index_mode():
+    df = _ghana_frame()
+    out = attach_currency(df, "GhanaLSS", "food_expenditures", mode="index")
+    assert out.index.names[-1] == CURRENCY_LEVEL
+    level = out.index.get_level_values(CURRENCY_LEVEL)
+    assert level.dtype == "string"
+    # Per-wave resolution: old cedi for 2005-06, new for 2016-17.
+    assert list(level) == ["GHC", "GHS"]
+    # attrs (id_converted) survives the set_index.
+    assert out.attrs.get("id_converted") is True
+    # Original frame untouched (no in-place mutation).
+    assert CURRENCY_LEVEL not in df.index.names
+
+
+def test_attach_currency_column_mode():
+    df = _ghana_frame()
+    out = attach_currency(df, "GhanaLSS", "food_expenditures", mode="column")
+    assert CURRENCY_LEVEL in out.columns
+    assert list(out[CURRENCY_LEVEL]) == ["GHC", "GHS"]
+    assert list(out.index.names) == ["i", "t", "j"]  # index unchanged
+
+
+def test_attach_currency_noop_for_non_monetary():
+    df = _ghana_frame().rename(columns={"Expenditure": "HouseholdSize"})
+    out = attach_currency(df, "GhanaLSS", "household_roster", mode="index")
+    assert out.index.names == df.index.names
+    assert CURRENCY_LEVEL not in out.columns
+
+
+def test_attach_currency_idempotent():
+    df = _ghana_frame()
+    once = attach_currency(df, "GhanaLSS", "food_expenditures", mode="index")
+    twice = attach_currency(once, "GhanaLSS", "food_expenditures", mode="index")
+    assert list(twice.index.names).count(CURRENCY_LEVEL) == 1
+
+
+def test_attach_currency_rejects_bad_mode():
+    with pytest.raises(ValueError):
+        attach_currency(_ghana_frame(), "GhanaLSS", "food_expenditures", mode="bogus")
+
+
+# ---------------------------------------------------------------------------
+# Country API guards (fire before any data load)
+# ---------------------------------------------------------------------------
+
+def test_country_guard_non_monetary_table():
+    uga = Country("Uganda", preload_panel_ids=False)
+    with pytest.raises(TypeError):
+        uga.household_roster(currency="index")
+
+
+def test_country_guard_bad_mode():
+    uga = Country("Uganda", preload_panel_ids=False)
+    with pytest.raises(ValueError):
+        uga.food_expenditures(currency="bogus")
+
+
+def test_country_default_is_backward_compatible():
+    """Default call must NOT carry a currency level (grain unchanged)."""
+    uga = Country("Uganda", preload_panel_ids=False)
+    try:
+        df = uga.food_expenditures()
+    except Exception as exc:  # microdata unavailable in this environment
+        pytest.skip(f"food_expenditures unavailable: {exc}")
+    if df.empty:
+        pytest.skip("food_expenditures empty (no microdata)")
+    assert CURRENCY_LEVEL not in df.index.names
+    assert CURRENCY_LEVEL not in df.columns
+
+
+def test_country_currency_index_roundtrip():
+    uga = Country("Uganda", preload_panel_ids=False)
+    try:
+        df = uga.food_expenditures(currency="index")
+    except Exception as exc:
+        pytest.skip(f"food_expenditures unavailable: {exc}")
+    if df.empty:
+        pytest.skip("food_expenditures empty (no microdata)")
+    assert df.index.names[-1] == CURRENCY_LEVEL
+    assert set(df.index.get_level_values(CURRENCY_LEVEL).dropna().unique()) == {"UGX"}
+
+
+# ---------------------------------------------------------------------------
+# Cross-country Feature (skipped when microdata unavailable)
+# ---------------------------------------------------------------------------
+
+def test_feature_xof_consistency():
+    try:
+        f = Feature("food_expenditures")(["Mali", "Niger"])
+    except Exception as exc:
+        pytest.skip(f"Feature unavailable: {exc}")
+    if f.empty or CURRENCY_LEVEL not in f.index.names:
+        pytest.skip("Mali/Niger food_expenditures unavailable")
+    codes = set(f.index.get_level_values(CURRENCY_LEVEL).dropna().unique())
+    assert codes == {"XOF"}, codes
+
+
+def test_feature_ghana_per_wave():
+    try:
+        g = Feature("food_expenditures")(["GhanaLSS"])
+    except Exception as exc:
+        pytest.skip(f"Feature unavailable: {exc}")
+    if g.empty or CURRENCY_LEVEL not in g.index.names:
+        pytest.skip("GhanaLSS food_expenditures unavailable")
+    flat = g.reset_index()
+    by_wave = flat.groupby("t")[CURRENCY_LEVEL].agg(
+        lambda s: set(s.dropna().unique())
+    )
+    if "2005-06" in by_wave.index:
+        assert by_wave.loc["2005-06"] == {"GHC"}
+    post = [w for w in ("2012-13", "2016-17") if w in by_wave.index]
+    for w in post:
+        assert by_wave.loc[w] == {"GHS"}
+    assert post or "2005-06" in by_wave.index, "no GhanaLSS waves materialized"
+
+
+def test_feature_non_monetary_unaffected():
+    """Default currency='index' must be a silent no-op for non-monetary tables."""
+    try:
+        r = Feature("household_roster")(["Uganda"])
+    except Exception as exc:
+        pytest.skip(f"Feature unavailable: {exc}")
+    if r.empty:
+        pytest.skip("Uganda household_roster unavailable")
+    assert CURRENCY_LEVEL not in r.index.names
+    assert CURRENCY_LEVEL not in r.columns


### PR DESCRIPTION
## What

Attaches an **ISO 4217 alpha-3 currency code** to monetary tables, so cross-country `ll.Feature('food_expenditures')` no longer stacks NGN/UGX/XOF/... at wildly different scales with no label. Useful on its own ("harmonize the interface, not the data") and the **join key** for a later FX/PPP/CPI conversion layer (**not** built here — phase 1 is label-only).

## Design (decisions locked with @ligon)

- **Generic** across all monetary tables (`food_*`, `assets`, `livestock`, `plot_labor.Wage`, `income`, `earnings`, prices), not just `food_expenditures`.
- **Representation is a user option**: `currency='index'` (append an index level), `'column'`, or `None`.
- **Keyed on (country, wave), not country** — this is load-bearing. Two in-sample redenominations changed both *scale* and *ISO code* mid-survey:
  - GhanaLSS: GHC → GHS at 2007 (1 GHS = 10,000 GHC) — `2005-06`→GHC, `2012-13`/`2016-17`→GHS
  - Tajikistan: TJR → TJS at 2000 (1 TJS = 1000 TJR) — `1999`→TJR
  
  Plus code-only cases (Azerbaijan, Serbia-and-Montenegro). Currency is also **not injective** with country: the 8 EHCVM/WAEMU countries all share XOF.
- **Defaults**: OFF for single-country `Country(...)` calls (backward-compatible — the grain `cfe.Regression` merges/reorders on is unchanged); **`'index'`** for `Feature(...)` (where mixed currencies are silently wrong).
- Applied at API read time, **after** the parquet cache read → cached parquet shapes are never rewritten, no cache invalidation. Survives `market=` / `labels=` and coexists with the `u` unit level on `food_prices`.

## Files

| File | Change |
|---|---|
| `data_info.yml` | new `Currency:` section (all 34 countries + GhanaSPS); `monetary: true` flags |
| `currency.py` (new) | `currency_for`, `is_monetary_table`/`_monetary_columns`, `attach_currency` |
| `country.py` | `currency=` kwarg threaded through `method()` → `_aggregate_wave_data` → `_finalize_result`; guards |
| `feature.py` | `currency='index'` default; no-op for non-monetary; widens `canonical_levels` |
| `__init__.py` | re-export `currency_for` |
| `tests/test_currency.py` (new) | resolution, per-wave redenomination, XOF, attach modes, guards, Feature |

## Usage

```python
import lsms_library as ll
ll.Country('Uganda').food_expenditures(currency='index')   # +currency level (UGX)
ll.Feature('food_expenditures')(['Mali','Niger'])          # currency level = XOF (default on)
ll.currency_for('GhanaLSS','2005-06')  # 'GHC';  ('GhanaLSS','2016-17') -> 'GHS'
```

## Tests

- `tests/test_currency.py`: **50 passed, 1 skipped** (skip = pre-existing GhanaLSS `food_acquired` build issue).
- `test_schema_consistency` 207, `test_feature` 16 — green.
- `test_table_structure` + `test_uganda_tables`: 623 passed, 9 skipped, **3 failed** — all `GhanaLSS/food_acquired`, **proven pre-existing** (fail identically on a clean baseline after `git stash` of this change set; root cause is a build error in `GhanaLSS/2016-17/_/food_acquired.py:117`).

## Reviewer notes / follow-ups

- A few `# VERIFY` currency codes need a domain eyeball: **Liberia** (LRD vs USD — HIES may be dual-currency), **Serbia and Montenegro 2002** (YUM vs CSD), Timor-Leste USD.
- **Phase 2** (conversion: FX/PPP/CPI → USD/intl\$/real) is unblocked by this — `currency_for()` + the `monetary:` flags are the inputs it consumes.
- Pre-existing GhanaLSS `food_acquired.py:117` build bug is **out of scope** here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)