### PR TITLE
fix(#518): bad market= on derived household_characteristics raises clean KeyError

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -3380,6 +3380,7 @@ class Country:
                 if (name in self._ROSTER_DERIVED
                         and 'household_roster' in self.data_scheme):
                     from .transformations import roster_to_characteristics
+                    derived = None
                     try:
                         roster = self._aggregate_wave_data(waves, 'household_roster')
                         if isinstance(roster, pd.DataFrame) and not roster.empty:
@@ -3391,14 +3392,25 @@ class Country:
                             rc_kwargs = {'drop': 'pid', 'final_index': final_index}
                             if age_cuts is not None:
                                 rc_kwargs['age_cuts'] = tuple(age_cuts)
-                            result = roster_to_characteristics(roster, **rc_kwargs)
-                            if market is not None:
-                                result = self._add_market_index(result, column=market)
-                            return result
+                            derived = roster_to_characteristics(roster, **rc_kwargs)
                     except (FileNotFoundError, KeyError, ValueError, RuntimeError) as exc:
                         logger.info(
                             "Deriving %s from household_roster failed (%s); "
                             "falling back to legacy aggregation", name, exc)
+                        derived = None
+                    if derived is not None:
+                        # _add_market_index lives OUTSIDE the except so a
+                        # user-facing KeyError (a market= column this country
+                        # lacks) propagates, instead of being misread as a
+                        # derivation failure and falling through to the legacy
+                        # make/DVC path -- which has no rule for the derived
+                        # household_characteristics table and so emits spurious
+                        # "Makefile execution failed" + a misleading "could not
+                        # materialize" error (GH #518).  Mirrors the food-derived
+                        # path above.
+                        if market is not None:
+                            derived = self._add_market_index(derived, column=market)
+                        return derived
 
                 result = self._aggregate_wave_data(waves, name, currency=currency)
                 # Apply relabeling to any table with a j index level


### PR DESCRIPTION
Closes #518.

When `household_characteristics` is **derived** from `household_roster` and the caller passes `market=` for a column the country's `cluster_features` lacks, `_add_market_index` raises `KeyError`. It sat *inside* the `try/except` that also guards the derivation, so the `KeyError` was caught as a "derivation failure" and the code fell through to the legacy make/DVC path — which has no rule for the derived table and dies with a misleading `Could not materialize .../household_characteristics` `RuntimeError`.

The fix separates the two: derive inside the `try` (a genuine derivation `KeyError` still falls back to legacy), and apply `_add_market_index` **outside** so a bad `market=` propagates the actionable `KeyError`. Mirrors the food-derived path.

### Verification — `Country('Azerbaijan').household_characteristics(market='Region')` (Azerbaijan cluster_features has only `Rural`)
| | result |
|---|---|
| unfixed | `RuntimeError: Could not materialize Azerbaijan/household_characteristics …` |
| fixed | `KeyError: "'Region' not in cluster_features columns. Available: ['Rural']"` |

Happy path intact: Uganda `household_characteristics()` → `[t,v,i]`; `(market='Region')` → `[t,m,i]`.

Re-targeted by hand onto `development` (the red-team draft's `master` base had moved). Salvaged from the `bench/feature_audit/` harness run.