### PR TITLE
feat(audit): Feature() cross-country audit harness (scan -> cluster -> triage/red-team/file)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ lsms_library/countries/*/var/*
 # Other ignored patterns
 .coder-session/
 .gitnexus
+
+# Feature-audit run artifacts (results.jsonl / scan.log / memos)
+bench/feature_audit/results/

--- a/bench/feature_audit/README.md
+++ b/bench/feature_audit/README.md
@@ -76,9 +76,49 @@ warn/fail/error subset is the candidate-finding list.
 - Warm vs cold cache: warm sweep is fast but a stale L2 parquet could mask/fake a
   finding. Red-team reproduces survivors **cold** (`LSMS_NO_CACHE=1`) from `/tmp`.
 
-## Downstream (planned `audit.workflow.js`)
+## cluster.py — collapse findings to root-cause patterns
 
-Consumes the warn/fail/error records:
+```bash
+python bench/feature_audit/cluster.py \
+  --in  bench/feature_audit/results/<date>/results.jsonl \
+  --out bench/feature_audit/results/<date>/clusters.json
+```
+
+The full sweep emits ~565 candidate findings, but most share a root cause (one
+schema mismatch in 30 countries; one repeated warning) or are by-design. This
+clusters the warn/fail/error records by `(check, severity, normalized-detail)`
+— numbers/countries/paths stripped from the detail — into ~56 patterns sorted
+hardest-first (`fail` → severity B → count). `clusters.json` is the input to the
+workflow. Fanning an agent per *raw record* would just re-derive the same
+handful of causes 30× over; fan per *cluster*.
+
+## audit.workflow.js — triage → red-team → file (Workflow tool)
+
+Multi-agent orchestration; requires explicit opt-in to run. Pass the clusters as
+`args` (the JS sandbox can't read files):
+
+```
+Workflow({ scriptPath: 'bench/feature_audit/audit.workflow.js',
+           args: { clusters: <parsed clusters.json>, file: false,
+                   repo: '<abs repo>', py: '<abs>/.venv/bin/python',
+                   resultsDir: '<abs>/bench/feature_audit/results/<date>' } })
+```
+
+- **Triage** (`pipeline`, one agent/cluster): classify real-bug / by-design /
+  false-positive / harness-artifact, with a repro and a number per claim.
+- **Red-team** (`parallel`, 3 lenses per real-bug — cold-repro, by-design
+  contract, source-truth): each tries to *refute*; default-refute-if-uncertain;
+  a majority refute kills it. A collapse/row-loss finding is only refuted if
+  losslessness is *proven* (skill caveat).
+- **File** (one agent): writes `audit_memo.md` + `confirmed_issues.jsonl`, dedups
+  against `gh issue list --state all --search "<fingerprint>"`, and — only when
+  `file: true` — runs `gh issue create` (labels `feature-audit` + class +
+  `auto-filed`, `audit-key: <fingerprint>` in the body for idempotency).
+  Default (`file: false`) is a **dry run** → `would_file.jsonl`.
+
+## Downstream — `audit.workflow.js` design notes
+
+Consumes the warn/fail/error records (via clusters):
 
 - **Phase 3 — triage** (`pipeline`, one agent per finding): read source config +
   transform + contract (CLAUDE.md, `.claude/skills/cross-country-features`,

--- a/bench/feature_audit/README.md
+++ b/bench/feature_audit/README.md
@@ -1,0 +1,106 @@
+# Feature() cross-country audit harness
+
+Systematically evaluate `ll.Feature('foo')` and `ll.Feature('foo')(**kwargs)`
+across every declaring country, surface candidate issues, red-team them, and
+file the survivors.
+
+This depends on **GH #508** (`Feature.__call__` forwards per-feature kwargs —
+`market`/`labels`/`units`/`age_cuts` — by signature introspection). Merged into
+`development` on 2026-06-18.
+
+## Two layers
+
+1. **Deterministic wide-net** (`scan.py`) — no agents. Builds every feature and
+   a per-feature kwarg grid, runs `diagnostics.is_this_feature_sane` per country
+   plus cross-country *assembly invariants*, writes one JSON record per check to
+   `results.jsonl`. Cheap; this is the wide net.
+2. **Agentic triage + red-team + file** (`audit.workflow.js`, *planned*) — runs
+   only on the warn/fail/error subset of `results.jsonl`. Each candidate is
+   investigated, then independently red-teamed (mandate: *refute*), and only the
+   survivors are filed. See "Downstream" below.
+
+## Issue severity classes (the `severity` field)
+
+| Class | Meaning | Caught by |
+|------|---------|-----------|
+| **A** | Loud — exception, empty frame, sanity `fail`. | deterministic |
+| **B** | Assembly defect — index collapse / unnamed level (GH#325/#326), missing canonical level, row loss vs sum-of-parts. | deterministic |
+| **C** | Silent semantic — units mode ~100% NaN, reaggregation total drift, kwarg cardinality change, unknown runtime warning. *Doesn't throw; needs judgement.* | deterministic flag → **agentic triage** |
+
+## scan.py
+
+```bash
+# smoke (warm cache, fast)
+python bench/feature_audit/scan.py --features food_prices --countries Uganda \
+  --out /tmp/fa_smoke.jsonl
+
+# full deterministic sweep (heavy). Cold = authoritative; run from a neutral CWD
+# (the .pth pins lsms_library to the main checkout — see CLAUDE.md / REALBUILD).
+LSMS_NO_CACHE=1 python /abs/path/bench/feature_audit/scan.py --features canonical \
+  --out bench/feature_audit/results/$(date +%F)/results.jsonl
+```
+
+Flags: `--features canonical|all|<names…>`, `--countries <names…>`,
+`--phases 1,2`, `--limit-countries N` (smoke), `--out`.
+
+**What it checks**
+
+- *Phase 1a* — per country: `Country(c).<feature>()` + `is_this_feature_sane`
+  (16 checks: index levels, null index, dup index, float-stringified IDs,
+  non-canonical `format_id`, value constraints, …). Build error → Class-A finding.
+- *Phase 1b* — `Feature(f)()` assembly: unnamed-level collapse, missing canonical
+  core level (market legitimately drops `v`), `market` adds `m`, row conservation
+  vs the sum of per-country builds.
+- *Phase 2* — `Feature(f)(**kwargs)` over the per-feature grid in `KWARG_GRID`
+  (units modes; `labels='Aggregate'`; `market='Region'`; an `age_cuts`):
+  units-mode NaN-rate blow-up, `labels='Aggregate'` additive-total conservation,
+  kwarg cardinality change vs baseline, ignored-kwarg warnings.
+
+**Output** — `results.jsonl`, one record per check (pass included). Each carries a
+stable `fingerprint` = `feature|country|kwargs|check` for downstream dedup. The
+warn/fail/error subset is the candidate-finding list.
+
+### Deliberate caveats (no silent caps)
+
+- Couples to a few private helpers (`feature._canonical_index_levels`,
+  `diagnostics._PROPERTY_FEATURES`). Stable within the repo; an internal tool.
+- **Flag, don't judge.** Row deltas / NaN blow-ups / total drift are emitted as
+  `warn` *with the numbers*. Whether each is a bug or by-design (units' documented
+  "no silent fallback", the GH#501 additive collapse, no-microdata countries
+  Nepal/Armenia/Timor-Leste-2001/Guatemala that *expectedly* warn `Failed to
+  load`) is the red-team's call.
+- Index-name equality is intentionally **not** asserted: `Feature` legitimately
+  widens the index (`currency` level for monetary tables under default
+  `currency='index'`; `m` under `market`) and `market` drops `v`. We check only
+  unnamed levels and missing canonical core levels.
+- Warm vs cold cache: warm sweep is fast but a stale L2 parquet could mask/fake a
+  finding. Red-team reproduces survivors **cold** (`LSMS_NO_CACHE=1`) from `/tmp`.
+
+## Downstream (planned `audit.workflow.js`)
+
+Consumes the warn/fail/error records:
+
+- **Phase 3 — triage** (`pipeline`, one agent per finding): read source config +
+  transform + contract (CLAUDE.md, `.claude/skills/cross-country-features`,
+  CONTENTS.org); classify real-bug / by-design / harness-false-positive; return a
+  minimal repro and *a number for every claim*.
+- **Phase 4 — red-team** (`parallel`, 2–3 skeptics per survivor, distinct lenses):
+  (a) stale-cache — re-run cold from `/tmp`, vanishes ⇒ stale; (b) by-design
+  contract; (c) source-truth (read the Stata variable *label*, cross-validate
+  values). Default-refute-if-uncertain, majority kills. *Caveat from the skill:* a
+  collapse-dismissal that didn't **prove** losslessness is flagged for human eyes,
+  not auto-killed (interview_date's visit-drop was wrongly ruled benign once).
+- **Phase 5 — file the survivors** ("passes"): per-feature markdown memo +
+  `confirmed_issues.jsonl`, then **GitHub issues** —
+  - title `[feature-audit] {feature} / {country}: {symptom}`
+  - body: classification, exact repro (the `Feature(...)` call + `/tmp` +
+    `LSMS_NO_CACHE=1`), every number, red-team verdict + which lenses, memo link,
+    and `audit-key: {fingerprint}` for idempotency.
+  - labels `feature-audit` + class (`assembly-defect`/`silent-corruption`) +
+    `auto-filed`.
+  - **dedup**: `gh issue list --search "{fingerprint}"` skips any match *open or
+    closed* (closed ⇒ a human already triaged it; don't refile).
+  - **dry-run by default**: writes `would_file.jsonl`; actual `gh issue create`
+    only under an explicit `--file` flag.
+
+`ISSUES.md` stays human-maintained and is never auto-modified (CLAUDE.md rule).

--- a/bench/feature_audit/audit.workflow.js
+++ b/bench/feature_audit/audit.workflow.js
@@ -66,7 +66,16 @@ const VERDICT_SCHEMA = {
 }
 
 // ---- prompt builders ------------------------------------------------------
-const ctx = (c) => `Cluster ${c.cluster_id} from a cross-country Feature() audit of the LSMS_Library repo.
+const GUARDRAIL = `HARD GUARDRAIL — this is a SHARED working tree with concurrent work in flight:
+  • NEVER run git that changes state: no checkout / switch / reset / stash / clean / branch / restore / merge.
+    (A prior run switched the branch and removed files from the working tree — do NOT repeat this.)
+  • NEVER edit, create, move, or delete a TRACKED file. Investigation is strictly READ-ONLY.
+  • Do NOT \`cd\` into the repo to run code. Read files by ABSOLUTE path; run every repro from /tmp
+    (\`cd /tmp && <py> -c "…"\`) so the import resolves the installed package, not the cwd.`
+
+const ctx = (c) => `${GUARDRAIL}
+
+Cluster ${c.cluster_id} from a cross-country Feature() audit of the LSMS_Library repo.
   repo: ${REPO}   python: ${PY} (use this exact interpreter)
   check: ${c.check}   severity-class: ${c.severity}   status: ${c.status}   occurrences: ${c.count}
   normalized pattern: ${c.pattern}
@@ -162,7 +171,11 @@ const payload = confirmed.map((t) => ({
   detail: t.cluster.example_detail,
 }))
 
-const filePrompt = `You are the filing step of the Feature() audit. ${confirmed.length} clusters survived
+const filePrompt = `${GUARDRAIL}
+(You MAY write new files under ${RESULTS} — it is gitignored — and run \`gh\`; that does not violate the
+guardrail. You must NOT run any git command or touch any tracked file.)
+
+You are the filing step of the Feature() audit. ${confirmed.length} clusters survived
 red-team as confirmed issues. Here is the payload (JSON):
 
 ${JSON.stringify(payload, null, 2)}

--- a/bench/feature_audit/audit.workflow.js
+++ b/bench/feature_audit/audit.workflow.js
@@ -10,19 +10,24 @@ export const meta = {
 }
 
 // ---- inputs --------------------------------------------------------------
-// Only small SCALARS travel via `args` (a large inline-JSON args blob does not
-// survive the scriptPath plumbing reliably).  The cluster list itself is loaded
-// from a file ON DISK by a loader agent — the JS sandbox can't read files, but
-// agents can.  Write the slice you want triaged to `slice` before launching.
+// `args` arrives as a JSON STRING (not a parsed object) through the Workflow
+// plumbing — so parse it.  Earlier failures (args.slice -> String.prototype.slice
+// the native function; args.clusters -> undefined) were this, NOT a size issue.
+// Cluster DATA is loaded from a file on disk by a loader agent (the JS sandbox
+// can't read files; agents can); only small scalars travel via args.
 // args = { file: bool, repo: str, py: str, resultsDir: str, slice: str }
-const doFile    = !!(args && args.file)                       // DRY-RUN unless explicitly true
-const REPO      = (args && args.repo) || '/global/scratch/fsa/fc_jevons/ligon/mirrors/LSMS_Library'
-const PY        = (args && args.py)   || `${REPO}/.venv/bin/python`
-const RESULTS   = (args && args.resultsDir) || `${REPO}/bench/feature_audit/results/2026-06-18`
-const SLICE     = (args && args.slice) || `${RESULTS}/clusters_slice.json`
+const A = (typeof args === 'string')
+  ? (() => { try { return JSON.parse(args) } catch (e) { return {} } })()
+  : (args && typeof args === 'object' ? args : {})
+
+const doFile    = !!A.file                                    // DRY-RUN unless explicitly true
+const REPO      = A.repo || '/global/scratch/fsa/fc_jevons/ligon/mirrors/LSMS_Library'
+const PY        = A.py   || `${REPO}/.venv/bin/python`
+const RESULTS   = A.resultsDir || `${REPO}/bench/feature_audit/results/2026-06-18`
+const SLICE     = A.slice || `${RESULTS}/clusters_slice.json`
 const SKILL     = `${REPO}/.claude/skills/cross-country-features/SKILL.md`
 
-log(`args keys: ${args ? Object.keys(args).join(',') : '(none)'}; loading clusters from ${SLICE}`)
+log(`parsed args keys: [${Object.keys(A).join(',')}]; slice=${SLICE}; file=${doFile}`)
 
 const CLUSTERS_SCHEMA = {
   type: 'object',
@@ -30,12 +35,15 @@ const CLUSTERS_SCHEMA = {
   properties: { clusters: { type: 'array', items: { type: 'object' } } },
 }
 const loaded = await agent(
-  `Run \`cat ${SLICE}\`. It is a JSON array of audit "cluster" objects. Return it verbatim as ` +
-  `{"clusters": <that exact array>} — no edits, additions, reordering, or summarizing. ` +
-  `If the file is missing or empty, return {"clusters": []}.`,
+  `Run exactly: cat ${SLICE}\n` +
+  `That file is a JSON array of audit "cluster" objects. Return it verbatim as ` +
+  `{"clusters": <that exact array>} — every element, no edits, additions, reordering, ` +
+  `truncation, or summarizing. Preserve all fields of every object. ` +
+  `If the file is genuinely missing or empty, return {"clusters": []}.`,
   { label: 'load-clusters', phase: 'Triage', schema: CLUSTERS_SCHEMA }
 )
 const clusters = (loaded && loaded.clusters) || []
+log(`loaded ${clusters.length} clusters from ${SLICE}`)
 if (!clusters.length) {
   log('no clusters loaded — nothing to triage')
   return { total_clusters: 0, confirmed: 0, items: [] }

--- a/bench/feature_audit/audit.workflow.js
+++ b/bench/feature_audit/audit.workflow.js
@@ -9,18 +9,36 @@ export const meta = {
   ],
 }
 
-// ---- inputs (passed via the Workflow tool's `args`) -----------------------
-// args = { clusters: [...], file: bool, repo: str, py: str, resultsDir: str }
-const clusters  = (args && args.clusters) || []
+// ---- inputs --------------------------------------------------------------
+// Only small SCALARS travel via `args` (a large inline-JSON args blob does not
+// survive the scriptPath plumbing reliably).  The cluster list itself is loaded
+// from a file ON DISK by a loader agent — the JS sandbox can't read files, but
+// agents can.  Write the slice you want triaged to `slice` before launching.
+// args = { file: bool, repo: str, py: str, resultsDir: str, slice: str }
 const doFile    = !!(args && args.file)                       // DRY-RUN unless explicitly true
 const REPO      = (args && args.repo) || '/global/scratch/fsa/fc_jevons/ligon/mirrors/LSMS_Library'
 const PY        = (args && args.py)   || `${REPO}/.venv/bin/python`
 const RESULTS   = (args && args.resultsDir) || `${REPO}/bench/feature_audit/results/2026-06-18`
+const SLICE     = (args && args.slice) || `${RESULTS}/clusters_slice.json`
 const SKILL     = `${REPO}/.claude/skills/cross-country-features/SKILL.md`
 
+log(`args keys: ${args ? Object.keys(args).join(',') : '(none)'}; loading clusters from ${SLICE}`)
+
+const CLUSTERS_SCHEMA = {
+  type: 'object',
+  required: ['clusters'],
+  properties: { clusters: { type: 'array', items: { type: 'object' } } },
+}
+const loaded = await agent(
+  `Run \`cat ${SLICE}\`. It is a JSON array of audit "cluster" objects. Return it verbatim as ` +
+  `{"clusters": <that exact array>} — no edits, additions, reordering, or summarizing. ` +
+  `If the file is missing or empty, return {"clusters": []}.`,
+  { label: 'load-clusters', phase: 'Triage', schema: CLUSTERS_SCHEMA }
+)
+const clusters = (loaded && loaded.clusters) || []
 if (!clusters.length) {
-  log('no clusters in args — nothing to triage')
-  return { total: 0, confirmed: 0, items: [] }
+  log('no clusters loaded — nothing to triage')
+  return { total_clusters: 0, confirmed: 0, items: [] }
 }
 
 // ---- structured-output schemas -------------------------------------------

--- a/bench/feature_audit/audit.workflow.js
+++ b/bench/feature_audit/audit.workflow.js
@@ -1,0 +1,179 @@
+export const meta = {
+  name: 'feature-audit-triage',
+  description: 'Triage + red-team cross-country Feature() audit clusters; file confirmed issues to GitHub',
+  whenToUse: 'After scan.py + cluster.py have produced clusters.json for a Feature() audit run.',
+  phases: [
+    { title: 'Triage',   detail: 'one agent per cluster: real-bug / by-design / false-positive + repro' },
+    { title: 'Red-team', detail: 'multi-lens skeptics try to REFUTE each candidate bug' },
+    { title: 'File',     detail: 'memo + would_file.jsonl; gh issue create (dedup) only if file=true' },
+  ],
+}
+
+// ---- inputs (passed via the Workflow tool's `args`) -----------------------
+// args = { clusters: [...], file: bool, repo: str, py: str, resultsDir: str }
+const clusters  = (args && args.clusters) || []
+const doFile    = !!(args && args.file)                       // DRY-RUN unless explicitly true
+const REPO      = (args && args.repo) || '/global/scratch/fsa/fc_jevons/ligon/mirrors/LSMS_Library'
+const PY        = (args && args.py)   || `${REPO}/.venv/bin/python`
+const RESULTS   = (args && args.resultsDir) || `${REPO}/bench/feature_audit/results/2026-06-18`
+const SKILL     = `${REPO}/.claude/skills/cross-country-features/SKILL.md`
+
+if (!clusters.length) {
+  log('no clusters in args — nothing to triage')
+  return { total: 0, confirmed: 0, items: [] }
+}
+
+// ---- structured-output schemas -------------------------------------------
+const TRIAGE_SCHEMA = {
+  type: 'object',
+  required: ['classification', 'confidence', 'rationale'],
+  properties: {
+    classification: { type: 'string', enum: ['real-bug', 'by-design', 'false-positive', 'harness-artifact'] },
+    confidence:     { type: 'string', enum: ['low', 'medium', 'high'] },
+    rationale:      { type: 'string', description: 'why, citing path:line and exact values/numbers' },
+    repro:          { type: 'string', description: 'minimal command that reproduces it, or "" if none' },
+    repro_confirmed:{ type: 'boolean', description: 'did you actually run the repro and observe the symptom?' },
+    affected:       { type: 'string', description: 'which features/countries genuinely affected' },
+    suggested_fix:  { type: 'string', description: 'one-line fix direction if real-bug, else ""' },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['refuted', 'reason'],
+  properties: {
+    refuted: { type: 'boolean', description: 'true if THIS lens shows the bug is not real / is expected' },
+    reason:  { type: 'string', description: 'evidence for the verdict, with numbers / path:line' },
+  },
+}
+
+// ---- prompt builders ------------------------------------------------------
+const ctx = (c) => `Cluster ${c.cluster_id} from a cross-country Feature() audit of the LSMS_Library repo.
+  repo: ${REPO}   python: ${PY} (use this exact interpreter)
+  check: ${c.check}   severity-class: ${c.severity}   status: ${c.status}   occurrences: ${c.count}
+  normalized pattern: ${c.pattern}
+  example detail: ${c.example_detail}
+  example kwargs: ${JSON.stringify(c.example_kwargs || {})}
+  affected features: ${(c.features || []).join(', ') || '(cross-country)'}
+  affected countries (${(c.countries || []).length}): ${(c.countries || []).slice(0, 12).join(', ')}${(c.countries||[]).length>12?' …':''}
+  raw records: grep this cluster's occurrences in ${RESULTS}/results.jsonl by check="${c.check}".
+
+Severity classes: A=loud (build error/empty); B=cross-country assembly defect (index collapse/unnamed level,
+missing canonical level, row loss vs sum-of-parts); C=silent-semantic (NaN blow-up, reaggregation drift, etc.).`
+
+const triagePrompt = (c) => `${ctx(c)}
+
+You are triaging this cluster. Read what you need (don't trust the wired column or a config comment — verify):
+  - ${SKILL}  (cross-country-features: silent-corruption traps, collapse semantics, redteam discipline)
+  - ${REPO}/CLAUDE.md  (Feature kwargs/units/labels/market contracts, no-microdata countries, derived tables)
+  - ${REPO}/lsms_library/feature.py, country.py, diagnostics.py as relevant
+  - the country config under ${REPO}/lsms_library/countries/<C>/_/ for an affected country, if structural
+
+If a repro is cheap, RUN IT from a neutral CWD (the .pth pins lsms_library to this checkout):
+  cd /tmp && LSMS_NO_CACHE=1 ${PY} -c "import lsms_library as ll; df=ll.Feature('<feature>')(<args>); print(df.index.names, len(df))"
+
+Classify the cluster:
+  real-bug         — a genuine defect in the framework or a country's wiring.
+  by-design        — expected per a documented contract (e.g. units 'no silent fallback' NaN; cluster-level
+                     tables have no household 'i' index; no-microdata countries Nepal/Armenia failing to load).
+  false-positive   — the scanner's invariant is wrong here.
+  harness-artifact — the scan itself induced it (e.g. it passed a deprecated arg form).
+
+Every claim carries a number or a path:line. Set repro_confirmed only if you actually ran the repro.`
+
+const LENSES = [
+  { key: 'cold-repro',  ask: `Reproduce COLD from /tmp with LSMS_NO_CACHE=1 using ${PY}. If the symptom vanishes cold, it was a stale-cache artifact -> refuted. If you cannot reproduce it at all, refuted.` },
+  { key: 'by-design',   ask: `Check the documented contract (${REPO}/CLAUDE.md, ${SKILL}, the country CONTENTS.org). If the behavior is expected-by-design (units no-fallback NaN, by-design collapse/dup per GH#323/#501, no-microdata country, Mover sentinel), it is NOT a bug -> refuted.` },
+  { key: 'source-truth',ask: `Verify against source truth: read the actual Stata/SPSS variable label and cross-validate values for an affected country. If the data/labels show the finding is a misdiagnosis, refuted.` },
+]
+
+const redteamPrompt = (c, t, lens) => `${ctx(c)}
+
+A triage agent classified this as a REAL BUG with ${t.confidence} confidence:
+  rationale: ${t.rationale}
+  repro: ${t.repro || '(none given)'}  (confirmed=${t.repro_confirmed})
+
+Your job is ADVERSARIAL: try to REFUTE it through one specific lens. Default to refuted=true if you are
+uncertain — the bar to confirm a bug is high. Re-derive the key facts independently (don't just re-read the
+triage note). Lens — ${lens.key}: ${lens.ask}
+
+CAVEAT (from the audit skill): do NOT refute a cross-country COLLAPSE or row-loss finding on a hand-wave —
+only refute it if you can PROVE the dropped/collapsed rows are identical/benign. An unproven dismissal of a
+collapse should come back refuted=false.`
+
+// ---- Phase 3 + 4: triage each cluster, red-team the real-bugs -------------
+log(`triaging ${clusters.length} clusters (file=${doFile ? 'LIVE gh' : 'dry-run'})`)
+
+const triaged = await pipeline(
+  clusters,
+  (c) => agent(triagePrompt(c), { label: `triage:${c.cluster_id}`, phase: 'Triage', schema: TRIAGE_SCHEMA })
+           .then((t) => ({ cluster: c, triage: t })),
+  ({ cluster, triage }) => {
+    if (!triage || triage.classification !== 'real-bug') {
+      return { cluster, triage, verdicts: [], confirmed: false }
+    }
+    return parallel(LENSES.map((lens) => () =>
+      agent(redteamPrompt(cluster, triage, lens),
+            { label: `redteam:${cluster.cluster_id}:${lens.key}`, phase: 'Red-team', schema: VERDICT_SCHEMA })
+    )).then((verdicts) => {
+      const refutes = verdicts.filter(Boolean).filter((v) => v.refuted).length
+      // confirmed only if a MAJORITY of lenses fail to refute (i.e. < 2 of 3 refute)
+      return { cluster, triage, verdicts, confirmed: refutes < 2 }
+    })
+  }
+)
+
+const ok = triaged.filter(Boolean)
+const confirmed = ok.filter((t) => t.confirmed)
+const byClass = {}
+for (const t of ok) { const k = t.triage ? t.triage.classification : 'null'; byClass[k] = (byClass[k] || 0) + 1 }
+log(`triage: ${JSON.stringify(byClass)} | red-team confirmed ${confirmed.length}`)
+
+// ---- Phase 5: file the survivors -----------------------------------------
+const payload = confirmed.map((t) => ({
+  cluster_id: t.cluster.cluster_id,
+  check: t.cluster.check,
+  severity: t.cluster.severity,
+  features: t.cluster.features,
+  countries: t.cluster.countries,
+  count: t.cluster.count,
+  fingerprint: t.cluster.example_fingerprint,
+  rationale: t.triage.rationale,
+  repro: t.triage.repro,
+  suggested_fix: t.triage.suggested_fix,
+  detail: t.cluster.example_detail,
+}))
+
+const filePrompt = `You are the filing step of the Feature() audit. ${confirmed.length} clusters survived
+red-team as confirmed issues. Here is the payload (JSON):
+
+${JSON.stringify(payload, null, 2)}
+
+Do ALL of this with Bash/Write, using repo ${REPO}:
+1. Write a human memo ${RESULTS}/audit_memo.md: one section per confirmed issue, grouped by feature, each with
+   severity, affected features/countries, the repro, the rationale (numbers/path:line), and suggested fix.
+2. Write ${RESULTS}/confirmed_issues.jsonl: one JSON line per issue from the payload.
+3. For EACH issue build a GitHub issue body containing a line "audit-key: <fingerprint>" plus title
+   "[feature-audit] <feature> / <scope>: <symptom>" and labels feature-audit + the severity class label
+   (B->assembly-defect, A->build-error, C->silent-corruption) + auto-filed.
+4. DEDUP before creating: gh issue list --state all --search "<fingerprint>"  — skip any that already exist
+   (open OR closed; a closed one means a human already triaged it).
+${doFile
+  ? '5. file=TRUE: actually run `gh issue create` for the non-duplicates. Report the URLs.'
+  : '5. file=FALSE (DRY RUN): do NOT run `gh issue create`. Instead write the would-be issues to '
+    + `${RESULTS}/would_file.jsonl (title, labels, body, fingerprint, dedup_status). Report the counts.`}
+
+Report: memo path, confirmed_issues count, and (filed URLs | would_file count + how many were dedup-skipped).`
+
+const filer = confirmed.length
+  ? await agent(filePrompt, { label: doFile ? 'file:gh' : 'file:dry-run', phase: 'File' })
+  : 'no confirmed issues to file'
+
+return {
+  total_clusters: clusters.length,
+  triage_breakdown: byClass,
+  confirmed: confirmed.length,
+  filed_mode: doFile ? 'gh-live' : 'dry-run',
+  items: payload,
+  filer_report: filer,
+}

--- a/bench/feature_audit/cluster.py
+++ b/bench/feature_audit/cluster.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+"""Collapse the scanner's raw findings into root-cause CLUSTERS.
+
+The deterministic wide-net (`scan.py`) emits one record per (country, feature,
+kwargs, check) — ~565 candidate findings on the full sweep.  Most share a root
+cause (one schema mismatch surfacing in 30 countries; one warning message
+repeated) or are by-design.  Fanning an agent per raw record would just
+re-derive the same handful of causes 30× over.
+
+This script clusters the warn/fail/error records by (check, severity,
+normalized-detail) so the agentic phase triages ~20-40 PATTERNS, each carrying
+its occurrence count and the affected features/countries.  Output: clusters.json
+(sorted hardest-first), which is fed to `audit.workflow.js` as its `args`.
+
+    python bench/feature_audit/cluster.py \
+        --in  bench/feature_audit/results/2026-06-18/results.jsonl \
+        --out bench/feature_audit/results/2026-06-18/clusters.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict
+
+# Severity order for "hardest first" sorting.
+SEV_RANK = {"B": 0, "A": 1, "C": 2, None: 3}
+STATUS_RANK = {"fail": 0, "error": 1, "warn": 2}
+
+
+def _normalize(detail: str, countries: set[str]) -> str:
+    """Strip the per-occurrence specifics from a detail string so the same root
+    cause clusters regardless of which country / number / path it mentions."""
+    s = detail or ""
+    # quoted strings and filesystem paths -> <X>
+    s = re.sub(r"'[^']*'|\"[^\"]*\"", "<X>", s)
+    s = re.sub(r"/\S+", "<PATH>", s)
+    # country names -> <C> (longest first so "Serbia and Montenegro" wins)
+    for c in sorted(countries, key=len, reverse=True):
+        if c:
+            s = s.replace(c, "<C>")
+    # numbers (ints, floats, percents, signed) -> <N>
+    s = re.sub(r"[-+]?\d[\d,]*\.?\d*%?", "<N>", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s[:240]
+
+
+def cluster(records: list[dict]) -> list[dict]:
+    cand = [r for r in records if r.get("status") in ("warn", "fail", "error")]
+    countries = {r.get("country") for r in cand if r.get("country")}
+
+    groups: dict[tuple, dict] = {}
+    for r in cand:
+        pat = _normalize(r.get("detail", ""), countries)
+        key = (r.get("check"), r.get("severity"), r.get("status"), pat)
+        g = groups.get(key)
+        if g is None:
+            g = groups[key] = {
+                "cluster_id": None,
+                "check": r.get("check"),
+                "severity": r.get("severity"),
+                "status": r.get("status"),
+                "pattern": pat,
+                "count": 0,
+                "features": set(),
+                "countries": set(),
+                "example_detail": r.get("detail", ""),
+                "example_fingerprint": r.get("fingerprint", ""),
+                "example_kwargs": r.get("kwargs", {}),
+            }
+        g["count"] += 1
+        if r.get("feature"):
+            g["features"].add(r["feature"])
+        if r.get("country"):
+            g["countries"].add(r["country"])
+
+    clusters = []
+    for g in groups.values():
+        g["features"] = sorted(g["features"])
+        g["countries"] = sorted(g["countries"])
+        clusters.append(g)
+
+    clusters.sort(key=lambda g: (
+        STATUS_RANK.get(g["status"], 9),
+        SEV_RANK.get(g["severity"], 9),
+        -g["count"],
+    ))
+    for i, g in enumerate(clusters, 1):
+        g["cluster_id"] = f"C{i:03d}"
+    return clusters
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--in", dest="inp", required=True, help="results.jsonl")
+    ap.add_argument("--out", default=None, help="clusters.json (default: stdout summary only)")
+    args = ap.parse_args(argv)
+
+    records = [json.loads(l) for l in open(args.inp) if l.strip()]
+    clusters = cluster(records)
+
+    raw = sum(1 for r in records if r.get("status") in ("warn", "fail", "error"))
+    print(f"{raw} candidate findings -> {len(clusters)} clusters")
+    print(f"{'id':6} {'stat':5} {'sev':3} {'n':>4}  {'check':26} feats/countries")
+    for g in clusters:
+        print(f"{g['cluster_id']:6} {g['status']:5} {str(g['severity']):3} "
+              f"{g['count']:>4}  {g['check']:26} "
+              f"{len(g['features'])}f/{len(g['countries'])}c  {g['pattern'][:48]}")
+
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            json.dump(clusters, fh, indent=2)
+        print(f"-> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/feature_audit/scan.py
+++ b/bench/feature_audit/scan.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python
+"""Deterministic wide-net scanner for the cross-country Feature() audit.
+
+Phases 0-2 of the Feature-audit workflow (see ``bench/feature_audit/README.md``).
+This script does *no* agentic judgement: it builds every ``Feature('foo')`` (and
+a per-feature grid of ``Feature('foo')(**kwargs)``), runs the existing
+``diagnostics.is_this_feature_sane`` per country plus a set of cross-country
+*assembly invariants*, and writes one JSON record per check to ``results.jsonl``.
+
+The warn/fail/error subset of that file is the candidate-finding list that the
+agentic triage + red-team phases (the Workflow script) consume.  Every record
+carries a stable ``fingerprint`` so the filing phase can dedup against GitHub.
+
+Design notes
+------------
+* **No silent caps.**  Every (feature, country, kwargs) cell we *skip* is logged
+  with a reason, so "covered everything" never reads as a lie.
+* **Flag, don't judge.**  Row-count mismatches, ~100% NaN under a units mode,
+  and reaggregation total drift are emitted as ``warn`` with the numbers
+  attached.  Whether each is a real bug or by-design (units' documented
+  "no silent fallback", the GH#501 additive-collapse, no-microdata countries)
+  is the red-team's call, not ours.
+* Couples to a few private helpers in ``lsms_library.feature`` /
+  ``lsms_library.diagnostics`` (canonical index levels, property-feature set).
+  Acceptable for an internal bench tool; they are stable within the repo.
+
+Usage
+-----
+    # smoke test: one feature, two countries, warm cache
+    python bench/feature_audit/scan.py --features food_prices \
+        --countries Uganda Malawi --out /tmp/fa_smoke.jsonl
+
+    # full deterministic sweep (heavy; cold for authority -> from a neutral CWD)
+    LSMS_NO_CACHE=1 python bench/feature_audit/scan.py --features canonical \
+        --out bench/feature_audit/results/$(date +%F)/results.jsonl
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import traceback
+import warnings
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable
+
+import pandas as pd
+
+import lsms_library as ll
+from lsms_library import diagnostics
+from lsms_library.diagnostics import (
+    is_this_feature_sane,
+    load_feature,
+    _PROPERTY_FEATURES,
+)
+from lsms_library.feature import (
+    _all_known_features,
+    _canonical_index_levels,
+    _DERIVED_SOURCE,
+)
+
+# ---------------------------------------------------------------------------
+# Scope: which features, and which kwargs to vary per feature
+# ---------------------------------------------------------------------------
+
+# Curated canonical set (registered tables in data_info.yml Index Info + the
+# runtime-derived tables).  `--features all` widens to _all_known_features().
+CANONICAL_FEATURES = [
+    "household_roster",
+    "household_characteristics",
+    "cluster_features",
+    "sample",
+    "food_acquired",
+    "food_expenditures",
+    "food_prices",
+    "food_quantities",
+    "plot_features",
+    "interview_date",
+    "shocks",
+    "assets",
+    "individual_education",
+]
+
+# Per-feature kwarg grid for Phase 2.  Each entry is ONE forwarded-kwarg call;
+# the no-kwarg baseline is always exercised in Phase 1b.  Kept deliberately
+# narrow to the documented "interesting" axes (units modes, Aggregate relabel,
+# market widening, an age-cut) rather than a full Cartesian product.
+KWARG_GRID: dict[str, list[dict[str, Any]]] = {
+    "food_prices": (
+        [{"units": u} for u in ("kgvalue", "unitvalue", "kgprice", "unitprice")]
+        + [{"labels": "Aggregate"}, {"market": "Region"}]
+    ),
+    "food_quantities": (
+        [{"units": u} for u in ("kgs", "units")]
+        + [{"labels": "Aggregate"}, {"market": "Region"}]
+    ),
+    "food_expenditures": [{"labels": "Aggregate"}, {"market": "Region"}],
+    "food_acquired": [{"labels": "Aggregate"}],
+    "assets": [{"labels": "Aggregate"}],
+    "household_characteristics": [{"age_cuts": [0, 5, 15, 60]}, {"market": "Region"}],
+    "household_roster": [{"market": "Region"}],
+}
+
+# Columns that are additive across countries -> a relabel/reaggregate must
+# CONSERVE their grand total (Price is per-unit and must NOT).
+ADDITIVE_MEASURES = ("Quantity", "Expenditure")
+
+# Substrings that classify a captured warning into an issue class + a quick
+# "expected?" hint for triage.  (severity, expected_by_default)
+WARNING_TAXONOMY: list[tuple[str, str, bool]] = [
+    ("cross-country index collapsed", "B", False),   # GH#325 assembly defect
+    ("does not accept", "A", True),                  # kwarg not supported by a country
+    ("No data for", "A", True),                      # empty per-country frame
+    ("Failed to load", "A", True),                   # per-country build error (often no-microdata)
+    ("duplicate", "B", False),                       # GH#323 dup-collapse
+]
+
+
+def _classify_warning(msg: str) -> tuple[str, bool]:
+    for needle, sev, expected in WARNING_TAXONOMY:
+        if needle.lower() in msg.lower():
+            return sev, expected
+    return "C", False  # unknown warning -> treat as a silent-corruption candidate
+
+
+# ---------------------------------------------------------------------------
+# Finding record
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Finding:
+    phase: str
+    feature: str
+    check: str
+    status: str                       # pass | warn | fail | error
+    country: str | None = None        # None => cross-country assembly
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    severity: str | None = None       # A (loud) | B (assembly) | C (silent semantic)
+    expected: bool | None = None      # provisional "by-design?" hint for triage
+    detail: str = ""
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def fingerprint(self) -> str:
+        kw = ",".join(f"{k}={self.kwargs[k]}" for k in sorted(self.kwargs))
+        return f"{self.feature}|{self.country or 'ALL'}|{kw}|{self.check}"
+
+    def to_record(self) -> dict[str, Any]:
+        rec = asdict(self)
+        rec["fingerprint"] = self.fingerprint
+        return rec
+
+
+# ---------------------------------------------------------------------------
+# Warning-capturing build helper
+# ---------------------------------------------------------------------------
+
+def _build(fn: Callable[[], Any]) -> tuple[Any, list[str], str | None, float]:
+    """Run *fn*, returning (result, warnings, error_repr, seconds).
+
+    Never raises: a build exception is returned as ``error_repr`` so one bad
+    cell can't abort the sweep.
+    """
+    t0 = time.perf_counter()
+    captured: list[str] = []
+    result = None
+    err = None
+    with warnings.catch_warnings(record=True) as wlist:
+        warnings.simplefilter("always")
+        try:
+            result = fn()
+        except Exception as e:  # noqa: BLE001 - sweep must continue
+            err = f"{type(e).__name__}: {e}"
+        captured = [str(w.message) for w in wlist]
+    return result, captured, err, time.perf_counter() - t0
+
+
+def _warnings_to_findings(
+    phase: str, feature: str, captured: list[str], kwargs: dict[str, Any]
+) -> list[Finding]:
+    out = []
+    for msg in captured:
+        sev, expected = _classify_warning(msg)
+        out.append(Finding(
+            phase=phase, feature=feature, check="runtime_warning",
+            status="warn", kwargs=dict(kwargs), severity=sev, expected=expected,
+            detail=msg,
+        ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Phase 1a -- per-country sanity (no kwargs)
+# ---------------------------------------------------------------------------
+
+def phase1a_country_sanity(feature: str, countries: list[str]) -> tuple[list[Finding], dict[str, int]]:
+    """Build each country's table alone and run is_this_feature_sane.
+
+    Returns (findings, per_country_rowcount) -- the row counts feed the Phase-1b
+    conservation invariant.
+    """
+    findings: list[Finding] = []
+    rows: dict[str, int] = {}
+    is_property = feature in _PROPERTY_FEATURES
+
+    for name in countries:
+        result, captured, err, secs = _build(lambda: load_feature(ll.Country(name), feature))
+        findings += _warnings_to_findings("1a-sanity", feature, captured, {})
+
+        if err is not None:
+            findings.append(Finding(
+                phase="1a-sanity", feature=feature, country=name, check="build",
+                status="error", severity="A", expected=False, detail=err,
+                metrics={"seconds": round(secs, 2)},
+            ))
+            continue
+
+        if is_property:
+            # panel_ids / updated_ids return dicts -> record load, skip df checks.
+            n = len(result) if hasattr(result, "__len__") else 0
+            findings.append(Finding(
+                phase="1a-sanity", feature=feature, country=name,
+                check="build", status="pass", detail=f"property loaded ({n} entries)",
+                metrics={"entries": n, "seconds": round(secs, 2)},
+            ))
+            continue
+
+        if not isinstance(result, pd.DataFrame) or result.empty:
+            findings.append(Finding(
+                phase="1a-sanity", feature=feature, country=name, check="build",
+                status="fail", severity="A", expected=False,
+                detail="empty / non-DataFrame result",
+            ))
+            continue
+
+        rows[name] = len(result)
+        report = is_this_feature_sane(result, name, feature)
+        for c in report.checks:
+            if c.status == "pass":
+                continue
+            findings.append(Finding(
+                phase="1a-sanity", feature=feature, country=name, check=c.name,
+                status=c.status, severity="B" if c.status == "fail" else "C",
+                expected=False, detail=c.message,
+            ))
+    return findings, rows
+
+
+# ---------------------------------------------------------------------------
+# Phase 1b -- cross-country assembly invariants (no kwargs)
+# ---------------------------------------------------------------------------
+
+def _assembly_invariants(
+    phase: str, feature: str, result: Any, per_country_rows: dict[str, int],
+    kwargs: dict[str, Any], check_rows: bool = True,
+) -> list[Finding]:
+    """Cross-country assembly invariants.
+
+    We deliberately do NOT assert exact index-name equality: ``Feature``
+    legitimately widens the canonical index (a ``currency`` level for monetary
+    tables under the default ``currency='index'``, an ``m`` level under
+    ``market=``) and ``market`` drops ``v``.  Reproducing that logic here would
+    just re-implement ``__call__``.  Instead we check the two things that are
+    unambiguously wrong: an UNNAMED level (full or partial GH#325 collapse) and
+    a MISSING canonical core level.
+    """
+    findings: list[Finding] = []
+    canon = _canonical_index_levels(feature)
+
+    if not isinstance(result, pd.DataFrame) or result.empty:
+        findings.append(Finding(
+            phase=phase, feature=feature, check="assembly_nonempty",
+            status="fail", severity="B", expected=False, kwargs=dict(kwargs),
+            detail="Feature() returned empty / non-DataFrame",
+        ))
+        return findings
+
+    names = list(result.index.names)
+
+    # (1) any unnamed index level -> full (GH#325) or partial collapse
+    if None in names:
+        findings.append(Finding(
+            phase=phase, feature=feature, check="index_unnamed_level",
+            status="fail", severity="B", expected=False, kwargs=dict(kwargs),
+            detail=f"cross-country index has unnamed level(s): {names}",
+            metrics={"names": names, "nrows": len(result)},
+        ))
+
+    # (2) a canonical core level went missing (market legitimately drops v)
+    core = set(canon)
+    if kwargs.get("market") is not None:
+        core.discard("v")
+    missing = core - set(names)
+    if missing:
+        findings.append(Finding(
+            phase=phase, feature=feature, check="missing_canonical_level",
+            status="warn", severity="B", expected=False, kwargs=dict(kwargs),
+            detail=f"canonical level(s) {sorted(missing)} absent from index {names}",
+            metrics={"missing": sorted(missing), "names": names},
+        ))
+
+    # (3) market widening actually added m
+    if kwargs.get("market") is not None:
+        ok_m = "m" in names
+        findings.append(Finding(
+            phase=phase, feature=feature, check="market_adds_m",
+            status="pass" if ok_m else "fail",
+            severity=None if ok_m else "B", expected=None if ok_m else False,
+            kwargs=dict(kwargs),
+            detail=f"m in index = {ok_m}; index = {names}",
+        ))
+
+    # (4) row-count conservation vs sum of per-country builds.  Only meaningful
+    # for the no-kwarg assembly pass: kwarg variants (units modes especially)
+    # legitimately change cardinality, so a delta there is kwarg semantics, not
+    # an assembly defect -- captured separately in phase2_kwargs.
+    if check_rows and per_country_rows:
+        present = [c for c in per_country_rows if c in result.index.get_level_values("country").unique()] \
+            if "country" in names else list(per_country_rows)
+        expected_rows = sum(per_country_rows[c] for c in present)
+        got = len(result)
+        if got < expected_rows:
+            findings.append(Finding(
+                phase=phase, feature=feature, check="row_conservation",
+                status="warn", severity="B", expected=False, kwargs=dict(kwargs),
+                detail=(f"assembled {got} rows < sum of per-country {expected_rows} "
+                        f"({expected_rows - got} dropped via harmonize/collapse — "
+                        f"triage losslessness)"),
+                metrics={"assembled": got, "sum_parts": expected_rows,
+                         "dropped": expected_rows - got},
+            ))
+
+    # (5) columns that went entirely NaN after the concat
+    for col in result.columns:
+        if result[col].isna().all():
+            findings.append(Finding(
+                phase=phase, feature=feature, country=None, check="all_nan_column",
+                status="warn", severity="B", expected=False, kwargs=dict(kwargs),
+                detail=f"column {col!r} is entirely NaN after assembly",
+                metrics={"column": col},
+            ))
+    return findings
+
+
+def phase1b_assembly(feature: str, countries: list[str], per_country_rows: dict[str, int]) -> tuple[list[Finding], Any]:
+    if feature in _PROPERTY_FEATURES:
+        return [], None  # properties don't assemble cross-country
+    result, captured, err, secs = _build(lambda: ll.Feature(feature)(countries))
+    findings = _warnings_to_findings("1b-assembly", feature, captured, {})
+    if err is not None:
+        findings.append(Finding(
+            phase="1b-assembly", feature=feature, check="assembly_build",
+            status="error", severity="B", expected=False, detail=err,
+        ))
+        return findings, None
+    findings += _assembly_invariants("1b-assembly", feature, result, per_country_rows, {})
+    return findings, result
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 -- kwarg cross-product
+# ---------------------------------------------------------------------------
+
+def _grand_totals(df: pd.DataFrame) -> dict[str, float]:
+    out = {}
+    for col in ADDITIVE_MEASURES:
+        if col in df.columns:
+            out[col] = float(pd.to_numeric(df[col], errors="coerce").sum())
+    return out
+
+
+def _nan_fractions(df: pd.DataFrame) -> dict[str, float]:
+    out = {}
+    for col in df.select_dtypes(include="number").columns:
+        out[col] = round(float(df[col].isna().mean()), 4)
+    return out
+
+
+def phase2_kwargs(feature: str, countries: list[str], baseline: Any,
+                  per_country_rows: dict[str, int]) -> list[Finding]:
+    grid = KWARG_GRID.get(feature, [])
+    if not grid:
+        return []
+    findings: list[Finding] = []
+    base_totals = _grand_totals(baseline) if isinstance(baseline, pd.DataFrame) else {}
+    base_nan = _nan_fractions(baseline) if isinstance(baseline, pd.DataFrame) else {}
+
+    for kwargs in grid:
+        result, captured, err, secs = _build(lambda kw=kwargs: ll.Feature(feature)(countries, **kw))
+        findings += _warnings_to_findings("2-kwargs", feature, captured, kwargs)
+        if err is not None:
+            findings.append(Finding(
+                phase="2-kwargs", feature=feature, check="kwarg_build",
+                status="error", severity="C", expected=False, kwargs=dict(kwargs),
+                detail=err,
+            ))
+            continue
+
+        findings += _assembly_invariants("2-kwargs", feature, result,
+                                          per_country_rows, kwargs, check_rows=False)
+        if not isinstance(result, pd.DataFrame) or result.empty:
+            continue
+
+        # kwarg changing cardinality vs the no-kwarg assembled baseline is a
+        # semantics signal (e.g. units price-modes drop unreported-price rows).
+        if isinstance(baseline, pd.DataFrame) and len(result) != len(baseline):
+            delta = len(result) - len(baseline)
+            findings.append(Finding(
+                phase="2-kwargs", feature=feature, check="kwarg_changes_rowcount",
+                status="warn", severity="C", expected=None, kwargs=dict(kwargs),
+                detail=(f"row count {len(baseline)} -> {len(result)} ({delta:+d}) "
+                        f"under this kwarg vs no-kwarg baseline"),
+                metrics={"baseline": len(baseline), "got": len(result), "delta": delta},
+            ))
+
+        # units mode that blows NaN-rate from <99% to ~100% on a value column
+        if "units" in kwargs:
+            for col, frac in _nan_fractions(result).items():
+                base = base_nan.get(col, 0.0)
+                if frac > 0.99 and base <= 0.99:
+                    findings.append(Finding(
+                        phase="2-kwargs", feature=feature, check="units_all_nan",
+                        status="warn", severity="C", expected=None, kwargs=dict(kwargs),
+                        detail=(f"units={kwargs['units']!r}: {col!r} is {frac:.1%} NaN "
+                                f"(baseline {base:.1%}) — by-design no-fallback or bug?"),
+                        metrics={"column": col, "nan_frac": frac, "baseline_nan_frac": base},
+                    ))
+
+        # labels='Aggregate' (reaggregate) must conserve additive grand totals
+        if kwargs.get("labels") == "Aggregate" and base_totals:
+            for col, base_tot in base_totals.items():
+                got = _grand_totals(result).get(col)
+                if got is None or base_tot == 0:
+                    continue
+                drift = abs(got - base_tot) / abs(base_tot)
+                if drift > 1e-3:
+                    findings.append(Finding(
+                        phase="2-kwargs", feature=feature, check="reaggregate_conservation",
+                        status="warn", severity="C", expected=False, kwargs=dict(kwargs),
+                        detail=(f"labels='Aggregate' changed {col} grand total by "
+                                f"{drift:.2%} ({base_tot:.0f} -> {got:.0f})"),
+                        metrics={"column": col, "baseline": base_tot, "got": got,
+                                 "rel_drift": drift},
+                    ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+def resolve_features(spec: list[str]) -> list[str]:
+    if spec == ["canonical"]:
+        return list(CANONICAL_FEATURES)
+    if spec == ["all"]:
+        return sorted(_all_known_features())
+    return spec
+
+
+def declaring_countries(feature: str, country_filter: list[str] | None) -> list[str]:
+    declared = ll.Feature(feature).countries
+    if country_filter:
+        keep = [c for c in declared if c in country_filter]
+        return keep
+    return declared
+
+
+def run(features: list[str], country_filter: list[str] | None,
+        phases: set[str], limit_countries: int | None,
+        out_path: str) -> None:
+    """Stream one JSON record per check to *out_path* as each feature completes.
+
+    Writing incrementally (and flushing per feature) means a multi-hour sweep is
+    crash-safe and tail-able for live progress, instead of producing nothing
+    until the very end.
+    """
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    by_status: dict[str, int] = {}
+    by_sev: dict[str, int] = {}
+    n_records = 0
+    n_skips = 0
+
+    with open(out_path, "w", encoding="utf-8") as fh:
+        def emit(findings: list[Finding]) -> None:
+            nonlocal n_records
+            for f in findings:
+                fh.write(json.dumps(f.to_record()) + "\n")
+                n_records += 1
+                by_status[f.status] = by_status.get(f.status, 0) + 1
+                if f.status in ("warn", "fail", "error"):
+                    by_sev[f.severity or "?"] = by_sev.get(f.severity or "?", 0) + 1
+            fh.flush()
+
+        def skip(feature: str, reason: str) -> None:
+            nonlocal n_skips
+            fh.write(json.dumps({"phase": "0-scope", "status": "skip",
+                                 "feature": feature, "reason": reason}) + "\n")
+            fh.flush()
+            n_skips += 1
+
+        for idx, feature in enumerate(features, 1):
+            try:
+                countries = declaring_countries(feature, country_filter)
+            except ValueError as e:  # unknown feature name
+                skip(feature, str(e))
+                continue
+            if limit_countries:
+                countries = countries[:limit_countries]
+            if not countries:
+                skip(feature, "no declaring country in filter")
+                continue
+
+            t0 = time.perf_counter()
+            print(f"[{idx}/{len(features)} {feature}] {len(countries)} countries: "
+                  f"{', '.join(countries)}", file=sys.stderr, flush=True)
+
+            per_country_rows: dict[str, int] = {}
+            baseline = None
+            before = n_records
+            if "1" in phases:
+                f1a, per_country_rows = phase1a_country_sanity(feature, countries)
+                emit(f1a)
+                f1b, baseline = phase1b_assembly(feature, countries, per_country_rows)
+                emit(f1b)
+
+            if "2" in phases:
+                if baseline is None and feature not in _PROPERTY_FEATURES:
+                    baseline, *_ = _build(lambda: ll.Feature(feature)(countries))
+                emit(phase2_kwargs(feature, countries, baseline, per_country_rows))
+
+            print(f"    done in {time.perf_counter() - t0:.0f}s  "
+                  f"(+{n_records - before} records)", file=sys.stderr, flush=True)
+
+    print("\n=== feature-audit scan summary ===", file=sys.stderr)
+    print(f"features: {len(features)}  records: {n_records}  skips: {n_skips}",
+          file=sys.stderr)
+    print(f"by status: {by_status}", file=sys.stderr)
+    print(f"candidate findings (warn/fail/error) by severity class: {by_sev}",
+          file=sys.stderr)
+    print(f"-> {out_path}", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--features", nargs="+", default=["canonical"],
+                    help="feature names, or 'canonical' (default) / 'all'")
+    ap.add_argument("--countries", nargs="*", default=None,
+                    help="restrict to these countries (intersect with declarers)")
+    ap.add_argument("--phases", default="1,2",
+                    help="comma list of phases to run (1,2). default 1,2")
+    ap.add_argument("--limit-countries", type=int, default=None,
+                    help="cap countries per feature (smoke testing)")
+    ap.add_argument("--out", default="bench/feature_audit/results.jsonl")
+    args = ap.parse_args(argv)
+
+    features = resolve_features(args.features)
+    phases = set(args.phases.replace(" ", "").split(","))
+    run(features, args.countries, phases, args.limit_countries, args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/feature_audit/scan.py
+++ b/bench/feature_audit/scan.py
@@ -462,17 +462,18 @@ def _nan_fractions(df: pd.DataFrame) -> dict[str, float]:
     return out
 
 
-def phase2_kwargs(feature: str, countries: list[str], baseline: Any,
-                  per_country_rows: dict[str, int]) -> list[Finding]:
-    grid = KWARG_GRID.get(feature, [])
-    if not grid:
-        return []
+def _scan_one_kwarg(feature: str, countries: list[str], kwargs: dict[str, Any],
+                    base_totals: dict[str, float], base_nan: dict[str, float],
+                    base_len: int | None,
+                    per_country_rows: dict[str, int]) -> list[Finding]:
+    """Build ONE Feature(feature)(countries, **kwargs) and check it against the
+    no-kwarg baseline summaries.  Module-level + never-raising so it ships to a
+    pool worker; baseline *summaries* (totals/nan-fracs/len) are passed instead
+    of the baseline DataFrame, which is too big to pickle and not needed here.
+    """
     findings: list[Finding] = []
-    base_totals = _grand_totals(baseline) if isinstance(baseline, pd.DataFrame) else {}
-    base_nan = _nan_fractions(baseline) if isinstance(baseline, pd.DataFrame) else {}
-
-    for kwargs in grid:
-        result, captured, err, secs = _build(lambda kw=kwargs: ll.Feature(feature)(countries, **kw))
+    try:
+        result, captured, err, secs = _build(lambda: ll.Feature(feature)(countries, **kwargs))
         findings += _warnings_to_findings("2-kwargs", feature, captured, kwargs)
         if err is not None:
             findings.append(Finding(
@@ -480,23 +481,23 @@ def phase2_kwargs(feature: str, countries: list[str], baseline: Any,
                 status="error", severity="C", expected=False, kwargs=dict(kwargs),
                 detail=err,
             ))
-            continue
+            return findings
 
         findings += _assembly_invariants("2-kwargs", feature, result,
                                           per_country_rows, kwargs, check_rows=False)
         if not isinstance(result, pd.DataFrame) or result.empty:
-            continue
+            return findings
 
         # kwarg changing cardinality vs the no-kwarg assembled baseline is a
         # semantics signal (e.g. units price-modes drop unreported-price rows).
-        if isinstance(baseline, pd.DataFrame) and len(result) != len(baseline):
-            delta = len(result) - len(baseline)
+        if base_len is not None and len(result) != base_len:
+            delta = len(result) - base_len
             findings.append(Finding(
                 phase="2-kwargs", feature=feature, check="kwarg_changes_rowcount",
                 status="warn", severity="C", expected=None, kwargs=dict(kwargs),
-                detail=(f"row count {len(baseline)} -> {len(result)} ({delta:+d}) "
+                detail=(f"row count {base_len} -> {len(result)} ({delta:+d}) "
                         f"under this kwarg vs no-kwarg baseline"),
-                metrics={"baseline": len(baseline), "got": len(result), "delta": delta},
+                metrics={"baseline": base_len, "got": len(result), "delta": delta},
             ))
 
         # units mode that blows NaN-rate from <99% to ~100% on a value column
@@ -528,6 +529,62 @@ def phase2_kwargs(feature: str, countries: list[str], baseline: Any,
                         metrics={"column": col, "baseline": base_tot, "got": got,
                                  "rel_drift": drift},
                     ))
+        return findings
+    except Exception as e:  # noqa: BLE001 - worker must not crash the pool
+        findings.append(Finding(
+            phase="2-kwargs", feature=feature, check="worker", status="error",
+            severity="C", expected=False, kwargs=dict(kwargs),
+            detail=f"worker crashed: {type(e).__name__}: {e}",
+        ))
+        return findings
+
+
+def phase2_kwargs(feature: str, countries: list[str], baseline: Any,
+                  per_country_rows: dict[str, int], jobs: int = 1,
+                  build_timeout: int = DEFAULT_BUILD_TIMEOUT) -> list[Finding]:
+    """Exercise the per-feature kwarg grid.  Each variant is an independent warm
+    Feature() rebuild + transform, so with ``jobs > 1`` the variants run
+    concurrently in a pool — this is the dominant cost on the food features
+    (6 units/label/market passes over ~40 countries back-to-back when serial).
+    """
+    grid = KWARG_GRID.get(feature, [])
+    if not grid:
+        return []
+    base_totals = _grand_totals(baseline) if isinstance(baseline, pd.DataFrame) else {}
+    base_nan = _nan_fractions(baseline) if isinstance(baseline, pd.DataFrame) else {}
+    base_len = len(baseline) if isinstance(baseline, pd.DataFrame) else None
+
+    if jobs > 1 and len(grid) > 1:
+        findings: list[Finding] = []
+        pool = get_context("fork").Pool(processes=min(jobs, len(grid)))
+        try:
+            ars = [(kw, pool.apply_async(_scan_one_kwarg,
+                    (feature, countries, kw, base_totals, base_nan, base_len, per_country_rows)))
+                   for kw in grid]
+            for kw, ar in ars:
+                try:
+                    findings += ar.get(timeout=build_timeout)
+                except MPTimeoutError:
+                    findings.append(Finding(
+                        phase="2-kwargs", feature=feature, check="kwarg_timeout",
+                        status="error", severity="C", expected=False, kwargs=dict(kw),
+                        detail=f"kwarg build exceeded {build_timeout}s — killed",
+                    ))
+                except Exception as e:  # noqa: BLE001
+                    findings.append(Finding(
+                        phase="2-kwargs", feature=feature, check="worker",
+                        status="error", severity="C", expected=False, kwargs=dict(kw),
+                        detail=f"worker died: {type(e).__name__}: {e}",
+                    ))
+        finally:
+            pool.terminate()
+            pool.join()
+        return findings
+
+    findings = []
+    for kw in grid:
+        findings += _scan_one_kwarg(feature, countries, kw, base_totals, base_nan,
+                                    base_len, per_country_rows)
     return findings
 
 
@@ -624,7 +681,8 @@ def run(features: list[str], country_filter: list[str] | None,
             if "2" in phases:
                 if baseline is None and feature not in _PROPERTY_FEATURES:
                     baseline, *_ = _build(lambda: ll.Feature(feature)(countries))
-                emit(phase2_kwargs(feature, countries, baseline, per_country_rows))
+                emit(phase2_kwargs(feature, countries, baseline, per_country_rows,
+                                   jobs, build_timeout))
 
             print(f"    done in {time.perf_counter() - t0:.0f}s  "
                   f"(+{n_records - before} records)", file=sys.stderr, flush=True)

--- a/bench/feature_audit/scan.py
+++ b/bench/feature_audit/scan.py
@@ -43,8 +43,8 @@ import sys
 import time
 import traceback
 import warnings
-from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import asdict, dataclass, field
+from multiprocessing import TimeoutError as MPTimeoutError, get_context
 from typing import Any, Callable
 
 # Pin per-process numerical thread pools to 1 BEFORE importing numpy/pandas.
@@ -115,6 +115,18 @@ KWARG_GRID: dict[str, list[dict[str, Any]]] = {
 # Columns that are additive across countries -> a relabel/reaggregate must
 # CONSERVE their grand total (Price is per-unit and must NOT).
 ADDITIVE_MEASURES = ("Quantity", "Expenditure")
+
+# Countries with no source microdata in the repo (CLAUDE.md "Countries Without
+# Microdata").  Their per-feature builds don't fail fast -- they spin in
+# fallback paths (Armenia's "manual aggregation", Nepal's make loop) -- so one
+# of them stalls the whole feature.  Skipped up front and logged transparently.
+# Override with --include-no-microdata.
+NO_MICRODATA = {"Nepal", "Armenia"}
+
+# Hard ceiling on a single country build (seconds).  A legitimate cold
+# food_acquired build for a big country is minutes, so this is generous; it only
+# trips on a genuine hang, after which the straggler worker is force-killed.
+DEFAULT_BUILD_TIMEOUT = 600
 
 # Substrings that classify a captured warning into an issue class + a quick
 # "expected?" hint for triage.  (severity, expected_by_default)
@@ -262,29 +274,57 @@ def _scan_one_country(feature: str, name: str) -> tuple[list[Finding], str, int 
         return findings, name, None
 
 
-def phase1a_country_sanity(feature: str, countries: list[str],
-                           jobs: int = 1) -> tuple[list[Finding], dict[str, int]]:
+def phase1a_country_sanity(
+    feature: str, countries: list[str], jobs: int = 1,
+    build_timeout: int = DEFAULT_BUILD_TIMEOUT,
+) -> tuple[list[Finding], dict[str, int]]:
     """Build each country's table alone and run is_this_feature_sane.
 
-    With ``jobs > 1`` the per-country builds fan out across a process pool —
-    safe because v0.7.3 reads are lock-free (direct S3) and each country writes
-    a distinct L2 cache path, so concurrent builds of different countries don't
-    contend.  Returns (findings, per_country_rowcount); the row counts feed the
-    Phase-1b conservation invariant.
+    ``countries`` is assumed already filtered of no-microdata countries by the
+    caller (``run``), since Phase 1b/2 share that filter.  With ``jobs > 1`` the
+    per-country builds fan out across a ``multiprocessing`` pool — safe because
+    v0.7.3 reads are lock-free (direct S3) and each country writes a distinct L2
+    cache path, so concurrent builds of different countries don't contend.  Each
+    build is bounded by ``build_timeout`` and a straggler is force-killed via
+    ``pool.terminate()`` so one hang can't block the feature.
+
+    Returns (findings, per_country_rowcount); the row counts feed the Phase-1b
+    conservation invariant.
     """
     findings: list[Finding] = []
     rows: dict[str, int] = {}
+    targets = countries
 
-    if jobs > 1 and len(countries) > 1:
-        with ProcessPoolExecutor(max_workers=min(jobs, len(countries))) as ex:
-            futs = {ex.submit(_scan_one_country, feature, c): c for c in countries}
-            for fut in as_completed(futs):
-                f_list, name, n = fut.result()  # _scan_one_country never raises
-                findings += f_list
-                if n is not None:
-                    rows[name] = n
+    if jobs > 1 and len(targets) > 1:
+        # fork: workers inherit the already-imported package + the BLAS=1 env,
+        # so no re-import cost and no thread oversubscription.
+        pool = get_context("fork").Pool(processes=min(jobs, len(targets)))
+        try:
+            ars = {c: pool.apply_async(_scan_one_country, (feature, c)) for c in targets}
+            for c, ar in ars.items():
+                try:
+                    f_list, name, n = ar.get(timeout=build_timeout)
+                    findings += f_list
+                    if n is not None:
+                        rows[name] = n
+                except MPTimeoutError:
+                    findings.append(Finding(
+                        phase="1a-sanity", feature=feature, country=c,
+                        check="build_timeout", status="error", severity="A",
+                        expected=False,
+                        detail=f"build exceeded {build_timeout}s — killed (likely hang)",
+                    ))
+                except Exception as e:  # noqa: BLE001 - worker died unexpectedly
+                    findings.append(Finding(
+                        phase="1a-sanity", feature=feature, country=c,
+                        check="worker", status="error", severity="A", expected=False,
+                        detail=f"worker died: {type(e).__name__}: {e}",
+                    ))
+        finally:
+            pool.terminate()   # force-kill any straggler still spinning
+            pool.join()
     else:
-        for name in countries:
+        for name in targets:
             f_list, name, n = _scan_one_country(feature, name)
             findings += f_list
             if n is not None:
@@ -513,7 +553,9 @@ def declaring_countries(feature: str, country_filter: list[str] | None) -> list[
 
 def run(features: list[str], country_filter: list[str] | None,
         phases: set[str], limit_countries: int | None,
-        out_path: str, jobs: int = 1) -> None:
+        out_path: str, jobs: int = 1,
+        build_timeout: int = DEFAULT_BUILD_TIMEOUT,
+        include_no_microdata: bool = False) -> None:
     """Stream one JSON record per check to *out_path* as each feature completes.
 
     Writing incrementally (and flushing per feature) means a multi-hour sweep is
@@ -552,19 +594,29 @@ def run(features: list[str], country_filter: list[str] | None,
                 continue
             if limit_countries:
                 countries = countries[:limit_countries]
+            # Drop known no-microdata countries BEFORE any phase: Feature() (used
+            # by Phase 1b/2) has no skip list and would spin on them in the main
+            # process.  Logged per (feature, country) so coverage stays honest.
+            excluded = set() if include_no_microdata else NO_MICRODATA
+            dropped = [c for c in countries if c in excluded]
+            countries = [c for c in countries if c not in excluded]
+            for c in dropped:
+                skip(feature, f"{c}: known no-source-data country (CLAUDE.md)")
             if not countries:
                 skip(feature, "no declaring country in filter")
                 continue
 
             t0 = time.perf_counter()
-            print(f"[{idx}/{len(features)} {feature}] {len(countries)} countries: "
+            print(f"[{idx}/{len(features)} {feature}] {len(countries)} countries"
+                  f"{f' (skipped {len(dropped)})' if dropped else ''}: "
                   f"{', '.join(countries)}", file=sys.stderr, flush=True)
 
             per_country_rows: dict[str, int] = {}
             baseline = None
             before = n_records
             if "1" in phases:
-                f1a, per_country_rows = phase1a_country_sanity(feature, countries, jobs)
+                f1a, per_country_rows = phase1a_country_sanity(
+                    feature, countries, jobs, build_timeout)
                 emit(f1a)
                 f1b, baseline = phase1b_assembly(feature, countries, per_country_rows)
                 emit(f1b)
@@ -602,13 +654,23 @@ def main(argv: list[str] | None = None) -> int:
                     help="parallel Phase-1a country builds (process pool). "
                          "Size to PHYSICAL cores (e.g. 24 on a 32-core node). "
                          "default 1 = sequential")
+    ap.add_argument("--build-timeout", type=int, default=DEFAULT_BUILD_TIMEOUT,
+                    help=f"per-country build hard ceiling, seconds "
+                         f"(default {DEFAULT_BUILD_TIMEOUT}); straggler is killed")
+    ap.add_argument("--include-no-microdata", action="store_true",
+                    help=f"don't skip the known no-source-data countries "
+                         f"({', '.join(sorted(NO_MICRODATA))})")
     args = ap.parse_args(argv)
 
     features = resolve_features(args.features)
     phases = set(args.phases.replace(" ", "").split(","))
+    skipped = "none" if args.include_no_microdata else ", ".join(sorted(NO_MICRODATA))
     print(f"feature-audit scan: {len(features)} features, jobs={args.jobs}, "
-          f"BLAS threads/worker={os.environ.get('OMP_NUM_THREADS')}", file=sys.stderr)
-    run(features, args.countries, phases, args.limit_countries, args.out, args.jobs)
+          f"BLAS threads/worker={os.environ.get('OMP_NUM_THREADS')}, "
+          f"build_timeout={args.build_timeout}s, skip_no_microdata=[{skipped}]",
+          file=sys.stderr)
+    run(features, args.countries, phases, args.limit_countries, args.out, args.jobs,
+        args.build_timeout, args.include_no_microdata)
     return 0
 
 

--- a/bench/feature_audit/scan.py
+++ b/bench/feature_audit/scan.py
@@ -108,7 +108,9 @@ KWARG_GRID: dict[str, list[dict[str, Any]]] = {
     "food_expenditures": [{"labels": "Aggregate"}, {"market": "Region"}],
     "food_acquired": [{"labels": "Aggregate"}],
     "assets": [{"labels": "Aggregate"}],
-    "household_characteristics": [{"age_cuts": [0, 5, 15, 60]}, {"market": "Region"}],
+    # no leading 0 in age_cuts: a leading 0 is deprecated and just emits a
+    # warning for every country (565-sweep cluster C023, a harness artifact).
+    "household_characteristics": [{"age_cuts": [5, 15, 60]}, {"market": "Region"}],
     "household_roster": [{"market": "Region"}],
 }
 

--- a/bench/feature_audit/scan.py
+++ b/bench/feature_audit/scan.py
@@ -43,8 +43,17 @@ import sys
 import time
 import traceback
 import warnings
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import asdict, dataclass, field
 from typing import Any, Callable
+
+# Pin per-process numerical thread pools to 1 BEFORE importing numpy/pandas.
+# With N parallel build workers we want N cores doing N independent country
+# builds, NOT one country fanning a BLAS op across all cores (oversubscription).
+# setdefault: respect an explicit override from the environment.
+for _v in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+           "NUMEXPR_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"):
+    os.environ.setdefault(_v, "1")
 
 import pandas as pd
 
@@ -195,17 +204,16 @@ def _warnings_to_findings(
 # Phase 1a -- per-country sanity (no kwargs)
 # ---------------------------------------------------------------------------
 
-def phase1a_country_sanity(feature: str, countries: list[str]) -> tuple[list[Finding], dict[str, int]]:
-    """Build each country's table alone and run is_this_feature_sane.
+def _scan_one_country(feature: str, name: str) -> tuple[list[Finding], str, int | None]:
+    """Build ONE (country, feature), run sanity, return (findings, name, rows).
 
-    Returns (findings, per_country_rowcount) -- the row counts feed the Phase-1b
-    conservation invariant.
+    Module-level and never-raising so it is safe to ship to a ProcessPoolExecutor
+    worker.  ``rows`` is None unless a non-empty DataFrame was built (it feeds the
+    Phase-1b row-conservation invariant).  Side effect: populates the country's
+    L2 cache, which is exactly the parallel cache-warming we want.
     """
     findings: list[Finding] = []
-    rows: dict[str, int] = {}
-    is_property = feature in _PROPERTY_FEATURES
-
-    for name in countries:
+    try:
         result, captured, err, secs = _build(lambda: load_feature(ll.Country(name), feature))
         findings += _warnings_to_findings("1a-sanity", feature, captured, {})
 
@@ -215,9 +223,9 @@ def phase1a_country_sanity(feature: str, countries: list[str]) -> tuple[list[Fin
                 status="error", severity="A", expected=False, detail=err,
                 metrics={"seconds": round(secs, 2)},
             ))
-            continue
+            return findings, name, None
 
-        if is_property:
+        if feature in _PROPERTY_FEATURES:
             # panel_ids / updated_ids return dicts -> record load, skip df checks.
             n = len(result) if hasattr(result, "__len__") else 0
             findings.append(Finding(
@@ -225,7 +233,7 @@ def phase1a_country_sanity(feature: str, countries: list[str]) -> tuple[list[Fin
                 check="build", status="pass", detail=f"property loaded ({n} entries)",
                 metrics={"entries": n, "seconds": round(secs, 2)},
             ))
-            continue
+            return findings, name, None
 
         if not isinstance(result, pd.DataFrame) or result.empty:
             findings.append(Finding(
@@ -233,9 +241,8 @@ def phase1a_country_sanity(feature: str, countries: list[str]) -> tuple[list[Fin
                 status="fail", severity="A", expected=False,
                 detail="empty / non-DataFrame result",
             ))
-            continue
+            return findings, name, None
 
-        rows[name] = len(result)
         report = is_this_feature_sane(result, name, feature)
         for c in report.checks:
             if c.status == "pass":
@@ -245,6 +252,43 @@ def phase1a_country_sanity(feature: str, countries: list[str]) -> tuple[list[Fin
                 status=c.status, severity="B" if c.status == "fail" else "C",
                 expected=False, detail=c.message,
             ))
+        return findings, name, len(result)
+    except Exception as e:  # noqa: BLE001 - a worker must never crash the pool
+        findings.append(Finding(
+            phase="1a-sanity", feature=feature, country=name, check="worker",
+            status="error", severity="A", expected=False,
+            detail=f"worker crashed: {type(e).__name__}: {e}",
+        ))
+        return findings, name, None
+
+
+def phase1a_country_sanity(feature: str, countries: list[str],
+                           jobs: int = 1) -> tuple[list[Finding], dict[str, int]]:
+    """Build each country's table alone and run is_this_feature_sane.
+
+    With ``jobs > 1`` the per-country builds fan out across a process pool —
+    safe because v0.7.3 reads are lock-free (direct S3) and each country writes
+    a distinct L2 cache path, so concurrent builds of different countries don't
+    contend.  Returns (findings, per_country_rowcount); the row counts feed the
+    Phase-1b conservation invariant.
+    """
+    findings: list[Finding] = []
+    rows: dict[str, int] = {}
+
+    if jobs > 1 and len(countries) > 1:
+        with ProcessPoolExecutor(max_workers=min(jobs, len(countries))) as ex:
+            futs = {ex.submit(_scan_one_country, feature, c): c for c in countries}
+            for fut in as_completed(futs):
+                f_list, name, n = fut.result()  # _scan_one_country never raises
+                findings += f_list
+                if n is not None:
+                    rows[name] = n
+    else:
+        for name in countries:
+            f_list, name, n = _scan_one_country(feature, name)
+            findings += f_list
+            if n is not None:
+                rows[name] = n
     return findings, rows
 
 
@@ -469,7 +513,7 @@ def declaring_countries(feature: str, country_filter: list[str] | None) -> list[
 
 def run(features: list[str], country_filter: list[str] | None,
         phases: set[str], limit_countries: int | None,
-        out_path: str) -> None:
+        out_path: str, jobs: int = 1) -> None:
     """Stream one JSON record per check to *out_path* as each feature completes.
 
     Writing incrementally (and flushing per feature) means a multi-hour sweep is
@@ -520,7 +564,7 @@ def run(features: list[str], country_filter: list[str] | None,
             baseline = None
             before = n_records
             if "1" in phases:
-                f1a, per_country_rows = phase1a_country_sanity(feature, countries)
+                f1a, per_country_rows = phase1a_country_sanity(feature, countries, jobs)
                 emit(f1a)
                 f1b, baseline = phase1b_assembly(feature, countries, per_country_rows)
                 emit(f1b)
@@ -554,11 +598,17 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--limit-countries", type=int, default=None,
                     help="cap countries per feature (smoke testing)")
     ap.add_argument("--out", default="bench/feature_audit/results.jsonl")
+    ap.add_argument("--jobs", "-j", type=int, default=1,
+                    help="parallel Phase-1a country builds (process pool). "
+                         "Size to PHYSICAL cores (e.g. 24 on a 32-core node). "
+                         "default 1 = sequential")
     args = ap.parse_args(argv)
 
     features = resolve_features(args.features)
     phases = set(args.phases.replace(" ", "").split(","))
-    run(features, args.countries, phases, args.limit_countries, args.out)
+    print(f"feature-audit scan: {len(features)} features, jobs={args.jobs}, "
+          f"BLAS threads/worker={os.environ.get('OMP_NUM_THREADS')}", file=sys.stderr)
+    run(features, args.countries, phases, args.limit_countries, args.out, args.jobs)
     return 0
 
 


### PR DESCRIPTION
A systematic audit system for `ll.Feature('foo')` and `ll.Feature('foo')(**kwargs)` across every declaring country: surface issues, red-team them, file the survivors. Pairs with the `cross-country-features` skill (#510).

## Pipeline (`bench/feature_audit/`)
1. **`scan.py`** — deterministic wide-net. Builds every feature × declaring-country × per-feature kwarg grid (`units`/`labels`/`market`/`age_cuts`), runs `diagnostics.is_this_feature_sane` per country plus cross-country *assembly invariants* (unnamed-level collapse, missing canonical level, row conservation, reaggregation drift, units NaN blow-up). Streams one fingerprinted JSON record per check. Parallel (Phase-1a country builds + Phase-2 kwarg variants via process pools, BLAS-pinned), with a no-microdata skip list and per-build timeout so one hang can't stall the sweep.
2. **`cluster.py`** — collapses the ~565 raw warn/fail/error findings into ~56 root-cause clusters by `(check, severity, normalized-detail)`, hardest-first, so the agentic phase fans one agent per *pattern*, not per record.
3. **`audit.workflow.js`** — a Workflow script (opt-in to run): triage each cluster (real-bug / by-design / false-positive / harness-artifact + repro + numbers), red-team each real-bug with 3 adversarial lenses (cold-repro, by-design-contract, source-truth; default-refute, majority kills), then file survivors — memo + `confirmed_issues.jsonl` always, `gh issue create` (deduped on an `audit-key` fingerprint, labelled) only when `file:true` (dry-run default). Includes a hard no-git/read-only guardrail on agent prompts.

## What it found (this run)
Confirmed and filed **#511–#519** (9 issues): cross-country index collapses (#511/#512, fixed in #520), `.first()`-collapse silent row loss in plot_features (#513) and EHCVM `food_acquired` (~6% Mali expenditure loss, #514), kinship-map gaps (#516), and five more. Run artifacts live under `bench/feature_audit/results/` (gitignored).

See `bench/feature_audit/README.md` for the full design, severity classes, and invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWX2gtG2RSUBuxW42J8RtZ