### PR TITLE
feat(#493): harmonize individual_education for 13 non-LSMS-ISA countries

### DIFF
--- a/lsms_library/countries/Albania/2005/_/data_info.yml
+++ b/lsms_library/countries/Albania/2005/_/data_info.yml
@@ -9,7 +9,9 @@ individual_education:
             - m0_q01
         pid: m2b_q00
     myvars:
-        Educational Attainment: m2b_q04
+        Educational Attainment:
+            - m2b_q04
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
 
 cluster_features:
     file: ../Data/identification_cl.dta

--- a/lsms_library/countries/Albania/2008/_/data_info.yml
+++ b/lsms_library/countries/Albania/2008/_/data_info.yml
@@ -9,7 +9,9 @@ individual_education:
             - hh
         pid: id
     myvars:
-        Educational Attainment: m2b_q04
+        Educational Attainment:
+            - m2b_q04
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
 
 household_roster:
     # i=[psu,hh] -> composite via mapping.py:i() ('psu-hh') to match sample()'s

--- a/lsms_library/countries/Albania/2012/_/data_info.yml
+++ b/lsms_library/countries/Albania/2012/_/data_info.yml
@@ -9,7 +9,9 @@ individual_education:
             - hh
         pid: idcode
     myvars:
-        Educational Attainment: m2b_q04
+        Educational Attainment:
+            - m2b_q04
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
 
 household_roster:
     file:

--- a/lsms_library/countries/Albania/_/categorical_mapping.org
+++ b/lsms_library/countries/Albania/_/categorical_mapping.org
@@ -1,0 +1,43 @@
+#+TITLE: Albania — country-specific categorical mappings
+
+* Education attainment (GH #493)
+
+Row-additive delta over the global
+~lsms_library/categorical_mapping/harmonize_education.org~ base.  Maps
+Albania's raw ~m2b_q04~ "Educational Attainment" labels (waves 2005, 2008,
+2012) onto the canonical ordinal vocabulary.  ~None~ is already covered by the
+global base and is not repeated here.
+
+Albanian-system notes:
+- "8 or 9 Years school" / "8/9 years of school" = the compulsory basic
+  education cycle (8-year pre-2004 reform, 9-year after) ending ~age 14-15 =
+  ISCED 2 completion -> Lower secondary complete.
+- "Gymnazium" = general academic upper-secondary (shkollë e mesme e
+  përgjithshme); "Secondary general" is the same academic upper-secondary
+  track in the 2005/2008 label set -> Upper secondary complete.
+- Vocational tracks (2-3 yr, 4/5 yr) and "Technicum <2 years" (short
+  post-secondary technical) -> Vocational/Technical.
+- University (Albania/Abroad) = first university degree -> Bachelor.
+- Master / Post-Graduate (Albania/Abroad) -> Postgraduate.
+- Doctorate/PhD (Albania/Abroad) -> Doctorate.
+
+#+name: harmonize_education
+| Original Label          | Preferred Label          |
+|-------------------------+--------------------------|
+| 8 or 9 Years school     | Lower secondary complete |
+| 8/9 years of school     | Lower secondary complete |
+| Secondary general       | Upper secondary complete |
+| Gymnazium               | Upper secondary complete |
+| Vocational 4/5          | Vocational/Technical     |
+| Vocational 4-5 years    | Vocational/Technical     |
+| Vocational 2-3  years   | Vocational/Technical     |
+| Vocational 2-3 years    | Vocational/Technical     |
+| Technicum <2 years      | Vocational/Technical     |
+| University - Albania    | Bachelor                 |
+| University - Abroad     | Bachelor                 |
+| Master - Albania        | Postgraduate             |
+| Master - Abroad         | Postgraduate             |
+| Post-Graduate - Albania | Postgraduate             |
+| Post-Graduate - Abroad  | Postgraduate             |
+| Doctorate/PhD - Albania | Doctorate                |
+| Doctorate/PhD - Abroad  | Doctorate                |

--- a/lsms_library/countries/Azerbaijan/1995/_/data_info.yml
+++ b/lsms_library/countries/Azerbaijan/1995/_/data_info.yml
@@ -76,7 +76,9 @@ individual_education:
         i: [ppid, hid]
         pid: pid
     myvars:
-        Educational Attainment: diploma
+        Educational Attainment:
+            - diploma
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
 
 interview_date:
     # Cover module A00.dta; Int_t from dayint/moint/yrint (yrint 2-digit ->

--- a/lsms_library/countries/Azerbaijan/_/categorical_mapping.org
+++ b/lsms_library/countries/Azerbaijan/_/categorical_mapping.org
@@ -1,0 +1,60 @@
+#+title: Categorical Mappings (Azerbaijan)
+
+* harmonize_education
+
+Azerbaijan SLC 1995 individual_education "Educational Attainment" comes
+from the =diploma= variable in =A03.dta= (Section 3 EDUCATION of the
+household questionnaire =queshhe.pdf=, question 2: "Highest diploma,
+degree or certificate received by [NAME]?").  Codes reach the API as
+stringified floats (=1.0=, =2.0=, ...).  The codebook (1-10) is decoded
+below and cross-checked against =yearsch= (years spent studying) and
+=agey= (age):
+
+| code | questionnaire label                                  | mean yearsch |
+|------+------------------------------------------------------+--------------|
+|    1 | Certificate of completing 8 classes                  |          8.2 |
+|    2 | Certificate of completing secondary school           |         10.2 |
+|    3 | Certificate of finishing prof/tech school (PTU)      |         11.3 |
+|    4 | Diploma of completing secondary technical school     |         12.9 |
+|    5 | Diploma of completing art/medical/other secondary    |         13.3 |
+|    6 | Diploma of completing a higher education establishment |       15.5 |
+|    7 | Diploma of a candidate of science                    |         17.5 |
+|    8 | Diploma of a doctor of science                       |         14.0 |
+|    9 | Diploma of professor                                 |         22.2 |
+|   10 | OTHER (no listed diploma)                            |          4.1 |
+|   13 | (undocumented; 3 children age 6-9, yearsch 0-1)      |          0.3 |
+
+Soviet-system rationale:
+- code 1 = "8 classes" = the 8-year compulsory incomplete-secondary
+  certificate -> Lower secondary complete.
+- code 2 = full general secondary (10/11 years) -> Upper secondary complete.
+- code 3 = PTU vocational school (worker qualification) -> Vocational/Technical.
+- codes 4 & 5 = "среднее специальное" specialized-secondary diplomas
+  (tekhnikum; medical/art college) award a mid-level-specialist diploma
+  one tier above the PTU -> Tertiary certificate/diploma.
+- code 6 = higher-education (university) diploma -> Bachelor.
+- codes 7, 8, 9 = candidate of science / doctor of science / professor
+  are postgraduate research degrees (candidate ~ PhD; doctor of science &
+  professor are the higher Soviet academic ranks) -> Doctorate.
+- code 10 = "OTHER" catch-all: largest group, mean age 25, age mode 5-15
+  (school-age children currently in primary/incomplete secondary) and
+  yearsch mode 0-8.  Genuinely heterogeneous "no diploma obtained" — not a
+  single attainment level — so mapped to Unknown rather than fabricating a
+  level.
+- code 13 = undocumented (outside 1-10); 3 children age 6-9 still in school
+  with no diploma -> Unknown.
+
+#+name: harmonize_education
+| Original Label | Preferred Label              |
+|----------------+------------------------------|
+| 1.0            | Lower secondary complete     |
+| 2.0            | Upper secondary complete     |
+| 3.0            | Vocational/Technical         |
+| 4.0            | Tertiary certificate/diploma |
+| 5.0            | Tertiary certificate/diploma |
+| 6.0            | Bachelor                     |
+| 7.0            | Doctorate                    |
+| 8.0            | Doctorate                    |
+| 9.0            | Doctorate                    |
+| 10.0           | Unknown                      |
+| 13.0           | Unknown                      |

--- a/lsms_library/countries/Cambodia/2019-20/_/data_info.yml
+++ b/lsms_library/countries/Cambodia/2019-20/_/data_info.yml
@@ -120,4 +120,6 @@ individual_education:
         i: HHID
         pid: children_out_of_H__id
     myvars:
-        Educational Attainment: s03q04
+        Educational Attainment:
+            - s03q04
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']

--- a/lsms_library/countries/Cambodia/_/categorical_mapping.org
+++ b/lsms_library/countries/Cambodia/_/categorical_mapping.org
@@ -1,0 +1,36 @@
+#+title: Cambodia categorical mappings
+
+Row-additive delta over the global
+=lsms_library/categorical_mapping/harmonize_education.org= base (GH #493).
+Cambodia 2019-20, source s03q04 (hh_sec_3.dta). Cambodia uses a 6-3-3 ladder:
+primary = grades 1-6, lower secondary = grades 7-9 (leaving = the lower
+education certificate / diploma), upper secondary = grades 10-12 (leaving = the
+BacII / Baccalaureate II higher-education-entrance certificate).
+
+#+name: harmonize_education
+| Original Label                                          | Preferred Label              |
+|---------------------------------------------------------+------------------------------|
+| No class completed                                      | None                         |
+| Pre-school/Kindergarten                                 | Pre-primary                  |
+| Class one completed                                     | Primary incomplete           |
+| Class two completed                                     | Primary incomplete           |
+| Class three completed                                   | Primary incomplete           |
+| Class four completed                                    | Primary incomplete           |
+| Class five completed                                    | Primary incomplete           |
+| Class six completed                                     | Primary complete             |
+| Class seven completed                                   | Lower secondary              |
+| Class eight completed                                   | Lower secondary              |
+| Class nine completed without certificate                | Lower secondary              |
+| Lower education certificate (diploma)                   | Lower secondary complete     |
+| Class ten completed                                     | Upper secondary              |
+| Class eleven completed                                  | Upper secondary              |
+| Class twelve completed without certificate              | Upper secondary              |
+| Higher education certificate (BacII)                    | Upper secondary complete     |
+| Technical/vocational pre-secondary diploma/certificate  | Vocational/Technical         |
+| Technical/vocational post-secondary diploma/certificate | Vocational/Technical         |
+| College/university undergraduate but no degree          | Tertiary certificate/diploma |
+| Bachelor degree (B.A., BSc, etc.)                       | Bachelor                     |
+| Masters degree (M.A., MSc, etc)                         | Postgraduate                 |
+| Doctorate degree (PhD)                                  | Doctorate                    |
+| DonÂ´t know                                             | Unknown                      |
+| Other (Specify)                                         | Unknown                      |

--- a/lsms_library/countries/Guatemala/2000/_/data_info.yml
+++ b/lsms_library/countries/Guatemala/2000/_/data_info.yml
@@ -70,13 +70,35 @@ household_roster:
                 13: other non-relative
 
 individual_education:
+    # Source is the education chapter (P07 section of ECV09P05.DTA), Q27
+    # "ultimo grado aprobado" (highest grade/level passed):
+    #   p07b27a = nivel  (value-labelled: ninguno / preparatoria / primaria /
+    #             educacion media / educacion superior / post-grado /
+    #             educacion adultos; code 9 is unlabelled -> Unknown).
+    #   p07b27b = grado  (year passed within that level; drives the
+    #             complete/incomplete and basico/diversificado splits).
+    # The former wiring pointed at ECV11P10.DTA:p10acp ("cp informante"), a
+    # work-module person code that does NOT correlate with schooling
+    # (corr ~0.04 with derived years of education) -- it was a placeholder,
+    # not Educational Attainment (GH #493).
+    # The `individual_education(df)` df_edit hook in guatemala.py combines
+    # nivel+grado into the Spanish phrases that `harmonize_education` maps
+    # onto the canonical ordinal vocabulary.
     file:
-        - ECV11P10.DTA
+        - ECV09P05.DTA
     idxvars:
         i: hogar
         pid: caso
     myvars:
-        Educational Attainment: p10acp
+        # The mappings table runs at extraction (BEFORE the df_edit hook) and
+        # maps the bare nivel value-labels onto coarse canonical levels; the
+        # individual_education(df) hook then refines "Primary complete" and
+        # "Lower secondary" by grado (edu_grade) into the (in)complete /
+        # basico-diversificado tiers, and drops the edu_grade helper column.
+        Educational Attainment:
+            - p07b27a
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+        edu_grade: p07b27b
 
 assets:
     # Section E14 durables: j is the item name; Quantity=p14a02 (number owned),

--- a/lsms_library/countries/Guatemala/_/categorical_mapping.org
+++ b/lsms_library/countries/Guatemala/_/categorical_mapping.org
@@ -1,0 +1,51 @@
+#+title: Guatemala categorical mappings
+#+description: Per-country, row-additive deltas over the global categorical
+#+  mapping bases (lsms_library/categorical_mapping/*.org).
+
+* Educational attainment (GH #493)
+
+Guatemala ENCOVI 2000 records highest education in the P07 (education)
+section of =ECV09P05.DTA=, Q27 "ultimo grado aprobado":
+
+- =p07b27a= (nivel) is value-labelled in Stata: ninguno / preparatoria /
+  primaria / educacion media / educacion superior / post-grado /
+  educacion adultos.  Code 9 is unlabelled (33 cases, scattered ages) and
+  is treated as Unknown.
+- =p07b27b= (grado) is the highest year passed within that level.
+
+This table maps the *bare* Stata value-labels of =p07b27a= onto coarse
+canonical levels.  The =individual_education(df)= df_edit hook in
+=guatemala.py= then *refines* the two grade-dependent levels using
+=p07b27b= (grado), which the bare nivel label cannot express:
+
+- "primaria" is a 6-year cycle: the table maps it to *Primary complete*;
+  the hook downgrades grado 1-5 to *Primary incomplete*.
+- "educacion media" spans the *ciclo basico* (lower secondary, media years
+  1-3) and the *ciclo diversificado* (upper secondary, media years 4-6).
+  The table maps it to *Lower secondary*; the hook promotes grado 3 ->
+  *Lower secondary complete*, grado 4-5 -> *Upper secondary*, grado 6+ ->
+  *Upper secondary complete*.
+- "educacion adultos" is non-graded adult literacy/equivalency -> Informal.
+- "educacion superior" is degree-track university -> Bachelor (the survey
+  does not separate a non-degree tertiary diploma here); "post-grado" ->
+  Postgraduate.
+- nivel code 9 is unlabelled in Stata, so it reaches the mapping as the
+  float-string "9.0" (and "9") -> Unknown.
+
+Only the Guatemala-specific Spanish labels appear below; canonical
+identity rows and English variants are inherited from the global base
+=lsms_library/categorical_mapping/harmonize_education.org= (so the hook's
+refined outputs such as "Primary incomplete" pass through unchanged).
+
+#+name: harmonize_education
+| Original Label     | Preferred Label  |
+|--------------------+------------------|
+| ninguno            | None             |
+| educacion adultos  | Informal         |
+| preparatoria       | Pre-primary      |
+| primaria           | Primary complete |
+| educacion media    | Lower secondary  |
+| educacion superior | Bachelor         |
+| post-grado         | Postgraduate     |
+| 9                  | Unknown          |
+| 9.0                | Unknown          |

--- a/lsms_library/countries/Guatemala/_/guatemala.py
+++ b/lsms_library/countries/Guatemala/_/guatemala.py
@@ -68,3 +68,54 @@ def harmonized_food_labels(fn='../../_/food_items.csv',key='Code',value='Preferr
     food_items = food_items.set_index(key)
 
     return food_items.squeeze().str.strip().to_dict()
+
+
+def individual_education(df):
+    """Refine Guatemala ENCOVI 2000 Educational Attainment with the grade year.
+
+    df_edit hook for ``individual_education`` (GH #493).  By the time this
+    runs, the YAML ``mappings: harmonize_education`` table has already mapped
+    the bare ``p07b27a`` nivel labels onto *coarse* canonical levels:
+
+        ninguno -> None,  preparatoria -> Pre-primary,
+        primaria -> "Primary complete",  educacion media -> "Lower secondary",
+        educacion superior -> Bachelor,  post-grado -> Postgraduate,
+        educacion adultos -> Informal,  nivel 9 -> Unknown.
+
+    Two levels need the grade year ``p07b27b`` (carried in ``edu_grade``) to
+    place them on the ordinal scale; this hook supplies that refinement and
+    drops the ``edu_grade`` helper column:
+
+      * Primary  (6-year cycle): grado 1-5 -> "Primary incomplete",
+        grado >=6 -> "Primary complete" (the coarse default, unchanged).
+      * Secondary "educacion media" = ciclo basico (years 1-3, lower
+        secondary) + ciclo diversificado (years 4-6, upper secondary):
+            grado 1-2 -> "Lower secondary"          (some basico)
+            grado 3   -> "Lower secondary complete" (basico finished)
+            grado 4-5 -> "Upper secondary"          (some diversificado)
+            grado >=6 -> "Upper secondary complete" (diversificado finished)
+
+    Rows with a missing/zero grade keep the coarse entry-tier label.
+    """
+    grade = pd.to_numeric(df.get('edu_grade'), errors='coerce')
+
+    # nivel code 9 is unlabelled in Stata, so convert_categoricals leaves it as
+    # the numeric value 9.0 -- the extraction-time `mappings:` table (string
+    # keys) can't reach it before it is stringified downstream.  Map it to
+    # Unknown here, where it is still numeric.  ``replace`` matches 9 / 9.0 /
+    # "9" / "9.0" so it is robust to either dtype.
+    att = df['Educational Attainment']
+    df['Educational Attainment'] = att = att.replace(
+        {9: 'Unknown', 9.0: 'Unknown', '9': 'Unknown', '9.0': 'Unknown'})
+
+    prim = att == 'Primary complete'
+    df.loc[prim & (grade < 6), 'Educational Attainment'] = 'Primary incomplete'
+
+    media = att == 'Lower secondary'
+    df.loc[media & (grade == 3), 'Educational Attainment'] = 'Lower secondary complete'
+    df.loc[media & (grade >= 4) & (grade <= 5), 'Educational Attainment'] = 'Upper secondary'
+    df.loc[media & (grade >= 6), 'Educational Attainment'] = 'Upper secondary complete'
+
+    if 'edu_grade' in df.columns:
+        df = df.drop(columns='edu_grade')
+    return df

--- a/lsms_library/countries/Guyana/1992/_/data_info.yml
+++ b/lsms_library/countries/Guyana/1992/_/data_info.yml
@@ -89,7 +89,9 @@ individual_education:
         i: [ED, HH]
         pid: PID
     myvars:
-        Educational Attainment: HS
+        Educational Attainment:
+            - HS
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
 
 housing:
     # Dwelling module HHCHAR.dta, block (16) HOUSING (questionnaire GUY02.pdf

--- a/lsms_library/countries/Guyana/_/categorical_mapping.org
+++ b/lsms_library/countries/Guyana/_/categorical_mapping.org
@@ -1,0 +1,59 @@
+#+title: Guyana categorical mappings (per-country delta)
+
+* Educational Attainment (GLSMS 1992 EDUCN.dta, variable HS)
+
+The =HS= variable ("Highest Standard") is the numeric code from
+Education-module Column 4 of the GLSMS questionnaire (GUY01.pdf p.5):
+"What was the highest standard or form ...[NAME]... completed at that
+school?".  The questionnaire defines codes 1-15; the bare numeric codes
+reach the API as the float-stringified labels ='1.0'='15.0'= (the column
+is declared =str= in data_scheme.yml).  Confirmed against age: the
+median age-at-last-attendance rises monotonically with the code
+(STNDRD 1 -> ~10, FORM 5 -> ~17, OTHER -> ~18), matching Column 4's
+ordering.
+
+Questionnaire Column 4 code list:
+  1 PREP A, 2 PREP B, 3 STNDRD 1, 4 STNDRD 2, 5 STNDRD 3, 6 STNDRD 4,
+  7 FORM 1, 8 FORM 2, 9 FORM 3, 10 FORM 4, 11 FORM 5, 12 LOWER 6,
+  13 UPPER 6, 14 OTHER, 15 NONE.
+
+Level rationale:
+- PREP A/B (1,2): Guyanese preparatory classes that precede Primary
+  Standard 1 -> Pre-primary.
+- STNDRD 1-3 (3,4,5): partial primary -> Primary incomplete.
+- STNDRD 4 (6): Standard 4 is the terminal primary standard in this
+  instrument (no Standards 5/6 offered) -> Primary complete.
+- FORM 1,2 (7,8): early lower-secondary -> Lower secondary.
+- FORM 3 (9): end of lower secondary -> Lower secondary complete.
+- FORM 4 (10): start of upper secondary -> Upper secondary.
+- FORM 5 (11): O-level / CXC, terminal general-secondary year ->
+  Upper secondary complete.
+- LOWER 6 (12): Lower Sixth (A-level year 1) -> Upper secondary.
+- UPPER 6 (13): Upper Sixth (A-levels complete) -> Upper secondary complete.
+- OTHER (14): explicit catch-all bucket; cross-tab against school-type
+  (SCTP) shows it spans PostSecondary / University / TeacherTraining /
+  Primary with no consistent level -> Unknown (cannot assign a defensible
+  ordinal level).
+- NONE (15): attended a school but completed no standard -> None.
+- 17: a single observation (n=1, age 50) for a code the questionnaire
+  does not define (no 16 either); undecodable -> Unknown.
+
+#+name: harmonize_education
+| Original Label | Preferred Label          |
+|----------------+--------------------------|
+| 1.0            | Pre-primary              |
+| 2.0            | Pre-primary              |
+| 3.0            | Primary incomplete       |
+| 4.0            | Primary incomplete       |
+| 5.0            | Primary incomplete       |
+| 6.0            | Primary complete         |
+| 7.0            | Lower secondary          |
+| 8.0            | Lower secondary          |
+| 9.0            | Lower secondary complete |
+| 10.0           | Upper secondary          |
+| 11.0           | Upper secondary complete |
+| 12.0           | Upper secondary          |
+| 13.0           | Upper secondary complete |
+| 14.0           | Unknown                  |
+| 15.0           | None                     |
+| 17.0           | Unknown                  |

--- a/lsms_library/countries/India/1997-98/_/data_info.yml
+++ b/lsms_library/countries/India/1997-98/_/data_info.yml
@@ -60,7 +60,9 @@ individual_education:
       pid: idcode
       v: village
   myvars:
-      Educational Attainment: v01a05
+      Educational Attainment:
+          - v01a05
+          - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
 
 housing:
   file:

--- a/lsms_library/countries/India/_/categorical_mapping.org
+++ b/lsms_library/countries/India/_/categorical_mapping.org
@@ -1,0 +1,35 @@
+#+title: India categorical mappings
+#+description: Per-country, row-additive deltas on top of the global
+#+  categorical_mapping/*.org bases.  See
+#+  lsms_library/categorical_mapping/harmonize_education.org for the
+#+  inherited canonical-identity + common-English rows.
+
+# harmonize_education (GH #493): per-country delta for the India SLC 1997-98
+# survey (Uttar Pradesh / Bihar).  v01a05 "Educational Attainment" carries
+# Stata value labels truncated to 8 characters.  Full meanings come from the
+# Indian school ladder of the period:
+#   Illitera  = Illiterate                                   -> None
+#   Literate  = Literate, no formal schooling                -> Informal
+#   < Primar  = Below primary (some primary, not completed)  -> Primary incomplete
+#   Primary   = Primary completed (~class 5)                 -> Primary complete
+#   Middle    = Middle school completed (class 8)            -> Lower secondary complete
+#   Matric    = Matriculation / SSC (class 10 board)         -> Upper secondary
+#   Intermed  = Intermediate / Higher Secondary (class 12)   -> Upper secondary complete
+#   Diploma   = Diploma                                      -> Tertiary certificate/diploma
+#   Prof. de  = Professional degree (first prof. degree)     -> Bachelor
+#   BA/BSc    = Bachelor's degree                            -> Bachelor
+#   MA/MSc    = Master's degree                              -> Postgraduate
+#+name: harmonize_education
+| Original Label | Preferred Label              |
+|----------------+------------------------------|
+| Illitera       | None                         |
+| Literate       | Informal                     |
+| < Primar       | Primary incomplete           |
+| Primary        | Primary complete             |
+| Middle         | Lower secondary complete     |
+| Matric         | Upper secondary              |
+| Intermed       | Upper secondary complete     |
+| Diploma        | Tertiary certificate/diploma |
+| Prof. de       | Bachelor                     |
+| BA/BSc         | Bachelor                     |
+| MA/MSc         | Postgraduate                 |

--- a/lsms_library/countries/Iraq/2006-07/_/data_info.yml
+++ b/lsms_library/countries/Iraq/2006-07/_/data_info.yml
@@ -104,7 +104,9 @@ individual_education:
         i: xhhkey
         pid: xpers
     myvars:
-        Educational Attainment: q0406
+        Educational Attainment:
+            - q0406
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
 
 housing:
     # Dwelling module 2007ihses03. One row per household (xhhkey, unique).

--- a/lsms_library/countries/Iraq/2012/_/data_info.yml
+++ b/lsms_library/countries/Iraq/2012/_/data_info.yml
@@ -38,7 +38,9 @@ individual_education:
         i: hh
         pid: idcode
     myvars:
-        Educational Attainment: q0503
+        Educational Attainment:
+            - q0503
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
 
 # assets is built via the script path (_/assets.py) so that physical
 # instances of a durable (multiple `durable_serial` rows per

--- a/lsms_library/countries/Iraq/_/categorical_mapping.org
+++ b/lsms_library/countries/Iraq/_/categorical_mapping.org
@@ -1,0 +1,36 @@
+#+title: Iraq categorical mappings
+#+description: Per-country categorical label harmonization (row-additive delta
+#+  over the global tables in lsms_library/categorical_mapping/).
+
+# Educational attainment (GH #493). Iraqi ladder (from the questionnaire value
+# labels, ascending): Primary (6y) -> Intermediate/Mutawasita (3y, lower
+# secondary) -> Preparatory/Secondary/I'dadiya (3y, upper secondary) ->
+# Institute diploma (2y technical institute) -> Bachelor -> High/Postgraduate
+# diploma -> Masters -> Doctorate.  Note: this redeclares "Secondary" to
+# OVERRIDE the global base (which maps bare "Secondary" -> Lower secondary
+# complete); in the Iraqi codebook "Secondary" (q0406 code 6) sits above
+# "Intermediate" and is the upper-secondary I'dadiya certificate.
+#+name: harmonize_education
+| Original Label                    | Preferred Label              |
+|-----------------------------------+------------------------------|
+| No diploma, do not read and write | None                         |
+| No diploma, read only             | None                         |
+| No diploma, read and write        | None                         |
+| No certificate                    | None                         |
+| Elementary                        | Primary complete             |
+| Intermediate                      | Lower secondary complete     |
+| Intermediate (mid school)         | Lower secondary complete     |
+| Basic                             | Lower secondary complete     |
+| Secondary                         | Upper secondary complete     |
+| Preparatory                       | Upper secondary complete     |
+| Institute diploma                 | Tertiary certificate/diploma |
+| Diploma from an institution       | Tertiary certificate/diploma |
+| Bachelors degree                  | Bachelor                     |
+| Bachelor degree                   | Bachelor                     |
+| High diploma                      | Postgraduate                 |
+| Postgraduate diploma              | Postgraduate                 |
+| Masters degree                    | Postgraduate                 |
+| Master degree                     | Postgraduate                 |
+| Doctorate degree                  | Doctorate                    |
+| Phd (doctorate)                   | Doctorate                    |
+| Other                             | Unknown                      |

--- a/lsms_library/countries/Kazakhstan/1996/_/data_info.yml
+++ b/lsms_library/countries/Kazakhstan/1996/_/data_info.yml
@@ -42,13 +42,18 @@ individual_education:
     myvars:
         Educational Attainment:
             - bw003_
+            # GH #493: map Soviet-era post-secondary levels directly to the
+            # canonical ordinal vocabulary. Inline mapping RHS is used (a
+            # separate `mappings:` table on the same myvar would raise
+            # "unhashable type: dict"). See _/categorical_mapping.org for the
+            # full-label -> canonical documentation and level rationale.
             - mapping:
-                'occ. cou': Occupational courses
-                'PTU with': PTU with secondary education
-                'PTU, FSO': PTU/FSO without secondary education
-                'tech. co': Technical college
-                'univ. an': University and institute
-                'post-gra': Post-graduate
+                'occ. cou': Vocational/Technical
+                'PTU with': Vocational/Technical
+                'PTU, FSO': Vocational/Technical
+                'tech. co': Tertiary certificate/diploma
+                'univ. an': Bachelor
+                'post-gra': Postgraduate
 
 cluster_features:
     file: ../Data/KZ96SMP_PUF.dta

--- a/lsms_library/countries/Kazakhstan/_/categorical_mapping.org
+++ b/lsms_library/countries/Kazakhstan/_/categorical_mapping.org
@@ -1,0 +1,33 @@
+#+title: Kazakhstan Categorical Mappings
+
+* Educational Attainment (GH #493)
+
+Kazakhstan 1996 (KLSS) records the highest professional / post-secondary
+institution attended in =bw003_= (general-school grade ladder is in =bw001_=,
+"completed secondary?" in =bw002_=).  The six =bw003_= categories are Soviet-era
+post-secondary levels.  Because the 1996 wave already carries an inline
+=mapping:= (truncated Stata code -> readable label) on Educational Attainment,
+the canonical levels are wired by pointing that inline mapping's right-hand
+values directly at the canonical vocabulary (a separate =mappings:= table on the
+same myvar would raise "unhashable type: dict").  This table documents the
+full-label -> canonical correspondence for review/reuse.
+
+Level rationale:
+- Occupational courses, PTU/FSO (with or without secondary): vocational-technical
+  schooling (PTU = Professionalno-Tekhnicheskoye Uchilishche, trade school) ->
+  Vocational/Technical.
+- Technical college (tekhnikum, среднее специальное): specialized-secondary
+  diploma, ISCED-5 short tertiary -> Tertiary certificate/diploma.
+- University and institute (vyssheye obrazovaniye, the Soviet 5-year specialist
+  diploma): first higher-education degree -> Bachelor.
+- Post-graduate (aspirantura, toward Candidate of Science) -> Postgraduate.
+
+#+name: harmonize_education
+| Original Label                     | Preferred Label              |
+|------------------------------------+------------------------------|
+| Occupational courses               | Vocational/Technical         |
+| PTU/FSO without secondary education | Vocational/Technical         |
+| PTU with secondary education       | Vocational/Technical         |
+| Technical college                  | Tertiary certificate/diploma |
+| University and institute           | Bachelor                     |
+| Post-graduate                      | Postgraduate                 |

--- a/lsms_library/countries/Kosovo/2000/_/data_info.yml
+++ b/lsms_library/countries/Kosovo/2000/_/data_info.yml
@@ -67,13 +67,22 @@ individual_education:
     myvars:
         Educational Attainment:
             - s04_q4b
+            # Kosovo (former-Yugoslav) education ladder, s04_q4b "highest
+            # level completed" (codes 0-5, see Documentation/hheng.pdf Q4b
+            # and categorical_mapping.org #+name: harmonize_education).
+            # Inline-mapped to canonical levels directly because this myvar
+            # already carries an inline mapping (a mappings:-table on the
+            # same myvar would raise "unhashable type: dict").  "Primary"
+            # is the 8-year compulsory basic school (grades 1-8 = ISCED 1+2)
+            # -> Lower secondary complete; Gymnasium / Second. technical are
+            # the upper-secondary tracks; University -> Bachelor (first degree).
             - mapping:
-                Pre-Scho: Pre-School
-                Primary: Primary
-                'Second. ': Secondary
-                Gymnasiu: Gymnasium
-                Vocation: Vocational
-                Universi: University
+                Pre-Scho: Pre-primary
+                Primary: Lower secondary complete
+                'Second. ': Upper secondary complete
+                Gymnasiu: Upper secondary complete
+                Vocation: Vocational/Technical
+                Universi: Bachelor
 
 sample:
     file: "../Data/ID.dta"

--- a/lsms_library/countries/Kosovo/_/categorical_mapping.org
+++ b/lsms_library/countries/Kosovo/_/categorical_mapping.org
@@ -1,0 +1,51 @@
+#+title: Kosovo categorical mappings
+
+* Educational attainment (GH #493)
+
+Kosovo 2000 LSMS, =individual_education.Educational Attainment=, source
+=EDUC.dta= column =s04_q4b= ("highest level completed").  The Kosovo /
+former-Yugoslav education ladder (codes 0-5; see =2000/Documentation/hheng.pdf=
+question 4b, and the =s04_q4a= "highest class completed" grade detail):
+
+| Code | Survey level (label)       | ISCED reading                         |
+|------+----------------------------+---------------------------------------|
+|    0 | Preschool                  | pre-primary                           |
+|    1 | Primary (8-year basic)     | grades 1-8 = ISCED 1 + ISCED 2        |
+|    2 | Gymnasium                  | academic upper secondary              |
+|    3 | Secondary technical        | technical upper secondary             |
+|    4 | Vocational                 | vocational                            |
+|    5 | University                 | first university degree               |
+
+Non-obvious decisions:
+- *Primary -> Lower secondary complete.*  In the former-Yugoslav/Kosovo system
+  "primary school" (osnovna shkolla / shkolle fillore) is the single 8-year
+  compulsory basic-education cycle spanning grades 1-8 (the questionnaire shows
+  Primary covering CLASS/YEAR 1 TO 8, and =s04_q4a= tops out at 8 only for the
+  Primary level).  That cycle covers ISCED 1 (primary) AND ISCED 2 (lower
+  secondary), so "highest level completed = Primary" means completion of basic
+  compulsory education -> *Lower secondary complete*, not the global base's
+  ISCED-1-only "Primary complete".
+- *Gymnasium and Secondary technical -> Upper secondary complete.*  Both are
+  post-basic (ISCED 3) tracks; the level is the highest *completed*, so a person
+  whose top level is gymnasium/secondary-technical finished that upper-secondary
+  track (parallel to A-level/baccalaureat).
+- *University -> Bachelor.*  =s04_q4b= records only the level, with no
+  bachelor/master/doctorate split, so the first university degree (Bachelor) is
+  the appropriate canonical collapse.
+
+The labels reach the API via the Stata value labels (8-char truncated:
+=Pre-Scho=, =Primary=, =Second. =, =Gymnasiu=, =Vocation=, =Universi=).  Because
+the wave's =data_info.yml= already carries an inline =mapping:= on this myvar,
+the canonical levels are applied directly in that inline mapping's right-hand
+values (a separate =mappings:= table on the same myvar would raise "unhashable
+type: dict").  This table is the documentation of that wiring.
+
+#+name: harmonize_education
+| Original Label      | Preferred Label          |
+|---------------------+--------------------------|
+| Pre-School          | Pre-primary              |
+| Primary             | Lower secondary complete |
+| Secondary           | Upper secondary complete |
+| Gymnasium           | Upper secondary complete |
+| Vocational          | Vocational/Technical     |
+| University          | Bachelor                 |

--- a/lsms_library/countries/Liberia/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Liberia/2018-19/_/data_info.yml
@@ -20,7 +20,9 @@ individual_education:
         i: hhid
         pid: member_id
     myvars:
-        Educational Attainment: S2_14
+        Educational Attainment:
+            - S2_14
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
 
 cluster_features:
     file:

--- a/lsms_library/countries/Liberia/_/categorical_mapping.org
+++ b/lsms_library/countries/Liberia/_/categorical_mapping.org
@@ -1,0 +1,42 @@
+#+title: Liberia Categorical Mappings
+#+description: Per-country row-additive harmonization deltas (GH #493).
+#+  Rows here extend the global base
+#+  lsms_library/categorical_mapping/harmonize_education.org with the
+#+  Liberia-specific raw labels from S2_14 ("what is the highest grade
+#+  completed by [name]?", 2018-19 HIES/Forestry survey).
+#+
+#+  Source code list (ordinal):
+#+    0=pre-primary/no grade; 11-22=grade 1..grade 12;
+#+    23=aad (Associate of Arts Degree, 2-yr post-secondary diploma);
+#+    24-27=u1..u4 (university years 1-4, Bachelor track);
+#+    28=master and above (u5).
+#+
+#+  Liberian school ladder: primary = grades 1-6; junior (lower) secondary =
+#+  grades 7-9; senior (upper) secondary = grades 10-12. "Highest grade
+#+  completed", so grade N completed means level N is done: grade 6 completes
+#+  primary, grade 9 completes lower secondary, grade 12 completes upper
+#+  secondary; the in-between grades are the corresponding incomplete/"in
+#+  progress" level.
+
+#+name: harmonize_education
+| Original Label        | Preferred Label              |
+|-----------------------+------------------------------|
+| pre-primary/no grade  | Pre-primary                  |
+| grade 1               | Primary incomplete           |
+| grade 2               | Primary incomplete           |
+| grade 3               | Primary incomplete           |
+| grade 4               | Primary incomplete           |
+| grade 5               | Primary incomplete           |
+| grade 6               | Primary complete             |
+| grade 7               | Lower secondary              |
+| grade 8               | Lower secondary              |
+| grade 9               | Lower secondary complete     |
+| grade 10              | Upper secondary              |
+| grade 11              | Upper secondary              |
+| grade 12              | Upper secondary complete     |
+| aad                   | Tertiary certificate/diploma |
+| u1                    | Bachelor                     |
+| u2                    | Bachelor                     |
+| u3                    | Bachelor                     |
+| u4                    | Bachelor                     |
+| master and above (u5) | Postgraduate                 |

--- a/lsms_library/countries/Serbia/2007/_/data_info.yml
+++ b/lsms_library/countries/Serbia/2007/_/data_info.yml
@@ -102,4 +102,6 @@ individual_education:
         i: [opstina, popkrug, dom]
         pid: lice
     myvars:
-        Educational Attainment: obrazovanje
+        Educational Attainment:
+            - obrazovanje
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']

--- a/lsms_library/countries/Serbia/_/categorical_mapping.org
+++ b/lsms_library/countries/Serbia/_/categorical_mapping.org
@@ -1,0 +1,33 @@
+#+title: Serbia categorical mappings
+
+* Educational attainment
+
+Serbia LSMS 2007 records ~obrazovanje~ ("highest level completed") as numeric
+codes 00-11.  The decode comes from the household questionnaire legend "Codes
+for B1. Education (highest level completed)" (srb07hhqe.pdf, p.2); the code ->
+age distribution in individual.dta corroborates it (code 00 median age 8,
+96.6% under 15; code 01 "No school" median age 73).  Row-additive delta on the
+global ~harmonize_education~ base.
+
+The leading ~Unknown -> Unknown~ row is intentional: the org reader
+(~df_from_orgfile~ -> ~_to_numeric~) coerces an all-numeric column to ints,
+which would strip the zero-padding ("00" -> 0) and break the match against the
+zero-padded raw codes ("00".."11").  One non-numeric cell forces the whole
+~Original Label~ column to stay string, preserving the codes verbatim.
+
+#+name: harmonize_education
+| Original Label | Preferred Label              |
+|----------------+------------------------------|
+| Unknown        | Unknown                      |
+| 00             | None                         |
+| 01             | None                         |
+| 02             | Primary incomplete           |
+| 03             | Primary complete             |
+| 04             | Vocational/Technical         |
+| 05             | Upper secondary complete     |
+| 06             | Upper secondary complete     |
+| 07             | Upper secondary complete     |
+| 08             | Tertiary certificate/diploma |
+| 09             | Bachelor                     |
+| 10             | Postgraduate                 |
+| 11             | Doctorate                    |

--- a/lsms_library/countries/South Africa/1993/_/data_info.yml
+++ b/lsms_library/countries/South Africa/1993/_/data_info.yml
@@ -88,30 +88,38 @@ individual_education:
             - mapping:
                 # SALDRU PSLSD 1993 educ_c: highest education completed.
                 # No value labels in source (.dta int codes); decoded from
-                # the pre-1994 South African schooling ladder.
+                # the pre-1994 South African schooling ladder and mapped
+                # directly onto the canonical ordinal levels (GH #493).
+                # Primary = Sub A..Standard 5 (Grades 1-7); junior/lower
+                # secondary = Standards 6-7 (Grades 8-9, GETC at Grade 9);
+                # senior/upper secondary = Standards 8-10 (Grades 10-12,
+                # Standard 10 = Matric = upper secondary complete).
+                # NB this wave carries an inline mapping: dict, so the RHS
+                # values are canonical levels directly (a mappings: table on
+                # the same myvar would raise "unhashable type: dict").
                 -4: ~          # sentinel for missing — null out
                 -3: ~          # sentinel for missing — null out
                 -1: ~          # sentinel for missing — null out
                 0: "None"
-                1: "Sub A (Grade 1)"
-                2: "Sub B (Grade 2)"
-                3: "Standard 1 (Grade 3)"
-                4: "Standard 2 (Grade 4)"
-                5: "Standard 3 (Grade 5)"
-                6: "Standard 4 (Grade 6)"
-                7: "Standard 5 (Grade 7)"
-                8: "Standard 6 (Grade 8)"
-                9: "Standard 7 (Grade 9)"
-                10: "Standard 8 (Grade 10)"
-                11: "Standard 9 (Grade 11)"
-                12: "Standard 10 (Matric, Grade 12)"
-                13: "Diploma/certificate with less than Standard 10"
-                14: "Diploma/certificate with Standard 10"
-                15: "Degree"
-                16: "Postgraduate degree or diploma"
-                17: "Other"
-                18: "Don't know"
-                19: "Adult education / literacy"
+                1: "Primary incomplete"          # Sub A (Grade 1)
+                2: "Primary incomplete"          # Sub B (Grade 2)
+                3: "Primary incomplete"          # Standard 1 (Grade 3)
+                4: "Primary incomplete"          # Standard 2 (Grade 4)
+                5: "Primary incomplete"          # Standard 3 (Grade 5)
+                6: "Primary incomplete"          # Standard 4 (Grade 6)
+                7: "Primary complete"            # Standard 5 (Grade 7) completes primary
+                8: "Lower secondary"             # Standard 6 (Grade 8)
+                9: "Lower secondary complete"    # Standard 7 (Grade 9) completes GET phase
+                10: "Upper secondary"            # Standard 8 (Grade 10)
+                11: "Upper secondary"            # Standard 9 (Grade 11)
+                12: "Upper secondary complete"   # Standard 10 (Matric, Grade 12)
+                13: "Vocational/Technical"       # Diploma/certificate w/o Matric (pre-tertiary trade cert)
+                14: "Tertiary certificate/diploma" # Diploma/certificate with Standard 10 (post-Matric)
+                15: "Bachelor"                   # Degree
+                16: "Postgraduate"               # Postgraduate degree or diploma
+                17: "Unknown"                    # Other
+                18: "Unknown"                    # Don't know
+                19: "Informal"                   # Adult education / literacy
 
 assets:
     # Durable-goods module M2_NFS4.dta: Quantity (dura_n, count owned) per item

--- a/lsms_library/countries/Tajikistan/1999/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/1999/_/data_info.yml
@@ -84,17 +84,20 @@ individual_education:
         pid: iid
     myvars:
         Educational Attainment:
+            # Soviet ladder (codes decoded from the HH questionnaire); right-hand
+            # values are canonical harmonize_education levels (GH #493) — a wave
+            # with an inline mapping: cannot also carry a mappings: table.
             - s3q2
             - mapping:
-                1.0: 8th (9th) class
-                2.0: secondary school
-                3.0: prof-tech school
-                4.0: spec tech school
-                5.0: higher ed institute
-                6.0: candidate of science
-                7.0: doctor of science
-                8.0: other
-                9.0: none
+                1.0: Lower secondary complete   # 8th (9th) class
+                2.0: Upper secondary complete   # secondary school
+                3.0: Vocational/Technical       # prof-tech school (PTU)
+                4.0: Vocational/Technical        # spec tech school (technikum)
+                5.0: Bachelor                    # higher ed institute (VUZ)
+                6.0: Doctorate                   # candidate of science (kandidat nauk)
+                7.0: Doctorate                   # doctor of science (doktor nauk)
+                8.0: Unknown                     # other
+                9.0: None
 
 housing:
     # SSEC2 Part 2A (structure) + Part 2B (tenure/toilet).  Value labels are

--- a/lsms_library/countries/Tajikistan/1999/_/mapping.py
+++ b/lsms_library/countries/Tajikistan/1999/_/mapping.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from lsms_library.local_tools import format_id
 
 
@@ -5,3 +7,19 @@ def i(value):
     """Format composite household id from pop_pt + hhid."""
     parts = [str(int(value.iloc[k])) for k in range(len(value))]
     return format_id('-'.join(parts))
+
+
+def individual_education(df):
+    """Map the out-of-ladder s3q2 code 0 (1 obs) to Unknown.
+
+    The 1999 inline mapping (data_info.yml) decodes the questionnaire ladder
+    codes 1-9; code 0 is not part of that ladder and survives the mapping as
+    the literal string '0.0'.  It is undecodable (GH #493) -> Unknown.
+    """
+    if 'Educational Attainment' in df.columns:
+        # The unmapped code survives as the float 0.0 here (stringified to
+        # '0.0' only in the API output), so replace both forms.
+        df['Educational Attainment'] = df['Educational Attainment'].replace(
+            {0.0: 'Unknown', '0.0': 'Unknown'}
+        )
+    return df

--- a/lsms_library/countries/Tajikistan/2003/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/2003/_/data_info.yml
@@ -84,13 +84,16 @@ individual_education:
         pid: hhlid
     myvars:
         Educational Attainment:
+            # Grades-explicit ladder; right-hand values are canonical
+            # harmonize_education levels (GH #493) — a wave with an inline
+            # mapping: cannot also carry a mappings: table.
             - m3bq5
             - mapping:
-                0.0: none
-                1.0: primary (grades 1-4)
-                2.0: basic (grades 1-8(9))
-                3.0: secondary general (grades 9-10(11))
-                4.0: secondary special
-                5.0: secondary technical
-                6.0: higher education
-                7.0: graduate school/aspirantura
+                0.0: None                       # none
+                1.0: Primary complete           # primary (grades 1-4)
+                2.0: Lower secondary complete   # basic (grades 1-8(9))
+                3.0: Upper secondary complete   # secondary general (grades 9-10(11))
+                4.0: Vocational/Technical       # secondary special (technikum)
+                5.0: Vocational/Technical       # secondary technical
+                6.0: Bachelor                   # higher education (VUZ)
+                7.0: Postgraduate               # graduate school/aspirantura

--- a/lsms_library/countries/Tajikistan/2007/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/2007/_/data_info.yml
@@ -81,7 +81,9 @@ individual_education:
         i: hhid
         pid: memid
     myvars:
-        Educational Attainment: m3bq5
+        Educational Attainment:
+            - m3bq5
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
 
 housing:
     # Module 7: r1m7a (structure + tenure), r1m7b (electricity),

--- a/lsms_library/countries/Tajikistan/2009/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/2009/_/data_info.yml
@@ -81,7 +81,9 @@ individual_education:
         i: HHID
         pid: MEMID
     myvars:
-        Educational Attainment: M3BQ4
+        Educational Attainment:
+            - M3BQ4
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
 
 housing:
     # 2009 TLSS dropped the physical-structure block (no walls/roof/floor/

--- a/lsms_library/countries/Tajikistan/_/categorical_mapping.org
+++ b/lsms_library/countries/Tajikistan/_/categorical_mapping.org
@@ -1,0 +1,49 @@
+#+title: Tajikistan Categorical Mappings
+
+* Educational attainment (GH #493)
+
+Row-additive delta over the global
+=lsms_library/categorical_mapping/harmonize_education.org=.  Maps the
+Tajikistan TLSS Soviet-era education ladder onto the canonical ordinal
+vocabulary.  The 2007/2009 .dta value labels (decoded by the source) and the
+2003 inline-mapped labels (grades-explicit) are wired here; the 1999 inline
+mapping is rewritten in-place (it carries codes the framework cannot also
+table-map).  See CONTENTS.org and per-wave data_info.yml for provenance.
+
+Notes on the non-obvious levels:
+- =8th (9th) class= / =basic (grades 1-8(9))= = end of Soviet basic/incomplete
+  secondary (8 or 9 years) -> Lower secondary complete.
+- =secondary general= = full general secondary (10/11 yrs) -> Upper secondary
+  complete.
+- =secondary special= (technikum, среднее специальное), =secondary technical=,
+  =prof-tech school= (PTU), =spec tech school= = post-/secondary vocational
+  tiers; the canonical vocabulary has one slot -> Vocational/Technical.
+- =higher education= / =higher ed institute= (VUZ specialist diploma) = first
+  university degree -> Bachelor.
+- =graduate school/aspirantura= = postgraduate study -> Postgraduate.
+- =candidate of science= (kandidat nauk) and =doctor of science= (doktor nauk)
+  = research doctoral degrees -> Doctorate.
+- =other= = uncodable residual -> Unknown.
+
+#+name: harmonize_education
+| Original Label                      | Preferred Label          |
+|-------------------------------------+--------------------------|
+| none                                | None                     |
+| primary                             | Primary complete         |
+| primary (grades 1-4)                | Primary complete         |
+| basic                               | Lower secondary complete |
+| basic (grades 1-8(9))               | Lower secondary complete |
+| 8th (9th) class                     | Lower secondary complete |
+| secondary general                   | Upper secondary complete |
+| secondary general (grades 9-10(11)) | Upper secondary complete |
+| secondary school                    | Upper secondary complete |
+| secondary special                   | Vocational/Technical     |
+| secondary technical                 | Vocational/Technical     |
+| prof-tech school                    | Vocational/Technical     |
+| spec tech school                    | Vocational/Technical     |
+| higher education                    | Bachelor                 |
+| higher ed institute                 | Bachelor                 |
+| graduate school/aspirantura         | Postgraduate             |
+| candidate of science                | Doctorate                |
+| doctor of science                   | Doctorate                |
+| other                               | Unknown                  |


### PR DESCRIPTION
Harmonizes `individual_education` to the canonical ordinal vocabulary for **13 of the 14** countries in #493, via per-country `harmonize_education` delta tables (row-additive over the global base). Built by a delegated fan-out (one agent per country), then **reviewed for semantic correctness** (not just "no leftovers").

## Countries (13)
- **Clean text (8):** Albania, Cambodia, India, Iraq, Kazakhstan, Kosovo, South Africa, Tajikistan.
- **Numeric — decoded from the survey questionnaire (5):** Azerbaijan, Guatemala, Guyana, Serbia, China*. Soviet-system levels (PTU→Vocational, tekhnikum→Tertiary diploma, "candidate/doctor of science"→Doctorate), apartheid-era Standard/Sub grades, etc. — rationale in each commit.

## Notable
- **Guatemala — bonus fix:** was mis-wired to `ECV11P10.DTA:p10acp` (a *work-module* person code, ~0.04 corr with schooling). The agent found the real education variable (`p07b27a` "último grado aprobado", age-validated) and **rewired** it.
- **Azerbaijan:** code `10`="OTHER" (modal, heterogeneous no-diploma bucket) → `Unknown` by design (not fabricated to a level) — a refinement candidate.

## Excluded → separate issue
- **China** is mis-wired to `s01b10` = the *mother's occupation code* ("MAIN TYPE OF WORK"), not education; the CLSS survey has **no categorical attainment variable** (only continuous years-of-schooling). The agent correctly refused to fabricate a mapping. Filed separately (re-derive from years-of-schooling, or drop).

## Verified
`Feature('individual_education')(<13>)` → **302,528 rows, zero non-canonical leftovers**; 8 categorical-merge tests pass. Each commit carries the per-country mapping rationale.

Substantially closes #493 (China tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)