### PR TITLE
merge: development → master (v0.8.0 release docs)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,12 +1,66 @@
 ---
 name: release
-description: Use this skill when cutting a release (poetry build + wheel upload) of the LSMS Library. Covers poetry-dynamic-versioning plugin install, the Linux keyring hang on headless hosts, broken-system-poetry workarounds, and Savio compute-node outbound-network status.
+description: Use this skill when cutting a release of the LSMS Library. The primary path is automated — publish a GitHub Release and CI builds + uploads to PyPI via Trusted Publishing. Covers that flow and its release-event gotcha + workflow_dispatch fallback, plus the manual `poetry build` fallback (dynamic-versioning plugin, Linux keyring hang, broken-system-poetry, Savio outbound-network).
 ---
 
-# Release Tooling Gotchas
+# Releasing `lsms_library`
 
-Collected hazards from actually shipping wheels of `lsms_library`.
-Read this before you run `poetry build`.
+## Primary path: automated publish on GitHub Release (CI)
+
+As of v0.8.0 the canonical release path is **CI-driven** — you do **not**
+`poetry build` + upload by hand. `.github/workflows/publish.yml` builds the
+sdist+wheel and uploads to PyPI via **Trusted Publishing (OIDC)** — no stored
+token, and it runs in CI so the keyring hang below never applies. The version
+is derived from the **git tag** by poetry-dynamic-versioning (the workflow
+checks out the tag, `fetch-depth: 0`), so there is no manual version bump and a
+guard fails the build if it resolves to `0.0.0`.
+
+Cut a release:
+
+```sh
+make release v=0.8.0           # runs tests, creates annotated tag v0.8.0 (local)
+git push origin v0.8.0         # push the tag
+gh release create v0.8.0 --title v0.8.0 --notes-file docs/releases/v0.8.0.md
+```
+
+Publishing the GitHub Release *should* fire the workflow (`on: release:
+published`). **Then verify it actually ran** — `pypi.org` shows the new version
+and `gh run list --workflow=publish.yml` shows a `release` run.
+
+### Gotcha: the `release` event sometimes doesn't fire
+
+GitHub silently suppresses the `release: published` trigger in some cases —
+notably a release **created/published via a token** (the `gh` CLI), an **old or
+recreated draft**, or a tag that predates the workflow. Symptom: the release is
+published but `gh api .../actions/workflows/publish.yml/runs` shows
+`total_count: 0`. Publishing via the **web-UI "Publish release" button** (your
+own user identity) is the most reliable way to fire it.
+
+If it doesn't fire, use the **`workflow_dispatch` fallback** — always reliable,
+and the way v0.7.4 was shipped:
+
+```sh
+gh workflow run publish.yml --ref master -f tag=v0.8.0
+gh run watch $(gh run list --workflow=publish.yml -L1 --json databaseId -q '.[0].databaseId')
+```
+
+Both triggers build from the **tag** (`github.event.release.tag_name ||
+inputs.tag`), so the dispatch produces an identically-versioned artifact.
+
+### One-time PyPI setup (already done for LSMS_Library)
+
+PyPI Trusted Publishing is configured for this project: repo `ligon/LSMS_Library`,
+workflow `publish.yml`, environment blank
+(`pypi.org/manage/project/LSMS_Library/settings/publishing/`). A *new* project
+or a fork needs this registered before the first automated publish, or the
+upload step fails auth (the build step still succeeds).
+
+---
+
+# Manual / local-build fallback (CI down, or a local sanity build)
+
+Collected hazards from actually shipping wheels of `lsms_library` by hand.
+Read this before you run `poetry build` locally.
 
 ## `poetry-dynamic-versioning` must be installed as a Poetry plugin
 
@@ -123,15 +177,15 @@ python3 -m pip install --user --upgrade packaging
 That fixes the system poetry in place but may have flow-on effects
 on other user-site packages.  Prefer the venv-local install above.
 
