### PR TITLE
feat(#575): food_expenditures(basis=) — purchased (default) vs total acquisition value

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -3397,7 +3397,8 @@ class Country:
 
         if name in self.data_scheme or name in self._FOOD_DERIVED or name in self._ROSTER_DERIVED:
             def method(waves=None, market=None, labels='Preferred', age_cuts=None,
-                       units=None, volume_as_mass=True, currency=None, numeraire=None):
+                       units=None, volume_as_mass=True, currency=None, numeraire=None,
+                       basis=None):
                 if age_cuts is not None and name not in self._ROSTER_DERIVED:
                     raise TypeError(
                         f"{name}() got an unexpected keyword argument 'age_cuts'; "
@@ -3409,6 +3410,20 @@ class Country:
                         f"{name}() got an unexpected keyword argument 'units'; "
                         "only 'food_prices' and 'food_quantities' accept units."
                     )
+                if basis is not None:
+                    if name != 'food_expenditures':
+                        raise TypeError(
+                            f"{name}() got an unexpected keyword argument 'basis'; "
+                            "only 'food_expenditures' accepts basis."
+                        )
+                    # Validate early: the derive path's broad except would
+                    # otherwise swallow the transform's ValueError and surface
+                    # a confusing "could not materialize" instead (#575).
+                    if basis not in {'purchased', 'total'}:
+                        raise ValueError(
+                            f"food_expenditures() basis= must be 'purchased' or "
+                            f"'total'; got {basis!r}"
+                        )
                 if (volume_as_mass is not True
                         and name not in {'food_prices', 'food_quantities'}):
                     raise TypeError(
@@ -3462,6 +3477,8 @@ class Country:
                         transform_kwargs['units'] = units
                     if name in {'food_prices', 'food_quantities'}:
                         transform_kwargs['volume_as_mass'] = volume_as_mass
+                    if name == 'food_expenditures' and basis is not None:
+                        transform_kwargs['basis'] = basis
                     derived = None
                     try:
                         fa = self._aggregate_wave_data(waves, 'food_acquired')

--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -632,24 +632,66 @@ def _apply_kg_conversion(df, factors):
     return v
 
 
-def food_expenditures_from_acquired(df):
+def food_expenditures_from_acquired(df, basis='purchased'):
     """Derive food expenditures from food_acquired.
 
-    Returns a DataFrame of total expenditure per household × item × period
-    × acquisition source (when ``s`` is present in the input index),
-    summed over units.
+    Returns a DataFrame of expenditure per household × item × period ×
+    acquisition source (when ``s`` is present in the input index), summed
+    over units.
 
-    Phase 4 of GH #169 / DESIGN_food_acquired_canonical_2026-05-05.org
-    extends the group-by to preserve the ``s`` (acquisition-source) index
-    level.  Users who want the legacy collapsed view call
-    ``food_expenditures.groupby(level=['t','v','i','j']).sum()``
-    explicitly.
+    Parameters
+    ----------
+    df : pd.DataFrame
+        food_acquired with an ``Expenditure`` column.
+    basis : {'purchased', 'total'}, default 'purchased'
+        Which acquisition sources contribute to ``Expenditure`` (GH #575):
+
+        - ``'purchased'`` (default): **cash outlay only** — keep rows with
+          ``s == 'purchased'``.  Own-production / in-kind / other sources
+          carry no cash expenditure, so they are excluded.  This is
+          *consistent across countries* regardless of whether the source
+          happened to record an imputed produced/in-kind value: some waves
+          (e.g. Serbia, GhanaSPS) populate ``Expenditure`` on produced/
+          in-kind rows, others (e.g. Guatemala, and every country built via
+          the stock ``food_acquired_to_canonical``) leave it NaN.  Filtering
+          to ``purchased`` removes that cross-country divergence.
+        - ``'total'``: **all recorded acquisition value** — sum
+          ``Expenditure`` across every ``s``.  Where the source recorded a
+          produced/in-kind value it is included; where it did not, ``'total'``
+          equals ``'purchased'`` for that country (no value is fabricated).
+          *Imputing* own-production value at purchase prices for purchased-
+          only-source countries is a tracked follow-up, NOT done here.
+
+    Notes
+    -----
+    Phase 4 of GH #169 preserves the ``s`` (acquisition-source) level in the
+    output.  Users who want the legacy collapsed view call
+    ``food_expenditures.groupby(level=['t','v','i','j']).sum()`` explicitly;
+    ``basis='purchased'`` then yields the purchased total, ``'total'`` the
+    sum across recorded sources.
+
+    When the input has no ``s`` level (pre-canonical waves) the two bases
+    coincide — there is no source split to filter on.
     """
+    valid_basis = {'purchased', 'total'}
+    if basis not in valid_basis:
+        raise ValueError(
+            f"food_expenditures basis= must be one of {sorted(valid_basis)}, "
+            f"got {basis!r}"
+        )
+
     df = _normalize_columns(df)
     if 'Expenditure' not in df.columns:
         raise ValueError("food_acquired must have an 'Expenditure' column")
 
     idx_names = list(df.index.names)
+
+    x = df[['Expenditure']].replace(0, np.nan).dropna()
+    if basis == 'purchased' and 's' in idx_names:
+        # Cash outlay only — drop non-purchased sources so the figure means
+        # the same thing across countries (#575).
+        x = x[x.index.get_level_values('s').astype(str) == 'purchased']
+
     # Preserve `s` in the output (Phase 4).  `u` is dropped — Expenditure
     # is currency-denominated, so summing across units is meaningful.
     # `v` is also omitted: with pandas's default ``dropna=True``, a
@@ -660,8 +702,6 @@ def food_expenditures_from_acquired(df):
     # asked, so dropping ``v`` here loses no information.  Closes #246
     # part (C-2) NaN-``v`` regression.
     group_by = [n for n in ['t', 'i', 'j', 's'] if n in idx_names]
-
-    x = df[['Expenditure']].replace(0, np.nan).dropna()
     x = x.groupby(group_by).sum()
     return x
 

--- a/slurm_logs/DESIGN_food_expenditures_basis_kwarg.org
+++ b/slurm_logs/DESIGN_food_expenditures_basis_kwarg.org
@@ -1,0 +1,71 @@
+#+TITLE: food_expenditures(basis=) — purchased vs total acquisition value (GH #575)
+#+filetags: design food_acquired food_expenditures 575
+#+DATE: <2026-06-25 Thu>
+#+AUTHOR: Sue (Claude Opus 4.8)
+
+* Problem
+=food_expenditures= had DIVERGED across countries.  =food_expenditures_from_acquired=
+summed =Expenditure= over whatever acquisition-source (=s=) rows carried a
+non-null value.  But the canonical builders disagree on whether produced/in-kind
+rows carry a value:
+- stock =food_acquired_to_canonical= (Burkina_Faso, Senegal, Tanzania, Guatemala,
+  ...) NaNs produced/in-kind =Expenditure= -> =food_expenditures= = purchased-only;
+- bespoke melts (Serbia, GhanaSPS, Uganda) populate produced/in-kind =Expenditure=
+  -> =food_expenditures= = total acquisition value.
+So =Feature('food_expenditures')= mixed two measures: Serbia/GhanaSPS showed
+systematically higher "expenditure" (own-production folded in) than the
+purchased-only countries.  Surfaced by the #218 adversarial review (=wuiofz6p0=).
+
+* Decision (user, 2026-06-25): a ``basis=`` kwarg, ``purchased`` the default
+Mirrors the Phase-4 =food_prices(units=)= / =food_quantities(units=)= precedent.
+
+- =food_expenditures(basis='purchased')= (DEFAULT): cash outlay only -- keep
+  rows with =s == 'purchased'=.  Consistent across ALL countries regardless of
+  whether the source recorded an imputed produced/in-kind value.  Removes the
+  divergence.
+- =food_expenditures(basis='total')=: sum recorded =Expenditure= across every
+  =s=.  Where the source recorded produced/in-kind value (Serbia, GhanaSPS,
+  Uganda) it is included; where it did not (Guatemala, stock-helper countries)
+  =total= equals =purchased= -- *no value is fabricated*.
+
+* Why purchased is the default
+"Expenditure" is a cash-outlay term of art.  A subsistence household that ate
+only its own produce has zero food *expenditure*; it correctly has no rows in
+the default view.  Analysts wanting consumption *value* (the usual CFE-demand
+input) pass =basis='total'= (and, once the follow-up lands, get imputed
+own-production value too).
+
+* Coverage consequence (documented, not a bug)
+Purchased-only default drops households whose food was entirely own-production.
+Measured: Uganda 2009-10 food_expenditures(market='Region') = 2900 HH at
+=basis='purchased'= vs 2929 at =basis='total'= (29 subsistence-only HH).  The
+=test_food_expenditures_retains_hybrid_v_HH= coverage invariant (which asserts
+the market-fallback v-retention, orthogonal to source) was updated to use
+=basis='total'= so it keeps measuring the full HH set it is about.
+
+* Implementation
+- =transformations.food_expenditures_from_acquired(df, basis='purchased')=:
+  validate basis; filter =s=='purchased'= for the default; group-by preserves
+  =s= (Phase 4).  No-=s= waves: bases coincide.
+- =country.py= generated method: new =basis=None= param; gate rejects =basis= on
+  non-=food_expenditures= tables AND validates the value EARLY (before the derive
+  path, whose broad =except= would otherwise swallow the ValueError and surface a
+  confusing "could not materialize").  Forwarded to the transform.
+- =Feature= forwards =basis= automatically (it is now in the method signature).
+- Tests: =tests/test_food_expenditures_basis.py= (6 synthetic-frame units);
+  =test_sample.py= coverage fixture switched to =basis='total'=.
+
+* Follow-up (NOT in this PR): impute own-production value for basis='total'
+For purchased-only-source countries, =basis='total'= currently == =purchased=
+(the source has no produced/in-kind value to sum).  A faithful "total
+acquisition value" should *impute* own-production / in-kind value at purchase
+unit prices (Deaton): produced value = produced Quantity x purchase unit-value
+for the same (t, j, u).  This is a modeling step (which price granularity --
+national (t,j,u) vs cluster/region -- and how to handle never-purchased items),
+deferred to its own issue.  Until then =basis='total'= is honestly "sum of
+recorded acquisition value", documented in the docstring.
+
+* References
+- GH #575, #218 (review =wuiofz6p0= that surfaced the divergence),
+  DESIGN_food_prices_units_kwarg_2026-05-06.org (the units= precedent),
+  transformations.py food_*_from_acquired, country.py _FOOD_DERIVED dispatch.

--- a/tests/test_food_expenditures_basis.py
+++ b/tests/test_food_expenditures_basis.py
@@ -1,0 +1,74 @@
+"""Unit tests for food_expenditures_from_acquired(basis=) — GH #575.
+
+Synthetic food_acquired frames (no data build) exercise the purchased-only
+default vs the total-recorded-value basis, the no-``s`` fallback, and
+validation.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lsms_library.transformations import food_expenditures_from_acquired
+
+
+def _fa_with_s():
+    """A canonical (t,i,j,u,s) food_acquired: HH 'h1' buys + grows item j1;
+    HH 'h2' ONLY grows j1 (no purchased row — a subsistence household)."""
+    rows = [
+        # t,   i,    j,    u,     s,           Quantity, Expenditure
+        ('2020', 'h1', 'j1', 'kg', 'purchased', 10.0, 100.0),
+        ('2020', 'h1', 'j1', 'kg', 'produced',   5.0,  40.0),   # source recorded a value
+        ('2020', 'h1', 'j2', 'kg', 'purchased',  2.0,  30.0),
+        ('2020', 'h2', 'j1', 'kg', 'produced',   8.0,  60.0),   # subsistence-only HH
+    ]
+    idx = pd.MultiIndex.from_tuples([r[:5] for r in rows],
+                                    names=['t', 'i', 'j', 'u', 's'])
+    return pd.DataFrame({'Quantity': [r[5] for r in rows],
+                         'Expenditure': [r[6] for r in rows]}, index=idx)
+
+
+class TestBasisDefault:
+    def test_default_is_purchased(self):
+        """Default basis keeps only s=='purchased' rows."""
+        out = food_expenditures_from_acquired(_fa_with_s())
+        assert set(out.index.get_level_values('s')) == {'purchased'}
+
+    def test_purchased_drops_subsistence_only_household(self):
+        """A HH whose food is entirely own-production has no cash expenditure
+        and is absent from the purchased (default) view."""
+        out = food_expenditures_from_acquired(_fa_with_s(), basis='purchased')
+        assert 'h2' not in set(out.index.get_level_values('i'))
+        # h1 purchased total = 100 (j1) + 30 (j2)
+        assert out['Expenditure'].sum() == pytest.approx(130.0)
+
+    def test_total_includes_recorded_nonpurchased(self):
+        """basis='total' sums recorded value across all sources, incl. the
+        subsistence HH, and is >= purchased."""
+        out = food_expenditures_from_acquired(_fa_with_s(), basis='total')
+        assert {'purchased', 'produced'} <= set(out.index.get_level_values('s'))
+        assert 'h2' in set(out.index.get_level_values('i'))
+        # 100 + 40 + 30 + 60
+        assert out['Expenditure'].sum() == pytest.approx(230.0)
+
+
+class TestBasisEdgeCases:
+    def test_no_s_level_bases_coincide(self):
+        """With no s level there is no split — both bases sum all rows."""
+        idx = pd.MultiIndex.from_tuples(
+            [('2020', 'h1', 'j1'), ('2020', 'h1', 'j2')],
+            names=['t', 'i', 'j'])
+        df = pd.DataFrame({'Quantity': [1.0, 2.0], 'Expenditure': [10.0, 20.0]},
+                          index=idx)
+        a = food_expenditures_from_acquired(df, basis='purchased')
+        b = food_expenditures_from_acquired(df, basis='total')
+        assert a['Expenditure'].sum() == b['Expenditure'].sum() == pytest.approx(30.0)
+
+    def test_invalid_basis_raises(self):
+        with pytest.raises(ValueError, match="basis="):
+            food_expenditures_from_acquired(_fa_with_s(), basis='bogus')
+
+    def test_missing_expenditure_raises(self):
+        df = _fa_with_s().drop(columns=['Expenditure'])
+        with pytest.raises(ValueError, match="Expenditure"):
+            food_expenditures_from_acquired(df)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -386,11 +386,18 @@ class TestUganda2009MarketFallback:
     def fe(self):
         """Uganda food_expenditures(market='Region'), or skip if the
         underlying microdata cannot be built in this environment
-        (e.g. CI without DVC S3 credentials)."""
+        (e.g. CI without DVC S3 credentials).
+
+        Uses ``basis='total'`` (#575): this test asserts the market-fallback
+        v-retention coverage (≥2929 HH), which is orthogonal to acquisition
+        source.  The purchased-only default (the new #575 default) legitimately
+        drops the 29 Uganda HH that consumed only own-production / in-kind food
+        (zero cash expenditure); ``basis='total'`` keeps the full HH set the
+        coverage invariant is about."""
         try:
             return (
                 ll.Country("Uganda")
-                .food_expenditures(market="Region")
+                .food_expenditures(market="Region", basis="total")
                 .squeeze()
             )
         except Exception as exc:  # broad catch intentional: skip on any build failure


### PR DESCRIPTION
## What
`food_expenditures` had **diverged across countries**: the derived path summed `Expenditure` over whatever acquisition-source (`s`) rows carried a value, but the canonical builders disagree on whether produced/in-kind rows carry one — stock `food_acquired_to_canonical` (BF/Senegal/Tanzania/Guatemala) NaNs it → *purchased-only*; bespoke melts (Serbia/GhanaSPS/Uganda) populate it → *total acquisition value*. So `Feature('food_expenditures')` mixed two measures. (Surfaced by the #218 adversarial review, `wuiofz6p0`.)

## Fix — `basis=` kwarg (purchased default), mirroring the Phase-4 `units=` precedent
- **`basis='purchased'` (default):** cash outlay only (`s=='purchased'`) — **consistent across all countries** regardless of whether the source recorded a produced/in-kind value. Removes the divergence.
- **`basis='total'`:** sum recorded `Expenditure` across every `s`; **no value fabricated** (equals purchased where the source recorded no produced/in-kind value).

Verified cold: Serbia 25.1M (purchased) → 29.7M (total); GhanaSPS 3.49M → 4.85M; Guatemala/Tanzania equal (no recorded produced value). Gate rejects `basis=` on non-`food_expenditures`; bad value → `ValueError` (validated *early*, before the derive path's broad `except` could mask it).

## Coverage consequence (documented, not a bug)
Purchased-only default drops own-production-only households (zero cash spend): **Uganda 2009-10 = 2900 HH (purchased) vs 2929 (total)** — 29 subsistence HH. The market-fallback `v`-retention coverage test (orthogonal to acquisition source) was switched to `basis='total'` so it keeps measuring the full HH set it asserts.

## Tests
- `tests/test_food_expenditures_basis.py` — 6 synthetic-frame units (default/purchased/total/no-s/validation).
- Full transform+schema+feature suite: **599 passed**. The only other failure (`Kosovo/household_roster` sanity) is **pre-existing + unrelated** — no `basis` code path reaches rosters (confirmed by stashing my changes).

## Scope
Own-production **value imputation** for `basis='total'` (value subsistence consumption at purchase prices, Deaton) is genuine modeling → **follow-up issue**, not faked here. Design: `slurm_logs/DESIGN_food_expenditures_basis_kwarg.org`.

`Addresses #575`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)