### PR TITLE
fix(#506): keep per-visit interview_date in Feature() (opt-in NaN fabrication)

### DIFF
--- a/lsms_library/data_info.yml
+++ b/lsms_library/data_info.yml
@@ -18,7 +18,7 @@ Index Info:
     household_characteristics: (t, v, i, m)
     plot_features: (t, v, i, plot_id)
     food_acquired: (t, v, i, j, u, s)
-    interview_date: (t, v, i)
+    interview_date: (t, v, i, visit)
     shocks: (t, i, Shock)
     panel_ids: (t, i)
     assets: (t, i, j)
@@ -34,6 +34,16 @@ Index Info:
     # need harmonizing before registration -- tracked separately.
     livestock: (t, i, animal)
     people_last7days: (t, v, i, pid)
+
+  # Features whose reduced-index countries get their MISSING canonical levels
+  # FABRICATED as NaN (so all countries share the full canonical shape and are
+  # KEPT) instead of being modal-excluded.  Use only where the reduced shape is
+  # legitimate variation, not an incompatible table.
+  # interview_date (#506): EHCVM countries are genuinely per-visit (t,v,i,visit);
+  # single-visit countries get visit=NaN so Feature() keeps the per-visit dates
+  # instead of dropping `visit` and first()-collapsing one date per household.
+  fabricate_missing_levels:
+    - interview_date
 
 # Cluster-id (v) join policy.  _finalize_result() joins v from sample() onto
 # household-level (i, t) tables that lack it.  A table is SKIPPED when its

--- a/lsms_library/feature.py
+++ b/lsms_library/feature.py
@@ -74,6 +74,24 @@ def _canonical_index_levels(table_name: str) -> list[str]:
     return [tok.strip() for tok in cleaned.split(",") if tok.strip()]
 
 
+def _fabricates_missing_levels(table_name: str) -> bool:
+    """Whether *table_name* opts into NaN-fabrication of missing canonical
+    levels (``Index Info: fabricate_missing_levels`` in data_info.yml).
+
+    When True, ``_harmonize_country_frame`` adds any missing canonical index
+    levels to a reduced-index country as a ``pd.NA`` level (so every country
+    shares the full canonical shape and is KEPT), instead of leaving it reduced
+    to be modal-excluded.  Use only where the reduced shape is legitimate
+    variation -- e.g. interview_date's single-visit countries vs per-visit
+    EHCVM ones (#506).
+    """
+    info_path = files("lsms_library") / "data_info.yml"
+    with open(info_path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    lst = data.get("Index Info", {}).get("fabricate_missing_levels", []) or []
+    return table_name in lst
+
+
 # Tables whose measure columns are ADDITIVE across a dropped recall/visit level.
 # When collapsing the duplicate index left after dropping that level, these must
 # be SUMMED (not reduced via first(), which undercounts the cross-country total).
@@ -105,7 +123,8 @@ def _collapse_duplicate_index(df: pd.DataFrame, table_name: str) -> pd.DataFrame
 
 
 def _harmonize_country_frame(
-    df: pd.DataFrame, canonical_levels: list[str], country: str, table_name: str
+    df: pd.DataFrame, canonical_levels: list[str], country: str, table_name: str,
+    fabricate_missing: bool = False,
 ) -> pd.DataFrame:
     """Coerce a single country's frame toward the canonical shape before concat.
 
@@ -115,7 +134,12 @@ def _harmonize_country_frame(
     for the WHOLE feature.  This drops all-NaN columns and removes index
     levels that are not part of the canonical index (only when every
     canonical level is present, so legitimately-reduced frames are left
-    alone).  It never fabricates missing levels.
+    alone).
+
+    By default it never fabricates missing levels.  When ``fabricate_missing``
+    (a per-feature opt-in, #506), any canonical level absent from this country's
+    index is added as a ``pd.NA`` level so reduced-index countries share the
+    full canonical shape and are KEPT (rather than modal-excluded in __call__).
     """
     if not isinstance(df, pd.DataFrame) or df.empty:
         return df
@@ -136,6 +160,17 @@ def _harmonize_country_frame(
     # there is at least one extra (keeps single-country reductions intact).
     if canonical_levels and isinstance(df.index, pd.MultiIndex):
         names = list(df.index.names)
+        # Opt-in (#506): fabricate any missing canonical level as a pd.NA index
+        # level so a legitimately-reduced country keeps the full canonical shape
+        # (and is KEPT, not modal-excluded).  E.g. interview_date single-visit
+        # countries gain visit=NaN to stack with per-visit EHCVM countries.
+        missing = [lvl for lvl in canonical_levels if lvl not in names]
+        if fabricate_missing and missing:
+            flat = df.reset_index()
+            for lvl in missing:
+                flat[lvl] = pd.NA
+            df = flat.set_index(names + missing)
+            names = list(df.index.names)
         have_all_canonical = all(lvl in names for lvl in canonical_levels)
         if have_all_canonical:
             # Put the canonical levels in canonical ORDER (then any extras).  Do
@@ -349,6 +384,7 @@ class Feature:
         targets = countries if countries is not None else self.countries
         frames: list[pd.DataFrame] = []
         canonical_levels = _canonical_index_levels(self.table_name)
+        fabricate_missing = _fabricates_missing_levels(self.table_name)  # #506
 
         # numeraire supersedes currency; both are no-ops for non-monetary tables.
         # Either way the output carries a `currency` index level (relabelled to
@@ -407,7 +443,7 @@ class Feature:
                 # column / extra index level can't collapse the whole
                 # concatenated index to object tuples (GH #325).
                 df = _harmonize_country_frame(
-                    df, canonical_levels, name, self.table_name
+                    df, canonical_levels, name, self.table_name, fabricate_missing
                 )
                 # Prepend country as an index level
                 df = pd.concat({name: df}, names=["country"])

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -72,3 +72,50 @@ def test_column_table_has_countries(table):
     """Every table with canonical columns should be declared by ≥1 country."""
     countries = _discover_countries_for_table(table)
     assert len(countries) > 0, f"No countries declare '{table}' in data_scheme.yml"
+
+
+# ---------------------------------------------------------------------------
+# _harmonize_country_frame: missing-level fabrication opt-in (GH #506)
+# ---------------------------------------------------------------------------
+
+import pandas as pd
+from lsms_library.feature import _harmonize_country_frame, _fabricates_missing_levels
+
+
+def _reduced_frame():
+    """A reduced (t,v,i) frame vs a canonical (t,v,i,visit) target."""
+    idx = pd.MultiIndex.from_tuples([('2020', 'c1', 'h1'), ('2020', 'c1', 'h2')],
+                                    names=['t', 'v', 'i'])
+    return pd.DataFrame({'Int_t': ['2020-01-01', '2020-02-01']}, index=idx)
+
+
+class TestFabricateMissingLevels:
+    def test_optout_leaves_reduced_frame_untouched(self):
+        """Default (no opt-in): a missing canonical level is NOT fabricated."""
+        df = _harmonize_country_frame(_reduced_frame(), ['t', 'v', 'i', 'visit'],
+                                      'X', 'sometable', fabricate_missing=False)
+        assert list(df.index.names) == ['t', 'v', 'i']
+
+    def test_optin_fabricates_missing_level_as_na(self):
+        """Opt-in (#506): the missing 'visit' level is added as a pd.NA level,
+        in canonical order, so the frame shares the full canonical shape."""
+        df = _harmonize_country_frame(_reduced_frame(), ['t', 'v', 'i', 'visit'],
+                                      'X', 'interview_date', fabricate_missing=True)
+        assert list(df.index.names) == ['t', 'v', 'i', 'visit']
+        assert df.index.get_level_values('visit').isna().all()
+        assert len(df) == 2  # no rows lost
+
+    def test_optin_preserves_existing_level(self):
+        """A frame that already has the per-visit level is left intact (ordered)."""
+        idx = pd.MultiIndex.from_tuples([('2020', 'c1', 'h1', '1'), ('2020', 'c1', 'h1', '2')],
+                                        names=['t', 'v', 'i', 'visit'])
+        full = pd.DataFrame({'Int_t': ['a', 'b']}, index=idx)
+        df = _harmonize_country_frame(full, ['t', 'v', 'i', 'visit'],
+                                      'Y', 'interview_date', fabricate_missing=True)
+        assert list(df.index.names) == ['t', 'v', 'i', 'visit']
+        assert df.index.get_level_values('visit').tolist() == ['1', '2']
+
+    def test_interview_date_opts_in(self):
+        """interview_date is registered for fabrication; a non-listed table is not."""
+        assert _fabricates_missing_levels('interview_date') is True
+        assert _fabricates_missing_levels('assets') is False


### PR DESCRIPTION
## What
`Feature('interview_date')` was registered canonical `(t,v,i)`, so the **per-visit `visit` level** that the EHCVM countries genuinely carry was treated as an *extra* → dropped and `first()`-collapsed to one date per household, **silently losing** the per-visit detail (added in commit `717e32f4`).

## Why pure registration doesn't work
Registering `(t,v,i,visit)` alone would **backfire**: single-visit countries (the majority) become reduced-index, so the per-visit EHCVM minority would be **modal-excluded** (#520) — dropping their data entirely (worse than the current behavior).

## Fix — per-feature opt-in for NaN-fabrication (Option 1)
New `Index Info: fabricate_missing_levels` list in `data_info.yml`. For a listed feature, `_harmonize_country_frame` adds any **missing** canonical level to a reduced country as a `pd.NA` level, so every country shares the full canonical shape and is **kept** (not modal-excluded). `interview_date` opts in + is registered `(t,v,i,visit)`; **`assets`/`livestock`/etc. are not opted in**, so their modal-exclusion behavior is untouched (**zero blast radius**).

## Verification (cold)
- `Feature('interview_date')()` → named `(country,t,v,i,visit)`, 537,173 rows, **27 countries**; `visit` non-null **287,705** (EHCVM per-visit dates preserved) / null **249,468** (single-visit, `visit=NaN`); **no** silent visit-drop.
- Regression: `assets` (23), `livestock` (13), `people_last7days` (12) byte-identical.
- 208 `test_schema_consistency` tests pass; **4 new** `_harmonize_country_frame` unit tests (opt-in / opt-out / preserve-existing / registered-list).

`Addresses #506`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)