### PR TITLE
fix(#530): wire Azerbaijan cluster_features Region/Rayon from PP.dta

### DIFF
--- a/lsms_library/countries/Azerbaijan/1995/_/data_info.yml
+++ b/lsms_library/countries/Azerbaijan/1995/_/data_info.yml
@@ -33,17 +33,41 @@ household_roster:
                 14: Other
 
 cluster_features:
-    file: ../Data/APP1.dta
-    idxvars:
-        v: ppid
-    myvars:
-        Rural:
-            - inout
-            - mapping:
-                1.0: Urban
-                2.0: Urban
-                3.0: Urban
-                4.0: Rural
+    # PSU-level cluster table.  APP1.dta carries Rural (from `inout`);
+    # PP.dta (the PSU file already read by `sample` as df_weights) carries
+    # PSU-level geography: `zone` -> canonical Region (8 economic regions)
+    # and `raion` -> Rayon (admin rayon).  PP.dta is PSU-level (one row per
+    # ppid, zone/raion constant within ppid) and every interviewed PSU in
+    # APP1 is present, so the v=ppid join is 1:1 (no row multiplication).
+    # GH #530.  `m`/market is NOT baked in here -- it's added on demand by
+    # _add_market_index() when the user passes market='Region'.
+    dfs:
+        - df_inout
+        - df_geo
+    df_inout:
+        file: ../Data/APP1.dta
+        idxvars:
+            v: ppid
+        myvars:
+            Rural:
+                - inout
+                - mapping:
+                    1.0: Urban
+                    2.0: Urban
+                    3.0: Urban
+                    4.0: Rural
+    df_geo:
+        file: ../Data/PP.dta
+        idxvars:
+            v: ppid
+        myvars:
+            Region: zone
+            Rayon: raion
+    merge_on:
+        - v
+    final_index:
+        - t
+        - v
 
 sample:
     dfs:


### PR DESCRIPTION
Closes #530.

`cluster_features` extracted only `Rural` (from `APP1.dta` `inout`), so `market='Region'` raised `KeyError`. But the geography exists: **`PP.dta`** — already read by `sample` as `df_weights` (`v: ppid`) — carries PSU-level **`zone`** (8 economic regions) and **`raion`** (admin rayon).

Converts `cluster_features` to a two-df merge (the Ethiopia/Burkina_Faso pattern): `df_inout`=APP1.dta→Rural; `df_geo`=PP.dta→Region (from `zone`), Rayon (from `raion`); `merge_on v`, `final_index (t, v)`. No `m`/market baked in.

### Verification — independent + 3 adversarial red-team agents, all `refuted=false`
| lens | verdict |
|---|---|
| join-correctness | 1:1 on `v=ppid`, no multiplication; NaN-ppid row dropped; 77 PP-only PSUs are real interviewed PSUs → `how='outer'` correct |
| data-sanity | 8 clean economic-region labels, 0 NaN, constant within cluster, non-sparse for demand estimation; `zone`→Region right over 68-value `raion` |
| regression | sample / household_roster / household_characteristics **byte-identical** vs development |

`market='Region'` → 2016 rows, 8 regions, **0 NaN m**; roster 10012 (unchanged).

**Note (intentional):** `cluster_features()` now returns 168 rows (one per PP.dta PSU) vs 91 — *necessary*, since households exist in all 168 PSUs and covering only the 91 APP1 PSUs would leave the other 77 with NaN Region (the 0-NaN result confirms it). Matches `sample()`'s 168-PSU `v` coverage.

Produced by an adversarial fix workflow; harvested + independently re-verified.