### PR TITLE
feat(#171): wire Uganda's 7 pre-2019-20 individual_education waves

### DIFF
--- a/lsms_library/countries/Uganda/2005-06/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2005-06/_/data_info.yml
@@ -12,6 +12,20 @@ household_roster:
         Age: h2q9
         MonthsSpent: h2q6
 
+individual_education:
+    file: ../Data/GSEC4.dta
+    idxvars:
+        i: HHID
+        pid: PID
+    myvars:
+        # GH #171: highest grade/class completed (h4q4 this wave; the GSEC4
+        # question moved to h4q7 from 2009-10 on).  2005-06's value labels are
+        # all-lowercase ('completed p.7', ...), covered by the row-additive
+        # harmonize_education table (global base + Uganda per-country delta).
+        Educational Attainment:
+            - h4q4
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+
 people_last7days:
     file: GSEC14.dta
     idxvars:

--- a/lsms_library/countries/Uganda/2009-10/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2009-10/_/data_info.yml
@@ -18,6 +18,19 @@ household_roster:
             - h2q9c
         MonthsSpent: h2q5
 
+individual_education:
+    file: ../Data/GSEC4.dta
+    idxvars:
+        i: HHID
+        pid: PID
+    myvars:
+        # GH #171: highest grade/class completed (h4q7).  Raw labels
+        # ('Completed P.7', ...) map onto the canonical ordinal levels via the
+        # row-additive harmonize_education table.
+        Educational Attainment:
+            - h4q7
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+
 people_last7days:
     file: GSEC15A.dta
     idxvars:

--- a/lsms_library/countries/Uganda/2010-11/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2010-11/_/data_info.yml
@@ -18,6 +18,19 @@ household_roster:
             - h2q9c
         MonthsSpent: h2q5
 
+individual_education:
+    file: ../Data/GSEC4.dta
+    idxvars:
+        i: HHID
+        pid: PID
+    myvars:
+        # GH #171: highest grade/class completed (h4q7).  Raw labels
+        # ('Completed P.7', ...) map onto the canonical ordinal levels via the
+        # row-additive harmonize_education table.
+        Educational Attainment:
+            - h4q7
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+
 housing:
     file: ../Data/GSEC9A.dta
     idxvars:

--- a/lsms_library/countries/Uganda/2010-11/_/mapping.py
+++ b/lsms_library/countries/Uganda/2010-11/_/mapping.py
@@ -17,6 +17,11 @@ _spec = importlib.util.spec_from_file_location("_uganda_age_helpers", _HELPERS)
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 
+_EDU_HELPERS = Path(__file__).resolve().parent.parent.parent / "_" / "_education_helpers.py"
+_edu_spec = importlib.util.spec_from_file_location("_uganda_education_helpers", _EDU_HELPERS)
+_edu_mod = importlib.util.module_from_spec(_edu_spec)
+_edu_spec.loader.exec_module(_edu_mod)
+
 INTERVIEW_YEAR = 2010
 
 
@@ -26,3 +31,8 @@ def Age(value):
 
 def household_roster(df):
     return _mod.run_household_roster(df, interview_year=INTERVIEW_YEAR)
+
+
+def individual_education(df):
+    # GH #171 df_edit hook: fold unlabeled float junk codes -> Unknown.
+    return _edu_mod.coerce_unmapped_to_unknown(df)

--- a/lsms_library/countries/Uganda/2011-12/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2011-12/_/data_info.yml
@@ -18,6 +18,19 @@ household_roster:
             - h2q9c
         MonthsSpent: h2q5
 
+individual_education:
+    file: ../Data/GSEC4.dta
+    idxvars:
+        i: HHID
+        pid: PID
+    myvars:
+        # GH #171: highest grade/class completed (h4q7).  Raw labels
+        # ('Completed P.7', ...) map onto the canonical ordinal levels via the
+        # row-additive harmonize_education table.
+        Educational Attainment:
+            - h4q7
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+
 housing:
     file: ../Data/GSEC9A.dta
     idxvars:

--- a/lsms_library/countries/Uganda/2011-12/_/mapping.py
+++ b/lsms_library/countries/Uganda/2011-12/_/mapping.py
@@ -13,6 +13,11 @@ _spec = importlib.util.spec_from_file_location("_uganda_age_helpers", _HELPERS)
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 
+_EDU_HELPERS = Path(__file__).resolve().parent.parent.parent / "_" / "_education_helpers.py"
+_edu_spec = importlib.util.spec_from_file_location("_uganda_education_helpers", _EDU_HELPERS)
+_edu_mod = importlib.util.module_from_spec(_edu_spec)
+_edu_spec.loader.exec_module(_edu_mod)
+
 INTERVIEW_YEAR = 2011
 
 
@@ -22,3 +27,8 @@ def Age(value):
 
 def household_roster(df):
     return _mod.run_household_roster(df, interview_year=INTERVIEW_YEAR)
+
+
+def individual_education(df):
+    # GH #171 df_edit hook: fold unlabeled float junk codes -> Unknown.
+    return _edu_mod.coerce_unmapped_to_unknown(df)

--- a/lsms_library/countries/Uganda/2013-14/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2013-14/_/data_info.yml
@@ -22,6 +22,19 @@ household_roster:
             - h2q9c
         MonthsSpent: h2q5
 
+individual_education:
+    file: ../Data/GSEC4.dta
+    idxvars:
+        i: HHID
+        pid: PID
+    myvars:
+        # GH #171: highest grade/class completed (h4q7).  Raw labels
+        # ('Completed P.7', ...) map onto the canonical ordinal levels via the
+        # row-additive harmonize_education table.
+        Educational Attainment:
+            - h4q7
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+
 people_last7days:
     file: GSEC15.dta
     idxvars:

--- a/lsms_library/countries/Uganda/2015-16/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2015-16/_/data_info.yml
@@ -18,6 +18,19 @@ household_roster:
             - h2q9c
         MonthsSpent: h2q5
 
+individual_education:
+    file: ../Data/gsec4.dta
+    idxvars:
+        i: hhid
+        pid: pid
+    myvars:
+        # GH #171: highest grade/class completed (h4q7).  Raw labels
+        # ('Completed P.7', ...) map onto the canonical ordinal levels via the
+        # row-additive harmonize_education table.
+        Educational Attainment:
+            - h4q7
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+
 housing:
     file: ../Data/gsec9.dta
     idxvars:

--- a/lsms_library/countries/Uganda/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2018-19/_/data_info.yml
@@ -19,6 +19,20 @@ household_roster:
             - h2q9c
         MonthsSpent: h2q5
 
+individual_education:
+    file: ../Data/GSEC4.dta
+    idxvars:
+        i: hhid
+        pid: PID
+    myvars:
+        # GH #171: highest grade/class completed (s4q07 — this wave renumbered
+        # the GSEC4 codes to the s4q.. scheme later kept by 2019-20).  Raw labels
+        # ('Completed P.7', ...) map onto the canonical ordinal levels via the
+        # row-additive harmonize_education table.
+        Educational Attainment:
+            - s4q07
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+
 people_last7days:
     file: GSEC15A.dta
     idxvars:

--- a/lsms_library/countries/Uganda/_/_education_helpers.py
+++ b/lsms_library/countries/Uganda/_/_education_helpers.py
@@ -1,0 +1,40 @@
+"""Shared ``individual_education`` ``df_edit`` helper for Uganda (GH #171).
+
+A handful of pre-2019 GSEC4 ``h4q7`` rows (1-2 records each in 2010-11 and
+2011-12) hold raw *float* codes (1.0, 2.0, 3.0, 52.0) that never received Stata
+value labels.  The ``harmonize_education`` categorical table is applied via
+``Series.map(lambda x: f.get(x, x))`` with string keys, so a float ``1.0``
+slips through unmapped and would surface as a non-canonical leftover.
+
+``coerce_unmapped_to_unknown`` runs as the wave-level ``df_edit`` hook
+(dispatched by ``Country`` as ``individual_education(df)``) and folds any
+remaining non-canonical ``Educational Attainment`` value onto the ``Unknown``
+sentinel, keeping the column fully within the canonical ordinal vocabulary.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+# Canonical ordinal vocabulary (categorical_mapping/canonical_education_labels.org).
+CANONICAL_EDUCATION_LABELS = frozenset({
+    "None", "Informal", "Pre-primary",
+    "Primary incomplete", "Primary complete",
+    "Lower secondary", "Lower secondary complete",
+    "Upper secondary", "Upper secondary complete",
+    "Vocational/Technical", "Tertiary certificate/diploma",
+    "Bachelor", "Postgraduate", "Doctorate", "Unknown",
+})
+
+_COL = "Educational Attainment"
+
+
+def coerce_unmapped_to_unknown(df: pd.DataFrame) -> pd.DataFrame:
+    """Map any leftover non-canonical ``Educational Attainment`` value -> ``Unknown``."""
+    if _COL not in df.columns:
+        return df
+    s = df[_COL]
+    leftover = s.notna() & ~s.isin(CANONICAL_EDUCATION_LABELS)
+    if leftover.any():
+        df = df.copy()
+        df.loc[leftover, _COL] = "Unknown"
+    return df

--- a/lsms_library/countries/Uganda/_/categorical_mapping.org
+++ b/lsms_library/countries/Uganda/_/categorical_mapping.org
@@ -950,6 +950,25 @@
 # harmonize_education (GH #171): Uganda per-country delta on the global ordinal
 # base (categorical_mapping/harmonize_education.org, row-additive). Maps Uganda's
 # P/J/S grade labels onto the canonical levels; "Don't Know" is inherited from global.
+#
+# The mapping is applied by exact, case-sensitive string match (the org table is
+# turned into a plain dict and .map()'d onto the raw labels), so each casing /
+# spelling variant that appears in any wave's GSEC4 attainment column must be
+# listed verbatim.  The table must stay ONE contiguous block of `|` rows — a
+# `#`-prefixed comment in the middle silently truncates it (the org reader stops
+# at the first non-table line), so all explanatory notes live here above #+name:.
+#
+# Rows below, grouped (by ordering, not by comments) as:
+#   * base Title-cased GSEC4 wording used by 2009-10..2019-20 (h4q7 / s4q07);
+#   * post-primary / post-secondary specialized-training spelling variants
+#     (2009-10..2015-16): post-primary -> Vocational/Technical,
+#     post-secondary -> Tertiary certificate/diploma;
+#   * "Some schooling ... not Completed P.1" capital-C variant;
+#   * 2005-06 all-lowercase GSEC4 (h4q4) wording (same canonical targets);
+#   * "Don't Know" / DK / dk sentinels -> Unknown;
+#   * sparse unlabeled numeric junk codes (1-2 records each in 2010-11/2011-12
+#     GSEC4; value labels never applied at source) -> Unknown, so the column
+#     stays fully canonical.
 #+name: harmonize_education
 | Original Label                                                      | Preferred Label              |
 |---------------------------------------------------------------------+------------------------------|
@@ -973,3 +992,34 @@
 | Completed S.6                                                       | Upper secondary complete     |
 | Completed post primary/junior specialized traing/certificat/diploma | Vocational/Technical         |
 | Some schooling but not completed P.1                                | Primary incomplete           |
+| Completed Post Primary Specialized Training or Certificate          | Vocational/Technical         |
+| Completed Post primary Specialized training or Certificate          | Vocational/Technical         |
+| Completed Post Secondary Specialized Training or diploma            | Tertiary certificate/diploma |
+| Some schooling but not Completed P.1                                | Primary incomplete           |
+| completed degree and above                                          | Bachelor                     |
+| completed j.1                                                       | Lower secondary              |
+| completed j.2                                                       | Lower secondary              |
+| completed j.3                                                       | Lower secondary              |
+| completed p.1                                                       | Primary incomplete           |
+| completed p.2                                                       | Primary incomplete           |
+| completed p.3                                                       | Primary incomplete           |
+| completed p.4                                                       | Primary incomplete           |
+| completed p.5                                                       | Primary incomplete           |
+| completed p.6                                                       | Primary incomplete           |
+| completed p.7                                                       | Primary complete             |
+| completed post primary specialized training or certificate          | Vocational/Technical         |
+| completed post secondary specialized training or diploma            | Tertiary certificate/diploma |
+| completed s.1                                                       | Lower secondary              |
+| completed s.2                                                       | Lower secondary              |
+| completed s.3                                                       | Lower secondary              |
+| completed s.4                                                       | Lower secondary complete     |
+| completed s.5                                                       | Upper secondary              |
+| completed s.6                                                       | Upper secondary complete     |
+| some schooling but not completed p.1                                | Primary incomplete           |
+| don't know                                                          | Unknown                      |
+| DK                                                                  | Unknown                      |
+| dk                                                                  | Unknown                      |
+| 1.0                                                                 | Unknown                      |
+| 2.0                                                                 | Unknown                      |
+| 3.0                                                                 | Unknown                      |
+| 52.0                                                                | Unknown                      |


### PR DESCRIPTION
## Summary

Uganda declared `individual_education` in only **1 of its 8 waves** (2019-20); the
other 7 were an extraction gap. This wires all 7 (each has a GSEC4 education
roster), so `Country('Uganda').individual_education()` now returns **all 8 waves**
(6,382 → **46,526 rows**), fully harmonized to the canonical ordinal vocabulary.

**Part of #171.**

### Wiring (source `file:column`, ids confirmed by probing the `.dta`)
- 2005-06 `GSEC4.dta:h4q4`; 2009-10/2010-11/2011-12/2013-14 `GSEC4.dta:h4q7`;
  2015-16 `gsec4.dta:h4q7`; 2018-19 `GSEC4.dta:s4q07` (identical var to the wired
  2019-20). Each `Educational Attainment` wired via
  `mappings: ['harmonize_education', ...]`.
- Uganda's per-country `harmonize_education` table extended (+30 rows) for the
  older waves' label variants (lowercase 2005-06 spellings, Title-cased
  post-primary/post-secondary, `DK`/`don't know` → Unknown).

### The float-code safety net
2010-11/2011-12 `h4q7` carry a handful (4 records total) of **unlabeled raw float
codes** (`1.0`/`3.0`/`52.0`) the string-keyed mapping can't catch. A small
`Uganda/_/_education_helpers.py` + an `individual_education(df)` `df_edit` hook in
those two waves fold any leftover non-canonical value → `Unknown`. Verified this
masks **no real labels**: every text grade label maps to a proper canonical
level; the only unmapped raw values are `nan` (never-schooled, dropped), `DK`
(→Unknown, legitimate), and the 4 float codes.

### Verified
- All 8 waves present; **zero non-canonical leftovers** (fully canonical).
- 12 education tests pass (`test_categorical_merge`, `test_harmonize_method_auto_dispatch`).
- Per-wave Unknown is legitimate DK (e.g. 2010-11: 121 DK + 4 floats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)