### PR TITLE
fix(#495): derive China individual_education from years-of-schooling (was mother's occupation)

### DIFF
--- a/lsms_library/countries/China/1995-97/_/data_info.yml
+++ b/lsms_library/countries/China/1995-97/_/data_info.yml
@@ -84,12 +84,15 @@ plot_features:
                 2: false
 
 individual_education:
-    # Education detail S01B.DTA; attainment code s01b10 (grade/level 1-12).
-    # pid maps from s01bid (person order); join to roster pid verified at build.
+    # CLSS 1995-97 has NO categorical attainment variable; education exists only
+    # as continuous years-of-schooling (S02.DTA s0201).  The prior wiring to
+    # S01B s01b10 was the MOTHER'S OCCUPATION code (#495).  Extract the raw years
+    # here; the china.py `individual_education` df_edit hook (auto-wired by table
+    # name) bins them to the canonical ordinal vocabulary.  S02 has clean hid/pid.
     file:
-        - ../Data/S01B.DTA
+        - ../Data/S02.DTA
     idxvars:
         i: hid
-        pid: s01bid
+        pid: pid
     myvars:
-        Educational Attainment: s01b10
+        Educational Attainment: s0201

--- a/lsms_library/countries/China/_/china.py
+++ b/lsms_library/countries/China/_/china.py
@@ -1,7 +1,8 @@
 # Formatting functions for China (CHNS).
 #
 # China is otherwise fully YAML-driven; this module exists for the
-# auto-wired (by table name) `plot_features` df_edit hook below.
+# auto-wired (by table name) `plot_features` and `individual_education`
+# df_edit hooks below.
 
 import pandas as pd
 
@@ -34,3 +35,57 @@ def plot_features(df):
             + '_' + (n[extra] + 1).astype('string'))
     idx = [c for c in ('t', 'i', 'plot_id') if c in flat.columns]
     return flat.set_index(idx)
+
+
+def _years_to_education_level(y):
+    """Bin years-of-schooling -> canonical Educational Attainment label (#495).
+
+    CLSS 1995-97 has NO categorical attainment variable; education exists only
+    as continuous years (S02.DTA s0201).  Cutoffs follow China's 6+3+3+4 system
+    (primary 6 / junior-secondary 3 / senior-secondary 3 / bachelor 4) mapped
+    onto canonical_education_labels.org; complete/incomplete is inferred from
+    cycle length (the standard approach when only years are recorded).  99 is
+    the survey's missing sentinel -> NaN.
+    """
+    if pd.isna(y):
+        return pd.NA
+    try:
+        y = int(round(float(y)))
+    except (TypeError, ValueError):
+        return pd.NA
+    if y == 99 or y < 0:
+        return pd.NA                       # missing sentinel
+    if y == 0:
+        return 'None'
+    if y <= 5:
+        return 'Primary incomplete'
+    if y == 6:
+        return 'Primary complete'
+    if y <= 8:
+        return 'Lower secondary'
+    if y == 9:
+        return 'Lower secondary complete'
+    if y <= 11:
+        return 'Upper secondary'
+    if y == 12:
+        return 'Upper secondary complete'
+    if y <= 15:
+        return 'Tertiary certificate/diploma'   # da-zhuan / non-degree college
+    if y == 16:
+        return 'Bachelor'                        # 12 + 4-yr degree
+    return 'Postgraduate'                        # >=17 (none observed this wave)
+
+
+def individual_education(df):
+    """df_edit hook (auto-wired by table name): derive canonical Educational
+    Attainment from S02 years-of-schooling for China CLSS 1995-97 (#495).
+
+    The wave data_info.yml extracts the raw years (s0201) into the
+    ``Educational Attainment`` column; here we bin it to the canonical ordinal
+    vocabulary.  Index (t, i, pid) is preserved.  Replaces the prior wiring to
+    S01B s01b10 (the *mother's occupation* code) -- a silent data-correctness bug.
+    """
+    out = df.copy()
+    out['Educational Attainment'] = (
+        out['Educational Attainment'].map(_years_to_education_level).astype('string'))
+    return out


### PR DESCRIPTION
## What

China CLSS 1995-97's `individual_education` was wired to `S01B.s01b10` — the **mother's occupation code** — so it silently returned occupation codes mislabeled as education (distribution spiked at `1.0`/`12.0`). The survey has **no categorical attainment variable**; education exists only as continuous years-of-schooling.

## Fix (per the #495 decision: *derive from years*)

- **Re-source** from `S02.DTA s0201` (the respondent's own years; clean `hid`/`pid` keys) — replacing the wrong S01B wiring.
- **Bin years → canonical ordinal vocabulary** via a `china.py` `individual_education` df_edit hook (auto-wired by table name), following China's 6+3+3+4 system (cutoffs signed off):

  | years | label | | years | label |
  |---|---|---|---|---|
  | 0 | None | | 10–11 | Upper secondary |
  | 1–5 | Primary incomplete | | 12 | Upper secondary complete |
  | 6 | Primary complete | | 13–15 | Tertiary certificate/diploma |
  | 7–8 | Lower secondary | | 16 | Bachelor |
  | 9 | Lower secondary complete | | ≥17 | Postgraduate |
  | | | | 99 | → NaN (missing sentinel) |

  Complete/incomplete is inferred from cycle length (standard when only years are recorded).

## Verification (cold)

- Distribution now **education-shaped**: Primary incomplete 839, Lower secondary 552, Primary complete 503, None 454, Lower secondary complete 355, Upper secondary 75, … Bachelor 2.
- **All values are canonical Preferred Labels** (`canonical_education_labels.org`) — zero strays.
- `is_this_feature_sane` all-pass except the universal `v`-not-in-declared-scheme warn.
- China's other features (household_roster/plot_features/sample) unaffected; **207** `test_schema_consistency` tests pass.

## Notes
`Addresses #495`; closes on the dev→master release merge. **Completes the China (14th-country) remainder of #493** — that issue can close once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)