### PR TITLE
feat(#170): roll out housing Roof/Floor harmonization to 8 more countries

### DIFF
--- a/lsms_library/categorical_mapping/canonical_housing_labels.org
+++ b/lsms_library/categorical_mapping/canonical_housing_labels.org
@@ -81,7 +81,8 @@ change is needed; the work is purely data curation.
 | Asbestos         | Uganda; possibly elsewhere.                                          |
 | Mud              | Includes ``Adobe`` (sun-dried mud brick).                            |
 | Mats             | Woven mats.  Togo: 1 obs.                                            |
-| Wood             | ``Wood, Planks`` / ``wood,planks``.                                  |
+| Wood             | ``Wood, Planks`` / ``wood,planks``.  Includes bamboo planks/strips.  |
+| Slate            | Slate / slate-tile roofing.  Tajikistan's dominant roof (#170).      |
 | Other            | ``Other (specify)``, ``OTHER(SPECIFY)``, etc.                        |
 
 * Canonical Floor Preferred Labels
@@ -94,9 +95,11 @@ change is needed; the work is purely data curation.
 | Cement            | Includes ``Smooth Cement``, ``Cement screed``.                       |
 | Concrete          | Aggregate + cement.  Distinct from ``Cement``.                       |
 | Tiles             | Includes ``Tile``, ``Mosaic or tiles``.                              |
-| Stone             | Stone floor.                                                         |
+| Stone             | Stone floor.  Includes polished stone / marble.                      |
 | Bricks            | Brick floor.                                                         |
-| Wood              | Wood plank / parquet.                                                |
+| Wood              | Wood plank / parquet.  Includes bamboo strips.                       |
+| Vinyl/Linoleum    | Resilient sheet/tile flooring (linoleum, vinyl, vinyl tiles) (#170). |
+| Carpet            | Carpeted floor.  South Africa: ~1.5k obs (#170).                     |
 | Other             | ``Other (specify)``, etc.                                            |
 
 * Per-country wiring

--- a/lsms_library/countries/Cambodia/_/categorical_mapping.org
+++ b/lsms_library/countries/Cambodia/_/categorical_mapping.org
@@ -34,3 +34,33 @@ BacII / Baccalaureate II higher-education-entrance certificate).
 | Doctorate degree (PhD)                                  | Doctorate                    |
 | DonÂ´t know                                             | Unknown                      |
 | Other (Specify)                                         | Unknown                      |
+
+* Housing (Roof / Floor) -- canonical harmonization (GH #170)
+
+Note: the =Other (Specify)= rows below are scoped to the Roof/Floor tables
+(housing); the education =Other (Specify) -> Unknown= row above is unaffected
+(each table is keyed independently).
+
+#+name: Roof
+| Alternate Spelling                                                                    | Preferred Label |
+|---------------------------------------------------------------------------------------+-----------------|
+| Galvanized iron or aluminium or other metal sheets                                    | Iron Sheets     |
+| Tiles                                                                                 | Clay Tiles      |
+| Fibrous cement                                                                        | Asbestos        |
+| Concrete                                                                              | Concrete        |
+| Thatch/leaves/grass                                                                   | Thatch          |
+| Mixed but predominantly made of galvanized iron/aluminium, tiles or fibrous cement    | Other           |
+| Other (Specify)                                                                       | Other           |
+
+#+name: Floor
+| Alternate Spelling      | Preferred Label |
+|-------------------------+-----------------|
+| Wooden planks           | Wood            |
+| Parquet, polished wood  | Wood            |
+| Bamboo strips           | Wood            |
+| Ceramic tiles           | Tiles           |
+| Cement/Brick/Stone      | Cement          |
+| Earth, clay             | Earth           |
+| Polished stone, marble  | Stone           |
+| Vinyl                   | Vinyl/Linoleum  |
+| Other (Specify)         | Other           |

--- a/lsms_library/countries/GhanaLSS/_/categorical_mapping.org
+++ b/lsms_library/countries/GhanaLSS/_/categorical_mapping.org
@@ -238,3 +238,33 @@ the full file.  Code -> native label; canonicalized to Preferred Label through
 | U8                      | Postgraduate                 |
 | JSS1                    | Lower secondary              |
 | JSS3                    | Lower secondary complete     |
+
+* Housing (Roof / Floor) -- canonical harmonization (GH #170)
+
+#+name: Roof
+| Alternate Spelling | Preferred Label |
+|--------------------+-----------------|
+| Metal Sheet        | Iron Sheets     |
+| Slate/Asbestos     | Asbestos        |
+| Cement/Concrete    | Concrete        |
+| Roofing Tiles      | Clay Tiles      |
+| Thatch             | Thatch          |
+| Bamboo             | Wood            |
+| Mud/Earth          | Mud             |
+| Wood               | Wood            |
+| Other              | Other           |
+
+#+name: Floor
+| Alternate Spelling   | Preferred Label |
+|----------------------+-----------------|
+| Cement/Concrete      | Concrete        |
+| Earth/Mud            | Earth           |
+| Ceramic/Marble Tiles | Tiles           |
+| Vinyl Tiles          | Vinyl/Linoleum  |
+| Terrazzo             | Concrete        |
+| Burnt Bricks         | Bricks          |
+| Stone                | Stone           |
+| Stone/Brick          | Stone           |
+| Wood                 | Wood            |
+| Fibre-glass          | Other           |
+| Other                | Other           |

--- a/lsms_library/countries/Guyana/_/categorical_mapping.org
+++ b/lsms_library/countries/Guyana/_/categorical_mapping.org
@@ -57,3 +57,19 @@ Level rationale:
 | 14.0           | Unknown                  |
 | 15.0           | None                     |
 | 17.0           | Unknown                  |
+
+* Housing (Roof) -- canonical harmonization (GH #170)
+
+Guyana housing has no Floor column; Roof only.
+
+#+name: Roof
+| Alternate Spelling | Preferred Label |
+|--------------------+-----------------|
+| Sheet Metal        | Iron Sheets     |
+| Concrete           | Concrete        |
+| Shingle (Wood)     | Wood            |
+| Shingle (Asphalt)  | Other           |
+| Shingle (Other)    | Other           |
+| Makeshift          | Other           |
+| Not Stated         | Other           |
+| Other              | Other           |

--- a/lsms_library/countries/Iraq/_/categorical_mapping.org
+++ b/lsms_library/countries/Iraq/_/categorical_mapping.org
@@ -34,3 +34,34 @@
 | Doctorate degree                  | Doctorate                    |
 | Phd (doctorate)                   | Doctorate                    |
 | Other                             | Unknown                      |
+
+* Housing (Roof / Floor) -- canonical harmonization (GH #170)
+
+Both case variants of each value are listed so the exact-match mapping
+also collapses the case-variance.
+
+#+name: Roof
+| Alternate Spelling          | Preferred Label |
+|-----------------------------+-----------------|
+| Reinforced concrete casting | Concrete        |
+| reinforced concrete casting | Concrete        |
+| Iron bars                   | Concrete        |
+| iron bars                   | Concrete        |
+| Wood                        | Wood            |
+| wood                        | Wood            |
+| Others                      | Other           |
+| other                       | Other           |
+
+#+name: Floor
+| Alternate Spelling | Preferred Label |
+|--------------------+-----------------|
+| Cement casting     | Cement          |
+| cement casting     | Cement          |
+| Tiles              | Tiles           |
+| tiles              | Tiles           |
+| Earth              | Earth           |
+| earth              | Earth           |
+| Brick              | Bricks          |
+| brick              | Bricks          |
+| Other              | Other           |
+| other              | Other           |

--- a/lsms_library/countries/Pakistan/_/categorical_mapping.org
+++ b/lsms_library/countries/Pakistan/_/categorical_mapping.org
@@ -1,0 +1,26 @@
+#+title: Categorical mappings for Pakistan
+
+* Housing (Roof / Floor) -- canonical harmonization (GH #170)
+
+Maps the Pakistan IHS 1991 roof/floor values onto the canonical housing
+vocabulary (=lsms_library/categorical_mapping/canonical_housing_labels.org=).
+Auto-applied by column name.
+
+#+name: Roof
+| Alternate Spelling | Preferred Label |
+|--------------------+-----------------|
+| Galvanized Iron    | Iron Sheets     |
+| Concrete/Cement    | Concrete        |
+| Wood/Planks        | Wood            |
+| Earth/Mud          | Mud             |
+| Straw/Thatch       | Thatch          |
+| Other              | Other           |
+
+#+name: Floor
+| Alternate Spelling | Preferred Label |
+|--------------------+-----------------|
+| Earth              | Earth           |
+| Cement/Tile        | Cement          |
+| Stone/Brick        | Stone           |
+| Wood               | Wood            |
+| Other              | Other           |

--- a/lsms_library/countries/South Africa/_/categorical_mapping.org
+++ b/lsms_library/countries/South Africa/_/categorical_mapping.org
@@ -1,0 +1,45 @@
+#+title: Categorical mappings for South Africa
+
+* Housing (Roof / Floor) -- canonical harmonization (GH #170)
+
+Maps the SALDRU 1993 IHS roof/floor material values onto the canonical
+housing vocabulary (=lsms_library/categorical_mapping/canonical_housing_labels.org=).
+Auto-applied by column name via =_apply_categorical_mappings=.
+
+#+name: Roof
+| Alternate Spelling        | Preferred Label  |
+|---------------------------+------------------|
+| Corrugated Iron           | Iron Sheets      |
+| Asbestos                  | Asbestos         |
+| Tile                      | Clay Tiles       |
+| Thatching                 | Thatch           |
+| Cement Block              | Concrete         |
+| Wood                      | Wood             |
+| Mud                       | Mud              |
+| Wattle and Daub           | Mud              |
+| Mixture of Mud and Cement | Mud              |
+| Plastic                   | Plastic Sheeting |
+| Bricks                    | Other            |
+| Cardboard                 | Other            |
+| Pre-fab                   | Other            |
+| Other                     | Other            |
+
+#+name: Floor
+| Alternate Spelling        | Preferred Label |
+|---------------------------+-----------------|
+| Mixture of Mud and Cement | Earth           |
+| Mud                       | Earth           |
+| Wattle and Daub           | Earth           |
+| Tile                      | Tiles           |
+| Carpet                    | Carpet          |
+| Linoleum                  | Vinyl/Linoleum  |
+| Cement Block              | Concrete        |
+| Bricks                    | Bricks          |
+| Wood                      | Wood            |
+| Asbestos                  | Other           |
+| Cardboard                 | Other           |
+| Corrugated Iron           | Other           |
+| Plastic                   | Other           |
+| Pre-fab                   | Other           |
+| Thatching                 | Other           |
+| Other                     | Other           |

--- a/lsms_library/countries/Tajikistan/_/categorical_mapping.org
+++ b/lsms_library/countries/Tajikistan/_/categorical_mapping.org
@@ -47,3 +47,30 @@ Notes on the non-obvious levels:
 | candidate of science                | Doctorate                |
 | doctor of science                   | Doctorate                |
 | other                               | Unknown                  |
+
+* Housing (Roof / Floor) -- canonical harmonization (GH #170)
+
+#+name: Roof
+| Alternate Spelling     | Preferred Label |
+|------------------------+-----------------|
+| slate                  | Slate           |
+| metal sheeting         | Iron Sheets     |
+| metal sheets           | Iron Sheets     |
+| plastic on metal       | Iron Sheets     |
+| bitumised concrete slab | Concrete       |
+| mud                    | Mud             |
+| thatch                 | Thatch          |
+| tiles                  | Clay Tiles      |
+| other                  | Other           |
+
+#+name: Floor
+| Alternate Spelling | Preferred Label |
+|--------------------+-----------------|
+| painted wood       | Wood            |
+| parquet            | Wood            |
+| clay/eatern floor  | Earth           |
+| clay/earthen floor | Earth           |
+| linoleum           | Vinyl/Linoleum  |
+| concrete           | Concrete        |
+| alabaster surface  | Concrete        |
+| other              | Other           |

--- a/lsms_library/countries/Timor-Leste/_/categorical_mapping.org
+++ b/lsms_library/countries/Timor-Leste/_/categorical_mapping.org
@@ -1,0 +1,44 @@
+#+title: Categorical mappings for Timor-Leste
+
+* Housing (Roof / Floor) -- canonical harmonization (GH #170)
+
+Maps the Timor-Leste roof/floor values onto the canonical housing
+vocabulary (=lsms_library/categorical_mapping/canonical_housing_labels.org=).
+Both case variants of each value are listed so the exact-match mapping
+also collapses the case-variance.  Auto-applied by column name.
+
+#+name: Roof
+| Alternate Spelling | Preferred Label |
+|--------------------+-----------------|
+| Metal sheets/zinc  | Iron Sheets     |
+| metal sheets/zinc  | Iron Sheets     |
+| Sugar palm fibre   | Thatch          |
+| sugar palm fibre   | Thatch          |
+| Leaves             | Thatch          |
+| leaves             | Thatch          |
+| Tile               | Clay Tiles      |
+| tile               | Clay Tiles      |
+| Concrete           | Concrete        |
+| concrete           | Concrete        |
+| Wood               | Wood            |
+| wood               | Wood            |
+| Other              | Other           |
+| other              | Other           |
+
+#+name: Floor
+| Alternate Spelling | Preferred Label |
+|--------------------+-----------------|
+| Earth/clay         | Earth           |
+| earth/clay         | Earth           |
+| Concrete/brick     | Concrete        |
+| concrete/brick     | Concrete        |
+| floor tile         | Tiles           |
+| Floor tille/cement | Tiles           |
+| Marble/ceramic     | Tiles           |
+| marble/ceramic     | Tiles           |
+| Bamboo             | Wood            |
+| bamboo             | Wood            |
+| Wood               | Wood            |
+| wood               | Wood            |
+| Other              | Other           |
+| other              | Other           |


### PR DESCRIPTION
## What

Extends the canonical housing Roof/Floor vocabulary to the **8 remaining** countries that still emitted raw values: GhanaLSS, Tajikistan, South Africa, Cambodia, Guyana (Roof only), Iraq, Pakistan, Timor-Leste. (#170's machinery + the 13-country LSMS-ISA/EHCVM set were already done; this is the classic-survey tail.)

## How
Per-country `#+name: Roof` / `#+name: Floor` tables in each `categorical_mapping.org`, auto-applied by column name at read time (`_apply_categorical_mappings` — **no code/framework change**). New files for SA/Pakistan/Timor-Leste; appended for the other 5. Case-variant spellings are listed explicitly so the exact-match mapping also **collapses case-variance** (Iraq `Reinforced…`/`reinforced…`, Timor `Metal sheets/zinc`×2, Tajik typo `clay/eatern floor`).

## 3 canonical-vocab additions (approved)
Dumping common materials into `Other` would gut those countries' data, so per the #170 sign-off:
- **`Slate`** (roof) — Tajikistan's dominant roof (4,659 obs)
- **`Vinyl/Linoleum`** (floor) — linoleum/vinyl/vinyl-tiles across SA/Tajikistan/Ghana
- **`Carpet`** (floor) — South Africa (~1.5k obs)

## Verification (cold)
All 8 countries now return **100% canonical** Roof/Floor values (zero strays); **207** `test_schema_consistency` tests pass; the 13 pre-existing harmonized countries are untouched.

## Not included: India
India's Roof/Floor are **undecoded numeric codes** (`1.0`–`5.0`) — it needs a *decode* step (codebook) before harmonization, so it's split to its own issue. (5 other housing countries — Albania, Azerbaijan, Kazakhstan, Kosovo, Serbia — have no Roof/Floor, so are N/A.)

`Addresses #170`; closes on the dev→master release merge once India is also handled (or #170 narrows to the India follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)