### PR TITLE
docs: step-2 design — cross-module build-transform cache hash (cf. #534)

### DIFF
--- a/SkunkWorks/build_transform_cache_hash.org
+++ b/SkunkWorks/build_transform_cache_hash.org
@@ -24,6 +24,13 @@ inside =_normalize_dataframe_index=), which is exactly how #514's
 build-relevant constant is reached.  Also folds in deterministic
 serialization of callable-valued constants, the =dedent= fix, and the
 corrected direct-tagging of the =build_transforms.py= functions.
+
+Rev 4 (post-#539 final remarks).  =apply_derived= resolves to *no* =tables=
+— scoping it to =['sample']= would be *under*-invalidation, not mere caution.
+The serialiser becomes an explicit type-dispatch with an else-*reject*, and a
+second red-test asserts no =0x= identity address leaks into any fingerprint
+part: paired with the resolve-to-None guard, two cheap invariants for the two
+genuinely hard sub-problems (resolution + serialization).
 #+end_quote
 
 * Background: what the hash covers today (v0.8.0)
@@ -183,9 +190,11 @@ def _resolve(fn, name):
                     return getattr(tgt, alias.name, None)
     return None
 
-def _ser(obj, seen, parts):                          # deterministic; recurse into callable values
+def _ser(obj, seen, parts):                          # deterministic type-dispatch; no identity leaks
+    if isinstance(obj, (str, int, float, bool, type(None))):
+        return repr(obj)                             # primitive: stable repr
     if callable(obj) and _is_ours(obj):
-        parts += _closure_parts(obj, seen)
+        parts += _closure_parts(obj, seen)           # callable: qualname + hash its source
         return f"<fn {obj.__module__}.{obj.__qualname__}>"   # qualname, NOT repr (no 0x address)
     if isinstance(obj, dict):
         return "{" + ",".join(f"{k!r}:{_ser(v, seen, parts)}"
@@ -193,7 +202,9 @@ def _ser(obj, seen, parts):                          # deterministic; recurse in
     if isinstance(obj, (list, tuple, set, frozenset)):
         xs = obj if isinstance(obj, (list, tuple)) else sorted(obj, key=repr)
         return type(obj).__name__ + "[" + ",".join(_ser(v, seen, parts) for v in xs) + "]"
-    return repr(obj)
+    raise TypeError(                                 # else: REJECT, don't leak a default 0x repr
+        f"build constant of un-serialisable type {type(obj).__name__!r}; "
+        f"add a case to _ser rather than fall back to identity repr")
 
 def _closure_parts(fn, seen):
     qn = f"{fn.__module__}.{fn.__qualname__}"
@@ -231,10 +242,14 @@ and stale data).
 
 - =build_transforms.py=: =food_acquired_to_canonical=,
   =_finalize_canonical_food_acquired= → =tables=['food_acquired']=;
-  =apply_derived=, =fill_v_with_coord_bin= → *no* =tables= (any table may carry
-  a =derived:= block and the static walk can't see the call is conditional —
-  honest over-invalidation; edited rarely).  These are tagged *directly*
-  because =grab_data='s function-level import would otherwise drop them.
+  =apply_derived=, =fill_v_with_coord_bin= → *no* =tables=.  This is
+  *under*-invalidation avoidance, not mere caution: scoping them to =['sample']=
+  (the only current =derived:= consumer, Uganda 2009-10) would silently leave a
+  future non-=sample= =derived:= table's code-dependency on =apply_derived=
+  uncovered — only =sample= would fold in =apply_derived='s source.  No-=tables=
+  (honest over-invalidation; these are edited rarely) is the safe call.  They
+  are tagged *directly* because =grab_data='s function-level import would
+  otherwise drop them from its closure.
 - =country.py=: =_normalize_dataframe_index=, =Wave.grab_data= → no =tables=
   (every build).
 
@@ -245,6 +260,12 @@ matters for the food-specific transforms: without it, editing
 =food_acquired_to_canonical= would rebuild all 40 countries' =household_roster=.
 The =country.py= tags carry no =tables= (every build), so they land in every
 table's fingerprint regardless.
+
+A precise middle ground for =apply_derived= (deferred): compute its =tables= at
+hash time from "does this table's =data_info.yml= declare a =derived:= block?"
+— covering every =derived:= table and over-invalidating none, at the cost of
+the fingerprint reading config that is already loaded.  No-=tables= is a fine
+first cut; this is the upgrade if the over-invalidation ever bites.
 
 * Alternatives considered (and rejected)
 
@@ -265,9 +286,17 @@ table's fingerprint regardless.
   strip module/function docstrings before dump if judged too eager.
 - =_resolve='s AST scan handles =ImportFrom=; bare =import x.y= and string-keyed
   =getattr= are still invisible — the drift guard (layer 3) is the backstop.
-- Constant =repr= must be stable; =_ser= replaces callables with qualnames to
-  avoid the =0x= address non-determinism (the =_DERIVED_TRANSFORMERS= case).
+- Constant serialisation must be stable; =_ser= is an explicit type-dispatch
+  (primitive→repr, callable→qualname+source-hash, container→recurse, *else
+  raise*) so an unhandled type fails loudly rather than leaking a default =0x=
+  identity =repr= (the =_DERIVED_TRANSFORMERS= case).  A red-test asserts no
+  =0x[0-9a-f]+= appears in any fingerprint part — catching the whole
+  identity-leak class, parallel to the resolve-to-None guard.
 - Decorating =Wave.grab_data= must return the function unchanged (no wrapper).
+- =inspect.getsource= of a decorated function includes the
+  =@build_transform(...)= line — desirable, since editing =tables= then
+  correctly invalidates; =textwrap.dedent= (already applied) handles the
+  class-indentation of methods.
 - =grab_data= over-invalidates (a plumbing-only edit triggers a rebuild) and is
   a known blunt instrument; isolating its extraction core is a later refinement.
 
@@ -279,8 +308,9 @@ table's fingerprint regardless.
 1. Add =lsms_library/_build_registry.py= (=build_transform=, =_resolve=, =_ser=,
    =_closure_parts=, =build_transforms_fingerprint=).
 2. Tag entry points (run =gitnexus_impact= on each first): the 4 in
-   =build_transforms.py= (food funcs with =tables=); =_normalize_dataframe_index=
-   and =Wave.grab_data= in =country.py= (no =tables=).
+   =build_transforms.py= (food funcs =tables=['food_acquired']=; =apply_derived=
+   / =fill_v_with_coord_bin= *no* =tables=); =_normalize_dataframe_index= and
+   =Wave.grab_data= in =country.py= (no =tables=).
 3. Fold =build_transforms_fingerprint(method_name)= into
    =Country._table_cache_hash= and =Wave._input_hash= (inside the existing
    =try/except=); update docstrings.
@@ -288,9 +318,11 @@ table's fingerprint regardless.
    module-level imported by =country= + =feature=; convert =grab_data='s
    =apply_derived= import to module level.  Confirms the cycle is gone.
 5. Demote =LSMS_CACHE_SCHEMA= to a backstop in =local_tools=.
-6. Add the drift guard: (a) tagged-entry-point set equals a checked-in set;
-   (b) walk each tagged function's =ImportFrom= nodes and fail on any
-   unresolved-and-not-allowlisted build dependency.
+6. Add the two red-tests for the hard sub-problems: (a) tagged-entry-point set
+   equals a checked-in set; (b) *resolution* — walk each tagged function's
+   =ImportFrom= nodes and fail on any unresolved-and-not-allowlisted build
+   dependency; (c) *serialization* — assert no =0x[0-9a-f]+= appears in any
+   fingerprint part (no identity-repr leak).
 7. Verify: changing =_ADDITIVE_MEASURE_COLUMNS= (add a table) or
    =_declared_index_levels= auto-rebuilds a warm Mali =food_acquired= read (no
    =LSMS_NO_CACHE=); a kinship-label edit does NOT invalidate; editing

--- a/SkunkWorks/build_transform_cache_hash.org
+++ b/SkunkWorks/build_transform_cache_hash.org
@@ -1,0 +1,212 @@
+#+TITLE: Versioning Build-Path Transform Code in the L2 Cache Hash — Step 2 Design
+#+filetags: skunkworks cache lsms_library design
+#+DATE: <2026-06-19 Fri>
+#+AUTHOR: Ethan Ligon + Sue (Claude Opus 4.8)
+
+* Purpose
+
+Close the last gap in the v0.8.0 content-hash cache layer: build-path
+*transform code* is not versioned, so editing it can leave a hash-valid
+but stale L2 parquet (the GH #522 blind spot).  This is the *step 2*
+follow-up to PR #534 (which made the build/read boundary structural by
+moving the framework build-path transforms into =build_transforms.py=).
+
+This document is a design, not an execution log.  The implementation is
+deferred to a fresh session that can start from the
+[[#implementation-checklist][checklist]] below.
+
+* Background: what the hash covers today (v0.8.0)
+
+The L2 cache embeds a content hash in each parquet's pyarrow schema
+metadata (=lsms_cache_hash=).  =Wave._input_hash= and
+=Country._table_cache_hash= compose it from:
+
+- =LSMS_CACHE_SCHEMA= (a manual, library-wide version lever);
+- the wave =data_info.yml= and country =data_scheme.yml=;
+- the wave module(s) (={wave_folder}.py=, =mapping.py=), the country
+  module ({country}.py, e.g. =uganda.py=) and country =mapping.py=;
+- the country-level concatenator script ={country}/_/{table}.py= and the
+  script-path wave scripts ={wave}/_/{table}.py=;
+- the country =Makefile= and the build-time =*.org= inputs;
+- the DVC sidecar md5 of each declared source (=.dta= never hashed).
+
+The deliberate exclusions are *read-path* transforms (kinship, spellings,
+categorical maps, =_join_v_from_sample=): they re-run on every read and
+never touch the cached parquet, so they must NOT invalidate it.
+
+* The gap
+
+The hash versions build-path /inputs/ (config) and /per-country scripts/,
+but not the *framework transform code* those scripts import and call.  Edit
+the body of a shared framework build-path function and nothing in the hash
+changes — the warm parquet stays valid and is served stale.
+
+PR #534 took the first step: it isolated the framework build-path transforms
+into =build_transforms.py= so a step-2 change could fold /that module's/
+source into the hash.  The #534 review (Ligon, 2026-06-19) then established
+the decisive refinement:
+
+#+begin_quote
+The build-path surface is NOT confined to one module.  Build-path code also
+lives in =country.py= — and a =build_transforms.py=-only hash misses it.
+#+end_quote
+
+** Evidence: build-path code in country.py
+
+=_normalize_dataframe_index= (=country.py=) has four call sites:
+
+| Site            | Context                         | Phase                |
+|-----------------+---------------------------------+----------------------|
+| =country.py:2056= | inside =_finalize_result=         | read (post-write)    |
+| =country.py:2610= | inside =load_from_waves= (per-wave) | *build* (pre-parquet) |
+| =country.py:2824= | stage loading, before =to_parquet= | *build* (pre-parquet) |
+| =country.py:2878= | cache-load path                 | *build* (pre-parquet) |
+
+The consequential work is the duplicate-collapse at =country.py:4049-4068=
+(=if not df.index.is_unique: ... groupby(...).first()=).  At the build sites
+this collapse is baked into the parquet; at the read site the cached data is
+already unique, so the block is a *no-op*.  Its meaningful effect is therefore
+build-time, even though it is also reachable on the read path.
+
+Concrete proof the gap bites: PR #533 (the #514 fix) flips that collapse from
+=first()= to a sum for =food_acquired=.  Under a =build_transforms.py=-only
+hash, a warm Mali parquet built with the old =first()= would stay hash-valid
+and never rebuild → stale data.  (That is precisely why #514 needed
+=LSMS_NO_CACHE= to verify and an =LSMS_CACHE_SCHEMA= bump to ship safely.)
+
+=Wave.grab_data= (=country.py=) is the same class of straddler: it both reads
+its own L2-wave parquet (read short-circuit) and, on a miss, extracts +
+=apply_derived= + writes the parquet (build).
+
+** Why module-boundary hashing is insufficient
+
+"One module = the hashable build unit" holds for =transformations.py= (now
+purely read-path) and =build_transforms.py= (purely build-path), but breaks
+for =country.py=, where build-path and read-path code share the =Country= /
+=Wave= classes.  We cannot hash all of =country.py= without invalidating every
+parquet on every read-path edit — which defeats the warm cache.  We need a
+hash that selects *specific functions across modules*.
+
+* Proposed design: a cross-module =@build_transform= registry
+
+Tag build-path functions wherever they live, and fold the source text of every
+registered member into the cache hash.
+
+** Mechanics
+
+1. A small leaf module (e.g. =lsms_library/_build_registry.py=, importing
+   nothing from the package) defines:
+   #+begin_src python
+   _BUILD_TRANSFORMS = {}  # qualname -> callable
+
+   def build_transform(fn):
+       """Mark fn as build-path: its output is baked into the cached L2
+       parquet, so its source is versioned by the cache hash."""
+       _BUILD_TRANSFORMS[f"{fn.__module__}.{fn.__qualname__}"] = fn
+       return fn
+
+   def build_transforms_fingerprint() -> str:
+       import hashlib, inspect
+       parts = []
+       for qn in sorted(_BUILD_TRANSFORMS):
+           parts.append(qn + "=" + inspect.getsource(_BUILD_TRANSFORMS[qn]))
+       return hashlib.sha256("\x1f".join(parts).encode()).hexdigest()
+   #+end_src
+2. Decorate the build-path functions:
+   - =build_transforms.py=: =food_acquired_to_canonical=,
+     =_finalize_canonical_food_acquired=, =fill_v_with_coord_bin=,
+     =apply_derived=;
+   - =country.py=: =_normalize_dataframe_index=, =Wave.grab_data=.
+3. Fold =build_transforms_fingerprint()= into =Country._table_cache_hash= and
+   =Wave._input_hash= (one more =parts.append("btf=" + ...)= term).
+4. Demote =LSMS_CACHE_SCHEMA= from a correctness lever to a belt-and-suspenders
+   backstop (it still exists; it just stops being the only thing standing
+   between a build-code edit and stale data).
+
+** Why this shape
+
+- *Spans modules* — the registry is keyed by qualname, not file.
+- *Self-maintaining* — a new build-path transform is versioned the moment it
+  is decorated; a future author who forgets the decorator is the only failure
+  mode, and a lint test (below) guards it.  This subsumes the #534 "marker
+  comment" minor.
+- *No relocation* — nothing else moves into =build_transforms.py=, so the
+  forward-cycle risk (a build transform needing a =transformations.py= helper)
+  never arises.  =_normalize_dataframe_index= stays where it is, entangled with
+  =_aggregate_wave_data=, and is simply tagged.
+
+** The over-invalidation trade-off (decide at implementation time)
+
+| Option | Hash | Cost | Verdict |
+|--------+------+------+---------|
+| *Whole registry per table* (simple) | every table folds in the full =build_transforms_fingerprint()= | editing =food_acquired_to_canonical= over-invalidates ALL tables | recommended first cut — safe; matches today's =LSMS_CACHE_SCHEMA= coarseness; build transforms are edited rarely |
+| *Per-table transform set* (precise) | each table folds in only the transforms its build actually calls | needs a static or runtime map table→transforms | defer; the simple cut is correct, just occasionally over-eager |
+
+Start simple.  The warm-cache fast path is unaffected for the common case
+(no build-transform edit), and a rare over-rebuild is strictly safer than a
+missed one.
+
+* Alternatives considered (and rejected)
+
+- *Relocate =_normalize_dataframe_index= into =build_transforms.py=.*  Rejected:
+  it is entangled with =_aggregate_wave_data= and is dual-call (also read-path);
+  extracting it cleanly is a much larger, riskier change than tagging it.
+- *Curated explicit list* (a module-level =[(module, qualname), ...]= hashed via
+  =getsource=).  Functionally equivalent to the registry but hand-maintained —
+  re-opens the "a new transform silently isn't covered" risk unless paired with
+  the same lint test, in which case the decorator is strictly nicer.
+- *Hash all of =country.py= / =transformations.py=.*  Rejected: invalidates every
+  parquet on every read-path edit; defeats the warm cache — the exact failure
+  the v0.8.0 design was built to avoid.
+
+* Risks / open questions
+
+- =inspect.getsource= requires the =.py= source on disk.  True for editable
+  installs and the in-tree =.venv=; verify for a built wheel (source is shipped,
+  but confirm) — fall back to =LSMS_CACHE_SCHEMA= if unavailable.
+- Decorating a method (=Wave.grab_data=): =getsource= on the function object works;
+  ensure the decorator returns the function unchanged (no wrapper) so binding and
+  call semantics are identical — this must remain a *no-behavior-change* tag.
+- Source-text hashing is coarse: a comment or whitespace edit inside a tagged
+  function invalidates.  Acceptable (same coarseness as the existing whole-file
+  config hashing) and rare.
+- Script-path /wave/ transforms are already covered by =_input_hash= (the script
+  text is hashed).  This design is only about *framework* build-path code; the
+  two layers compose.
+
+* A guard against registry drift
+
+Add a test that asserts the set of =@build_transform=-decorated functions equals
+a checked-in expected set (or at least that the known build-path functions are
+all tagged).  This converts "someone forgot the decorator" from a silent
+stale-cache bug into a red test.
+
+* Implementation checklist
+:PROPERTIES:
+:CUSTOM_ID: implementation-checklist
+:END:
+
+1. Add =lsms_library/_build_registry.py= (=build_transform= decorator +
+   =build_transforms_fingerprint=).
+2. Decorate the 4 funcs in =build_transforms.py= and
+   =_normalize_dataframe_index= / =Wave.grab_data= in =country.py=
+   (run =gitnexus_impact= on each first per CLAUDE.md).
+3. Fold the fingerprint into =Country._table_cache_hash= and
+   =Wave._input_hash=; update their docstrings.
+4. Demote =LSMS_CACHE_SCHEMA= to a backstop in =local_tools= (keep it; restate
+   its role in CLAUDE.md's cache section).
+5. Add the registry-drift guard test.
+6. Verify: edit =_normalize_dataframe_index= (or apply #533) and confirm a warm
+   Mali =food_acquired= read now auto-rebuilds (no =LSMS_NO_CACHE= needed); confirm
+   a read-path edit (e.g. a kinship label) does NOT invalidate.
+7. Update the CLAUDE.md cache section to describe the build-transform fingerprint.
+
+* References
+
+- PR #534 — step 1 (build/read split: =build_transforms.py=).
+- PR #531 — the cache-aware verification discussion that started this.
+- PR #533 / GH #514 — the =_normalize_dataframe_index= collapse-policy change that
+  proves the gap.
+- GH #522 — the framework-transform-code cache blind spot.
+- GH #537 — =validate_acquisition_source= dormancy (surfaced alongside #534).
+- =SkunkWorks/dvc_object_management.org= — the v0.7.0/v0.8.0 cache design lineage.

--- a/SkunkWorks/build_transform_cache_hash.org
+++ b/SkunkWorks/build_transform_cache_hash.org
@@ -15,6 +15,12 @@ This document is a design, not an execution log.  The implementation is
 deferred to a fresh session that can start from the
 [[#implementation-checklist][checklist]] below.
 
+#+begin_quote
+Rev 2 (post-#539 review).  Incorporates the load-bearing finding that the
+hashable unit is a tagged function's *transitive build-relevant closure*,
+not its own source text — see [[#closure][The closure is the hashable unit]].
+#+end_quote
+
 * Background: what the hash covers today (v0.8.0)
 
 The L2 cache embeds a content hash in each parquet's pyarrow schema
@@ -43,13 +49,8 @@ changes — the warm parquet stays valid and is served stale.
 
 PR #534 took the first step: it isolated the framework build-path transforms
 into =build_transforms.py= so a step-2 change could fold /that module's/
-source into the hash.  The #534 review (Ligon, 2026-06-19) then established
-the decisive refinement:
-
-#+begin_quote
-The build-path surface is NOT confined to one module.  Build-path code also
-lives in =country.py= — and a =build_transforms.py=-only hash misses it.
-#+end_quote
+source into the hash.  The #534 review then established that the build-path
+surface is *not confined to one module*: it also lives in =country.py=.
 
 ** Evidence: build-path code in country.py
 
@@ -68,12 +69,6 @@ this collapse is baked into the parquet; at the read site the cached data is
 already unique, so the block is a *no-op*.  Its meaningful effect is therefore
 build-time, even though it is also reachable on the read path.
 
-Concrete proof the gap bites: PR #533 (the #514 fix) flips that collapse from
-=first()= to a sum for =food_acquired=.  Under a =build_transforms.py=-only
-hash, a warm Mali parquet built with the old =first()= would stay hash-valid
-and never rebuild → stale data.  (That is precisely why #514 needed
-=LSMS_NO_CACHE= to verify and an =LSMS_CACHE_SCHEMA= bump to ship safely.)
-
 =Wave.grab_data= (=country.py=) is the same class of straddler: it both reads
 its own L2-wave parquet (read short-circuit) and, on a miss, extracts +
 =apply_derived= + writes the parquet (build).
@@ -87,126 +82,210 @@ for =country.py=, where build-path and read-path code share the =Country= /
 parquet on every read-path edit — which defeats the warm cache.  We need a
 hash that selects *specific functions across modules*.
 
-* Proposed design: a cross-module =@build_transform= registry
+* The closure is the hashable unit (rev-2 load-bearing finding)
+:PROPERTIES:
+:CUSTOM_ID: closure
+:END:
 
-Tag build-path functions wherever they live, and fold the source text of every
-registered member into the cache hash.
+The #539 review surfaced the gap in a naive "hash each tagged function's own
+source" scheme: =getsource(tagged_fn)= is byte-blind to the *helpers it calls*
+and the *module-level constants it reads*.  Verified against the current tree:
 
-** Mechanics
+- =_normalize_dataframe_index= references =_declared_index_levels=
+  (=country.py=) — confirmed via =__code__.co_names=, which lists it as the
+  sole =lsms_library=-owned callee.  Change =_declared_index_levels= → the
+  collapse keys (=present_levels=) change → the parquet changes →
+  =getsource(_normalize_dataframe_index)= is unchanged → *stale cache*.  This
+  is live in =development= today, independent of any open PR.
 
-1. A small leaf module (e.g. =lsms_library/_build_registry.py=, importing
-   nothing from the package) defines:
-   #+begin_src python
-   _BUILD_TRANSFORMS = {}  # qualname -> callable
+- A migrating constant: =_ADDITIVE_MEASURE_COLUMNS= (=feature.py:82=) is, in
+  the *current* tree, consumed only by =_collapse_duplicate_index=
+  (=feature.py:94=) — i.e. =Feature()= cross-country assembly, which is
+  *read-path and never cached*, so editing it is harmless today.  But PR #533
+  (the #514 fix) would wire additive-sum into =_normalize_dataframe_index=,
+  at which point that *read-path* constant becomes *build-relevant*.  The
+  lesson: build-relevance is a property of the *call graph at a point in
+  time*, not a fixed per-symbol label — so the closure must be computed, not
+  hand-classified.
 
-   def build_transform(fn):
-       """Mark fn as build-path: its output is baked into the cached L2
-       parquet, so its source is versioned by the cache hash."""
-       _BUILD_TRANSFORMS[f"{fn.__module__}.{fn.__qualname__}"] = fn
-       return fn
+So the hashable boundary is a tagged function's *transitive build-relevant
+closure*: the function, plus the =lsms_library=-owned callables it reaches,
+plus the module-level constants it reads.
 
-   def build_transforms_fingerprint() -> str:
-       import hashlib, inspect
-       parts = []
-       for qn in sorted(_BUILD_TRANSFORMS):
-           parts.append(qn + "=" + inspect.getsource(_BUILD_TRANSFORMS[qn]))
-       return hashlib.sha256("\x1f".join(parts).encode()).hexdigest()
-   #+end_src
-2. Decorate the build-path functions:
-   - =build_transforms.py=: =food_acquired_to_canonical=,
-     =_finalize_canonical_food_acquired=, =fill_v_with_coord_bin=,
-     =apply_derived=;
-   - =country.py=: =_normalize_dataframe_index=, =Wave.grab_data=.
-3. Fold =build_transforms_fingerprint()= into =Country._table_cache_hash= and
-   =Wave._input_hash= (one more =parts.append("btf=" + ...)= term).
-4. Demote =LSMS_CACHE_SCHEMA= from a correctness lever to a belt-and-suspenders
-   backstop (it still exists; it just stops being the only thing standing
-   between a build-code edit and stale data).
+* Proposed design: a cross-module =@build_transform= registry + closure hash
+
+Tag build-path /entry points/ wherever they live; the fingerprint then walks
+each one's transitive closure and hashes it.
+
+** The decorator
+
+#+begin_src python
+# lsms_library/_build_registry.py  -- a leaf module; imports nothing from the package.
+_BUILD_TRANSFORMS = {}  # qualname -> (callable, tables)
+
+def build_transform(*, tables=None):
+    """Mark fn as a build-path entry point: its output (and that of its
+    transitive lsms_library closure) is baked into the cached L2 parquet,
+    so the cache hash versions it.  ``tables`` scopes which table hashes
+    fold it in; None/empty => every table (e.g. _normalize_dataframe_index)."""
+    def deco(fn):
+        _BUILD_TRANSFORMS[f"{fn.__module__}.{fn.__qualname__}"] = (fn, tuple(tables or ()))
+        return fn                      # NO wrapper: binding + call semantics unchanged
+    return deco
+#+end_src
+
+Tag (with =gitnexus_impact= on each first, per CLAUDE.md):
+
+- =build_transforms.py=: =food_acquired_to_canonical= /
+  =_finalize_canonical_food_acquired= → =tables=['food_acquired']=;
+  =fill_v_with_coord_bin= / =apply_derived= → =tables=['sample']= (their only
+  current =derived:= consumer) or untagged-tables if broader;
+- =country.py=: =_normalize_dataframe_index=, =Wave.grab_data= → no =tables=
+  (they run for every table's build).
+
+** The fingerprint (transitive closure, AST-normalised)
+
+#+begin_src python
+import ast, hashlib, importlib, inspect
+
+def _norm(src):                                   # comment/whitespace-insensitive (#539 pt 3)
+    return ast.dump(ast.parse(src))               # (optionally strip docstring nodes first)
+
+def _closure_parts(fn, seen):
+    qn = f"{fn.__module__}.{fn.__qualname__}"
+    if qn in seen:
+        return []
+    seen.add(qn)
+    parts = [qn + "=" + _norm(inspect.getsource(fn))]
+    mod = importlib.import_module(fn.__module__)
+    for name in fn.__code__.co_names:             # validated: filters to exactly the owned refs
+        obj = getattr(mod, name, None)
+        if obj is None:
+            continue
+        if callable(obj) and (getattr(obj, "__module__", "") or "").startswith("lsms_library"):
+            parts += _closure_parts(obj, seen)     # recurse into owned callees
+        elif isinstance(obj, (dict, list, tuple, set, frozenset, str, int, float)):
+            parts.append(f"{fn.__module__}.{name}=" + repr(obj))   # build-relevant constant
+    return parts
+
+def build_transforms_fingerprint(table=None):
+    seen, parts = set(), []
+    for qn, (fn, tables) in sorted(_BUILD_TRANSFORMS.items()):
+        if table is not None and tables and table not in tables:
+            continue                               # per-table precision (#539 pt 2)
+        parts += _closure_parts(fn, seen)
+    return hashlib.sha256("\x1f".join(sorted(set(parts))).encode()).hexdigest()
+#+end_src
+
+Fold =build_transforms_fingerprint(method_name)= into =Country._table_cache_hash=
+and =Wave._input_hash= as one more term, and demote =LSMS_CACHE_SCHEMA= to a
+backstop (it stays; it just stops being the only thing between a build-code
+edit and stale data).
 
 ** Why this shape
 
-- *Spans modules* — the registry is keyed by qualname, not file.
-- *Self-maintaining* — a new build-path transform is versioned the moment it
-  is decorated; a future author who forgets the decorator is the only failure
-  mode, and a lint test (below) guards it.  This subsumes the #534 "marker
-  comment" minor.
+- *Closure, not function* — changing =_declared_index_levels= (or a post-#533
+  =_ADDITIVE_MEASURE_COLUMNS=) propagates automatically; no one must remember
+  to tag a dependency.  Validated: filtering =_normalize_dataframe_index='s
+  =co_names= to =lsms_library=-owned objects yields exactly
+  =_declared_index_levels=, with zero pandas/builtin noise.
+- *Spans modules* — keyed by qualname, not file.
+- *Self-maintaining /entry points/* — a new build-path entry point is versioned
+  the moment it is decorated.  The residual risk (a brand-new entry point left
+  untagged, or a dynamic =getattr=-by-string the =co_names= walk can't resolve)
+  is caught by the [[#drift-guard][drift guard]], converting it from a silent
+  stale-cache bug into a red test.
 - *No relocation* — nothing else moves into =build_transforms.py=, so the
-  forward-cycle risk (a build transform needing a =transformations.py= helper)
-  never arises.  =_normalize_dataframe_index= stays where it is, entangled with
-  =_aggregate_wave_data=, and is simply tagged.
+  forward-cycle risk never arises; =_normalize_dataframe_index= stays put and
+  is simply tagged.
+- *Mitigates the =grab_data= under-coverage* (#539 pt 4): the closure walk pulls
+  in =grab_data='s framework callees (=df_data_grabber=, =to_parquet=, …)
+  automatically.  The residual issue is /over-invalidation/ — a plumbing-only
+  edit to =grab_data= (its read short-circuit) triggers a rebuild.  Accept as a
+  known blunt instrument; isolating its build-deterministic extraction core into
+  a small tagged helper is a later refinement.
 
-** The over-invalidation trade-off (decide at implementation time)
+* Per-table precision is in the first cut (#539 pt 2)
 
-| Option | Hash | Cost | Verdict |
-|--------+------+------+---------|
-| *Whole registry per table* (simple) | every table folds in the full =build_transforms_fingerprint()= | editing =food_acquired_to_canonical= over-invalidates ALL tables | recommended first cut — safe; matches today's =LSMS_CACHE_SCHEMA= coarseness; build transforms are edited rarely |
-| *Per-table transform set* (precise) | each table folds in only the transforms its build actually calls | needs a static or runtime map table→transforms | defer; the simple cut is correct, just occasionally over-eager |
-
-Start simple.  The warm-cache fast path is unaffected for the common case
-(no build-transform edit), and a rare over-rebuild is strictly safer than a
-missed one.
+=tables=['food_acquired']= rides the decorator — no call-graph analysis, the
+author declares scope where they tag.  Without it, editing
+=food_acquired_to_canonical= would rebuild all 40 countries' =household_roster=.
+The two =country.py= tags carry no =tables= (they run for every build), so they
+land in every table's fingerprint regardless; per-table scoping matters only
+for the food-specific transforms — which is exactly where the blast radius is
+worst, so it is worth doing now rather than deferring.
 
 * Alternatives considered (and rejected)
 
+- *Hash each tagged function's own source only.*  Rejected — the rev-2 finding:
+  misses the transitive closure (=_declared_index_levels=), so the #522 gap
+  reopens from the very code (#514) cited as proof.
 - *Relocate =_normalize_dataframe_index= into =build_transforms.py=.*  Rejected:
-  it is entangled with =_aggregate_wave_data= and is dual-call (also read-path);
-  extracting it cleanly is a much larger, riskier change than tagging it.
-- *Curated explicit list* (a module-level =[(module, qualname), ...]= hashed via
-  =getsource=).  Functionally equivalent to the registry but hand-maintained —
-  re-opens the "a new transform silently isn't covered" risk unless paired with
-  the same lint test, in which case the decorator is strictly nicer.
+  entangled with =_aggregate_wave_data= and dual-call (also read-path); tagging
+  is far less risky than extracting.
+- *Curated explicit list hashed via =getsource=.*  Functionally close to the
+  registry but hand-maintained and still needs closure-walking to be correct —
+  the decorator + closure walk subsumes it.
 - *Hash all of =country.py= / =transformations.py=.*  Rejected: invalidates every
-  parquet on every read-path edit; defeats the warm cache — the exact failure
-  the v0.8.0 design was built to avoid.
+  parquet on every read-path edit; defeats the warm cache.
+
+* A guard against registry drift
+:PROPERTIES:
+:CUSTOM_ID: drift-guard
+:END:
+
+A test that (a) asserts the set of =@build_transform= entry points equals a
+checked-in expected set (catches a forgotten brand-new entry point), and (b)
+walks each tagged closure and flags any =co_names= reference it *cannot*
+statically resolve to an =lsms_library= object (catches dynamic
+=getattr=-by-string that the fingerprint would miss).  Same philosophy as the
+hash: turn "someone forgot" into a red test rather than a silent stale cache.
 
 * Risks / open questions
 
-- =inspect.getsource= requires the =.py= source on disk.  True for editable
-  installs and the in-tree =.venv=; verify for a built wheel (source is shipped,
-  but confirm) — fall back to =LSMS_CACHE_SCHEMA= if unavailable.
-- Decorating a method (=Wave.grab_data=): =getsource= on the function object works;
-  ensure the decorator returns the function unchanged (no wrapper) so binding and
-  call semantics are identical — this must remain a *no-behavior-change* tag.
-- Source-text hashing is coarse: a comment or whitespace edit inside a tagged
-  function invalidates.  Acceptable (same coarseness as the existing whole-file
-  config hashing) and rare.
-- Script-path /wave/ transforms are already covered by =_input_hash= (the script
-  text is hashed).  This design is only about *framework* build-path code; the
-  two layers compose.
-
-* A guard against registry drift
-
-Add a test that asserts the set of =@build_transform=-decorated functions equals
-a checked-in expected set (or at least that the known build-path functions are
-all tagged).  This converts "someone forgot the decorator" from a silent
-stale-cache bug into a red test.
+- =inspect.getsource= needs =.py= source on disk — true for the in-tree =.venv=
+  and a normal wheel (source ships); fall back to =LSMS_CACHE_SCHEMA= if absent.
+- =ast.dump= still includes docstring nodes, so a docstring edit invalidates;
+  strip module/function docstrings before dump if that is judged too eager.
+- The =co_names= walk resolves *module-global* references only — instance
+  attributes (=self.foo=) and string-keyed dispatch are invisible (hence the
+  drift guard's part (b)).
+- Hashing constants via =repr()= assumes a stable repr (true for the dict/tuple
+  constants in play).
+- Decorating =Wave.grab_data= must return the function unchanged (no wrapper) —
+  this is a no-behaviour-change tag, not a transform.
+- Script-path /wave/ transforms are already covered by =_input_hash= (script
+  text hashed); this design is only about *framework* build-path code — the two
+  layers compose.
 
 * Implementation checklist
 :PROPERTIES:
 :CUSTOM_ID: implementation-checklist
 :END:
 
-1. Add =lsms_library/_build_registry.py= (=build_transform= decorator +
-   =build_transforms_fingerprint=).
-2. Decorate the 4 funcs in =build_transforms.py= and
-   =_normalize_dataframe_index= / =Wave.grab_data= in =country.py=
-   (run =gitnexus_impact= on each first per CLAUDE.md).
-3. Fold the fingerprint into =Country._table_cache_hash= and
-   =Wave._input_hash=; update their docstrings.
+1. Add =lsms_library/_build_registry.py= (=build_transform= decorator,
+   =_closure_parts=, =build_transforms_fingerprint=).
+2. Tag the entry points: 4 in =build_transforms.py= (with =tables=) and
+   =_normalize_dataframe_index= / =Wave.grab_data= in =country.py= (no =tables=).
+   Run =gitnexus_impact= on each first.
+3. Fold =build_transforms_fingerprint(method_name)= into
+   =Country._table_cache_hash= and =Wave._input_hash=; update their docstrings.
 4. Demote =LSMS_CACHE_SCHEMA= to a backstop in =local_tools= (keep it; restate
    its role in CLAUDE.md's cache section).
-5. Add the registry-drift guard test.
-6. Verify: edit =_normalize_dataframe_index= (or apply #533) and confirm a warm
-   Mali =food_acquired= read now auto-rebuilds (no =LSMS_NO_CACHE= needed); confirm
-   a read-path edit (e.g. a kinship label) does NOT invalidate.
+5. Add the drift-guard test (entry-point set + unresolved-reference walk).
+6. Verify: edit =_declared_index_levels= (or =_normalize_dataframe_index=, or
+   apply #533) and confirm a warm Mali =food_acquired= read now auto-rebuilds
+   (no =LSMS_NO_CACHE=); confirm a read-path edit (a kinship label) does NOT
+   invalidate; confirm editing =food_acquired_to_canonical= invalidates only
+   =food_acquired=, not =household_roster=.
 7. Update the CLAUDE.md cache section to describe the build-transform fingerprint.
 
 * References
 
 - PR #534 — step 1 (build/read split: =build_transforms.py=).
 - PR #531 — the cache-aware verification discussion that started this.
-- PR #533 / GH #514 — the =_normalize_dataframe_index= collapse-policy change that
-  proves the gap.
+- PR #533 / GH #514 — the =_normalize_dataframe_index= collapse-policy change
+  that would turn =_ADDITIVE_MEASURE_COLUMNS= build-relevant.
 - GH #522 — the framework-transform-code cache blind spot.
 - GH #537 — =validate_acquisition_source= dormancy (surfaced alongside #534).
 - =SkunkWorks/dvc_object_management.org= — the v0.7.0/v0.8.0 cache design lineage.

--- a/SkunkWorks/build_transform_cache_hash.org
+++ b/SkunkWorks/build_transform_cache_hash.org
@@ -12,29 +12,29 @@ follow-up to PR #534 (which made the build/read boundary structural by
 moving the framework build-path transforms into =build_transforms.py=).
 
 This document is a design, not an execution log.  The implementation is
-deferred to a fresh session that can start from the
-[[#implementation-checklist][checklist]] below.
+deferred to a session that can start from the [[#implementation-checklist][checklist]] below.
 
 #+begin_quote
-Rev 2 (post-#539 review).  Incorporates the load-bearing finding that the
-hashable unit is a tagged function's *transitive build-relevant closure*,
-not its own source text — see [[#closure][The closure is the hashable unit]].
+Rev 3 (post-#539 review round 2).  Rev 2 established that the hashable
+unit is a tagged function's *transitive closure*, not its own source.
+Rev 3 closes the load-bearing follow-on: *name resolution* is the hard
+part — the =getattr(own_module, name)= walk silently drops the
+function-level-import idiom (=from .feature import _ADDITIVE_MEASURE_COLUMNS=
+inside =_normalize_dataframe_index=), which is exactly how #514's
+build-relevant constant is reached.  Also folds in deterministic
+serialization of callable-valued constants, the =dedent= fix, and the
+corrected direct-tagging of the =build_transforms.py= functions.
 #+end_quote
 
 * Background: what the hash covers today (v0.8.0)
 
 The L2 cache embeds a content hash in each parquet's pyarrow schema
 metadata (=lsms_cache_hash=).  =Wave._input_hash= and
-=Country._table_cache_hash= compose it from:
-
-- =LSMS_CACHE_SCHEMA= (a manual, library-wide version lever);
-- the wave =data_info.yml= and country =data_scheme.yml=;
-- the wave module(s) (={wave_folder}.py=, =mapping.py=), the country
-  module ({country}.py, e.g. =uganda.py=) and country =mapping.py=;
-- the country-level concatenator script ={country}/_/{table}.py= and the
-  script-path wave scripts ={wave}/_/{table}.py=;
-- the country =Makefile= and the build-time =*.org= inputs;
-- the DVC sidecar md5 of each declared source (=.dta= never hashed).
+=Country._table_cache_hash= compose it from: =LSMS_CACHE_SCHEMA=; the wave
+=data_info.yml= and country =data_scheme.yml=; the wave/country modules and
+=mapping.py=; the country concatenator and script-path wave scripts; the
+=Makefile= and build-time =*.org= inputs; and the DVC sidecar md5 of each
+declared source (=.dta= never hashed).
 
 The deliberate exclusions are *read-path* transforms (kinship, spellings,
 categorical maps, =_join_v_from_sample=): they re-run on every read and
@@ -45,247 +45,266 @@ never touch the cached parquet, so they must NOT invalidate it.
 The hash versions build-path /inputs/ (config) and /per-country scripts/,
 but not the *framework transform code* those scripts import and call.  Edit
 the body of a shared framework build-path function and nothing in the hash
-changes — the warm parquet stays valid and is served stale.
+changes — the warm parquet stays valid and is served stale (#522).
 
-PR #534 took the first step: it isolated the framework build-path transforms
-into =build_transforms.py= so a step-2 change could fold /that module's/
-source into the hash.  The #534 review then established that the build-path
+PR #534 isolated the framework build-path transforms into
+=build_transforms.py=.  The #534 review then established that the build-path
 surface is *not confined to one module*: it also lives in =country.py=.
 
 ** Evidence: build-path code in country.py
 
-=_normalize_dataframe_index= (=country.py=) has four call sites:
+=_normalize_dataframe_index= (=country.py=) has four call sites; three are
+build-time, pre-=to_parquet= (=:2610= in =load_from_waves=, =:2824= in stage
+loading, =:2878= in the cache-load path), one is read-time (=:2056= in
+=_finalize_result=, post-write, a no-op on already-unique cached data).  Its
+consequential work — the duplicate-collapse — is now (as of *#533, merged
+2026-06-19 19:59*) an additive sum: it reads =_ADDITIVE_MEASURE_COLUMNS= via
+a *function-level* =from .feature import _ADDITIVE_MEASURE_COLUMNS=
+(=country.py:4067=), sums the additive columns (=:4068-4072=), and falls back
+to =.first()= (=:4076=).  So a *read-path* module's constant is now
+*build-relevant*, reached through the cycle-dodge import idiom — which is the
+crux of [[#resolution][name resolution]] below.
 
-| Site            | Context                         | Phase                |
-|-----------------+---------------------------------+----------------------|
-| =country.py:2056= | inside =_finalize_result=         | read (post-write)    |
-| =country.py:2610= | inside =load_from_waves= (per-wave) | *build* (pre-parquet) |
-| =country.py:2824= | stage loading, before =to_parquet= | *build* (pre-parquet) |
-| =country.py:2878= | cache-load path                 | *build* (pre-parquet) |
-
-The consequential work is the duplicate-collapse at =country.py:4049-4068=
-(=if not df.index.is_unique: ... groupby(...).first()=).  At the build sites
-this collapse is baked into the parquet; at the read site the cached data is
-already unique, so the block is a *no-op*.  Its meaningful effect is therefore
-build-time, even though it is also reachable on the read path.
-
-=Wave.grab_data= (=country.py=) is the same class of straddler: it both reads
-its own L2-wave parquet (read short-circuit) and, on a miss, extracts +
-=apply_derived= + writes the parquet (build).
+=Wave.grab_data= is the same class of straddler (reads its own L2-wave
+parquet; on a miss, extracts + =apply_derived= + writes), and it imports its
+build callee the same way: function-level =from .transformations import
+apply_derived= (=country.py:994=).
 
 ** Why module-boundary hashing is insufficient
 
-"One module = the hashable build unit" holds for =transformations.py= (now
-purely read-path) and =build_transforms.py= (purely build-path), but breaks
-for =country.py=, where build-path and read-path code share the =Country= /
-=Wave= classes.  We cannot hash all of =country.py= without invalidating every
-parquet on every read-path edit — which defeats the warm cache.  We need a
-hash that selects *specific functions across modules*.
+"One module = the hashable build unit" holds for =transformations.py=
+(read-path) and =build_transforms.py= (build-path) but breaks for
+=country.py=, where build and read code share the =Country= / =Wave=
+classes.  Hashing all of =country.py= invalidates every parquet on every
+read-path edit — defeating the warm cache.  We need a hash that selects
+*specific functions across modules*: the closure.
 
-* The closure is the hashable unit (rev-2 load-bearing finding)
+* The closure is the hashable unit (rev-2)
+
+The hashable boundary is a tagged function's *transitive build-relevant
+closure*: the function, plus the =lsms_library=-owned callables it reaches,
+plus the module-level constants it reads.  A naive "hash each tagged
+function's own =getsource=" misses the closure — change =_declared_index_levels=
+(which =_normalize_dataframe_index= calls) and the collapse keys change while
+=getsource(_normalize_dataframe_index)= does not → stale cache.
+
+* Name resolution is the hard part (rev-3 load-bearing finding)
 :PROPERTIES:
-:CUSTOM_ID: closure
+:CUSTOM_ID: resolution
 :END:
 
-The #539 review surfaced the gap in a naive "hash each tagged function's own
-source" scheme: =getsource(tagged_fn)= is byte-blind to the *helpers it calls*
-and the *module-level constants it reads*.  Verified against the current tree:
+Computing the closure means mapping each =co_names= string to the object it
+denotes.  The obvious resolver — =getattr(import_module(fn.__module__), name)=
+— only catches *own-module globals*.  It silently drops:
 
-- =_normalize_dataframe_index= references =_declared_index_levels=
-  (=country.py=) — confirmed via =__code__.co_names=, which lists it as the
-  sole =lsms_library=-owned callee.  Change =_declared_index_levels= → the
-  collapse keys (=present_levels=) change → the parquet changes →
-  =getsource(_normalize_dataframe_index)= is unchanged → *stale cache*.  This
-  is live in =development= today, independent of any open PR.
+- *function-level imports* (the =feature=↔=country= cycle-dodge idiom);
+- re-exports and conditional / =TYPE_CHECKING= imports.
 
-- A migrating constant: =_ADDITIVE_MEASURE_COLUMNS= (=feature.py:82=) is, in
-  the *current* tree, consumed only by =_collapse_duplicate_index=
-  (=feature.py:94=) — i.e. =Feature()= cross-country assembly, which is
-  *read-path and never cached*, so editing it is harmless today.  But PR #533
-  (the #514 fix) would wire additive-sum into =_normalize_dataframe_index=,
-  at which point that *read-path* constant becomes *build-relevant*.  The
-  lesson: build-relevance is a property of the *call graph at a point in
-  time*, not a fixed per-symbol label — so the closure must be computed, not
-  hand-classified.
+Verified against =development @ 2c561bae= by compiling
+=_normalize_dataframe_index= in isolation (no package import):
 
-So the hashable boundary is a tagged function's *transitive build-relevant
-closure*: the function, plus the =lsms_library=-owned callables it reaches,
-plus the module-level constants it reads.
+#+begin_example
+'_ADDITIVE_MEASURE_COLUMNS' in co_names     -> True    # via IMPORT_FROM
+'_ADDITIVE_MEASURE_COLUMNS' in co_varnames  -> True    # it's a LOCAL (func-level import)
+module-level binding in country.py          -> none    # getattr(country, name) -> None
+from .feature import _ADDITIVE_MEASURE_COLUMNS  @ country.py:4067
+#+end_example
 
-* Proposed design: a cross-module =@build_transform= registry + closure hash
+So the rev-2 walk drops =_ADDITIVE_MEASURE_COLUMNS= — the very symbol the
+closure exists to catch.  The idiom is *pervasive*: =apply_derived= is
+imported the same way in =grab_data= (=country.py:994=), so it is dropped
+too — which is why the =build_transforms.py= functions must be *tagged
+directly*, not merely reached through =grab_data='s closure.
 
-Tag build-path /entry points/ wherever they live; the fingerprint then walks
-each one's transitive closure and hashes it.
+** Three complementary layers
 
-** The decorator
+1. *Resolver handles function-level imports.*  When =getattr(own_module, name)=
+   is =None=, scan the tagged function's AST for =ImportFrom= nodes and resolve
+   the name through the named (relative) module.  Closes the gap with no source
+   churn.  (See =_resolve= in the snippet.)
+2. *Leaf-module hygiene (recommended).*  Relocate shared build constants
+   (=_ADDITIVE_MEASURE_COLUMNS= and kin) into a leaf module imported at
+   *module level* by both =country= and =feature=, and convert =grab_data='s
+   =apply_derived= import to a module-level =from .build_transforms import
+   apply_derived= (safe — =build_transforms= imports nothing back).  This
+   removes #514's cycle dodge *and* makes =getattr(own_module, name)= sound, so
+   layer 1 becomes a backstop rather than the primary path.
+3. *Drift guard (essential backstop).*  A test that walks each tagged
+   function's AST and *fails* on any function-level =ImportFrom= whose target
+   is not resolved by the closure (and is not allowlisted as build-irrelevant).
+   Converts "a future edit re-introduced a hidden build dependency" from a
+   silent stale-cache bug into a red test.  (Targets =ImportFrom= specifically;
+   a blanket "fail on =co_names= → =None=" is too noisy — builtins =str=/=len=
+   and attribute names =groupby=/=first= all resolve to =None= benignly.)
+
+Ligon's stated preference is layers 2 + 3 (ship simple, no smarter resolver);
+the more general layer 1 needs no relocation.  Recommendation: implement
+*1 + 3* as the correctness core (works against the code as-is), and do *2* as
+follow-up hygiene that also kills the circular-import dodge.
+
+* Proposed design: =@build_transform= registry + closure hash
 
 #+begin_src python
 # lsms_library/_build_registry.py  -- a leaf module; imports nothing from the package.
+import ast, hashlib, importlib, inspect, textwrap
+
 _BUILD_TRANSFORMS = {}  # qualname -> (callable, tables)
 
 def build_transform(*, tables=None):
-    """Mark fn as a build-path entry point: its output (and that of its
-    transitive lsms_library closure) is baked into the cached L2 parquet,
-    so the cache hash versions it.  ``tables`` scopes which table hashes
-    fold it in; None/empty => every table (e.g. _normalize_dataframe_index)."""
+    """Mark fn as a build-path entry point (output baked into the cached
+    parquet).  ``tables`` scopes which table hashes fold it in; None => every
+    table.  Returns fn UNCHANGED (no wrapper) — a tag, not a transform."""
     def deco(fn):
         _BUILD_TRANSFORMS[f"{fn.__module__}.{fn.__qualname__}"] = (fn, tuple(tables or ()))
-        return fn                      # NO wrapper: binding + call semantics unchanged
+        return fn
     return deco
-#+end_src
 
-Tag (with =gitnexus_impact= on each first, per CLAUDE.md):
+def _is_ours(o):
+    return (getattr(o, "__module__", "") or "").startswith("lsms_library")
 
-- =build_transforms.py=: =food_acquired_to_canonical= /
-  =_finalize_canonical_food_acquired= → =tables=['food_acquired']=;
-  =fill_v_with_coord_bin= / =apply_derived= → =tables=['sample']= (their only
-  current =derived:= consumer) or untagged-tables if broader;
-- =country.py=: =_normalize_dataframe_index=, =Wave.grab_data= → no =tables=
-  (they run for every table's build).
+def _norm(fn):
+    return ast.dump(ast.parse(textwrap.dedent(inspect.getsource(fn))))  # dedent: methods are indented
 
-** The fingerprint (transitive closure, AST-normalised)
+def _resolve(fn, name):
+    mod = importlib.import_module(fn.__module__)
+    obj = getattr(mod, name, None)
+    if obj is not None:
+        return obj
+    try:                                            # layer 1: function-level imports
+        tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+    except (OSError, SyntaxError):
+        return None
+    parent = fn.__module__.rsplit(".", 1)[0]
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if (alias.asname or alias.name) == name:
+                    tgt = importlib.import_module("." * node.level + (node.module or ""), package=parent)
+                    return getattr(tgt, alias.name, None)
+    return None
 
-#+begin_src python
-import ast, hashlib, importlib, inspect
-
-def _norm(src):                                   # comment/whitespace-insensitive (#539 pt 3)
-    return ast.dump(ast.parse(src))               # (optionally strip docstring nodes first)
+def _ser(obj, seen, parts):                          # deterministic; recurse into callable values
+    if callable(obj) and _is_ours(obj):
+        parts += _closure_parts(obj, seen)
+        return f"<fn {obj.__module__}.{obj.__qualname__}>"   # qualname, NOT repr (no 0x address)
+    if isinstance(obj, dict):
+        return "{" + ",".join(f"{k!r}:{_ser(v, seen, parts)}"
+                              for k, v in sorted(obj.items(), key=lambda kv: repr(kv[0]))) + "}"
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        xs = obj if isinstance(obj, (list, tuple)) else sorted(obj, key=repr)
+        return type(obj).__name__ + "[" + ",".join(_ser(v, seen, parts) for v in xs) + "]"
+    return repr(obj)
 
 def _closure_parts(fn, seen):
     qn = f"{fn.__module__}.{fn.__qualname__}"
     if qn in seen:
         return []
     seen.add(qn)
-    parts = [qn + "=" + _norm(inspect.getsource(fn))]
-    mod = importlib.import_module(fn.__module__)
-    for name in fn.__code__.co_names:             # validated: filters to exactly the owned refs
-        obj = getattr(mod, name, None)
+    parts = [qn + "=" + _norm(fn)]
+    for name in fn.__code__.co_names:
+        obj = _resolve(fn, name)
         if obj is None:
             continue
-        if callable(obj) and (getattr(obj, "__module__", "") or "").startswith("lsms_library"):
-            parts += _closure_parts(obj, seen)     # recurse into owned callees
-        elif isinstance(obj, (dict, list, tuple, set, frozenset, str, int, float)):
-            parts.append(f"{fn.__module__}.{name}=" + repr(obj))   # build-relevant constant
+        if callable(obj) and _is_ours(obj):
+            parts += _closure_parts(obj, seen)
+        elif isinstance(obj, (dict, list, tuple, set, frozenset, str, int, float, bool)):
+            parts.append(f"{fn.__module__}.{name}=" + _ser(obj, seen, parts))
     return parts
 
 def build_transforms_fingerprint(table=None):
     seen, parts = set(), []
     for qn, (fn, tables) in sorted(_BUILD_TRANSFORMS.items()):
         if table is not None and tables and table not in tables:
-            continue                               # per-table precision (#539 pt 2)
+            continue                                 # per-table precision
         parts += _closure_parts(fn, seen)
     return hashlib.sha256("\x1f".join(sorted(set(parts))).encode()).hexdigest()
 #+end_src
 
 Fold =build_transforms_fingerprint(method_name)= into =Country._table_cache_hash=
-and =Wave._input_hash= as one more term, and demote =LSMS_CACHE_SCHEMA= to a
-backstop (it stays; it just stops being the only thing between a build-code
-edit and stale data).
+and =Wave._input_hash= as one term, inside their existing
+=try/except -> None= guard so a fingerprint failure degrades to "unverifiable
+-> read-if-present" rather than breaking reads.  Demote =LSMS_CACHE_SCHEMA= to
+a backstop (keep it; it stops being the *only* thing between a build-code edit
+and stale data).
 
-** Why this shape
+** Tagging (direct — corrects rev-2's "rely on grab_data's closure")
 
-- *Closure, not function* — changing =_declared_index_levels= (or a post-#533
-  =_ADDITIVE_MEASURE_COLUMNS=) propagates automatically; no one must remember
-  to tag a dependency.  Validated: filtering =_normalize_dataframe_index='s
-  =co_names= to =lsms_library=-owned objects yields exactly
-  =_declared_index_levels=, with zero pandas/builtin noise.
-- *Spans modules* — keyed by qualname, not file.
-- *Self-maintaining /entry points/* — a new build-path entry point is versioned
-  the moment it is decorated.  The residual risk (a brand-new entry point left
-  untagged, or a dynamic =getattr=-by-string the =co_names= walk can't resolve)
-  is caught by the [[#drift-guard][drift guard]], converting it from a silent
-  stale-cache bug into a red test.
-- *No relocation* — nothing else moves into =build_transforms.py=, so the
-  forward-cycle risk never arises; =_normalize_dataframe_index= stays put and
-  is simply tagged.
-- *Mitigates the =grab_data= under-coverage* (#539 pt 4): the closure walk pulls
-  in =grab_data='s framework callees (=df_data_grabber=, =to_parquet=, …)
-  automatically.  The residual issue is /over-invalidation/ — a plumbing-only
-  edit to =grab_data= (its read short-circuit) triggers a rebuild.  Accept as a
-  known blunt instrument; isolating its build-deterministic extraction core into
-  a small tagged helper is a later refinement.
+- =build_transforms.py=: =food_acquired_to_canonical=,
+  =_finalize_canonical_food_acquired= → =tables=['food_acquired']=;
+  =apply_derived=, =fill_v_with_coord_bin= → *no* =tables= (any table may carry
+  a =derived:= block and the static walk can't see the call is conditional —
+  honest over-invalidation; edited rarely).  These are tagged *directly*
+  because =grab_data='s function-level import would otherwise drop them.
+- =country.py=: =_normalize_dataframe_index=, =Wave.grab_data= → no =tables=
+  (every build).
 
-* Per-table precision is in the first cut (#539 pt 2)
+* Per-table precision is in the first cut
 
-=tables=['food_acquired']= rides the decorator — no call-graph analysis, the
-author declares scope where they tag.  Without it, editing
+=tables=['food_acquired']= rides the decorator — no call-graph analysis.  It
+matters for the food-specific transforms: without it, editing
 =food_acquired_to_canonical= would rebuild all 40 countries' =household_roster=.
-The two =country.py= tags carry no =tables= (they run for every build), so they
-land in every table's fingerprint regardless; per-table scoping matters only
-for the food-specific transforms — which is exactly where the blast radius is
-worst, so it is worth doing now rather than deferring.
+The =country.py= tags carry no =tables= (every build), so they land in every
+table's fingerprint regardless.
 
 * Alternatives considered (and rejected)
 
-- *Hash each tagged function's own source only.*  Rejected — the rev-2 finding:
-  misses the transitive closure (=_declared_index_levels=), so the #522 gap
-  reopens from the very code (#514) cited as proof.
-- *Relocate =_normalize_dataframe_index= into =build_transforms.py=.*  Rejected:
-  entangled with =_aggregate_wave_data= and dual-call (also read-path); tagging
-  is far less risky than extracting.
-- *Curated explicit list hashed via =getsource=.*  Functionally close to the
-  registry but hand-maintained and still needs closure-walking to be correct —
-  the decorator + closure walk subsumes it.
-- *Hash all of =country.py= / =transformations.py=.*  Rejected: invalidates every
-  parquet on every read-path edit; defeats the warm cache.
-
-* A guard against registry drift
-:PROPERTIES:
-:CUSTOM_ID: drift-guard
-:END:
-
-A test that (a) asserts the set of =@build_transform= entry points equals a
-checked-in expected set (catches a forgotten brand-new entry point), and (b)
-walks each tagged closure and flags any =co_names= reference it *cannot*
-statically resolve to an =lsms_library= object (catches dynamic
-=getattr=-by-string that the fingerprint would miss).  Same philosophy as the
-hash: turn "someone forgot" into a red test rather than a silent stale cache.
+- *Hash each tagged function's own source only* (rev-1 implicit).  Misses the
+  transitive closure (=_declared_index_levels=) — reopens #522.
+- *=getattr(own_module, name)= resolution only* (rev-2).  Misses function-level
+  imports (=_ADDITIVE_MEASURE_COLUMNS=, =apply_derived=) — the rev-3 finding.
+- *Relocate =_normalize_dataframe_index= into =build_transforms.py=.*  Entangled
+  with =_aggregate_wave_data= and dual-call; tagging is far less risky.
+- *Hash all of =country.py= / =transformations.py=.*  Invalidates every parquet
+  on every read-path edit; defeats the warm cache.
 
 * Risks / open questions
 
-- =inspect.getsource= needs =.py= source on disk — true for the in-tree =.venv=
-  and a normal wheel (source ships); fall back to =LSMS_CACHE_SCHEMA= if absent.
-- =ast.dump= still includes docstring nodes, so a docstring edit invalidates;
-  strip module/function docstrings before dump if that is judged too eager.
-- The =co_names= walk resolves *module-global* references only — instance
-  attributes (=self.foo=) and string-keyed dispatch are invisible (hence the
-  drift guard's part (b)).
-- Hashing constants via =repr()= assumes a stable repr (true for the dict/tuple
-  constants in play).
-- Decorating =Wave.grab_data= must return the function unchanged (no wrapper) —
-  this is a no-behaviour-change tag, not a transform.
-- Script-path /wave/ transforms are already covered by =_input_hash= (script
-  text hashed); this design is only about *framework* build-path code — the two
-  layers compose.
+- =inspect.getsource= needs =.py= on disk (true for in-tree =.venv= and a normal
+  wheel); =LSMS_CACHE_SCHEMA= remains the fallback if absent.
+- =ast.dump= still carries docstring nodes, so a docstring edit invalidates —
+  strip module/function docstrings before dump if judged too eager.
+- =_resolve='s AST scan handles =ImportFrom=; bare =import x.y= and string-keyed
+  =getattr= are still invisible — the drift guard (layer 3) is the backstop.
+- Constant =repr= must be stable; =_ser= replaces callables with qualnames to
+  avoid the =0x= address non-determinism (the =_DERIVED_TRANSFORMERS= case).
+- Decorating =Wave.grab_data= must return the function unchanged (no wrapper).
+- =grab_data= over-invalidates (a plumbing-only edit triggers a rebuild) and is
+  a known blunt instrument; isolating its extraction core is a later refinement.
 
 * Implementation checklist
 :PROPERTIES:
 :CUSTOM_ID: implementation-checklist
 :END:
 
-1. Add =lsms_library/_build_registry.py= (=build_transform= decorator,
+1. Add =lsms_library/_build_registry.py= (=build_transform=, =_resolve=, =_ser=,
    =_closure_parts=, =build_transforms_fingerprint=).
-2. Tag the entry points: 4 in =build_transforms.py= (with =tables=) and
-   =_normalize_dataframe_index= / =Wave.grab_data= in =country.py= (no =tables=).
-   Run =gitnexus_impact= on each first.
+2. Tag entry points (run =gitnexus_impact= on each first): the 4 in
+   =build_transforms.py= (food funcs with =tables=); =_normalize_dataframe_index=
+   and =Wave.grab_data= in =country.py= (no =tables=).
 3. Fold =build_transforms_fingerprint(method_name)= into
-   =Country._table_cache_hash= and =Wave._input_hash=; update their docstrings.
-4. Demote =LSMS_CACHE_SCHEMA= to a backstop in =local_tools= (keep it; restate
-   its role in CLAUDE.md's cache section).
-5. Add the drift-guard test (entry-point set + unresolved-reference walk).
-6. Verify: edit =_declared_index_levels= (or =_normalize_dataframe_index=, or
-   apply #533) and confirm a warm Mali =food_acquired= read now auto-rebuilds
-   (no =LSMS_NO_CACHE=); confirm a read-path edit (a kinship label) does NOT
-   invalidate; confirm editing =food_acquired_to_canonical= invalidates only
-   =food_acquired=, not =household_roster=.
-7. Update the CLAUDE.md cache section to describe the build-transform fingerprint.
+   =Country._table_cache_hash= and =Wave._input_hash= (inside the existing
+   =try/except=); update docstrings.
+4. (Layer 2 hygiene) relocate =_ADDITIVE_MEASURE_COLUMNS= to a leaf module,
+   module-level imported by =country= + =feature=; convert =grab_data='s
+   =apply_derived= import to module level.  Confirms the cycle is gone.
+5. Demote =LSMS_CACHE_SCHEMA= to a backstop in =local_tools=.
+6. Add the drift guard: (a) tagged-entry-point set equals a checked-in set;
+   (b) walk each tagged function's =ImportFrom= nodes and fail on any
+   unresolved-and-not-allowlisted build dependency.
+7. Verify: changing =_ADDITIVE_MEASURE_COLUMNS= (add a table) or
+   =_declared_index_levels= auto-rebuilds a warm Mali =food_acquired= read (no
+   =LSMS_NO_CACHE=); a kinship-label edit does NOT invalidate; editing
+   =food_acquired_to_canonical= invalidates only =food_acquired=, not
+   =household_roster=; the fingerprint is byte-stable across two processes.
+8. Update CLAUDE.md's cache section to describe the build-transform fingerprint.
 
 * References
 
 - PR #534 — step 1 (build/read split: =build_transforms.py=).
 - PR #531 — the cache-aware verification discussion that started this.
-- PR #533 / GH #514 — the =_normalize_dataframe_index= collapse-policy change
-  that would turn =_ADDITIVE_MEASURE_COLUMNS= build-relevant.
+- PR #533 / GH #514 — merged 2026-06-19 19:59; wired additive-sum +
+  =_ADDITIVE_MEASURE_COLUMNS= into =_normalize_dataframe_index= via a
+  function-level import — the live proof of the resolution gap.
 - GH #522 — the framework-transform-code cache blind spot.
 - GH #537 — =validate_acquisition_source= dormancy (surfaced alongside #534).
 - =SkunkWorks/dvc_object_management.org= — the v0.7.0/v0.8.0 cache design lineage.


### PR DESCRIPTION
## What

A **design note** (no code) for **step 2** of the build/read cache work:
versioning build-path transform *code* in the L2 content hash, to close the
GH #522 blind spot. Follows #534 (step 1 — the `build_transforms.py` module
split) and incorporates the #534 review.

`SkunkWorks/build_transform_cache_hash.org`.

## The core finding it builds on

The #534 review established that the build-path surface is **not confined to
one module**: build-path code also lives in `country.py` —
`_normalize_dataframe_index` (whose duplicate-collapse is baked into the
parquet) and `Wave.grab_data`. A `build_transforms.py`-only hash would miss
them, and PR #533 (the #514 collapse-policy change) is concrete proof: under
such a hash a warm Mali `food_acquired` parquet built with the old `first()`
would stay hash-valid and serve stale data.

## Proposed approach

A cross-module **`@build_transform` decorator + registry** whose members'
`inspect.getsource()` is folded into `_table_cache_hash` / `_input_hash`:

- **spans modules** (keyed by qualname, not file),
- **self-maintaining** (a new build transform is versioned the moment it's
  tagged — subsumes the "marker comment" minor, guarded by a drift test),
- **no relocation** (so the forward-cycle risk never arises;
  `_normalize_dataframe_index` stays put and is simply tagged).

The note spells out the **over-invalidation trade-off** (whole-registry-per-table,
simple & safe — recommended first cut — vs. a precise per-table transform set),
the rejected alternatives (relocate; curated list; hash whole modules), the
risks (`getsource` on a wheel; method decoration must stay no-op), a
registry-drift guard test, and an implementation checklist.

## Status

Design only — defers implementation to a fresh session starting from the
checklist. Filing as a PR so the approach can be reviewed before any code lands.

## References
#534 (step 1) · #531 (cache-aware verification) · #533 / #514 (proof) · #522 (the blind spot) · #537 (`validate_acquisition_source`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
