### PR TITLE
fix(s3): retry transient TLS errors on blob fetch; document LSMS_MAKE_JOBS

### DIFF
--- a/docs/guide/caching.md
+++ b/docs/guide/caching.md
@@ -294,3 +294,22 @@ Make-based builds default to half of available CPU cores. Override with:
 ```bash
 export LSMS_MAKE_JOBS=4
 ```
+
+A country-level build fans out to one `python <table>.py` per wave, so `-jN`
+runs `N` wave builds — and therefore `N` concurrent large-blob S3 fetches — in
+parallel. On most hosts that is pure speedup. On a host where **concurrent
+multipart S3 reads occasionally corrupt a TLS record under load** (symptoms:
+`ssl.SSLError: ... DECRYPTION_FAILED_OR_BAD_RECORD_MAC`, or
+`aiohttp.ClientPayloadError: Response payload is not completed`, mid-build), the
+fix is *not* a network change — connectivity is fine and a single fetch
+succeeds. Two levers:
+
+```bash
+export LSMS_MAKE_JOBS=1      # serialize wave builds (one S3 fetch at a time)
+export LSMS_FETCH_ATTEMPTS=5 # or: keep parallelism, retry transient TLS errors
+```
+
+The blob fetch (`local_tools._get_file_with_retry`) already retries these
+transient errors (`LSMS_FETCH_ATTEMPTS`, default 3) with exponential backoff
+before falling back to a single-stream read, so most such hiccups self-heal
+without touching `-j`. Reach for `LSMS_MAKE_JOBS=1` only if they persist.

--- a/lsms_library/__init__.py
+++ b/lsms_library/__init__.py
@@ -80,6 +80,12 @@ Environment variables
 - ``LSMS_BUILD_BACKEND=make`` — force rebuild from source, bypassing
   both the cache and the DVC stage layer.
 - ``LSMS_SKIP_AUTH`` — suppress the import-time authentication attempt.
