### PR TITLE
fix(#515): missing optional geo column aborts cluster_features (silent market= row loss)

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -947,11 +947,23 @@ class Wave:
                     try:
                         sub_df = get_data(sub_data_info, sub_mapping_details)
                         merge_dfs.append(sub_df.reset_index())
-                    except (FileNotFoundError, PathMissingError, DvcException) as exc:
+                    except (FileNotFoundError, PathMissingError, DvcException,
+                            KeyError) as exc:
                         if idx == 0:
                             # The primary sub-df is required; re-raise
                             raise
-                        # Secondary sub-dfs (e.g. geo files) are optional
+                        # Secondary sub-dfs (e.g. geo files) are optional.
+                        # ``KeyError`` covers the case where the source file
+                        # exists but lacks the requested columns -- e.g. a
+                        # df_geo whose YAML asks for ``lat_dd_mod``/``lon_dd_mod``
+                        # that the file doesn't carry (or carries under a
+                        # different casing/name).  df_data_grabber raises
+                        # ``KeyError`` for a missing column when ``missing_ok``
+                        # is False, and a single-file sub-df gets
+                        # ``missing_ok=False``.  Treat it like a missing file:
+                        # drop the optional sub-df rather than abort the whole
+                        # cluster_features table and lose the Region/District
+                        # that the primary df_main provides.  GH #515.
                         sub_file = sub_data_info.get('file', i)
                         warnings.warn(
                             f"{self.name}/{request}: could not load "


### PR DESCRIPTION
Closes #515.

`Wave.grab_data()`'s multi-file merge only treated `FileNotFoundError` / `PathMissingError` / `DvcException` as an optional-sub-df-missing condition. A secondary sub-df whose **file exists but lacks the requested columns** raises `KeyError` from `df_data_grabber` (single-file sub-dfs get `missing_ok=False`), which propagated and aborted the whole `cluster_features` build. `_market_lookup` then caught it and **skipped `cluster_features` for that wave**, silently dropping those households from any `market=` query.

Burkina_Faso/2014 and 2018-19 declare a `df_geo` sub-df asking for `lat_dd_mod`/`lon_dd_mod` that the GPS file doesn't carry under that name. The fix adds `KeyError` to the optional-sub-df `except` (the required primary sub-df, `idx==0`, still re-raises), so the geo file is dropped with a warning and the primary df's Region/District survives.

### Verification — `Country('Burkina_Faso').household_roster(market='Region')`, forced rebuild, counterfactual
| | rows | signal |
|---|---|---|
| unfixed | 22,362 | `skipping cluster_features for Burkina_Faso/2014 (KeyError: 'lat_dd_mod ...')` |
| fixed | 145,011 | 2× `could not load sub-df 'df_geo' ... proceeding without it` |

~122k household_roster rows recovered. Salvaged + re-verified from a `bench/feature_audit/` red-team draft.