### PR TITLE
fix(household_characteristics): residence filter was silently deleting 8 entire wave-cells

### DIFF
--- a/.coder/ledger/roster-characteristics-wave-deletion.md
+++ b/.coder/ledger/roster-characteristics-wave-deletion.md
@@ -1,0 +1,113 @@
+# Prior-Art Ledger — roster-characteristics-wave-deletion
+
+> Per-task ledger. Inherits the repo §0 baseline in `STANDING.md`. Living
+> snapshot; git history is the journal.
+
+**Search tier used:** ripgrep + git floor (gitnexus not consulted this session),
+plus an empirical census: `Country(c).household_characteristics()` per-wave row
+counts for all 40 countries that declare `household_roster`, warm cache.
+
+## §1 Task, restated
+
+`household_characteristics` is a **derived** table (`Country._ROSTER_DERIVED`,
+`STANDING.md §2`): `country.py` aggregates `household_roster` across *all* waves
+into one frame and hands it to `transformations.roster_to_characteristics()`,
+which drops non-resident members using whichever residence-duration column is
+present (`MonthsSpent` / `MonthsAway` / `WeeksAway`, per `CLAUDE.md`
+§"MonthsSpent / MonthsAway / WeeksAway"). Because the frame handed to the
+transform is the **country-level concat**, a residence column contributed by
+*one* wave is unioned onto *every* wave. Where the resolved months series is
+unusable for a wave, the keep-mask is all-False **for that whole wave** and
+`household_characteristics` silently returns nothing for it, even though
+`household_roster` is fully populated. 8 wave-cells are currently destroyed.
+The task fixes the resolution + the guard, and repairs one wave whose
+`MonthsSpent` is an untranslated French label — in **config**, not in code.
+
+## §2 Existing machinery (this task's area)
+
+| symbol | path:line | what it does | tested? | reuse / extend / new |
+|--------|-----------|--------------|---------|----------------------|
+| `roster_to_characteristics` | `lsms_library/transformations.py:177` | roster → household sex×age counts + `log HSize`; owns the residence filter (L251-265) | `tests/test_roster_to_characteristics_movers.py`, `tests/test_age_intervals.py`, `tests/test_uganda_api_vs_replication.py` | **extend** (the residence-resolution block only) |
+| `Country._ROSTER_DERIVED` + dispatch | `lsms_library/country.py:3325`, `3515-3530` | resolves the transform by *name* at call time and passes the **all-waves** roster with `final_index` = the roster's own index levels | integration surface | reuse unchanged |
+| YAML `mapping:` on a `myvars` entry | e.g. `Mali/2017-18/_/data_info.yml:76`, `Mali/2018-19/_/data_info.yml:163` (`MonthsSpent: [s1q13, {mapping: {Oui: 12, Non: 0}}]`) | maps a categorical source label to the canonical numeric months value **at config level** | per-country builds | **reuse** — this is the sanctioned pattern for D3 |
+| `mover_sentinel` / NaN-in-`final_index` handling | `transformations.py:287-337` | GH #197 / #268: keeps movers rather than silently dropping them | `tests/test_roster_to_characteristics_movers.py` | untouched (same *class* of silent-drop bug, one layer down) |
+
+Searched by concept — "months present", "residence", "drop departed", "keep
+mask" — not just by identifier. No other implementation of a residence filter
+exists in the library; `roster_to_characteristics` is the only site.
+
+## §3 Definitions & conventions in force
+
+- **MonthsSpent / MonthsAway / WeeksAway semantics** — `CLAUDE.md`
+  §"MonthsSpent / MonthsAway / WeeksAway" (cited, not restated): `MonthsSpent`
+  = months present 0–12; `MonthsAway` → `12 - value`; `WeeksAway` →
+  `12 - weeks/(52/12)`. Filter excludes NaN (question not asked) and 0 months,
+  **except** infants (age < 1). **"Countries without any residence column are
+  unaffected — the old count-everyone behavior continues."** That sentence is
+  the definition the D2 guard restores at *wave* granularity.
+- **Ethiopia W4–W5 switched months→weeks** — same section: "`WeeksAway`: …
+  Used by Ethiopia W4–W5 and Cambodia, where the questionnaire switched from
+  months to weeks." So Ethiopia legitimately carries **both** columns at country
+  level, disjointly populated. The `elif` chain contradicts this documented fact.
+- **EHCVM binary → 12/0** — same section: "The binary `s01q12` … is mapped to
+  0/12", done in the wave `data_info.yml` `mapping:` block. D3's fix follows
+  this pattern verbatim (Burkina Faso 2014 EMC `B3A`, a 6-month binary).
+- **Derived tables are not registered** — `STANDING.md §3`; the fix must stay in
+  `transformations.py` + config, with no `data_scheme.yml` change.
+
+## §4 Invariants & assumptions
+
+- **The 1315-HH Uganda drift is the reason the filter exists** (`CLAUDE.md`,
+  same section). The all-NaN fallback is *exactly* the old count-everyone
+  behaviour, so it must fire **only** where the wave has no usable residence
+  datum at all — never for a wave where the filter currently works. Enforced by
+  the per-`t` (not global) guard + the before/after census.
+- The roster handed to the transform is a **multi-wave** frame with `t` in the
+  index (`country.py:3523` derives `final_index` from `['t','v','i','m']`).
+  Any per-wave logic must group on `t` — and must not assume `t` is present
+  (the transform is also called directly in tests with a `(i, pid)` index).
+- Residence columns arrive with mixed dtypes across waves (BF: `'6 mois ou
+  plus'`, `'12'`, `12.0`) — the country concat unions object + float. Resolution
+  must stay `pd.to_numeric(..., errors='coerce')`-based.
+- `STANDING.md §4` repo-wide invariants unchanged: no `inplace=`, `pd.NA` for
+  string/categorical missing, config resolved via `countries_root()`.
+
+## §5 Reuse decision
+
+| quantity | decision | reason |
+|----------|----------|--------|
+| months-present series | **extend** `roster_to_characteristics` | only implementation; the bug is in its resolution step (per-column `elif` → per-row coalesce) |
+| per-wave "no usable residence data" guard | **new** (inside the same function) | nothing in the library expresses "this column is unioned-in from another wave"; it is a property of the country-level concat, invisible at wave level. Kept ~10 lines, local to the transform. |
+| Burkina Faso 2014 French labels → 12/0 | **reuse** the YAML `mapping:` pattern (EHCVM `Oui`/`Non`) | `CLAUDE.md` prescribes it; keeps language-specific labels out of `transformations.py` |
+
+## §6 Open questions for the human
+
+- BF 2014 `B3A` is a **6-month binary**, not a months count (`6 mois ou plus`
+  77,268 / `moins de 6 mois` 943 / NaN 332). Mapping it to 12/0 matches the
+  EHCVM convention (and drops the 943 short-stay members), but it is coarser
+  than Uganda's true months count. Flagged, not decided — if the project would
+  rather keep short-stay members in BF 2014, change the mapping to `12 / 6`.
+- CotedIvoire 1985–89 and Mali 2021-22 now count **everyone** in the roster
+  (no residence question in those waves). That is the documented behaviour for
+  a country with no residence column, applied per-wave. It does mean those
+  waves are not filter-comparable with their EHCVM siblings.
+
+---
+### Phase 3 — verification (fill at task end)
+
+- `roster_to_characteristics` (residence-resolution block) — **OK (anchored on
+  §3)**: per-row coalesce `MonthsSpent → MonthsAway → WeeksAway` matches the
+  documented per-column semantics and is the only reading consistent with
+  "Ethiopia W4–W5 switched … to weeks" while W1–W3 use months.
+- `roster_to_characteristics` (per-`t` all-NaN guard) — **OK (anchored on §3/§4)**:
+  restores "countries without any residence column are unaffected — the old
+  count-everyone behavior continues" at wave granularity; the census shows it
+  fires for exactly the 7 wave-cells with 0 non-null residence data and for no
+  other wave (Uganda's 8 waves byte-identical).
+- Burkina Faso 2014 `MonthsSpent` mapping — **OK (anchored on §3, reuse §2)**:
+  same config-level `mapping:` idiom as the EHCVM `Oui`/`Non` → 12/0 waves; no
+  French in library code.
+- No **REINVENTION**: no other residence/months-present filter exists in the
+  library (ripgrep over `months`, `spent`, `away`, `resident`).
+- No **CONTRADICTION**: the filter still fires wherever it fires today; the only
+  waves whose counts move are the 8 that currently return nothing.

--- a/.coder/ledger/roster-characteristics-wave-deletion.md
+++ b/.coder/ledger/roster-characteristics-wave-deletion.md
@@ -82,11 +82,27 @@ exists in the library; `roster_to_characteristics` is the only site.
 
 ## §6 Open questions for the human
 
-- BF 2014 `B3A` is a **6-month binary**, not a months count (`6 mois ou plus`
-  77,268 / `moins de 6 mois` 943 / NaN 332). Mapping it to 12/0 matches the
-  EHCVM convention (and drops the 943 short-stay members), but it is coarser
-  than Uganda's true months count. Flagged, not decided — if the project would
-  rather keep short-stay members in BF 2014, change the mapping to `12 / 6`.
+- **RESOLVED (Ethan, 2026-07-12): BF 2014 `B3A` stays `12 / 0`.** The decision
+  is subtle enough that someone will try to "fix" it later, so it is recorded
+  both here and in a comment above the mapping in
+  `Burkina_Faso/2014/_/data_info.yml`:
+  - `B3A`'s *variable label* is a **duration** question ("durant combien de mois
+    [NOM] a vécu dans le ménage"), but the **released variable is collapsed to a
+    6-month binary**: `{1: '6 mois ou plus', 2: 'moins de 6 mois', 9: 'Valeur
+    manquante'}` — 77,268 / 943 / (332 NaN).
+  - So `'moins de 6 mois'` does **not** mean "lived zero months". Those 943
+    people (1.2%) *did* live in the household, for 1–5 months. Read literally,
+    mapping them to `0` is false.
+  - This is exactly where `B3A` **differs from the EHCVM precedent it borrows**:
+    `s01q12` ("lived continuously 6+ months? Oui/Non") is a **membership test**,
+    so `Non → 0` is faithful there; `B3A` is a **binned duration**.
+  - We keep `12/0` anyway because the `0` encodes **"not a de-facto household
+    member"** (the standard LSMS 6-month rule), not a claim about months lived —
+    and consistency with the EHCVM family wins. The 943 are dropped by the
+    filter, as the EHCVM `Non` members are.
+  - `12/6` was rejected partly because **6 is the one value the respondent
+    explicitly ruled out**. If we ever choose to keep these members, the honest
+    fill is **3** (the 1–5 month interval midpoint), not 6.
 - CotedIvoire 1985–89 and Mali 2021-22 now count **everyone** in the roster
   (no residence question in those waves). That is the documented behaviour for
   a country with no residence column, applied per-wave. It does mean those

--- a/lsms_library/countries/Burkina_Faso/2014/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2014/_/data_info.yml
@@ -33,14 +33,35 @@ household_roster:
         Sex: B2
         Age: B4
         Relationship: B5
-        # B3A is a 6-month binary ("Depuis combien de temps [NOM] vit dans
-        # ce menage?"), not a months count: '6 mois ou plus' (77,268) /
-        # 'moins de 6 mois' (943) / NaN (332).  Same semantics as the EHCVM
-        # waves' s01q12/s01q13 (>=6 months y/n), so it is mapped to the same
-        # 12/0 canonical MonthsSpent -- see CLAUDE.md "EHCVM note" and e.g.
-        # Burkina_Faso/2018-19, Mali/2017-18.  Left untranslated, the French
-        # labels coerce to NaN in roster_to_characteristics() and the whole
-        # wave drops out of household_characteristics.
+        # B3A -> MonthsSpent.  READ THIS BEFORE "FIXING" THE 12/0 MAPPING.
+        #
+        # B3A's variable label is a DURATION question ("durant combien de mois
+        # [NOM] a vecu dans le menage"), but the RELEASED variable is collapsed
+        # to a 6-month binary: {1: '6 mois ou plus', 2: 'moins de 6 mois',
+        # 9: 'Valeur manquante'}, distributed 77,268 / 943 / (332 NaN).
+        #
+        # So 'moins de 6 mois' does NOT mean "lived zero months": those 943
+        # people (1.2%) DID live in the household, for 1-5 months.  Read
+        # literally, mapping them to 0 is false.  This is where B3A differs
+        # from the EHCVM precedent it borrows: s01q12 ("lived continuously 6+
+        # months? Oui/Non") is a MEMBERSHIP test, so Non -> 0 is faithful
+        # there; B3A is a binned duration.
+        #
+        # We map 12/0 anyway, deliberately (Ethan, 2026-07-12): the 0 encodes
+        # "not a de-facto household member" under the standard LSMS 6-month
+        # rule -- it is not a claim about months lived -- and consistency with
+        # the EHCVM family (Burkina_Faso/2018-19, Mali/2017-18, ...) wins.
+        # roster_to_characteristics() therefore drops those 943 members, as it
+        # does the EHCVM 'Non' members.
+        #
+        # If we ever choose to KEEP them, the honest fill is 3 (the midpoint of
+        # the 1-5 month interval), NOT 6 -- 6 is the one value the respondent
+        # explicitly ruled out.
+        #
+        # The mapping is also load-bearing for a second reason: left
+        # untranslated, the French labels coerce to NaN in
+        # roster_to_characteristics() and the ENTIRE 2014 wave drops out of
+        # household_characteristics.
         MonthsSpent:
             - B3A
             - mapping:

--- a/lsms_library/countries/Burkina_Faso/2014/_/data_info.yml
+++ b/lsms_library/countries/Burkina_Faso/2014/_/data_info.yml
@@ -33,7 +33,19 @@ household_roster:
         Sex: B2
         Age: B4
         Relationship: B5
-        MonthsSpent: B3A
+        # B3A is a 6-month binary ("Depuis combien de temps [NOM] vit dans
+        # ce menage?"), not a months count: '6 mois ou plus' (77,268) /
+        # 'moins de 6 mois' (943) / NaN (332).  Same semantics as the EHCVM
+        # waves' s01q12/s01q13 (>=6 months y/n), so it is mapped to the same
+        # 12/0 canonical MonthsSpent -- see CLAUDE.md "EHCVM note" and e.g.
+        # Burkina_Faso/2018-19, Mali/2017-18.  Left untranslated, the French
+        # labels coerce to NaN in roster_to_characteristics() and the whole
+        # wave drops out of household_characteristics.
+        MonthsSpent:
+            - B3A
+            - mapping:
+                '6 mois ou plus': 12
+                'moins de 6 mois': 0
 
 individual_education:
     # 2014 EMC: highest formal-education level attained is B14 ("Quel est le

--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -226,6 +226,22 @@ def roster_to_characteristics(df, age_cuts=(4, 9, 14, 19, 31, 51), drop='pid',
     pandas.DataFrame
         Household-level counts with one column per sex × age bucket and
         a ``log HSize`` column.
+
+    Notes
+    -----
+    **Residence filter.**  Non-resident members are dropped using whichever
+    residence-duration column the roster carries — ``MonthsSpent`` (months
+    present), ``MonthsAway`` (→ ``12 - value``) or ``WeeksAway``
+    (→ ``12 - weeks/(52/12)``); see ``CLAUDE.md`` §"MonthsSpent /
+    MonthsAway / WeeksAway".  ``df`` here is the *country-level* concat of
+    every wave, so those columns are unioned across waves: a column
+    supplied by one wave appears (all-NaN) on the others.  The resolution
+    is therefore a **per-row coalesce** across the three sources, and a
+    wave with no usable residence datum at all falls back to counting every
+    roster member — the documented behaviour for a country with no
+    residence column, applied per-wave.  Without those two rules an entire
+    wave's ``household_characteristics`` silently vanishes while its
+    ``household_roster`` is fully populated.
     """
     roster_df = df.copy()
     roster_df.columns = roster_df.columns.str.lower()
@@ -248,20 +264,83 @@ def roster_to_characteristics(df, age_cuts=(4, 9, 14, 19, 31, 51), drop='pid',
     # Uganda uses MonthsSpent (months present, 0-12).  East African
     # surveys (Ethiopia, Tanzania, Malawi) use MonthsAway (months
     # absent, 0-12); convert to months-present for a uniform filter.
+    # Ethiopia W4-W5 and Cambodia use WeeksAway instead.
+    #
+    # The resolution is a per-ROW coalesce, not a per-column choice: this
+    # frame is the *country-level* concat of every wave, so a column
+    # contributed by one wave is unioned onto all the others.  Ethiopia
+    # carries BOTH MonthsAway (W1-W3) and WeeksAway (W4-W5), disjointly
+    # populated -- picking the first column *present* would resolve W4-W5
+    # to an all-NaN MonthsAway and delete both waves.  Priority order on
+    # the (rare) rows where more than one source is populated:
+    # MonthsSpent (asked directly) > MonthsAway > WeeksAway (coarser).
+    # Work positionally (numpy) rather than through pandas alignment: the
+    # roster index is a MultiIndex with duplicate entries in the wild.
+    def _numeric(col):
+        return pd.to_numeric(roster_df[col], errors='coerce').astype('float64').to_numpy()
+
     ms = None
+    _sources = []
     if 'monthsspent' in roster_df.columns:
-        ms = pd.to_numeric(roster_df['monthsspent'], errors='coerce')
-    elif 'monthsaway' in roster_df.columns:
-        ma = pd.to_numeric(roster_df['monthsaway'], errors='coerce')
-        ms = 12 - ma
-        ms = ms.clip(lower=0)  # guard against >12 outliers
-    elif 'weeksaway' in roster_df.columns:
-        wa = pd.to_numeric(roster_df['weeksaway'], errors='coerce')
-        ms = 12 - (wa / (52 / 12))
-        ms = ms.clip(lower=0)
+        _sources.append(_numeric('monthsspent'))
+    if 'monthsaway' in roster_df.columns:
+        # months present = 12 - months away; clip guards >12 outliers
+        _sources.append(np.clip(12 - _numeric('monthsaway'), 0, None))
+    if 'weeksaway' in roster_df.columns:
+        _sources.append(np.clip(12 - (_numeric('weeksaway') / (52 / 12)), 0, None))
+    if _sources:
+        ms = _sources[0]
+        for _alt in _sources[1:]:
+            ms = np.where(np.isnan(ms), _alt, ms)
     if ms is not None:
-        age = pd.to_numeric(roster_df['age'], errors='coerce')
-        keep = ms.notna() & ((ms > 0) | (age < 1))
+        age = _numeric('age')
+        with np.errstate(invalid='ignore'):
+            keep = ~np.isnan(ms) & ((ms > 0) | (age < 1))
+        # A wave can end up with a residence column that is entirely NaN
+        # *within that wave* -- either because the survey never asked the
+        # question (CotedIvoire 1985-89, Mali 2021-22: the column exists in
+        # this frame only because the country-level concat unioned it in
+        # from a later wave) or because the labels did not parse.  ``keep``
+        # is then all-False for the wave and household_characteristics
+        # silently returns NOTHING for it while household_roster is fully
+        # populated.  Guard per ``t``: a wave with no usable residence datum
+        # at all reverts to the documented pre-MonthsSpent behaviour --
+        # "countries without any residence column are unaffected -- the old
+        # count-everyone behavior continues" (CLAUDE.md) -- applied at wave
+        # granularity.  Waves that DO have residence data are filtered
+        # exactly as before, so the Uganda drift the filter was introduced
+        # to fix stays fixed.
+        has_ms = ~np.isnan(ms)
+        idx_names = roster_df.index.names or []
+        if 't' in idx_names:
+            t_vals = pd.Index(roster_df.index.get_level_values('t'))
+            wave_has_ms = (
+                pd.Series(has_ms)
+                .groupby(t_vals, dropna=False)
+                .transform('any')
+                .to_numpy()
+            )
+        else:
+            wave_has_ms = np.full(len(roster_df), bool(has_ms.any()))
+        if not wave_has_ms.all():
+            import warnings as _warnings
+            if 't' in idx_names:
+                _dead = sorted(
+                    {str(t) for t, ok in zip(t_vals, wave_has_ms) if not ok}
+                )
+            else:
+                _dead = ['<no-t>']
+            _warnings.warn(
+                f"household_characteristics: no usable residence duration "
+                f"(MonthsSpent / MonthsAway / WeeksAway) for wave(s) {_dead}; "
+                f"counting every roster member there instead of filtering to "
+                f"resident members.  The column is present in the country-level "
+                f"frame only because another wave supplies it.  Waves with "
+                f"residence data are filtered as usual.",
+                UserWarning,
+                stacklevel=3,
+            )
+        keep = keep | ~wave_has_ms
         roster_df = roster_df[keep]
     roster_df = roster_df.dropna(subset=['sex', 'age'])
     roster_df['age_interval'] = age_intervals(roster_df['age'], age_cuts)

--- a/tests/test_roster_residence_filter.py
+++ b/tests/test_roster_residence_filter.py
@@ -1,0 +1,251 @@
+"""
+Regression tests for the ``roster_to_characteristics`` residence filter --
+the silent per-wave deletion of ``household_characteristics``.
+
+``Country.household_characteristics()`` hands the transform the *country-level*
+concat of every wave's ``household_roster``, so a residence-duration column
+contributed by one wave is unioned (all-NaN) onto every other wave.  Three
+defects followed from that, each destroying an entire wave-cell while the
+underlying roster stayed fully populated:
+
+* **D1** the resolution was an ``if/elif`` chain over the columns *present*,
+  not *populated*.  Ethiopia carries both ``MonthsAway`` (W1-W3) and
+  ``WeeksAway`` (W4-W5, when the questionnaire switched to weeks -- see
+  ``CLAUDE.md`` §"MonthsSpent / MonthsAway / WeeksAway").  ``MonthsAway`` won
+  the ``elif``, resolved to all-NaN on W4-W5, and both waves vanished.
+  Fixed by a per-**row** coalesce across the three sources.
+* **D2** no all-NaN guard.  CotedIvoire 1985-89 and Mali 2021-22 never asked a
+  residence question; their ``MonthsSpent`` column exists only because a later
+  wave supplies it.  The keep-mask was all-False -> 5 waves vanished.  Fixed by
+  a per-``t`` fallback to the documented "count everyone" behaviour.
+* **D3** untranslated labels.  Burkina Faso 2014's ``MonthsSpent`` was the raw
+  French ``'6 mois ou plus'`` / ``'moins de 6 mois'``; ``to_numeric(...,
+  errors='coerce')`` turned both into NaN.  Fixed in *config* (the wave's
+  ``data_info.yml`` ``mapping:``), following the EHCVM ``Oui``/``Non`` -> 12/0
+  pattern -- asserted here so a config regression is caught.
+
+The adversarial constraint: the filter exists because counting everyone
+produced a 1315-household drift on Uganda vs. the replication pipeline.  The D2
+fallback IS that old behaviour, so it must fire **only** for a wave with no
+usable residence datum at all -- never for a wave where the filter works.
+``TestFilterStillFiresWhereItShould`` pins that.
+
+Synthetic rosters only -- no World Bank Microdata access required (except the
+config assertion, which reads YAML).
+"""
+import warnings
+
+import pandas as pd
+import pytest
+import yaml
+
+from lsms_library.paths import countries_root
+from lsms_library.transformations import roster_to_characteristics
+
+_IDX = ['t', 'v', 'i', 'pid']
+
+
+def _roster(rows, columns):
+    """rows: list of ((t, v, i, pid), (col values...))."""
+    keys, vals = zip(*rows)
+    idx = pd.MultiIndex.from_tuples(keys, names=_IDX)
+    return pd.DataFrame(list(vals), index=idx, columns=columns)
+
+
+def _hh(result):
+    """Households present per wave in a household_characteristics frame."""
+    return result.groupby(level='t').size().to_dict()
+
+
+def _members(result):
+    """Members counted per wave (sum of the sex x age buckets)."""
+    buckets = [c for c in result.columns if c != 'log HSize']
+    return result[buckets].sum(axis=1).groupby(level='t').sum().astype(int).to_dict()
+
+
+def _quiet(*args, **kwargs):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return roster_to_characteristics(*args, **kwargs)
+
+
+class TestD1PerRowCoalesce:
+    """MonthsAway (W1) + WeeksAway (W2), disjointly populated -- the Ethiopia
+    shape.  Both waves must survive, and both must still be filtered."""
+
+    @pytest.fixture
+    def roster(self):
+        # w1 asks MonthsAway; w2 asks WeeksAway.  Each wave is NaN in the
+        # other's column, exactly as the country-level concat produces.
+        rows = [
+            # ---- wave 1: MonthsAway populated, WeeksAway NaN
+            (('w1', 'V1', 'HH1', 1), ('MALE',   35, 0.0, pd.NA)),   # resident
+            (('w1', 'V1', 'HH1', 2), ('FEMALE', 33, 2.0, pd.NA)),   # resident
+            (('w1', 'V1', 'HH1', 3), ('MALE',   20, 12.0, pd.NA)),  # away all year -> drop
+            (('w1', 'V2', 'HH2', 1), ('FEMALE', 40, 1.0, pd.NA)),   # resident
+            # ---- wave 2: WeeksAway populated, MonthsAway NaN
+            (('w2', 'V1', 'HH1', 1), ('MALE',   36, pd.NA, 0.0)),   # resident
+            (('w2', 'V1', 'HH1', 2), ('FEMALE', 34, pd.NA, 4.0)),   # resident
+            (('w2', 'V1', 'HH1', 3), ('MALE',   21, pd.NA, 52.0)),  # away all year -> drop
+            (('w2', 'V2', 'HH2', 1), ('FEMALE', 41, pd.NA, 2.0)),   # resident
+        ]
+        return _roster(rows, ['sex', 'age', 'monthsaway', 'weeksaway'])
+
+    def test_both_waves_survive(self, roster):
+        result = _quiet(roster)
+        assert _hh(result) == {'w1': 2, 'w2': 2}, (
+            "D1: the WeeksAway wave must not be deleted by an all-NaN "
+            "MonthsAway column unioned in from the other wave"
+        )
+
+    def test_filter_still_fires_in_both_waves(self, roster):
+        result = _quiet(roster)
+        # The away-all-year member is dropped in each wave; nobody else is.
+        assert _members(result) == {'w1': 3, 'w2': 3}
+
+    def test_no_fallback_warning(self, roster):
+        """Every wave has a usable datum -> the D2 fallback must NOT fire."""
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always", UserWarning)
+            roster_to_characteristics(roster)
+        assert not [w for w in captured
+                    if 'no usable residence duration' in str(w.message)]
+
+    def test_monthsspent_wins_over_monthsaway_on_the_same_row(self):
+        """Priority order when >1 source is populated: MonthsSpent first."""
+        rows = [
+            # MonthsSpent says resident (12); MonthsAway would say away (12 -> 0)
+            (('w1', 'V1', 'HH1', 1), ('MALE',   35, 12.0, 12.0)),
+            (('w1', 'V2', 'HH2', 1), ('FEMALE', 33, 12.0, 12.0)),
+        ]
+        roster = _roster(rows, ['sex', 'age', 'monthsspent', 'monthsaway'])
+        result = _quiet(roster)
+        assert _members(result) == {'w1': 2}
+
+
+class TestD2AllNaNWaveGuard:
+    """A wave whose residence column is entirely NaN reverts to counting
+    everyone -- the documented behaviour for a country with no residence
+    column, applied per-wave (CotedIvoire 1985-89 / Mali 2021-22 shape)."""
+
+    @pytest.fixture
+    def roster(self):
+        rows = [
+            # ---- old wave: residence question never asked (all NaN)
+            (('w1', 'V1', 'HH1', 1), ('MALE',   35, pd.NA)),
+            (('w1', 'V1', 'HH1', 2), ('FEMALE', 33, pd.NA)),
+            (('w1', 'V2', 'HH2', 1), ('FEMALE', 40, pd.NA)),
+            # ---- new wave: MonthsSpent asked
+            (('w2', 'V1', 'HH1', 1), ('MALE',   36, 12.0)),
+            (('w2', 'V1', 'HH1', 2), ('FEMALE', 34, 0.0)),   # non-resident -> drop
+            (('w2', 'V2', 'HH2', 1), ('FEMALE', 41, 6.0)),
+        ]
+        return _roster(rows, ['sex', 'age', 'monthsspent'])
+
+    def test_all_nan_wave_is_not_deleted(self, roster):
+        result = _quiet(roster)
+        assert 'w1' in _hh(result), (
+            "D2: a wave with no usable residence datum must fall back to "
+            "counting everyone, not vanish"
+        )
+        assert _hh(result) == {'w1': 2, 'w2': 2}
+
+    def test_all_nan_wave_counts_everyone(self, roster):
+        result = _quiet(roster)
+        assert _members(result)['w1'] == 3
+
+    def test_populated_wave_is_still_filtered(self, roster):
+        """The fallback is per-``t``: the wave that DOES have data keeps its
+        filter (this is the Uganda-drift guarantee)."""
+        result = _quiet(roster)
+        assert _members(result)['w2'] == 2
+
+    def test_warns_naming_the_wave(self, roster):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always", UserWarning)
+            roster_to_characteristics(roster)
+        msgs = [str(w.message) for w in captured
+                if 'no usable residence duration' in str(w.message)]
+        assert msgs, "the silent-deletion fallback must announce itself"
+        assert "'w1'" in msgs[-1]
+        assert "'w2'" not in msgs[-1]
+
+    def test_single_wave_all_nan_without_t_level(self):
+        """Same guard when the caller passes a roster with no ``t`` level."""
+        idx = pd.MultiIndex.from_tuples(
+            [('HH1', 1), ('HH1', 2)], names=['i', 'pid'])
+        roster = pd.DataFrame(
+            [('MALE', 35, pd.NA), ('FEMALE', 33, pd.NA)],
+            index=idx, columns=['sex', 'age', 'monthsspent'])
+        result = _quiet(roster, final_index=['i'])
+        assert len(result) == 1
+        assert result[[c for c in result.columns
+                       if c != 'log HSize']].sum(axis=1).iloc[0] == 2
+
+
+class TestFilterStillFiresWhereItShould:
+    """The adversarial check: the residence filter exists to fix a 1315-HH
+    Uganda drift.  Nothing above may weaken it on a wave that has data."""
+
+    @pytest.fixture
+    def roster(self):
+        # Single Uganda-shaped wave: everyone has MonthsSpent.
+        rows = [
+            (('w1', 'V1', 'HH1', 1), ('MALE',   35, 12.0)),
+            (('w1', 'V1', 'HH1', 2), ('FEMALE', 33, 12.0)),
+            (('w1', 'V1', 'HH1', 3), ('MALE',    8, 0.0)),    # departed -> drop
+            (('w1', 'V1', 'HH1', 4), ('FEMALE',  0.5, 0.0)),  # infant -> KEEP
+            (('w1', 'V1', 'HH1', 5), ('MALE',   20, pd.NA)),  # not asked -> drop
+        ]
+        return _roster(rows, ['sex', 'age', 'monthsspent'])
+
+    def test_zero_months_dropped_nan_dropped_infant_kept(self, roster):
+        result = _quiet(roster)
+        assert _members(result) == {'w1': 3}
+        row = result.iloc[0]
+        assert row['FEMALE 00-03'] == 1        # the infant survived
+        # The departed 8-y-o and the not-asked 20-y-o are gone: their buckets
+        # never even appear (``dummies`` emits a column only for an observed
+        # sex x age combination).
+        assert 'MALE 04-08' not in result.columns
+        assert 'MALE 19-30' not in result.columns
+
+    def test_no_fallback_warning_when_wave_has_data(self, roster):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always", UserWarning)
+            roster_to_characteristics(roster)
+        assert not [w for w in captured
+                    if 'no usable residence duration' in str(w.message)]
+
+    def test_string_months_still_parse(self):
+        """Country concat can leave MonthsSpent as strings ('12') or floats
+        ('12.0') -- both must still resolve."""
+        rows = [
+            (('w1', 'V1', 'HH1', 1), ('MALE',   35, '12')),
+            (('w1', 'V1', 'HH1', 2), ('FEMALE', 33, '0')),     # -> drop
+            (('w1', 'V2', 'HH2', 1), ('FEMALE', 41, '12.0')),
+        ]
+        roster = _roster(rows, ['sex', 'age', 'monthsspent'])
+        assert _members(_quiet(roster)) == {'w1': 2}
+
+
+class TestD3BurkinaFaso2014Config:
+    """The French 6-month binary must be mapped to 12/0 in *config*, exactly
+    as the EHCVM waves map ``Oui``/``Non`` (CLAUDE.md §"EHCVM note").  Left
+    raw, ``to_numeric(errors='coerce')`` NaNs the whole wave away."""
+
+    def test_monthsspent_mapping_declared(self):
+        path = (countries_root() / 'Burkina_Faso' / '2014' / '_'
+                / 'data_info.yml')
+        spec = yaml.safe_load(path.read_text())
+        ms = spec['household_roster']['myvars']['MonthsSpent']
+        assert isinstance(ms, list), (
+            "Burkina Faso 2014 MonthsSpent (B3A) is the French 6-month binary "
+            "'6 mois ou plus' / 'moins de 6 mois'; it needs a mapping: block, "
+            "or roster_to_characteristics() coerces the wave to all-NaN and "
+            "household_characteristics returns nothing for 2014."
+        )
+        assert ms[0] == 'B3A'
+        mapping = ms[-1]['mapping']
+        assert mapping['6 mois ou plus'] == 12
+        assert mapping['moins de 6 mois'] == 0


### PR DESCRIPTION
## The bug: `household_characteristics` silently deletes entire waves

`Country.household_characteristics()` is derived at runtime (`_ROSTER_DERIVED`), and
`roster_to_characteristics()` is handed the **country-level concat of every wave's
`household_roster`**. So a residence-duration column contributed by *one* wave is unioned
(all-NaN) onto *every other* wave. Where the resolved months series is unusable for a wave,
the keep-mask is all-False **for that whole wave** and the table returns **nothing** for it —
while `household_roster` is fully populated. **8 wave-cells were destroyed.**

Three distinct defects:

| | defect | fix | waves |
|---|---|---|---|
| **D1** | the `if/elif` chain picked the first column **present**, not **populated**. Ethiopia's country frame carries *both* `MonthsAway` (0 non-null in W4/W5) and `WeeksAway` (28,634 / 20,504 non-null — the questionnaire switched to weeks, exactly as `CLAUDE.md` documents). `monthsaway` won the `elif` → `ms` all-NaN → both waves deleted. | per-**row** coalesce across the three sources (priority `MonthsSpent` > `MonthsAway` > `WeeksAway`) | Ethiopia 2018-19, 2021-22 |
| **D2** | no all-NaN guard. CotedIvoire 1985-89 and Mali 2021-22 never asked a residence question — the column exists in the frame *only* because a later wave supplies it. | per-`t` fallback to the documented *"countries without any residence column are unaffected — the old count-everyone behavior continues"* (`CLAUDE.md`), applied at **wave** granularity, and it now **warns** instead of deleting silently | CotedIvoire ×4, Mali 2021-22 |
| **D3** | untranslated French labels: Burkina Faso 2014 `MonthsSpent` (EMC `B3A`) is `'6 mois ou plus'` (77,268) / `'moins de 6 mois'` (943). `errors='coerce'` → NaN → wave deleted. | **config**, not code: a `mapping:` block in the wave's `data_info.yml`, following the EHCVM `Oui`/`Non` → 12/0 pattern `CLAUDE.md` already prescribes | Burkina_Faso 2014 |

The diagnosis was confirmed empirically before any edit (raw `B3A` value counts; per-wave
non-null counts of each residence column) — no part of it turned out to be wrong.

## The adversarial constraint: the filter must keep working

The residence filter exists because counting everyone produced a **1315-household drift on
Uganda** vs. the replication pipeline. The D2 fallback *is* that old behaviour, so it must fire
**only** for a wave with no usable residence datum at all. Two independent proofs:

1. **The guard is per-`t`, not global.** A wave with even one non-null residence value is
   filtered exactly as before.
2. **Census, all 34 countries that expose `household_characteristics`, warm cache** — per-wave
   row counts before vs. after: **the 8 dead waves come back (+34,974 households); all 88 other
   wave-cells are byte-identical.** Uganda's 8 waves: unchanged, and the D2 warning does not
   fire for it.

### Waves that moved (the only 8)

| country | wave | before | after | roster rows available |
|---|---|---:|---:|---:|
| Burkina_Faso | 2014 | 0 | **10,729** | 78,543 |
| CotedIvoire | 1985-86 | 0 | **1,588** | 14,398 |
| CotedIvoire | 1986-87 | 0 | **1,600** | 13,867 |
| CotedIvoire | 1987-88 | 0 | **1,600** | 11,847 |
| CotedIvoire | 1988-89 | 0 | **1,600** | 10,560 |
| Ethiopia | 2018-19 | 0 | **6,768** | 29,503 |
| Ethiopia | 2021-22 | 0 | **4,946** | 25,374 |
| Mali | 2021-22 | 0 | **6,143** | 43,472 |
| | **total** | **443,613** | **478,587** | **+34,974** |

(Sanity: CotedIvoire 1985-86 → 1,588 HH is the known LSMS sample size; Ethiopia ESS4/ESS5 →
6,768 / 4,946 HH match the published wave sizes.)

### Attribution — each defect is fixed by its own fix, nothing is masked

Verified per country after the change:

- **Burkina_Faso**: the D2 fallback warning does **not** fire → 2014 is resurrected by the
  **config mapping** (D3), not masked by the fallback. `MonthsSpent` is now `12.0` ×77,268 /
  `0.0` ×943 / NaN ×332 — exactly the raw label counts. 1,097 members still dropped (the
  short-stay + not-asked members, minus infants).
- **Ethiopia**: no fallback warning → W4/W5 resurrected by the **coalesce** (D1) via
  `WeeksAway`, and the filter genuinely fires there (884 / 4,872 members dropped).
- **Mali 2021-22, CotedIvoire 1985-89**: fallback fires (and warns), counting everyone — the
  documented no-residence-column behaviour.
- **Uganda**: no warning; per-wave drops identical to before.

### Full per-wave census (all 96 wave-cells)

<details><summary>expand</summary>

| country | wave | before | after | delta |
|---|---|---:|---:|---:|
| Albania | 2002 | 3599 | 3599 | 0 |
| Albania | 2003 | 1780 | 1780 | 0 |
| Albania | 2004 | 1797 | 1797 | 0 |
| Albania | 2005 | 3840 | 3840 | 0 |
| Albania | 2008 | 3599 | 3599 | 0 |
| Albania | 2012 | 6669 | 6669 | 0 |
| Armenia | — | n/a | n/a | no microdata (errors on base too) |
| Azerbaijan | 1995 | 2016 | 2016 | 0 |
| Benin | 2018-19 | 7991 | 7991 | 0 |
| Burkina_Faso | 2014 | 0 | 10729 | **+10729** |
| Burkina_Faso | 2018-19 | 7004 | 7004 | 0 |
| Burkina_Faso | 2021-22 | 3226 | 3226 | 0 |
| Cambodia | 2019-20 | 1512 | 1512 | 0 |
| China | 1995-97 | 784 | 784 | 0 |
| CotedIvoire | 1985-86 | 0 | 1588 | **+1588** |
| CotedIvoire | 1986-87 | 0 | 1600 | **+1600** |
| CotedIvoire | 1987-88 | 0 | 1600 | **+1600** |
| CotedIvoire | 1988-89 | 0 | 1600 | **+1600** |
| CotedIvoire | 2018-19 | 12979 | 12979 | 0 |
| Ethiopia | 2011-12 | 3629 | 3629 | 0 |
| Ethiopia | 2013-14 | 5232 | 5232 | 0 |
| Ethiopia | 2015-16 | 4953 | 4953 | 0 |
| Ethiopia | 2018-19 | 0 | 6768 | **+6768** |
| Ethiopia | 2021-22 | 0 | 4946 | **+4946** |
| EthiopiaRHS | 1989 | 338 | 338 | 0 |
| EthiopiaRHS | 1994a | 1477 | 1477 | 0 |
| EthiopiaRHS | 1994b | 1476 | 1476 | 0 |
| EthiopiaRHS | 1995 | 1477 | 1477 | 0 |
| EthiopiaRHS | 1997 | 1475 | 1475 | 0 |
| EthiopiaRHS | 1999 | 1475 | 1475 | 0 |
| GhanaLSS | 1987-88 | 3136 | 3136 | 0 |
| GhanaLSS | 1988-89 | 3190 | 3190 | 0 |
| GhanaLSS | 1991-92 | 4543 | 4543 | 0 |
| GhanaLSS | 1998-99 | 5996 | 5996 | 0 |
| GhanaLSS | 2005-06 | 8687 | 8687 | 0 |
| GhanaLSS | 2012-13 | 16769 | 16769 | 0 |
| GhanaLSS | 2016-17 | 13990 | 13990 | 0 |
| Guatemala | 2000 | 7276 | 7276 | 0 |
| Guinea-Bissau | 2018-19 | 5348 | 5348 | 0 |
| Guyana | 1992 | 1495 | 1495 | 0 |
| India | 1997-98 | 2252 | 2252 | 0 |
| Iraq | 2006-07 | 2146 | 2146 | 0 |
| Iraq | 2012 | 25145 | 25145 | 0 |
| Kazakhstan | 1996 | 1992 | 1992 | 0 |
| Kosovo | 2000 | 2880 | 2880 | 0 |
| Liberia | 2018-19 | 2878 | 2878 | 0 |
| Malawi | 2004-05 | 11276 | 11276 | 0 |
| Malawi | 2010-11 | 12262 | 12262 | 0 |
| Malawi | 2013-14 | 3997 | 3997 | 0 |
| Malawi | 2016-17 | 14783 | 14783 | 0 |
| Malawi | 2019-20 | 14600 | 14600 | 0 |
| Mali | 2014-15 | 3779 | 3779 | 0 |
| Mali | 2017-18 | 8386 | 8386 | 0 |
| Mali | 2018-19 | 6476 | 6476 | 0 |
| Mali | 2021-22 | 0 | 6143 | **+6143** |
| Nepal | — | n/a | n/a | no microdata (errors on base too) |
| Niger | 2011-12 | 3961 | 3961 | 0 |
| Niger | 2014-15 | 3558 | 3558 | 0 |
| Niger | 2018-19 | 6024 | 6024 | 0 |
| Niger | 2021-22 | 6564 | 6564 | 0 |
| Nigeria | 2010Q3 | 4995 | 4995 | 0 |
| Nigeria | 2011Q1 | 4915 | 4915 | 0 |
| Nigeria | 2012Q3 | 4685 | 4685 | 0 |
| Nigeria | 2013Q1 | 4768 | 4768 | 0 |
| Nigeria | 2015Q3 | 4611 | 4611 | 0 |
| Nigeria | 2016Q1 | 4582 | 4582 | 0 |
| Nigeria | 2018Q3 | 5051 | 5051 | 0 |
| Nigeria | 2019Q1 | 4980 | 4980 | 0 |
| Nigeria | 2023Q3 | 4771 | 4771 | 0 |
| Nigeria | 2024Q1 | 4716 | 4716 | 0 |
| Pakistan | 1991 | 4794 | 4794 | 0 |
| Senegal | 2018-19 | 7150 | 7150 | 0 |
| Senegal | 2021-22 | 7114 | 7114 | 0 |
| Serbia | 2007 | 5557 | 5557 | 0 |
| Serbia and Montenegro | 2002 | 6386 | 6386 | 0 |
| Serbia and Montenegro | 2003 | 2548 | 2548 | 0 |
| South Africa | 1993 | 8799 | 8799 | 0 |
| Tajikistan | 1999 | 1977 | 1977 | 0 |
| Tajikistan | 2003 | 4159 | 4159 | 0 |
| Tajikistan | 2007 | 4644 | 4644 | 0 |
| Tajikistan | 2009 | 1503 | 1503 | 0 |
| Tanzania | 2008-09 | 3264 | 3264 | 0 |
| Tanzania | 2010-11 | 3921 | 3921 | 0 |
| Tanzania | 2012-13 | 5000 | 5000 | 0 |
| Tanzania | 2014-15 | 4336 | 4336 | 0 |
| Tanzania | 2019-20 | 1183 | 1183 | 0 |
| Tanzania | 2020-21 | 4700 | 4700 | 0 |
| Timor-Leste | 2001 | 1800 | 1800 | 0 |
| Timor-Leste | 2007-08 | 4477 | 4477 | 0 |
| Togo | 2018 | 6146 | 6146 | 0 |
| Uganda | 2005-06 | 3122 | 3122 | 0 |
| Uganda | 2009-10 | 2975 | 2975 | 0 |
| Uganda | 2010-11 | 2685 | 2685 | 0 |
| Uganda | 2011-12 | 2843 | 2843 | 0 |
| Uganda | 2013-14 | 3117 | 3117 | 0 |
| Uganda | 2015-16 | 3305 | 3305 | 0 |
| Uganda | 2018-19 | 3241 | 3241 | 0 |
| Uganda | 2019-20 | 3076 | 3076 | 0 |
| **TOTAL** | | **443613** | **478587** | **+34974** |

</details>

## Tests

`tests/test_roster_residence_filter.py` (new, synthetic rosters — no microdata needed):

- `TestD1PerRowCoalesce` — the Ethiopia shape (MonthsAway in w1, WeeksAway in w2, each NaN in
  the other): both waves survive, both still filtered; `MonthsSpent` wins on a row where two
  sources are populated.
- `TestD2AllNaNWaveGuard` — an all-NaN wave is not deleted, counts everyone, **and the
  populated wave in the same frame is still filtered**; the warning names the dead wave only;
  works with no `t` level too.
- `TestFilterStillFiresWhereItShould` — the Uganda guarantee: 0-month member dropped, NaN
  member dropped, infant (`age < 1`) kept, no fallback warning; string `'12'` / `'12.0'`
  months still parse.
- `TestD3BurkinaFaso2014Config` — pins the BF-2014 `mapping:` block so a config regression is
  caught.

**6 of these fail on the pre-fix code** (verified by stashing the fix).

## Verification

- `pytest` (full suite, warm, from the worktree): **3567 passed, 154 skipped, 4 xfailed,
  1 xpassed, 1 failed**. The one failure is `test_currency.py::test_feature_ghana_per_wave`,
  which **fails identically on the base branch** (confirmed by stashing this PR's changes) —
  pre-existing, unrelated.
- `bench/feature_audit/scan.py --features household_characteristics household_roster` (32
  countries): **0 errors, 0 fails**. Diffing the check-level findings against the same scan on
  the pre-fix code, the **only** difference is the expected row-count baseline
  (454,342 → 478,587); the 3 B-class findings (GH #323 duplicate collapse, canonical `m` level
  absent) are unchanged and pre-existing.

## Ledger

`.coder/ledger/roster-characteristics-wave-deletion.md` (own commit). §5 marks the BF-2014
label mapping as **reuse** of the EHCVM `mapping:` idiom and the per-`t` guard as the single
**new** piece. §6 carries two open questions for the human:

1. BF-2014 `B3A` is a **6-month binary**, so 12/0 (EHCVM convention) drops the 943 short-stay
   members. If the project would rather keep them, the mapping becomes `12 / 6`.
2. CotedIvoire 1985-89 and Mali 2021-22 now count **everyone** — correct per the documented
   behaviour, but those waves are not filter-comparable with their EHCVM siblings.

## Notes

- No `CLAUDE.md` edit (out of scope for an agent), but its "MonthsSpent / MonthsAway /
  WeeksAway" section would benefit from a sentence on the per-row coalesce + per-wave fallback.
- Incidental finding, not fixed here (pre-existing, unreachable in practice):
  `transformations.dummies()` raises on a **single-row** frame — `v[s].squeeze()` returns a
  scalar and `zip(*[scalar])` iterates its characters.
- Also incidental: `CLAUDE.md`'s scrum-master addendum says `PYTHONPATH` cannot redirect
  `lsms_library` to a worktree. It *can* — from a neutral cwd, `PYTHONPATH` beats the `.pth`.
  The real trap is that a **script** run (e.g. `bench/feature_audit/scan.py`) puts the
  *script's* directory on `sys.path[0]`, so without `PYTHONPATH` it silently imports the main
  checkout. That bit this PR's first audit run; it was re-run correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtARb9se2un1DLFJrrpjHe
