### PR TITLE
fix(#519): Iraq 2012 individual_education keys on questid (recovers ~68k dropped records)

### DIFF
--- a/lsms_library/countries/Iraq/2012/_/data_info.yml
+++ b/lsms_library/countries/Iraq/2012/_/data_info.yml
@@ -52,11 +52,15 @@ household_roster:
 
 individual_education:
     # Education module; q0503 = highest attainment (12 English-labeled levels).
-    # i=hh, pid=idcode match the roster (0% spine orphans).
+    # i=questid (matches sample/roster/housing/shocks); the source `hh` field is
+    # a within-dwelling sequence number (nunique 9 vs questid 25146), so keying
+    # on it gave 100% NaN v after _join_v_from_sample and silently dropped the
+    # 2012 wave from derived tables (GH #519; residual of the #505/#499 Iraq fix
+    # that missed this table).  pid=idcode matches the roster.
     file:
         - "../Data/2012ihses05_education.dta"
     idxvars:
-        i: hh
+        i: questid
         pid: idcode
     myvars:
         Educational Attainment:


### PR DESCRIPTION
Closes #519.

`individual_education` was wired `idxvars.i: hh`, but `hh` is a within-dwelling sequence number (nunique **9**) while the canonical household id is `questid` (nunique **25,146** — matches `sample`/`roster`/`housing`/`shocks`). Keying on `hh`:
- collapsed the 25,146-household 2012 wave to ~9 index values via `groupby().first()` (175k duplicate tuples), and
- produced **100% NaN `v`** after `_join_v_from_sample`, silently dropping the wave from derived tables.

Residual of #505/#499, which fixed this wave's roster/housing/shocks/assets (`hh`→`questid`) but **explicitly missed** `individual_education`. One-line config align + corrected the stale wiring comment.

### Verification (warm — config edit auto-invalidates only Iraq via the v0.8.0 content hash)
`Feature('individual_education')(['Iraq'])`:
| | rows | NaN-v warning | 2012 wave |
|---|---|---|---|
| before (`i:hh`) | 52,692 | 1 | collapsed to ~9 `hh` |
| after (`i:questid`) | 121,047 | 0 | 68,606 rows, v-null 0% |

~68k Iraq 2012 education records recovered. Diagnosed via the read-only backlog-workflow diagnosis pass; independently re-verified (questid present in the education source, cardinality matches the roster).