### PR TITLE
fix(#496): register livestock + people_last7days in index_info (named Feature index)

### DIFF
--- a/lsms_library/data_info.yml
+++ b/lsms_library/data_info.yml
@@ -25,6 +25,15 @@ Index Info:
     individual_education: (t, v, i, pid)
     food_prices: (t, v, i, j, u, s)
     food_quantities: (t, v, i, j, u, s)
+    # GH #496: register so Feature() assembles a named MultiIndex instead of
+    # collapsing to a single object-tuple Index.  livestock is homogeneous
+    # across countries; people_last7days is (t,v,i,pid) for all but Uganda
+    # (reduced to (t,v,i) -- handled as a reduced-index country).  The plot-
+    # level ag features (plot_labor/crop_production/plot_inputs) are NOT here:
+    # their per-country index NAMES diverge (plot vs plot_id, crop vs j) and
+    # need harmonizing before registration -- tracked separately.
+    livestock: (t, i, animal)
+    people_last7days: (t, v, i, pid)
 
 # Cluster-id (v) join policy.  _finalize_result() joins v from sample() onto
 # household-level (i, t) tables that lack it.  A table is SKIPPED when its


### PR DESCRIPTION
## What
Two of #496's features (`livestock`, `people_last7days`) collapsed to a single object-tuple `Index` in `Feature()` — no `index_info` entry, so `_harmonize_country_frame` was skipped and `pd.concat` aligned heterogeneous per-country indices by position. Register the two that are homogeneous enough to fix by registration alone:

```
livestock:        (t, i, animal)
people_last7days: (t, v, i, pid)   # Uganda reduced to (t,v,i) -> reduced-index country
```

## Verification (cold)
- `Feature('livestock')()` → named `['country','t','i','animal','currency']`, 253,615 rows, 13 countries.
- `Feature('people_last7days')()` → named `['country','t','v','i','pid']`, 1,015,837 rows, 12 countries.
- `groupby('country')` works for both (the API #496 says was impossible). 207 schema tests pass.

## Scope
`food_prices`/`food_quantities` were already registered (#507). The remaining three — **plot_labor, crop_production, plot_inputs** — are NOT registerable as-is: their per-country index **names diverge** (`plot`↔`plot_id`, `crop`↔`j`, extra `season`/`u`), so `_harmonize_country_frame` (aligns by name) can't stack them even with an entry. They need name-harmonization first → split to a follow-up.

`Addresses #496`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)