### PR TITLE
fix(GhanaLSS): 2016-17 food_acquired from _small + org unit labels (closes #453, #384)

### DIFF
--- a/lsms_library/countries/GhanaLSS/2016-17/_/food_acquired.py
+++ b/lsms_library/countries/GhanaLSS/2016-17/_/food_acquired.py
@@ -22,14 +22,20 @@ Sources:
         s8hq{i}p = selling price -> Price (farmgate)
     -> s='produced'.  No produced expenditure column -> Expenditure = NaN.
 
-Unit decode (D-units / GH #348):
-  The full g7sec9b/g7sec8h .dta carry Stata value labels on the unit columns, so
-  convert_categoricals=True yields native unit *label strings* (e.g. 'Heap').
-  Production labels are prefixed with the numeric code ("7. Bowl"); the prefix is
-  stripped.  Both are then mapped through the country-level unit_label org table
-  (raw label string -> canonical Preferred Label) so `u` holds clean labels with
-  no leading digits (leak audit clean).  NB: g7sec9b_small.dta does NOT carry the
-  value labels, so we read the full g7sec9b.dta here.
+Unit decode (D-units / GH #348, #453, #384):
+  - 9B (purchases): the full g7sec9b.dta is 3.2 GB (a dense food x household
+    matrix), so we read the 284 MB g7sec9b_small.dta -- which carries the
+    numeric s9bq*c unit codes but NO Stata value labels.  The code -> native
+    label map was lifted once from the full file's value labels (metadata-only
+    read) into categorical_mapping.org (#+name: unit_9b); decode_unit_code_9b
+    turns each numeric code into its native label.
+  - 8H (production): g7sec8h.dta is only 99 MB, so it is read categorically
+    (convert_categoricals=True) to get native unit label strings directly.
+    Its labels are prefixed with the numeric code ("7. Bowl"); the prefix is
+    stripped.
+  Both paths then map the native label through the country-level unit_label org
+  table (raw label string -> canonical Preferred Label) so `u` holds clean
+  labels with no leading digits (leak audit clean).
 """
 import re
 import warnings
@@ -69,14 +75,37 @@ def decode_unit(label):
     return _unit_map.get(s, pd.NA)
 
 
+# --- 9B units: numeric code -> native label, lifted once from the full
+# g7sec9b.dta's Stata value labels into categorical_mapping.org (unit_9b) so the
+# build reads the 284 MB g7sec9b_small.dta (no value labels) instead of the
+# 3.2 GB full file.  See #453 / #384.
+_u9b = df_from_orgfile('../../_/categorical_mapping.org', name='unit_9b').dropna()
+_unit_code_9b = dict(zip(_u9b['Code'].astype(int),
+                         _u9b['Label'].astype(str).str.strip()))
+
+
+def decode_unit_code_9b(code):
+    """9B numeric unit code -> canonical Preferred Label (code -> native -> PL)."""
+    if pd.isna(code):
+        return pd.NA
+    try:
+        native = _unit_code_9b.get(int(code))
+    except (ValueError, TypeError):
+        return pd.NA
+    return decode_unit(native) if native is not None else pd.NA
+
+
 def _stack_visits(df_num, df_cat, visits, qty_stem, unit_stem, label_map,
-                  item_col, exp_stem=None, price_stem=None):
+                  item_col, exp_stem=None, price_stem=None, unit_decoder=None):
     """Reshape one source module (one row per HH x item) into long form.
 
     `df_num` (convert_categoricals=False) supplies the numeric food codes and
-    amounts; `df_cat` (convert_categoricals=True) supplies the decoded unit
-    *label strings* for the unit columns.  The two reads are the same source
-    rows in the same order, so columns line up positionally.
+    amounts.  Units are decoded either from numeric codes in `df_num` via
+    `unit_decoder` (a code -> Preferred Label callable -- used for 9B, which
+    reads the small label-less file) or, when `unit_decoder` is None, from the
+    decoded *label strings* in `df_cat` (convert_categoricals=True; used for 8H,
+    whose source is small enough to read categorically).  `df_num`/`df_cat` are
+    the same source rows in the same order, so columns line up positionally.
 
     Stacks each visit into rows; emits columns Quantity/u (+ optional
     Expenditure, Price) with i (household), j (harmonized item), visit.
@@ -87,8 +116,12 @@ def _stack_visits(df_num, df_cat, visits, qty_stem, unit_stem, label_map,
 
     frames = []
     for v in visits:
+        if unit_decoder is not None:
+            u_vals = df_num[unit_stem.format(v=v)].apply(unit_decoder).values
+        else:
+            u_vals = df_cat[unit_stem.format(v=v)].apply(decode_unit).values
         cols = {'Quantity': _to_numeric(df_num[qty_stem.format(v=v)]).values,
-                'u': df_cat[unit_stem.format(v=v)].apply(decode_unit).values}
+                'u': u_vals}
         if exp_stem is not None:
             cols['Expenditure'] = _to_numeric(df_num[exp_stem.format(v=v)]).values
         if price_stem is not None:
@@ -114,12 +147,14 @@ purch_labels = get_categorical_mapping(
     tablename='harmonize_food',
     idxvars={'Code': ('Code_9b', format_id)}, **{'Label': 'Preferred Label'})
 
-num9b = get_dataframe('../Data/g7sec9b.dta', convert_categoricals=False)
-cat9b = get_dataframe('../Data/g7sec9b.dta', convert_categoricals=True)
-fe = _stack_visits(num9b, cat9b, range(1, 7),
+# Read the 284 MB g7sec9b_small.dta (NOT the 3.2 GB full g7sec9b.dta): _small
+# lacks value labels, but units are now decoded from numeric s9bq*c codes via
+# the unit_9b org table (decode_unit_code_9b).  See #453 / #384.
+num9b = get_dataframe('../Data/g7sec9b_small.dta', convert_categoricals=False)
+fe = _stack_visits(num9b, None, range(1, 7),
                    qty_stem='s9bq{v}b', unit_stem='s9bq{v}c',
                    label_map=purch_labels, item_col='freqcd',
-                   exp_stem='s9bq{v}a')
+                   exp_stem='s9bq{v}a', unit_decoder=decode_unit_code_9b)
 fe['s'] = 'purchased'
 
 

--- a/lsms_library/countries/GhanaLSS/_/categorical_mapping.org
+++ b/lsms_library/countries/GhanaLSS/_/categorical_mapping.org
@@ -36,3 +36,88 @@ See https://microdata.worldbank.org/index.php/catalog/2313/data-dictionary/F184?
 |   12 | Servant               |
 |   13 | Tenant                |
 |   14 | Others not related    |
+
+* Units (Section 9B, GLSS7 / 2016-17)
+Stata value labels for the =s9bq*c= unit columns, lifted once from the full
+=g7sec9b.dta= (the 3.2 GB dense file) via a metadata-only read so the build can
+read the 284 MB =g7sec9b_small.dta= (which carries no value labels) instead of
+the full file.  Code -> native label; canonicalized to Preferred Label through
+=unit_labels.org= at build time.  See #453 / #384.
+#+name: unit_9b
+| Code | Label                         |
+|------+-------------------------------|
+|    1 | American Tin (Olonka)         |
+|    2 | Balls                         |
+|    3 | Bar                           |
+|    4 | Barrel                        |
+|    5 | Basket                        |
+|    6 | Beer bottle                   |
+|    7 | Bowl                          |
+|    8 | Box/Carton                    |
+|    9 | Bucket                        |
+|   10 | Bunch                         |
+|   11 | Bundle                        |
+|   12 | Crate                         |
+|   13 | Dozen                         |
+|   14 | Fanta bottle                  |
+|   15 | Fingers                       |
+|   16 | Litres                        |
+|   17 | Loaf                          |
+|   18 | Log                           |
+|   19 | Margarin tin                  |
+|   20 | Maxi bag                      |
+|   21 | Mini bag                      |
+|   22 | Packet                        |
+|   23 | Pair                          |
+|   24 | Piece                         |
+|   25 | Pot                           |
+|   26 | Pound                         |
+|   27 | Satchet                       |
+|   28 | Set                           |
+|   29 | Sheet                         |
+|   30 | Single                        |
+|   31 | Stick                         |
+|   32 | Tree                          |
+|   33 | Tubers                        |
+|   34 | Yards                         |
+|   35 | Meter                         |
+|   36 | Drum                          |
+|   37 | 1000 kg /metric tonnes/tonnes |
+|   38 | Millilitre                    |
+|   39 | Ream                          |
+|   40 | Watts                         |
+|   41 | Kilowatts                     |
+|   42 | Megawatts                     |
+|   43 | Volt                          |
+|   44 | Kilovolt                      |
+|   45 | Acre                          |
+|   46 | Hectare                       |
+|   47 | Ounce                         |
+|   48 | Gigabyte                      |
+|   49 | Tetrabyte                     |
+|   50 | Gigawatts                     |
+|   51 | Kelvin                        |
+|   52 | Mole                          |
+|   53 | Ampere                        |
+|   54 | Kilojoules                    |
+|   55 | Carat                         |
+|   56 | Rolls                         |
+|   57 | Coil                          |
+|   58 | Bail                          |
+|   59 | Inches                        |
+|   60 | Blister / Strip               |
+|   61 | Feet                          |
+|   62 | Plot                          |
+|   63 | Plate (food)                  |
+|   64 | Room                          |
+|   65 | Ampoule                       |
+|   66 | Heap                          |
+|   67 | Tin                           |
+|   68 | Kilometre                     |
+|   69 | Hours                         |
+|   70 | Minutes                       |
+|   71 | Tot (25mls)                   |
+|   72 | Visit                         |
+|   73 | Kilogram                      |
+|   74 | Gram                          |
+|   99 | Other unit                    |


### PR DESCRIPTION
## Root cause

GhanaLSS 2016-17 `food_acquired.py` read the full `g7sec9b.dta` **twice** (numeric + `convert_categoricals=True`). That file is a **3.2 GB dense food×household matrix** (a row per food per household, mostly empty), so the categorical read made the build impractically slow/heavy — it never completed honestly. The passing-looking state was a **stale cached parquet** that lacked canonical `Quantity`/`u`/`s` (the #453 symptom), and the GLSS7 units map was empty (#384). `g7sec9b_small.dta` (284 MB) exists precisely to avoid the full file, but the script reached for the full one only to decode the `s9bq*c` unit value-labels.

## Fix — never read the 3.2 GB file at build time

1. **Lift the unit value-labels once** (`pyreadstat` metadata-only read of the full file) into `categorical_mapping.org` → `#+name: unit_9b` (code → native label). *This is the #384 GLSS7 units map.*
2. `food_acquired.py` now reads the **284 MB `g7sec9b_small.dta`** (numeric; no value labels) and decodes `s9bq*c` codes via `unit_9b` → `decode_unit` → `Preferred Label` (`decode_unit_code_9b`). 8H (99 MB) is unchanged. `_stack_visits` gains a `unit_decoder` callable for the code path.

## Result

`Country('GhanaLSS').food_acquired()` builds in **~25 s** with canonical columns `[Quantity, Expenditure, Price]` over `(t, v, i, j, u, s, visit)` across all **7 waves** (5.26 M rows); units decode cleanly (`Bowl, Tin, Kilogram, Heap, …`). All 6 `tests/test_table_structure.py::*[GhanaLSS/food_acquired]` cases pass — including the three #453 reported failing (`test_index_levels`, `test_declared_columns_present`, `test_feature_is_sane`).

Closes #453. Addresses #384 (GLSS7 unit map populated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)