### PR TITLE
fix(#516): decode 4 Albania kinship labels + SA rel_head int sentinel

### DIFF
--- a/lsms_library/categorical_mapping/kinship.yml
+++ b/lsms_library/categorical_mapping/kinship.yml
@@ -612,3 +612,15 @@ P:                                       [1, 0, consanguineal]   # low-confidenc
 "Other Unrelated Person":        [0, 0, unrelated]
 "Servants":                      [0, 0, servant]
 "Tenant/Boarder":                [0, 0, guest]
+
+# --- Albania LSMS variants (GH #516) ---
+# Source labels carry spaces around "/" and/or a lowercase "in-law" that the
+# title-case fallback ('X'.title()) does not reduce to any existing key:
+#   'Father / mother-in-law' -> 'Father / Mother-In-Law'
+#   'Grandfather / Mother'   -> 'Grandfather / Mother'  (gendered grandparent pair)
+#   'brother/sister in-law'  -> 'Brother/Sister In-Law'
+#   'father/mother in-law'   -> 'Father/Mother In-Law'
+"Father / Mother-In-Law":        [1, 0, affinal]
+"Grandfather / Mother":          [2, 0, consanguineal]
+"Brother/Sister In-Law":         [0, 1, affinal]
+"Father/Mother In-Law":          [1, 0, affinal]

--- a/lsms_library/countries/South Africa/1993/_/data_info.yml
+++ b/lsms_library/countries/South Africa/1993/_/data_info.yml
@@ -54,7 +54,7 @@ household_roster:
         Relationship:
             - rel_head
             - mapping:
-                '-1': ~        # sentinel for missing — null out
+                -1: ~          # sentinel for missing — null out (rel_head is int8; bare-int key)
                 1: "Resident Head"
                 2: "Absent Head"
                 3: "Wife or husband or partner"


### PR DESCRIPTION
Closes #516.

`Country.household_roster()` warned `Unknown relationship labels` (and skipped kinship decomposition) for labels the `.title()` fallback can't normalise.

**Albania** — 4 spacing/casing variants mapped to (Generation, Distance, Affinity):
| source label | tuple |
|---|---|
| `Father / mother-in-law` | `[1, 0, affinal]` |
| `Grandfather / Mother` | `[2, 0, consanguineal]` |
| `brother/sister in-law` | `[0, 1, affinal]` |
| `father/mother in-law` | `[1, 0, affinal]` |

**South Africa/1993** — the `rel_head=-1` missing-sentinel was keyed as string `'-1'` but `rel_head` is int8, so it never matched and `-1` leaked to kinship expansion. Fixed to bare-int key `-1`.

### Verification (warm cache, counterfactual confirmed)
| country | rows | kinship warnings (unfixed → fixed) |
|---|---|---|
| Albania | 90,731 | 1 (4 labels) → 0 |
| South Africa | 43,687 | 1 (`['-1']`) → 0 |

Row counts unchanged. Salvaged + re-verified from a red-team draft produced by the `bench/feature_audit/` harness run.