### PR TITLE
fix(#504): guard update_id suffix-mint against re-using a live household id

### DIFF
--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -1778,18 +1778,37 @@ def update_id(d: dict[str, str], id_splits: dict[str, int]) -> tuple[dict[str, s
         else:
             D_inv[v].append(k)
 
+    # GH #504: a minted suffix ``k_N`` must never equal an id a real household
+    # already holds -- a target value carried forward into this wave
+    # (``d.values()``) or one already emitted in this call.  The old code minted
+    # ``k_N`` from a per-base counter that could re-use a *live* suffix (a
+    # ``previous_i`` carried forward as ``k_N``), silently collapsing two
+    # distinct lineages onto one canonical id (60 such collisions in Malawi
+    # 2019-20; they propagate to anthropometry/sample/plot_features via the
+    # groupby().first() collapse).  Guard the mint by bumping past any clash.
+    # Single-source and ``it == 0`` passes are unchanged, so non-colliding
+    # households keep their original ids (byte-stable for healthy panels).
+    live = set(d.values())
+    emitted = set()
+
     updated_id = {}
     for k, v in D_inv.items():
-        if len(v)==1: 
+        if len(v)==1:
             updated_id[v[0]] = k
             id_splits[k] = 0
+            emitted.add(k)
         else:
             for it,v_element in enumerate(v):
-                split = id_splits.get(k, 0) + it
                 if it == 0:
-                    updated_id[v_element] = k
+                    cand = k
                 else:
-                    updated_id[v_element] = '%s_%d' % (k,split)
+                    split = id_splits.get(k, 0) + it
+                    cand = '%s_%d' % (k, split)
+                    while cand in live or cand in emitted:
+                        split += 1
+                        cand = '%s_%d' % (k, split)
+                updated_id[v_element] = cand
+                emitted.add(cand)
             id_splits[k] = id_splits.get(k, 0)+len(v)-1
 
     return updated_id, id_splits


### PR DESCRIPTION
Closes #504. Addresses the **Malawi** portion of #536 / #513.

`update_id` could mint a `k_N` suffix that a *real* household already holds (carried forward as a `previous_i`), collapsing two distinct lineages into one canonical id. The guard bumps the suffix past any id already live in the wave or already emitted; healthy passes are byte-stable.

### Verified (forced rebuild, counterfactual)
Malawi `updated_ids['2019-20']`: **60 collisions → 0**. anthropometry +37 / sample +60 / plot_features +23 rows; all dupwarn →0. Healthy panels (Burkina_Faso / Tanzania / Ethiopia) `updated_ids` **byte-identical**; 84-id churn confined to Malawi 2019-20.

### Red-team (v2, 3 lenses)
No regression, **no household/row lost** (pure recovery). Auto-invalidates under the v0.8.0 build-transform hash (a warm read rebuilds with the fix — demonstrated).

### Scope / known-open
Fixes the **`update_id` mechanism** (Malawi). The same rename-onto-occupied *class* survives in countries whose **bespoke `panel_ids.py` bypasses `update_id`** (Niger 59, GhanaLSS 2) — pre-existing, identical on `development`, **filed as follow-up**, out of scope here.