-## Typical release sequence
+## Manual release sequence (fallback only — prefer the CI path above)
 
 ```sh
 # 1. Make sure you're on a tagged commit
-git tag v0.7.0
+git tag v0.8.0
 PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring poetry build
 
 # 2. Verify the wheel filename carries the right version
-ls dist/        # should show lsms_library-0.7.0-*.whl
+ls dist/        # should show lsms_library-0.8.0-*.whl
 
 # 3. Upload (from a machine that can reach PyPI)
 poetry publish

--- a/Makefile
+++ b/Makefile
@@ -66,21 +66,25 @@ build: setup
 	$(POETRY) build
 
 # ── Release ───────────────────────────────────────────────
-# Usage: make release v=0.6.0
+# Usage: make release v=0.8.0
 #   1. Validates the tag doesn't already exist
 #   2. Runs the test suite in parallel (see PYTEST_ARGS above)
 #   3. Creates an annotated git tag (vX.Y.Z)
-#   4. Builds the distribution
+#   4. Builds the distribution locally as a SANITY check
 #
-# The version is derived from the tag by poetry-dynamic-versioning,
-# so no files need editing.
+# Publishing to PyPI is NOT done here — it is automated in CI
+# (.github/workflows/publish.yml) via Trusted Publishing when a GitHub
+# Release is published.  The version is derived from the tag by
+# poetry-dynamic-versioning, so no files need editing.  See the
+# `release` skill (.claude/skills/release/SKILL.md) for the full flow,
+# the release-event gotcha, and the workflow_dispatch fallback.
 #
 # For a long release test run, prefer a compute node over the login
 # node --- the test suite triggers cold country builds that can
 # saturate a shared login node for 45+ minutes.
 release:
 ifndef v
-	$(error Usage: make release v=0.6.0)
+	$(error Usage: make release v=0.8.0)
 endif
 	@if git rev-parse "v$(v)" >/dev/null 2>&1; then \
 		echo "Error: tag v$(v) already exists"; exit 1; \
@@ -89,8 +93,12 @@ endif
 	git tag -a "v$(v)" -m "Release $(v)"
 	$(POETRY) build
 	@echo ""
-	@echo "Tagged v$(v) and built dist/. When ready:"
+	@echo "Tagged v$(v) and built dist/ (local sanity build)."
+	@echo "To publish to PyPI (CI does the upload — no local twine):"
 	@echo "  git push origin v$(v)"
+	@echo "  gh release create v$(v) --title v$(v) --notes-file docs/releases/v$(v).md"
+	@echo "  # if the release event doesn't fire (see release skill):"
+	@echo "  gh workflow run publish.yml --ref master -f tag=v$(v)"
 
 # Delegate country-specific targets to the inner Makefile.
 # Usage: make country-test country=Uganda

--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,8 +1,6 @@
 # LSMS Library v0.8.0
 
-*Release range: v0.7.4 → v0.8.0 (53 merged PRs).*
-
-> **DRAFT** — pending CI green on `development` and a cache workout on Savio.
+*Release range: v0.7.4 → v0.8.0 (60+ merged PRs).*
 
 ## Headline — Automatic content-hash cache invalidation
 
@@ -61,6 +59,12 @@ overrides (`LSMS_NO_CACHE`, `lsms-library cache clear`, `pytest
 - **`interview_date`** (#473, #477) — visit-level interview dates, incl. EHCVM.
 - **Grain / unit policy** (#471, #472) — `u` carried in the index; no implicit
   aggregation in core.
+- **`labels=X` contract** (#550) — requesting a label a country never curated
+  (e.g. `labels='Aggregate'` on an EHCVM country) now degrades cleanly:
+  `Country(...)` raises a typed `LabelUnavailableError` (a `KeyError` subclass,
+  back-compatible), and `Feature(...)` drops only the unsupported countries with
+  one aggregated warning + a `df.attrs['labels_unavailable']` marker — instead
+  of silently returning a partial table.
 - **GhanaLSS `food_acquired`** (#457, phase 1).
 
 ## Cross-country `Feature()` & audit tooling
@@ -69,9 +73,10 @@ overrides (`LSMS_NO_CACHE`, `lsms-library cache clear`, `pytest
   per-feature kwargs (`market`/`labels`/`units`/`age_cuts`) forward by signature.
 - **Cross-country assembly fixes** (#520, GH #511/#512) — index collapse under
   `market=` and reduced-index countries.
-- **Feature() audit harness** (#521, #505, #507, #523) — a deterministic
+- **Feature() audit harness** (#521, #505, #507, #523, #549) — a deterministic
   cross-country sweep (`bench/feature_audit/`) that builds every feature, checks
-  sanity + assembly invariants, and triages findings.
+  sanity + assembly invariants, and triages findings; the scanner parallelizes
+  one worker per feature to saturate a warm cache.
 - **Backlog workflow** (#524, #529) — multi-agent triage/fix of the GitHub
   backlog, building on the audit harness.
 
@@ -85,10 +90,24 @@ overrides (`LSMS_NO_CACHE`, `lsms-library cache clear`, `pytest
 - **Kinship** (#525, GH #516) — Albania labels + South Africa sentinel.
 - **Derived-table & visit-level fixes** (#527 food_prices visit; #528 derived
   `household_characteristics` `market=`; #526 cluster_features geo).
-- **EHCVM sanity** (#523, #480) and **region fixes** (#540 Azerbaijan).
+- **EHCVM sanity** (#523, #480) and **region fixes** (#540 Azerbaijan, #545
+  Guatemala — surface a recoverable `Region` so `market='Region'` works; GH #530).
+- **Panel-id household collisions** (#547, #546, GH #504/#536/#513) —
+  `update_id` no longer mints a suffix that re-uses a live household id (Malawi:
+  60 collisions → 0; anthropometry +37 / sample +60 / plot_features +23 rows),
+  and Mali's `id_walk` no longer renames a moved household onto an occupied
+  non-panel slot (sample +8 / plot_features +6). Healthy panels byte-identical.
 - **Robustness** — S3 fetch retry/backoff (#483), `u`-code NaN-safe leak fix
   (#451), missing-orgfile-table handling (#464), Malawi floor casing (#484),
   GhanaLSS food units (#486).
+
+## Release & packaging
+
+- **Automated PyPI publishing** (#554, #556) — publishing a GitHub Release now
+  builds and uploads to PyPI in CI via **Trusted Publishing (OIDC)**: no stored
+  token, no local `poetry build`/keyring hang, version derived from the tag. A
+  `workflow_dispatch(tag)` fallback ships a release manually if the release event
+  doesn't fire. See the `release` skill for the flow and gotchas.
 
 ## Upgrade notes
 


### PR DESCRIPTION
Brings the finalized v0.8.0 notes + updated release skill/Makefile onto master ahead of tagging v0.8.0.