### PR TITLE
fix(#530): surface Guatemala cluster_features Region for market='Region'

### DIFF
--- a/lsms_library/countries/Guatemala/2000/_/data_info.yml
+++ b/lsms_library/countries/Guatemala/2000/_/data_info.yml
@@ -29,6 +29,13 @@ cluster_features:
             - mapping:
                 urbana: Urban
                 rural: Rural
+        # `region` is the 8 Guatemalan geographic regions (string-labelled:
+        # central / metropolitana / norte / nororiente / noroccidente /
+        # suroriente / suroccidente / peten).  It is already the cluster index
+        # (v) but was never surfaced as a column, so market='Region' raised
+        # KeyError.  Expose it so demand estimation by region works (GH #530,
+        # same class as Azerbaijan).
+        Region: region
 
 household_roster:
     file: ECV09P05.DTA


### PR DESCRIPTION
Same class as Azerbaijan #530 (PR #540), surfaced by the post-fix `Feature()` audit — the predicted repeat of the unsurfaced-geography pattern.

Guatemala 2000 `cluster_features` keys on `v: region` (the 8 geographic regions) but never exposed `region` as a *column*, so `market='Region'` raised `KeyError: "'Region' not in cluster_features columns. Available: ['Rural']"`. The region is already in `ECV01H01.DTA` with clean string labels — one-line fix: `Region: region` in cluster_features myvars.

### Verification (forced rebuild, counterfactual)
| | `market='Region'` | roster |
|---|---|---|
| before | `KeyError` | 37,771 |
| after | 7,276 rows, **8 named regions** (central, metropolitana, noroccidente, nororiente, norte, peten, suroccidente, suroriente), **0 NaN m** | 37,771 (unchanged) |

No regression. (Even simpler than Azerbaijan — the region was already the cluster index, just unsurfaced.)