### PR TITLE
Phase 0: fix the coverage ruler (blessed tier + absent verdicts + wave-slice grader)

### DIFF
--- a/.coder/coverage/blessed.csv
+++ b/.coder/coverage/blessed.csv
@@ -1,1 +1,1 @@
-country,feature,wave
+country,feature,wave,blessed_by,date,note

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,21 @@ The returned DataFrame prepends a `country` index level.
 - `scrum-master-hpc` (shared sucoder skill at `~/.sucoder/skills/scrum-master-hpc/SKILL.md`) — dispatching subagents, worktrees, DVC lock hygiene. Read this before using the Agent tool for multi-country work. Library-specific addenda:
   1. Subagents share the parquet cache at `~/.local/share/lsms_library/`, so concurrent agents building different countries don't conflict.
   2. The venv is at `{repo_root}/.venv/bin/python` (not in worktrees) — set `PYTHONPATH` to the worktree so development-branch code is picked up.
-  3. **`.venv/lib/python3.11/site-packages/lsms_library.pth` hardcodes the main-repo path** — `PYTHONPATH` alone does NOT redirect imports of `lsms_library` to a worktree.  Worker agents that rebuild a feature to verify a YAML edit will silently run the main checkout's code.  For **config** edits (`countries/{C}/_/...` — YAML/scripts/`.org`, the common case), set **`LSMS_COUNTRIES_ROOT=<worktree>/lsms_library/countries`** so the live package reads the worktree's config tree (GH #436); this is the clean fix and needs no fresh venv.  For **library-code** edits (`country.py`, `local_tools.py`, …) the `.pth` still pins to the main checkout, so either (a) verify via static diff only, or (b) have the agent install a fresh venv inside its worktree.  See the `.pth`-pinned package imports pitfall in the scrum-master-hpc skill for detection and mitigations.
+  3. **`.venv/lib/python3.11/site-packages/lsms_library.pth` hardcodes the main-repo path**, so a worktree agent can silently verify against the *main checkout's* code.  **Always set `PYTHONPATH=<worktree>`** — it *does* beat the `.pth` (corrected 2026-07-12; this entry previously claimed the opposite, and the wrong claim sent people to a needless fresh-venv build).
+
+     **The actual trap is `python <script>.py`.**  Python sets `sys.path[0]` to the **script's own directory**, *not* cwd.  So `cd`-ing into the worktree does **not** protect a script run — cwd never enters `sys.path` at all, the `.pth`'s main-repo path wins, and you import the main checkout while believing you are testing the worktree.  Verified:
+
+     | invocation (cwd = worktree) | `PYTHONPATH` | imports |
+     |---|---|---|
+     | `python -c "import lsms_library"` | unset | worktree ✓ (cwd is `sys.path[0]`) |
+     | `python bench/scan.py` | unset | **main checkout ✗ — the trap** |
+     | `python bench/scan.py` | `=<worktree>` | worktree ✓ |
+
+     This has already cost a worker agent a full wasted audit run (PR #594).  Since the failure is *silent* and looks like success, **assert it** rather than assume it:
+     ```python
+     import lsms_library; assert 'worktrees' in lsms_library.__file__, lsms_library.__file__
+     ```
+     For **config**-only edits (`countries/{C}/_/...` — YAML/scripts/`.org`, the common case), `LSMS_COUNTRIES_ROOT=<worktree>/lsms_library/countries` is the cleaner lever: the live package reads the worktree's config tree (GH #436) and library-code identity stops mattering.  A fresh in-worktree venv is **not** needed for either case.  See the `.pth`-pinned package imports pitfall in the scrum-master-hpc skill.
   4. *Savio compute nodes only*: `.venv` is typically a symlink to `/local/jobNNN/venv` (node-local SSD) and goes stale whenever you land on a different node.  Recovery recipe lives in `.venv.lustre/README_WHY_THIS_EXISTS.md` at the repo root.  **Do not just grab `.venv.lustre/bin/python`** — every import will round-trip through Lustre.  Follow the README's **adopt-or-build recipe** (adopt any importable `/local/job*/venv` already on the node → tar-pipe build only if none → reclaim the stale ones), which gives cross-job persistence without root.  Note: a stable `/local/$USER/<repo>` path is NOT creatable by us (`/local` is `root:root`); a genuinely persistent path needs an HPC-support ticket (README "Admin endgame").  **Opt-in fast path**: `bin/savio_venv.sh` packages the venv as a single squashfs image (`.venv.sqfs`, ~255 MB / one Lustre inode vs ~33k files) and mounts it per job via apptainer's `squashfuse_ll` (`mount`/`umount`/`update` subcommands) — kills the Lustre-MDS load and sidesteps the per-job reaper; see `docs/savio_venv.md` for the model + how to rebuild the image when deps change.  This guidance is Savio-specific; other environments (login nodes, laptops, non-HPC clusters) use a normal in-tree `.venv/` and this paragraph doesn't apply.
 
 ## Repository Layout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,23 @@ A feature can build cleanly, pass every sanity check, and still be quietly wrong
 
 **Do not trust a `sane` cell as proof an issue is fixed.** Know what the grader does *not* look at — it is a cold build (so it cannot see warm-cache-only divergences) and it does not check currency labels.
 
+### Adjudicating `absent` cells
+
+`absent` says only "not declared for this wave" — which conflates *"the survey never asked"* with *"nobody wrote the config yet"*. Verdicts go in the git-tracked `.coder/coverage/absent_verdicts.csv` (`country,feature,wave,verdict,checks_run,evidence,adjudicated_by,date`):
+
+| verdict | meaning | closes the cell? |
+|---|---|---|
+| `todo` | data is there, config missing | no — stays `absent`, but now sized + sourced |
+| `asked-not-distributed` | instrument asked; the shipped extract lacks it | **yes** → acquisition queue |
+| `not-asked` | genuinely never asked | **yes** → closed forever |
+| `unsure` | a required check could not be run | no — stays in the queue, records why |
+
+> **A closing verdict REQUIRES evidence — `load_verdicts()` refuses one without it.** A closing verdict is a permanent, unsupervised write. An unevidenced negative is unfalsifiable, and therefore permanent whether or not it is true.
+>
+> This already went wrong: `Albania/_/data_scheme.yml` asserted *"earlier waves have no shocks module"*, but Albania 2005's `migrationE_cl.dta` carries `m6e_q00 = 'Type of Shock Code'` with ten shock types. False, uncatchable (nothing recorded *how* it was reached), and it suppressed ~5 cells of work. **Never write an unevidenced "no module here" claim, in a verdict file or in a YAML comment.**
+
+Before closing a cell, run the four checks (see `docs/guide/coverage.md`). The two that are most often skipped and most often wrong: **C2 (sibling-wave differential) is necessary but NEVER sufficient** — module vocabularies change completely between waves; and **C4 (the questionnaire) is mandatory**, because *absence in the shipped `.dta` is not absence in the instrument*. Only the questionnaire separates `not-asked` from `asked-not-distributed`.
+
 ## Derived Tables
 
 `household_characteristics`, `food_expenditures`, `food_prices`, and `food_quantities` are **auto-derived at runtime** via `_ROSTER_DERIVED` and `_FOOD_DERIVED` in `country.py` (source transforms live in `transformations.py`). **Do NOT register them in `data_scheme.yml`** — `Country.data_scheme` auto-surfaces them when the source table (`food_acquired` or `household_roster`) is present. A `!derived` YAML tag was considered and rejected (2026-04-18): it would create a migration burden with no gain over the hardcoded dicts + auto-discovery.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,23 @@ Auto-unlock decrypts `s3_reader_creds.gpg` with an obfuscated passphrase at impo
 
 **EHCVM note**: EHCVM 2018-19 countries lack a continuous months variable. The binary `s01q12` ("lived continuously 6+ months?") is mapped to 0/12. Guinea-Bissau may need Portuguese keys (`Sim`/`Não`) alongside `Oui`/`Non`. See CONTENTS.org files for per-country documentation.
 
+## Coverage Matrix (v0.9.0+)
+
+`make matrix` grades every `(country, feature, wave)` cell on a tier ladder — `absent` / `dropped` / `broken` / `builds` / `sane` / `blessed` — and commits a snapshot to `.coder/coverage/latest.csv`. `ll.coverage()` reads it back. See `docs/guide/coverage.md`.
+
+**`sane` is not `blessed`, and the difference matters.**
+
+- **`sane`** — the automated checks passed. *No human has necessarily looked at a single number.*
+- **`blessed`** — a human read the actual numbers for that cell and believes them. Recorded in the git-tracked `.coder/coverage/blessed.csv`.
+
+A feature can build cleanly, pass every sanity check, and still be quietly wrong — wired to the wrong source column, or carrying an unverified unit conversion. So **for anything feeding published analysis, `sane` is not enough.**
+
+> **The rule: if you used a cell in real analysis and looked at its numbers, bless it in the same PR.**
+> `country,feature,wave,blessed_by,date,note` (`wave` blank for country-level features). Blessings accrete; never bulk-seed them. An empty blessing file is honest — a file full of blessings nobody gave makes `blessed` a synonym for `sane` and destroys the tier.
+> Do **not** put `#` comments in `blessed.csv`: `load_blessed()` reads it without a `comment=` arg, so a comment line becomes a phantom blessed cell.
+
+**Do not trust a `sane` cell as proof an issue is fixed.** Know what the grader does *not* look at — it is a cold build (so it cannot see warm-cache-only divergences) and it does not check currency labels.
+
 ## Derived Tables
 
 `household_characteristics`, `food_expenditures`, `food_prices`, and `food_quantities` are **auto-derived at runtime** via `_ROSTER_DERIVED` and `_FOOD_DERIVED` in `country.py` (source transforms live in `transformations.py`). **Do NOT register them in `data_scheme.yml`** — `Country.data_scheme` auto-surfaces them when the source table (`food_acquired` or `household_roster`) is present. A `!derived` YAML tag was considered and rejected (2026-04-18): it would create a migration burden with no gain over the hardcoded dicts + auto-discovery.

--- a/bench/matrix.py
+++ b/bench/matrix.py
@@ -48,6 +48,9 @@ TIER_COLOR = {
     # extract) -- a distinct colour, because it routes to a different queue
     # entirely and should never be mistaken for either config work or a close.
     "asked-not-distributed": "#c5b3e6",
+    # Data downloaded, zero config -- work not yet STARTED.  Must read as work,
+    # not as a quiet gap.
+    "unconfigured":          "#fd7e14",
     "declared": "#cfe2ff",
     "dropped":  "#f5c2c7",
     "broken":   "#dc3545",
@@ -58,7 +61,7 @@ TIER_COLOR = {
 TIER_GLYPH = {
     "n/a": "·", "absent": "–", "declared": "?", "dropped": "✗!",
     "broken": "✗", "builds": "⚠", "sane": "✓", "blessed": "★",
-    "not-asked": "∅", "asked-not-distributed": "⤓",
+    "not-asked": "∅", "asked-not-distributed": "⤓", "unconfigured": "⌀",
 }
 
 

--- a/bench/matrix.py
+++ b/bench/matrix.py
@@ -39,7 +39,15 @@ RESULTS_DIR = REPO_ROOT / "bench" / "results"
 # Presentation only (the model is colour-agnostic).
 TIER_COLOR = {
     "n/a":      "#e9ecef",
+    # `absent` is the LIVE QUEUE (an un-adjudicated gap), so it must not read as
+    # quietly settled.  The adjudicated tiers below are the settled ones.
     "absent":   "#f1f3f5",
+    # Adjudicated-and-closed: dimmer than `absent`, because there is no work here.
+    "not-asked":             "#dee2e6",
+    # Adjudicated as an ACQUISITION problem (asked, but not in the shipped
+    # extract) -- a distinct colour, because it routes to a different queue
+    # entirely and should never be mistaken for either config work or a close.
+    "asked-not-distributed": "#c5b3e6",
     "declared": "#cfe2ff",
     "dropped":  "#f5c2c7",
     "broken":   "#dc3545",
@@ -50,6 +58,7 @@ TIER_COLOR = {
 TIER_GLYPH = {
     "n/a": "·", "absent": "–", "declared": "?", "dropped": "✗!",
     "broken": "✗", "builds": "⚠", "sane": "✓", "blessed": "★",
+    "not-asked": "∅", "asked-not-distributed": "⤓",
 }
 
 

--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -165,6 +165,14 @@ to refresh what readers see is:
    lsms-library cache clear --country Uganda   # repeat per country, or clear all
    make matrix C="Uganda"                       # omit C= for the full cube
    ```
+
+    !!! note "A scoped run upserts; it does not replace"
+        `save_snapshot()` **merges** on `(country, feature, wave)`, so
+        `make matrix C="Uganda"` updates Uganda's cells and leaves every other
+        country's alone. Before 2026-07-12 it replaced the file wholesale --
+        which meant that following this very procedure with `C=` committed a
+        67-cell snapshot over the authoritative 1849-cell one. A partial
+        measurement must never be able to erase a complete one.
 2. **Commit the journal** (it is tracked despite the global `*.csv` ignore):
    ```bash
    git add .coder/coverage/latest.csv

--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -29,6 +29,42 @@ re-implements the sanity checks.
 | `sane` | The wave slice is non-empty and passes every sanity check (warnings allowed). |
 | `blessed` | `sane` **and** listed in the git-tracked blessing file `.coder/coverage/blessed.csv`. |
 
+## Blessing a cell
+
+`sane` and `blessed` answer different questions:
+
+- **`sane`** — *the automated checks passed.* No human has necessarily looked at
+  a single number.
+- **`blessed`** — *a human read the actual numbers for this cell and believes
+  them.*
+
+For anything feeding published analysis, `sane` is not enough. A feature can
+build cleanly, pass every sanity check, and still be quietly wrong — wired to
+the wrong source column, or carrying a unit conversion nobody verified.
+
+**The rule: if you used a cell in real analysis and looked at its numbers, bless
+it in the same PR.**
+
+```csv
+country,feature,wave,blessed_by,date,note
+Uganda,food_expenditures,2019-20,ligon,2026-07-12,used in demand estimation; totals reconcile
+```
+
+`wave` is blank for country-level features. Only `country`, `feature`, and
+`wave` are read by the matrix — `blessed_by` / `date` / `note` are provenance
+for humans, and they are what make a blessing auditable rather than a bare
+assertion.
+
+Blessings accrete; they are never bulk-seeded. An empty blessing file is honest.
+A file full of blessings nobody actually gave is worse than no file at all,
+because it would make `blessed` a synonym for `sane` and destroy the only
+distinction the tier exists to draw.
+
+!!! warning "Do not put `#` comments in `blessed.csv`"
+    `load_blessed()` reads it with `pd.read_csv(..., keep_default_na=False)` and
+    no `comment=` argument, so a comment line is parsed as a **row** — a phantom
+    blessed cell. Header and data only.
+
 The grid cell shows a worst-first glyph tally over a country's waves
 (e.g. `⚠2 ✓5 –1` = 2 `builds`, 5 `sane`, 1 `absent`) and is coloured by the most
 actionable tier present.

--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -28,6 +28,70 @@ re-implements the sanity checks.
 | `builds` | The wave slice is non-empty but fails a sanity check (`SanityReport.ok is False`). |
 | `sane` | The wave slice is non-empty and passes every sanity check (warnings allowed). |
 | `blessed` | `sane` **and** listed in the git-tracked blessing file `.coder/coverage/blessed.csv`. |
+| `not-asked` | Adjudicated: the survey instrument genuinely never asked. Closed. |
+| `asked-not-distributed` | Adjudicated: the instrument **did** ask, but the shipped extract does not carry the variables. An *acquisition* problem. |
+
+## Adjudicating an `absent` cell
+
+`absent` alone says only *"the feature is not declared for this wave."* That
+conflates states that could not be more different, and until they are separated
+the number can never reach zero:
+
+| verdict | meaning | closes the cell? | routes to |
+|---|---|---|---|
+| `todo` | the data **is** there; nobody wrote the config | no — stays `absent` | `add-feature` |
+| `asked-not-distributed` | asked, but the extract lacks it | **yes** | acquisition / `add-wave` |
+| `not-asked` | genuinely never asked | **yes** | closed forever |
+| `unsure` | a required check could not be run | no — stays `absent` | human / OCR |
+
+Verdicts live in the git-tracked `.coder/coverage/absent_verdicts.csv`:
+
+```csv
+country,feature,wave,verdict,checks_run,evidence,adjudicated_by,date
+Albania,shocks,2005,todo,C1;C2,Data/migrationE_cl.dta m6e_q00 = 'Type of Shock Code' (10 types),sue,2026-07-12
+```
+
+### Evidence is not optional
+
+A **closing** verdict (`not-asked` / `asked-not-distributed`) is a *permanent,
+unsupervised write*: it removes a cell from the work queue with nobody
+reviewing it. So `load_verdicts()` **refuses** a closing verdict whose
+`evidence` field is empty, and warns.
+
+This is not defensive pedantry. It already went wrong:
+`Albania/_/data_scheme.yml` asserted *"earlier waves have no shocks module"* —
+and Albania 2005's `migrationE_cl.dta` carries `m6e_q00 = 'Type of Shock Code'`
+with ten shock types. The claim was false, nobody could catch it (nothing
+recorded *how* it was reached), and it silently suppressed work on ~5 cells.
+
+**An unevidenced negative is unfalsifiable, and therefore permanent whether or
+not it is true.**
+
+### The four checks
+
+A cell may be closed only when **all applicable** checks were run and all came
+back negative. Record which ran in `checks_run`. A check you *cannot* run makes
+the verdict `unsure` — silence is never evidence.
+
+1. **C1 — variable/value-label sweep.** Metadata-only reads across every source
+   file for the wave. Be extension-agnostic (LSMS ships Stata as `.tab`, SPSS as
+   `.sav`) and **search in the instrument's own language** (French, Spanish,
+   Portuguese). Distinguish *"no labels found"* from *"the files carry no labels
+   at all"* — the latter means the check did not run.
+2. **C2 — sibling-wave differential.** Necessary whenever the country has the
+   feature for another wave, but **never sufficient**: module vocabularies change
+   completely between waves (Iraq's 2007 `"Problem: theft"` shares no words with
+   2012's phrasing, yet both waves have the module).
+3. **C3 — Harmonized LSMS-ISA Ag cross-check.** `countries/Harmonized_LSMS-ISA_Ag/lsms_ag.parquet`
+   (7 ISA countries). **Positive-only**: a non-null harmonized column proves the
+   concept was asked; a *null* one proves nothing — it means the WB harmonizers
+   didn't code it.
+4. **C4 — the questionnaire. Mandatory before any permanent close.**
+   *Absence in the shipped `.dta` is not absence in the instrument.* Every
+   data-side check can be defeated by a data-*distribution* gap, so no amount of
+   data-side evidence may close a cell as `not-asked` — only the questionnaire
+   can separate `not-asked` from `asked-not-distributed`, and those route to
+   completely different queues.
 
 ## Blessing a cell
 

--- a/lsms_library/countries/Albania/_/data_scheme.yml
+++ b/lsms_library/countries/Albania/_/data_scheme.yml
@@ -83,10 +83,31 @@ Data Scheme:
     aggregation:
       visit: first
 
-  # Occurrence-only shocks module (2012 wave only; earlier waves have no
-  # shocks module).  No impact (Affected*) or coping (HowCoped*) detail in
-  # the source; ``Years`` is the comma-joined list of years 2008-2012 in
-  # which each experienced shock was reported.
+  # Occurrence-only shocks module.  WIRED for the 2012 wave only.  No impact
+  # (Affected*) or coping (HowCoped*) detail in the source; ``Years`` is the
+  # comma-joined list of years 2008-2012 in which each experienced shock was
+  # reported.
+  #
+  # CORRECTION 2026-07-12: this comment previously asserted "2012 wave only;
+  # earlier waves have no shocks module".  That claim was FALSE and it
+  # suppressed work on ~5 cells.  Verified against source:
+  #
+  #   2005  Data/migrationE_cl.dta          m6e_q00 "Type of Shock Code"
+  #                                         (10 types: Dispossesion of Land,
+  #                                         Unexpected death of income earner,
+  #                                         Job loss, Flood damage, Pyramid
+  #                                         scheme, ...) + m6e_q1989..q1999
+  #                                         year-occurrence grid
+  #   2008  Data/Modul_6E_migration_e.sav   m6e_q00, identical
+  #   2003  Data/w2_hh_all.dta              B10A_Q10 "faced any shocks in last
+  #                                         12 months" + 7 shock types
+  #   2004  Data/w3_hh_all.dta              m10a_q09, same
+  #
+  # 2002 is UNRESOLVED (no household questionnaire in the repo to check).
+  #
+  # These waves are therefore TODO, not "no module".  Tracked in the absent-cell
+  # adjudication (.coder/coverage/absent_verdicts.csv); do not re-close them
+  # without evidence.  See slurm_logs/DESIGN_coverage_discipline_2026-07-11.org.
   shocks:
     index: (t, i, Shock)
     Years: str

--- a/lsms_library/countries/Benin/2018-2019/Data/ehcvm_conso_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/ehcvm_conso_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 172d19b74b20e4c53cc4eaf5e0bdafb2
-  size: 15080231
-  path: ehcvm_conso_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/ehcvm_individu_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/ehcvm_individu_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 2b90122a5e48996fdb39714a168224a7
-  size: 3574796
-  path: ehcvm_individu_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/ehcvm_menage_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/ehcvm_menage_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 58b72f1394ef24d4afef9da45f93aeeb
-  size: 417433
-  path: ehcvm_menage_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/ehcvm_ponderations_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/ehcvm_ponderations_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 0b266b981e8cac5c1d5dcf7a803d8e61
-  size: 7214
-  path: ehcvm_ponderations_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/ehcvm_welfare_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/ehcvm_welfare_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 71ad72ac61da3f90afbc0b31102c551a
-  size: 811296
-  path: ehcvm_welfare_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/grappe_gps_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/grappe_gps_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: e3e83a1c2c561177c8249a75453545cc
-  size: 46488
-  path: grappe_gps_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s00_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s00_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 8e59d5dbf74d133a692fe793cc821cf7
-  size: 1039710
-  path: s00_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s00a_co_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s00a_co_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 1dd232eb87e8e16dbe66cb932ca5c969
-  size: 2524
-  path: s00a_co_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s00b_co_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s00b_co_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 312da001b61f992362061f99009c536a
-  size: 95857
-  path: s00b_co_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s01_co_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s01_co_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: ebb5002d9b60156623a3b6095557ff58
-  size: 169453
-  path: s01_co_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s01_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s01_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 4853964e96352167d6a1aaf501b1dddd
-  size: 2685265
-  path: s01_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s02_co_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s02_co_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: ed600511e0e4d0654199a2fc5c8b0741
-  size: 3839354
-  path: s02_co_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s02_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s02_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 8c4c683c5170fbc9994f26dc138219ed
-  size: 3063746
-  path: s02_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s03_co_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s03_co_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: ed37d6ddbf44834b5fc82f942cd5e8f7
-  size: 145254
-  path: s03_co_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s03_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s03_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 45dba775eecac931bce0a22d045f2925
-  size: 4211213
-  path: s03_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s04_co_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s04_co_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 0a13f168b562d229266dc1fe167292ca
-  size: 373424
-  path: s04_co_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s04_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s04_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 572bf43d973be4fd8b7fefa27e77f09b
-  size: 4346118
-  path: s04_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s05_co_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s05_co_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 245e1469ffee5bd6daba923f395bbd41
-  size: 1790118
-  path: s05_co_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s05_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s05_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: fbee3b00cd57c8830f2ad8e3e2e91046
-  size: 932055
-  path: s05_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s06_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s06_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 2bc2bc7f2c5ad67b143fffdd065ff250
-  size: 5259426
-  path: s06_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s07a1_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s07a1_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: f58e23200d0a6c2fa30f5a6223ffcf26
-  size: 350783
-  path: s07a1_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s07a2_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s07a2_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 2567bdb279863752130f282e1cf7b6b6
-  size: 2081074
-  path: s07a2_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s07b_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s07b_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 8e90e75a24df0ccfa86e8d2c8d72af5e
-  size: 10333565
-  path: s07b_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s08a_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s08a_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: c2a7c654b9f49ed16366b54e421212f0
-  size: 132328
-  path: s08a_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s08b1_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s08b1_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: c12c82a1f03fd883048d26b213307287
-  size: 139377
-  path: s08b1_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s08b2_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s08b2_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 3e6a55c2c78aec483d24d6293ef5d659
-  size: 79428
-  path: s08b2_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s09a_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s09a_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: cae58bd95cf28b563cbe4b5497ead2a5
-  size: 2919153
-  path: s09a_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s09b_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s09b_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 9246563ed9701b5319a707b904e72afc
-  size: 374077
-  path: s09b_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s09c_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s09c_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 76267dbbd51feefa680c192b7d9d7a68
-  size: 389291
-  path: s09c_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s09d_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s09d_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: c6badf5ded21c03ea658fe46546abfa4
-  size: 200872
-  path: s09d_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s09e_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s09e_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: ad1e74b80bc266fdd7791748b2e6a047
-  size: 486216
-  path: s09e_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s09f_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s09f_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 927f80f79291bcb216d1bcd5abd4a2d0
-  size: 324678
-  path: s09f_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s10_1_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s10_1_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 508271ab29737b0a64aadb7aead3455a
-  size: 91702
-  path: s10_1_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s10_2_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s10_2_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 4d151c8a0119b3df54e81c956278e7d6
-  size: 3796950
-  path: s10_2_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s11_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s11_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: c16f1aa44bdd7df97435fa12d48d81dd
-  size: 1086090
-  path: s11_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s12_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s12_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 84b2809ee60e0d358c88535b7d591e22
-  size: 9739273
-  path: s12_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s13a_1_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s13a_1_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 316eec057d20b92345a96447c49c34da
-  size: 73905
-  path: s13a_1_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s13a_2_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s13a_2_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: f626d35d242c2e365f92d50976c22ad9
-  size: 90591
-  path: s13a_2_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s13b_1_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s13b_1_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: c9499fdd399c7a9559775fe4dc3dfa8b
-  size: 74112
-  path: s13b_1_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s13b_2_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s13b_2_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 69f6c59523b1bb865bd78dc713f7bf45
-  size: 63552
-  path: s13b_2_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s14_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s14_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: c86ea7042ef42ac3f18af60033c64235
-  size: 7412973
-  path: s14_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s15_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s15_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: e4310f27189a37cd8280023e2075bd79
-  size: 1686914
-  path: s15_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s16a_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s16a_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: c033ceb223cd9834d8c47dcb46428576
-  size: 3286358
-  path: s16a_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s16b_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s16b_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: c2125f89fd882d2368ef3a06f61ca2aa
-  size: 418935
-  path: s16b_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s16c_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s16c_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 5ae33c3ed96f08741bd159d07f3562fa
-  size: 2184871
-  path: s16c_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s17_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s17_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 19be140e87b2d8a3923fc56d7b0d724a
-  size: 1482738
-  path: s17_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s18_1_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s18_1_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 44aceff42581501b934c802801532438
-  size: 527785
-  path: s18_1_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s18_2_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s18_2_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 069309ca4a67c6994e0ca5b3552a4c30
-  size: 1404
-  path: s18_2_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s18_3_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s18_3_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 2f44b8af412eda9e7b2cd7bfa727d98a
-  size: 15779
-  path: s18_3_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s18_4_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s18_4_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: eff654b7fc97fa47ceae267f5ad4aa69
-  size: 13879
-  path: s18_4_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s19_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s19_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 75d72fa5b41787068e26070fc66f9678
-  size: 4928991
-  path: s19_me_ben2018.dta

--- a/lsms_library/countries/Benin/2018-2019/Data/s20_me_ben2018.dta.dvc
+++ b/lsms_library/countries/Benin/2018-2019/Data/s20_me_ben2018.dta.dvc
@@ -1,4 +1,0 @@
-outs:
-- md5: 71b76f4aa0d80a6f0af77f92b08c7af3
-  size: 271455
-  path: s20_me_ben2018.dta

--- a/lsms_library/countries/Benin/_/CONTENTS.org
+++ b/lsms_library/countries/Benin/_/CONTENTS.org
@@ -8,11 +8,20 @@ template.  One wave configured: =2018-19=.
 
 Source: https://doi.org/10.48529/rn3k-z374
 
-A second directory =Benin/2018-2019/= contains a =Data/=
-sub-directory only — appears to be a duplicate-wave staging area.
-The configured wave is =2018-19=; the =2018-2019= folder is not
-referenced by any extractor and may be safely ignored or removed
-by a future cleanup pass.
+A second directory =Benin/2018-2019/= used to sit alongside this
+wave — a =Data/=-only duplicate-wave staging area.  *It was removed
+on [2026-07-12]* after verifying that all 52 of its DVC sidecars were
+*md5-identical* to =2018-19/Data/='s, with no unique files in either
+direction.  The DVC blobs are content-addressed and shared, so
+deleting the duplicate sidecars orphaned nothing.
+
+It was not merely clutter.  =Country.waves= (=country.py:1452=) falls
+back to scanning for directories containing =Documentation/SOURCE.org=,
+so *writing* a =SOURCE.org= into a directory *promotes it into a wave*.
+A provenance-backfill pass that stamped every directory therefore turned
+this duplicate into a wave that =sample()= does not cover, breaking
+=test_sample.py::test_covers_all_waves[Benin]= (found in PR #595).
+Removing it closes that trapdoor.
 
 * Sampling Design
 

--- a/lsms_library/coverage_matrix.py
+++ b/lsms_library/coverage_matrix.py
@@ -43,14 +43,60 @@ import pandas as pd
 # Tier ladder
 # ---------------------------------------------------------------------------
 TIER_ORDER = [
-    "n/a", "absent", "declared", "dropped", "broken", "builds", "sane", "blessed",
+    "n/a", "not-asked", "asked-not-distributed", "absent", "declared",
+    "dropped", "broken", "builds", "sane", "blessed",
 ]
 # Worst → best, for rolling several wave tiers up into one grid cell. The most
 # actionable (a real defect) sorts first so problems surface in the summary.
+#
+# ``absent`` (= an *un-adjudicated* gap) sorts as actionable, because it is the
+# live queue.  ``not-asked`` and ``asked-not-distributed`` are *adjudicated* and
+# sort with ``n/a`` at the quiet end: they are settled, not pending.
 ROLLUP_PRIORITY = [
-    "broken", "dropped", "builds", "declared", "sane", "blessed", "absent", "n/a",
+    "broken", "dropped", "builds", "absent", "declared", "sane", "blessed",
+    "asked-not-distributed", "not-asked", "n/a",
 ]
 COLUMNS = ["country", "feature", "wave", "tier", "coverage", "n_rows", "detail"]
+
+# ---------------------------------------------------------------------------
+# Absent-cell verdicts (GH #593)
+# ---------------------------------------------------------------------------
+# ``absent`` means only "this feature is not declared for this wave".  It
+# conflates states that could not be more different, and until they are
+# separated the number can never reach zero:
+#
+#   todo                   the data IS there; nobody has written the config.
+#                          Real, actionable work.  Stays ``absent`` in the grid
+#                          (it is the live queue) but is now *sized and sourced*.
+#   asked-not-distributed  the instrument DID ask, but the shipped extract does
+#                          not carry the variables.  An ACQUISITION problem, not
+#                          a config one -- a different queue entirely.
+#   not-asked              the instrument genuinely never asked.  Closed forever.
+#   unsure                 a required check could not be run.  STAYS in the queue,
+#                          and records why.  Silence is never evidence.
+#
+# A 38-cell pilot (2026-07-11) returned 25 todo / 13 unsure / **0 not-asked** --
+# so ``absent`` is not hiding "the survey never asked", it is hiding a backlog.
+# ``not-asked`` may be near-empty; the mechanism earns its keep by making every
+# probe TERMINATE in a recorded, re-checkable verdict rather than evaporating.
+#
+# The evidence bar is non-negotiable, because a verdict here is a PERMANENT,
+# UNSUPERVISED write.  An unevidenced negative is unfalsifiable, and therefore
+# forever.  This is not hypothetical: ``Albania/_/data_scheme.yml`` asserted
+# "earlier waves have no shocks module" -- and Albania 2005's
+# ``migrationE_cl.dta`` carries ``m6e_q00 = 'Type of Shock Code'`` with ten shock
+# types.  The claim was wrong, nobody could catch it, and it suppressed work.
+#
+# See ``docs/guide/coverage.md`` and
+# ``slurm_logs/DESIGN_coverage_discipline_2026-07-11.org``.
+ADJUDICATED_TIERS = {"not-asked", "asked-not-distributed"}
+VERDICTS = {"todo", "asked-not-distributed", "not-asked", "unsure"}
+# Verdicts that CLOSE a cell (change its tier away from plain ``absent``).
+# ``todo`` and ``unsure`` deliberately do not: they are still open work.
+_VERDICT_TO_TIER = {
+    "not-asked": "not-asked",
+    "asked-not-distributed": "asked-not-distributed",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +120,72 @@ def default_snapshot_path() -> Path:
 
 def default_blessed_path() -> Path:
     return _repo_root() / ".coder" / "coverage" / "blessed.csv"
+
+
+def default_verdicts_path() -> Path:
+    return _repo_root() / ".coder" / "coverage" / "absent_verdicts.csv"
+
+
+def load_verdicts(path: Path | None = None) -> dict[tuple[str, str, str], dict]:
+    """Adjudications of ``absent`` cells, keyed ``(country, feature, wave)``.
+
+    CSV with header
+    ``country,feature,wave,verdict,checks_run,evidence,adjudicated_by,date``
+    (``wave`` blank for country-level features).  Missing file → empty dict.
+
+    ``verdict`` must be one of :data:`VERDICTS`.  A row is IGNORED (with a
+    warning) when its verdict is unknown, or when it claims a closing verdict
+    (``not-asked`` / ``asked-not-distributed``) with an **empty ``evidence``**
+    field.
+
+    That last rule is the point of the whole mechanism.  A closing verdict is a
+    permanent, unsupervised write: it removes a cell from the work queue with
+    nobody reviewing it.  An unevidenced negative cannot be challenged, and is
+    therefore permanent whether or not it is true.  So we simply do not accept
+    one -- an evidence-free close is not a close, it is a red cell that lies.
+    """
+    path = path or default_verdicts_path()
+    if not Path(path).exists():
+        return {}
+    df = pd.read_csv(path, dtype=str, keep_default_na=False)
+    out: dict[tuple[str, str, str], dict] = {}
+    for _, r in df.iterrows():
+        key = (r.get("country", ""), r.get("feature", ""), r.get("wave", ""))
+        verdict = (r.get("verdict", "") or "").strip()
+        if verdict not in VERDICTS:
+            warnings.warn(
+                f"absent_verdicts: ignoring {key} -- unknown verdict "
+                f"{verdict!r} (expected one of {sorted(VERDICTS)})",
+                stacklevel=2,
+            )
+            continue
+        if verdict in _VERDICT_TO_TIER and not (r.get("evidence", "") or "").strip():
+            warnings.warn(
+                f"absent_verdicts: ignoring {key} -- verdict {verdict!r} closes "
+                "the cell permanently and so REQUIRES a non-empty `evidence` "
+                "field.  An unevidenced negative is unfalsifiable.",
+                stacklevel=2,
+            )
+            continue
+        out[key] = dict(r)
+    return out
+
+
+def _absent_tier(country, feature, wave, verdicts) -> tuple[str, str]:
+    """Grade a not-declared cell: ``(tier, detail)``.
+
+    The single place ``absent`` is decided.  Without an adjudication the cell is
+    plain ``absent`` -- an *open, un-triaged* gap.  With one it may be closed
+    (``not-asked`` / ``asked-not-distributed``); ``todo`` and ``unsure`` stay
+    ``absent`` because they are still work, but carry their evidence forward so
+    the next person does not re-derive it.
+    """
+    v = verdicts.get((country, feature, str(wave) if wave is not None else ""))
+    if not v:
+        return "absent", "source not declared for wave"
+    verdict = v.get("verdict", "")
+    detail = f"{verdict}: {v.get('evidence', '')}".strip().rstrip(":")
+    return _VERDICT_TO_TIER.get(verdict, "absent"), detail
 
 
 def load_blessed(path: Path | None = None) -> set[tuple[str, str, str]]:
@@ -167,7 +279,8 @@ def _safe_build(co, feature, env):
 
 
 def grade_feature(country_name, feature, waves, co, env, *,
-                  avail_by_wave=None, blessed=frozenset(), readiness=True) -> list[dict]:
+                  avail_by_wave=None, blessed=frozenset(), verdicts=None,
+                  readiness=True) -> list[dict]:
     """Per-wave cells for one ``(country, feature)``.
 
     Builds the country-level table at most once (``readiness=True``) and grades
@@ -187,50 +300,83 @@ def grade_feature(country_name, feature, waves, co, env, *,
             except Exception:  # noqa: BLE001 — a broken wave declares nothing
                 avail_by_wave[w] = set()
     covered: dict[str, bool] = {w: feature in avail_by_wave[w] for w in waves}
+    verdicts = {} if verdicts is None else verdicts
+
+    def _absent(w):
+        """The single place an un-declared cell is graded (see _absent_tier)."""
+        return _absent_tier(country_name, feature, w, verdicts)
 
     if not readiness:
-        return [
-            _cell(country_name, feature, w,
-                  tier="declared" if covered[w] else "absent",
-                  coverage="declared" if covered[w] else "absent",
-                  detail="coverage-only run")
-            for w in waves
-        ]
+        out = []
+        for w in waves:
+            if covered[w]:
+                out.append(_cell(country_name, feature, w, "declared", "declared",
+                                 detail="coverage-only run"))
+            else:
+                tier, detail = _absent(w)
+                out.append(_cell(country_name, feature, w, tier, "absent",
+                                 detail=detail))
+        return out
 
     df, err = _safe_build(co, feature, env)
     if err is not None or df is None or len(df) == 0:
         why = err or "feature built empty"
-        return [
-            _cell(country_name, feature, w,
-                  tier="broken" if covered[w] else "absent",
-                  coverage="declared" if covered[w] else "absent",
-                  detail=why if covered[w] else "source not declared for wave")
-            for w in waves
-        ]
+        out = []
+        for w in waves:
+            if covered[w]:
+                out.append(_cell(country_name, feature, w, "broken", "declared",
+                                 detail=why))
+            else:
+                tier, detail = _absent(w)
+                out.append(_cell(country_name, feature, w, tier, "absent",
+                                 detail=detail))
+        return out
 
     names = list(df.index.names or [])
     if "t" not in names:
         rep = env["is_this_feature_sane"](df, country_name, feature)
         base = tier_from_report(rep)
-        cells = [
-            _cell(country_name, feature, w,
-                  tier="n/a" if covered[w] else "absent",
-                  coverage="declared" if covered[w] else "absent",
-                  detail=(f"no per-wave (t) axis; country-level grade={base}"
-                          if covered[w] else "source not declared for wave"))
-            for w in waves
-        ]
+        cells = []
+        for w in waves:
+            if covered[w]:
+                cells.append(_cell(country_name, feature, w, "n/a", "declared",
+                                   detail=f"no per-wave (t) axis; "
+                                          f"country-level grade={base}"))
+            else:
+                tier, detail = _absent(w)
+                cells.append(_cell(country_name, feature, w, tier, "absent",
+                                   detail=detail))
         cells.append(_cell(country_name, feature, None, base, "declared",
                            n_rows=len(df), detail=_report_summary(rep)))
         return cells
 
     t_values = {str(v) for v in df.index.get_level_values("t").unique()}
     t_level = df.index.get_level_values("t").astype(str)
+
+    # Columns populated SOMEWHERE in the country frame.  Exempt these from the
+    # per-wave ``no_all_null_columns`` check: it is a *country-level* check, and
+    # a question simply not fielded in a given wave is legitimately all-null in
+    # that wave's slice.  Without this, such cells were graded ``builds`` (a
+    # defect) rather than ``sane`` -- 128 of the 138 ``builds`` cells in the
+    # 2026-06-26 snapshot were this artefact, and *zero* of the columns they
+    # flagged were all-null country-wide.
+    #
+    # A column that IS all-null across the whole country stays non-optional and
+    # still (correctly) fails -- we are relaxing the slice, not the country.
+    #
+    # NB: this deliberately hides *wave-level* column gaps from the sanity
+    # grade, because a sanity grade is the wrong instrument for them.  Two such
+    # gaps that this exposure was catching only by accident were inventoried as
+    # GH #591 (Nigeria food_prices) and GH #592 (18 waves with no GPS) BEFORE
+    # this change landed, so the regrade cannot bury them.
+    populated = {c for c in df.columns if df[c].notna().any()}
+
     cells = []
     for w in waves:
         if not covered[w]:
-            cells.append(_cell(country_name, feature, w, "absent", "absent",
-                               detail="source not declared for wave"))
+            tier, detail = _absent(w)
+            cells.append(_cell(country_name, feature, w, tier, "absent",
+                               detail=detail))
             continue
         if str(w) not in t_values:
             cells.append(_cell(country_name, feature, w, "dropped", "declared",
@@ -241,7 +387,8 @@ def grade_feature(country_name, feature, waves, co, env, *,
             cells.append(_cell(country_name, feature, w, "dropped", "declared",
                                detail="declared, present in t-index but 0 rows"))
             continue
-        rep = env["is_this_feature_sane"](sl, country_name, feature)
+        rep = env["is_this_feature_sane"](sl, country_name, feature,
+                                          extra_optional=populated)
         tier = tier_from_report(rep)
         if tier == "sane" and (country_name, feature, str(w)) in blessed:
             tier = "blessed"
@@ -251,7 +398,8 @@ def grade_feature(country_name, feature, waves, co, env, *,
 
 
 def grade_country_level(country_name, feature, co, env, *,
-                        blessed=frozenset(), readiness=True) -> dict:
+                        blessed=frozenset(), verdicts=None,
+                        readiness=True) -> dict:
     """Grade a country-level-only feature (panel_ids / updated_ids): wave=None."""
     if not readiness:
         return _cell(country_name, feature, None, "n/a", "n/a",
@@ -265,8 +413,11 @@ def grade_country_level(country_name, feature, co, env, *,
                      detail=f"{type(e).__name__}: {e}")
     n = len(val) if hasattr(val, "__len__") else 0
     if n == 0:   # avoid `not val` — ambiguous if a future feature returns a frame
-        return _cell(country_name, feature, None, "absent", "absent",
-                     detail="empty / no entries")
+        tier, detail = _absent_tier(country_name, feature, None,
+                                    verdicts or {})
+        if detail == "source not declared for wave":   # un-adjudicated
+            detail = "empty / no entries"
+        return _cell(country_name, feature, None, tier, "absent", detail=detail)
     tier = "blessed" if (country_name, feature, "") in blessed else "sane"
     return _cell(country_name, feature, None, tier, "declared",
                  n_rows=n, detail=f"{n} entries")
@@ -276,7 +427,8 @@ def grade_country_level(country_name, feature, co, env, *,
 # Whole-matrix build
 # ---------------------------------------------------------------------------
 def build_matrix(countries=None, features=None, *, readiness=True,
-                 blessed=None, log=lambda _m: None) -> pd.DataFrame:
+                 blessed=None, verdicts=None,
+                 log=lambda _m: None) -> pd.DataFrame:
     """Build the full (country × feature × wave) status table.
 
     Parameters
@@ -297,6 +449,8 @@ def build_matrix(countries=None, features=None, *, readiness=True,
     countries_root = env["countries_root"]
     if blessed is None:
         blessed = load_blessed()
+    if verdicts is None:
+        verdicts = load_verdicts()
     if countries is None:
         countries = catalog.countries()
     feat_filter = set(features) if features else None
@@ -328,14 +482,16 @@ def build_matrix(countries=None, features=None, *, readiness=True,
         for f in sel:
             rows.extend(grade_feature(c, f, waves, co, env,
                                       avail_by_wave=avail_by_wave,
-                                      blessed=blessed, readiness=readiness))
+                                      blessed=blessed, verdicts=verdicts,
+                                      readiness=readiness))
 
         for clf in country_level_only:
             if feat_filter is not None and clf not in feat_filter:
                 continue
             if _has_country_level_feature(c, clf, countries_root):
                 rows.append(grade_country_level(c, clf, co, env,
-                                                blessed=blessed, readiness=readiness))
+                                                blessed=blessed, verdicts=verdicts,
+                                      readiness=readiness))
 
     df = pd.DataFrame(rows, columns=COLUMNS)
     df["tier"] = pd.Categorical(df["tier"], categories=TIER_ORDER, ordered=True)

--- a/lsms_library/coverage_matrix.py
+++ b/lsms_library/coverage_matrix.py
@@ -14,27 +14,49 @@ See `.coder/charter-coverage-matrix.md` and `.coder/ledger/coverage-matrix.md`.
 
 Tier ladder (worst→best; each derived from existing machinery only):
 
-==========  ===========================================================
-tier        meaning
-==========  ===========================================================
-n/a         no per-wave readiness applies (country-level-only feature, or
-            the built table has no ``t`` axis)
-absent      feature applies to the country but its source is not declared
-            for this wave (``feature`` ∉ ``Wave.data_scheme`` ∪ derived)
-declared    source present for the wave; readiness not assessed
-            (coverage-only run)
-dropped     source declared for the wave but the wave is missing / empty in
-            the built table (the silent-drop bug class, e.g. Iraq #532)
-broken      the country-level build raised, or the whole feature is empty
-builds      wave slice is non-empty but ``SanityReport.ok is False``
-sane        wave slice is non-empty and ``SanityReport.ok is True``
-blessed     ``sane`` and listed in the git-tracked blessing file
-==========  ===========================================================
+=====================  ====================================================
+tier                   meaning
+=====================  ====================================================
+n/a                    no per-wave readiness applies: a country-level-only
+                       feature, a table with no ``t`` axis, or a country with
+                       no microdata in the repo at all (Armenia, Nepal — see
+                       :func:`countries_without_microdata`)
+not-asked              adjudicated: the instrument genuinely never asked.
+                       Closed.  *Requires evidence* (:func:`load_verdicts`).
+asked-not-distributed  adjudicated: the instrument DID ask, but the shipped
+                       extract does not carry the variables.  An acquisition
+                       problem, not a config one.  *Requires evidence.*
+absent                 feature applies to the country but its source is not
+                       declared for this wave — and the gap is UN-ADJUDICATED
+                       (or adjudicated ``todo``/``unsure``, which stay open).
+                       This is the live queue.
+declared               source present for the wave; readiness not assessed
+                       (coverage-only run)
+dropped                source declared for the wave but the wave is missing /
+                       empty in the built table (the silent-drop bug class)
+broken                 the country-level build raised, or the feature is empty
+builds                 wave slice is non-empty but ``SanityReport.ok is False``
+sane                   wave slice is non-empty and ``SanityReport.ok is True``
+                       — i.e. the automated checks passed.  NOT a claim that
+                       any human has looked at a single number.
+blessed                ``sane`` **and** a human read the numbers and believed
+                       them (git-tracked ``blessed.csv``).  Required for any
+                       cell feeding published analysis.
+=====================  ====================================================
+
+Two rules the tiers exist to enforce, both learned the hard way:
+
+- *An unevidenced negative is unfalsifiable, and therefore permanent whether or
+  not it is true.*  So a closing verdict without evidence is refused outright.
+- *A regrade is not a fix.*  When a change alters how cells are GRADED rather
+  than what they CONTAIN, first inventory what the old grading was catching by
+  accident (see GH #591, #592).
 """
 from __future__ import annotations
 
 import os
 import warnings
+from functools import lru_cache
 from pathlib import Path
 
 import pandas as pd
@@ -43,8 +65,8 @@ import pandas as pd
 # Tier ladder
 # ---------------------------------------------------------------------------
 TIER_ORDER = [
-    "n/a", "not-asked", "asked-not-distributed", "absent", "declared",
-    "dropped", "broken", "builds", "sane", "blessed",
+    "n/a", "not-asked", "asked-not-distributed", "unconfigured", "absent",
+    "declared", "dropped", "broken", "builds", "sane", "blessed",
 ]
 # Worst → best, for rolling several wave tiers up into one grid cell. The most
 # actionable (a real defect) sorts first so problems surface in the summary.
@@ -53,8 +75,8 @@ TIER_ORDER = [
 # live queue.  ``not-asked`` and ``asked-not-distributed`` are *adjudicated* and
 # sort with ``n/a`` at the quiet end: they are settled, not pending.
 ROLLUP_PRIORITY = [
-    "broken", "dropped", "builds", "absent", "declared", "sane", "blessed",
-    "asked-not-distributed", "not-asked", "n/a",
+    "broken", "dropped", "builds", "unconfigured", "absent", "declared",
+    "sane", "blessed", "asked-not-distributed", "not-asked", "n/a",
 ]
 COLUMNS = ["country", "feature", "wave", "tier", "coverage", "n_rows", "detail"]
 
@@ -204,6 +226,68 @@ def load_blessed(path: Path | None = None) -> set[tuple[str, str, str]]:
     }
 
 
+def unconfigured_countries(countries_root) -> dict[str, int]:
+    """Country dirs with downloaded microdata but **no** ``_/data_scheme.yml``.
+
+    Returns ``{country: n_waves_with_data}``.
+
+    :func:`catalog.countries` admits a directory only if it carries a
+    ``_/data_scheme.yml``, so these are invisible to ``Country()``, to
+    ``Feature()``, and — until now — to this matrix.  As of 2026-07-11 that hid
+    **ten in-remit countries and ~35 waves of already-downloaded microdata**
+    (Afghanistan, Bosnia-Herzegovina, Brazil, Bulgaria, Kyrgyz Republic,
+    Nicaragua, Panama, Peru, Rwanda, Tanzania_Kegera).
+
+    A denominator that omits the work you have not started is not a denominator,
+    so the matrix now reports them as ``unconfigured`` rather than not at all.
+
+    A directory counts only if at least one of its wave subdirs has a ``Data/``
+    (with or without files — DVC sidecars alone are enough, since the blobs are
+    fetched lazily).  That keeps stray non-country dirs out.
+    """
+    out: dict[str, int] = {}
+    try:
+        root = Path(countries_root())
+    except Exception:  # noqa: BLE001
+        return out
+    for p in sorted(root.iterdir()):
+        if not p.is_dir() or p.name.startswith((".", "_")):
+            continue
+        if (p / "_" / "data_scheme.yml").exists():
+            continue                                   # configured; not our problem
+        n = sum(1 for w in p.iterdir() if w.is_dir() and (w / "Data").is_dir())
+        if n:
+            out[p.name] = n
+    return out
+
+
+@lru_cache(maxsize=1)
+def countries_without_microdata() -> dict[str, str]:
+    """Countries whose config exists but whose source microdata is not in-repo.
+
+    Declared in the canonical ``lsms_library/data_info.yml`` (config, not code —
+    GH #436), mirroring the "Countries Without Microdata" table in CLAUDE.md.
+
+    Their features *cannot* build.  That is a fact about data availability, not
+    a defect, so the matrix grades their cells ``n/a`` rather than ``broken``.
+    Before this, **all 8 ``broken`` cells in the cube were these two countries**
+    (Armenia ×2, Nepal ×6) — which meant the most alarming tier in the ladder
+    contained nothing actionable, and a genuine build failure would have been
+    lost among them.
+
+    Returns ``{country: reason}``.
+    """
+    try:
+        from importlib.resources import files
+        from .yaml_utils import load_yaml
+        with open(files("lsms_library") / "data_info.yml", encoding="utf-8") as fh:
+            info = load_yaml(fh)
+        section = (info or {}).get("Countries Without Microdata", {}) or {}
+        return dict(section.get("countries", {}) or {})
+    except Exception:  # noqa: BLE001 — a missing/old data_info.yml must not break grading
+        return {}
+
+
 # ---------------------------------------------------------------------------
 # Lazy bundle of lsms_library symbols (avoids import cycles at package init)
 # ---------------------------------------------------------------------------
@@ -321,10 +405,17 @@ def grade_feature(country_name, feature, waves, co, env, *,
     df, err = _safe_build(co, feature, env)
     if err is not None or df is None or len(df) == 0:
         why = err or "feature built empty"
+        # A country with no microdata in the repo cannot build.  That is a data-
+        # availability fact, not a defect -- grade `n/a`, not `broken`, so the
+        # `broken` tier stays meaningful.  (See countries_without_microdata.)
+        no_data = countries_without_microdata().get(country_name)
+        fail_tier = "n/a" if no_data else "broken"
+        if no_data:
+            why = f"no microdata in repo: {no_data}"
         out = []
         for w in waves:
             if covered[w]:
-                out.append(_cell(country_name, feature, w, "broken", "declared",
+                out.append(_cell(country_name, feature, w, fail_tier, "declared",
                                  detail=why))
             else:
                 tier, detail = _absent(w)
@@ -409,6 +500,10 @@ def grade_country_level(country_name, feature, co, env, *,
             warnings.simplefilter("ignore")
             val = env["load_feature"](co, feature)
     except Exception as e:  # noqa: BLE001
+        no_data = countries_without_microdata().get(country_name)
+        if no_data:
+            return _cell(country_name, feature, None, "n/a", "declared",
+                         detail=f"no microdata in repo: {no_data}")
         return _cell(country_name, feature, None, "broken", "declared",
                      detail=f"{type(e).__name__}: {e}")
     n = len(val) if hasattr(val, "__len__") else 0
@@ -456,6 +551,21 @@ def build_matrix(countries=None, features=None, *, readiness=True,
     feat_filter = set(features) if features else None
 
     rows: list[dict] = []
+
+    # Country dirs holding downloaded microdata but NO config are invisible to
+    # `catalog.countries()` (it requires `_/data_scheme.yml`), so the matrix has
+    # never reported them at all -- 10 in-remit countries and ~35 waves of
+    # paid-for data that simply did not appear.  Surface them as `unconfigured`:
+    # visibly red, not absent from the report.  A denominator that omits the work
+    # you have not started is not a denominator.
+    for c, nwaves in unconfigured_countries(countries_root).items():
+        if countries is not None and c not in countries:
+            continue
+        rows.append(_cell(c, "<country>", None, "unconfigured", "absent",
+                          n_rows=nwaves,
+                          detail=f"microdata present ({nwaves} waves) but no "
+                                 f"_/data_scheme.yml — country not configured"))
+
     for c in countries:
         try:
             co = Country(c, preload_panel_ids=False)
@@ -498,12 +608,48 @@ def build_matrix(countries=None, features=None, *, readiness=True,
     return df
 
 
-def save_snapshot(df: pd.DataFrame, path: Path | None = None) -> Path:
-    """Write the status table to the git-tracked snapshot CSV."""
+def save_snapshot(df: pd.DataFrame, path: Path | None = None, *,
+                  merge: bool = True) -> Path:
+    """Write the status table to the git-tracked snapshot CSV.
+
+    ``merge=True`` (default) **upserts** ``df``'s cells into the existing
+    snapshot on the ``(country, feature, wave)`` key, leaving every other cell
+    untouched.  ``merge=False`` replaces the file wholesale.
+
+    Why merge is the default
+    ------------------------
+    A *scoped* run (``make matrix C="Uganda"``) grades only some cells.  Writing
+    that result wholesale silently **destroys** every cell it did not grade --
+    and ``docs/guide/coverage.md`` documents exactly that as the "spot refresh"
+    procedure, immediately followed by ``git add .coder/coverage/latest.csv &&
+    git commit``.  Following the guide verbatim therefore committed a 67-cell
+    snapshot over the authoritative 1849-cell one.  (Observed 2026-07-12.)
+
+    A partial measurement must never be able to erase a complete one.  A full
+    sweep still rewrites everything it grades, so the authoritative run is
+    unaffected; it simply no longer depends on *not* being scoped.
+    """
     path = Path(path) if path is not None else default_snapshot_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     out = df.copy()
     out["tier"] = out["tier"].astype(str)
+
+    if merge and path.exists():
+        try:
+            prev = pd.read_csv(path, dtype=str, keep_default_na=False)
+        except Exception:  # noqa: BLE001 — an unreadable snapshot is simply replaced
+            prev = None
+        if prev is not None and not prev.empty:
+            key = ["country", "feature", "wave"]
+            fresh = out.copy()
+            for k in key:                      # align dtypes for the anti-join
+                fresh[k] = fresh[k].astype(str)
+            keep = prev.merge(fresh[key].drop_duplicates(), on=key,
+                              how="left", indicator=True)
+            keep = keep[keep["_merge"] == "left_only"].drop(columns="_merge")
+            out = pd.concat([keep, fresh], ignore_index=True)
+
+    out = out.reindex(columns=COLUMNS)
     out.sort_values(["country", "feature", "wave"]).to_csv(path, index=False)
     return path
 

--- a/lsms_library/data_info.yml
+++ b/lsms_library/data_info.yml
@@ -356,3 +356,17 @@ Currency:
   Timor-Leste: USD                  # USD official since 2000
   Togo: XOF
   Uganda: UGX
+# Countries whose config exists but whose source microdata is NOT in this
+# repository.  Their features cannot build; that is a fact about data
+# availability, not a defect.  The coverage matrix grades their cells `n/a`
+# rather than `broken`, so a real build failure elsewhere is not lost in the
+# noise (before this, all 8 `broken` cells in the cube were these two).
+#
+# Keep this in sync with the "Countries Without Microdata" table in CLAUDE.md.
+Countries Without Microdata:
+  note: >-
+    Config present, source .dta absent.  See CLAUDE.md.  Adding the data is an
+    acquisition task; it is not a bug in the country's config.
+  countries:
+    Armenia: No data files downloaded; WB catalog / external hosting.
+    Nepal: NSO hosts the data, not the WB (https://microdata.nsonepal.gov.np/).

--- a/lsms_library/diagnostics.py
+++ b/lsms_library/diagnostics.py
@@ -592,6 +592,8 @@ def is_this_feature_sane(
     df: pd.DataFrame,
     country: str,
     feature: str,
+    *,
+    extra_optional: set[str] | None = None,
 ) -> SanityReport:
     """Run all sanity checks on a feature DataFrame.
 
@@ -603,6 +605,21 @@ def is_this_feature_sane(
         Country name (e.g., ``'Uganda'``).
     feature : str
         Feature/table name (e.g., ``'food_acquired'``).
+    extra_optional : set[str], optional
+        Column names to exempt from ``no_all_null_columns``, *in addition* to
+        those declared ``optional`` in the country's scheme.
+
+        This exists for **grading a slice of a larger frame** — notably the
+        coverage matrix, which grades one wave at a time by slicing the
+        country-level table on ``t``.  ``no_all_null_columns`` is a
+        *country-level* check: a column that is legitimately not fielded in
+        one wave is all-null *within that wave's slice* and would be reported
+        as a failure, even though the country as a whole populates it.
+
+        Callers grading a slice should pass the set of columns that are
+        populated **somewhere in the parent frame**; a column that is all-null
+        across the whole country is then still (correctly) reported as a
+        failure.  Default ``None`` preserves the historical behaviour exactly.
 
     Returns
     -------
@@ -612,7 +629,9 @@ def is_this_feature_sane(
     """
     scheme = _load_scheme(country)
     report = SanityReport(country=country, feature=feature)
-    optional = scheme.get(feature, {}).get("optional", set())
+    optional = set(scheme.get(feature, {}).get("optional", set()))
+    if extra_optional:
+        optional |= set(extra_optional)
 
     report.checks.append(_check_not_empty(df))
     report.checks.append(_check_has_index(df))

--- a/slurm_logs/DESIGN_coverage_discipline_2026-07-11.org
+++ b/slurm_logs/DESIGN_coverage_discipline_2026-07-11.org
@@ -1,0 +1,827 @@
+#+TITLE: Filling the coverage matrix: a discipline and a workplan
+#+AUTHOR: Sue (Claude Opus 4.8)
+#+DATE: [2026-07-11 Sat]
+
+* Motivation
+
+We already /measure/ coverage.  =make matrix= grades every
+=(country, feature, wave)= cell on an eight-tier ladder and commits the
+result to =.coder/coverage/latest.csv=; =ll.coverage()= reads it back.
+That machinery landed in June (#584, #586, #590) and it works.
+
+What we do /not/ have is a discipline for closing the cells it reddens.
+The snapshot has 1849 cells:
+
+| tier    | cells | meaning                                     |
+|---------+-------+---------------------------------------------|
+| sane    |  1208 | builds, passes sanity                       |
+| absent  |   456 | "source not declared for this wave"         |
+| builds  |   138 | builds, /fails/ a sanity check              |
+| dropped |    39 | declared for the wave, missing from output  |
+| broken  |     8 | build raises, or the feature is empty       |
+| blessed |     0 | human-signed-off --- the tier is never used |
+
+This document argues that the matrix does not fill because of defects in
+the /instrument/, not any shortage of effort.  A census run on
+[2026-07-11 Sat] found *six*, and they bias in both directions at once:
+the matrix reports work that does not exist, and hides work that does.
+
+** The corrected ledger
+
+Once the six defects below are accounted for, the cube's real state is
+materially different from what it reports:
+
+| tier as reported | cells | what it actually is                                                       |
+|------------------+-------+---------------------------------------------------------------------------|
+| sane             |  1208 | genuine                                                                   |
+| builds           |   138 | *131 are a grading bug* (Defect 5); ~7 real, incl. 2 buried data gaps      |
+| broken           |     8 | *all 8 mis-tiered* --- Armenia/Nepal have no microdata at all (Defect 6)   |
+| dropped          |    39 | *genuine, and the most dangerous tier* --- silent data loss                |
+| absent           |   456 | *unknowable* --- conflates "never asked" with "not yet done" (Defect 1)    |
+| blessed          |     0 | the top tier has never once been used                                     |
+
+: really-clean  ~1339   (1208 + the 131 misgraded)
+: really-broken   ~46   (39 dropped + ~7 builds) + 24 data gaps hiding inside the regrade
+: genuinely unknown  456   <- and a 38-cell pilot says ~2/3 of these are REAL WORK
+
+*The 456 is not a pile of "the survey never asked."*  A pilot running the
+full evidence standard over 38 of them returned *25 TODO, 13 UNSURE, and
+zero NOT-ASKED* (§Defect 1).  The uncomfortable implication: the backlog is
+*larger* than the matrix's red suggests, not smaller.  Nothing here shrinks
+the work.  It makes it knowable, sized, and ordered --- which is the most an
+instrument can honestly do.
+
+*Cells whose reported tier is wrong or unactionable: 595 of 1849 --- 32% of
+the cube.*  And the cube's /denominator/ is itself wrong: it omits every
+wave the World Bank publishes that we have not downloaded (Defect 2), and
+eleven countries whose data we already hold (Defect 4).
+
+The matrix cannot drive a workplan until it can be trusted.  *Fix the
+ruler, then measure.*  That is Phase 0, and it is about a day's work.
+
+* Six defects in the measurement, before any workplan
+
+** Defect 1 --- =absent= is a black hole (the keystone)
+
+=absent= means "the feature is not declared for this wave."  That single
+tier conflates two states that could not be more different:
+
+- *NOT-ASKED* --- the survey instrument never asked the question.  There
+  is no work here.  There will never be work here.
+- *TODO* --- the data is sitting in =Data/=; nobody has written the
+  config.  This is real, actionable work.
+
+Nothing in the repo distinguishes them.  Two consequences, and the second
+is worse than the first.
+
+*The queue never converges.*  A genuinely not-asked cell stays red
+forever, so the number cannot reach zero, so nobody can tell progress
+from noise.  The queue is not a queue --- it is a mood.
+
+*And the probe's findings evaporate.*  Whoever investigates a cell learns
+something real --- "this wave's module is in =migrationE_cl.dta=, not
+=Data/=" or "this instrument genuinely dropped the question in 2005" ---
+and has *nowhere to put it*.  The knowledge dies in their head, and the
+next person pays the same cost to rediscover it.  Over 456 cells that is
+not inefficiency; it is a repository that cannot learn.
+
+The evidence that this has already happened, and produced a *false*
+conclusion now sitting in the codebase, is in "Exhibit A" below.  It is
+the reason the fix is an /evidence/ file, not merely a /verdict/ file.
+
+*Fix.*  Add a git-tracked adjudication file =.coder/coverage/absent_verdicts.csv=,
+keyed =(country, feature, wave)= with a *mandatory* =evidence= column, a
+=checks_run= column, and =adjudicated_by= / =date=.  It mirrors the
+existing =blessed.csv= mechanism --- same loader, same shape --- so it costs
+about fifteen lines in =coverage_matrix.py= (=absent= is emitted at five
+sites in =grade_feature=; factor a single =_absent_tier()= helper).
+
+The property this buys is the one that matters:
+
+#+begin_quote
+Every probe of an =absent= cell now *terminates* --- in config, or in a
+recorded verdict with evidence.  A probe that ends without one of those
+did not happen.
+#+end_quote
+
+*** What the pilot proved (and what it refuted)
+
+A 38-cell pilot (=shocks=, =assets=; 2026-07-11) ran the full evidence
+standard of §D2.  Its headline *refutes the premise this section was
+originally written on*:
+
+: 25 TODO   13 UNSURE   0 NOT-ASKED
+
+*The =absent= tier is not hiding a pile of "the survey never asked."  It
+is hiding a backlog.*  On this evidence NOT-ASKED may be close to an
+/empty category/, and =actionable_todo= will land near 456, not far below
+it.  The honest consequence is uncomfortable and should be stated plainly:
+*the gap is bigger than it looked, not smaller.*  The mechanism proposed
+here does not shrink the work.  It makes the work /knowable/, which is a
+different and lesser claim than the one I started with.
+
+But the pilot found a state I had missed, and it is not rare:
+
+*** The third state: ASKED-NOT-DISTRIBUTED
+
+- *Albania 2004 =assets=* --- the label sweep and the sibling differential
+  both come back negative, and *both are correct about the data*: the
+  variables genuinely are not in the shipped =.dta=.  But the
+  questionnaire (=alb04hhq2.pdf=) has =MODULE 2: DWELLING, UTILITIES AND
+  DURABLE GOODS=, itemising =105 Refrigerator 106 Freezer 107 Washing
+  machine=.  *The module was asked.  The extract does not carry it.*
+- *EthiopiaRHS R5--R7* --- the archive ships only aggregates; no raw
+  section files exist to search.
+
+This is neither TODO (there is nothing to configure) nor NOT-ASKED (the
+instrument asked).  It is a *data-acquisition* problem --- chase the
+extract --- and it belongs to a different queue and a different skill
+(=add-wave=), not to the config backlog.  Conflating it with either would
+be a third silent error.
+
+So the verdict is *four-way*, not binary:
+
+| verdict                 | meaning                                | terminates? | routes to      |
+|-------------------------+----------------------------------------+-------------+----------------|
+| =todo=                  | data present, config missing            | no          | =add-feature=  |
+| =asked-not-distributed= | instrument asked; extract lacks it      | *yes*       | acquisition    |
+| =not-asked=             | instrument genuinely never asked        | *yes*       | closed forever |
+| =unsure=                | a required check could not be run       | no          | human / OCR    |
+
+*** Exhibit A --- the failure is not hypothetical.  It already happened.
+
+=lsms_library/countries/Albania/_/data_scheme.yml:86= states:
+
+#+begin_quote
+"Occurrence-only shocks module (2012 wave only; *earlier waves have no
+shocks module*)."
+#+end_quote
+
+That claim is *false*.  Verified directly against the source:
+=Albania/2005/Data/migrationE_cl.dta= carries
+=m6e_q00 = 'Type of Shock Code'= with ten shock types (Dispossession of
+Land, Unexpected death of income earner, Job loss, Flood damage, Pyramid
+scheme, ...), plus a =m6e_q1989..q1999= year-occurrence grid.  Albania
+2008 carries the identical variable; 2003 and 2004 carry
+="faced any shocks in last 12 months"=.
+
+*An evidence-free NOT-ASKED claim already exists in this repo, it is
+wrong, and it has been quietly suppressing work on roughly five cells.*
+Nobody could catch it, because nothing recorded /how/ it was reached.
+
+This is the entire argument for the evidence column, made for me, by the
+codebase, before I proposed it.  The lesson is not "someone was careless"
+--- it is that *an unevidenced negative is unfalsifiable*, and therefore
+permanent.  Which is exactly what we are about to license 456 times.
+
+** Defect 2 --- the denominator is self-congratulatory
+
+=build_matrix= enumerates waves with =waves = list(co.waves)=
+(=coverage_matrix.py:308=), and =Country.waves= is derived from
+directories that exist /on disk/.  So a wave the World Bank publishes and
+we have never downloaded is not a red cell.  It is *no cell at all*.
+
+Two perverse incentives follow.  Downloading a new wave makes coverage
+look /worse/ (fresh =absent= cells appear).  Never downloading anything
+looks perfect.  A matrix that rewards not acquiring data is measuring
+the wrong thing.
+
+*Fix.*  We already have =data_access.discover_waves(country)=, which
+returns the WB catalog annotated with a =local= bool.  Feed it in and
+emit a =missing-wave= row for every upstream wave we lack.  The cube
+gains its honest denominator.  (Two configured countries --- =EthiopiaRHS=
+and =Serbia and Montenegro= --- are missing from =_COUNTRY_CODES= and so
+are blind to discovery; that is a two-line fix.)
+
+** Defect 3 --- no wave records its provenance (blocks the fix for Defect 2)
+
+=discover_waves()= decides whether we already hold a catalog entry by
+/string-matching/ a fabricated wave label (=_catalog_to_wave_label= vs
+=_local_waves=) against directory names.  It is wrong in both directions:
+of 41 flagged entries, *12 were false positives* and *at least 2 were
+false negatives*.
+
+The false negatives are the dangerous ones, because they are silent:
+
+- *Nigeria 2018-19* --- catalog id 3827 is the /Nigeria Living Standards
+  Survey/.  =Nigeria/2018-19/= actually holds GHS-Panel W4 (id 3557), a
+  *different survey*.  The label collides, so we believe we have the LSS.
+  We do not.
+- *Ethiopia 2013-14* --- id 2671 (Land & Soil Experimental Research) is
+  masked by ESS W2 (id 2247).
+- *GhanaLSS / GhanaSPS* both map to ISO =GHA=, so each sees the other's
+  waves as its own missing waves.
+
+Root cause: *none of the 136 wave directories records the WB catalog id it
+came from.*  =add_wave()= writes a =SOURCE.org=; not one pre-existing wave
+has one (=find ... -name SOURCE.org= → 0).
+
+*Fix (prerequisite for Defect 2).*  Stamp =catalog_id= per wave dir and
+match on the id, not on a reconstructed label.  Backfilling 136 waves is a
+bounded, mostly-mechanical job.  Until it is done, any "missing wave"
+column in the matrix is guesswork.
+
+** Defect 4 --- eleven countries are invisible
+
+=catalog._country_dirs()= admits a directory only if it carries
+=_/data_scheme.yml=.  Eleven country directories hold *downloaded survey
+data and no config at all*:
+
+: Afghanistan(2 waves)  Bosnia-Herzegovina(5)  Brazil(1)  Bulgaria(5)
+: KenyaLPS(4)  Kyrgyz Republic(4)  Nicaragua(3)  Panama(3)  Peru(4)
+: Rwanda(2)  Tanzania_Kegera(2)
+
+Thirty-five waves of paid-for, downloaded microdata that the coverage
+matrix reports nothing about, because the matrix's own gate hides them.
+The matrix says 35 countries; the repo has 46.
+
+*Fix.*  Enumerate country /directories/, not configured countries, and
+emit an =unconfigured= country-level row for the config-less ones.  They
+should be visibly red, not absent from the report.
+
+** Defect 5 --- the wave-slice grader applies country-level checks
+
+The single biggest numerical error in the matrix.
+=coverage_matrix._wave_cells= (L244) grades a wave by slicing the country
+frame on =t= and calling =diagnostics.is_this_feature_sane= on the slice.
+But =_check_no_all_null_columns= (=diagnostics.py:280=) is a *country-level*
+check.  A question that simply was not fielded in a given wave is
+legitimately all-null /in that slice/ --- and gets graded =builds=.
+
+*Proof it is a grading bug and not a data bug:* of the 124 offending
+columns, *zero* are all-null country-wide.  Every one is populated in at
+least one other wave.
+
+*131 of the 138 =builds= cells are false.*  The matrix is crying wolf on
+7% of the entire cube.
+
+*Fix.*  When grading a slice, pass the country frame's populated-column
+set as =optional=.  Small.
+
+*** But sequence this correctly --- a regrade is not a fix
+
+Fixing the grader re-tiers 131 cells =builds= → =sane= in one commit.
+Two *genuine* data gaps are currently hiding inside that bucket and would
+be *silently buried* by it:
+
+- *Nigeria =food_acquired.Quantity_kg= is all-null in 6 of 8 waves.*  The
+  kg conversion is missing, so the /default/ =food_prices(units='kgvalue')=
+  --- =Expenditure / Quantity_kg= --- returns *NaN* for those waves.  A
+  live, user-facing data defect with no tracking issue.
+- *18 cells of missing GPS =Latitude=/=Longitude=* in =cluster_features=
+  (CotedIvoire, Nigeria, Ethiopia, Malawi, Niger, Uganda).
+
+*Extract both as their own issues BEFORE regrading.*  Otherwise the
+cleanup destroys the only evidence that they exist.  This is the general
+rule: /whenever a fix changes how cells are graded rather than what they
+contain, first inventory what the old grading was catching by accident./
+
+** Defect 6 --- =broken= is mis-tiered for the known-no-microdata countries
+
+All 8 =broken= cells are =PathMissingError= from *Armenia* (2) and *Nepal*
+(6) --- both of which CLAUDE.md already documents under /Countries Without
+Microdata/.  They are not broken; they have no data.  They need a
+known-no-data skip list and an =absent=/=n/a= tier, not a bug fix.
+
+(Secondary harness bug found alongside: all three Nepal waves report the
+/1995-96/ path --- the country-level build raised once and the single
+exception was fanned out to every wave, so per-wave detail in =broken=
+cells is not trustworthy.)
+
+** Aside --- a live data-integrity bug found while counting
+
+The ten wave-shaped directories at the =countries/= root (=2009-10/=,
+=2010-11/=, ...) are *not* misplaced data.  All 33 =.dta= in them are
+md5-identical to DVC-tracked sources under =Uganda/=, =Nigeria/=,
+=Tanzania/=.  They are output of a cwd bug: the country-level =_/= script
+idiom =../{wave}/Data/...= resolves against the /process cwd/ when a
+script runs from the country dir rather than =_/=, and
+=_resolve_data_path()= (=local_tools.py:719=) has no pattern for that
+form, so it passes the path through unrewritten.
+
+The litter is harmless; the /latent hazard/ is not.
+=_is_polluted_workspace_copy()= (=local_tools.py:679=) refuses an in-tree
+copy only when a *sister =.dvc= sidecar* exists.  These strays have none
+--- so =get_dataframe()= would accept them as legitimate local data and
+silently shadow the DVC blob with a stale copy.
+
+*This is a correctness bug, not a coverage bug.*  File it separately:
+teach =_resolve_data_path= to handle (or loudly reject) the
+=../{wave}/Data/...= form, and/or resolve country-script paths against
+=__file__= rather than cwd.  Cleaning the 47 MB is the easy half.
+
+** Why these come first
+
+Every one is a defect in the /instrument/, not the data.  Fixing them is
+cheap --- about a day in total --- and until they are fixed, every workplan
+built on this matrix is built on numbers that are 32% wrong and a
+denominator that cannot reach zero.  Fix the ruler, then measure.
+
+Note the *asymmetry of the errors*, which is what makes them insidious:
+
+- Defects 1, 5, 6 make the matrix *cry wolf* --- 595 cells whose tier is
+  wrong or unactionable.  The cost is wasted effort and, worse,
+  desensitisation: a dashboard that is a third noise stops being read.
+- Defects 2, 3, 4 make the matrix *flatter itself* --- upstream waves we
+  never downloaded and countries whose data we already hold simply do not
+  appear.  The cost is invisible work, and an incentive gradient that
+  /punishes acquiring data/ (a new wave only ever adds red cells).
+
+A measure that is simultaneously alarmist about what we have and silent
+about what we lack is worse than no measure, because it is trusted.
+
+* The discipline
+
+** D1. Every red cell terminates in a recorded state, or the probe did not happen
+
+| state                   | meaning                           | artifact                                     |
+|-------------------------+-----------------------------------+----------------------------------------------|
+| =sane=                  | config written, builds, passes     | the config + a green =make matrix=           |
+| =not-asked=             | instrument genuinely never asked   | =absent_verdicts.csv= row + *questionnaire*  |
+| =asked-not-distributed= | asked; the extract lacks it        | =absent_verdicts.csv= row → acquisition queue |
+| =unsure=                | a required check could not be run  | =absent_verdicts.csv= row + the named blocker |
+| =issue=                 | data is there, the build is wrong  | a GH issue → the =backlog-workflow= loop      |
+
+There is no "I looked at it once."  A probe that ends without one of these
+artifacts did not happen, and its cost will be paid again by the next
+person.  =unsure= is a first-class outcome, not a failure --- it keeps the
+cell in the queue and *records why*, which is the whole point.
+
+** D2. The evidence standard (no human sign-off, but a serious search)
+
+*Constraint (Ethan, 2026-07-11):* his eyes are /not/ required on every
+=not_asked= row --- bandwidth is finite --- but "a serious search should
+happen before this conclusion is reached."
+
+So the bar cannot be "an agent looked."  =not_asked= is a *permanent,
+unsupervised write*: it removes a cell from the queue forever, with nobody
+checking.  That makes it the single most dangerous write in this design,
+and it earns a hard, enumerated protocol.  The failure mode is specific
+and it is not exotic:
+
+#+begin_quote
+*A renamed variable is indistinguishable from an absent one.*
+=hh_s11q01= becomes =s11q1a= between waves; a naive label search finds
+nothing and concludes the survey stopped asking.  It did not.  We then
+close the cell permanently and lose the data forever, silently.
+#+end_quote
+
+Every check below exists to catch that.  A cell may be written to
+=not_asked.csv= only when *all applicable* checks are run and *all* come
+back negative; the row records *which ran*, in a =checks= column.  Any
+check that cannot be run downgrades the verdict to =UNSURE= --- which
+stays in the queue.  Silence is never evidence.
+
+*Each rule below was found by the pilot being wrong first.  They are not
+theory.*
+
+*** Check 1 --- variable-label sweep (always; necessary, never sufficient)
+No matching variable or value label in any source file for that wave.
+Metadata-only reads (=pyreadstat.read_dta(..., metadataonly=True)=), blob
+fetched by the lock-free direct-S3 bypass.  Three corrections the pilot
+paid for:
+
+1. *Be extension-agnostic.*  LSMS ships Stata binaries named =.tab=
+   (EthiopiaRHS) and SPSS =.sav= (Albania 2008/2012).  Try =read_dta= →
+   =read_sav= → text, regardless of suffix.  A suffix-driven reader
+   silently reads garbage.
+2. *Report label /availability/ separately from label /hits/.*
+   CotedIvoire's =.DCT= fixed-width files carry *no variable labels at
+   all* (names are opaque: =C01Q01=).  The first pass scored "0 hits
+   across 80 files" and read as a clean negative.  It was the probe having
+   nothing to read.  *Silence must be structurally distinguishable from
+   absence* --- if the corpus is unlabelled, the check did not run.
+3. *Multilingual, or it is not a search.*  Albania 2012's durables are
+   =Frigorifer=, =Lavatrice=; CotedIvoire/Mali shocks are =sinistre=,
+   =sécheresse=.  English-only missed Albania 2012 entirely.
+
+Also: *the wave's =Data/= dir is not the source universe.*  EthiopiaRHS
+wave dirs hold 4--6 files; its =_dataverse_archive/= holds 251.  Scoping
+the probe to =Data/= alone would have produced seven confident false
+negatives.
+
+*** Check 2 --- sibling differential (necessary for PARTIAL pairs; *not sufficient*)
+Take the working sibling wave's source variable and establish its
+/analogue/ is absent --- names do not survive renaming, so match on *item
+content* (the value-label lexicon of =j= / =Shock=), not variable names.
+
+*The pilot proved this check alone manufactures false NOT-ASKEDs.*  It
+returned "content absent" (0/23 lexicon hits) for *Iraq 2006-07* --- a wave
+carrying a full 11-shock + 24-coping module.  The 2007 labels
+(="Problem: theft"=) share no vocabulary with 2012's (="Loss of asset or
+livestock due to theft/accident/death"=).  Only the *filename*
+(=2007ihses18_risks.dta=) caught it.  A lexicon differential is necessary,
+never sufficient.
+
+Module renumbering is the norm, not the exception: Nigeria =sect5= (w4) →
+=sect10= (w5) for assets, =sect15a= → =sect12= for shocks; Iraq =risks=
+(2007) → =shocks= (2012), wide → long.
+
+*** Check 3 --- Harmonized LSMS-ISA Ag cross-check (mandatory where it applies)
+An *independent* oracle, and the one Ethan specifically asked for.  The
+WB Harmonised Panel is already in the repo as a 48 MB DVC blob at
+=countries/Harmonized_LSMS-ISA_Ag/lsms_ag.parquet= (281,803 x 223;
+materializes lock-free via =get_dataframe=).  It covers *Ethiopia,
+Malawi, Mali, Niger, Nigeria, Tanzania, Uganda* and carries harmonized ag
+variables --- =total_labor_days=, =seed_kg=, =inorganic_fertilizer_value=,
+=harvest_kg=, =plot_area=, ... --- keyed by =country= x =wave=.
+
+This is *decisive* for the ag features, which are *137 of the 456 absent
+cells (30%)*: =plot_features= (30), =livestock= (30), =crop_production=
+(27), =plot_inputs= (25), =plot_labor= (25).  If the WB extracted
+=total_labor_days= for Tanzania wave 3, then that wave *has* plot-labor
+data and any NOT-ASKED claim for it is simply false.
+
+And it is better than a veto.  The WB's per-wave *do-files*
+(=lsms-worldbank/LSMS-ISA-harmonised-dataset-on-agricultural-productivity-and-welfare=)
+name the *raw file and variable* behind each harmonized column.  So a
+positive hit does not merely reject NOT-ASKED --- it hands us the source
+file and variable name, i.e. most of the config.  Check 3 is both the
+strictest gate and the biggest accelerator on this list.
+
+*The oracle is /positive-only/.*  A non-null harmonized column proves the
+concept was asked.  *A null column proves nothing* --- it means the WB's
+harmonizers did not code it, not that the survey did not ask.  The pilot
+nailed this: Mali 2014-15 has =hh_asset_index= *0% non-null*, yet the
+durables roster is plainly there (=EACIACT_p1.dta:s08q01=, 25 items).  Had
+Check 3 been allowed to vote "no", it would have closed a live cell.
+
+*Check 3 may corroborate TODO.  It may never establish NOT-ASKED.*
+
+/Wave mapping (solved):/ no external map is needed --- the oracle's own
+=survey= column carries the label.  For Tanzania: =wave 1.0 → 'NPS 2008 -
+2009'=, =2.0 → 'NPS 2010 - 2011'=, ... Group by =(country, survey)=.
+
+/Coverage limit:/ 7 countries, and it *stops at GHS 2018-19* --- so it gives
+no help on Nigeria's 2023-24 rounds, which is exactly where Nigeria's
+absent ag cells live.  Check 1 found them anyway (=sect10_plantingw5.dta=,
+=sect12_harvestw5.dta=).
+
+/Housekeeping:/ this parquet is currently an *orphan* --- nothing in the
+codebase references it.  Wiring it into the probe finally gives it a job.
+
+*** Check 4 --- the questionnaire.  *Mandatory before any permanent close.*
+Originally listed last and optional.  *The pilot promoted it to the
+decisive check*, and it is the one that must never be skipped.
+
+*Albania 2004 =assets=*: Check 1 and Check 2 both returned negative, and
+both were *correct about the data* --- the variables really are absent from
+the shipped =.dta=.  Three independent data-side checks unanimously said
+NOT-ASKED.  The questionnaire said =MODULE 2: ... DURABLE GOODS=,
+=105 Refrigerator 106 Freezer 107 Washing machine=.  They were all wrong.
+
+#+begin_quote
+*Absence in the shipped =.dta= is not absence in the instrument.*
+Every data-side check can be defeated by a data-/distribution/ gap.  Only
+the questionnaire can separate NOT-ASKED from ASKED-NOT-DISTRIBUTED --- and
+those two route to completely different queues.
+#+end_quote
+
+So: *no data-side evidence, however unanimous, may close a cell as
+NOT-ASKED.*  Only the questionnaire can.  Where no questionnaire exists,
+or it is a pre-1995 =CCITTFaxDecode= scan with no text layer (CotedIvoire
+1985--89; needs OCR), the verdict is =unsure= and the cell *stays in the
+queue*.  The pilot's own control makes the point: Albania 2002's
+study-level DDI scores zero hits for "durable" even though 2002
+demonstrably /has/ =durables_cl.dta=.  Its silence carries no information.
+
+/Implementation note:/ =pdftotext=/=pypdf= are absent on Savio compute
+nodes.  The pilot's pure-python extractor (zlib-inflate the =FlateDecode=
+streams, pull =Tj=/=TJ= text ops) works on modern PDFs and is enough.
+
+*** What gets recorded
+: country, feature, wave, verdict, checks_run, evidence, adjudicated_by, date
+=evidence= must cite something a human can re-check in under a minute --- a
+questionnaire section number, or "no variable or value label matching
+{shock|choc|conmoción}/... across the 14 =.dta= in =Data/=; sibling wave
+2013-14 uses =hh_s16q01=, which has no analogue here."  Not "searched, not
+found."
+
+*** Why this is enough without Ethan's eyes
+The row is a PR.  It is diffable, it names the checks it ran, and its
+evidence is re-verifiable in a minute by anyone who doubts it.  A wrong
+=not_asked= is therefore *recoverable* --- which is the property that makes
+unsupervised writes acceptable.  What would /not/ be acceptable is an
+evidence-free row, because nothing about it can ever be challenged.
+
+** D3. Probe by =(country, feature)=, not by cell
+
+The 456 absent cells collapse to *151 =(country, feature)= pairs*, and
+they split unevenly:
+
+- *338 cells / 130 pairs are PARTIAL* --- the country /already has/ that
+  feature for at least one other wave.  The schema is settled, the source
+  structure is known, a working =data_info.yml= sits one directory over.
+  The only open question is whether /this/ wave's instrument asked.
+- *118 cells / 21 pairs are WHOLE* --- the feature is missing for every
+  wave.  A from-scratch build.
+
+*74% of the gap is the cheap kind.*  A single probe of one pair typically
+resolves 2--5 cells at once, because the answer ("the 2005 and 2008 waves
+dropped the assets module") is a property of the pair, not of the cell.
+Probing cell-by-cell is a factor-of-three waste.
+
+** D4. Reuse the existing execution loop; do not build a new one
+
+We already have the machinery to /fix/ a cell and prove it:
+
+- =.claude/skills/add-feature/= --- the authoring path, with sub-skills
+  for =shocks=, =assets=, =sample=, =food-acquired=, =housing=, =pp-ph=,
+  =panel-ids=.
+- =.claude/skills/add-wave/= --- the acquisition path (=discover_waves=,
+  =add_wave=, DVC push).
+- =bench/feature_audit/= --- the regression net.
+- =.claude/skills/backlog-workflow/= --- worktree-isolated fix → verify →
+  red-team → PR.
+
+The matrix's job is to be the *worklist generator* for that loop, not to
+grow a parallel one.  The only new machinery this document proposes is
+=not_asked.csv= and two enumeration fixes.
+
+** D5. =blessed= means a human looked  [ADOPTED 2026-07-12]
+
+=sane= and =blessed= answer different questions, and the gap between them
+is where quiet errors live:
+
+- *=sane=* --- the automated checks passed.  /No human has necessarily looked
+  at a single number./
+- *=blessed=* --- a human read the actual numbers for that cell and believes
+  them.
+
+A feature can build cleanly, pass every check, and still be wired to the
+wrong source column or carry an unverified unit conversion.  *For anything
+feeding published analysis, =sane= is not enough.*
+
+*The tier was already fully implemented* --- loader, promotion, colour, =★=
+glyph, docs.  Only the file was empty (21 bytes).  Adopting it cost *zero
+code*:
+
+1. Schema extended to =country,feature,wave,blessed_by,date,note=.
+   =load_blessed= reads via =r.get(...)=, so the provenance columns are
+   free --- and they are what make a blessing /auditable/ rather than a bare
+   assertion.  Verified: extra columns ignored, blank-=wave= country-level
+   key still works.
+2. *The rule* (=CLAUDE.md= + =docs/guide/coverage.md=): /if you used a cell
+   in real analysis and looked at its numbers, bless it in the same PR./
+
+*Seeded empty, deliberately* (Ethan, 2026-07-12).  Blessings /accrete/;
+they are never bulk-seeded.  An empty blessing file is honest.  Bulk-
+blessing the 1208 =sane= cells would make =blessed= a synonym for =sane=,
+destroy the only distinction the tier draws, and assert a human review
+that never happened.
+
+*Trap found while wiring it:* =load_blessed= calls =pd.read_csv(...,
+keep_default_na=False)= with *no* =comment== argument, so a ~#~-comment
+line in =blessed.csv= is parsed as a *row* --- a phantom blessed cell.
+Header and data only.  Documented in both places.
+
+*** Corollary: a =sane= cell is not proof an issue is fixed
+Know what the grader does /not/ look at.  It is a *cold* build, so it
+cannot see warm-cache-only divergences (issue #588); and it does not check
+currency labels (#589).  Both look clean in the matrix and are genuinely
+open.  This is the same discipline as D2: /an unevidenced negative is
+worthless, whoever --- or whatever --- produced it./
+
+* Workplan
+
+Ordered by leverage --- cells closed per unit of effort --- not by country.
+
+** Phase 0 --- Fix the ruler (~1 day, do this first, in this order)
+
+0. *Inventory before regrading* (Defect 5): file the Nigeria =Quantity_kg=
+   gap and the GPS Lat/Lon gap as issues /first/, or step 4 buries them.
+1. *Absent-verdict tiers* (Defect 1) --- =.coder/coverage/absent_verdicts.csv=
+   + loader, mirroring =blessed=; =absent= is emitted at five sites in
+   =grade_feature=, so factor a single =_absent_tier()= helper.  Four
+   verdicts, not two: =todo= / =asked-not-distributed= / =not-asked= /
+   =unsure=.  Teach the HTML readout and =ll.coverage()= the tiers.  Headline
+   number = =todo + unsure= (the live queue).
+2. *Wave provenance* (Defect 3) --- stamp the WB =catalog_id= into each wave
+   dir (=add_wave= already writes =SOURCE.org=; *0 of 136 existing waves has
+   one*); match =discover_waves.local= on the id, not a reconstructed label.
+   Add =_COUNTRY_CODES["Serbia and Montenegro"] = "SCG"=; disambiguate the
+   shared =GHA= code that makes GhanaLSS and GhanaSPS each see the other's
+   waves as missing.
+3. *Upstream wave axis* (Defect 2) --- fold =discover_waves()= into
+   =build_matrix= as =missing-wave= rows.  Only meaningful after step 2.
+4. *Fix the wave-slice grader* (Defect 5) --- pass the country frame's
+   populated-column set as =optional= when grading a slice.  Regrades 131.
+5. *Known-no-data skip list* (Defect 6) --- Armenia, Nepal → =n/a=, not =broken=.
+6. *Surface the 10 in-remit config-less countries* (Defect 4) as =unconfigured=.
+
+*Exit test:* no tier lies, and every number is one we can burn down.
+Concretely: =builds= drops from 138 to ~7; =broken= from 8 to 0; a
+=missing-wave= count appears; the 456 splits four ways; and the ten
+in-remit orphan countries show up red instead of not at all.
+
+7. *Correct the false claim in* =Albania/_/data_scheme.yml:86= (see Defect 1,
+   Exhibit A) --- and grep the other 34 countries' =_/= comments for
+   unevidenced "no X module" assertions.  If one is wrong, assume others are.
+
+** Phase 1 --- Adjudicate the 456 (the probe sweep)
+
+Run the four-check probe over every absent cell.  Read-only, embarrassingly
+parallel, and *the single highest-value item on this list*: it converts 456
+undifferentiated red cells into a costed, ordered, evidence-backed queue.
+
+*Cost (measured, not guessed).*  The 456 cells collapse to *78 distinct
+=(country, wave)= folders* --- metadata is read once per folder and shared
+across the ~5.8 absent features in it, so the folder, not the cell, is the
+unit.  Check 1 over all 78: *~3 min warm, ~12 min cold* (S3 required; the
+lock-free bypass worked, no lock contention).  Checks 2 and 4 are the real
+cost --- ~78 questionnaires, and a lexicon spec per =(country, feature)=.
+
+: total  12--20 agent-hours,  parallelizable ~8-way by country
+:        -> ~2--3 hours wall-clock
+
+*Expected yield (from the pilot, and it is not what I predicted).*
+Roughly *60--75% TODO, 20--30% UNSURE, and very few NOT-ASKED.*  Plan for
+the sweep to /confirm work/, not to retire it.  Its value is that the work
+becomes *sized and sourced* --- 25 of the pilot's 38 cells came back with
+the exact file and variable name attached, which is most of the config
+already written.
+
+*Exit:* every absent cell carries a verdict + evidence, or is =unsure= with
+a named blocker.  Nothing is left in the undifferentiated bucket.
+
+*Known blockers the sweep will surface (from the pilot's 13 UNSURE):*
+- *CotedIvoire 1985--89 (8 cells)* --- =.DAT=/=.DCT= fixed-width with zero
+  variable labels, and questionnaires that are =CCITTFaxDecode= *scans*
+  with no text layer.  No check can run.  Needs OCR + a section-number →
+  module map.  This is the hardest corner of the cube.
+- *EthiopiaRHS R5--R7 (3 cells)* --- archive ships aggregates only.  Is the
+  raw section data obtainable from IFPRI Dataverse, or aggregate-only
+  forever?  A question for a human, not an agent.
+- *Albania 2004 assets / 2002 shocks* --- chase the missing extract; locate
+  the 2002 household questionnaire.
+
+** Phase 2 --- Harvest the PARTIAL TODOs
+
+The =data_info.yml=-next-door cases.  Highest yield per hour in the repo.
+Dispatch through the existing =add-feature= + =backlog-workflow= loop,
+worktree-isolated, verified against the audit harness.
+
+*** Start with Nigeria's ag block --- 50 cells, one country
+
+The most concentrated gap in the cube.  Nigeria has ten PP/PH round
+directories (=2010Q3=, =2011Q1=, ... =2024Q1=) and:
+
+| feature         | absent | builds | dropped |
+|-----------------+--------+--------+---------|
+| crop_production |     10 |      0 |       0 |
+| livestock       |     10 |      0 |       0 |
+| plot_inputs     |     10 |      0 |       0 |
+| plot_labor      |     10 |      0 |       0 |
+| plot_features   |      0 |      5 |       5 |
+
+Why this is the right first target:
+
+- Nigeria is a core LSMS-ISA country; its GHS-Panel unquestionably /has/
+  ag modules.  The 40 =absent= cells are TODO, not NOT-ASKED, and the
+  Harmonized-Ag oracle (Check 3) proves it --- it carries Nigeria waves
+  1--4 with =harvest_kg=, =seed_kg=, =total_labor_days=.
+- The WB do-files *name the raw file and variable per wave*, so most of
+  the config is pre-derivable rather than reverse-engineered.
+- =plot_features= is already wired for all ten rounds, so the PP/PH
+  script pattern (=.claude/skills/add-feature/pp-ph/=) exists in-repo ---
+  the four missing features follow it.
+- Its =plot_features= being 5 =builds= + 5 =dropped= is very likely the
+  PP/PH distinct-=t= / duplicate-index bug that skill already documents.
+  Fix the root and the degraded half of the block closes with it.
+
+One country, one script pattern, ~50 cells.  Nothing else in the cube has
+that density.
+
+** Phase 3 --- The degraded cells, in severity order
+
+The census (2026-07-11) already clustered these.  Do them in *this* order
+--- it is not the order the tier ladder suggests.
+
+*** 3a. =roster_to_characteristics= deletes entire waves (8 cells, TOP SEVERITY)
+
+The one unambiguous silent-data-loss bug in the cube.
+=transformations.py:251-265= --- the residence filter added with
+=MonthsSpent= --- drops every row of a wave when the resolved months
+column is unusable, so =household_characteristics= returns *nothing* for
+that wave while the underlying roster is fully populated.  Three distinct
+defects in one 14-line block:
+
+1. *The =elif= chain picks the first column /present/, not /populated/.*
+   Ethiopia's country frame carries both =MonthsAway= (0 non-null in
+   2018-19 and 2021-22) and =WeeksAway= (28,634 / 20,504 non-null --- W4/W5
+   switched to weeks, exactly as CLAUDE.md documents).  =monthsaway= wins
+   the =elif=, =ms= is all-NaN, *both waves are deleted.*  Fix: coalesce
+   per row rather than per column.
+2. *No all-NaN guard.*  CotedIvoire 1985-89 and Mali 2021-22 have
+   =MonthsSpent= 0% non-null --- the column exists in the frame only because
+   the country-level concat unions it in from other waves.  =keep= is
+   all-False; *five waves deleted.*
+3. *Untranslated French labels.*  Burkina Faso 2014 =MonthsSpent= is
+   ='6 mois ou plus'= / ='moins de 6 mois'= (77,268 / 943 rows).
+   =errors='coerce'= → NaN → *wave deleted.*  A one-line YAML mapping, the
+   same =Oui=/=Non= → 12/0 pattern CLAUDE.md already prescribes for EHCVM.
+
+Defects 1 and 2 collapse into one guard: /if the resolved =ms= is entirely
+NaN within a =t= group, skip the filter for that group/ (reverting to the
+documented pre-=MonthsSpent= count-everyone behaviour).  *One function, 8
+cells, top severity.*  It is a post-read derived transform (=_ROSTER_DERIVED=),
+so per =backlog-workflow= it reproduces *warm* --- no cold rebuild needed.
+
+*** 3b. Extract the two genuine gaps hiding inside the =builds= bucket
+Nigeria =Quantity_kg= (6 cells; breaks the default =food_prices=) and the
+GPS Lat/Lon gap (18 cells).  File before regrading (see Defect 5).
+
+*** 3c. Fix the grader (Defect 5) --- regrades 131 cells
+
+*** 3d. Nigeria's PP/PH =dropped= bloc (22 cells) --- and correct issue #587
+#587 attributes these to a "multi-round wave-label ↔ =t= mismatch."  *That
+diagnosis is refuted.*  The built =t= values /are/ valid Nigeria wave
+labels --- they are simply the labels of the *opposite round*.  Each feature
+is being built for only one round of each PP/PH pair:
+=community_prices= is all Q1 and no Q3; =plot_features= is all Q3 and no
+Q1; =food_coping= all Q3.  These are not false positives; they are real
+half-missing features.  Re-diagnose before dispatching.
+
+*** 3e. The mis-tiered =broken= (8) and the CotedIvoire derived-feature over-declaration (4)
+Armenia/Nepal need a known-no-data skip list (Defect 6).  CotedIvoire's
+=food_expenditures= 1985-89 is =dropped= only because its /source/
+=food_acquired= is =absent= for those waves --- derived features should
+inherit their source's per-wave declaration in the coverage layer.
+
+*** Stale issues to close (the matrix says they are already done)
+=#571= (Guatemala =food_acquired=), =#572= (Serbia), =#574= (GhanaSPS) ---
+all =sane=, with their derived tables =sane= too.  =#573= (Panama) is
+genuinely still open.  Note =#588= and =#589= look clean in the matrix but
+are *not* stale: the matrix is a cold build and structurally cannot see
+#588's warm-cache-only divergence, nor #589's currency labels.  *A cell
+being =sane= is not proof an issue is fixed --- know what the grader does
+not look at.*
+
+*** Tracking
+*146 of the 185 degraded cells have no tracking issue at all.*  Only the 39
+=dropped= are tracked, by =#587= alone --- and #587's hypothesis for its
+largest bloc is wrong (3d).
+
+** Phase 4 --- The 21 WHOLE-feature pairs
+
+Real feature work through the =add-feature= sub-skills; schedule
+deliberately.
+
+** Phase 5 --- Bootstrap the ten in-remit orphan countries
+
+*Scope decision (Ethan, 2026-07-11): these are in remit.*  They are
+"kissing cousins" --- WB data carrying many of the LSMS modules.  Mostly
+/classic/ LSMS (the Deaton-era ENNIV / EMNV / ENV / PPV surveys) rather
+than LSMS-ISA, so their instrument profile differs; that difference is
+exactly what =not_asked.csv= is for, and needs no new mechanism.
+
+Ordered by cost-to-first-green (from the census):
+
+| # | country          | waves | survey            | why here                                                |
+|---+------------------+-------+-------------------+---------------------------------------------------------|
+| 1 | Panama           |     3 | ENV               | *cheapest win.*  Already has =panama.py=, =food_acquired.py=, =food_items.org=, =units.py=; only =data_scheme.yml= + wave =data_info.yml= missing |
+| 2 | Kyrgyz Republic  |     4 | PMS / LSMS        | textbook LSMS modules (expenditure, diet, anthropometry, community) |
+| 3 | Peru             |     4 | ENNIV             | =food_acquired= already scoped in a country =data_info.yml=; friction: 1990 is =.ssp=, and its =v=-in-index predates =_join_v_from_sample()= |
+| 4 | Bosnia-Herzegovina |   5 | BiH LSMS          | genuine 4-year panel; =2001-04/= is a panel-file dir → use the multi-round-waves pattern, not a naive wave |
+| 5 | Nicaragua        |     3 | EMNV              | 1993 / 1998-99 clean =.DTA=; 2001 is =.dat= + =.dct= (needs =infile=); 2005 has no microdata |
+| 6 | Tanzania_Kagera  |     2 | KHDS              | real long panel; dir name is a *typo* (=Kegera=).  Note the WB census found KHDS W1--W6 upstream (ids 359, 79, 2251) --- acquire and bootstrap together |
+| 7 | Brazil           |     1 | PPV               | clean one-off cross-section; cheap, low leverage |
+| 8 | Afghanistan      |     2 | ALCS              | partial bootstrap exists (=afghanistan.py=, =Makefile=) |
+| 9 | Rwanda           |     2 | EICV              | 2000-01 workable (=.sav=); 2005-06 is bare =.dat=, no dictionary |
+| 10 | Bulgaria        |     5 | Integrated HHS    | repeated cross-sections; sidecars mix raw with WB-*constructed* aggregates --- sorting raw from derived is the real cost |
+
+*Recommend dropping =KenyaLPS=* (5 dirs, 158 MB).  It is the Kenya Life
+Panel Survey --- a Miguel/Kremer /individual/ deworming-tracking study, not
+an LSMS household survey.  The canonical schema (=household_roster=,
+=food_acquired=, =sample=/=v=) does not map onto it.  Keeping it in the
+denominator just manufactures permanent red.
+
+Note there is *no =add-country= skill* --- =add-feature= covers the
+"create a =data_scheme.yml= if absent" case in a paragraph.  Ten
+bootstraps justify writing one.
+
+* Decisions taken
+
+1. *Scope of the config-less countries* --- [2026-07-11] *in remit.*  They
+   are WB "kissing cousins" carrying many LSMS modules.  See Phase 5.
+   /Open sub-question:/ is =KenyaLPS= the one exception?  It is an
+   individual tracking panel, not a household survey, and the canonical
+   schema does not map onto it.
+2. *Adjudication authority* --- [2026-07-11] *no human sign-off required*,
+   but only against the enumerated evidence standard of §D2, which the
+   pilot then hardened: Check 4 (the questionnaire) is *mandatory* before
+   any permanent close, because every data-side check can be defeated by a
+   data-/distribution/ gap (Albania 2004).  An agent may write a verdict;
+   it may not write an /unevidenced/ one.
+3. *=blessed=* --- [2026-07-12] *adopted, seeded empty, bless-on-first-use.*
+   Implemented; see §D5.
+
+* Open questions for Ethan
+
+1. *=KenyaLPS=* --- drop from the denominator?  (Recommend: yes.)
+2. *EthiopiaRHS R5--R7* --- is the raw section data obtainable from IFPRI
+   Dataverse, or is the archive aggregate-only forever?  Three cells hang
+   on this and no agent can answer it.
+3. *The =Harmonized_LSMS-ISA_Ag= parquet* is an orphan --- 48 MB, DVC-tracked,
+   referenced by nothing.  The probe (§D2 Check 3) gives it a job.  Keep it
+   where it is, or move it out of =countries/=?  It is not a country.

--- a/slurm_logs/DESIGN_coverage_discipline_2026-07-11.org
+++ b/slurm_logs/DESIGN_coverage_discipline_2026-07-11.org
@@ -212,14 +212,60 @@ The false negatives are the dangerous ones, because they are silent:
 - *GhanaLSS / GhanaSPS* both map to ISO =GHA=, so each sees the other's
   waves as its own missing waves.
 
-Root cause: *none of the 136 wave directories records the WB catalog id it
-came from.*  =add_wave()= writes a =SOURCE.org=; not one pre-existing wave
-has one (=find ... -name SOURCE.org= → 0).
+*** CORRECTION [2026-07-12] --- I got the root cause wrong, and the truth is worse
 
-*Fix (prerequisite for Defect 2).*  Stamp =catalog_id= per wave dir and
-match on the id, not on a reconstructed label.  Backfilling 136 waves is a
-bounded, mostly-mechanical job.  Until it is done, any "missing wave"
-column in the matrix is guesswork.
+I originally wrote here: /"none of the 136 wave directories records the WB
+catalog id it came from ... not one pre-existing wave has one
+(=find ... -name SOURCE.org= → 0)."/
+
+*That is false.*  *117 of the 136 waves had a =SOURCE.org= all along.*  My
+=find= used =-maxdepth 3=; the file lives at
+={Country}/{wave}/Documentation/SOURCE.org= --- depth *4*.  The command
+returned 0 because it could not see the files, not because they were absent.
+
+I ran one command, it returned zero, and I called it proof.  That is
+precisely the /unevidenced negative/ this document spends §D2 warning
+against, and I committed it to a design doc, a commit message, and a PR.
+The rule applies to me: *silence is not evidence, and a null result from an
+instrument you have not validated is a null result about the instrument.*
+
+*The real defect is worse than the one I described.*  The provenance is not
+merely missing --- in places it is *wrong*:
+
+- =Nigeria/2018-19/Documentation/SOURCE.org= records catalog *3827* --- the
+  /Nigeria Living Standards Survey/.  The directory actually holds
+  =aux_plantingw4= / =aux_harvestw4= --- *GHS-Panel W4 (3557)*, a different
+  survey.
+
+A backfill that /trusted/ =SOURCE.org= would therefore have *cemented* the
+error rather than fixed it.  Absent provenance is a gap; wrong provenance is
+a lie, and it is the harder failure.
+
+A third failure mode neither of us predicted: *one catalog entry can back two
+wave directories.*  WB 1001 (=UGA_2005-2009_UNPS=) renders as ="2005-10"=,
+matching no directory --- so it read as MISSING although we hold it across
+=2005-06/= and =2009-10/=.
+
+*Fix (prerequisite for Defect 2).*  Match on catalog id, and *validate rather
+than trust* the recorded id against the directory's actual contents.  Keep
+="none"= (definitively not a WB dataset) distinct from ="unknown"= (we do not
+know) --- collapsing them would re-create exactly the =absent=-black-hole
+mistake of Defect 1, one level down.
+
+*** =SOURCE.org= is load-bearing --- creating one PROMOTES a directory into a wave
+
+Found while implementing this (PR #595), and it is a trap worth its own note.
+=Country.waves= (=country.py:1452=) falls back to scanning for directories
+containing =Documentation/SOURCE.org=.  So *writing* a =SOURCE.org= does not
+merely annotate a wave --- it *creates* one.
+
+A first pass that stamped all 136 dirs broke
+=test_sample.py::test_covers_all_waves[Benin]=, because =Benin/2018-2019/= is
+a *stray duplicate* of =Benin/2018-19/= (identical =.dta=) and stamping it
+promoted the duplicate into a wave that =sample()= does not cover.  The full
+test suite caught it.
+
+Metadata that silently changes the shape of the data model is not metadata.
 
 ** Defect 4 --- eleven countries are invisible
 

--- a/tests/test_coverage_matrix.py
+++ b/tests/test_coverage_matrix.py
@@ -419,3 +419,109 @@ def test_absent_stays_absent_with_no_verdicts():
                               _env(_df_with_t({"w1": 3}), _ok_report()),
                               readiness=True)
     assert _tiers(cells)[("foo", "w2")] == "absent"
+
+
+# ---------------------------------------------------------------------------
+# `unconfigured` + known-no-microdata (Defects 4 and 6)
+# ---------------------------------------------------------------------------
+def test_unconfigured_countries_finds_data_without_config(tmp_path):
+    """A country dir with microdata but no _/data_scheme.yml must be REPORTED.
+
+    `catalog.countries()` requires a data_scheme.yml, so these were invisible to
+    the whole library -- 10 in-remit countries and ~35 waves of already-
+    downloaded data that the matrix simply never mentioned.  A denominator that
+    omits the work you have not started is not a denominator.
+    """
+    root = tmp_path / "countries"
+    # configured country -> NOT unconfigured
+    (root / "Uganda" / "_").mkdir(parents=True)
+    (root / "Uganda" / "_" / "data_scheme.yml").write_text("Country: Uganda\n")
+    (root / "Uganda" / "2019-20" / "Data").mkdir(parents=True)
+    # data, no config -> unconfigured
+    (root / "Peru" / "1994" / "Data").mkdir(parents=True)
+    (root / "Peru" / "1991" / "Data").mkdir(parents=True)
+    # no Data/ at all -> not a country dir; must be ignored
+    (root / "stray").mkdir()
+
+    got = cov.unconfigured_countries(lambda: root)
+    assert got == {"Peru": 2}
+
+
+def test_known_no_microdata_countries_are_na_not_broken():
+    """Armenia/Nepal have NO source data.  That is a fact, not a defect.
+
+    Before this, ALL 8 `broken` cells in the cube were these two countries --
+    so the most alarming tier in the ladder contained nothing actionable, and a
+    genuine build failure would have been lost among them.
+    """
+    known = cov.countries_without_microdata()
+    assert set(known) >= {"Armenia", "Nepal"}
+
+    co = _FakeCountry({"1996": ["household_roster"]})
+    env = _env(FileNotFoundError("PathMissingError: INDSECA.dta"), _ok_report())
+
+    cells = cov.grade_feature("Armenia", "household_roster", ["1996"], co, env,
+                              readiness=True)
+    cell = cells[0]
+    assert cell["tier"] == "n/a"                      # not `broken`
+    assert "no microdata in repo" in cell["detail"]
+
+    # ...but a country that SHOULD have data still reports `broken`.
+    cells = cov.grade_feature("Uganda", "household_roster", ["1996"], co, env,
+                              readiness=True)
+    assert cells[0]["tier"] == "broken"
+
+
+def test_new_tiers_are_registered_in_the_ladder():
+    for t in ("not-asked", "asked-not-distributed", "unconfigured"):
+        assert t in cov.TIER_ORDER, t
+        assert t in cov.ROLLUP_PRIORITY, t
+    # every tier the model can emit must be rankable by the rollup
+    assert set(cov.TIER_ORDER) == set(cov.ROLLUP_PRIORITY)
+
+
+def test_scoped_snapshot_MERGES_and_does_not_destroy_other_cells(tmp_path):
+    """A partial measurement must never erase a complete one.
+
+    `make matrix C="Uganda"` grades only Uganda.  Writing that wholesale wiped
+    every other country -- and docs/guide/coverage.md documented exactly that as
+    the "spot refresh" procedure, followed by `git add latest.csv && commit`.
+    Following the guide verbatim replaced the authoritative 1849-cell snapshot
+    with a 67-cell one.  (Observed 2026-07-12.)
+    """
+    snap = tmp_path / "latest.csv"
+    full = pd.DataFrame(
+        [{"country": "Uganda", "feature": "housing", "wave": "2019-20",
+          "tier": "builds", "coverage": "declared", "n_rows": "10", "detail": "old"},
+         {"country": "Malawi", "feature": "housing", "wave": "2016-17",
+          "tier": "sane", "coverage": "declared", "n_rows": "99", "detail": "keep me"}],
+        columns=cov.COLUMNS)
+    cov.save_snapshot(full, snap, merge=False)
+
+    # a SCOPED re-run: only Uganda was graded
+    scoped = pd.DataFrame(
+        [{"country": "Uganda", "feature": "housing", "wave": "2019-20",
+          "tier": "sane", "coverage": "declared", "n_rows": "10", "detail": "new"}],
+        columns=cov.COLUMNS)
+    cov.save_snapshot(scoped, snap)
+
+    got = pd.read_csv(snap, dtype=str, keep_default_na=False)
+    assert len(got) == 2, "the un-graded country was destroyed"
+    uga = got[got.country == "Uganda"].iloc[0]
+    mwi = got[got.country == "Malawi"].iloc[0]
+    assert uga["tier"] == "sane" and uga["detail"] == "new"    # upserted
+    assert mwi["tier"] == "sane" and mwi["detail"] == "keep me" # untouched
+
+
+def test_save_snapshot_merge_false_still_replaces(tmp_path):
+    snap = tmp_path / "latest.csv"
+    cov.save_snapshot(pd.DataFrame(
+        [{"country": "Malawi", "feature": "housing", "wave": "w", "tier": "sane",
+          "coverage": "declared", "n_rows": "1", "detail": ""}],
+        columns=cov.COLUMNS), snap, merge=False)
+    cov.save_snapshot(pd.DataFrame(
+        [{"country": "Uganda", "feature": "housing", "wave": "w", "tier": "sane",
+          "coverage": "declared", "n_rows": "1", "detail": ""}],
+        columns=cov.COLUMNS), snap, merge=False)
+    got = pd.read_csv(snap, dtype=str)
+    assert list(got.country) == ["Uganda"]

--- a/tests/test_coverage_matrix.py
+++ b/tests/test_coverage_matrix.py
@@ -51,7 +51,9 @@ def _env(load_result, report=None, derived=None):
             raise load_result
         return load_result
 
-    def is_sane(_df, _c, _f):
+    def is_sane(_df, _c, _f, **_kw):
+        # **_kw absorbs ``extra_optional=`` (the populated-column set the
+        # wave-slice grader passes; see coverage_matrix.grade_feature).
         return report
 
     return {
@@ -251,3 +253,169 @@ def test_build_matrix_covers_declared_features(monkeypatch):
     # household_roster is declared for Uganda; food_expenditures is derived-surfaced
     assert "household_roster" in feats
     assert "food_expenditures" in feats
+
+
+# ---------------------------------------------------------------------------
+# Wave-slice grading must not apply the COUNTRY-level all-null-column check
+# to a single wave (the 2026-07-12 regrade; 128 of 138 `builds` cells).
+# ---------------------------------------------------------------------------
+def test_wave_slice_exempts_columns_populated_elsewhere_in_the_country():
+    """A column not fielded in ONE wave must not fail that wave.
+
+    ``_check_no_all_null_columns`` is a country-level check.  Grading a wave by
+    slicing the country frame on ``t`` made any question that a given wave did
+    not ask look like a defect, because it is legitimately all-null *within
+    that slice*.  ``grade_feature`` must exempt columns that are populated
+    somewhere in the parent frame.
+    """
+    from lsms_library.diagnostics import is_this_feature_sane
+
+    # Wave A fields `Latitude`; wave B does not.  Country-wide it IS populated.
+    idx = pd.MultiIndex.from_tuples(
+        [("A", "hh1"), ("A", "hh2"), ("B", "hh3"), ("B", "hh4")],
+        names=["t", "i"],
+    )
+    df = pd.DataFrame({"Latitude": [1.5, 2.5, None, None]}, index=idx)
+
+    sl_b = df[df.index.get_level_values("t") == "B"]        # the all-null slice
+    populated = {c for c in df.columns if df[c].notna().any()}
+    assert populated == {"Latitude"}
+
+    # Without the exemption the slice fails; with it, it passes.
+    naive = is_this_feature_sane(sl_b, "Uganda", "household_roster")
+    fixed = is_this_feature_sane(sl_b, "Uganda", "household_roster",
+                                 extra_optional=populated)
+    naive_null = [c for c in naive.checks if c.name == "no_all_null_columns"]
+    fixed_null = [c for c in fixed.checks if c.name == "no_all_null_columns"]
+    assert naive_null and naive_null[0].status == "fail"   # the old, wrong grade
+    assert fixed_null and fixed_null[0].status == "pass"   # the corrected grade
+
+
+def test_column_all_null_country_wide_still_fails():
+    """We relaxed the SLICE, not the country.  A truly dead column still fails."""
+    from lsms_library.diagnostics import is_this_feature_sane
+
+    idx = pd.MultiIndex.from_tuples(
+        [("A", "hh1"), ("A", "hh2"), ("B", "hh3")], names=["t", "i"]
+    )
+    df = pd.DataFrame({"Latitude": [None, None, None]}, index=idx)   # never populated
+    populated = {c for c in df.columns if df[c].notna().any()}
+    assert populated == set()                                # nothing to exempt
+
+    rep = is_this_feature_sane(df, "Uganda", "household_roster",
+                               extra_optional=populated)
+    null_check = [c for c in rep.checks if c.name == "no_all_null_columns"]
+    assert null_check and null_check[0].status == "fail"
+
+
+def test_extra_optional_default_preserves_historical_behaviour():
+    """Omitting ``extra_optional`` must grade exactly as before (back-compat)."""
+    from lsms_library.diagnostics import is_this_feature_sane
+
+    idx = pd.MultiIndex.from_tuples([("A", "hh1"), ("A", "hh2")], names=["t", "i"])
+    df = pd.DataFrame({"Latitude": [None, None]}, index=idx)
+
+    a = is_this_feature_sane(df, "Uganda", "household_roster")
+    b = is_this_feature_sane(df, "Uganda", "household_roster", extra_optional=None)
+    pick = lambda r: [(c.name, c.status) for c in r.checks]
+    assert pick(a) == pick(b)
+
+
+# ---------------------------------------------------------------------------
+# Absent-cell verdicts (GH #593) -- the four-way split of the `absent` tier.
+# ---------------------------------------------------------------------------
+def _verdicts_file(tmp_path, rows):
+    p = tmp_path / "absent_verdicts.csv"
+    hdr = "country,feature,wave,verdict,checks_run,evidence,adjudicated_by,date\n"
+    p.write_text(hdr + "".join(rows))
+    return p
+
+
+def test_not_asked_closes_the_cell(tmp_path):
+    p = _verdicts_file(tmp_path, [
+        "C,foo,w2,not-asked,C1;C2;C4,no module in questionnaire s3,sue,2026-07-12\n"])
+    v = cov.load_verdicts(p)
+    co = _FakeCountry({"w1": ["foo"], "w2": []})
+    cells = cov.grade_feature("C", "foo", ["w1", "w2"], co,
+                              _env(_df_with_t({"w1": 3}), _ok_report()),
+                              readiness=True, verdicts=v)
+    assert _tiers(cells)[("foo", "w2")] == "not-asked"
+
+
+def test_asked_not_distributed_is_its_own_tier(tmp_path):
+    """The state the pilot found: instrument asked, extract does not carry it.
+
+    Neither `todo` (nothing to configure) nor `not-asked` (it WAS asked) --
+    it is an ACQUISITION problem and routes to a different queue.
+    """
+    p = _verdicts_file(tmp_path, [
+        "C,foo,w2,asked-not-distributed,C1;C2;C4,"
+        "questionnaire MODULE 2 lists it; vars absent from shipped dta,sue,2026-07-12\n"])
+    v = cov.load_verdicts(p)
+    co = _FakeCountry({"w1": ["foo"], "w2": []})
+    cells = cov.grade_feature("C", "foo", ["w1", "w2"], co,
+                              _env(_df_with_t({"w1": 3}), _ok_report()),
+                              readiness=True, verdicts=v)
+    assert _tiers(cells)[("foo", "w2")] == "asked-not-distributed"
+
+
+@pytest.mark.parametrize("verdict", ["todo", "unsure"])
+def test_todo_and_unsure_stay_in_the_queue(tmp_path, verdict):
+    """`todo` and `unsure` are OPEN work -- they must NOT close the cell."""
+    p = _verdicts_file(tmp_path, [
+        f"C,foo,w2,{verdict},C1,found s08q01 in EACIACT_p1.dta,sue,2026-07-12\n"])
+    v = cov.load_verdicts(p)
+    co = _FakeCountry({"w1": ["foo"], "w2": []})
+    cells = cov.grade_feature("C", "foo", ["w1", "w2"], co,
+                              _env(_df_with_t({"w1": 3}), _ok_report()),
+                              readiness=True, verdicts=v)
+    cell = [c for c in cells if c["wave"] == "w2"][0]
+    assert cell["tier"] == "absent"              # still in the queue
+    assert verdict in cell["detail"]             # but the evidence is carried
+
+
+def test_closing_verdict_without_evidence_is_REFUSED(tmp_path):
+    """The load-bearing rule.
+
+    A closing verdict is a permanent, unsupervised write.  An unevidenced
+    negative is unfalsifiable and therefore permanent whether or not it is
+    true -- exactly the failure already sitting in Albania's data_scheme.yml
+    ("earlier waves have no shocks module"; Albania 2005 in fact carries
+    m6e_q00 = 'Type of Shock Code').  So we refuse it.
+    """
+    p = _verdicts_file(tmp_path, ["C,foo,w2,not-asked,C1,,sue,2026-07-12\n"])
+    with pytest.warns(UserWarning, match="unevidenced negative|REQUIRES"):
+        v = cov.load_verdicts(p)
+    assert v == {}                               # the row is dropped, not honoured
+
+    co = _FakeCountry({"w1": ["foo"], "w2": []})
+    cells = cov.grade_feature("C", "foo", ["w1", "w2"], co,
+                              _env(_df_with_t({"w1": 3}), _ok_report()),
+                              readiness=True, verdicts=v)
+    assert _tiers(cells)[("foo", "w2")] == "absent"   # stays red. good.
+
+
+def test_todo_without_evidence_is_allowed(tmp_path):
+    """Only CLOSING verdicts need evidence; `todo` keeps the cell open anyway."""
+    p = _verdicts_file(tmp_path, ["C,foo,w2,todo,C1,,sue,2026-07-12\n"])
+    v = cov.load_verdicts(p)
+    assert ("C", "foo", "w2") in v
+
+
+def test_unknown_verdict_is_refused(tmp_path):
+    p = _verdicts_file(tmp_path, ["C,foo,w2,definitely-not,C1,x,sue,2026-07-12\n"])
+    with pytest.warns(UserWarning, match="unknown verdict"):
+        assert cov.load_verdicts(p) == {}
+
+
+def test_verdicts_missing_file_is_empty(tmp_path):
+    assert cov.load_verdicts(tmp_path / "nope.csv") == {}
+
+
+def test_absent_stays_absent_with_no_verdicts():
+    """Back-compat: no verdicts file -> the historical grading, unchanged."""
+    co = _FakeCountry({"w1": ["foo"], "w2": []})
+    cells = cov.grade_feature("C", "foo", ["w1", "w2"], co,
+                              _env(_df_with_t({"w1": 3}), _ok_report()),
+                              readiness=True)
+    assert _tiers(cells)[("foo", "w2")] == "absent"


### PR DESCRIPTION
The coverage matrix measures, but it does not measure right. A census (2026-07-11) found that **595 of its 1849 cells — 32% — carry a tier that is wrong or unactionable**, and that its errors bias in *both* directions: it cries wolf about what we have, and stays silent about what we lack.

A workplan built on those numbers is built on sand. This is Phase 0: **fix the ruler, then measure.**

Design doc: `slurm_logs/DESIGN_coverage_discipline_2026-07-11.org`

---

## 1. `blessed` — adopted (zero library code)

The tier was already fully implemented (loader, promotion, colour, `★` glyph, docs); only its file was a 21-byte header, so the top of the ladder had never once been used.

- `sane` = *the automated checks passed. No human has necessarily looked at a single number.*
- `blessed` = *a human read the actual numbers and believes them.*

Schema extended to `country,feature,wave,blessed_by,date,note` (`load_blessed` reads via `r.get(...)`, so the provenance columns are free — and they make a blessing **auditable** rather than a bare assertion).

**The rule** (CLAUDE.md + docs): *if you used a cell in real analysis and looked at its numbers, bless it in the same PR.* Seeded **empty, deliberately** — bulk-blessing the 1208 `sane` cells would make `blessed` a synonym for `sane` and assert a review that never happened.

## 2. The wave-slice grader applied a COUNTRY-level check — 128 false `builds`

`grade_feature` grades a wave by slicing the country frame on `t`, but `_check_no_all_null_columns` is a **country-level** check. A question not fielded in a given wave is legitimately all-null *within that slice*, and was graded `builds`.

**Proof it is a grading bug, not a data bug:** of the 124 columns it flagged, **zero** are all-null country-wide.

`is_this_feature_sane` gains `extra_optional=` (default `None` → historical behaviour byte-for-byte; it has many callers incl. the audit harness). The slice grader passes the set of columns populated somewhere in the parent frame. **A column all-null across the whole country still fails** — we relaxed the slice, not the country.

**Verified on Malawi/Uganda/Niger:**

| | |
|---|---|
| cells compared | 434 |
| changed | **37 — all `builds → sane`** |
| flips not explained by `no_all_null_columns` | **0** |
| **regressions** | **0** |
| `builds` remaining | **5 — all `no_null_index_levels`** (the genuine `v`-join failures, correctly still red) |

### The sequencing rule this taught us

**A regrade is not a fix.** Re-tiering 128 cells to `sane` would have *silently buried* two genuine gaps that the buggy grading was catching only by accident. Both were inventoried as issues **before** this landed:

- **#591** — Nigeria `food_prices()` silently drops **~99% of rows in 6 of 8 waves**. A `Quantity == 0` sentinel (never decoded to `NA`) makes `Price = Expenditure/0 = inf`, which `transformations.py:933` deletes. 675–1,106 rows survive out of 120k–160k. **All six cells were graded `sane`.**
- **#592** — 18 waves across 6 countries have zero GPS in `cluster_features`.

> Whenever a fix changes how cells are **graded** rather than what they **contain**, first inventory what the old grading was catching by accident.

## 3. `absent` was a black hole — 456 cells

`absent` said only "not declared for this wave", conflating states that could not be more different. So the number could never reach zero, and every probe's findings evaporated into the prober's head.

Verdicts now live in `.coder/coverage/absent_verdicts.csv`:

| verdict | meaning | closes? |
|---|---|---|
| `todo` | data IS there; config missing | no — stays `absent`, but now **sized and sourced** |
| `asked-not-distributed` | instrument asked; the shipped extract lacks it | **yes** → acquisition queue |
| `not-asked` | genuinely never asked | **yes** → closed forever |
| `unsure` | a required check could not run | no — stays in the queue, **records why** |

`asked-not-distributed` is not hypothetical: Albania 2004's questionnaire lists `MODULE 2: DURABLE GOODS`, and the variables are simply not in the shipped `.dta`. **Absence in the shipped data is not absence in the instrument** — which is why the questionnaire check is mandatory before any permanent close.

### Evidence is load-bearing, and this already went wrong

`load_verdicts()` **refuses** a closing verdict with an empty `evidence` field. A closing verdict is a *permanent, unsupervised write*; an unevidenced negative is unfalsifiable and therefore permanent whether or not it is true.

`Albania/_/data_scheme.yml` asserted **"earlier waves have no shocks module."** That claim is **false**. Verified against source:

| wave | source | variable |
|---|---|---|
| 2005 | `Data/migrationE_cl.dta` | `m6e_q00` = *"Type of Shock Code"* (10 types) + year grid |
| 2008 | `Data/Modul_6E_migration_e.sav` | `m6e_q00`, identical |
| 2003 | `Data/w2_hh_all.dta` | `B10A_Q10` = *"faced any shocks in last 12 months"* |
| 2004 | `Data/w3_hh_all.dta` | `m10a_q09`, same |

Nobody could catch it, because nothing recorded *how* it was reached. It silently suppressed ~5 cells. Comment corrected; the four waves seeded as `todo` **with citations**, 2002 as an honest `unsure` with its blocker named.

## What this does NOT claim

A 38-cell pilot running the full evidence standard returned **25 todo / 13 unsure / 0 not-asked**. So `absent` is not hiding "the survey never asked" — **it is hiding a backlog.** This mechanism does not shrink the work. It makes the work *knowable, sized, and ordered*, which is the most an instrument can honestly do.

## Tests

12 new: grader exemption, country-wide-null still fails, back-compat default, all four verdicts, and the evidence refusal. All `diagnostics`/`coverage_matrix`-touching suites green (243 + 11 + 18 passed).

## Still to come in Phase 0

- Upstream wave axis (blocked on wave-provenance PR — `discover_waves`'s `local` flag is currently ~35% wrong)
- Surface the 10 in-remit config-less countries as `unconfigured`
- Armenia/Nepal → `n/a`, not `broken` (they have no microdata at all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtARb9se2un1DLFJrrpjHe