+- ``LSMS_MAKE_JOBS`` — make ``-j`` parallelism for source rebuilds
+  (default ``cpu_count // 2``). A country build runs one wave build per
+  job, i.e. that many concurrent large S3 fetches; set ``LSMS_MAKE_JOBS=1``
+  to serialize them on hosts where concurrent multipart reads are flaky.
+- ``LSMS_FETCH_ATTEMPTS`` — retry budget (default ``3``) for a single
+  blob's S3 fetch on a transient TLS error before falling back to streaming.
 
 Further reading
 ---------------

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -315,6 +315,13 @@ def _make_jobs_flag() -> str | None:
     """
     Determine an appropriate make -j flag based on environment or CPU count.
     Returns the flag string (e.g. '-j4') or None if no parallelism is desired.
+
+    ``LSMS_MAKE_JOBS`` overrides the default (``cpu_count // 2``).  A
+    country-level build fans out to one ``python <table>.py`` per wave, so
+    ``-jN`` runs N wave builds -- and thus N concurrent large-blob S3 fetches --
+    in parallel.  On a host where concurrent multipart S3 reads occasionally
+    corrupt a TLS record under load (see ``local_tools._get_file_with_retry``,
+    which retries those), set ``LSMS_MAKE_JOBS=1`` to serialize the fetches.
     """
     make_jobs = os.getenv("LSMS_MAKE_JOBS")
     if make_jobs:

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -78,6 +78,7 @@ from pathlib import Path
 import os
 import ast
 import hashlib
+import ssl
 import time
 import uuid
 from importlib.resources import files
@@ -147,6 +148,70 @@ def _dvc_working_directory(path):
         yield
     finally:
         os.chdir(previous)
+
+
+#: Bounded retry for a single-blob S3 fetch before giving up to the streaming
+#: fallback (see :func:`_get_file_with_retry`).  Overridable via env for
+#: constrained / flaky-egress hosts.
+_FETCH_ATTEMPTS = int(os.getenv("LSMS_FETCH_ATTEMPTS", "3"))
+_FETCH_BASE_DELAY = 0.5  # seconds; doubled per retry
+
+
+def _is_transient_fetch_error(exc: BaseException) -> bool:
+    """Whether *exc* is a transient remote-read error worth retrying.
+
+    Concurrent multipart S3 downloads (s3fs ``_download_file_part_concurrent``)
+    occasionally corrupt a TLS record under heavy parallel load -- e.g. a
+    ``make -jN`` country build fetching several large ``.dta`` blobs at once --
+    raising ``ssl.SSLError('... DECRYPTION_FAILED_OR_BAD_RECORD_MAC ...')`` or
+    ``aiohttp.ClientPayloadError('Response payload is not completed')``.  These
+    are not connectivity failures (a retry succeeds) and not the same as
+    ``FileNotFoundError`` (wrong cache layout), which must NOT be retried.
+    """
+    if isinstance(exc, FileNotFoundError):
+        return False
+    if isinstance(exc, (ConnectionError, TimeoutError, ssl.SSLError)):
+        return True
+    name = type(exc).__name__
+    msg = str(exc)
+    return (
+        name in {"ClientPayloadError", "ClientError", "ClientOSError",
+                 "ServerTimeoutError", "ServerDisconnectedError",
+                 "IncompleteRead", "ReadTimeoutError", "ConnectTimeoutError"}
+        or "DECRYPTION_FAILED" in msg
+        or "BAD_RECORD_MAC" in msg
+        or "payload is not completed" in msg
+    )
+
+
+def _get_file_with_retry(fs, src: str, dst: str, *,
+                         attempts: int | None = None,
+                         base_delay: float = _FETCH_BASE_DELAY,
+                         sleep=time.sleep) -> None:
+    """``fs.get_file(src, dst)`` with bounded retry on transient TLS errors.
+
+    Re-raises ``FileNotFoundError`` immediately (the caller then tries the next
+    cache layout).  Retries transient errors (see
+    :func:`_is_transient_fetch_error`) with exponential backoff, cleaning up any
+    partial ``dst`` between attempts; re-raises once ``attempts`` is exhausted
+    or the error is non-transient (the caller then falls through to the
+    streaming fallback).  ``sleep`` is injectable for tests.
+    """
+    attempts = attempts if attempts is not None else _FETCH_ATTEMPTS
+    for attempt in range(max(1, attempts)):
+        try:
+            fs.get_file(src, dst)
+            return
+        except FileNotFoundError:
+            raise
+        except Exception as exc:  # noqa: BLE001 -- classify, then retry or re-raise
+            try:
+                Path(dst).unlink()
+            except OSError:
+                pass
+            if attempt + 1 >= attempts or not _is_transient_fetch_error(exc):
+                raise
+            sleep(base_delay * (2 ** attempt))
 
 
 def _ensure_dvc_pulled(fn) -> None:
@@ -304,14 +369,16 @@ def _ensure_dvc_pulled(fn) -> None:
         tmp = dst.with_suffix(dst.suffix + f".tmp.{os.getpid()}")
         for src in src_candidates:
             try:
-                fs.get_file(src, str(tmp))
+                _get_file_with_retry(fs, src, str(tmp))
                 tmp.rename(dst)
                 return
             except FileNotFoundError:
-                continue  # try the other layout
-            except OSError:
-                # Network / permission / disk error.  Clean up the tmp
-                # file if any partial write happened.
+                continue  # wrong layout -- try the other one
+            except Exception:  # noqa: BLE001
+                # Transient retries exhausted, or a non-transient remote / disk
+                # error (incl. aiohttp ClientPayloadError, not an OSError).
+                # Clean up any partial temp and fall through to the streaming
+                # fallback at the call site -- this function swallows by design.
                 try:
                     tmp.unlink()
                 except OSError:

--- a/tests/test_s3_fetch_retry.py
+++ b/tests/test_s3_fetch_retry.py
@@ -1,0 +1,71 @@
+"""Unit tests for the transient-S3-error retry in local_tools.
+
+Concurrent multipart S3 reads under heavy parallel build load (make -jN
+fetching several large .dta blobs at once) occasionally corrupt a TLS record
+(`ssl.SSLError: ... DECRYPTION_FAILED_OR_BAD_RECORD_MAC`) or truncate a payload
+(`aiohttp.ClientPayloadError`).  `_get_file_with_retry` retries those; it must
+NOT retry `FileNotFoundError` (wrong cache layout) or non-transient errors.
+"""
+import ssl
+
+import pytest
+
+from lsms_library.local_tools import (
+    _get_file_with_retry,
+    _is_transient_fetch_error,
+)
+
+_NOSLEEP = lambda _delay: None  # noqa: E731 -- keep tests instant
+
+
+class _FakeFS:
+    """fs.get_file that raises a queued sequence of errors, then succeeds."""
+
+    def __init__(self, errors):
+        self.errors = list(errors)
+        self.calls = 0
+
+    def get_file(self, src, dst):
+        self.calls += 1
+        if self.errors:
+            raise self.errors.pop(0)
+
+
+def test_retry_succeeds_after_transient_tls_errors():
+    fs = _FakeFS([ssl.SSLError("DECRYPTION_FAILED_OR_BAD_RECORD_MAC")] * 2)
+    _get_file_with_retry(fs, "src", "/tmp/nope.blob", attempts=3, sleep=_NOSLEEP)
+    assert fs.calls == 3  # two failures + one success
+
+
+def test_file_not_found_is_not_retried():
+    fs = _FakeFS([FileNotFoundError("wrong layout")])
+    with pytest.raises(FileNotFoundError):
+        _get_file_with_retry(fs, "src", "/tmp/nope.blob", attempts=3, sleep=_NOSLEEP)
+    assert fs.calls == 1  # caller tries the next layout, no retry
+
+
+def test_non_transient_error_is_not_retried():
+    fs = _FakeFS([ValueError("programmer bug")])
+    with pytest.raises(ValueError):
+        _get_file_with_retry(fs, "src", "/tmp/nope.blob", attempts=3, sleep=_NOSLEEP)
+    assert fs.calls == 1
+
+
+def test_exhausts_attempts_then_reraises():
+    fs = _FakeFS([ssl.SSLError("BAD_RECORD_MAC")] * 5)
+    with pytest.raises(ssl.SSLError):
+        _get_file_with_retry(fs, "src", "/tmp/nope.blob", attempts=3, sleep=_NOSLEEP)
+    assert fs.calls == 3  # capped at attempts
+
+
+def test_classifier():
+    assert _is_transient_fetch_error(ssl.SSLError("x"))
+    assert _is_transient_fetch_error(ConnectionError())
+    assert _is_transient_fetch_error(TimeoutError())
+    assert not _is_transient_fetch_error(FileNotFoundError())
+    assert not _is_transient_fetch_error(ValueError("x"))
+
+    class ClientPayloadError(Exception):
+        pass
+
+    assert _is_transient_fetch_error(ClientPayloadError("Response payload is not completed"))


### PR DESCRIPTION
## Problem

During large parallel builds (a country `make -jN` build fans out to one `python <table>.py` per wave, so N large-blob S3 fetches run at once), s3fs's concurrent multipart download occasionally corrupts a TLS record:

- `ssl.SSLError: [SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC]`
- `aiohttp.ClientPayloadError: Response payload is not completed`

This is **not** a connectivity problem. A standalone MWE confirmed: HEAD 0.02s, a sequential read of the full 284 MB blob at **~30 MB/s**, and `get_file` (concurrent multipart) **3/3 OK** in isolation. The corruption only appears under concurrent multi-file load, and a retry succeeds — classic flaky-TLS-under-concurrency, not a network or data bug. (It's also what produced my earlier false "GhanaLSS rebuild fails" on #453, now corrected there.)

## Fix

- **`local_tools._get_file_with_retry`** wraps `fs.get_file` with bounded exponential-backoff retry on transient errors:
  - `FileNotFoundError` → re-raised immediately (caller tries the next DVC cache layout — *not* a transient).
  - transient (`SSLError`/`ConnectionError`/`TimeoutError`/`ClientPayloadError`/`IncompleteRead`, by type-name + message) → retry up to `LSMS_FETCH_ATTEMPTS` (default 3), cleaning up the partial temp between attempts.
  - non-transient or exhausted → re-raise; the fetch loop falls through to the single-stream `DVCFS.open` fallback.
  - The loop now also catches non-`OSError` transients (`ClientPayloadError`) instead of letting them escape the best-effort fetcher.
- **Keep the adaptive `-j` default** (`cpu//2`); document **`LSMS_MAKE_JOBS=1`** as the serialize-the-fetches lever in `_make_jobs_flag`, the package env-var docstring, and `docs/guide/caching.md` → Build Parallelism. Retrying (above) is the preferred mitigation since it keeps parallelism.

## Tests
`tests/test_s3_fetch_retry.py` (5): retry-then-succeed, `FileNotFoundError` not retried, non-transient not retried, attempts exhausted, classifier. `test_dvc_caching.py` + retry: **43 passed**, no regression; package import clean; live cache-hit path unaffected.

## Scope
Independent of the currency work (PRs #478 merged / #481 open) — this is the S3 fetch layer. Based on `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)