### PR TITLE
fix(feature): cross-country index collapse under market= and reduced-index countries (#511, #512)

### DIFF
--- a/lsms_library/feature.py
+++ b/lsms_library/feature.py
@@ -356,11 +356,18 @@ class Feature:
         pass_currency = None if use_numeraire else (currency if monetary else None)
         if (use_numeraire is not None or pass_currency == 'index') and canonical_levels:
             canonical_levels = canonical_levels + [CURRENCY_LEVEL]
-        # `market` (forwarded below) adds an `m` index level via
-        # Country._add_market_index; widen the canonical index so the
-        # cross-country concat keeps it (GH #508), as for the currency level.
-        if kwargs.get("market") is not None and canonical_levels and "m" not in canonical_levels:
-            canonical_levels = canonical_levels + ["m"]
+        # `market` (forwarded below) is applied by Country._add_market_index,
+        # which DROPS the `v` level and inserts an `m` level.  Mirror that in the
+        # canonical level list -- drop `v`, add `m` -- so (a) _harmonize_country_frame
+        # can still reorder each frame to canonical order (with `v` gone, requiring
+        # every *original* canonical level to be present would skip the reorder),
+        # and (b) `expected_names` matches the real per-country nlevels, letting the
+        # GH#326 set_names restoration fire instead of leaving a trailing unnamed
+        # level (issue #511: food_prices(market='Region') -> [..., 's', None]).
+        if kwargs.get("market") is not None and canonical_levels:
+            canonical_levels = [lvl for lvl in canonical_levels if lvl != "v"]
+            if "m" not in canonical_levels:
+                canonical_levels = canonical_levels + ["m"]
 
         for name in targets:
             try:
@@ -409,6 +416,34 @@ class Feature:
         if not frames:
             return pd.DataFrame()
 
+        # pandas cannot stack frames whose index DEPTH/NAMES differ into a named
+        # MultiIndex -- it falls back to an unnamed object index, collapsing the
+        # WHOLE feature (issue #512: EthiopiaRHS's documented (t,i) reduced assets
+        # stacked with item-level (t,i,j); also surfaces under labels='Aggregate'
+        # when most countries KeyError-drop and a j-less survivor remains).  Keep
+        # the modal index shape and exclude the divergent frame(s) with a loud,
+        # named warning -- the excluded country stays available via
+        # Country(name).<table>().
+        if len(frames) > 1:
+            from collections import Counter
+            shape_of = lambda f: tuple(f.index.names)
+            counts = Counter(shape_of(f) for f in frames)
+            if len(counts) > 1:
+                modal = counts.most_common(1)[0][0]
+                kept = [f for f in frames if shape_of(f) == modal]
+                dropped = [f for f in frames if shape_of(f) != modal]
+                dropped_names = [f.index.get_level_values("country")[0]
+                                 for f in dropped if len(f)]
+                warnings.warn(
+                    f"{self.table_name}: excluded {len(dropped)} country frame(s) "
+                    f"{dropped_names} with a divergent index shape from the "
+                    f"cross-country assembly (kept modal shape {list(modal)}); "
+                    f"stacking heterogeneous index depths would collapse the whole "
+                    f"result to an unnamed index. Access the excluded data via "
+                    f"Country(name).{self.table_name}()."
+                )
+                frames = kept
+
         result = pd.concat(frames)
 
         # GH #326: pd.concat can leave the (structurally-consistent) index
@@ -424,9 +459,11 @@ class Feature:
             result.index = result.index.set_names(expected_names)
 
         # Surface (rather than silently return) the pathological case where
-        # heterogeneous per-country indices made pandas fall back to an
-        # unnamed object index of stringified tuples (GH #325).
-        if len(frames) > 1 and list(result.index.names) == [None]:
+        # heterogeneous per-country indices left an unnamed level -- either a full
+        # fallback to an unnamed object index (GH #325, names == [None]) or a
+        # PARTIAL collapse (e.g. ['country', None, None]) that previously slipped
+        # through silently (issue #512, labels='Aggregate' variant).
+        if len(frames) > 1 and None in list(result.index.names):
             shapes = {
                 f.index.get_level_values(0)[0] if len(f) else "?":
                     list(f.index.names)


### PR DESCRIPTION
Fixes two cross-country assembly defects in `Feature.__call__`, both surfaced by the `Feature()` audit harness and red-team-confirmed.

## #511 — `food_prices(market='Region')` returns a trailing unnamed level
`market` is applied by `Country._add_market_index`, which **drops `v` and inserts `m`** — but the widening appended `m` while keeping `v`, so `expected_names` over-counted (9 vs the real 8 levels), the GH#326 `set_names` restore was skipped, and `_harmonize_country_frame` declined to reorder (with `v` gone, "all original canonical levels present" was False). **Fix:** when `market` is set, mirror `_add_market_index` in the canonical level list — drop `v`, add `m`. Result is now fully named `['country','t','i','j','u','s','currency','m']`.

## #512 — `Feature('assets')()` collapses to an unnamed index
EthiopiaRHS ships a documented reduced `(t,i)` HH-value assets variant (GH #277) while the other 24 countries are item-level `(t,i,j)`; pandas cannot stack heterogeneous index depths into a named MultiIndex, so the whole feature fell back to `[None]` (and `['country',None,None,None]` under `labels='Aggregate'`, which slipped through silently). **Fix:** keep the modal index shape and exclude divergent frame(s) with a loud, named warning (excluded data stays available via `Country(name).assets()`); also extend the collapse warning to fire on **any** unnamed level, not only exactly `[None]`. This also resolves audit cluster C010 (the `runtime_warning` symptom of the same root cause).

## Verification
- Issue repros now return fully-named indices; regressions (assets w/o a reduced country, food_prices w/o market, household_roster) unchanged.
- **710 feature/assembly tests pass.** The 13 `test_table_structure` sanity failures are pre-existing (18 on the unpatched base) — EHCVM `people_last7days`/`cluster_features` null/dup issues, unrelated to this path.

Stacked on #508 (already in `development` via #509).

Closes #511, #512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWX2gtG2RSUBuxW42J8RtZ