### PR TITLE
fix(#170): close Malawi Floor title-case leak (Smoothed Mud / Smooth Cement)

### DIFF
--- a/lsms_library/countries/Malawi/_/categorical_mapping.org
+++ b/lsms_library/countries/Malawi/_/categorical_mapping.org
@@ -457,8 +457,10 @@
 |--------------------+-----------------|
 | Smoothed mud       | Earth           |
 | SMOOTHED MUD       | Earth           |
+| Smoothed Mud       | Earth           |
 | Smooth cement      | Cement          |
 | SMOOTH CEMENT      | Cement          |
+| Smooth Cement      | Cement          |
 | Sand               | Sand            |
 | sand               | Sand            |
 | SAND               | Sand            |


### PR DESCRIPTION
## Summary

`Country('Malawi').housing()['Floor']` leaked two un-canonicalized values —
**`Smoothed Mud` (8,658 rows)** and **`Smooth Cement` (2,244 rows)**. Malawi
2004-05's inline `mapping:` emits these in Title Case, but the `Floor`
categorical-mapping table only enumerated the lower-case (`Smoothed mud`,
`Smooth cement`) and UPPER-CASE (`SMOOTHED MUD`, `SMOOTH CEMENT`) variants.

Add the two Title-Case spellings (`Smoothed Mud → Earth`, `Smooth Cement →
Cement`), matching the table's existing case-variant pattern.

## Verification (read-time mapping; no rebuild needed)

| value | before | after |
|---|---|---|
| Earth | 30,902 | **39,560** (+8,658) |
| Cement | 13,581 | **15,825** (+2,244) |
| Smoothed Mud | 8,658 | — (gone) |
| Smooth Cement | 2,244 | — (gone) |

Counts reconcile exactly; no other Floor value changed.

## Scope

A concrete, self-contained gap surfaced while triaging #170 (cross-country
housing harmonization). This does **not** close #170 — the broader 11-country
Roof/Floor rollout remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)