### PR TITLE
feat(cache): version build-path transform code in the L2 hash (#522 step 2)

### DIFF
--- a/lsms_library/_build_registry.py
+++ b/lsms_library/_build_registry.py
@@ -29,12 +29,17 @@ Two genuinely hard sub-problems, each with a red-test in
   :func:`_ser` is an explicit type-dispatch with an else-*reject*; a red-test
   asserts no `` at 0x`` identity repr appears in any fingerprint part.
 
-Resolution coverage (hardened over five red-team rounds): module globals,
+Resolution coverage (hardened over seven red-team rounds): module globals,
 function-level / cycle-dodge imports, NESTED code objects (comprehensions /
 lambdas / inner defs), callables held in constant containers, ``self.<method>``
-build calls resolved against the module's classes, the out-of-process SCRIPT
-route (every ``_/*.py`` build module's ``lsms_library`` imports), local helper
-modules (``spec_from_file_location``), and ``df_edit`` hooks.
+build calls resolved against the module's classes, and the build ORCHESTRATOR
+``Country._aggregate_wave_data`` (its nested ``safe_concat`` cross-wave concat).
+The out-of-process SCRIPT route is covered in two complementary layers by the
+hash methods themselves (``Wave._input_hash`` / ``Country._table_cache_hash``):
+they (1) file-hash EVERY ``_/*.py`` build module's own body -- so a local helper
+loaded by ``spec_from_file_location`` (Nigeria ``_age_helpers.py``) or a
+``df_edit`` hook is versioned -- and (2) call ``framework_imports_fingerprint``
+to fold the ``lsms_library``-import closures those modules reach.
 
 KNOWN RESIDUAL (accepted): a framework build helper reached by purely STRING-
 KEYED dynamic dispatch -- ``getattr(some_module, runtime_string)()`` /

--- a/lsms_library/_build_registry.py
+++ b/lsms_library/_build_registry.py
@@ -256,3 +256,50 @@ def build_transforms_fingerprint(table: str | None = None) -> str:
             continue
         parts += _closure_parts(fn, seen)
     return hashlib.sha256("\x1f".join(sorted(set(parts))).encode()).hexdigest()
+
+
+@functools.lru_cache(maxsize=None)
+def framework_imports_fingerprint(paths: tuple) -> str:
+    """Fingerprint of the lsms_library framework callables imported by the given
+    build-route .py files (the SCRIPT-path ``_/{table}.py`` scripts and the
+    country/wave modules they import) plus their closures.
+
+    The script route runs out-of-process (``make`` invokes the script), so the
+    in-process closure walk from the tagged entry points cannot reach the
+    framework helpers a script uses (e.g. ``conversion_table_matching_global``,
+    ``melt_visit_intervals``, ``get_categorical_mapping``).  Those helpers DO
+    transform content baked into the L2 parquet -- the residual GH #522 hazard
+    for the script route.  A script's ``from lsms_library.X import name`` (any
+    scope) and ``import lsms_library.X [as Y]`` + attribute use are statically
+    resolvable, so we fold their closures in.  Returns "" when no framework
+    import is found.  Memoised per path-tuple (content fixed per process)."""
+    seen: set = set()
+    parts: list = []
+    for path in paths:
+        try:
+            tree = ast.parse(open(path, encoding="utf-8").read())
+        except (OSError, SyntaxError, UnicodeDecodeError, ValueError):
+            continue
+        targets = []          # (module_name, attr)
+        aliases = {}          # local alias -> lsms_library module name
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("lsms_library"):
+                for a in node.names:
+                    targets.append((node.module, a.name))
+            elif isinstance(node, ast.Import):
+                for a in node.names:
+                    if a.name.startswith("lsms_library"):
+                        aliases[a.asname or a.name] = a.name
+        if aliases:
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) \
+                        and node.value.id in aliases:
+                    targets.append((aliases[node.value.id], node.attr))
+        for modname, attr in sorted(set(targets)):
+            try:
+                obj = getattr(importlib.import_module(modname), attr, None)
+            except Exception:
+                obj = None
+            if _is_build_callable(obj):
+                parts += _closure_parts(obj, seen)
+    return hashlib.sha256("\x1f".join(sorted(set(parts))).encode()).hexdigest() if parts else ""

--- a/lsms_library/_build_registry.py
+++ b/lsms_library/_build_registry.py
@@ -79,6 +79,34 @@ def _is_ours(obj) -> bool:
     return m.startswith("lsms_library") and m not in _EXCLUDED_MODULES
 
 
+# Pure hash/freshness MECHANISM callables: they compute or compare the embedded
+# cache hash and never touch DataFrame CONTENT.  Excluded per-callable (they sit
+# in local_tools beside genuine transforms) so folding them does not make the
+# content fingerprint self-referential -- editing the cache layer would
+# otherwise rebuild every cache.  Lets us re-tag Wave.grab_data (whose body IS a
+# content transform: check_adding_t, the >1e99 sentinel filter, the dfs merge,
+# map_index) without dragging the cache layer in.
+# DELIBERATELY NOT excluded: to_parquet -- it mutates content on write
+# (astype/reset_index/set_index/replace), so it is genuine build-path code and
+# must stay versioned.  Each entry below was verified write/hash-only.
+_EXCLUDED_CALLABLES = frozenset({
+    "lsms_library.local_tools.cache_freshness",
+    "lsms_library.local_tools.read_parquet_cache_hash",
+    "lsms_library.local_tools.stamp_parquet_hash",
+    "lsms_library.local_tools.source_fingerprint",
+    "lsms_library.local_tools.cached_file_hash",
+})
+
+
+def _is_build_callable(obj) -> bool:
+    """A recursable build-path callable: ours, not in an excluded module, and
+    not a cache/hash-mechanism primitive (which never transforms content)."""
+    if not (callable(obj) and _is_ours(obj)):
+        return False
+    qn = f"{getattr(obj, '__module__', '')}.{getattr(obj, '__qualname__', '')}"
+    return qn not in _EXCLUDED_CALLABLES
+
+
 def _unwrap(fn):
     # follow functools.wraps / lru_cache __wrapped__ chains to the real function
     # (a cached helper is a _lru_cache_wrapper with no __code__ / source).
@@ -139,7 +167,8 @@ def _ser(obj, seen, parts) -> str:
     if isinstance(obj, (str, int, float, bool, type(None))):
         return repr(obj)
     if callable(obj) and _is_ours(obj):
-        parts += _closure_parts(obj, seen)
+        if _is_build_callable(obj):     # excluded cache primitives: name only, no recurse
+            parts += _closure_parts(obj, seen)
         return f"<fn {obj.__module__}.{obj.__qualname__}>"
     if isinstance(obj, dict):
         return "{" + ",".join(
@@ -202,7 +231,7 @@ def _closure_parts(fn, seen) -> list:
             obj = imap.get(name)
             if obj is None:
                 continue
-        if callable(obj) and _is_ours(obj):
+        if _is_build_callable(obj):
             parts += _closure_parts(obj, seen)
         elif isinstance(obj, _CONST_TYPES):
             parts.append(f"{fn.__module__}.{name}=" + _ser(obj, seen, parts))

--- a/lsms_library/_build_registry.py
+++ b/lsms_library/_build_registry.py
@@ -36,7 +36,9 @@ import functools
 import hashlib
 import importlib
 import inspect
+import sys
 import textwrap
+import types
 from typing import Callable
 
 # qualname -> (callable, tables).  ``tables == ()`` means "every table".
@@ -61,8 +63,20 @@ def registered_entry_points() -> frozenset:
     return frozenset(_BUILD_TRANSFORMS)
 
 
+# Modules excluded from the closure recursion: data ACCESS (DVC / S3 fetch +
+# credentials) and path/location code.  Neither transforms parquet *content* --
+# the source bytes are already versioned by the DVC sidecar md5
+# (source_fingerprint) and the config by the per-table hashes -- so descending
+# into them is pure over-invalidation (an S3-credential or path-layout edit
+# would needlessly rebuild every cache).  Transform code in local_tools
+# (df_data_grabber, format_id, get_dataframe, ...) is NOT excluded.  Keep this
+# set tiny and access-only; a transform must never live here.
+_EXCLUDED_MODULES = frozenset({"lsms_library.data_access", "lsms_library.paths"})
+
+
 def _is_ours(obj) -> bool:
-    return (getattr(obj, "__module__", "") or "").startswith("lsms_library")
+    m = getattr(obj, "__module__", "") or ""
+    return m.startswith("lsms_library") and m not in _EXCLUDED_MODULES
 
 
 def _unwrap(fn):
@@ -132,9 +146,12 @@ def _ser(obj, seen, parts) -> str:
             f"{k!r}:{_ser(v, seen, parts)}"
             for k, v in sorted(obj.items(), key=lambda kv: repr(kv[0]))
         ) + "}"
-    if isinstance(obj, (list, tuple, set, frozenset)):
-        xs = obj if isinstance(obj, (list, tuple)) else sorted(obj, key=repr)
-        return type(obj).__name__ + "[" + ",".join(_ser(v, seen, parts) for v in xs) + "]"
+    if isinstance(obj, (list, tuple)):
+        return type(obj).__name__ + "[" + ",".join(_ser(v, seen, parts) for v in obj) + "]"
+    if isinstance(obj, (set, frozenset)):
+        # Sort by SERIALISED form, not repr(obj): repr of a set element is
+        # PYTHONHASHSEED-sensitive when the element is itself a set/frozenset.
+        return type(obj).__name__ + "[" + ",".join(sorted(_ser(v, seen, parts) for v in obj)) + "]"
     raise TypeError(
         f"build constant of un-serialisable type {type(obj).__name__!r}; add a "
         f"case to lsms_library._build_registry._ser rather than leak an identity repr"
@@ -143,6 +160,24 @@ def _ser(obj, seen, parts) -> str:
 
 # Types we know how to fold into the fingerprint as a referenced constant.
 _CONST_TYPES = (dict, list, tuple, set, frozenset, str, int, float, bool)
+
+
+def _all_co_names(code) -> set:
+    """Every global/attribute name referenced by ``code`` AND its nested code
+    objects (comprehensions, lambdas, nested defs).
+
+    CPython keeps names referenced inside a nested scope out of the enclosing
+    function's ``co_names`` -- so a callable used only from an inner helper
+    (e.g. ``df_data_grabber``, called only from ``grab_data``'s nested
+    ``get_data``) would otherwise be invisible to the walk: a silent
+    under-invalidation (stale cache, GH #522).  Recursing ``co_consts`` closes
+    that.  (``co_freevars`` are closure cells, not global refs, so excluded.)
+    """
+    names = set(code.co_names)
+    for const in code.co_consts:
+        if isinstance(const, types.CodeType):
+            names |= _all_co_names(const)
+    return names
 
 
 def _closure_parts(fn, seen) -> list:
@@ -156,7 +191,10 @@ def _closure_parts(fn, seen) -> list:
     parts = [qn + "=" + _norm(fn)]
     mod = importlib.import_module(fn.__module__)
     imap = None  # parsed lazily, only if getattr misses
-    for name in fn.__code__.co_names:
+    # sorted(): _all_co_names is a set, so iteration order must be pinned.
+    for name in sorted(_all_co_names(fn.__code__)):
+        if name.startswith("__") and name.endswith("__"):
+            continue                    # dunder (e.g. __file__) -> import metadata / abs path: non-deterministic
         obj = getattr(mod, name, None)
         if obj is None:
             if imap is None:
@@ -181,7 +219,9 @@ def build_transforms_fingerprint(table: str | None = None) -> str:
     :func:`build_transforms_fingerprint.cache_clear` in tests that re-tag.
     """
     seen: set = set()
-    parts: list = []
+    # ast.dump's output format drifts across Python minor versions, so pin it:
+    # a 3.11 -> 3.12 move then invalidates uniformly rather than silently.
+    parts: list = [f"py={sys.version_info.major}.{sys.version_info.minor}"]
     for _qn, (fn, tables) in sorted(_BUILD_TRANSFORMS.items()):
         if table is not None and tables and table not in tables:
             continue

--- a/lsms_library/_build_registry.py
+++ b/lsms_library/_build_registry.py
@@ -27,7 +27,23 @@ Two genuinely hard sub-problems, each with a red-test in
 - *serialization* -- a default ``repr`` of a referenced object would embed a
   ``0x`` identity address and make the fingerprint non-deterministic.
   :func:`_ser` is an explicit type-dispatch with an else-*reject*; a red-test
-  asserts no ``0x[0-9a-f]+`` appears in any fingerprint part.
+  asserts no `` at 0x`` identity repr appears in any fingerprint part.
+
+Resolution coverage (hardened over five red-team rounds): module globals,
+function-level / cycle-dodge imports, NESTED code objects (comprehensions /
+lambdas / inner defs), callables held in constant containers, ``self.<method>``
+build calls resolved against the module's classes, the out-of-process SCRIPT
+route (every ``_/*.py`` build module's ``lsms_library`` imports), local helper
+modules (``spec_from_file_location``), and ``df_edit`` hooks.
+
+KNOWN RESIDUAL (accepted): a framework build helper reached by purely STRING-
+KEYED dynamic dispatch -- ``getattr(some_module, runtime_string)()`` /
+``importlib.import_module(runtime_string)`` where the name is not a static
+literal -- cannot be resolved statically and is NOT folded.  This is the same
+residual the v0.8.0 design accepts; it is backstopped by the manual
+``LSMS_CACHE_SCHEMA`` lever (folded into ``Wave._input_hash`` /
+``Country._table_cache_hash``), which a maintainer bumps on such an edit, plus
+``LSMS_NO_CACHE`` / ``cache clear`` / the ``make`` backend.
 """
 from __future__ import annotations
 

--- a/lsms_library/_build_registry.py
+++ b/lsms_library/_build_registry.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Build-path transform registry + content fingerprint (L2 cache, step 2).
+
+A *leaf* module: it imports nothing from the ``lsms_library`` package, so any
+module may import it without re-introducing an import cycle.
+
+``@build_transform`` tags a function whose output is baked into the cached L2
+parquet -- a *build-path* transform.  ``build_transforms_fingerprint(table)``
+returns a content hash of the transitive ``lsms_library`` closure of every
+tagged function relevant to ``table``: the function's (AST-normalised) source,
+plus the source of the ``lsms_library``-owned callables it reaches and the
+module-level constants it reads.  Folded into ``Country._table_cache_hash`` and
+``Wave._input_hash``, this versions build-path *code* -- closing the GH #522
+blind spot -- without invalidating the warm cache on read-path edits.
+
+Design + rationale: ``SkunkWorks/build_transform_cache_hash.org`` (rev 4).
+
+Two genuinely hard sub-problems, each with a red-test in
+``tests/test_build_transform_hash.py``:
+
+- *resolution* -- ``co_names`` is a flat list of bare strings;
+  ``getattr(own_module, name)`` misses the function-level
+  ``from .mod import name`` cycle-dodge idiom (GH #514's
+  ``_ADDITIVE_MEASURE_COLUMNS``, ``grab_data``'s ``apply_derived``).  The AST
+  ``ImportFrom`` walk in :func:`_import_map` closes that; the drift guard fails
+  on any unresolved reference.
+- *serialization* -- a default ``repr`` of a referenced object would embed a
+  ``0x`` identity address and make the fingerprint non-deterministic.
+  :func:`_ser` is an explicit type-dispatch with an else-*reject*; a red-test
+  asserts no ``0x[0-9a-f]+`` appears in any fingerprint part.
+"""
+from __future__ import annotations
+
+import ast
+import functools
+import hashlib
+import importlib
+import inspect
+import textwrap
+from typing import Callable
+
+# qualname -> (callable, tables).  ``tables == ()`` means "every table".
+_BUILD_TRANSFORMS: dict[str, tuple[Callable, tuple]] = {}
+
+
+def build_transform(*, tables=None):
+    """Mark a function as a build-path entry point.
+
+    ``tables`` scopes which per-table fingerprints fold it in; ``None`` / empty
+    means every table.  Returns the function **unchanged** (a tag, not a
+    wrapper) so binding and call semantics are byte-for-byte identical.
+    """
+    def deco(fn):
+        _BUILD_TRANSFORMS[f"{fn.__module__}.{fn.__qualname__}"] = (fn, tuple(tables or ()))
+        return fn
+    return deco
+
+
+def registered_entry_points() -> frozenset:
+    """Qualnames of every ``@build_transform``-tagged function (drift guard)."""
+    return frozenset(_BUILD_TRANSFORMS)
+
+
+def _is_ours(obj) -> bool:
+    return (getattr(obj, "__module__", "") or "").startswith("lsms_library")
+
+
+def _unwrap(fn):
+    # follow functools.wraps / lru_cache __wrapped__ chains to the real function
+    # (a cached helper is a _lru_cache_wrapper with no __code__ / source).
+    try:
+        return inspect.unwrap(fn)
+    except ValueError:
+        return fn
+
+
+def _source(fn) -> str:
+    return textwrap.dedent(inspect.getsource(fn))  # dedent: methods are class-indented
+
+
+def _norm(fn) -> str:
+    # ast.dump drops comments + normalises whitespace, so a comment-only edit
+    # does not invalidate (docstring nodes are still included -- by design).
+    try:
+        return ast.dump(ast.parse(_source(fn)))
+    except (OSError, SyntaxError, TypeError):
+        return f"<unsourced {fn.__module__}.{fn.__qualname__}>"
+
+
+def _import_map(fn) -> dict:
+    """``name -> object`` for every ``from .mod import name`` in ``fn``.
+
+    Parses the function once and resolves both module-level and function-level
+    (cycle-dodge) relative imports -- the references ``getattr(own_module, ...)``
+    silently drops.  Returns ``{name: None}`` for an unresolved target so the
+    drift guard can distinguish "saw the import, could not resolve" from "never
+    referenced".
+    """
+    out: dict = {}
+    try:
+        tree = ast.parse(_source(fn))
+    except (OSError, SyntaxError, TypeError):
+        return out
+    parent = fn.__module__.rsplit(".", 1)[0]
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            try:
+                tgt = importlib.import_module("." * node.level + (node.module or ""), package=parent)
+            except Exception:
+                tgt = None
+            for alias in node.names:
+                out[alias.asname or alias.name] = getattr(tgt, alias.name, None) if tgt else None
+    return out
+
+
+def _ser(obj, seen, parts) -> str:
+    """Deterministic serialisation of a referenced build constant.
+
+    Explicit type-dispatch with an else-*reject*: an unhandled type raises
+    rather than leaking a default ``repr`` (which would embed a ``0x`` identity
+    address).  ``lsms_library`` callables are replaced by their qualname and
+    their source is folded into ``parts`` (so a callable held in a registry dict
+    -- e.g. ``_DERIVED_TRANSFORMERS`` -- is versioned by *code*, not address).
+    """
+    if isinstance(obj, (str, int, float, bool, type(None))):
+        return repr(obj)
+    if callable(obj) and _is_ours(obj):
+        parts += _closure_parts(obj, seen)
+        return f"<fn {obj.__module__}.{obj.__qualname__}>"
+    if isinstance(obj, dict):
+        return "{" + ",".join(
+            f"{k!r}:{_ser(v, seen, parts)}"
+            for k, v in sorted(obj.items(), key=lambda kv: repr(kv[0]))
+        ) + "}"
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        xs = obj if isinstance(obj, (list, tuple)) else sorted(obj, key=repr)
+        return type(obj).__name__ + "[" + ",".join(_ser(v, seen, parts) for v in xs) + "]"
+    raise TypeError(
+        f"build constant of un-serialisable type {type(obj).__name__!r}; add a "
+        f"case to lsms_library._build_registry._ser rather than leak an identity repr"
+    )
+
+
+# Types we know how to fold into the fingerprint as a referenced constant.
+_CONST_TYPES = (dict, list, tuple, set, frozenset, str, int, float, bool)
+
+
+def _closure_parts(fn, seen) -> list:
+    fn = _unwrap(fn)
+    if not hasattr(fn, "__code__"):
+        return []                       # builtin / C / unresolvable callable
+    qn = f"{fn.__module__}.{fn.__qualname__}"
+    if qn in seen:
+        return []
+    seen.add(qn)
+    parts = [qn + "=" + _norm(fn)]
+    mod = importlib.import_module(fn.__module__)
+    imap = None  # parsed lazily, only if getattr misses
+    for name in fn.__code__.co_names:
+        obj = getattr(mod, name, None)
+        if obj is None:
+            if imap is None:
+                imap = _import_map(fn)
+            obj = imap.get(name)
+            if obj is None:
+                continue
+        if callable(obj) and _is_ours(obj):
+            parts += _closure_parts(obj, seen)
+        elif isinstance(obj, _CONST_TYPES):
+            parts.append(f"{fn.__module__}.{name}=" + _ser(obj, seen, parts))
+    return parts
+
+
+@functools.lru_cache(maxsize=None)
+def build_transforms_fingerprint(table: str | None = None) -> str:
+    """sha256 of the build-path closure relevant to ``table`` (every tagged
+    transform when ``table`` is ``None``).
+
+    Memoised: source is fixed per process, so this is ~free after the first call
+    per table -- the v0.7.0 fast path is preserved.  Call
+    :func:`build_transforms_fingerprint.cache_clear` in tests that re-tag.
+    """
+    seen: set = set()
+    parts: list = []
+    for _qn, (fn, tables) in sorted(_BUILD_TRANSFORMS.items()):
+        if table is not None and tables and table not in tables:
+            continue
+        parts += _closure_parts(fn, seen)
+    return hashlib.sha256("\x1f".join(sorted(set(parts))).encode()).hexdigest()

--- a/lsms_library/_build_registry.py
+++ b/lsms_library/_build_registry.py
@@ -146,7 +146,12 @@ def _unwrap(fn):
         return fn
 
 
+@functools.lru_cache(maxsize=None)
 def _source(fn) -> str:
+    # Memoised per function object: source is fixed per process, and the
+    # ALL-scoped orchestrators (_aggregate_wave_data/grab_data/df_data_grabber/
+    # _normalize_dataframe_index) sit in EVERY table's closure -- without this
+    # they are re-read+parsed per table (~300 ms each on the read gate).
     return textwrap.dedent(inspect.getsource(fn))  # dedent: methods are class-indented
 
 
@@ -163,13 +168,27 @@ def _strip_docstrings(tree):
     return tree
 
 
+@functools.lru_cache(maxsize=None)
 def _norm(fn) -> str:
     # ast.dump drops comments + normalises whitespace; we also strip docstrings,
     # so neither a comment nor a docstring edit invalidates -- only logic does.
+    # Memoised per function (cross-table sharing of the shared-orchestrator parse).
     try:
         return ast.dump(_strip_docstrings(ast.parse(_source(fn))))
     except (OSError, SyntaxError, TypeError):
         return f"<unsourced {fn.__module__}.{fn.__qualname__}>"
+
+
+def clear_caches() -> None:
+    """Clear every memoised cache (source, norm, module-classes, both
+    fingerprints).  Production never needs this (source is fixed per process);
+    tests that simulate a source edit by monkeypatching ``inspect.getsource``
+    MUST call it so the stale per-function ``_source``/``_norm`` are re-read."""
+    _source.cache_clear()
+    _norm.cache_clear()
+    _module_classes.cache_clear()
+    build_transforms_fingerprint.cache_clear()
+    framework_imports_fingerprint.cache_clear()
 
 
 def _import_map(fn) -> dict:

--- a/lsms_library/_build_registry.py
+++ b/lsms_library/_build_registry.py
@@ -79,22 +79,26 @@ def _is_ours(obj) -> bool:
     return m.startswith("lsms_library") and m not in _EXCLUDED_MODULES
 
 
-# Pure hash/freshness MECHANISM callables: they compute or compare the embedded
-# cache hash and never touch DataFrame CONTENT.  Excluded per-callable (they sit
-# in local_tools beside genuine transforms) so folding them does not make the
-# content fingerprint self-referential -- editing the cache layer would
-# otherwise rebuild every cache.  Lets us re-tag Wave.grab_data (whose body IS a
-# content transform: check_adding_t, the >1e99 sentinel filter, the dfs merge,
-# map_index) without dragging the cache layer in.
+# Cache/hash MECHANISM callables: they compute or compare the embedded cache
+# hash and never touch DataFrame CONTENT.  Excluded per-callable so folding them
+# does not make the content fingerprint self-referential -- editing the cache
+# layer would otherwise rebuild every cache, and the Wave._input_hash /
+# Country._table_cache_hash methods would recurse into the fingerprint machinery
+# itself (they CALL build_transforms_fingerprint).  This lets us re-tag
+# Wave.grab_data (body IS a content transform: check_adding_t, the >1e99
+# sentinel filter, the dfs merge, map_index) and resolve self.<method> build
+# calls (column_mapping, formatting_functions) without dragging the cache in.
 # DELIBERATELY NOT excluded: to_parquet -- it mutates content on write
-# (astype/reset_index/set_index/replace), so it is genuine build-path code and
-# must stay versioned.  Each entry below was verified write/hash-only.
+# (astype/reset_index/set_index/replace), so it is genuine build-path code.
+# The local_tools entries were verified write/hash-only.
 _EXCLUDED_CALLABLES = frozenset({
     "lsms_library.local_tools.cache_freshness",
     "lsms_library.local_tools.read_parquet_cache_hash",
     "lsms_library.local_tools.stamp_parquet_hash",
     "lsms_library.local_tools.source_fingerprint",
     "lsms_library.local_tools.cached_file_hash",
+    "lsms_library.country.Wave._input_hash",          # the hash mechanism itself
+    "lsms_library.country.Country._table_cache_hash",  # (would self-reference)
 })
 
 
@@ -120,11 +124,24 @@ def _source(fn) -> str:
     return textwrap.dedent(inspect.getsource(fn))  # dedent: methods are class-indented
 
 
+def _strip_docstrings(tree):
+    # Docstrings are documentation, not build logic -- drop them so a docstring
+    # edit doesn't invalidate, and a stale pasted repr/address in a docstring
+    # (country.py column_mapping has one) can't land in the fingerprint.
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            b = node.body
+            if (b and isinstance(b[0], ast.Expr) and isinstance(getattr(b[0], "value", None), ast.Constant)
+                    and isinstance(b[0].value.value, str)):
+                node.body = b[1:] or [ast.Pass()]
+    return tree
+
+
 def _norm(fn) -> str:
-    # ast.dump drops comments + normalises whitespace, so a comment-only edit
-    # does not invalidate (docstring nodes are still included -- by design).
+    # ast.dump drops comments + normalises whitespace; we also strip docstrings,
+    # so neither a comment nor a docstring edit invalidates -- only logic does.
     try:
-        return ast.dump(ast.parse(_source(fn)))
+        return ast.dump(_strip_docstrings(ast.parse(_source(fn))))
     except (OSError, SyntaxError, TypeError):
         return f"<unsourced {fn.__module__}.{fn.__qualname__}>"
 
@@ -209,6 +226,34 @@ def _all_co_names(code) -> set:
     return names
 
 
+@functools.lru_cache(maxsize=None)
+def _module_classes(module_name: str) -> tuple:
+    mod = importlib.import_module(module_name)
+    return tuple(v for v in vars(mod).values()
+                 if isinstance(v, type) and getattr(v, "__module__", "") == module_name)
+
+
+def _resolve_methods(module_name: str, name: str) -> list:
+    """Resolve a bare attribute name (a ``self.X`` reference) against the methods
+    and properties of the classes defined in ``module_name``.
+
+    ``getattr(module, name)`` only finds module GLOBALS, so a build method called
+    on self -- e.g. ``Wave.column_mapping`` / ``Wave.formatting_functions``, which
+    drive YAML-route extraction -- is otherwise dropped (a stale-cache miss, GH
+    #522).  A name can live on more than one class (``formatting_functions`` on
+    both Wave and Country), so return all build-relevant matches.  The hash
+    machinery (Wave._input_hash, Country._table_cache_hash) is filtered by
+    _is_build_callable / _EXCLUDED_CALLABLES so the walk can't self-reference."""
+    out = []
+    for cls in _module_classes(module_name):
+        m = getattr(cls, name, None)
+        if isinstance(m, property):
+            m = m.fget
+        if _is_build_callable(m):
+            out.append(m)
+    return out
+
+
 def _closure_parts(fn, seen) -> list:
     fn = _unwrap(fn)
     if not hasattr(fn, "__code__"):
@@ -229,8 +274,11 @@ def _closure_parts(fn, seen) -> list:
             if imap is None:
                 imap = _import_map(fn)
             obj = imap.get(name)
-            if obj is None:
-                continue
+        if obj is None:
+            # Not a module global / import -> maybe a self.<method> build call.
+            for m in _resolve_methods(fn.__module__, name):
+                parts += _closure_parts(m, seen)
+            continue
         if _is_build_callable(obj):
             parts += _closure_parts(obj, seen)
         elif isinstance(obj, _CONST_TYPES):

--- a/lsms_library/_build_registry.py
+++ b/lsms_library/_build_registry.py
@@ -115,6 +115,11 @@ _EXCLUDED_CALLABLES = frozenset({
     "lsms_library.local_tools.cached_file_hash",
     "lsms_library.country.Wave._input_hash",          # the hash mechanism itself
     "lsms_library.country.Country._table_cache_hash",  # (would self-reference)
+    # _finalize_result is READ-path: re-applied on every read AFTER the cache,
+    # so an edit surfaces regardless of cache freshness.  It is reached from the
+    # tagged orchestrator _aggregate_wave_data; excluding it keeps the build
+    # fingerprint from over-invalidating on read-path edits (kinship/spellings).
+    "lsms_library.country.Country._finalize_result",
 })
 
 

--- a/lsms_library/build_transforms.py
+++ b/lsms_library/build_transforms.py
@@ -21,7 +21,10 @@ backward compatibility with the country scripts that import them from there.
 import numpy as np
 import pandas as pd
 
+from ._build_registry import build_transform
 
+
+@build_transform(tables=['food_acquired'])
 def food_acquired_to_canonical(df: pd.DataFrame, drop_columns=('visit',)) -> pd.DataFrame:
     """Reshape wide-form ``food_acquired`` into canonical long-form on ``s``.
 
@@ -130,6 +133,7 @@ def food_acquired_to_canonical(df: pd.DataFrame, drop_columns=('visit',)) -> pd.
     return out
 
 
+@build_transform(tables=['food_acquired'])
 def _finalize_canonical_food_acquired(out: pd.DataFrame,
                                       *,
                                       index_levels=('t', 'i', 'j', 'u', 's'),
@@ -204,6 +208,7 @@ def _finalize_canonical_food_acquired(out: pd.DataFrame,
     return out.sort_index()
 
 
+@build_transform()
 def fill_v_with_coord_bin(df, target='v', lat='_lat', lon='_lon',
                           grid_degrees=0.05, prefix='@'):
     """Fill blank ``target`` entries with a synthetic ``{prefix}lat,lon`` label.
@@ -296,6 +301,7 @@ _DERIVED_TRANSFORMERS = {
 }
 
 
+@build_transform()
 def apply_derived(df, derived_spec):
     """Apply a ``derived:`` block from ``data_info.yml`` to a DataFrame.
 

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -49,7 +49,7 @@ from .local_tools import (
 from .paths import data_root, countries_root
 from .yaml_utils import load_yaml
 from .currency import attach_currency, is_monetary_table
-from ._build_registry import build_transform, build_transforms_fingerprint
+from ._build_registry import build_transform, build_transforms_fingerprint, framework_imports_fingerprint
 import importlib.util
 import hashlib
 import logging
@@ -639,6 +639,19 @@ class Wave:
             for ref in sorted(set(scan_script_data_refs(script))):
                 data_path = Path(os.path.normpath(self.file_path / "Data" / ref))
                 parts.append("sref:" + source_fingerprint(data_path))
+            # Script route runs OUT-OF-PROCESS, so the in-process closure walk
+            # can't reach the framework helpers the script (and the country/wave
+            # modules it imports) use -- e.g. conversion_table_matching_global.
+            # Fold their import closures (GH #522, script route).  Best-effort.
+            try:
+                cmod = self.country.file_path / "_" / f"{self.country.name.lower()}.py"
+                fw = framework_imports_fingerprint((
+                    str(script), str(wave_dir / f"{self.wave_folder}.py"),
+                    str(wave_dir / "mapping.py"), str(cmod)))
+                if fw:
+                    parts.append("fwimp=" + fw)
+            except Exception:
+                pass
 
         # Build-path framework transform CODE (GH #522 / cache step 2): version
         # the @build_transform closure relevant to this table, so editing e.g.
@@ -2250,8 +2263,23 @@ class Country:
                 btf = build_transforms_fingerprint(method_name)
             except Exception:
                 btf = "none"
+            # Script route (country-level concatenator runs out-of-process): fold
+            # the framework helpers it + the country module import (GH #522,
+            # script route).  Gated on the concatenator existing so YAML-path
+            # tables are unaffected.  Per-wave script tables get this via each
+            # wave's _input_hash (composed into wave_hashes).
+            concat = cdir / f"{method_name}.py"
+            fwimp = ""
+            if concat.exists():
+                try:
+                    fwimp = framework_imports_fingerprint((
+                        str(concat), str(cdir / f"{self.name.lower()}.py"),
+                        str(cdir / "mapping.py")))
+                except Exception:
+                    fwimp = ""
             payload = (f"schema={LSMS_CACHE_SCHEMA}\x1ftable={method_name}\x1f"
                        + f"btf={btf}\x1f"
+                       + (f"fwimp={fwimp}\x1f" if fwimp else "")
                        + "\x1f".join(country_parts) + "\x1f"
                        + "\x1f".join(wave_hashes))
             return hashlib.sha256(payload.encode()).hexdigest()

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -2373,6 +2373,8 @@ class Country:
                 f"{self.name}/_/data_scheme.yml."
             )
 
+    @build_transform()  # orchestrator: nested safe_concat_dataframe_dict / load_from_waves bake cross-wave
+                        # alignment+concat into the parquet, not re-applied on read (#522, round-6)
     def _aggregate_wave_data(self, waves: list[str] | None = None, method_name: str | None = None,
                              currency: str | None = None) -> pd.DataFrame | dict[str, Any]:
         """Aggregates data across multiple waves using a single dataset method.

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -440,6 +440,11 @@ _DATA_INFO_CACHE: dict[str, dict[str, Any]] = {}
 # pure documentation never read by a build step -- hashing them would
 # cause a spurious full-country rebuild on a docs edit.
 _ORG_HASH_SKIP = {"CONTENTS.org"}
+# Build-input file suffixes content-hashed from a country/wave _/ dir (helper
+# module bodies + data/conversion tables).  .org is handled separately (skip
+# list above).  Build OUTPUTS go to the cache (data_root()), not _/, so every
+# matching _/ file is a committed build input (GH #522, rounds 7-8).
+_BUILD_INPUT_SUFFIXES = {".py", ".csv", ".json", ".txt", ".tab", ".tsv"}
 
 
 def _parse_data_info_cached(path: Path, content_hash: str | None) -> dict[str, Any]:
@@ -651,9 +656,18 @@ class Wave:
             cdir = self.country.file_path / "_"
             wave_pys = tuple(sorted(str(p) for p in wave_dir.glob("*.py"))) if wave_dir.is_dir() else ()
             country_pys = tuple(sorted(str(p) for p in cdir.glob("*.py"))) if cdir.is_dir() else ()
-            # (1) body hash, keyed by filename (NOT abs path -> machine-independent)
-            for p in wave_pys + country_pys:
-                parts.append(f"py:{Path(p).name}=" + (cached_file_hash(Path(p)) or "none"))
+            # (1) content-hash EVERY build INPUT in the wave + country _/ dirs --
+            # .py helper bodies AND .csv/.json/.txt conversion tables (e.g. Malawi
+            # ihs3_conversions.csv -> cfactor -> Quantity_kg, baked and not
+            # re-applied on read) -- keyed by filename -> machine-independent
+            # (GH #522, rounds 7-8).  Outputs go to the cache, not _/, so every
+            # such file is a committed build input.
+            for d in (wave_dir, self.country.file_path / "_"):
+                if not d.is_dir():
+                    continue
+                for p in sorted(d.glob("*")):
+                    if p.suffix.lower() in _BUILD_INPUT_SUFFIXES:
+                        parts.append(f"binp:{p.name}=" + (cached_file_hash(p) or "none"))
             # (2) import-closure fold; two calls so the country tuple memoises
             # ONCE across waves (a combined tuple differs per wave).
             fw_w = framework_imports_fingerprint(wave_pys)
@@ -2254,12 +2268,13 @@ class Country:
                 # since the Makefile is edited rarely).
                 "cmake=" + (cached_file_hash(cdir / "Makefile") or "none"),
             ]
-            # File-hash EVERY country-level build module (not just ctbl/cmod/cmap)
-            # so a LOCAL helper's own body -- e.g. _age_helpers.py
-            # (_clean_year / apply_age_handler, loaded via spec_from_file_location)
-            # -- is versioned (GH #522, round-7).
-            for p in sorted(cdir.glob("*.py")):
-                country_parts.append(f"cpy:{p.name}=" + (cached_file_hash(p) or "none"))
+            # Content-hash EVERY country-level build INPUT (not just ctbl/cmod/cmap):
+            # .py helper bodies (e.g. _age_helpers.py) AND .csv/.json/.txt data
+            # tables -- so a LOCAL helper or conversion table is versioned
+            # (GH #522, rounds 7-8).
+            for p in sorted(cdir.glob("*")):
+                if p.suffix.lower() in _BUILD_INPUT_SUFFIXES:
+                    country_parts.append(f"cbinp:{p.name}=" + (cached_file_hash(p) or "none"))
             # Country-level build-time .org inputs (food_items.org,
             # categorical_mapping.org, unit_labels.org, ...), CONTENTS.org
             # excluded.  These are read by the country-level concatenator /

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -640,19 +640,22 @@ class Wave:
                 data_path = Path(os.path.normpath(self.file_path / "Data" / ref))
                 parts.append("sref:" + source_fingerprint(data_path))
 
-        # Framework helpers reached via DYNAMIC dispatch -- out-of-process script
-        # builds, spec_from_file_location local helpers (Nigeria _age_helpers ->
-        # age_handler), and the df_edit hook dispatched by name (Malawi
-        # interview_date -> melt_visit_intervals) -- are invisible to the
-        # in-process closure walk.  Fold the lsms_library-import closures of EVERY
-        # build module in the wave's and country's _/ dirs, covering any local
-        # helper on BOTH routes (GH #522).  Best-effort; never raises.
+        # Every build module in the wave + country _/ dirs contributes to the
+        # parquet via DYNAMIC dispatch (out-of-process scripts, df_edit hooks,
+        # spec_from_file_location LOCAL helpers like Nigeria _age_helpers.py).
+        # Two layers (GH #522): (1) file-hash each module's OWN body -- so e.g.
+        # _age_helpers.py's _clean_year/apply_age_handler is versioned; (2) fold
+        # the lsms_library-import CLOSURES those modules reach (age_handler,
+        # conversion_table_matching_global, ...).  Best-effort; never raises.
         try:
             cdir = self.country.file_path / "_"
             wave_pys = tuple(sorted(str(p) for p in wave_dir.glob("*.py"))) if wave_dir.is_dir() else ()
             country_pys = tuple(sorted(str(p) for p in cdir.glob("*.py"))) if cdir.is_dir() else ()
-            # Two calls so the country tuple memoises ONCE across all waves
-            # (the combined tuple differs per wave -> would re-parse country _/).
+            # (1) body hash, keyed by filename (NOT abs path -> machine-independent)
+            for p in wave_pys + country_pys:
+                parts.append(f"py:{Path(p).name}=" + (cached_file_hash(Path(p)) or "none"))
+            # (2) import-closure fold; two calls so the country tuple memoises
+            # ONCE across waves (a combined tuple differs per wave).
             fw_w = framework_imports_fingerprint(wave_pys)
             fw_c = framework_imports_fingerprint(country_pys)
             if fw_w or fw_c:
@@ -2251,6 +2254,12 @@ class Country:
                 # since the Makefile is edited rarely).
                 "cmake=" + (cached_file_hash(cdir / "Makefile") or "none"),
             ]
+            # File-hash EVERY country-level build module (not just ctbl/cmod/cmap)
+            # so a LOCAL helper's own body -- e.g. _age_helpers.py
+            # (_clean_year / apply_age_handler, loaded via spec_from_file_location)
+            # -- is versioned (GH #522, round-7).
+            for p in sorted(cdir.glob("*.py")):
+                country_parts.append(f"cpy:{p.name}=" + (cached_file_hash(p) or "none"))
             # Country-level build-time .org inputs (food_items.org,
             # categorical_mapping.org, unit_labels.org, ...), CONTENTS.org
             # excluded.  These are read by the country-level concatenator /

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -49,6 +49,7 @@ from .local_tools import (
 from .paths import data_root, countries_root
 from .yaml_utils import load_yaml
 from .currency import attach_currency, is_monetary_table
+from ._build_registry import build_transform, build_transforms_fingerprint
 import importlib.util
 import hashlib
 import logging
@@ -639,6 +640,16 @@ class Wave:
                 data_path = Path(os.path.normpath(self.file_path / "Data" / ref))
                 parts.append("sref:" + source_fingerprint(data_path))
 
+        # Build-path framework transform CODE (GH #522 / cache step 2): version
+        # the @build_transform closure relevant to this table, so editing e.g.
+        # apply_derived / food_acquired_to_canonical invalidates the L2-wave
+        # parquet.  Degrades to "none" (closure unversioned -> read-if-present),
+        # never raises out of the hash.  See lsms_library/_build_registry.py.
+        try:
+            parts.append("btf=" + build_transforms_fingerprint(table))
+        except Exception:
+            parts.append("btf=none")
+
         return hashlib.sha256("\x1f".join(parts).encode()).hexdigest()
 
     @property
@@ -825,6 +836,7 @@ class Wave:
     def mapping(self) -> dict[str, Any]:
         return {**self.categorical_mapping, **self.formatting_functions}
 
+    @build_transform()
     def grab_data(self, request: str) -> pd.DataFrame:
         '''
         get data from the data file
@@ -2231,7 +2243,15 @@ class Country:
                 any_hash = True
             if not any_hash:
                 return None
+            # Build-path framework transform CODE (GH #522 / cache step 2):
+            # folded in AFTER the any_hash gate so it never makes an otherwise
+            # unintrospectable table falsely "verifiable"; degrades to "none".
+            try:
+                btf = build_transforms_fingerprint(method_name)
+            except Exception:
+                btf = "none"
             payload = (f"schema={LSMS_CACHE_SCHEMA}\x1ftable={method_name}\x1f"
+                       + f"btf={btf}\x1f"
                        + "\x1f".join(country_parts) + "\x1f"
                        + "\x1f".join(wave_hashes))
             return hashlib.sha256(payload.encode()).hexdigest()
@@ -3974,6 +3994,7 @@ def _enforce_canonical_dtypes(df: pd.DataFrame, method_name: str) -> None:
             pass  # best-effort; don't break loading
 
 
+@build_transform()
 def _normalize_dataframe_index(
     df: pd.DataFrame,
     schema_entry: dict[str, Any],

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -836,7 +836,6 @@ class Wave:
     def mapping(self) -> dict[str, Any]:
         return {**self.categorical_mapping, **self.formatting_functions}
 
-    @build_transform()
     def grab_data(self, request: str) -> pd.DataFrame:
         '''
         get data from the data file

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -639,19 +639,26 @@ class Wave:
             for ref in sorted(set(scan_script_data_refs(script))):
                 data_path = Path(os.path.normpath(self.file_path / "Data" / ref))
                 parts.append("sref:" + source_fingerprint(data_path))
-            # Script route runs OUT-OF-PROCESS, so the in-process closure walk
-            # can't reach the framework helpers the script (and the country/wave
-            # modules it imports) use -- e.g. conversion_table_matching_global.
-            # Fold their import closures (GH #522, script route).  Best-effort.
-            try:
-                cmod = self.country.file_path / "_" / f"{self.country.name.lower()}.py"
-                fw = framework_imports_fingerprint((
-                    str(script), str(wave_dir / f"{self.wave_folder}.py"),
-                    str(wave_dir / "mapping.py"), str(cmod)))
-                if fw:
-                    parts.append("fwimp=" + fw)
-            except Exception:
-                pass
+
+        # Framework helpers reached via DYNAMIC dispatch -- out-of-process script
+        # builds, spec_from_file_location local helpers (Nigeria _age_helpers ->
+        # age_handler), and the df_edit hook dispatched by name (Malawi
+        # interview_date -> melt_visit_intervals) -- are invisible to the
+        # in-process closure walk.  Fold the lsms_library-import closures of EVERY
+        # build module in the wave's and country's _/ dirs, covering any local
+        # helper on BOTH routes (GH #522).  Best-effort; never raises.
+        try:
+            cdir = self.country.file_path / "_"
+            wave_pys = tuple(sorted(str(p) for p in wave_dir.glob("*.py"))) if wave_dir.is_dir() else ()
+            country_pys = tuple(sorted(str(p) for p in cdir.glob("*.py"))) if cdir.is_dir() else ()
+            # Two calls so the country tuple memoises ONCE across all waves
+            # (the combined tuple differs per wave -> would re-parse country _/).
+            fw_w = framework_imports_fingerprint(wave_pys)
+            fw_c = framework_imports_fingerprint(country_pys)
+            if fw_w or fw_c:
+                parts.append(f"fwimp={fw_w}:{fw_c}")
+        except Exception:
+            pass
 
         # Build-path framework transform CODE (GH #522 / cache step 2): version
         # the @build_transform closure relevant to this table, so editing e.g.
@@ -2263,20 +2270,16 @@ class Country:
                 btf = build_transforms_fingerprint(method_name)
             except Exception:
                 btf = "none"
-            # Script route (country-level concatenator runs out-of-process): fold
-            # the framework helpers it + the country module import (GH #522,
-            # script route).  Gated on the concatenator existing so YAML-path
-            # tables are unaffected.  Per-wave script tables get this via each
-            # wave's _input_hash (composed into wave_hashes).
-            concat = cdir / f"{method_name}.py"
-            fwimp = ""
-            if concat.exists():
-                try:
-                    fwimp = framework_imports_fingerprint((
-                        str(concat), str(cdir / f"{self.name.lower()}.py"),
-                        str(cdir / "mapping.py")))
-                except Exception:
-                    fwimp = ""
+            # Country-level build modules run framework helpers via dynamic
+            # dispatch (concatenator scripts, df_edit hooks in the country
+            # module).  Fold the lsms_library-import closures of every build
+            # module in the country _/ dir (GH #522, both routes).  Per-wave
+            # script tables also get this via each wave's _input_hash.
+            try:
+                country_pys = tuple(sorted(str(p) for p in cdir.glob("*.py"))) if cdir.is_dir() else ()
+                fwimp = framework_imports_fingerprint(country_pys)
+            except Exception:
+                fwimp = ""
             payload = (f"schema={LSMS_CACHE_SCHEMA}\x1ftable={method_name}\x1f"
                        + f"btf={btf}\x1f"
                        + (f"fwimp={fwimp}\x1f" if fwimp else "")

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -836,6 +836,7 @@ class Wave:
     def mapping(self) -> dict[str, Any]:
         return {**self.categorical_mapping, **self.formatting_functions}
 
+    @build_transform()  # body is build-path: check_adding_t, >1e99 sentinel, dfs merge, map_index (#522)
     def grab_data(self, request: str) -> pd.DataFrame:
         '''
         get data from the data file

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -56,6 +56,7 @@ See ``CLAUDE.md`` for the full anti-pattern list and data-access rules.
 """
 from __future__ import annotations
 
+from ._build_registry import build_transform
 from ligonlibrary.dataframes import from_dta
 import pyreadstat
 import struct
@@ -1013,6 +1014,7 @@ def get_dataframe(fn: str | Path, convert_categoricals: bool = True, encoding: s
 
 #def regularize_string(s):
 
+@build_transform()  # build-path: extraction/formatting baked verbatim into the L2 parquet (#522)
 def df_data_grabber(fn: str | Path, idxvars: dict[str, Any] | str, convert_categoricals: bool = True, encoding: str | None = None, orgtbl: str | None = None, missing_ok: bool = False, **kwargs: Any) -> pd.DataFrame:
     """From a file named fn, grab both index variables and additional variables
     specified in kwargs and construct a pandas dataframe.

--- a/tests/test_build_transform_hash.py
+++ b/tests/test_build_transform_hash.py
@@ -190,33 +190,37 @@ def test_cache_mechanism_is_excluded_but_to_parquet_is_not():
         "to_parquet mutates content on write and MUST be versioned"
 
 
-def test_script_route_framework_helpers_are_versioned(monkeypatch):
-    """Round-3 fix (GH #522, script route): framework helpers reached only via
-    the OUT-OF-PROCESS script route -- e.g. conversion_table_matching_global,
-    imported by malawi.py and used by Malawi's food_acquired wave scripts -- are
-    invisible to the in-process closure walk.  framework_imports_fingerprint must
-    fold them, so editing the helper changes the wave hash (else: stale content)."""
+@pytest.mark.parametrize("country,table,helper", [
+    # script route, framework helper imported by the country module:
+    ("Malawi", "food_acquired", "conversion_table_matching_global"),
+    # script route, framework helper reached via a spec_from_file_location LOCAL
+    # helper (Nigeria _age_helpers.py -> age_handler) -- round-4 finding:
+    ("Nigeria", "household_roster", "age_handler"),
+    # YAML route, framework helper reached via a df_edit hook in the country
+    # module (Malawi interview_date -> melt_visit_intervals) -- round-4 finding:
+    ("Malawi", "interview_date", "melt_visit_intervals"),
+])
+def test_dynamically_dispatched_framework_helpers_are_versioned(monkeypatch, country, table, helper):
+    """GH #522, dynamic-dispatch routes (rounds 3-4): a framework content helper
+    reached out-of-process / via a local helper module / via a df_edit hook must
+    still invalidate its table's L2 hash when edited.  We fold the lsms_library
+    closures of every build module in the wave + country _/ dirs, so perturbing
+    the helper's source changes _table_cache_hash."""
     import inspect
     import lsms_library.local_tools as lt
-    c = lsms_library.country.Country("Malawi")
-    waves = [w for w in c.waves if (c[w].file_path / "_" / "food_acquired.py").exists()]
-    if not waves:
-        pytest.skip("no script-path food_acquired wave for Malawi")
-    w = c[waves[0]]
-    paths = (str(w.file_path / "_" / "food_acquired.py"),
-             str(c.file_path / "_" / "malawi.py"))
-    R.framework_imports_fingerprint.cache_clear()
-    base = R.framework_imports_fingerprint(paths)
-    assert base, "no framework-import closure folded for the Malawi script route"
-    # Editing the framework matcher's source must change the script-route hash.
-    target = inspect.unwrap(lt.conversion_table_matching_global)
+    c = lsms_library.country.Country(country)
+    base = c._table_cache_hash(table, c.waves)
+    if base is None:
+        pytest.skip(f"{country}.{table} not introspectable")
+    target = inspect.unwrap(getattr(lt, helper))
     real = inspect.getsource
     monkeypatch.setattr(inspect, "getsource",
                         lambda o: real(o) + "\n_redteam_probe = 1\n" if o is target else real(o))
     R.framework_imports_fingerprint.cache_clear()
     R.build_transforms_fingerprint.cache_clear()
-    assert R.framework_imports_fingerprint(paths) != base, \
-        "editing conversion_table_matching_global did not change the script-route fingerprint"
+    after = c._table_cache_hash(table, c.waves)
+    assert base != after, \
+        f"editing framework helper {helper} did NOT invalidate {country}.{table} (#522 reopened)"
 
 
 def test_excluded_callables_are_write_or_hash_only():

--- a/tests/test_build_transform_hash.py
+++ b/tests/test_build_transform_hash.py
@@ -74,10 +74,29 @@ def test_additive_measure_columns_is_in_the_closure():
 
 
 def test_no_identity_address_leak():
-    """Serialization red-test: a default repr of any referenced object would
-    embed ``0x...`` and make the fingerprint non-deterministic."""
-    leaks = [p[:120] for p in _all_parts() if re.search(r"0x[0-9a-fA-F]+", p)]
+    """Serialization red-test: a default repr of any referenced object embeds an
+    identity address ('<X object at 0x..>' / '<function .. at 0x..>') and makes
+    the fingerprint non-deterministic.  Match the identity-repr signature ' at
+    0x' specifically -- a stray '0x' in a source string literal is deterministic
+    source, not a runtime leak (and docstrings are stripped in _norm anyway)."""
+    leaks = [p[:120] for p in _all_parts() if re.search(r"at 0x[0-9a-fA-F]+", p)]
     assert not leaks, f"identity-repr leak in fingerprint parts: {leaks}"
+
+
+def test_self_method_build_calls_are_versioned():
+    """Round-5 fix (GH #522): a build METHOD called on self from a tagged
+    transform -- Wave.column_mapping / formatting_functions, which drive
+    YAML-route extraction -- is resolved against the module's classes, not just
+    module globals.  Their source must be folded; the hash MECHANISM methods
+    (_input_hash, _table_cache_hash) must NOT (self-reference)."""
+    seen, parts = set(), []
+    for _qn, (fn, _t) in R._BUILD_TRANSFORMS.items():
+        parts += R._closure_parts(fn, seen)
+    assert any("Wave.column_mapping=" in p for p in parts), "column_mapping not versioned"
+    assert any("formatting_functions=" in p for p in parts), "formatting_functions not versioned"
+    leaked_mech = [q for q in seen if q.endswith("._input_hash") or q.endswith("._table_cache_hash")
+                   or "build_transforms_fingerprint" in q or "framework_imports_fingerprint" in q]
+    assert not leaked_mech, f"hash mechanism leaked into the closure (self-reference): {leaked_mech}"
 
 
 def test_fingerprint_is_deterministic():
@@ -231,6 +250,8 @@ def test_excluded_callables_are_write_or_hash_only():
     mutators = ("astype(", "reset_index(", "set_index(", "rename(", "fillna(",
                 "replace(", "dropna(", "groupby(", "merge(", "reindex(")
     for qn in R._EXCLUDED_CALLABLES:
+        if ".local_tools." not in qn:
+            continue  # country hash methods are excluded for self-reference, not content
         fn = getattr(lt, qn.rsplit(".", 1)[1], None)
         assert fn is not None, f"excluded callable {qn} not found"
         src = inspect.getsource(inspect.unwrap(fn))

--- a/tests/test_build_transform_hash.py
+++ b/tests/test_build_transform_hash.py
@@ -190,6 +190,35 @@ def test_cache_mechanism_is_excluded_but_to_parquet_is_not():
         "to_parquet mutates content on write and MUST be versioned"
 
 
+def test_script_route_framework_helpers_are_versioned(monkeypatch):
+    """Round-3 fix (GH #522, script route): framework helpers reached only via
+    the OUT-OF-PROCESS script route -- e.g. conversion_table_matching_global,
+    imported by malawi.py and used by Malawi's food_acquired wave scripts -- are
+    invisible to the in-process closure walk.  framework_imports_fingerprint must
+    fold them, so editing the helper changes the wave hash (else: stale content)."""
+    import inspect
+    import lsms_library.local_tools as lt
+    c = lsms_library.country.Country("Malawi")
+    waves = [w for w in c.waves if (c[w].file_path / "_" / "food_acquired.py").exists()]
+    if not waves:
+        pytest.skip("no script-path food_acquired wave for Malawi")
+    w = c[waves[0]]
+    paths = (str(w.file_path / "_" / "food_acquired.py"),
+             str(c.file_path / "_" / "malawi.py"))
+    R.framework_imports_fingerprint.cache_clear()
+    base = R.framework_imports_fingerprint(paths)
+    assert base, "no framework-import closure folded for the Malawi script route"
+    # Editing the framework matcher's source must change the script-route hash.
+    target = inspect.unwrap(lt.conversion_table_matching_global)
+    real = inspect.getsource
+    monkeypatch.setattr(inspect, "getsource",
+                        lambda o: real(o) + "\n_redteam_probe = 1\n" if o is target else real(o))
+    R.framework_imports_fingerprint.cache_clear()
+    R.build_transforms_fingerprint.cache_clear()
+    assert R.framework_imports_fingerprint(paths) != base, \
+        "editing conversion_table_matching_global did not change the script-route fingerprint"
+
+
 def test_excluded_callables_are_write_or_hash_only():
     """Guard the _EXCLUDED_CALLABLES list: every excluded callable must be free
     of content-mutating ops, so the exclusion can never become a stale-cache."""

--- a/tests/test_build_transform_hash.py
+++ b/tests/test_build_transform_hash.py
@@ -118,9 +118,9 @@ def test_self_method_build_calls_are_versioned():
 
 
 def test_fingerprint_is_deterministic():
-    R.build_transforms_fingerprint.cache_clear()
+    R.clear_caches()
     a = R.build_transforms_fingerprint("food_acquired")
-    R.build_transforms_fingerprint.cache_clear()
+    R.clear_caches()
     b = R.build_transforms_fingerprint("food_acquired")
     assert a == b
 
@@ -253,8 +253,7 @@ def test_dynamically_dispatched_framework_helpers_are_versioned(monkeypatch, cou
     real = inspect.getsource
     monkeypatch.setattr(inspect, "getsource",
                         lambda o: real(o) + "\n_redteam_probe = 1\n" if o is target else real(o))
-    R.framework_imports_fingerprint.cache_clear()
-    R.build_transforms_fingerprint.cache_clear()
+    R.clear_caches()  # _source/_norm are memoised -> must clear to see the getsource edit
     after = c._table_cache_hash(table, c.waves)
     assert base != after, \
         f"editing framework helper {helper} did NOT invalidate {country}.{table} (#522 reopened)"

--- a/tests/test_build_transform_hash.py
+++ b/tests/test_build_transform_hash.py
@@ -260,6 +260,27 @@ def test_dynamically_dispatched_framework_helpers_are_versioned(monkeypatch, cou
         f"editing framework helper {helper} did NOT invalidate {country}.{table} (#522 reopened)"
 
 
+@pytest.mark.parametrize("country_name", ["Nigeria", "Uganda"])
+def test_local_helper_module_body_is_versioned(country_name, monkeypatch):
+    """Round-7 fix (GH #522): a LOCAL helper module loaded by spec_from_file_location
+    (e.g. _age_helpers.py: _clean_year / apply_age_handler bake DOB->Age into
+    household_roster) must have its OWN body file-hashed.  framework_imports_fingerprint
+    folds only its lsms_library-import closure (age_handler), not its own logic; the
+    all-_/*.py file-hash closes that.  Perturb the helper's content hash -> table hash changes."""
+    c = lsms_library.country.Country(country_name)
+    helper = c.file_path / "_" / "_age_helpers.py"
+    if not helper.exists():
+        pytest.skip(f"no _age_helpers.py for {country_name}")
+    base = c._table_cache_hash("household_roster", c.waves)
+    if base is None:
+        pytest.skip("household_roster not introspectable")
+    real = lsms_library.country.cached_file_hash
+    monkeypatch.setattr(lsms_library.country, "cached_file_hash",
+                        lambda p, _r=real, _h=str(helper): ((_r(p) or "") + "X") if str(p) == _h else _r(p))
+    assert c._table_cache_hash("household_roster", c.waves) != base, \
+        f"{country_name} _age_helpers.py body not file-hashed -> editing it serves stale cache"
+
+
 def test_excluded_callables_are_write_or_hash_only():
     """Guard the _EXCLUDED_CALLABLES list: every excluded callable must be free
     of content-mutating ops, so the exclusion can never become a stale-cache."""

--- a/tests/test_build_transform_hash.py
+++ b/tests/test_build_transform_hash.py
@@ -13,6 +13,7 @@ Plus drift (the tagged-entry-point set is pinned), determinism, per-table
 scoping, the no-wrapper tag invariant, and that the fingerprint is actually
 folded into both hash methods.
 """
+import os
 import re
 
 import pytest
@@ -29,7 +30,7 @@ EXPECTED_ENTRY_POINTS = {
     "lsms_library.build_transforms.fill_v_with_coord_bin",
     "lsms_library.build_transforms.apply_derived",
     "lsms_library.country._normalize_dataframe_index",
-    "lsms_library.country.Wave.grab_data",
+    "lsms_library.local_tools.df_data_grabber",
 }
 
 
@@ -56,7 +57,7 @@ def test_no_unresolved_build_imports():
     unresolved = []
     for qn, (fn, _t) in R._BUILD_TRANSFORMS.items():
         fn = R._unwrap(fn)
-        co = set(fn.__code__.co_names)
+        co = R._all_co_names(fn.__code__)   # nested scopes too (the #522-class fix)
         for name, obj in R._import_map(fn).items():
             if name in co and obj is None:
                 unresolved.append(f"{qn} -> {name}")
@@ -127,3 +128,75 @@ def test_fingerprint_is_wired_into_table_cache_hash(country_name, monkeypatch):
                         lambda table=None: "PERTURBED")
     perturbed = c._table_cache_hash("food_acquired", waves)
     assert perturbed != base, "build-transform fingerprint is NOT folded into _table_cache_hash"
+
+
+@pytest.mark.parametrize("country_name", ["Uganda"])
+def test_fingerprint_is_wired_into_input_hash(country_name, monkeypatch):
+    """Wave-level fold (red-team #5): perturbing the fingerprint must change
+    Wave._input_hash, else a refactor could drop the wave-level fold and serve
+    stale L2-wave parquets with every other test still green."""
+    c = lsms_library.country.Country(country_name)
+    w = c[c.waves[0]]
+    base = w._input_hash("food_acquired")
+    if base is None:
+        pytest.skip("wave input hash not introspectable")
+    monkeypatch.setattr(lsms_library.country, "build_transforms_fingerprint",
+                        lambda table=None: "PERTURBED")
+    assert w._input_hash("food_acquired") != base, \
+        "build-transform fingerprint is NOT folded into Wave._input_hash"
+
+
+def test_nested_scope_references_are_walked():
+    """Red-team #1/#2 regression: a callable referenced ONLY from a nested
+    helper (comprehension/lambda/inner def) must appear in _all_co_names.
+    Without co_consts recursion, df_data_grabber-class deps vanish -> stale cache."""
+    def outer():
+        def inner():
+            return _SENTINEL_NESTED_NAME()  # referenced only here
+        return [inner() for _ in range(_SENTINEL_NESTED_NAME and 1)]
+    names = R._all_co_names(outer.__code__)
+    assert "_SENTINEL_NESTED_NAME" in names, "nested-scope name not captured by _all_co_names"
+
+
+def test_df_data_grabber_is_versioned():
+    """Red-team #6 positive-coverage: the core extraction transform's SOURCE
+    must be a folded closure part (so editing it invalidates)."""
+    seen, parts = set(), []
+    for _qn, (fn, _t) in R._BUILD_TRANSFORMS.items():
+        parts += R._closure_parts(fn, seen)
+    joined = "\x1f".join(parts)
+    assert "local_tools.df_data_grabber=" in joined, \
+        "df_data_grabber not folded into the closure -> extraction edits would not invalidate"
+
+
+def test_no_absolute_path_or_dunder_leak():
+    """Red-team #3: __file__ resolves to the package's ABSOLUTE path; folding it
+    as a constant makes the hash machine/install-dependent.  Assert the package's
+    absolute path never appears in any part, and no dunder name=value constant
+    leaks.  (AST *source* dumps legitimately contain the literal string
+    'lsms_library' -- that is source, not a runtime path, so we match the real
+    absolute install path instead.)"""
+    seen, parts = set(), []
+    for _qn, (fn, _t) in R._BUILD_TRANSFORMS.items():
+        parts += R._closure_parts(fn, seen)
+    pkg_abs = os.path.dirname(lsms_library.__file__)        # /.../lsms_library (runtime, machine-specific)
+    bad = [p[:120] for p in parts if pkg_abs in p or re.search(r"\.__\w+__=", p)]
+    assert not bad, f"absolute-path / dunder constant leak: {bad}"
+
+
+def test_fingerprint_stable_across_pythonhashseed():
+    """Red-team #7: set/dict ordering must not depend on PYTHONHASHSEED.  Compute
+    the fingerprint in two subprocesses with different seeds and compare."""
+    import os
+    import subprocess
+    import sys
+    code = ("import lsms_library.country, lsms_library.build_transforms, lsms_library.local_tools;"
+            "from lsms_library import _build_registry as R;"
+            "print(R.build_transforms_fingerprint('food_acquired'))")
+    outs = []
+    for seed in ("0", "1"):
+        env = dict(os.environ, PYTHONHASHSEED=seed)
+        r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+        assert r.returncode == 0, r.stderr
+        outs.append(r.stdout.strip())
+    assert outs[0] == outs[1], f"fingerprint depends on PYTHONHASHSEED: {outs}"

--- a/tests/test_build_transform_hash.py
+++ b/tests/test_build_transform_hash.py
@@ -281,6 +281,24 @@ def test_local_helper_module_body_is_versioned(country_name, monkeypatch):
         f"{country_name} _age_helpers.py body not file-hashed -> editing it serves stale cache"
 
 
+def test_local_data_file_build_input_is_versioned(monkeypatch):
+    """Round-8 fix (GH #522): a .csv/.json data table in a _/ dir (Malawi
+    ihs3_conversions.csv -> cfactor -> Quantity_kg, baked and not re-applied on
+    read) must be content-hashed like the .py helper bodies."""
+    c = lsms_library.country.Country("Malawi")
+    csv = c.file_path / "2010-11" / "_" / "ihs3_conversions.csv"
+    if not csv.exists():
+        pytest.skip("no ihs3_conversions.csv")
+    base = c._table_cache_hash("food_acquired", c.waves)
+    if base is None:
+        pytest.skip("food_acquired not introspectable")
+    real = lsms_library.country.cached_file_hash
+    monkeypatch.setattr(lsms_library.country, "cached_file_hash",
+                        lambda p, _r=real, _h=str(csv): ((_r(p) or "") + "X") if str(p) == _h else _r(p))
+    assert c._table_cache_hash("food_acquired", c.waves) != base, \
+        "ihs3_conversions.csv not content-hashed -> editing it serves stale Quantity_kg"
+
+
 def test_excluded_callables_are_write_or_hash_only():
     """Guard the _EXCLUDED_CALLABLES list: every excluded callable must be free
     of content-mutating ops, so the exclusion can never become a stale-cache."""

--- a/tests/test_build_transform_hash.py
+++ b/tests/test_build_transform_hash.py
@@ -1,0 +1,129 @@
+"""Red-tests for the build-path transform cache fingerprint (cache step 2).
+
+Guards the two genuinely hard sub-problems behind
+``lsms_library/_build_registry.py`` (see
+``SkunkWorks/build_transform_cache_hash.org``):
+
+- *resolution* -- the closure walk must not silently drop a referenced
+  ``lsms_library`` object via the function-level-import (cycle-dodge) idiom;
+- *serialization* -- no referenced constant may leak a ``0x`` identity address
+  into the fingerprint (which would make it non-deterministic).
+
+Plus drift (the tagged-entry-point set is pinned), determinism, per-table
+scoping, the no-wrapper tag invariant, and that the fingerprint is actually
+folded into both hash methods.
+"""
+import re
+
+import pytest
+
+import lsms_library  # noqa: F401  (ensure package import side effects)
+import lsms_library.country  # noqa: F401
+import lsms_library.build_transforms  # noqa: F401
+from lsms_library import _build_registry as R
+
+
+EXPECTED_ENTRY_POINTS = {
+    "lsms_library.build_transforms.food_acquired_to_canonical",
+    "lsms_library.build_transforms._finalize_canonical_food_acquired",
+    "lsms_library.build_transforms.fill_v_with_coord_bin",
+    "lsms_library.build_transforms.apply_derived",
+    "lsms_library.country._normalize_dataframe_index",
+    "lsms_library.country.Wave.grab_data",
+}
+
+
+def _all_parts():
+    seen, parts = set(), []
+    for _qn, (fn, _tables) in R._BUILD_TRANSFORMS.items():
+        parts += R._closure_parts(fn, seen)
+    return parts
+
+
+def test_entry_point_set_is_pinned():
+    """Drift guard: a new/removed build-path tag must be a conscious change."""
+    assert R.registered_entry_points() == EXPECTED_ENTRY_POINTS
+
+
+def test_no_unresolved_build_imports():
+    """Resolution red-test: every referenced function-level import resolves.
+
+    This is the GH #514 class -- ``getattr(own_module, name)`` misses the
+    ``from .feature import _ADDITIVE_MEASURE_COLUMNS`` cycle-dodge import.  If a
+    future edit adds such an import and the AST walk can't resolve it, the
+    closure would silently drop a build dependency -> stale cache.  Fail loudly.
+    """
+    unresolved = []
+    for qn, (fn, _t) in R._BUILD_TRANSFORMS.items():
+        fn = R._unwrap(fn)
+        co = set(fn.__code__.co_names)
+        for name, obj in R._import_map(fn).items():
+            if name in co and obj is None:
+                unresolved.append(f"{qn} -> {name}")
+    assert not unresolved, f"unresolved build imports (closure would drop them): {unresolved}"
+
+
+def test_additive_measure_columns_is_in_the_closure():
+    """The motivating symbol: reached via a function-level import, its VALUE
+    (not just its name) must be folded in, so editing it invalidates."""
+    joined = "\x1f".join(_all_parts())
+    assert "_ADDITIVE_MEASURE_COLUMNS" in joined
+    assert "country._ADDITIVE_MEASURE_COLUMNS=" in joined  # value serialized, not just referenced
+
+
+def test_no_identity_address_leak():
+    """Serialization red-test: a default repr of any referenced object would
+    embed ``0x...`` and make the fingerprint non-deterministic."""
+    leaks = [p[:120] for p in _all_parts() if re.search(r"0x[0-9a-fA-F]+", p)]
+    assert not leaks, f"identity-repr leak in fingerprint parts: {leaks}"
+
+
+def test_fingerprint_is_deterministic():
+    R.build_transforms_fingerprint.cache_clear()
+    a = R.build_transforms_fingerprint("food_acquired")
+    R.build_transforms_fingerprint.cache_clear()
+    b = R.build_transforms_fingerprint("food_acquired")
+    assert a == b
+
+
+def test_per_table_scoping():
+    """food_acquired folds in its food-specific tags; household_roster does
+    not -- so their fingerprints differ."""
+    fa = R.build_transforms_fingerprint("food_acquired")
+    hr = R.build_transforms_fingerprint("household_roster")
+    assert fa != hr
+
+
+def test_tags_do_not_wrap():
+    """@build_transform must return the function unchanged (no wrapper)."""
+    assert lsms_library.build_transforms.apply_derived.__name__ == "apply_derived"
+    assert lsms_library.build_transforms.food_acquired_to_canonical.__qualname__ == \
+        "food_acquired_to_canonical"
+    assert lsms_library.country._normalize_dataframe_index.__code__ is not None
+
+
+def test_serialiser_rejects_unknown_types():
+    """_ser must raise on an un-serialisable type rather than leak an identity
+    repr (the else-reject branch)."""
+    class Weird:
+        pass
+    with pytest.raises(TypeError):
+        R._ser(Weird(), set(), [])
+
+
+@pytest.mark.parametrize("country_name", ["Uganda"])
+def test_fingerprint_is_wired_into_table_cache_hash(country_name, monkeypatch):
+    """The country-level hash must fold in the build-transform fingerprint:
+    perturbing the fingerprint (simulating a build-code edit) must change
+    _table_cache_hash without any data/config change."""
+    c = lsms_library.country.Country(country_name)
+    waves = c.waves
+    base = c._table_cache_hash("food_acquired", waves)
+    if base is None:
+        pytest.skip("table not introspectable for this country")
+    monkeypatch.setattr(R, "build_transforms_fingerprint", lambda table=None: "PERTURBED")
+    # country.py imported the name, so patch there too
+    monkeypatch.setattr(lsms_library.country, "build_transforms_fingerprint",
+                        lambda table=None: "PERTURBED")
+    perturbed = c._table_cache_hash("food_acquired", waves)
+    assert perturbed != base, "build-transform fingerprint is NOT folded into _table_cache_hash"

--- a/tests/test_build_transform_hash.py
+++ b/tests/test_build_transform_hash.py
@@ -30,6 +30,7 @@ EXPECTED_ENTRY_POINTS = {
     "lsms_library.build_transforms.fill_v_with_coord_bin",
     "lsms_library.build_transforms.apply_derived",
     "lsms_library.country._normalize_dataframe_index",
+    "lsms_library.country.Wave.grab_data",
     "lsms_library.local_tools.df_data_grabber",
 }
 
@@ -147,15 +148,61 @@ def test_fingerprint_is_wired_into_input_hash(country_name, monkeypatch):
 
 
 def test_nested_scope_references_are_walked():
-    """Red-team #1/#2 regression: a callable referenced ONLY from a nested
-    helper (comprehension/lambda/inner def) must appear in _all_co_names.
-    Without co_consts recursion, df_data_grabber-class deps vanish -> stale cache."""
+    """Red-team #1/#2 regression -- NON-VACUOUS: a name referenced ONLY inside a
+    nested def must be ABSENT from the flat top-level co_names yet PRESENT in the
+    recursive _all_co_names.  (round-2 caught the earlier version putting the
+    sentinel in a comprehension iterable, which leaks into the enclosing
+    co_names and made the test pass even with the co_consts recursion removed.)"""
     def outer():
         def inner():
-            return _SENTINEL_NESTED_NAME()  # referenced only here
-        return [inner() for _ in range(_SENTINEL_NESTED_NAME and 1)]
-    names = R._all_co_names(outer.__code__)
-    assert "_SENTINEL_NESTED_NAME" in names, "nested-scope name not captured by _all_co_names"
+            return _SENTINEL_NESTED_NAME()   # referenced ONLY in this nested def
+        return inner
+    flat = set(outer.__code__.co_names)
+    assert "_SENTINEL_NESTED_NAME" not in flat, "test vacuous: name leaked into flat co_names"
+    assert "_SENTINEL_NESTED_NAME" in R._all_co_names(outer.__code__), \
+        "nested-scope name not captured -> co_consts recursion is broken (GH #522 reopens)"
+
+
+def test_grab_data_body_is_versioned():
+    """Round-2 fix: Wave.grab_data's inline content logic (check_adding_t, the
+    >1e99 sentinel filter, the dfs merge) and map_index (the j->i swap) must be
+    folded into the closure, else editing them serves a stale L2-wave parquet."""
+    seen, parts = set(), []
+    for _qn, (fn, _t) in R._BUILD_TRANSFORMS.items():
+        parts += R._closure_parts(fn, seen)
+    joined = "\x1f".join(parts)
+    assert "country.Wave.grab_data=" in joined, "grab_data body not versioned"
+    assert any("map_index" in p for p in parts), "map_index (j->i swap) not versioned"
+
+
+def test_cache_mechanism_is_excluded_but_to_parquet_is_not():
+    """Round-2 fix: re-tagging grab_data must NOT drag the pure hash/freshness
+    mechanism into the content fingerprint (self-referential over-invalidation)
+    -- BUT to_parquet mutates content on write (astype/reset_index/replace), so
+    it MUST stay versioned (excluding it would be a new under-invalidation)."""
+    seen = set()
+    for _qn, (fn, _t) in R._BUILD_TRANSFORMS.items():
+        R._closure_parts(fn, seen)
+    for prim in ("lsms_library.local_tools.cache_freshness",
+                 "lsms_library.local_tools.source_fingerprint"):
+        assert prim not in seen, f"pure hash primitive {prim} leaked into the content closure"
+    assert "lsms_library.local_tools.to_parquet" in seen, \
+        "to_parquet mutates content on write and MUST be versioned"
+
+
+def test_excluded_callables_are_write_or_hash_only():
+    """Guard the _EXCLUDED_CALLABLES list: every excluded callable must be free
+    of content-mutating ops, so the exclusion can never become a stale-cache."""
+    import inspect
+    from lsms_library import local_tools as lt
+    mutators = ("astype(", "reset_index(", "set_index(", "rename(", "fillna(",
+                "replace(", "dropna(", "groupby(", "merge(", "reindex(")
+    for qn in R._EXCLUDED_CALLABLES:
+        fn = getattr(lt, qn.rsplit(".", 1)[1], None)
+        assert fn is not None, f"excluded callable {qn} not found"
+        src = inspect.getsource(inspect.unwrap(fn))
+        bad = [m for m in mutators if m in src]
+        assert not bad, f"excluded {qn} contains content-mutating ops {bad} -> unsafe to exclude"
 
 
 def test_df_data_grabber_is_versioned():

--- a/tests/test_build_transform_hash.py
+++ b/tests/test_build_transform_hash.py
@@ -31,6 +31,7 @@ EXPECTED_ENTRY_POINTS = {
     "lsms_library.build_transforms.apply_derived",
     "lsms_library.country._normalize_dataframe_index",
     "lsms_library.country.Wave.grab_data",
+    "lsms_library.country.Country._aggregate_wave_data",
     "lsms_library.local_tools.df_data_grabber",
 }
 
@@ -81,6 +82,23 @@ def test_no_identity_address_leak():
     source, not a runtime leak (and docstrings are stripped in _norm anyway)."""
     leaks = [p[:120] for p in _all_parts() if re.search(r"at 0x[0-9a-fA-F]+", p)]
     assert not leaks, f"identity-repr leak in fingerprint parts: {leaks}"
+
+
+def test_orchestrator_versioned_but_read_path_is_not():
+    """Round-6 fix: the build orchestrator _aggregate_wave_data bakes cross-wave
+    alignment+concat (nested safe_concat_dataframe_dict) into the parquet, NOT
+    re-applied on read, so it must be versioned.  But _finalize_result and its
+    read-path subtree (kinship/spellings), re-applied on every read, must NOT be
+    in the closure (else read-path edits over-invalidate the warm cache)."""
+    seen, parts = set(), []
+    for _qn, (fn, _t) in R._BUILD_TRANSFORMS.items():
+        parts += R._closure_parts(fn, seen)
+    joined = "\x1f".join(parts)
+    assert any("_aggregate_wave_data=" in p for p in parts), "orchestrator not versioned"
+    assert "safe_concat_dataframe_dict" in joined, "nested cross-wave concat not folded"
+    leaked = [q for q in seen if q.endswith("._finalize_result") or "_expand_kinship" in q
+              or "enforce_canonical_spellings" in q or q.endswith("._join_v_from_sample")]
+    assert not leaked, f"read-path transforms leaked into the build closure: {leaked}"
 
 
 def test_self_method_build_calls_are_versioned():


### PR DESCRIPTION
## What

**Step 2** of the build/read cache work (follows #534's module split; design in #539, rev-4): version build-path transform **code** in the L2 content hash, closing the **GH #522** blind spot. Before this, the v0.8.0 hash versioned build-path *inputs* (config, per-country scripts) but not the framework transform *code* those scripts call — so editing e.g. `food_acquired_to_canonical`, `_normalize_dataframe_index`'s collapse, or `_aggregate_wave_data`'s cross-wave concat left a hash-valid **stale** parquet, served silently.

## Mechanism (`lsms_library/_build_registry.py` + two folds in the hash methods)

A build transform is tagged `@build_transform()` (a no-op tag). `build_transforms_fingerprint(table)` hashes the **transitive `lsms_library` closure** of every tagged entry point relevant to `table`, folded into `Wave._input_hash` and `Country._table_cache_hash` (degrading to read-if-present on any failure — never raises out of the hash).

Coverage is **two complementary layers**:

1. **In-process closure** (the YAML/`grab_data` route). Tagged: `food_acquired_to_canonical`, `_finalize_canonical_food_acquired`, `apply_derived`, `fill_v_with_coord_bin`, `_normalize_dataframe_index`, `Wave.grab_data`, `Country._aggregate_wave_data` (the build orchestrator), `df_data_grabber`. Resolution handles: module globals, function-level/cycle-dodge imports, **nested** code objects, callables in constant containers, and `self.<method>` build calls. Read-path (`_finalize_result` + kinship/spellings/`_join_v_from_sample`) and the cache **mechanism** (`_input_hash`/`_table_cache_hash`/freshness primitives) are *excluded* — the former is re-applied on every read, the latter would self-reference. `data_access`/`paths` modules excluded (access/location, not content). `to_parquet` *kept* (it mutates content on write).
2. **File-hash + import-closure layer** (the out-of-process **script** route, `spec_from_file_location` local helpers, `df_edit` hooks). Both hash methods content-hash **every** build input in the wave/country `_/` dirs (`.py`/`.csv`/`.json`/`.txt`/`.tab`/`.tsv`, keyed by filename → machine-independent) **and** fold the `lsms_library`-import closures those modules reach.

Determinism: AST-normalized source (comments + docstrings stripped), sets sorted by serialized form, no identity-`repr` (type-dispatch serializer with else-*reject*), Python-minor folded in. Verified byte-identical across `PYTHONHASHSEED`/cwd. Cost: one-time ~250–400ms per-process warmup (memoized), **warm hash ~8ms** (was ~1–4ms) — the v0.7.0 warm fast path is preserved.

## Adversarially hardened (8 red-team rounds)

This was built and then **red-teamed across 8 multi-agent rounds**, each finding independently verified before it counted. Every round surfaced a real defect, fixed in the correspondingly-named commit:

| Round | Finding (severity) | Fix |
|---|---|---|
| 1 | nested `co_consts` references dropped (**critical**) | recurse nested code objects |
| 2 | `grab_data` body unversioned; vacuous test (medium) | re-tag + exclude only true mechanism |
| 3 | script-route framework helpers (high) | `framework_imports_fingerprint` |
| 4 | local helpers / `df_edit` hooks (high) | fold all `_/*.py` import closures |
| 5 | `self.<method>` build calls (high) | method resolution + mechanism exclusion |
| 6 | build orchestrator `_aggregate_wave_data` (high) | tag orchestrator; exclude read-path `_finalize_result` |
| 7 | local helper module **bodies** (high) | file-hash every `_/*.py` body |
| 8 | `_/`-dir `.csv`/`.json` build inputs (high) | content-hash `_BUILD_INPUT_SUFFIXES` |

Each fix is reproduced by an end-to-end test (e.g. editing `_aggregate_wave_data`/`column_mapping`/`age_handler`/`ihs3_conversions.csv` now invalidates the relevant table, while a read-path edit does **not**).

## Known residual (accepted, documented)

A framework helper reached by **purely string-keyed dynamic dispatch** (`getattr(mod, runtime_string)()` / `import_module(runtime_string)`) is not statically resolvable and is **not** folded. This is the same residual the v0.8.0 design already accepts; it is backstopped by the manual `LSMS_CACHE_SCHEMA` lever (folded into both hash methods) plus `LSMS_NO_CACHE` / `cache clear` / the `make` backend. Documented in `_build_registry.py`.

## Tests / scope

- `tests/test_build_transform_hash.py` — 25 tests: drift-pin of the entry-point set, two resolution/serialization red-tests, the per-round regression tests above, determinism (incl. cross-`PYTHONHASHSEED` subprocess), and the exclusion-safety guards.
- 5 files, +825 lines; full suite collects clean (1995 tests); offline `Country(...)` verified across 7 countries.

`LSMS_CACHE_SCHEMA` is retained as the belt-and-suspenders backstop. Step-1 (#534) is already merged; this builds on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
