### PR TITLE
fix: per-country config bugs from the Feature() audit (#499, #500, #502)

### DIFF
--- a/lsms_library/countries/Cambodia/_/cambodia.py
+++ b/lsms_library/countries/Cambodia/_/cambodia.py
@@ -42,6 +42,28 @@ def _household_roster_from_df(df, sex, age, HHID, sex_converter=None, age_conver
     return g.sum()
 
 
+def WeeksAway(value):
+    '''
+    Decode the 2019-20 weeks-away question (s02q14) to a numeric value.
+
+    The source column mixes the label 'Absent less than one week' with
+    numeric week counts (1.0 .. 52.0).  Left undecoded the label leaks
+    into household_roster['WeeksAway'] as a string, breaking the numeric
+    dtype and roster_to_characteristics' ``12 - weeks`` conversion
+    (GH #502).  'Absent less than one week' means essentially no absence
+    in the recall window, so it maps to 0; numeric counts pass through.
+    '''
+    if pd.isna(value):
+        return pd.NA
+    s = str(value).strip()
+    if s.lower().startswith('absent less than'):
+        return 0
+    try:
+        return int(float(s))
+    except (TypeError, ValueError):
+        return pd.NA
+
+
 def age_sex_composition(df):
     Age_ints = ((0,4),(4,9),(9,14),(14,19),(19,31),(31,51),(51,100))
     testdf = _household_roster_from_df(df, sex='s02q03',

--- a/lsms_library/countries/EthiopiaRHS/_/categorical_mapping.org
+++ b/lsms_library/countries/EthiopiaRHS/_/categorical_mapping.org
@@ -175,16 +175,20 @@ coverage gap).
 * erhs_sex
 
 Codes 0 and 6 are 1989 demog89_1.sex data-entry errors (the
-labelled scheme is 1=Male/2=Female only) -> empty -> NA Sex, same
-treatment as the relnhhed 11/36 and reltn4 -9 sentinels.
+labelled scheme is 1=Male/2=Female only) -> NA Sex, same treatment
+as the relnhhed 11/36 and reltn4 -9 sentinels.  Their Preferred
+Label is the '---' null sentinel (df_from_orgfile maps '---' -> NA),
+not a blank cell: a blank cell loads as the empty string '' and
+leaks into the required Sex column instead of resolving to <NA>
+(GH #502).
 
 #+NAME: erhs_sex
 | Code | Preferred Label |
 |------+-----------------|
-|    0 |                 |
+|    0 | ---             |
 |    1 | M               |
 |    2 | F               |
-|    6 |                 |
+|    6 | ---             |
 
 * harmonize_food
 

--- a/lsms_library/countries/Iraq/2012/_/2012.py
+++ b/lsms_library/countries/Iraq/2012/_/2012.py
@@ -6,6 +6,28 @@ runs on the extracted, (t, i, Shock)-indexed frame after the column mapping.
 """
 
 
+def months_away(x):
+    """Constant MonthsAway=0 for every 2012 roster member (GH #499).
+
+    The IHSES 2012 household roster (2012ihses01) enumerates current
+    household members and carries NO residence-duration question — the
+    only YES/NO person attributes are parental presence (q110/q113) and
+    birthplace (q108), not months present/away.  Every listed member is a
+    current resident, so MonthsAway=0 (present all 12 months).
+
+    We deliberately emit MonthsAway (not MonthsSpent) so this wave keys the
+    same residence column as 2006-07, which carries real MonthsAway (q0113
+    in that wave).  ``roster_to_characteristics`` picks ONE residence
+    column for the whole country-concatenated roster (monthsspent has
+    precedence over monthsaway); introducing MonthsSpent here would make
+    2006-07's all-NaN MonthsSpent column drop that wave instead.  Keeping
+    both Iraq waves on MonthsAway lets the per-wave real/constant values
+    coexist without an all-NaN column silently dropping a whole wave from
+    ``household_characteristics``.
+    """
+    return 0
+
+
 def shocks(df):
     """Collapse the 23-shock x household cross-product to experienced shocks.
 

--- a/lsms_library/countries/Iraq/2012/_/data_info.yml
+++ b/lsms_library/countries/Iraq/2012/_/data_info.yml
@@ -22,12 +22,33 @@ household_roster:
         - "../Data/2012ihses01_household_roster.dta"
     idxvars:
         v: cluster
-        i: hh
+        # i=questid is the unique household id (25,146 distinct, matching the
+        # cover-page sample keyspace 100%).  The roster `hh` field is only a
+        # within-dwelling sequence number (9 distinct values), so keying on it
+        # collapsed every household into 9 ids that matched 0% of sample, made
+        # v 100% NaN after _join_v_from_sample, and dropped wave 2012 entirely
+        # from household_characteristics (GH #499).  Mirrors housing/shocks/
+        # assets in this same wave, which already key on questid.
+        i: questid
         pid: idcode
     myvars:
         Sex: q0102
         Relationship: q0105
         Age: q0104
+        # IHSES 2012 roster has no residence-duration question, so every
+        # listed member is a current resident: MonthsAway=0 (constant via
+        # the months_away hook in 2012.py).  We use MonthsAway (not
+        # MonthsSpent) to match wave 2006-07, which carries real MonthsAway
+        # (q0113): roster_to_characteristics resolves a SINGLE residence
+        # column across the whole country-concatenated roster (monthsspent
+        # has precedence over monthsaway), so a wave that introduced
+        # MonthsSpent would make 2006-07's all-NaN MonthsSpent drop that
+        # wave instead.  Keeping both waves on MonthsAway avoids the
+        # all-NaN-column contamination that otherwise drops a whole wave
+        # from household_characteristics (GH #499).
+        MonthsAway:
+            - q0102
+            - mapping: months_away
 
 individual_education:
     # Education module; q0503 = highest attainment (12 English-labeled levels).

--- a/lsms_library/countries/Kosovo/2000/_/data_info.yml
+++ b/lsms_library/countries/Kosovo/2000/_/data_info.yml
@@ -49,7 +49,7 @@ household_roster:
 
 
         Age: s1a_q05
-        Marital_status:
+        Marital:
             - s1a_q06
             - mapping:
                   1: Married

--- a/lsms_library/countries/Kosovo/_/data_scheme.yml
+++ b/lsms_library/countries/Kosovo/_/data_scheme.yml
@@ -23,7 +23,7 @@ Data Scheme:
     Generation: int
     Distance: int
     Affinity: str
-    Marital_status: str
+    Marital: str
 
   sample:
     index: (i, t)

--- a/lsms_library/countries/Malawi/2016-17/_/food_acquired.py
+++ b/lsms_library/countries/Malawi/2016-17/_/food_acquired.py
@@ -6,6 +6,7 @@ sys.path.append('../../_/')
 import pandas as pd
 import numpy as np
 import json
+from lsms_library.local_tools import format_id
 from malawi import (handling_unusual_units, conversion_table_matching,
                     food_acquired_to_canonical, normalize_food_label)
 
@@ -21,6 +22,13 @@ hh_cs = get_dataframe('../Data/Cross_Sectional/hh_mod_a_filt.dta', convert_categ
 hh_pn = get_dataframe('../Data/Panel/hh_mod_a_filt_16.dta', convert_categoricals=True)
 regions_cs = hh_cs[['case_id', 'region']].rename(columns={'case_id': 'j'})
 regions_pn = hh_pn[['y3_hhid', 'region']].rename(columns={'y3_hhid': 'j'})
+# Apply the same household-id keyspace the framework's cs_i mapping applies
+# to sample/cluster_features/interview_date (GH #499): cross-sectional cases
+# get the 'cs-17-' prefix, panel cases stay bare; both pass through format_id.
+# Done here too so the `regions` join below (keyed on j) still matches after
+# the i/j ids are prefixed in `df`/`panel_df`.
+regions_cs['j'] = 'cs-17-' + regions_cs['j'].apply(format_id)
+regions_pn['j'] = regions_pn['j'].apply(format_id)
 regions = pd.concat([regions_cs, regions_pn]).drop_duplicates().set_index('j')['region']
 regions = regions.replace({'South': 'Southern'})
 regions.name = 'm'
@@ -34,6 +42,13 @@ df = df.rename(columns_dict, axis=1)
 panel_df = panel_df.rename(columns_dict, axis=1)
 df = df.loc[:, list(set(columns_dict.values()))]
 panel_df = panel_df.loc[:, list(set(columns_dict.values()))]
+# Align the household-id keyspace with sample/cluster_features/interview_date,
+# which apply the cs_i mapping ('cs-17-'+format_id(case_id)) to the
+# cross-sectional half and a bare format_id(y3_hhid) to the panel half
+# (GH #499).  Without this, food_acquired's household id never carried the
+# 'cs-17-' prefix, so _join_v_from_sample produced NULL v for ~141k rows.
+df['j'] = 'cs-17-' + df['j'].apply(format_id)
+panel_df['j'] = panel_df['j'].apply(format_id)
 df = pd.concat([df, panel_df], axis=0)
 df['i'] = normalize_food_label(df['i'].astype(str).str.capitalize())
 

--- a/lsms_library/countries/Mali/_/mali.py
+++ b/lsms_library/countries/Mali/_/mali.py
@@ -45,10 +45,40 @@ def Relationship(value):
     else:
         return value.title()
 
+def MonthsSpent(value):
+    '''
+    Decode the 2014-15 EACI residence-duration question (s01q11) to a
+    numeric months-present value in 0..12.
+
+    Unlike the EHCVM waves (2017-18 s1q13, 2018-19 s01q12) whose source
+    column is a binary Oui/Non gate, the 2014-15 EACI column is a MONTHS
+    COUNT carrying raw French labels: a '36 mois et plus' top-code and a
+    'Manquant' missing sentinel alongside integer 0..35.  Left undecoded
+    those labels leak into household_roster['MonthsSpent'], and
+    roster_to_characteristics' to_numeric(errors='coerce') then turns
+    every '36 mois et plus' / 'Manquant' row into NaN, silently dropping
+    those members from household_characteristics (GH #502).
+
+    Mapping: '36 mois et plus' -> 12 (capped; resident the whole window),
+    'Manquant'/missing -> <NA>, numeric n -> min(n, 12).
+    '''
+    if pd.isna(value):
+        return pd.NA
+    s = str(value).strip()
+    if s in ('Manquant', 'NSP', ''):
+        return pd.NA
+    if s.lower().startswith('36 mois'):  # '36 mois et plus' top-code
+        return 12
+    try:
+        n = int(float(s))
+    except (TypeError, ValueError):
+        return pd.NA
+    return min(max(n, 0), 12)
+
 def Int_t(value):
     '''
     Formatting interview date
-    '''   
+    '''
     if pd.isna(value) or value == 'Manquant':
         return pd.NA
     else:

--- a/lsms_library/countries/Serbia/2007/_/data_info.yml
+++ b/lsms_library/countries/Serbia/2007/_/data_info.yml
@@ -47,12 +47,26 @@ sample:
             i: [opstina, popkrug, dom]
         myvars:
             v: popkrug
+            # GH #500: carry the full settlement key (opstina, popkrug) as
+            # plain columns so the df_hh<->df_ed join can match on it.  The
+            # household id `i` collapses [opstina, popkrug, dom] into one
+            # composite string, so opstina/popkrug aren't otherwise available
+            # as merge keys.  Dropped after the merge via `drop:` below.
+            opstina: opstina
+            popkrug: popkrug
             weight: hhweight
             panel_weight: popweight
     df_ed:
         file: "../Data/enumeration_district.dta"
+        # GH #500: opstina+popkrug is the unique settlement key in the
+        # enumeration-district file (popkrug alone is non-unique: 510 rows ->
+        # 328 unique popkrug).  Merging on popkrug (= v) alone multiplied
+        # household rows ~2x, then _normalize_dataframe_index collapsed the
+        # duplicate (i,t) tuples via groupby().first(), arbitrarily picking one
+        # cluster per household.  Joining on the full key makes it 1:1.
         idxvars:
-            v: popkrug
+            opstina: opstina
+            popkrug: popkrug
         myvars:
             Rural:
                 - tip
@@ -61,7 +75,11 @@ sample:
                     rural: Rural
             strata: region2
     merge_on:
-        - v
+        - opstina
+        - popkrug
+    drop:
+        - opstina
+        - popkrug
     final_index:
         - i
         - t


### PR DESCRIPTION
Per-country config fixes from the cross-feature `Feature()` audit. Each was implemented in an isolated worktree and verified (before/after) via `LSMS_COUNTRIES_ROOT`. Several are **silent-data-loss recoveries**, not cosmetic:

## Recoveries (silent data loss)
- **#499 Iraq 2012** — roster `i: hh` was a within-dwelling sequence (9 distinct values!) → `questid`; plus an inherited all-NaN `MonthsAway`. **Whole wave recovered: 25,145 households** were missing from `household_characteristics`.
- **#499 Malawi 2016-17** — `cs-17-` household-id prefix applied in `food_acquired.py` (matching sample/cluster_features). **141,089 `food_expenditures` rows** (78.8%) no longer dropped on the v-join.
- **#502 Mali 2014-15** — `MonthsSpent` decoder (`36 mois et plus`→12, `Manquant`→NA) for the months-count `s01q11`. **3,662 households recovered** (2014-15 `household_characteristics` 117 → 3,779).
- **#500 Serbia** — `sample()` merged on the full `[opstina, popkrug]` settlement key (was non-unique `popkrug` → 2× row multiplication then lossy `groupby().first()`). Now 1:1, 5,557 rows = source count.

## Harmonization / schema
- **#502** Cambodia `WeeksAway`→numeric; EthiopiaRHS `Sex=''`→`<NA>`; Kosovo `Marital_status`→`Marital`.

## Reclassified / split out (not fixed here)
- **#500 Mali** — false inclusion (joins already 1:1).
- **#500 Guyana** → **#503** (household-identity `i=[ED,HH,SN]`, country-wide).
- **#499 Malawi 2019-20** → **#504** (framework: `update_id` transitive-chain `_N`-suffix collision).

Schema-consistency tests pass for all touched countries. Verified holistically in the post-merge green re-audit (with the framework fixes, separate PR).