### PR TITLE
fix(#466): mark EHCVM crop_production harvest_month optional

### DIFF
--- a/lsms_library/countries/Benin/_/data_scheme.yml
+++ b/lsms_library/countries/Benin/_/data_scheme.yml
@@ -149,7 +149,9 @@ Data Scheme:
     Quantity: float
     Quantity_sold: float
     Value_sold: float
-    harvest_month: float
+    harvest_month:
+      type: float
+      optional: true
     intercropped: bool
     materialize: make
 

--- a/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
+++ b/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
@@ -189,7 +189,9 @@ Data Scheme:
     Quantity: float
     Quantity_sold: float
     Value_sold: float
-    harvest_month: float
+    harvest_month:
+      type: float
+      optional: true
     intercropped: bool
     materialize: make
 

--- a/lsms_library/countries/CotedIvoire/_/data_scheme.yml
+++ b/lsms_library/countries/CotedIvoire/_/data_scheme.yml
@@ -171,7 +171,9 @@ Data Scheme:
     Quantity: float
     Quantity_sold: float
     Value_sold: float
-    harvest_month: float
+    harvest_month:
+      type: float
+      optional: true
     intercropped: bool
     materialize: make
 

--- a/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
+++ b/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
@@ -162,7 +162,9 @@ Data Scheme:
     Quantity: float
     Quantity_sold: float
     Value_sold: float
-    harvest_month: float
+    harvest_month:
+      type: float
+      optional: true
     intercropped: bool
     materialize: make
 

--- a/lsms_library/countries/Senegal/_/data_scheme.yml
+++ b/lsms_library/countries/Senegal/_/data_scheme.yml
@@ -164,7 +164,9 @@ Data Scheme:
     Quantity: float
     Quantity_sold: float
     Value_sold: float
-    harvest_month: float
+    harvest_month:
+      type: float
+      optional: true
     intercropped: bool
     materialize: make
 

--- a/lsms_library/countries/Togo/_/data_scheme.yml
+++ b/lsms_library/countries/Togo/_/data_scheme.yml
@@ -149,7 +149,9 @@ Data Scheme:
     Quantity: float
     Quantity_sold: float
     Value_sold: float
-    harvest_month: float
+    harvest_month:
+      type: float
+      optional: true
     intercropped: bool
     materialize: make
 


### PR DESCRIPTION
## Summary

All 6 EHCVM `crop_production` builds (Benin, Burkina_Faso, CotedIvoire,
Guinea-Bissau, Senegal, Togo) declare `harvest_month` as a **required** `float`,
but the EHCVM s16c module has no harvest-date question, so each wave script
hardcodes the column to `pd.NA`. The all-null column fails
`no_all_null_columns` / `test_feature_is_sane` on any honest build. This marks
`harvest_month` `optional: true` in those 6 `_/data_scheme.yml` blocks — the
established convention for genuinely-unavailable columns.

**Closes #466.**

## Why optional (not drop, not populate)

- `harvest_month` is genuinely all-null for **all 6** EHCVM countries (verified
  on fresh `LSMS_NO_CACHE=1` builds: Benin 0/9056, Togo 0/11563, Burkina_Faso
  0/15587, Senegal 0/8416, Guinea-Bissau 0/10579, CotedIvoire 0/22216) — so
  `optional` masks no real data.
- It is **not** a removal candidate: **Malawi populates `harvest_month` for
  126637/128006 rows**, and Nigeria/Ethiopia/Malawi all declare it. Keeping the
  column present-but-optional preserves a uniform cross-country interface.
- `optional: true` is the house convention (17 countries use it), honored by
  `_check_no_all_null_columns` and `_check_declared_columns` via the
  extended-syntax parser (`diagnostics.py:181-184`).

## Verification

- Sanity check `no_all_null_columns`: **FAIL → PASS**.
- `test_feature_is_sane[Senegal/crop_production]`: **FAIL → PASS**;
  `household_roster` unaffected.
- No downstream consumer of `harvest_month` (`crop_production` feeds
  `area_output`/`harvest_kg`/`yield_kg`, none read it).
- **Independently adversarially reviewed** (separate agent re-ran all builds and
  tests; verdict SOUND, no holes).

Config-only; 6 files, +18/-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)