### PR TITLE
ci: publish to PyPI on GitHub Release (Trusted Publishing / OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,74 @@
+name: publish
+
+# Build a wheel + sdist and publish to PyPI when a GitHub Release is PUBLISHED.
+# Draft releases do NOT fire this (the `published` type only) -- so a release can
+# be staged as a draft and shipped by publishing it. The version is derived from
+# the release's git tag by poetry-dynamic-versioning, so there is no manual
+# version bump and no risk of the mis-versioned-wheel failure mode (see
+# .claude/skills/release/SKILL.md). Running in CI also sidesteps the local
+# keyring hang documented there -- Trusted Publishing (OIDC) stores no token.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # poetry-dynamic-versioning reads git tags to derive the version; the
+          # default shallow clone has none, which silently yields 0.0.0. Full
+          # history + tags is REQUIRED.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install poetry + dynamic-versioning plugin
+        # The [tool.poetry.requires-plugins] declaration is NOT enough in Poetry
+        # 2.x; the plugin must be actually installed or `poetry build` produces a
+        # 0.0.0 wheel. (release skill, "must be installed as a Poetry plugin".)
+        run: |
+          pip install poetry
+          poetry self add "poetry-dynamic-versioning[plugin]>=1.0.0,<2.0.0"
+
+      - name: Resolve & sanity-check version
+        run: |
+          VERSION=$(poetry version -s)
+          echo "Building $VERSION (release tag: ${GITHUB_REF_NAME})"
+          if [ "$VERSION" = "0.0.0" ]; then
+            echo "::error::Dynamic version resolved to 0.0.0 -- plugin inactive or tags not fetched (need fetch-depth: 0)."
+            exit 1
+          fi
+
+      - name: Build sdist + wheel
+        run: poetry build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Trusted Publishing (OIDC) -- no stored PyPI token. One-time setup on PyPI:
+    # add this repo (owner=ligon, repo=LSMS_Library, workflow=publish.yml) as a
+    # Trusted Publisher for the LSMS_Library project at
+    # https://pypi.org/manage/project/LSMS_Library/settings/publishing/
+    # (leave the "environment" field blank to match this workflow as written).
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Closes the gap where releases were manual — and **PyPI is currently stuck at 0.7.3 while the latest tag is v0.7.4** (tagged, never published).

### What it does
`on: release: published` → build sdist+wheel with poetry (+ dynamic-versioning plugin) → upload to PyPI via `pypa/gh-action-pypi-publish` with **Trusted Publishing (OIDC)** — no stored token.

- **Version is automatic** — derived from the release tag by `poetry-dynamic-versioning`. `fetch-depth: 0` (full history+tags) and `poetry self add` the plugin are both required to avoid the documented **0.0.0 mis-versioned wheel** failure; the build **fails fast** if the version resolves to 0.0.0.
- **Sidesteps the release-skill gotchas**: no local keyring hang (runs in CI), no secret to rotate (OIDC).
- **Drafts are safe** — only `published` fires it. Publishing a release ships it (publishing the existing **v0.7.4 draft** would close the gap).

### ⚠️ One-time setup you must do (I can't — it's a PyPI web-UI step)
Register this repo as a **Trusted Publisher** for the project at
`https://pypi.org/manage/project/LSMS_Library/settings/publishing/`:
- **Owner:** `ligon`
- **Repository:** `LSMS_Library`
- **Workflow filename:** `publish.yml`
- **Environment:** *(leave blank — matches the workflow as written)*

Until that's configured, the publish step will fail auth (the build step still works). Optional hardening later: add a GH `environment: pypi` with required reviewers (must match the PyPI env field).

### Suggested validation
Cut a patch release (or publish the v0.7.4 draft) once the trusted publisher is registered, and confirm the run uploads. If you'd rather dry-run first, I can add a `workflow_dispatch` → **TestPyPI** path (needs a parallel trusted-publisher registration on test.pypi.org).