### PR TITLE
fix(ehcvm): mark people_last7days hours/Industry columns optional (6 countries)

### DIFF
--- a/lsms_library/countries/Benin/_/data_scheme.yml
+++ b/lsms_library/countries/Benin/_/data_scheme.yml
@@ -240,9 +240,9 @@ Data Scheme:
     farm_work: bool
     SOB_work: bool
     wage_work: bool
-    farm_hrs: float
-    SB_hrs: float
-    wage_hrs: float
-    Industry: str
+    farm_hrs: {type: float, optional: true}
+    SB_hrs: {type: float, optional: true}
+    wage_hrs: {type: float, optional: true}
+    Industry: {type: str, optional: true}
     working_age: bool
     materialize: make

--- a/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
+++ b/lsms_library/countries/Burkina_Faso/_/data_scheme.yml
@@ -283,10 +283,10 @@ Data Scheme:
     farm_work: bool
     SOB_work: bool
     wage_work: bool
-    farm_hrs: float
-    SB_hrs: float
-    wage_hrs: float
-    Industry: str
+    farm_hrs: {type: float, optional: true}
+    SB_hrs: {type: float, optional: true}
+    wage_hrs: {type: float, optional: true}
+    Industry: {type: str, optional: true}
     working_age: bool
     materialize: make
 

--- a/lsms_library/countries/CotedIvoire/_/data_scheme.yml
+++ b/lsms_library/countries/CotedIvoire/_/data_scheme.yml
@@ -246,9 +246,9 @@ Data Scheme:
     farm_work: bool
     SOB_work: bool
     wage_work: bool
-    farm_hrs: float
-    SB_hrs: float
-    wage_hrs: float
-    Industry: str
+    farm_hrs: {type: float, optional: true}
+    SB_hrs: {type: float, optional: true}
+    wage_hrs: {type: float, optional: true}
+    Industry: {type: str, optional: true}
     working_age: bool
     materialize: make

--- a/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
+++ b/lsms_library/countries/Guinea-Bissau/_/data_scheme.yml
@@ -264,9 +264,9 @@ Data Scheme:
     farm_work: bool
     SOB_work: bool
     wage_work: bool
-    farm_hrs: float
-    SB_hrs: float
-    wage_hrs: float
-    Industry: str
+    farm_hrs: {type: float, optional: true}
+    SB_hrs: {type: float, optional: true}
+    wage_hrs: {type: float, optional: true}
+    Industry: {type: str, optional: true}
     working_age: bool
     materialize: make

--- a/lsms_library/countries/Senegal/_/data_scheme.yml
+++ b/lsms_library/countries/Senegal/_/data_scheme.yml
@@ -260,9 +260,9 @@ Data Scheme:
     farm_work: bool
     SOB_work: bool
     wage_work: bool
-    farm_hrs: float
-    SB_hrs: float
-    wage_hrs: float
-    Industry: str
+    farm_hrs: {type: float, optional: true}
+    SB_hrs: {type: float, optional: true}
+    wage_hrs: {type: float, optional: true}
+    Industry: {type: str, optional: true}
     working_age: bool
     materialize: make

--- a/lsms_library/countries/Togo/_/data_scheme.yml
+++ b/lsms_library/countries/Togo/_/data_scheme.yml
@@ -209,9 +209,9 @@ Data Scheme:
     farm_work: bool
     SOB_work: bool
     wage_work: bool
-    farm_hrs: float
-    SB_hrs: float
-    wage_hrs: float
-    Industry: str
+    farm_hrs: {type: float, optional: true}
+    SB_hrs: {type: float, optional: true}
+    wage_hrs: {type: float, optional: true}
+    Industry: {type: str, optional: true}
     working_age: bool
     materialize: make


### PR DESCRIPTION
Resolves the `test_no_fully_null_columns` / `test_feature_is_sane` failures for EHCVM `people_last7days`.

`farm_hrs`, `SB_hrs`, `wage_hrs`, `Industry` are all-NaN for Benin, Burkina_Faso, CotedIvoire, Guinea-Bissau, Senegal, Togo because EHCVM 2018-19's `s04` module has no 7-day activity-split hours / WB 7-day industry section (its productive-hours vars are 12-month usual-hours-per-job — a different construct, correctly not wired). They're real schema members (Niger's ECVMA waves populate them, ~51k non-null), so marked `optional` rather than removed, preserving cross-wave schema parity.

Diagnosed by cold repro + reading the `s04` variable labels directly. Niger/Mali keep them required.

**Verified:** 72 people_last7days table-structure tests pass.

The `cluster_features` duplicate-index failures (Burkina/Ethiopia/Nigeria) in the same batch are a **stale-cache artifact**, not a code bug — the current build produces 0 duplicates on rebuild and CI is green. The systemic root cause (the v0.8.0 cache hash versions inputs + per-country scripts but not framework transform code) is filed as #522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWX2gtG2RSUBuxW42J8RtZ