### PR TITLE
fix(#514): sum additive columns when collapsing duplicate food_acquired tuples (EHCVM silent loss)

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -2041,7 +2041,7 @@ class Country:
 
         if isinstance(df, pd.DataFrame):
             df = self._augment_index_from_related_tables(df, scheme_entry, None)
-            df = _normalize_dataframe_index(df, scheme_entry, None)
+            df = _normalize_dataframe_index(df, scheme_entry, None, method_name)
 
             # Join v from sample() for household-level tables that lack it.
             # Skip if v is already in the index OR already present as a
@@ -2595,7 +2595,7 @@ class Country:
                         scheme_entry,
                         w,
                     )
-                    wave_result = _normalize_dataframe_index(wave_result, scheme_entry, w)
+                    wave_result = _normalize_dataframe_index(wave_result, scheme_entry, w, method_name)
 
                 if wave_result is None and not wave_has_table:
                     continue
@@ -2809,7 +2809,7 @@ class Country:
                                     scheme_entry,
                                     stage.wave,
                                 )
-                                df_wave = _normalize_dataframe_index(df_wave, scheme_entry, stage.wave)
+                                df_wave = _normalize_dataframe_index(df_wave, scheme_entry, stage.wave, method_name)
                                 stage_results[stage.wave or "ALL"] = df_wave
                         return stage_results
 
@@ -2867,6 +2867,7 @@ class Country:
                                 cached_df,
                                 scheme_entry,
                                 wave_hint,
+                                method_name,
                             )
                             return cached_df
                         except (FileNotFoundError, PathMissingError):
@@ -3953,6 +3954,7 @@ def _normalize_dataframe_index(
     df: pd.DataFrame,
     schema_entry: dict[str, Any],
     wave: str | None,
+    table_name: str | None = None,
 ) -> pd.DataFrame:
     """
     Reorder and reduce a dataframe's MultiIndex to match the declared schema.
@@ -3960,7 +3962,9 @@ def _normalize_dataframe_index(
     - Reorders index levels to match the declared order.
     - Drops unexpected index levels.
     - Synthesizes missing 't' levels for wave-specific tables.
-    - Collapses duplicate entries via first-observation aggregation.
+    - Collapses duplicate entries: SUMs the additive measure columns for
+      tables in ``_ADDITIVE_MEASURE_COLUMNS`` (``table_name``), else keeps the
+      first row per group (the historical default).
     """
 
     if not isinstance(df, pd.DataFrame):
