### PR TITLE
feat(#171): education harmonization foundation (global ordinal vocab + Uganda pilot)

### DIFF
--- a/lsms_library/categorical_mapping/canonical_education_labels.org
+++ b/lsms_library/categorical_mapping/canonical_education_labels.org
@@ -1,0 +1,49 @@
+#+title: Canonical Educational-Attainment Labels (Global Ordinal Vocabulary)
+#+author: LSMS Library
+#+description: The shared ordered vocabulary for the `individual_education`
+#+  `Educational Attainment` column (GH #171).  This is a documentation /
+#+  style-guide file: it is NOT read by code.  The applied mappings live in
+#+  `harmonize_education.org` (global base) and each country's
+#+  `categorical_mapping.org` (`#+name: harmonize_education`, row-additive over
+#+  the global base).  Per-country tables should map onto these Preferred
+#+  Labels and add new ones here only with care (the vocabulary is a social
+#+  convention, ordered low -> high).
+
+* Ordered levels
+
+The `Order` column is the intended ordinal rank (low education -> high); it is
+documentary here.  A future enhancement may emit it as a numeric column
+alongside the label for quantitative analysis.
+
+| Order | Preferred Label             | Covers                                                                 |
+|-------+-----------------------------+------------------------------------------------------------------------|
+|     0 | None                        | Never attended; no formal schooling; "not educated"                    |
+|     1 | Informal                    | Adult literacy; quranic / religious / integrated; non-graded informal  |
+|     2 | Pre-primary                 | Nursery; kindergarten; pre-school                                      |
+|     3 | Primary incomplete          | Some primary grades; primary cycle not finished                        |
+|     4 | Primary complete            | Full primary cycle finished (e.g. Uganda P.7, PSLC, Fondamental 1)      |
+|     5 | Lower secondary             | Some lower-secondary / junior / O-level grades                         |
+|     6 | Lower secondary complete    | Lower-secondary cycle finished (O-level, MSCE, BEPC, JCE)               |
+|     7 | Upper secondary             | Some upper-secondary / senior / A-level grades                         |
+|     8 | Upper secondary complete    | Upper-secondary cycle finished (A-level, baccalauréat)                  |
+|     9 | Vocational/Technical        | Technical / vocational training (post-primary or post-secondary)        |
+|    10 | Tertiary certificate/diploma | Non-degree tertiary: certificate, diploma, NCE, teacher training        |
+|    11 | Bachelor                    | First university degree (BA / BSc / licence / 1st degree)               |
+|    12 | Postgraduate                | Master's / postgraduate below doctorate                                |
+|    13 | Doctorate                   | PhD                                                                    |
+|     — | Unknown                     | Don't Know / refused / unmappable (non-ordinal sentinel)               |
+
+* Notes
+
+- *Country grade detail collapses here.* Country-specific grades (Uganda P.1-P.7,
+  S.1-S.6; Mali numeric codes; Ethiopia numbered grades) map onto these coarse
+  levels for cross-country comparability.  Grade-level detail, where needed,
+  stays in the survey-specific data.
+- *Long-pole countries.* Mali, Nigeria and Tanzania encode attainment as raw
+  numeric grade codes that are not yet decoded at extraction; those need a
+  per-wave code->label decode before a `harmonize_education` table can map them
+  (tracked under #171).
+- *Never-schooled handling.* The universal `dropna(how='all')` drops rows whose
+  only column (`Educational Attainment`) is NaN, so never-schooled members are
+  currently dropped rather than represented as `None`.  Whether to surface them
+  as a `None` row is an open #171 design question.

--- a/lsms_library/categorical_mapping/harmonize_education.org
+++ b/lsms_library/categorical_mapping/harmonize_education.org
@@ -1,0 +1,49 @@
+#+title: Harmonized Educational-Attainment Labels (Global)
+#+author: LSMS Library
+#+description: Global base mapping from raw survey education labels to the
+#+  canonical ordinal Preferred Labels (see canonical_education_labels.org).
+#+  Row-additive (GH #171): per-country `#+name: harmonize_education` tables
+#+  inherit these rows and override only their country-specific labels.
+#+  Holds canonical-identity rows plus common English/universal variants;
+#+  French/Portuguese/numeric variants live in the per-country tables.
+
+#+name: harmonize_education
+| Original Label               | Preferred Label              |
+|------------------------------+------------------------------|
+| None                         | None                         |
+| NONE                         | None                         |
+| No education                 | None                         |
+| Not educated                 | None                         |
+| Never attended               | None                         |
+| Informal                     | Informal                     |
+| Adult education              | Informal                     |
+| Quranic                      | Informal                     |
+| Pre-primary                  | Pre-primary                  |
+| Pre-school                   | Pre-primary                  |
+| Nursery                      | Pre-primary                  |
+| Kindergarten                 | Pre-primary                  |
+| Primary incomplete           | Primary incomplete           |
+| Primary complete             | Primary complete             |
+| Primary                      | Primary complete             |
+| Lower secondary              | Lower secondary              |
+| Lower secondary complete     | Lower secondary complete     |
+| Secondary                    | Lower secondary complete     |
+| Upper secondary              | Upper secondary              |
+| Upper secondary complete     | Upper secondary complete     |
+| Vocational/Technical         | Vocational/Technical         |
+| Vocational                   | Vocational/Technical         |
+| Technical                    | Vocational/Technical         |
+| Tertiary certificate/diploma | Tertiary certificate/diploma |
+| Diploma                      | Tertiary certificate/diploma |
+| Certificate                  | Tertiary certificate/diploma |
+| Bachelor                     | Bachelor                     |
+| Degree                       | Bachelor                     |
+| 1st Degree                   | Bachelor                     |
+| Postgraduate                 | Postgraduate                 |
+| Masters                      | Postgraduate                 |
+| Master's Degree              | Postgraduate                 |
+| Doctorate                    | Doctorate                    |
+| PhD                          | Doctorate                    |
+| Unknown                      | Unknown                      |
+| Don't Know                   | Unknown                      |
+| Refused                      | Unknown                      |

--- a/lsms_library/countries/Uganda/2019-20/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2019-20/_/data_info.yml
@@ -25,7 +25,12 @@ individual_education:
         i: hhid
         pid: pid
     myvars:
-        Educational Attainment: s4q07
+        # GH #171: map raw attainment labels onto the canonical ordinal vocab
+        # via the row-additive harmonize_education table (global base +
+        # this country's per-country delta in _/categorical_mapping.org).
+        Educational Attainment:
+            - s4q07
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
 
 people_last7days:
     file: HH/gsec15a.dta

--- a/lsms_library/countries/Uganda/_/categorical_mapping.org
+++ b/lsms_library/countries/Uganda/_/categorical_mapping.org
@@ -946,3 +946,30 @@
 |   40 | Other Poultry   |
 |   41 | Other Poultry   |
 |   42 | Bees            |
+
+# harmonize_education (GH #171): Uganda per-country delta on the global ordinal
+# base (categorical_mapping/harmonize_education.org, row-additive). Maps Uganda's
+# P/J/S grade labels onto the canonical levels; "Don't Know" is inherited from global.
+#+name: harmonize_education
+| Original Label                                                      | Preferred Label              |
+|---------------------------------------------------------------------+------------------------------|
+| Completed Degree and above                                          | Bachelor                     |
+| Completed J.1                                                       | Lower secondary              |
+| Completed J.2                                                       | Lower secondary              |
+| Completed J.3                                                       | Lower secondary              |
+| Completed P.1                                                       | Primary incomplete           |
+| Completed P.2                                                       | Primary incomplete           |
+| Completed P.3                                                       | Primary incomplete           |
+| Completed P.4                                                       | Primary incomplete           |
+| Completed P.5                                                       | Primary incomplete           |
+| Completed P.6                                                       | Primary incomplete           |
+| Completed P.7                                                       | Primary complete             |
+| Completed Post secondary Specialized training or diploma            | Tertiary certificate/diploma |
+| Completed S.1                                                       | Lower secondary              |
+| Completed S.2                                                       | Lower secondary              |
+| Completed S.3                                                       | Lower secondary              |
+| Completed S.4                                                       | Lower secondary complete     |
+| Completed S.5                                                       | Upper secondary              |
+| Completed S.6                                                       | Upper secondary complete     |
+| Completed post primary/junior specialized traing/certificat/diploma | Vocational/Technical         |
+| Some schooling but not completed P.1                                | Primary incomplete           |

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -120,7 +120,12 @@ def _augment_numeric_code_keys(rdict: dict) -> dict:
 # needs to declare its country-specific rows; a country row wins on a
 # source-label key collision.  Every other table keeps the historical
 # full-table override.  Keep this allow-list small and explicit.
-_ADDITIVE_CATEGORICAL_TABLES = frozenset({'u'})
+#
+# ``harmonize_education`` (GH #171): a global ordinal-level vocabulary
+# (categorical_mapping/harmonize_education.org) is the shared base; per-country
+# tables add only their country-specific attainment labels (English grade
+# names, French/Portuguese levels, numeric grade codes) as overrides on top.
+_ADDITIVE_CATEGORICAL_TABLES = frozenset({'u', 'harmonize_education'})
 
 
 def _categorical_key_column(table: "pd.DataFrame") -> str | None:

--- a/tests/test_categorical_merge.py
+++ b/tests/test_categorical_merge.py
@@ -23,6 +23,12 @@ def test_u_is_additive():
     assert "u" in _ADDITIVE_CATEGORICAL_TABLES
 
 
+def test_harmonize_education_is_additive():
+    # GH #171: the global harmonize_education.org ordinal vocabulary is the
+    # shared base; per-country tables override only their own attainment labels.
+    assert "harmonize_education" in _ADDITIVE_CATEGORICAL_TABLES
+
+
 def test_row_union_country_wins_and_inherits_global():
     glob = _tbl([["kg", "Kg"], ["g", "g"], ["l", "Litre"]])
     ctry = _tbl([["kg", "KILO"], ["Tas", "Tas"]])   # overrides kg, adds Tas


### PR DESCRIPTION
## Summary

Lays the foundation for cross-country `individual_education` harmonization,
mirroring the #168 assets architecture but adapted for education's two
differences: the vocabulary is **ordinal**, and the value lives in a **column**
(`Educational Attainment`), not a `j` index.

**Starts #171** (foundation + Uganda pilot; rollout deferred).

### What's here
1. **Global ordinal vocabulary** — `categorical_mapping/harmonize_education.org`
   (14 ordered levels `None`→`Doctorate` + `Unknown`), documented in
   `canonical_education_labels.org` (the ordered style-guide).
2. **Row-additive hierarchy** — `harmonize_education` added to
   `_ADDITIVE_CATEGORICAL_TABLES`, so per-country tables inherit the global base
   and override only their own labels (the `u`/`harmonize_assets` precedent).
3. **Uganda pilot** — a per-country `harmonize_education` table mapping Uganda's
   P/J/S grade labels onto canonical levels, wired into the 2019-20 wave's
   `Educational Attainment` via the explicit `mappings:` syntax (column, so not
   the `harmonize_<method>` `j`-hook).

### Verified
- Uganda education rebuilds **fully canonical** (`Primary incomplete` 3276,
  `Primary complete` 987, `Lower secondary` 696, … `Bachelor` 153, `Unknown` 24)
  — zero leftovers.
- **Inheritance proven**: Uganda's delta omits `Don't Know`; it maps to
  `Unknown` via the global base row (merged table = 57 rows = global + delta).
- 7 categorical-merge tests pass (incl. `test_harmonize_education_is_additive`).

### Deferred (tracked on #171)
- Multi-country rollout (per-country tables for the rest).
- **Mali/Nigeria/Tanzania numeric-code decode** — they encode attainment as raw
  numeric grade codes; need a per-wave code→label decode first (long-poles).
- Optional ordinal-rank numeric column; whether to surface never-schooled
  members as a `None` row vs. the current `dropna` drop.

> NOTE: adds `harmonize_education` to `_ADDITIVE_CATEGORICAL_TABLES`, a one-line
> overlap with the still-open #485 (which adds `harmonize_assets`). Trivial
> conflict if both land — resolution is `{'u','harmonize_assets','harmonize_education'}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)