### PR TITLE
fix(#535): drop per-quarter doubling in the script-path wave fallback (Nigeria plot_features false-alarm)

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -2594,6 +2594,24 @@ class Country:
 
                 if use_legacy:
                     wave_result = run_make_target(method_name, wave=w)
+                    # GH #535: run_make_target reads the whole shared folder's
+                    # script output, so for a country whose ``waves`` splits one
+                    # folder into several quarter-waves (Nigeria PP/PH share one
+                    # folder, e.g. 2010Q3 + 2011Q1 -> 2010-11) every quarter
+                    # re-injects the same script-tagged rows -- an exact doubling
+                    # at concat that surfaces as a false-positive GH #323
+                    # "duplicate tuple(s)" warning (plus a wasted 2x build).
+                    # Mirror grab_data's per-wave t-filter (~country.py:1092):
+                    # keep only the rows whose ``t`` matches the requested wave
+                    # ``w``.  No-op for single-t-per-folder tables and for
+                    # Tanzania's multi-round folder (``t == wave`` holds there);
+                    # ``w`` is never None on this in-loop path.
+                    if (isinstance(wave_result, pd.DataFrame)
+                            and not wave_result.empty
+                            and 't' in (wave_result.index.names or [])):
+                        wave_result = wave_result[
+                            wave_result.index.get_level_values('t') == w
+                        ]
 
                 if isinstance(wave_result, pd.DataFrame):
                     if (


### PR DESCRIPTION
Closes #535.

Nigeria's `waves` splits each survey wave into two quarter-waves (PP 2010Q3 + PH 2011Q1) sharing one folder. PP-only script-path tables are built once per quarter-wave via the `use_legacy`→`run_make_target` fallback in `load_from_waves` — but that fallback, **unlike `grab_data` (which filters `df['t'] == self.year`)**, returns the whole shared folder's output unfiltered. So every quarter-wave re-injects the same PP-tagged rows → an **exact 2× doubling** at concat (76,222 = 2×38,111), surfacing as a false-positive GH #323 `38,111 duplicate tuple(s); possible silent data loss` warning.

**Not `id_walk`** (Nigeria's `updated_ids` is a pure identity map — the original hypothesis is disproven) and **not actual data loss** (exact copies; `first()` already de-dupes correctly — final output is set-identical). The defect is the false-alarm warning (which dilutes #323's signal for *real* loss) plus a wasted 2× build.

### Fix
Mirror `grab_data`'s per-wave t-filter in the `run_make_target` fallback: keep only rows whose `t` matches the requested wave `w`. No-op for single-t-per-folder tables and Tanzania multi-round (`t == wave` there); `w` is never `None` on this in-loop path; the `wave=None` country-level fallback is a separate call site, untouched.

### Verification (forced rebuild, counterfactual)
| table | dup warning | content |
|---|---|---|
| Nigeria plot_features | 1 → **0** | set-identical (sorted fp `0319772a0a29` both; row order only) |
| Nigeria household_roster | 0 → 0 | byte-identical (grab_data path, never falls back) |
| Tanzania household_roster (multi-round) | 0 → 0 | byte-identical (no-op) |

Diagnosed + adversarially verified (both red-team skeptics `refuted=False`) by the plot_features cluster workflow. The proposal's headline "rows rise 38045→38111" was itself refuted — the final count is 38045 before and after (the doubling never reached the output; `first()` removed it). This PR removes the *spurious work and false warning*, not data.