### PR TITLE
docs(#109): refresh GhanaLSS CONTENTS.org to the built state

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -15,6 +15,30 @@ is derived from the **git tag** by poetry-dynamic-versioning (the workflow
 checks out the tag, `fetch-depth: 0`), so there is no manual version bump and a
 guard fails the build if it resolves to `0.0.0`.
 
+### Before cutting: merge `development` → `master` and auto-close resolved issues
+
+Releases tag `master` (the default branch); routine PRs land on `development`.
+So **before** `make release`, open a **`development` → `master` merge PR** and
+put closing keywords for every issue resolved since the last release in its body:
+
+```
+Closes #498, #499, #500, #501, #502, #530, #551
+```
+
+This is the *only* point those issues auto-close: GitHub fires closing keywords
+only when they reach the default branch, and only via `Closes`/`Fixes`/`Resolves
+#N` (keyword + space) — **not** the `fix(#N):` conventional-commit scope style
+the fix commits use. Omit this and the resolved issues stay open after the merge
+(exactly what happened up to v0.8.0 — a batch had to be closed by hand). Build a
+candidate list, then **verify each is genuinely resolved** (not an umbrella issue
+a PR merely touched) before listing it:
+
+```sh
+# open issues whose fix PR branch (fix/<n>-… / feat/<n>-…) merged since the last tag
+gh pr list --state merged --limit 400 --json number,headRefName \
+  -q '.[].headRefName' | grep -oE '(fix|feat)/[0-9]+' | grep -oE '[0-9]+' | sort -un
+```
+
 Cut a release:
 
 ```sh
@@ -180,6 +204,8 @@ on other user-site packages.  Prefer the venv-local install above.
 ## Manual release sequence (fallback only — prefer the CI path above)
 
 ```sh
+# 0. First merge development -> master + close resolved issues (see "Before cutting" above)
+
 # 1. Make sure you're on a tagged commit
 git tag v0.8.0
 PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring poetry build

--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -685,3 +685,26 @@ Capturing the exact commands you ran (and any gotchas) in your pull request keep
 Note: the ~make test~ target expects the relevant Parquet/Stata assets to be
 available through DVC. Ensure you've authenticated and pulled/streamed the
 required files before relying on the smoke test.
+
+** Referencing issues from a pull request
+
+The repository's default branch is ~master~, but routine pull requests
+target ~development~.  GitHub only auto-closes an issue when a closing
+keyword reaches the *default* branch -- so a ~Closes #123~ in a PR that
+merges into ~development~ does **not** close the issue.  Two consequences
+worth knowing:
+
+- The conventional-commit scope style ~fix(#123):~ that we use in commit
+  subjects is *not* a GitHub closing keyword.  GitHub recognises only
+  ~Closes #123~ / ~Fixes #123~ / ~Resolves #123~ (keyword + space + ~#N~);
+  in ~fix(#123):~ the ~(~ breaks the pattern.  So fix commits never
+  auto-close their issues even once they reach ~master~.
+- Because fix PRs land on ~development~ (not the default branch), they
+  accumulate without closing their issues.  The issues close when
+  ~development~ is merged into ~master~ at release time -- *only if* the
+  closing keywords are in that merge PR's body.
+
+So: in a fix PR, reference the issue for traceability (~Addresses #123~),
+but list the closing keywords on the ~development -> master~ release-merge
+PR instead (~Closes #123, #124, ...~).  Merging that to ~master~ closes
+them all at once.  See the =release= skill for the release-merge step.

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -121,17 +121,33 @@ linkage via the =Waves= dictionary.
 We have tried to make it possible to compare food expenditures not only across rounds within one of these surveys, but also across surveys.  The main tool needed for harmonization is a set of consistent food labels.  Those consistent labels are the "Aggregate Labels" found in https://docs.google.com/spreadsheets/d/1qZhbq5gpAmCsYH1ixUn0Ix_Cb5YKSIpU-Pc2_hh2lhU/.
 
 
+* Status (2026-06-20, #109)
+The food harmonization that made GhanaLSS the least-complete country is DONE:
+=food_acquired= is canonical =(t, i, j, u, s)= and registered
+(=materialize: make=); =food_prices= / =food_quantities= / =food_expenditures=
+derive at runtime (=_FOOD_DERIVED=); =household_characteristics= /
+=household_roster= build; the legacy
+=food_prices_quantities_and_expenditures.py= is retired; =shocks= is ruled out
+(data-gap, #352).  The full GhanaLSS test sweep is green (41 passed).  The
+remaining work is split out: =community_prices= + inverse price->quantity
+imputation (#562), and the nutrition Food Conversion Table (#563).
+
 * Files in GhanaLSS/_/
-** TODO ghana_lss.py
-Contains code common to different GLSS rounds.
-** TODO food_items.org
-See discussion above for harmonization of food labels across rounds and surveys.  But we should provide code here to usefully extract that information.
-
-** TODO conversion_to_kgs.json
-
-** TODO other_features.py
-** TODO household_characteristics.py
-** TODO food_acquired.py
+** DONE ghana_lss.py
+Common code across GLSS rounds (=ghanalss.py=); handles the GLSS1--GLSS2 panel
+linkage via the =Waves= dictionary.
+** DONE food_items.org
+Food labels harmonized across all 7 waves (the "Aggregate Labels").
+** DONE conversion_to_kgs.json -- intentionally NOT used
+The canonicalization fills missing quantities via the inverse market-price
+ladder (=transformations.median_price_valuation=) in native units, which
+obviates a bespoke kg table (design D2/D4).  kg conversion stays a separate
+downstream concern.
+** DONE other_features.py
+Obsolete -- replaced by =cluster_features= (added at query time).
+** DONE household_characteristics.py
+Auto-derived at runtime from =household_roster= (=_ROSTER_DERIVED=); builds.
+** DONE food_acquired.py (canonical, #109)
 Data on expenditures is somewhat unusual, in two different ways.
 
 First, for waves before 2016--17, the survey instrument elicits the amount spent in purchasing different items, but does /not/ elicit quantities purchased.  (A separate price survey was conducted, and could presumably be used to obtain quantities.)  A separate module elicits quantities of home produced food consumed, as well as the hypothetical price at which home produced goods could be sold.
@@ -194,7 +210,10 @@ print(fa.describe())
 #+end_src
 
 
-** TODO food_prices_quantities_and_expenditures.py
+** DONE food_prices_quantities_and_expenditures.py -- RETIRED
+Removed (#109).  =food_prices= / =food_quantities= / =food_expenditures= are
+derived at API time from =food_acquired= by =_FOOD_DERIVED= -- no per-country
+script.
 Test...
 #+begin_src python :results output
 import pandas as pd
@@ -205,8 +224,12 @@ print(pd.read_parquet('../var/food_expenditures.parquet').describe())
 #+end_src
 
 
-*** TODO food_expenditures
-This parquet file built in a non-standard fashion, and is missing indices (t,m).  Code here acquires those indices from =household_characteristics=.
+*** DONE food_expenditures
+Now derived canonically by =_FOOD_DERIVED= -- index =(i, t, v, j, s)=.  The old
+non-standard build (missing =(t, m)=, indices borrowed from
+=household_characteristics=) is gone; =m= is added on demand via =market=.
+(The demand-estimation snippet below predates the canonical shape and references
+the old =purchased_value= column -- illustrative only.)
 #+begin_src python
 import pandas as pd
 import numpy as np
@@ -236,7 +259,9 @@ r.get_gamma_se()
 r.to_pickle('../var/cfe_demands.rgsn')
 #+end_src
 
-** TODO Food Conversion Table
+** DEFERRED Food Conversion Table -- tracked in #563
+West Africa FCT -> a =nutrition= feature; split out of #109 as a data-gap so it
+does not block the food harmonization (cf. Cambodia #560).  Sources:
 West Africa Food Conversion Table (Inputs into Ghana Food Expenditure Data):
 https://docs.google.com/spreadsheets/d/1Ar88nD6jQl4u8iCIsAIkLxOjHpfvi6ZBVJlwf91HOOQ/edit?usp=sharing
 Ghana Food Expenditure Data with Aggregate Labels and FTC Codes:
@@ -252,9 +277,13 @@ The only tangentially related content is in GLSS7 Section 13E (governance module
 Ghana's LSMS-ISA participation is through the GhanaSPS (Social Panel Survey), not the GLSS.  Shocks data for Ghana should be sought in GhanaSPS if available.
 
 * Files in GhanaLSS/<SOMEYEAR>/_/
-** TODO household_characteristics.py
-** TODO food_acquired.py
-** TODO other_features.py
+** DONE food_acquired.py
+Wave scripts emit canonical =(t, i, j, u, s, visit)=; the framework joins =v=
+and derives the food tables.
+** DONE household_characteristics.py
+Auto-derived from =household_roster= (=_ROSTER_DERIVED=).
+** DONE other_features.py
+Obsolete -- =cluster_features= at query time.
 
 * subjective_well_being — not available (2026-06-06)
 No GLSS wave (1987-88…2016-17) carries a subjective-well-being / life-evaluation /


### PR DESCRIPTION
Reconciles the stale GhanaLSS `CONTENTS.org` (its TODOs predated the food_acquired canonicalization and mis-led backlog triage) to reality: `food_acquired` canonical `(t,i,j,u,s)` + registered; `food_prices`/`food_quantities`/`food_expenditures` derive at runtime; `household_characteristics`/`household_roster` build; legacy `food_prices_quantities_and_expenditures.py` retired; `conversion_to_kgs.json` intentionally unused (inverse price ladder, D2/D4); `shocks` ruled out (#352). Full GhanaLSS test sweep green (**41 passed, 1 skipped, 1 xpassed**). Adds a Status banner; splits the genuine remainder into #562 (community_prices + price→quantity imputation) and #563 (West Africa FCT / nutrition). Docs-only.

Addresses #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)