### PR TITLE
feat(labels): loud structured degrade for labels=X on countries lacking the column

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -49,6 +49,7 @@ from .local_tools import (
 from .paths import data_root, countries_root
 from .yaml_utils import load_yaml
 from .currency import attach_currency, is_monetary_table
+from .errors import LabelUnavailableError
 from ._build_registry import build_transform, build_transforms_fingerprint, framework_imports_fingerprint
 import importlib.util
 import hashlib
@@ -2053,18 +2054,27 @@ class Country:
         if table is None:
             table = cat_maps.get('harmonize_food')
         if table is None:
-            raise KeyError(
+            # Country never curated a food-label table -> it cannot honour the
+            # relabel.  LabelUnavailableError (a KeyError subclass) lets Feature
+            # degrade gracefully while direct callers still catch KeyError.
+            raise LabelUnavailableError(
                 f"No food label table ('food_items' or 'harmonize_food') "
                 f"on {self.name!r} for labels={labels!r}"
             )
         if 'Preferred Label' not in table.columns:
+            # Malformed table (has a food-label table but no key column) -> a
+            # genuine data defect, NOT a missing-curation case.  Plain KeyError
+            # so it surfaces loudly rather than being degraded-over by Feature.
             raise KeyError(
                 f"Food label table on {self.name!r} has no 'Preferred Label' column"
             )
         target = f"{labels} Label" if f"{labels} Label" in table.columns else labels
         if target not in table.columns:
             available = [c for c in table.columns if c != 'Preferred Label']
-            raise KeyError(
+            # Country curates a food-label table but not THIS label column
+            # (e.g. labels='Aggregate' against an EHCVM 'Original Label'-only
+            # table) -> missing curation, degradable by Feature.
+            raise LabelUnavailableError(
                 f"Column {target!r} not in food label table on {self.name!r}; "
                 f"available: {available}"
             )

--- a/lsms_library/errors.py
+++ b/lsms_library/errors.py
@@ -1,0 +1,22 @@
+"""Shared exception types for lsms_library.
+
+Kept dependency-free (a leaf module) so both ``country`` and ``feature`` can
+import it without a circular reference.
+"""
+from __future__ import annotations
+
+
+class LabelUnavailableError(KeyError):
+    """A country cannot honour a ``labels=X`` relabeling request.
+
+    Raised by :meth:`Country._relabel_j` when the country has no food-label
+    table, or its table lacks the requested column (e.g. ``labels='Aggregate'``
+    against an EHCVM country that only curates ``Original Label``).
+
+    Subclasses :class:`KeyError` so existing ``except KeyError`` handlers -- and
+    direct ``Country(...).food_*(labels=...)`` callers -- keep catching it
+    unchanged.  ``Feature`` catches it *specifically* to degrade gracefully:
+    drop the country with one aggregated warning plus a ``df.attrs`` marker,
+    rather than conflating a country that simply never curated the label with a
+    genuine per-country build failure (a malformed table, a real bug, ...).
+    """

--- a/lsms_library/feature.py
+++ b/lsms_library/feature.py
@@ -25,6 +25,7 @@ from importlib.resources import files
 from .yaml_utils import load_yaml
 from .currency import CURRENCY_LEVEL, is_monetary_table
 from .paths import countries_root
+from .errors import LabelUnavailableError
 
 
 def _load_global_columns() -> dict[str, dict[str, Any]]:
@@ -369,6 +370,11 @@ class Feature:
             if "m" not in canonical_levels:
                 canonical_levels = canonical_levels + ["m"]
 
+        # Countries dropped because they cannot honour a labels=X request (no
+        # curated column).  Accumulated and reported ONCE after the loop, with a
+        # df.attrs marker -- distinct from genuine per-country build failures.
+        labels_unavailable: list[str] = []
+
         for name in targets:
             try:
                 c = Country(name, trust_cache=effective_trust_cache)
@@ -406,6 +412,11 @@ class Feature:
                 # Prepend country as an index level
                 df = pd.concat({name: df}, names=["country"])
                 frames.append(df)
+            except LabelUnavailableError:
+                # Country curates no such label column -> degrade, don't conflate
+                # with a build failure.  Reported once after the loop (Contract B).
+                labels_unavailable.append(name)
+                continue
             except Exception as e:  # broad catch intentional: surface per-country failures as warnings
                 # Cross-country aggregation must not crash on one country's
                 # implementation error; the warning carries the specific type.
@@ -413,8 +424,23 @@ class Feature:
                     f"Failed to load {self.table_name} for {name}: {type(e).__name__}: {e}"
                 )
 
+        def _mark_labels_unavailable(result: pd.DataFrame, n_kept: int) -> pd.DataFrame:
+            """Contract B: one aggregated warning + a df.attrs marker for the
+            countries dropped because they curate no requested label column."""
+            if not labels_unavailable:
+                return result
+            warnings.warn(
+                f"{self.table_name}: labels={kwargs.get('labels')!r} unavailable "
+                f"for {len(labels_unavailable)} country(ies) {labels_unavailable} "
+                f"-- they curate no such food-label column and were dropped from "
+                f"the assembly (kept {n_kept}). Add the column or pass a country "
+                f"subset to silence this."
+            )
+            result.attrs['labels_unavailable'] = list(labels_unavailable)
+            return result
+
         if not frames:
-            return pd.DataFrame()
+            return _mark_labels_unavailable(pd.DataFrame(), 0)
 
         # pandas cannot stack frames whose index DEPTH/NAMES differ into a named
         # MultiIndex -- it falls back to an unnamed object index, collapsing the
@@ -445,6 +471,7 @@ class Feature:
                 frames = kept
 
         result = pd.concat(frames)
+        n_kept = result.index.get_level_values("country").nunique()
 
         # GH #326: pd.concat can leave the (structurally-consistent) index
         # levels UNNAMED, forcing callers to index positionally instead of
@@ -474,4 +501,4 @@ class Feature:
                 f"unnamed object index; per-country index names differ: {shapes}"
             )
 
-        return result
+        return _mark_labels_unavailable(result, n_kept)


### PR DESCRIPTION
Settles the `labels=X` API contract surfaced by the post-fix `Feature()` audit (bucket 3). Chosen contract: **B — loud structured degrade**.

### The problem (inconsistent contract across API levels)
| call | a country lacking the `Aggregate` column (today) |
|---|---|
| `Country('Benin').food_acquired(labels='Aggregate')` | hard `KeyError` |
| `Feature('food_acquired')(labels='Aggregate')` | **silently dropped**, buried in a generic "Failed to load … KeyError" |

So `Feature('food_prices')(labels='Aggregate')` over all 16 food countries returned only the **4** that curate the column, with the 12 omissions looking like build failures. A demand system built on that silently covered a quarter of the data.

### Contract B
- **`lsms_library/errors.py`** (new): `LabelUnavailableError(KeyError)`. A `KeyError` subclass, so existing `except KeyError` and direct `Country(...).food_*(labels=)` callers are unaffected.
- **`country.py _relabel_j`**: raise it for the two *missing-curation* cases (no food-label table; column absent). The malformed-table and no-`j`-level cases stay **plain `KeyError`** — genuine defects must surface loudly, not be degraded over.
- **`feature.py`**: catch it *specifically* (before the broad except), accumulate dropped countries, then emit **one** aggregated warning + stamp `result.attrs['labels_unavailable'] = [...]` (machine-detectable).

### Verified
- Country: `Benin … labels='Aggregate'` → `LabelUnavailableError` (`isinstance KeyError == True`).
- Feature `['Uganda','Benin','Niger']`: keeps `['Uganda']`; **one** warning; `attrs['labels_unavailable']==['Benin','Niger']`.
- all-have (Uganda+Malawi): no warning/marker, 1.33M rows. all-dropped: empty + marker + warning. no-labels baseline: unaffected.
- **747 passed** (label/feature suite). The 1 `test_currency::test_feature_ghana_per_wave` failure is **pre-existing on `development`** (a list-vs-set test bug, no `labels=` path) — filed separately.

### Follow-ups (not in scope)
- Per-country content: add `Aggregate` columns to the 12 missing countries (the real coverage fix).
- A skill documenting this contract (guardrail) + the how-to-add-the-column workflow.