@@ -4025,22 +4029,37 @@ def _normalize_dataframe_index(
     if not df.index.is_unique:
         present_levels = [lvl for lvl in declared if lvl in df.index.names]
         n_dropped = int(df.index.duplicated().sum())
-        # Convert unordered categoricals to strings so groupby.first() works
+        # Convert unordered categoricals to strings so the groupby below works
         for col in df.columns:
             if hasattr(df[col], 'cat') and not df[col].cat.ordered:
                 df[col] = df[col].astype(str).replace({'nan': pd.NA, 'None': pd.NA, '<NA>': pd.NA})
-        df = df.groupby(level=present_levels, observed=True).first()
-        if n_dropped:
-            # GH #323: collapsing a non-unique canonical index with .first()
-            # silently DISCARDS the dropped rows.  Surface it loudly rather
-            # than lose data quietly; a feature whose source legitimately has
-            # multiple rows per index tuple needs an explicit duplicate-
-            # aggregation policy (e.g. sum quantities) instead of .first().
-            warnings.warn(
-                f"Canonical index over {present_levels} had {n_dropped} "
-                f"duplicate tuple(s); collapsed via groupby().first(), dropping "
-                f"those rows (possible silent data loss — GH #323).",
-                RuntimeWarning,
-            )
+        # GH #514/#323: collapsing a non-unique canonical index with .first()
+        # silently DISCARDS the dropped rows.  For additive-measure tables
+        # (food_acquired, whose source legitimately records the same item across
+        # several transactions per (t,v,i,j,u,s)) SUM the additive columns and
+        # re-derive any per-unit Price from the summed totals -- no data lost,
+        # no warning.  Single source of truth for the additive column map lives
+        # in feature.py (imported lazily to avoid an import cycle).
+        from .feature import _ADDITIVE_MEASURE_COLUMNS
+        additive = _ADDITIVE_MEASURE_COLUMNS.get(table_name) if table_name else None
+        present_additive = [c for c in (additive or ()) if c in df.columns]
+        if present_additive:
+            agg = {c: ('sum' if c in present_additive else 'first') for c in df.columns}
+            df = df.groupby(level=present_levels, observed=True).agg(agg)
+            if 'Price' in df.columns and {'Expenditure', 'Quantity'} <= set(df.columns):
+                df['Price'] = df['Expenditure'] / df['Quantity'].where(df['Quantity'] != 0)
+        else:
+            df = df.groupby(level=present_levels, observed=True).first()
+            if n_dropped:
+                # No aggregation policy for this table -- surface the loss
+                # loudly rather than drop rows quietly (a table whose source
+                # legitimately has multiple rows per index tuple needs an
+                # explicit policy, like the additive sum above).
+                warnings.warn(
+                    f"Canonical index over {present_levels} had {n_dropped} "
+                    f"duplicate tuple(s); collapsed via groupby().first(), dropping "
+                    f"those rows (possible silent data loss — GH #323).",
+                    RuntimeWarning,
+                )
 
     return df


### PR DESCRIPTION
Closes #514.

`_normalize_dataframe_index` (country.py) collapsed a non-unique canonical index with `groupby().first()`, silently dropping rows. **EHCVM `food_acquired` legitimately records the same item across several transactions** per `(t,v,i,j,u,s)` (Mali alone: **34,591** duplicate tuples), so `first()` undercounted Quantity and Expenditure — e.g. `Arachide/Boîte/purchased` kept 400 CFA and dropped 600.

### Fix
Make the collapse **additive-aware**: for tables in `_ADDITIVE_MEASURE_COLUMNS` (`food_acquired` → Quantity, Expenditure) **sum** the additive columns and re-derive per-unit `Price` from the summed totals; every other table keeps `first()`. The silent-loss warning now fires only on the `first()` fallback (the sum path loses nothing). The table name is threaded into `_normalize_dataframe_index` (`method_name` at all 4 call sites; defaults to `None` → `first()`, the prior behavior). `_ADDITIVE_MEASURE_COLUMNS` stays the single source of truth in `feature.py`, imported **lazily** to avoid any import cycle.

This is the **country.py build-path counterpart to #501/#507**, which added the same summing in `feature.py`'s `_collapse_duplicate_index` but only for the extra-level-drop path (GhanaLSS `visit`) — EHCVM duplicates never reached it.

### Verification (forced rebuild, counterfactual)
| | dup-loss warnings | Expenditure | Quantity | rows |
|---|---|---|---|---|
| Mali unfixed | 3 (34,591 + …) | 5,582,578,172 | 13,674,524 | 430,188 |
| Mali fixed | 0 | 5,921,736,334 (**+339.2M**) | 14,587,280 (**+913k**) | 430,188 |
| Uganda (non-EHCVM) | 0 → 0 | byte-identical | byte-identical | 355,571 |

Gated on `not df.index.is_unique` **and** additive-map membership, so non-EHCVM and non-additive tables (which keep `first()`+warning, incl. plot_features/#513) are untouched. (Note: ~10 residual dups remain in Mali's *final* output identically on both sides — a separate downstream v-join artifact, not #514.)

Diagnosed via the read-only backlog-workflow pass; re-judged + independently verified (the agent's circular-import worry was unfounded; its all-names-vs-declared grouping was corrected to preserve current semantics).