### PR TITLE
feat(provenance): record each wave's WB catalog id; match discover_waves on it

### DIFF
--- a/.claude/skills/add-wave/SKILL.md
+++ b/.claude/skills/add-wave/SKILL.md
@@ -29,7 +29,40 @@ from lsms_library.data_access import discover_waves
 discover_waves("Ethiopia")
 ```
 
-Returns a list of dicts annotated with `"local": True/False`. Waves marked `local=False` are on the WB but not yet in the repo.
+Returns a list of dicts annotated with:
+
+| key            | meaning                                                                 |
+|----------------|-------------------------------------------------------------------------|
+| `local`        | `bool` — `True` only when a wave dir *records* this catalog id.          |
+| `local_status` | `"yes"` / `"no"` / `"unknown"` — the honest tri-state (see below).       |
+| `local_waves`  | the wave directories backing this entry.                                 |
+
+Waves with `local_status == "no"` are on the WB but not yet in the repo.
+
+**Matching is on the WB catalog id, not on the wave label.** Each wave dir
+records the catalog entry it came from in `Documentation/SOURCE.org`
+(`#+CATALOG_ID:` — see `lsms_library/provenance.py`). Label matching used to
+be the mechanism and was wrong in both directions: two different surveys can
+share a year range (Nigeria's GHS-Panel W4 **3557** and Living Standards
+Survey **3827** both span 2018–2019), and one catalog entry can span two of
+our wave dirs (Uganda **1001** covers both `2005-06/` and `2009-10/`).
+
+`local_status == "unknown"` means a directory whose label matches exists but
+has **no recorded WB catalog id** — so we cannot say whether it holds this
+study or a different one with the same year range. Such rows carry
+`local=False`: an unverified claim is treated as not-held, because wrongly
+believing we hold a survey is the failure mode that hides missing data.
+
+To (re)stamp provenance across the tree:
+
+```sh
+python scripts/backfill_wave_provenance.py --dry-run   # report only
+python scripts/backfill_wave_provenance.py             # write SOURCE.org
+```
+
+Countries that are not WB datasets (`EthiopiaRHS`, `KenyaLPS`) are marked
+`discoverable=False` in `_COUNTRY_CATALOG` and return `[]` with an explanatory
+log — deliberately, rather than being silently absent.
 
 ### Step 2: Add the wave
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,8 @@ override.
 
 **Adding new waves**: `lsms_library.data_access.discover_waves()` / `add_wave()`; `push_to_cache_batch()` for batched `dvc add` + `dvc push`. See `CONTRIBUTING.org`.
 
+**Wave provenance (`lsms_library/provenance.py`).** Every wave dir records the WB catalog entry it came from in `Documentation/SOURCE.org`, as org keyword lines (`#+CATALOG_ID:`, `#+CATALOG_IDNO:`, `#+PROVENANCE_SOURCE:` ∈ {`worldbank`, `external`, `unknown`}, …) appended beneath the original free-text URL — which stays the file's first URL, so the legacy `_read_source_url()` reader is unaffected. Human-written prose in a pre-existing `SOURCE.org` is preserved verbatim under a `* Notes (preserved …)` heading; the writer is idempotent. `discover_waves()` matches on the **catalog id**, never on a wave label reconstructed from the entry's year range — labels collide across distinct surveys (Nigeria GHS-Panel W4 `3557` vs. Living Standards Survey `3827`, both 2018–2019) and one entry can span two wave dirs (Uganda `1001` → `2005-06/` + `2009-10/`). Where no id is recorded it falls back to the label heuristic but reports `local_status='unknown'` with `local=False` — silence must not masquerade as knowledge. Countries sharing an ISO code (GhanaLSS/GhanaSPS → GHA; Tanzania/Tanzania_Kegera → TZA) are disambiguated by an `idno_pattern` in `_COUNTRY_CATALOG`; non-WB countries (`EthiopiaRHS`, `KenyaLPS`) are explicitly `discoverable=False`. Re-stamp with `python scripts/backfill_wave_provenance.py`.
+
 **Three-tier credential model.** The WB Microdata API key is the sole real gate; the S3 bucket is a read cache over the authoritative WB NADA downloads.
 
 | User has                                                   | Gets                                                  |

--- a/lsms_library/countries/Albania/1996/Documentation/SOURCE.org
+++ b/lsms_library/countries/Albania/1996/Documentation/SOURCE.org
@@ -1,1 +1,13 @@
-https://microdata.worldbank.org/index.php/catalog/2311/study-description
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2311
+
+#+CATALOG_ID: 2311
+#+CATALOG_IDNO: ALB_1996_EWS_v01_M
+#+CATALOG_TITLE: Employment and Welfare Survey 1996
+#+CATALOG_YEARS: 1996-1996
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2311
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Albania/2002/Documentation/SOURCE.org
+++ b/lsms_library/countries/Albania/2002/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/q9zx-4b28]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/86
+
+#+CATALOG_ID: 86
+#+CATALOG_IDNO: ALB_2002_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2002 (Wave 1 Panel)
+#+CATALOG_YEARS: 2002-2002
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/q9zx-4b28
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/86
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Albania/2003/Documentation/SOURCE.org
+++ b/lsms_library/countries/Albania/2003/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/bd62-r051]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/87
+
+#+CATALOG_ID: 87
+#+CATALOG_IDNO: ALB_2003_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2003 (Wave 2 Panel)
+#+CATALOG_YEARS: 2003-2003
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/bd62-r051
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/87
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Albania/2004/Documentation/SOURCE.org
+++ b/lsms_library/countries/Albania/2004/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/5hyw-bv37]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/88
+
+#+CATALOG_ID: 88
+#+CATALOG_IDNO: ALB_2004_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2004 (Wave 3 Panel)
+#+CATALOG_YEARS: 2004-2004
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/5hyw-bv37
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/88
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Albania/2005/Documentation/SOURCE.org
+++ b/lsms_library/countries/Albania/2005/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/kzst-d297]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/64
+
+#+CATALOG_ID: 64
+#+CATALOG_IDNO: ALB_2005_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2005
+#+CATALOG_YEARS: 2005-2005
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/kzst-d297
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/64
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Albania/2008/Documentation/SOURCE.org
+++ b/lsms_library/countries/Albania/2008/Documentation/SOURCE.org
@@ -1,1 +1,13 @@
-https://microdata.worldbank.org/index.php/catalog/1933/get-microdata
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/1933
+
+#+CATALOG_ID: 1933
+#+CATALOG_IDNO: ALB_2008_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2008
+#+CATALOG_YEARS: 2008-2008
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/1933
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Albania/2012/Documentation/SOURCE.org
+++ b/lsms_library/countries/Albania/2012/Documentation/SOURCE.org
@@ -1,1 +1,13 @@
-https://microdata.worldbank.org/index.php/catalog/1970/get-microdata
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/1970
+
+#+CATALOG_ID: 1970
+#+CATALOG_IDNO: ALB_2012_LSMS_v01_M_v01_A_PUF
+#+CATALOG_TITLE: Living Standards Measurement Survey 2012
+#+CATALOG_YEARS: 2012-2012
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/1970
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Armenia/1996/Documentation/SOURCE.org
+++ b/lsms_library/countries/Armenia/1996/Documentation/SOURCE.org
@@ -1,1 +1,13 @@
-https://microdata.worldbank.org/index.php/catalog/2324/related-materials
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2324
+
+#+CATALOG_ID: 2324
+#+CATALOG_IDNO: ARM_1996_HBS_v01_M
+#+CATALOG_TITLE: Household Budget Survey 1996
+#+CATALOG_YEARS: 1996-1996
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2324
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Azerbaijan/1995/Documentation/SOURCE.org
+++ b/lsms_library/countries/Azerbaijan/1995/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/z7ee-4p39]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/408
+
+#+CATALOG_ID: 408
+#+CATALOG_IDNO: AZE_1995_SLC_v01_M
+#+CATALOG_TITLE: Survey of Living Conditions 1995
+#+CATALOG_YEARS: 1995-1995
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/z7ee-4p39
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/408
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Benin/2018-19/Documentation/SOURCE.org
+++ b/lsms_library/countries/Benin/2018-19/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/rn3k-z374]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/4291
+
+#+CATALOG_ID: 4291
+#+CATALOG_IDNO: BEN_2018_EHCVM_v02_M
+#+CATALOG_TITLE: Enquête Harmonisée sur le Conditions de Vie des Ménages 2018-2019
+#+CATALOG_YEARS: 2018-2019
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/rn3k-z374
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/4291
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Bosnia-Herzegovina/2001-04/Documentation/SOURCE.org
+++ b/lsms_library/countries/Bosnia-Herzegovina/2001-04/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/em0z-s354]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2919
+
+#+CATALOG_ID: 2919
+#+CATALOG_IDNO: BIH_2001-2004_LSMS_v01_M_v01_A_EPCT
+#+CATALOG_TITLE: Living Standards Measurement Study Panel Data 2001-2004, Entrepreneurship in Post-Conflict Transition: The Role of Informality and Access to Finance
+#+CATALOG_YEARS: 2001-2004
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/em0z-s354
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2919
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Bosnia-Herzegovina/2001/Documentation/SOURCE.org
+++ b/lsms_library/countries/Bosnia-Herzegovina/2001/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/tzem-9k74]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/65
+
+#+CATALOG_ID: 65
+#+CATALOG_IDNO: BIH_2001_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2001 (Wave 1 Panel)
+#+CATALOG_YEARS: 2001-2001
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/tzem-9k74
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/65
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Bosnia-Herzegovina/2002/Documentation/SOURCE.org
+++ b/lsms_library/countries/Bosnia-Herzegovina/2002/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/g9rb-hd09]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/66
+
+#+CATALOG_ID: 66
+#+CATALOG_IDNO: BIH_2002_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2002 (Wave 2 Panel)
+#+CATALOG_YEARS: 2002-2003
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/g9rb-hd09
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/66
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Bosnia-Herzegovina/2003/Documentation/SOURCE.org
+++ b/lsms_library/countries/Bosnia-Herzegovina/2003/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/xj8a-g134]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/67
+
+#+CATALOG_ID: 67
+#+CATALOG_IDNO: BIH_2003_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2003 (Wave 3 Panel)
+#+CATALOG_YEARS: 2003-2003
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/xj8a-g134
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/67
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Bosnia-Herzegovina/2004/Documentation/SOURCE.org
+++ b/lsms_library/countries/Bosnia-Herzegovina/2004/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/61xp-7h14]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/68
+
+#+CATALOG_ID: 68
+#+CATALOG_IDNO: BIH_2004_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2004 (Wave 4 Panel)
+#+CATALOG_YEARS: 2004-2005
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/61xp-7h14
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/68
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Burkina_Faso/2014/Documentation/SOURCE.org
+++ b/lsms_library/countries/Burkina_Faso/2014/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/2538
+
+#+CATALOG_ID: 2538
+#+CATALOG_IDNO: BFA_2014_EMC_v01_M
+#+CATALOG_TITLE: Enquête Multisectorielle Continue 2014
+#+CATALOG_YEARS: 2014-2014
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/e39g-m952
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2538
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Burkina_Faso/2018-19/Documentation/SOURCE.org
+++ b/lsms_library/countries/Burkina_Faso/2018-19/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/4290
+
+#+CATALOG_ID: 4290
+#+CATALOG_IDNO: BFA_2018_EHCVM_v03_M
+#+CATALOG_TITLE: Enquête Harmonisée sur le Conditions de Vie des Ménages 2018-2019
+#+CATALOG_YEARS: 2018-2019
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/wv88-j486
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/4290
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Burkina_Faso/2021-22/Documentation/SOURCE.org
+++ b/lsms_library/countries/Burkina_Faso/2021-22/Documentation/SOURCE.org
@@ -1,3 +1,13 @@
-SOURCE 
+SOURCE
 
-https://microdata.worldbank.org/index.php/catalog/6224/
+https://microdata.worldbank.org/index.php/catalog/6224
+
+#+CATALOG_ID: 6224
+#+CATALOG_IDNO: BFA_2021_EHCVM-P_v04_M
+#+CATALOG_TITLE: Enquête Harmonisée sur le Conditions de Vie des Ménages, Panel Survey 2021-2022
+#+CATALOG_YEARS: 2021-2022
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/6224
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Cambodia/2019-20/Documentation/SOURCE.org
+++ b/lsms_library/countries/Cambodia/2019-20/Documentation/SOURCE.org
@@ -1,2 +1,17 @@
-https://microdata.worldbank.org/index.php/catalog/4045/get-microdata
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/4045
+
+#+CATALOG_ID: 4045
+#+CATALOG_IDNO: KHM_2019_LSMS-PLUS_v02_M
+#+CATALOG_TITLE: Living Standards Measurement Study - Plus 2019-2020
+#+CATALOG_YEARS: 2019-2020
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/agcn-nn81
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/4045
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12
+
+* Notes (preserved from the original SOURCE.org)
 Cambodia National Institute of Statistics. Cambodia Living Standards Measurement Study - Plus 2019-2020. Ref. KHM_2019_LSMS-PLUS_v01_M. Dataset downloaded from [url] on [date].

--- a/lsms_library/countries/China/1995-97/Documentation/SOURCE.org
+++ b/lsms_library/countries/China/1995-97/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/ymjj-w136]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/409
+
+#+CATALOG_ID: 409
+#+CATALOG_IDNO: CHN_1995_LSS_v01_M
+#+CATALOG_TITLE: Living Standards Survey 1995 -1997
+#+CATALOG_YEARS: 1995-1997
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/ymjj-w136
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/409
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/CotedIvoire/1985-86/Documentation/SOURCE.org
+++ b/lsms_library/countries/CotedIvoire/1985-86/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
+SOURCE
+
 https://microdata.worldbank.org/index.php/catalog/83
+
+#+CATALOG_ID: 83
+#+CATALOG_IDNO: CIV_1985_EPAM_v01_M
+#+CATALOG_TITLE: Enquête Permanente Auprès des Ménages 1985-1986, Wave 1 Panel
+#+CATALOG_YEARS: 1985-1986
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/3cxh-1847
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/83
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/CotedIvoire/1986-87/Documentation/SOURCE.org
+++ b/lsms_library/countries/CotedIvoire/1986-87/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
+SOURCE
+
 https://microdata.worldbank.org/index.php/catalog/84
+
+#+CATALOG_ID: 84
+#+CATALOG_IDNO: CIV_1986_EPAM_v01_M
+#+CATALOG_TITLE: Enquête Permanente Auprès des Ménages 1986-1987 (Wave 2 Panel)
+#+CATALOG_YEARS: 1986-1987
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/qcr8-kp70
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/84
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/CotedIvoire/1987-88/Documentation/SOURCE.org
+++ b/lsms_library/countries/CotedIvoire/1987-88/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
+SOURCE
+
 https://microdata.worldbank.org/index.php/catalog/85
+
+#+CATALOG_ID: 85
+#+CATALOG_IDNO: CIV_1987_EPAM_v01_M
+#+CATALOG_TITLE: Enquête Permanente Auprès des Ménages 1987-1988 (Wave 3 Panel)
+#+CATALOG_YEARS: 1987-1988
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/y918-sy70
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/85
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/CotedIvoire/1988-89/Documentation/SOURCE.org
+++ b/lsms_library/countries/CotedIvoire/1988-89/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
+SOURCE
+
 https://microdata.worldbank.org/index.php/catalog/82
+
+#+CATALOG_ID: 82
+#+CATALOG_IDNO: CIV_1988_EPAM_v01_M
+#+CATALOG_TITLE: Enquête Permanente Auprès des Ménages 1988-1989 (Wave 4 Panel)
+#+CATALOG_YEARS: 1988-1989
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/kdy4-zz15
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/82
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/CotedIvoire/2018-19/Documentation/SOURCE.org
+++ b/lsms_library/countries/CotedIvoire/2018-19/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/4292
+
+#+CATALOG_ID: 4292
+#+CATALOG_IDNO: CIV_2018_EHCVM_v02_M
+#+CATALOG_TITLE: Enquête Harmonisée sur le Conditions de Vie des Ménages 2018-2019
+#+CATALOG_YEARS: 2018-2019
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/8wh3-bf40
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/4292
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Ethiopia/2011-12/Documentation/SOURCE.org
+++ b/lsms_library/countries/Ethiopia/2011-12/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/2053
+
+#+CATALOG_ID: 2053
+#+CATALOG_IDNO: ETH_2011_ERSS_v02_M
+#+CATALOG_TITLE: Rural Socioeconomic Survey 2011-2012
+#+CATALOG_YEARS: 2011-2012
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/80xt-9m68
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2053
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Ethiopia/2013-14/Documentation/SOURCE.org
+++ b/lsms_library/countries/Ethiopia/2013-14/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/2247
+
+#+CATALOG_ID: 2247
+#+CATALOG_IDNO: ETH_2013_ESS_v03_M
+#+CATALOG_TITLE: Socioeconomic Survey 2013-2014
+#+CATALOG_YEARS: 2013-2014
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/mccp-y123
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2247
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Ethiopia/2015-16/Documentation/SOURCE.org
+++ b/lsms_library/countries/Ethiopia/2015-16/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/2783
+
+#+CATALOG_ID: 2783
+#+CATALOG_IDNO: ETH_2015_ESS_v03_M
+#+CATALOG_TITLE: Socioeconomic Survey 2015-2016, Wave 3
+#+CATALOG_YEARS: 2015-2016
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/ampf-7988
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2783
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Ethiopia/2018-19/Documentation/SOURCE.org
+++ b/lsms_library/countries/Ethiopia/2018-19/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/3823
+
+#+CATALOG_ID: 3823
+#+CATALOG_IDNO: ETH_2018_ESS_v04_M
+#+CATALOG_TITLE: Socioeconomic Survey 2018-2019
+#+CATALOG_YEARS: 2018-2019
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/3gma-7g23
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/3823
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Ethiopia/2021-22/Documentation/SOURCE.org
+++ b/lsms_library/countries/Ethiopia/2021-22/Documentation/SOURCE.org
@@ -1,3 +1,13 @@
 SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/6161
+
+#+CATALOG_ID: 6161
+#+CATALOG_IDNO: ETH_2021_ESPS-W5_v02_M
+#+CATALOG_TITLE: Socio-Economic Panel Survey 2021-2022
+#+CATALOG_YEARS: 2021-2022
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/6161
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/EthiopiaRHS/1989/Documentation/SOURCE.org
+++ b/lsms_library/countries/EthiopiaRHS/1989/Documentation/SOURCE.org
@@ -1,9 +1,16 @@
 SOURCE
 
-Ethiopian Rural Household Survey (ERHS) -- 1989 wave, pre-expansion (1989).
-
-IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 https://doi.org/10.7910/DVN/T8G8IV
 
+#+CATALOG_ID: none
+#+CATALOG_URL: https://doi.org/10.7910/DVN/T8G8IV
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: not-a-wb-dataset
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Ethiopian Rural Household Survey is an IFPRI/Addis Ababa University study distributed via Harvard Dataverse (doi:10.7910/DVN/T8G8IV), not the World Bank Microdata Library.  There is nothing to discover in the WB catalog.
+
+* Notes (preserved from the original SOURCE.org)
+Ethiopian Rural Household Survey (ERHS) -- 1989 wave, pre-expansion (1989).
+IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 All ERHS rounds share one Dataverse deposit; see ../../_/CONTENTS.org
 for the round->file map.

--- a/lsms_library/countries/EthiopiaRHS/1994a/Documentation/SOURCE.org
+++ b/lsms_library/countries/EthiopiaRHS/1994a/Documentation/SOURCE.org
@@ -1,9 +1,16 @@
 SOURCE
 
-Ethiopian Rural Household Survey (ERHS) -- 1994a wave, Round 1 (early 1994).
-
-IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 https://doi.org/10.7910/DVN/T8G8IV
 
+#+CATALOG_ID: none
+#+CATALOG_URL: https://doi.org/10.7910/DVN/T8G8IV
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: not-a-wb-dataset
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Ethiopian Rural Household Survey is an IFPRI/Addis Ababa University study distributed via Harvard Dataverse (doi:10.7910/DVN/T8G8IV), not the World Bank Microdata Library.  There is nothing to discover in the WB catalog.
+
+* Notes (preserved from the original SOURCE.org)
+Ethiopian Rural Household Survey (ERHS) -- 1994a wave, Round 1 (early 1994).
+IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 All ERHS rounds share one Dataverse deposit; see ../../_/CONTENTS.org
 for the round->file map.

--- a/lsms_library/countries/EthiopiaRHS/1994b/Documentation/SOURCE.org
+++ b/lsms_library/countries/EthiopiaRHS/1994b/Documentation/SOURCE.org
@@ -1,9 +1,16 @@
 SOURCE
 
-Ethiopian Rural Household Survey (ERHS) -- 1994b wave, Round 2 (late 1994).
-
-IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 https://doi.org/10.7910/DVN/T8G8IV
 
+#+CATALOG_ID: none
+#+CATALOG_URL: https://doi.org/10.7910/DVN/T8G8IV
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: not-a-wb-dataset
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Ethiopian Rural Household Survey is an IFPRI/Addis Ababa University study distributed via Harvard Dataverse (doi:10.7910/DVN/T8G8IV), not the World Bank Microdata Library.  There is nothing to discover in the WB catalog.
+
+* Notes (preserved from the original SOURCE.org)
+Ethiopian Rural Household Survey (ERHS) -- 1994b wave, Round 2 (late 1994).
+IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 All ERHS rounds share one Dataverse deposit; see ../../_/CONTENTS.org
 for the round->file map.

--- a/lsms_library/countries/EthiopiaRHS/1995/Documentation/SOURCE.org
+++ b/lsms_library/countries/EthiopiaRHS/1995/Documentation/SOURCE.org
@@ -1,9 +1,16 @@
 SOURCE
 
-Ethiopian Rural Household Survey (ERHS) -- 1995 wave, Round 3 (1995).
-
-IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 https://doi.org/10.7910/DVN/T8G8IV
 
+#+CATALOG_ID: none
+#+CATALOG_URL: https://doi.org/10.7910/DVN/T8G8IV
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: not-a-wb-dataset
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Ethiopian Rural Household Survey is an IFPRI/Addis Ababa University study distributed via Harvard Dataverse (doi:10.7910/DVN/T8G8IV), not the World Bank Microdata Library.  There is nothing to discover in the WB catalog.
+
+* Notes (preserved from the original SOURCE.org)
+Ethiopian Rural Household Survey (ERHS) -- 1995 wave, Round 3 (1995).
+IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 All ERHS rounds share one Dataverse deposit; see ../../_/CONTENTS.org
 for the round->file map.

--- a/lsms_library/countries/EthiopiaRHS/1997/Documentation/SOURCE.org
+++ b/lsms_library/countries/EthiopiaRHS/1997/Documentation/SOURCE.org
@@ -1,9 +1,16 @@
 SOURCE
 
-Ethiopian Rural Household Survey (ERHS) -- 1997 wave, Round 4 (1997).
-
-IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 https://doi.org/10.7910/DVN/T8G8IV
 
+#+CATALOG_ID: none
+#+CATALOG_URL: https://doi.org/10.7910/DVN/T8G8IV
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: not-a-wb-dataset
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Ethiopian Rural Household Survey is an IFPRI/Addis Ababa University study distributed via Harvard Dataverse (doi:10.7910/DVN/T8G8IV), not the World Bank Microdata Library.  There is nothing to discover in the WB catalog.
+
+* Notes (preserved from the original SOURCE.org)
+Ethiopian Rural Household Survey (ERHS) -- 1997 wave, Round 4 (1997).
+IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 All ERHS rounds share one Dataverse deposit; see ../../_/CONTENTS.org
 for the round->file map.

--- a/lsms_library/countries/EthiopiaRHS/1999/Documentation/SOURCE.org
+++ b/lsms_library/countries/EthiopiaRHS/1999/Documentation/SOURCE.org
@@ -1,9 +1,16 @@
 SOURCE
 
-Ethiopian Rural Household Survey (ERHS) -- 1999 wave, Round 5 (1999).
-
-IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 https://doi.org/10.7910/DVN/T8G8IV
 
+#+CATALOG_ID: none
+#+CATALOG_URL: https://doi.org/10.7910/DVN/T8G8IV
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: not-a-wb-dataset
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Ethiopian Rural Household Survey is an IFPRI/Addis Ababa University study distributed via Harvard Dataverse (doi:10.7910/DVN/T8G8IV), not the World Bank Microdata Library.  There is nothing to discover in the WB catalog.
+
+* Notes (preserved from the original SOURCE.org)
+Ethiopian Rural Household Survey (ERHS) -- 1999 wave, Round 5 (1999).
+IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 All ERHS rounds share one Dataverse deposit; see ../../_/CONTENTS.org
 for the round->file map.

--- a/lsms_library/countries/EthiopiaRHS/2004/Documentation/SOURCE.org
+++ b/lsms_library/countries/EthiopiaRHS/2004/Documentation/SOURCE.org
@@ -1,9 +1,16 @@
 SOURCE
 
-Ethiopian Rural Household Survey (ERHS) -- 2004 wave, Round 6 (2004).
-
-IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 https://doi.org/10.7910/DVN/T8G8IV
 
+#+CATALOG_ID: none
+#+CATALOG_URL: https://doi.org/10.7910/DVN/T8G8IV
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: not-a-wb-dataset
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Ethiopian Rural Household Survey is an IFPRI/Addis Ababa University study distributed via Harvard Dataverse (doi:10.7910/DVN/T8G8IV), not the World Bank Microdata Library.  There is nothing to discover in the WB catalog.
+
+* Notes (preserved from the original SOURCE.org)
+Ethiopian Rural Household Survey (ERHS) -- 2004 wave, Round 6 (2004).
+IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 All ERHS rounds share one Dataverse deposit; see ../../_/CONTENTS.org
 for the round->file map.

--- a/lsms_library/countries/EthiopiaRHS/2009/Documentation/SOURCE.org
+++ b/lsms_library/countries/EthiopiaRHS/2009/Documentation/SOURCE.org
@@ -1,9 +1,16 @@
 SOURCE
 
-Ethiopian Rural Household Survey (ERHS) -- 2009 wave, Round 7 (2009).
-
-IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 https://doi.org/10.7910/DVN/T8G8IV
 
+#+CATALOG_ID: none
+#+CATALOG_URL: https://doi.org/10.7910/DVN/T8G8IV
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: not-a-wb-dataset
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Ethiopian Rural Household Survey is an IFPRI/Addis Ababa University study distributed via Harvard Dataverse (doi:10.7910/DVN/T8G8IV), not the World Bank Microdata Library.  There is nothing to discover in the WB catalog.
+
+* Notes (preserved from the original SOURCE.org)
+Ethiopian Rural Household Survey (ERHS) -- 2009 wave, Round 7 (2009).
+IFPRI Dataverse, doi:10.7910/DVN/T8G8IV (hdl:1902.1/15646)
 All ERHS rounds share one Dataverse deposit; see ../../_/CONTENTS.org
 for the round->file map.

--- a/lsms_library/countries/GhanaLSS/1987-88/Documentation/SOURCE.org
+++ b/lsms_library/countries/GhanaLSS/1987-88/Documentation/SOURCE.org
@@ -1,1 +1,10 @@
+SOURCE
+
 https://www2.statsghana.gov.gh/nada/index.php/catalog/7/get_microdata
+
+#+CATALOG_ID: none
+#+CATALOG_URL: https://www2.statsghana.gov.gh/nada/index.php/catalog/7/get_microdata
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: external-source
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Obtained from www2.statsghana.gov.gh, not the World Bank Microdata Library.

--- a/lsms_library/countries/GhanaLSS/1988-89/Documentation/SOURCE.org
+++ b/lsms_library/countries/GhanaLSS/1988-89/Documentation/SOURCE.org
@@ -1,1 +1,10 @@
+SOURCE
+
 https://www2.statsghana.gov.gh/nada/index.php/catalog/4/get_microdata
+
+#+CATALOG_ID: none
+#+CATALOG_URL: https://www2.statsghana.gov.gh/nada/index.php/catalog/4/get_microdata
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: external-source
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Obtained from www2.statsghana.gov.gh, not the World Bank Microdata Library.

--- a/lsms_library/countries/GhanaLSS/1991-92/Documentation/SOURCE.org
+++ b/lsms_library/countries/GhanaLSS/1991-92/Documentation/SOURCE.org
@@ -1,3 +1,13 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/2315
+
+#+CATALOG_ID: 2315
+#+CATALOG_IDNO: GHA_1991_GLSS_v02_M
+#+CATALOG_TITLE: Living Standards Survey III 1991
+#+CATALOG_YEARS: 1991-1992
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2315
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/GhanaLSS/1998-99/Documentation/SOURCE.org
+++ b/lsms_library/countries/GhanaLSS/1998-99/Documentation/SOURCE.org
@@ -1,1 +1,10 @@
+SOURCE
+
 https://www2.statsghana.gov.gh/nada/index.php/catalog/14/get_microdata
+
+#+CATALOG_ID: none
+#+CATALOG_URL: https://www2.statsghana.gov.gh/nada/index.php/catalog/14/get_microdata
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: external-source
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Obtained from www2.statsghana.gov.gh, not the World Bank Microdata Library.

--- a/lsms_library/countries/GhanaLSS/2005-06/Documentation/SOURCE.org
+++ b/lsms_library/countries/GhanaLSS/2005-06/Documentation/SOURCE.org
@@ -1,2 +1,10 @@
+SOURCE
+
 https://www2.statsghana.gov.gh/nada/index.php/catalog/5/get_microdata
-https://microdata.worldbank.org/index.php/catalog/1064
+
+#+CATALOG_ID: none
+#+CATALOG_URL: https://www2.statsghana.gov.gh/nada/index.php/catalog/5/get_microdata
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: external-source
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Obtained from www2.statsghana.gov.gh, not the World Bank Microdata Library.

--- a/lsms_library/countries/GhanaLSS/2012-13/Documentation/SOURCE.org
+++ b/lsms_library/countries/GhanaLSS/2012-13/Documentation/SOURCE.org
@@ -1,1 +1,10 @@
+SOURCE
+
 https://microdata.statsghana.gov.gh/index.php/catalog/72/study-description
+
+#+CATALOG_ID: none
+#+CATALOG_URL: https://microdata.statsghana.gov.gh/index.php/catalog/72/study-description
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: external-source
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Obtained from microdata.statsghana.gov.gh, not the World Bank Microdata Library.

--- a/lsms_library/countries/GhanaLSS/2016-17/Documentation/SOURCE.org
+++ b/lsms_library/countries/GhanaLSS/2016-17/Documentation/SOURCE.org
@@ -1,1 +1,10 @@
+SOURCE
+
 https://www2.statsghana.gov.gh/nada/index.php/catalog/97/get_microdata
+
+#+CATALOG_ID: none
+#+CATALOG_URL: https://www2.statsghana.gov.gh/nada/index.php/catalog/97/get_microdata
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: external-source
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Obtained from www2.statsghana.gov.gh, not the World Bank Microdata Library.

--- a/lsms_library/countries/GhanaSPS/2009-10/Documentation/SOURCE.org
+++ b/lsms_library/countries/GhanaSPS/2009-10/Documentation/SOURCE.org
@@ -1,2 +1,14 @@
-https://microdata.worldbank.org/index.php/catalog/2534/get-microdata
-https://egc.yale.edu/data/egc-isser-northwestern-ghana-panel-survey
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2534
+
+#+CATALOG_ID: 2534
+#+CATALOG_IDNO: GHA_2009_GSPS_v01_M
+#+CATALOG_TITLE: Socioeconomic Panel Survey: 2009-2010
+#+CATALOG_YEARS: 2009-2010
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/851p-b825
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2534
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/GhanaSPS/2013-14/Documentation/SOURCE.org
+++ b/lsms_library/countries/GhanaSPS/2013-14/Documentation/SOURCE.org
@@ -1,0 +1,12 @@
+SOURCE
+
+(source URL not recorded)
+
+#+CATALOG_ID: unknown
+#+PROVENANCE_SOURCE: unknown
+#+PROVENANCE_METHOD: unresolved
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: No source URL recorded for this wave; its World Bank catalog id is unknown.  Deliberately NOT inferred from the directory name -- year-range labels collide across distinct surveys.
+
+* Notes (preserved from the original SOURCE.org)
+(source URL not recorded)

--- a/lsms_library/countries/GhanaSPS/2017-18/Documentation/SOURCE.org
+++ b/lsms_library/countries/GhanaSPS/2017-18/Documentation/SOURCE.org
@@ -1,0 +1,12 @@
+SOURCE
+
+(source URL not recorded)
+
+#+CATALOG_ID: unknown
+#+PROVENANCE_SOURCE: unknown
+#+PROVENANCE_METHOD: unresolved
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: No source URL recorded for this wave; its World Bank catalog id is unknown.  Deliberately NOT inferred from the directory name -- year-range labels collide across distinct surveys.
+
+* Notes (preserved from the original SOURCE.org)
+(source URL not recorded)

--- a/lsms_library/countries/Guatemala/2000/Documentation/SOURCE.org
+++ b/lsms_library/countries/Guatemala/2000/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/c86m-bn65]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/586
+
+#+CATALOG_ID: 586
+#+CATALOG_IDNO: GTM_2000_ENCOVI_v01_M
+#+CATALOG_TITLE: Encuesta Nacional sobre Condiciones de Vida 2000
+#+CATALOG_YEARS: 2000-2000
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/c86m-bn65
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/586
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Guinea-Bissau/2018-19/Documentation/SOURCE.org
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/1ekb-m086]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/4293
+
+#+CATALOG_ID: 4293
+#+CATALOG_IDNO: GNB_2018_EHCVM_v02_M
+#+CATALOG_TITLE: Inquérito Harmonizado sobre as Condiçöes de vide dos Agreagados Familiares 2018-2019
+#+CATALOG_YEARS: 2018-2019
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/1ekb-m086
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/4293
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Guyana/1992/Documentation/SOURCE.org
+++ b/lsms_library/countries/Guyana/1992/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/8nx3-cc48]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2319
+
+#+CATALOG_ID: 2319
+#+CATALOG_IDNO: GUY_1992_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurements Survey 1992
+#+CATALOG_YEARS: 1992-1992
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/8nx3-cc48
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2319
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/India/1997-98/Documentation/SOURCE.org
+++ b/lsms_library/countries/India/1997-98/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/q6sh-b869]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/276
+
+#+CATALOG_ID: 276
+#+CATALOG_IDNO: IND_1997_SLCUPB_v01_M
+#+CATALOG_TITLE: Uttar Pradesh and Bihar Survey of Living Conditions 1997-1998
+#+CATALOG_YEARS: 1997-1998
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/q6sh-b869
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/276
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Iraq/2006-07/Documentation/SOURCE.org
+++ b/lsms_library/countries/Iraq/2006-07/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/ebk1-rr24]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/69
+
+#+CATALOG_ID: 69
+#+CATALOG_IDNO: IRQ_2006_IHSES_v02_M
+#+CATALOG_TITLE: Household Socio-Economic Survey 2006-2007
+#+CATALOG_YEARS: 2006-2007
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/ebk1-rr24
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/69
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Iraq/2012/Documentation/SOURCE.org
+++ b/lsms_library/countries/Iraq/2012/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/xh5a-y392]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2334
+
+#+CATALOG_ID: 2334
+#+CATALOG_IDNO: IRQ_2012_IHSES_v02_M
+#+CATALOG_TITLE: Household Socio-Economic Survey 2012, Second Round
+#+CATALOG_YEARS: 2012-2013
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/xh5a-y392
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2334
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Kazakhstan/1996/Documentation/SOURCE.org
+++ b/lsms_library/countries/Kazakhstan/1996/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/56ce-y079]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2292
+
+#+CATALOG_ID: 2292
+#+CATALOG_IDNO: KAZ_1996_LSMS_v01_M_v01_A_PUF
+#+CATALOG_TITLE: Living Standards Measurement Survey 1996
+#+CATALOG_YEARS: 1996-1996
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/56ce-y079
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2292
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/KenyaLPS/2003-2005/Documentation/SOURCE.org
+++ b/lsms_library/countries/KenyaLPS/2003-2005/Documentation/SOURCE.org
@@ -1,0 +1,12 @@
+SOURCE
+
+(source URL not recorded)
+
+#+CATALOG_ID: none
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: not-a-wb-dataset
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Kenya Life Panel Survey is not distributed via the World Bank Microdata Library (a KEN/lsms catalog query returns no entries).
+
+* Notes (preserved from the original SOURCE.org)
+(source URL not recorded)

--- a/lsms_library/countries/Kosovo/2000/Documentation/SOURCE.org
+++ b/lsms_library/countries/Kosovo/2000/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/215m-9g90]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/77
+
+#+CATALOG_ID: 77
+#+CATALOG_IDNO: KSV_2000_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2000
+#+CATALOG_YEARS: 2000-2000
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/215m-9g90
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/77
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Kyrgyz Republic/1993/Documentation/SOURCE.org
+++ b/lsms_library/countries/Kyrgyz Republic/1993/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/1494-v479]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/280
+
+#+CATALOG_ID: 280
+#+CATALOG_IDNO: KGZ_1993_KMPS_v01_M
+#+CATALOG_TITLE: Multipurpose Poverty Survey 1993
+#+CATALOG_YEARS: 1993-1993
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/1494-v479
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/280
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Kyrgyz Republic/1996/Documentation/SOURCE.org
+++ b/lsms_library/countries/Kyrgyz Republic/1996/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/3jxw-nn78]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/281
+
+#+CATALOG_ID: 281
+#+CATALOG_IDNO: KGZ_1996_KPMS_v01_M
+#+CATALOG_TITLE: Poverty Monitoring Survey 1996
+#+CATALOG_YEARS: 1996-1996
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/3jxw-nn78
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/281
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Kyrgyz Republic/1997/Documentation/SOURCE.org
+++ b/lsms_library/countries/Kyrgyz Republic/1997/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/b97a-kj83]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/282
+
+#+CATALOG_ID: 282
+#+CATALOG_IDNO: KGZ_1997_KPMS_v01_M
+#+CATALOG_TITLE: Poverty Monitoring Survey 1997
+#+CATALOG_YEARS: 1997-1997
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/b97a-kj83
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/282
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Kyrgyz Republic/1998/Documentation/SOURCE.org
+++ b/lsms_library/countries/Kyrgyz Republic/1998/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/twzy-7936]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/283
+
+#+CATALOG_ID: 283
+#+CATALOG_IDNO: KGZ_1998_KPMS_v01_M
+#+CATALOG_TITLE: Poverty Monitoring Survey 1998
+#+CATALOG_YEARS: 1998-1998
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/twzy-7936
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/283
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Liberia/2018-19/Documentation/SOURCE.org
+++ b/lsms_library/countries/Liberia/2018-19/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/rdhm-h904]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/3787
+
+#+CATALOG_ID: 3787
+#+CATALOG_IDNO: LBR_2018_NHFS_v01_M
+#+CATALOG_TITLE: National Household Forest Survey 2018-2019
+#+CATALOG_YEARS: 2018-2019
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/rdhm-h904
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/3787
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Malawi/2004-05/Documentation/SOURCE.org
+++ b/lsms_library/countries/Malawi/2004-05/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-https://microdata.worldbank.org/index.php/catalog/2307/get-microdata
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2307
+
+#+CATALOG_ID: 2307
+#+CATALOG_IDNO: MWI_2004_IHS-II_v01_M
+#+CATALOG_TITLE: Second Integrated Household Survey 2004-2005
+#+CATALOG_YEARS: 2004-2005
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/2ked-2t88
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2307
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Malawi/2010-11/Documentation/SOURCE.org
+++ b/lsms_library/countries/Malawi/2010-11/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-https://microdata.worldbank.org/index.php/catalog/1003/get-microdata
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/1003
+
+#+CATALOG_ID: 1003
+#+CATALOG_IDNO: MWI_2010_IHS-III_v01_M
+#+CATALOG_TITLE: Third Integrated Household Survey 2010-2011
+#+CATALOG_YEARS: 2010-2011
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/w1jq-qh85
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/1003
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Malawi/2013-14/Documentation/SOURCE.org
+++ b/lsms_library/countries/Malawi/2013-14/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-https://microdata.worldbank.org/index.php/catalog/2248/get-microdata
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2248
+
+#+CATALOG_ID: 2248
+#+CATALOG_IDNO: MWI_2010-2013_IHPS_v01_M
+#+CATALOG_TITLE: Integrated Household Panel Survey 2010-2013 (Short-Term Panel, 204 EAs)
+#+CATALOG_YEARS: 2010-2013
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/4q9f-2288
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2248
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Malawi/2016-17/Documentation/SOURCE.org
+++ b/lsms_library/countries/Malawi/2016-17/Documentation/SOURCE.org
@@ -1,2 +1,14 @@
-https://microdata.worldbank.org/index.php/catalog/2936/get-microdata
-https://microdata.worldbank.org/index.php/catalog/2248/get-microdata
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2936
+
+#+CATALOG_ID: 2936
+#+CATALOG_IDNO: MWI_2016_IHS-IV_v04_M
+#+CATALOG_TITLE: Fourth Integrated Household Survey 2016-2017
+#+CATALOG_YEARS: 2016-2017
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/g2p9-9r19
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2936
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Malawi/2019-20/Documentation/SOURCE.org
+++ b/lsms_library/countries/Malawi/2019-20/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-https://microdata.worldbank.org/index.php/catalog/3818/get-microdata
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/3818
+
+#+CATALOG_ID: 3818
+#+CATALOG_IDNO: MWI_2019_IHS-V_v06_M
+#+CATALOG_TITLE: Fifth Integrated Household Survey 2019-2020
+#+CATALOG_YEARS: 2019-2020
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/mpyk-ds48
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/3818
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Mali/2014-15/Documentation/SOURCE.org
+++ b/lsms_library/countries/Mali/2014-15/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/2583
+
+#+CATALOG_ID: 2583
+#+CATALOG_IDNO: MLI_2014_EACI_v03_M
+#+CATALOG_TITLE: Enquête Agricole de Conjoncture Intégrée 2014
+#+CATALOG_YEARS: 2014-2015
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/qqam-mn86
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2583
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Mali/2017-18/Documentation/SOURCE.org
+++ b/lsms_library/countries/Mali/2017-18/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/3409
+
+#+CATALOG_ID: 3409
+#+CATALOG_IDNO: MLI_2017_EAC-I_v03_M
+#+CATALOG_TITLE: Enquête Agricole de Conjoncture Intégrée aux Conditions de Vie des Ménages 2017
+#+CATALOG_YEARS: 2017-2018
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/0v50-h966
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/3409
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Mali/2018-19/Documentation/SOURCE.org
+++ b/lsms_library/countries/Mali/2018-19/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/4295
+
+#+CATALOG_ID: 4295
+#+CATALOG_IDNO: MLI_2018_EHCVM_v02_M
+#+CATALOG_TITLE: Enquête Harmonisée sur le Conditions de Vie des Ménages 2018-2019
+#+CATALOG_YEARS: 2018-2019
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/90e9-4e91
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/4295
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Mali/2021-22/Documentation/SOURCE.org
+++ b/lsms_library/countries/Mali/2021-22/Documentation/SOURCE.org
@@ -1,3 +1,13 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/6275
+
+#+CATALOG_ID: 6275
+#+CATALOG_IDNO: MLI_2021_EHCVM-2_v01_M
+#+CATALOG_TITLE: Enquête Harmonisée sur le Conditions de Vie des Ménages, 2021-2022
+#+CATALOG_YEARS: 2021-2022
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/6275
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Nepal/1995-96/Documentation/SOURCE.org
+++ b/lsms_library/countries/Nepal/1995-96/Documentation/SOURCE.org
@@ -1,1 +1,13 @@
-https://microdata.worldbank.org/index.php/catalog/2301/get-microdata
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2301
+
+#+CATALOG_ID: 2301
+#+CATALOG_IDNO: NPL_1995_LSS-I_v01_M
+#+CATALOG_TITLE: Living Standards Survey 1995-1996, First Round
+#+CATALOG_YEARS: 1995-1996
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2301
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Nepal/2003-04/Documentation/SOURCE.org
+++ b/lsms_library/countries/Nepal/2003-04/Documentation/SOURCE.org
@@ -1,0 +1,12 @@
+SOURCE
+
+(source URL not recorded)
+
+#+CATALOG_ID: unknown
+#+PROVENANCE_SOURCE: unknown
+#+PROVENANCE_METHOD: unresolved
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: No source URL recorded for this wave; its World Bank catalog id is unknown.  Deliberately NOT inferred from the directory name -- year-range labels collide across distinct surveys.
+
+* Notes (preserved from the original SOURCE.org)
+(source URL not recorded)

--- a/lsms_library/countries/Nepal/2010-11/Documentation/SOURCE.org
+++ b/lsms_library/countries/Nepal/2010-11/Documentation/SOURCE.org
@@ -1,1 +1,13 @@
+SOURCE
+
 https://microdata.worldbank.org/index.php/catalog/1000
+
+#+CATALOG_ID: 1000
+#+CATALOG_IDNO: NPL_2010_LSS-III_v01_M
+#+CATALOG_TITLE: Living Standards Survey 2010-2011, Third Round
+#+CATALOG_YEARS: 2010-2011
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/1000
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Nicaragua/1993/Documentation/SOURCE.org
+++ b/lsms_library/countries/Nicaragua/1993/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/tj77-3f05]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2349
+
+#+CATALOG_ID: 2349
+#+CATALOG_IDNO: NIC_1993_EMNV_v01_M
+#+CATALOG_TITLE: Encuesta Nacional de Hogares sobre Medición de Niveles de Vida 1993
+#+CATALOG_YEARS: 1993-1993
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/tj77-3f05
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2349
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Nicaragua/1998-99/Documentation/SOURCE.org
+++ b/lsms_library/countries/Nicaragua/1998-99/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/96jx-pv42]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/587
+
+#+CATALOG_ID: 587
+#+CATALOG_IDNO: NIC_1998_EMNV_v01_M
+#+CATALOG_TITLE: Encuesta Nacional de Hogares sobre Medición de Niveles de Vida 1998-1999 (Panel)
+#+CATALOG_YEARS: 1998-1999
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/96jx-pv42
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/587
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Nicaragua/2001/Documentation/SOURCE.org
+++ b/lsms_library/countries/Nicaragua/2001/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/nkrr-1w20]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/599
+
+#+CATALOG_ID: 599
+#+CATALOG_IDNO: NIC_2001_EMNV_v01_M
+#+CATALOG_TITLE: Encuesta Nacional de Hogares sobre Medición de Niveles de Vida 2001
+#+CATALOG_YEARS: 2001-2001
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/nkrr-1w20
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/599
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Nicaragua/2005/Documentation/SOURCE.org
+++ b/lsms_library/countries/Nicaragua/2005/Documentation/SOURCE.org
@@ -1,1 +1,13 @@
-/https://microdata.worldbank.org/index.php/catalog/2347/related-materials/
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2347
+
+#+CATALOG_ID: 2347
+#+CATALOG_IDNO: NIC_2005_EMNV_v01_M
+#+CATALOG_TITLE: Encuesta Nacional de Hogares sobre Medición de Niveles de Vida 2005
+#+CATALOG_YEARS: 2005-2005
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2347
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Niger/2011-12/Documentation/SOURCE.org
+++ b/lsms_library/countries/Niger/2011-12/Documentation/SOURCE.org
@@ -1,0 +1,12 @@
+SOURCE
+
+(source URL not recorded)
+
+#+CATALOG_ID: unknown
+#+PROVENANCE_SOURCE: unknown
+#+PROVENANCE_METHOD: unresolved
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: No source URL recorded for this wave; its World Bank catalog id is unknown.  Deliberately NOT inferred from the directory name -- year-range labels collide across distinct surveys.
+
+* Notes (preserved from the original SOURCE.org)
+(source URL not recorded)

--- a/lsms_library/countries/Niger/2014-15/Documentation/SOURCE.org
+++ b/lsms_library/countries/Niger/2014-15/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/2676
+
+#+CATALOG_ID: 2676
+#+CATALOG_IDNO: NER_2014_ECVMA-II_v02_M
+#+CATALOG_TITLE: National Survey on Household Living Conditions and Agriculture 2014, Wave 2 Panel Data
+#+CATALOG_YEARS: 2014-2015
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/3xnb-sd96
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2676
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Niger/2018-19/Documentation/SOURCE.org
+++ b/lsms_library/countries/Niger/2018-19/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/ggam-ax39]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/4296
+
+#+CATALOG_ID: 4296
+#+CATALOG_IDNO: NER_2018_EHCVM_v02_M
+#+CATALOG_TITLE: Enquête Harmonisée sur le Conditions de Vie des Ménages 2018-2019
+#+CATALOG_YEARS: 2018-2019
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/ggam-ax39
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/4296
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Niger/2021-22/Documentation/SOURCE.org
+++ b/lsms_library/countries/Niger/2021-22/Documentation/SOURCE.org
@@ -1,3 +1,13 @@
 SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/6276
+
+#+CATALOG_ID: 6276
+#+CATALOG_IDNO: NER_2021_EHCVM-2_v01_M
+#+CATALOG_TITLE: Enquête Harmonisée sur le Conditions de Vie des Ménages, 2021-2022
+#+CATALOG_YEARS: 2021-2022
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/6276
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Nigeria/2010-11/Documentation/SOURCE.org
+++ b/lsms_library/countries/Nigeria/2010-11/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/1002
+
+#+CATALOG_ID: 1002
+#+CATALOG_IDNO: NGA_2010_GHSP-W1_v03_M
+#+CATALOG_TITLE: General Household Survey, Panel 2010-2011, Wave 1
+#+CATALOG_YEARS: 2010-2011
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/y9e2-b753
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/1002
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Nigeria/2012-13/Documentation/SOURCE.org
+++ b/lsms_library/countries/Nigeria/2012-13/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/1952
+
+#+CATALOG_ID: 1952
+#+CATALOG_IDNO: NGA_2012_GHSP-W2_v02_M
+#+CATALOG_TITLE: General Household Survey, Panel  2012-2013, Wave 2
+#+CATALOG_YEARS: 2012-2013
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/kxpy-aa72
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/1952
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Nigeria/2015-16/Documentation/SOURCE.org
+++ b/lsms_library/countries/Nigeria/2015-16/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/2734
+
+#+CATALOG_ID: 2734
+#+CATALOG_IDNO: NGA_2015_GHSP-W3_v02_M
+#+CATALOG_TITLE: General Household Survey, Panel  2015-2016, Wave 3
+#+CATALOG_YEARS: 2015-2016
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/7xmj-q133
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2734
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Nigeria/2018-19/Documentation/SOURCE.org
+++ b/lsms_library/countries/Nigeria/2018-19/Documentation/SOURCE.org
@@ -1,3 +1,16 @@
-SOURCE 
+SOURCE
 
-https://microdata.worldbank.org/index.php/catalog/3827
+https://microdata.worldbank.org/index.php/catalog/3557
+
+#+CATALOG_ID: 3557
+#+CATALOG_IDNO: NGA_2018_GHSP-W4_v03_M
+#+CATALOG_TITLE: General Household Survey, Panel 2018-2019, Wave 4
+#+CATALOG_YEARS: 2018-2019
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/1hgw-dq47
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/3557
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: manual-override
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_SUPERSEDED_URL: https://microdata.worldbank.org/index.php/catalog/3827
+#+PROVENANCE_NOTE: Corrected from catalog 3827 (NGA_2018_LSS, 'Living Standards Survey 2018-2019').  The data files in this directory are sect*_plantingw4 / sect*_harvestw4 / nga_*_y4 -- i.e. General Household Survey Panel Wave 4 (NGA_2018_GHSP-W4, catalog 3557). Both studies span 2018-2019, so the previously recorded id was the wrong one of the two.  Every sibling Nigeria wave is also GHS-Panel (W1=1002, W2=1952, W3=2734, W5=6410).

--- a/lsms_library/countries/Nigeria/2023-24/Documentation/SOURCE.org
+++ b/lsms_library/countries/Nigeria/2023-24/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-https://microdata.worldbank.org/index.php/catalog/6410/
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/6410
+
+#+CATALOG_ID: 6410
+#+CATALOG_IDNO: NGA_2023_GHSP-W5_v01_M
+#+CATALOG_TITLE: General Household Survey, Panel 2023-2024
+#+CATALOG_YEARS: 2023-2024
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/zd5s-tj25
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/6410
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Pakistan/1991/Documentation/SOURCE.org
+++ b/lsms_library/countries/Pakistan/1991/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/azv8-cf20]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/543
+
+#+CATALOG_ID: 543
+#+CATALOG_IDNO: PAK_1991_IHS_v01_M
+#+CATALOG_TITLE: Integrated Household Survey 1991
+#+CATALOG_YEARS: 1991-1991
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/azv8-cf20
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/543
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Panama/1997/Documentation/SOURCE.org
+++ b/lsms_library/countries/Panama/1997/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/2yt8-e468]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/598
+
+#+CATALOG_ID: 598
+#+CATALOG_IDNO: PAN_1997_ENV_v01_M
+#+CATALOG_TITLE: Encuesta de Niveles de Vida 1997
+#+CATALOG_YEARS: 1997-1997
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/2yt8-e468
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/598
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Panama/2003/Documentation/SOURCE.org
+++ b/lsms_library/countries/Panama/2003/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/ey4q-j612]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2346
+
+#+CATALOG_ID: 2346
+#+CATALOG_IDNO: PAN_2003_ENV_v01_M
+#+CATALOG_TITLE: Encuesta de Niveles de Vida 2003
+#+CATALOG_YEARS: 2003-2003
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/ey4q-j612
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2346
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Panama/2008/Documentation/SOURCE.org
+++ b/lsms_library/countries/Panama/2008/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/ymsp-m052]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/70
+
+#+CATALOG_ID: 70
+#+CATALOG_IDNO: PAN_2008_ENV_v01_M
+#+CATALOG_TITLE: Encuesta de Niveles de Vida 2008
+#+CATALOG_YEARS: 2008-2008
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/ymsp-m052
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/70
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Peru/1985/Documentation/SOURCE.org
+++ b/lsms_library/countries/Peru/1985/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/dsz6-gh05]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/597
+
+#+CATALOG_ID: 597
+#+CATALOG_IDNO: PER_1985_ENNIV_v01_M
+#+CATALOG_TITLE: Encuesta Nacional de Hogares sobre Medición de Niveles de Vida 1985
+#+CATALOG_YEARS: 1985-1986
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/dsz6-gh05
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/597
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Peru/1990/Documentation/SOURCE.org
+++ b/lsms_library/countries/Peru/1990/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/w7v4-sz09]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/596
+
+#+CATALOG_ID: 596
+#+CATALOG_IDNO: PER_1990_ENNIV_v01_M
+#+CATALOG_TITLE: Encuesta Nacional de Hogares sobre Medición de Niveles de Vida 1990
+#+CATALOG_YEARS: 1990-1990
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/w7v4-sz09
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/596
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Peru/1991/Documentation/SOURCE.org
+++ b/lsms_library/countries/Peru/1991/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/n513-d685]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/618
+
+#+CATALOG_ID: 618
+#+CATALOG_IDNO: PER_1991_ENNIV_v01_M
+#+CATALOG_TITLE: Encuesta Nacional de Hogares sobre Medición de Niveles de Vida 1991
+#+CATALOG_YEARS: 1991-1991
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/n513-d685
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/618
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Peru/1994/Documentation/SOURCE.org
+++ b/lsms_library/countries/Peru/1994/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/ntxg-ed63]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/617
+
+#+CATALOG_ID: 617
+#+CATALOG_IDNO: PER_1994_ENNIV_v01_M
+#+CATALOG_TITLE: Encuesta Nacional de Hogares sobre Medición de Niveles de Vida 1994
+#+CATALOG_YEARS: 1994-1994
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/ntxg-ed63
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/617
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Rwanda/2000-01/Documentation/SOURCE.org
+++ b/lsms_library/countries/Rwanda/2000-01/Documentation/SOURCE.org
@@ -1,1 +1,10 @@
+SOURCE
+
 https://microdata.statistics.gov.rw/index.php/catalog/27
+
+#+CATALOG_ID: none
+#+CATALOG_URL: https://microdata.statistics.gov.rw/index.php/catalog/27
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: external-source
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Obtained from microdata.statistics.gov.rw, not the World Bank Microdata Library.

--- a/lsms_library/countries/Rwanda/2005-06/Documentation/SOURCE.org
+++ b/lsms_library/countries/Rwanda/2005-06/Documentation/SOURCE.org
@@ -1,1 +1,10 @@
+SOURCE
+
 https://microdata.statistics.gov.rw/index.php/catalog/39/get_microdata
+
+#+CATALOG_ID: none
+#+CATALOG_URL: https://microdata.statistics.gov.rw/index.php/catalog/39/get_microdata
+#+PROVENANCE_SOURCE: external
+#+PROVENANCE_METHOD: external-source
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: Obtained from microdata.statistics.gov.rw, not the World Bank Microdata Library.

--- a/lsms_library/countries/Senegal/2018-19/Documentation/SOURCE.org
+++ b/lsms_library/countries/Senegal/2018-19/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/hhhx-j012]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/4297
+
+#+CATALOG_ID: 4297
+#+CATALOG_IDNO: SEN_2018_EHCVM_v02_M
+#+CATALOG_TITLE: Enquête Harmonisée sur le Conditions de Vie des Ménages 2018-2019
+#+CATALOG_YEARS: 2018-2019
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/hhhx-j012
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/4297
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Senegal/2021-22/Documentation/SOURCE.org
+++ b/lsms_library/countries/Senegal/2021-22/Documentation/SOURCE.org
@@ -1,0 +1,12 @@
+SOURCE
+
+(source URL not recorded)
+
+#+CATALOG_ID: unknown
+#+PROVENANCE_SOURCE: unknown
+#+PROVENANCE_METHOD: unresolved
+#+PROVENANCE_RECORDED: 2026-07-12
+#+PROVENANCE_NOTE: No source URL recorded for this wave; its World Bank catalog id is unknown.  Deliberately NOT inferred from the directory name -- year-range labels collide across distinct surveys.
+
+* Notes (preserved from the original SOURCE.org)
+(source URL not recorded)

--- a/lsms_library/countries/Serbia and Montenegro/2002/Documentation/SOURCE.org
+++ b/lsms_library/countries/Serbia and Montenegro/2002/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/kb2h-4476]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/80
+
+#+CATALOG_ID: 80
+#+CATALOG_IDNO: SCG_2002_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2002 (General Population, Wave 1 Panel) and Family Income Support Survey 2002
+#+CATALOG_YEARS: 2002-2002
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/kb2h-4476
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/80
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Serbia and Montenegro/2003/Documentation/SOURCE.org
+++ b/lsms_library/countries/Serbia and Montenegro/2003/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/h5ve-n970]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/81
+
+#+CATALOG_ID: 81
+#+CATALOG_IDNO: SCG_2003_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2003 (General Population, Wave 2 Panel) and Roma Settlement Survey 2003
+#+CATALOG_YEARS: 2003-2003
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/h5ve-n970
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/81
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Serbia/2007/Documentation/SOURCE.org
+++ b/lsms_library/countries/Serbia/2007/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/rg2s-9v14]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/2291
+
+#+CATALOG_ID: 2291
+#+CATALOG_IDNO: SRB_2007_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Measurement Survey 2007
+#+CATALOG_YEARS: 2007-2007
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/rg2s-9v14
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2291
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/South Africa/1993/Documentation/SOURCE.org
+++ b/lsms_library/countries/South Africa/1993/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/9567-t539]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/297
+
+#+CATALOG_ID: 297
+#+CATALOG_IDNO: ZAF_1993_IHS_v01_M
+#+CATALOG_TITLE: Integrated Household Survey 1993
+#+CATALOG_YEARS: 1993-1993
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/9567-t539
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/297
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Tajikistan/1999/Documentation/SOURCE.org
+++ b/lsms_library/countries/Tajikistan/1999/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/hjw2-fg61]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/279
+
+#+CATALOG_ID: 279
+#+CATALOG_IDNO: TJK_1999_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Survey 1999
+#+CATALOG_YEARS: 1999-1999
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/hjw2-fg61
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/279
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Tajikistan/2003/Documentation/SOURCE.org
+++ b/lsms_library/countries/Tajikistan/2003/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/v9gt-4x62]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/278
+
+#+CATALOG_ID: 278
+#+CATALOG_IDNO: TJK_2003_LSMS_v01_M
+#+CATALOG_TITLE: Living Standards Survey 2003
+#+CATALOG_YEARS: 2003-2003
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/v9gt-4x62
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/278
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Tajikistan/2007/Documentation/SOURCE.org
+++ b/lsms_library/countries/Tajikistan/2007/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/39ay-kr43]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/72
+
+#+CATALOG_ID: 72
+#+CATALOG_IDNO: TJK_2007_TLSS_v01_M
+#+CATALOG_TITLE: Living Standards Survey 2007
+#+CATALOG_YEARS: 2007-2007
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/39ay-kr43
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/72
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Tajikistan/2009/Documentation/SOURCE.org
+++ b/lsms_library/countries/Tajikistan/2009/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/frwh-7q04]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/73
+
+#+CATALOG_ID: 73
+#+CATALOG_IDNO: TJK_2009_TLSS_v01_M
+#+CATALOG_TITLE: Living Standards Survey 2009
+#+CATALOG_YEARS: 2009-2009
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/frwh-7q04
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/73
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Tanzania/2008-15/Documentation/SOURCE.org
+++ b/lsms_library/countries/Tanzania/2008-15/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/3814
+
+#+CATALOG_ID: 3814
+#+CATALOG_IDNO: TZA_2008-2014_NPS-UPD_v01_M
+#+CATALOG_TITLE: National Panel Survey 2008-2015, Uniform Panel Dataset
+#+CATALOG_YEARS: 2008-2015
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/655c-x145
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/3814
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Tanzania/2019-20/Documentation/SOURCE.org
+++ b/lsms_library/countries/Tanzania/2019-20/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/3885
+
+#+CATALOG_ID: 3885
+#+CATALOG_IDNO: TZA_2019_NPS-SDD_v06_M
+#+CATALOG_TITLE: National Panel Survey 2019-2020 - Extended Panel with Sex Disaggregated Data
+#+CATALOG_YEARS: 2019-2020
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/0y7d-1v78
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/3885
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Tanzania/2020-21/Documentation/SOURCE.org
+++ b/lsms_library/countries/Tanzania/2020-21/Documentation/SOURCE.org
@@ -1,3 +1,13 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/5639
+
+#+CATALOG_ID: 5639
+#+CATALOG_IDNO: TZA_2020_NPS-R5_v02_M
+#+CATALOG_TITLE: National Panel Survey 2020-21, Wave 5
+#+CATALOG_YEARS: 2020-2022
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/5639
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Tanzania_Kegera/2004-05/Documentation/SOURCE.org
+++ b/lsms_library/countries/Tanzania_Kegera/2004-05/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-https://microdata.worldbank.org/index.php/catalog/79/get-microdata
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/79
+
+#+CATALOG_ID: 79
+#+CATALOG_IDNO: TZA_2004_KHDS_v01_M
+#+CATALOG_TITLE: Kagera Health and Development Survey 2004 (Wave 5 Panel)
+#+CATALOG_YEARS: 2004-2004
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/5ayf-re90
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/79
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Tanzania_Kegera/2010-11/Documentation/SOURCE.org
+++ b/lsms_library/countries/Tanzania_Kegera/2010-11/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
+SOURCE
+
 https://microdata.worldbank.org/index.php/catalog/2251
+
+#+CATALOG_ID: 2251
+#+CATALOG_IDNO: TZA_2010_KHDS_v01_M
+#+CATALOG_TITLE: Kagera Health and Development Survey 2010, Wave 6
+#+CATALOG_YEARS: 2010-2010
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/x11b-sx16
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2251
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Timor-Leste/2001/Documentation/SOURCE.org
+++ b/lsms_library/countries/Timor-Leste/2001/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/3gq7-sk98]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/75
+
+#+CATALOG_ID: 75
+#+CATALOG_IDNO: TLS_2001_TLSS_v01_M
+#+CATALOG_TITLE: Living Standards Survey 2001
+#+CATALOG_YEARS: 2001-2001
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/3gq7-sk98
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/75
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Timor-Leste/2007-08/Documentation/SOURCE.org
+++ b/lsms_library/countries/Timor-Leste/2007-08/Documentation/SOURCE.org
@@ -1,1 +1,14 @@
-[[https://doi.org/10.48529/x7qj-ne03]]
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/78
+
+#+CATALOG_ID: 78
+#+CATALOG_IDNO: TLS_2007_TLSLS_v01_M
+#+CATALOG_TITLE: Survey of Living Standards 2007 and Extension 2008
+#+CATALOG_YEARS: 2007-2008
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/x7qj-ne03
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/78
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: doi-lookup
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Togo/2018/Documentation/SOURCE.org
+++ b/lsms_library/countries/Togo/2018/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/4298
+
+#+CATALOG_ID: 4298
+#+CATALOG_IDNO: TGO_2018_EHCVM_v02_M
+#+CATALOG_TITLE: Enquête Harmonisée sur le Conditions de Vie des Ménages 2018-2019
+#+CATALOG_YEARS: 2018-2019
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/ww9z-d865
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/4298
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Uganda/2005-06/Documentation/SOURCE.org
+++ b/lsms_library/countries/Uganda/2005-06/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/1001
+
+#+CATALOG_ID: 1001
+#+CATALOG_IDNO: UGA_2005-2009_UNPS_v03_M
+#+CATALOG_TITLE: National Panel Survey 2005-2009
+#+CATALOG_YEARS: 2005-2010
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/9vep-e461
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/1001
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Uganda/2009-10/Documentation/SOURCE.org
+++ b/lsms_library/countries/Uganda/2009-10/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/1001
+
+#+CATALOG_ID: 1001
+#+CATALOG_IDNO: UGA_2005-2009_UNPS_v03_M
+#+CATALOG_TITLE: National Panel Survey 2005-2009
+#+CATALOG_YEARS: 2005-2010
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/9vep-e461
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/1001
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Uganda/2010-11/Documentation/SOURCE.org
+++ b/lsms_library/countries/Uganda/2010-11/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/2166
+
+#+CATALOG_ID: 2166
+#+CATALOG_IDNO: UGA_2010_UNPS_v03_M
+#+CATALOG_TITLE: National Panel Survey 2010-2011
+#+CATALOG_YEARS: 2010-2011
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/w2d8-t244
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2166
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Uganda/2011-12/Documentation/SOURCE.org
+++ b/lsms_library/countries/Uganda/2011-12/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/2059
+
+#+CATALOG_ID: 2059
+#+CATALOG_IDNO: UGA_2011_UNPS_v02_M
+#+CATALOG_TITLE: National Panel Survey 2011-2012
+#+CATALOG_YEARS: 2011-2012
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/wjg5-bg56
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2059
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Uganda/2013-14/Documentation/SOURCE.org
+++ b/lsms_library/countries/Uganda/2013-14/Documentation/SOURCE.org
@@ -1,3 +1,13 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/2663
+
+#+CATALOG_ID: 2663
+#+CATALOG_IDNO: UGA_2013_UNPS_v02_M
+#+CATALOG_TITLE: National Panel Survey 2013-2014
+#+CATALOG_YEARS: 2013-2014
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/2663
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Uganda/2015-16/Documentation/SOURCE.org
+++ b/lsms_library/countries/Uganda/2015-16/Documentation/SOURCE.org
@@ -1,1 +1,13 @@
-https://microdata.worldbank.org/index.php/catalog/3460/
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/3460
+
+#+CATALOG_ID: 3460
+#+CATALOG_IDNO: UGA_2015_UNPS_v02_M
+#+CATALOG_TITLE: National Panel Survey 2015-2016
+#+CATALOG_YEARS: 2015-2016
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/3460
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Uganda/2018-19/Documentation/SOURCE.org
+++ b/lsms_library/countries/Uganda/2018-19/Documentation/SOURCE.org
@@ -1,1 +1,13 @@
-https://microdata.worldbank.org/index.php/catalog/3795/
+SOURCE
+
+https://microdata.worldbank.org/index.php/catalog/3795
+
+#+CATALOG_ID: 3795
+#+CATALOG_IDNO: UGA_2018_UNPS_v02_M
+#+CATALOG_TITLE: Uganda National Panel Survey 2018-2019
+#+CATALOG_YEARS: 2018-2019
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/3795
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/countries/Uganda/2019-20/Documentation/SOURCE.org
+++ b/lsms_library/countries/Uganda/2019-20/Documentation/SOURCE.org
@@ -1,3 +1,14 @@
-SOURCE 
+SOURCE
 
 https://microdata.worldbank.org/index.php/catalog/3902
+
+#+CATALOG_ID: 3902
+#+CATALOG_IDNO: UGA_2019_UNPS_v03_M
+#+CATALOG_TITLE: National Panel Survey 2019-2020
+#+CATALOG_YEARS: 2019-2020
+#+CATALOG_REPOSITORY: lsms
+#+CATALOG_DOI: https://doi.org/10.48529/nqzx-f196
+#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/3902
+#+PROVENANCE_SOURCE: worldbank
+#+PROVENANCE_METHOD: source-url
+#+PROVENANCE_RECORDED: 2026-07-12

--- a/lsms_library/data_access.py
+++ b/lsms_library/data_access.py
@@ -60,6 +60,12 @@ from urllib.parse import urlparse
 
 from . import config
 from .paths import countries_root
+from .provenance import (
+    SOURCE_WORLDBANK,
+    WaveProvenance,
+    read_provenance,
+    write_provenance,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -69,23 +75,122 @@ logger = logging.getLogger(__name__)
 # ``countries_root.cache_clear()`` within the same process.
 _COUNTRIES_DIR = countries_root()
 
-# WB LSMS collection: ISO-3166 alpha-3 codes for countries we track.
-# Used by discover_waves() to query the WB Microdata Library catalog.
+# ---------------------------------------------------------------------------
+# Country -> WB catalog registry
+# ---------------------------------------------------------------------------
+#
+# An ISO alpha-3 code alone is not enough to identify "our" surveys, because
+# several of our country directories are *different survey series from the
+# same nation*:
+#
+#   GhanaLSS / GhanaSPS  -- both ISO GHA (Living Standards Survey vs.
+#                           Socioeconomic Panel Survey)
+#   Tanzania / Tanzania_Kegera
+#                        -- both ISO TZA (National Panel Survey vs. the
+#                           Kagera Health and Development Survey)
+#
+# Without a discriminator each of those directories sees the other's catalog
+# entries as *its own* missing waves.  ``idno_pattern`` is a regex matched
+# against the catalog entry's ``idno`` (e.g. ``GHA_1987_GLSS_v02_M``), which
+# encodes the survey series and is the WB's own stable study identifier.
+#
+# ``discoverable=False`` marks a country whose data does not come from the WB
+# catalog at all.  It is recorded explicitly -- rather than simply omitted --
+# so that "we deliberately do not discover this" is distinguishable from "we
+# forgot to add a country code".
+
+
+class CountryCatalog:
+    """How a country directory maps onto the WB Microdata Library catalog."""
+
+    __slots__ = ("code", "idno_pattern", "discoverable", "reason")
+
+    def __init__(self, code: str | None, idno_pattern: str | None = None,
+                 discoverable: bool = True, reason: str | None = None):
+        self.code = code
+        self.idno_pattern = idno_pattern
+        self.discoverable = discoverable
+        self.reason = reason
+
+    def matches(self, entry: dict) -> bool:
+        """True when a catalog *entry* belongs to this country directory."""
+        if not self.idno_pattern:
+            return True
+        return bool(re.search(self.idno_pattern, str(entry.get("idno", ""))))
+
+
+_COUNTRY_CATALOG: dict[str, CountryCatalog] = {
+    "Afghanistan": CountryCatalog("AFG"),
+    "Albania": CountryCatalog("ALB"),
+    "Armenia": CountryCatalog("ARM"),
+    "Azerbaijan": CountryCatalog("AZE"),
+    "Benin": CountryCatalog("BEN"),
+    "Bosnia-Herzegovina": CountryCatalog("BIH"),
+    "Brazil": CountryCatalog("BRA"),
+    "Bulgaria": CountryCatalog("BGR"),
+    "Burkina_Faso": CountryCatalog("BFA"),
+    "Cambodia": CountryCatalog("KHM"),
+    "China": CountryCatalog("CHN"),
+    "CotedIvoire": CountryCatalog("CIV"),
+    "Ethiopia": CountryCatalog("ETH"),
+    # GHA is shared: GLSS (Living Standards Survey) vs GSPS (Socioeconomic
+    # Panel Survey).  Without the idno filter each sees the other's waves.
+    "GhanaLSS": CountryCatalog("GHA", idno_pattern=r"_GLSS"),
+    "GhanaSPS": CountryCatalog("GHA", idno_pattern=r"_GSPS"),
+    "Guatemala": CountryCatalog("GTM"),
+    "Guinea-Bissau": CountryCatalog("GNB"),
+    "Guyana": CountryCatalog("GUY"),
+    "India": CountryCatalog("IND"),
+    "Iraq": CountryCatalog("IRQ"),
+    "Kazakhstan": CountryCatalog("KAZ"),
+    "Kosovo": CountryCatalog("XKX"),
+    "Kyrgyz Republic": CountryCatalog("KGZ"),
+    "Liberia": CountryCatalog("LBR"),
+    "Malawi": CountryCatalog("MWI"),
+    "Mali": CountryCatalog("MLI"),
+    "Nepal": CountryCatalog("NPL"),
+    "Nicaragua": CountryCatalog("NIC"),
+    "Niger": CountryCatalog("NER"),
+    "Nigeria": CountryCatalog("NGA"),
+    "Pakistan": CountryCatalog("PAK"),
+    "Panama": CountryCatalog("PAN"),
+    "Peru": CountryCatalog("PER"),
+    "Rwanda": CountryCatalog("RWA"),
+    "Senegal": CountryCatalog("SEN"),
+    "Serbia": CountryCatalog("SRB"),
+    # Serbia and Montenegro was a distinct ISO entity (SCG); its two LSMS
+    # rounds are catalog ids 80 and 81, matching our 2002/ and 2003/ dirs.
+    "Serbia and Montenegro": CountryCatalog("SCG"),
+    "South Africa": CountryCatalog("ZAF"),
+    "Tajikistan": CountryCatalog("TJK"),
+    # TZA is shared: the National Panel Survey vs the Kagera Health and
+    # Development Survey (a separate longitudinal study).
+    "Tanzania": CountryCatalog("TZA", idno_pattern=r"_NPS"),
+    "Tanzania_Kegera": CountryCatalog("TZA", idno_pattern=r"_KHDS"),
+    "Timor-Leste": CountryCatalog("TLS"),
+    "Togo": CountryCatalog("TGO"),
+    "Uganda": CountryCatalog("UGA"),
+
+    # --- Not World Bank datasets -------------------------------------------
+    "EthiopiaRHS": CountryCatalog(
+        None, discoverable=False,
+        reason="Ethiopian Rural Household Survey is an IFPRI/Addis Ababa "
+               "University study distributed via Harvard Dataverse "
+               "(doi:10.7910/DVN/T8G8IV), not the World Bank Microdata "
+               "Library.  There is nothing to discover in the WB catalog."),
+    "KenyaLPS": CountryCatalog(
+        None, discoverable=False,
+        reason="Kenya Life Panel Survey is not distributed via the World "
+               "Bank Microdata Library (a KEN/lsms catalog query returns no "
+               "entries)."),
+}
+
+# Backwards-compatible view: the plain {country: ISO code} mapping that this
+# module exposed before the registry above.  Countries that are not WB-sourced
+# are absent, exactly as they were before.
 _COUNTRY_CODES: dict[str, str] = {
-    "Afghanistan": "AFG", "Albania": "ALB", "Armenia": "ARM",
-    "Azerbaijan": "AZE", "Benin": "BEN", "Bosnia-Herzegovina": "BIH",
-    "Brazil": "BRA", "Bulgaria": "BGR", "Burkina_Faso": "BFA",
-    "Cambodia": "KHM", "China": "CHN", "CotedIvoire": "CIV",
-    "Ethiopia": "ETH", "GhanaLSS": "GHA", "GhanaSPS": "GHA",
-    "Guatemala": "GTM", "Guinea-Bissau": "GNB", "Guyana": "GUY",
-    "India": "IND", "Iraq": "IRQ", "Kazakhstan": "KAZ",
-    "Kosovo": "XKX", "Kyrgyz Republic": "KGZ", "Liberia": "LBR",
-    "Malawi": "MWI", "Mali": "MLI", "Nepal": "NPL",
-    "Nicaragua": "NIC", "Niger": "NER", "Nigeria": "NGA",
-    "Pakistan": "PAK", "Panama": "PAN", "Peru": "PER",
-    "Rwanda": "RWA", "Senegal": "SEN", "Serbia": "SRB",
-    "South Africa": "ZAF", "Tajikistan": "TJK", "Tanzania": "TZA",
-    "Timor-Leste": "TLS", "Togo": "TGO", "Uganda": "UGA",
+    name: spec.code for name, spec in _COUNTRY_CATALOG.items()
+    if spec.code is not None
 }
 
 
@@ -1116,12 +1221,20 @@ def populate_and_push(country: str, wave: str,
 # ---------------------------------------------------------------------------
 
 def _wb_catalog_search(country_code: str,
-                       collection: str = "lsms",
+                       collection: str | None = "lsms",
                        ) -> list[dict]:
     """Query the WB Microdata Library catalog for a country.
 
     Returns a list of dicts with keys: ``id``, ``idno``, ``title``,
-    ``year_start``, ``year_end``, ``url``.
+    ``year_start``, ``year_end``, ``url``, ``doi``, ``repository``.
+
+    ``collection=None`` searches every collection, which is what provenance
+    resolution needs: a wave we hold may sit outside the ``lsms`` collection.
+
+    The ``doi`` field is what lets us resolve the many ``SOURCE.org`` files
+    that record a ``https://doi.org/10.48529/…`` link instead of a
+    ``/catalog/{id}`` URL -- the DOI does not encode the numeric id, but the
+    catalog row carries both.
     """
     import json
     import urllib.request
@@ -1131,33 +1244,52 @@ def _wb_catalog_search(country_code: str,
         logger.error("No MICRODATA_API_KEY; cannot search WB catalog.")
         return []
 
-    url = ("https://microdata.worldbank.org/index.php/api/catalog/search"
-           f"?ps=100&collection={collection}&country={country_code}")
-    req = urllib.request.Request(url)
-    req.add_header("X-API-KEY", api_key)
-    req.add_header("Accept", "application/json")
+    base = "https://microdata.worldbank.org/index.php/api/catalog/search"
+    results: list[dict] = []
+    page = 1
+    page_size = 100
 
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            data = json.loads(resp.read())
-    except (urllib.error.URLError, OSError, TimeoutError,
-            json.JSONDecodeError) as exc:
-        # network / HTTP / decode failure; programmer bugs propagate.
-        logger.error("WB catalog search failed: %s", exc)
-        return []
+    while True:
+        url = f"{base}?ps={page_size}&page={page}&country={country_code}"
+        if collection:
+            url += f"&collection={collection}"
+        req = urllib.request.Request(url)
+        req.add_header("X-API-KEY", api_key)
+        req.add_header("Accept", "application/json")
 
-    results = []
-    for row in data.get("result", {}).get("rows", []):
-        sid = str(row.get("id", ""))
-        results.append({
-            "id": sid,
-            "idno": row.get("idno", ""),
-            "title": row.get("title", ""),
-            "year_start": row.get("year_start", ""),
-            "year_end": row.get("year_end", ""),
-            "url": (f"https://microdata.worldbank.org"
-                    f"/index.php/catalog/{sid}"),
-        })
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = json.loads(resp.read())
+        except (urllib.error.URLError, OSError, TimeoutError,
+                json.JSONDecodeError) as exc:
+            # network / HTTP / decode failure; programmer bugs propagate.
+            logger.error("WB catalog search failed: %s", exc)
+            return results
+
+        result = data.get("result", {})
+        rows = result.get("rows", []) or []
+        for row in rows:
+            sid = str(row.get("id", ""))
+            results.append({
+                "id": sid,
+                "idno": row.get("idno", ""),
+                "title": row.get("title", ""),
+                "year_start": row.get("year_start", ""),
+                "year_end": row.get("year_end", ""),
+                "doi": row.get("doi", "") or "",
+                "repository": row.get("repositoryid", "") or "",
+                "url": (f"https://microdata.worldbank.org"
+                        f"/index.php/catalog/{sid}"),
+            })
+
+        try:
+            found = int(result.get("found", 0))
+        except (TypeError, ValueError):
+            found = len(results)
+        if len(rows) < page_size or len(results) >= found:
+            break
+        page += 1
+
     return results
 
 
@@ -1184,14 +1316,67 @@ def _catalog_to_wave_label(entry: dict) -> str:
     return ys
 
 
+def wave_provenance(country: str, wave: str) -> WaveProvenance:
+    """Return the recorded provenance of one local wave directory.
+
+    A wave with no ``SOURCE.org`` yields a record whose ``source`` is
+    ``"unknown"`` -- never a guess.  See :mod:`lsms_library.provenance`.
+    """
+    return read_provenance(_COUNTRIES_DIR, country, wave)
+
+
+def local_catalog_ids(country: str) -> dict[str, list[str]]:
+    """Map each WB catalog id we hold locally -> the wave dirs holding it.
+
+    One catalog entry can legitimately back **several** wave directories: WB
+    id 1001 (``UGA_2005-2009_UNPS``) covers both ``Uganda/2005-06/`` and
+    ``Uganda/2009-10/``.  Hence a list, not a scalar.
+    """
+    held: dict[str, list[str]] = {}
+    for wave in _local_waves(country):
+        prov = read_provenance(_COUNTRIES_DIR, country, wave)
+        if prov.is_worldbank and prov.catalog_id:
+            held.setdefault(prov.catalog_id, []).append(wave)
+    return {k: sorted(v) for k, v in held.items()}
+
+
 def discover_waves(country: str,
                    collection: str = "lsms",
                    ) -> list[dict]:
-    """Find WB catalog entries for *country* that we don't have locally.
+    """Find WB catalog entries for *country*, flagging which we already hold.
 
-    Each returned dict has the WB catalog fields plus ``"wave"`` (our
-    directory-name convention) and ``"local"`` (bool, True if we
-    already have it).
+    Matching is done on the **WB catalog id** recorded in each wave's
+    ``Documentation/SOURCE.org`` (see :mod:`lsms_library.provenance`), not on
+    a wave label reconstructed from the entry's year range.  Label matching
+    was wrong in both directions:
+
+    * *False positive* -- ``Nigeria/2018-19/`` holds GHS-Panel Wave 4 (id
+      3557), but the Living Standards Survey (id 3827) also spans 2018-2019,
+      so it too rendered as the label ``"2018-19"`` and was reported as
+      already held.  It is not.
+    * *False negative* -- WB id 1001 (``UGA_2005-2009_UNPS``) renders as
+      ``"2005-10"``, which matches no directory, so it looked missing even
+      though we hold it, split across ``2005-06/`` and ``2009-10/``.
+
+    Each returned dict carries the WB catalog fields plus:
+
+    ``wave``
+        Our directory-name convention, derived from the entry's year range.
+        Retained for display and for the label fallback below.
+    ``local``
+        ``bool`` -- ``True`` only when a local wave directory *records* this
+        catalog id.  Unchanged in type and truthiness from previous releases,
+        so existing callers keep working.
+    ``local_status``
+        ``"yes"`` / ``"no"`` / ``"unknown"`` -- the honest tri-state.
+        ``"unknown"`` means a directory whose label matches this entry exists
+        but has no recorded WB catalog id, so we cannot say whether it holds
+        this study or a different one that happens to share a year range.
+        These rows have ``local=False``: an unverified claim is treated as
+        not-held, because wrongly believing we hold a survey is the failure
+        mode that hides missing data.
+    ``local_waves``
+        The wave directories backing this entry (empty unless ``local``).
 
     Parameters
     ----------
@@ -1203,22 +1388,50 @@ def discover_waves(country: str,
     Returns
     -------
     list[dict]
-        Catalog entries sorted by year, annotated with local status.
+        Catalog entries sorted by year, annotated with local status.  Empty
+        for countries whose data does not come from the WB catalog at all
+        (e.g. ``EthiopiaRHS``); those log an explanatory message.
     """
-    code = _COUNTRY_CODES.get(country)
-    if not code:
-        logger.error("No ISO country code for %r. Add it to "
-                     "_COUNTRY_CODES in data_access.py.", country)
+    spec = _COUNTRY_CATALOG.get(country)
+    if spec is None:
+        logger.error("No WB catalog mapping for %r. Add it to "
+                     "_COUNTRY_CATALOG in data_access.py.", country)
+        return []
+    if not spec.discoverable or not spec.code:
+        logger.info("%s is not discoverable via the WB catalog: %s",
+                    country, spec.reason or "not a World Bank dataset.")
         return []
 
-    entries = _wb_catalog_search(code, collection)
-    local = set(_local_waves(country))
+    entries = [e for e in _wb_catalog_search(spec.code, collection)
+               if spec.matches(e)]
+
+    held = local_catalog_ids(country)
+    # Wave dirs whose WB catalog id we do NOT know: either no SOURCE.org, or
+    # one that records a non-WB source.  These are the only dirs for which we
+    # fall back to the old label heuristic -- and we mark the result unknown.
+    unresolved = {
+        w for w in _local_waves(country)
+        if not read_provenance(_COUNTRIES_DIR, country, w).is_worldbank
+    }
 
     for e in entries:
         e["wave"] = _catalog_to_wave_label(e)
-        e["local"] = e["wave"] in local
+        if e["id"] in held:
+            e["local"] = True
+            e["local_status"] = "yes"
+            e["local_waves"] = held[e["id"]]
+        elif e["wave"] in unresolved:
+            # A directory with this label exists, but nothing records what it
+            # actually holds.  Do not claim either way.
+            e["local"] = False
+            e["local_status"] = "unknown"
+            e["local_waves"] = [e["wave"]]
+        else:
+            e["local"] = False
+            e["local_status"] = "no"
+            e["local_waves"] = []
 
-    return sorted(entries, key=lambda e: e.get("year_start", ""))
+    return sorted(entries, key=lambda e: str(e.get("year_start", "")))
 
 
 def _get_console(verbose: bool):
@@ -1305,15 +1518,19 @@ def add_wave(country: str, catalog_id: str,
         return []
     log(f"IDNO: [bold]{idno}[/bold]")
 
-    # --- Derive wave label --------------------------------------------------
+    # --- Look up the catalog entry (wave label + provenance metadata) --------
+    entry: dict | None = None
+    spec = _COUNTRY_CATALOG.get(country)
+    if spec is not None and spec.code:
+        with status("Looking up catalog entry ..."):
+            for e in _wb_catalog_search(spec.code, collection=None):
+                if str(e["id"]) == cat_id:
+                    entry = e
+                    break
+
     if wave is None:
-        with status("Looking up wave years ..."):
-            code = _COUNTRY_CODES.get(country)
-            if code:
-                for e in _wb_catalog_search(code):
-                    if str(e["id"]) == cat_id:
-                        wave = _catalog_to_wave_label(e)
-                        break
+        if entry is not None:
+            wave = _catalog_to_wave_label(entry)
         if not wave:
             logger.error("Cannot derive wave label; pass wave= explicitly.")
             return []
@@ -1352,9 +1569,28 @@ def add_wave(country: str, catalog_id: str,
     (wave_dir / "Documentation").mkdir(parents=True, exist_ok=True)
     (wave_dir / "_").mkdir(parents=True, exist_ok=True)
 
-    source_file = wave_dir / "Documentation" / "SOURCE.org"
-    if not source_file.exists():
-        source_file.write_text(f"SOURCE\n\n{catalog_url}\n")
+    # Record provenance: the WB catalog *id* this directory came from, so
+    # discover_waves() can match on identity instead of guessing from a
+    # year-derived label.  Always (re)written -- add_wave knows the id for a
+    # fact, and an existing bare-URL SOURCE.org carries strictly less
+    # information than the record we can write here.
+    years = None
+    if entry is not None:
+        ys, ye = entry.get("year_start"), entry.get("year_end")
+        years = f"{ys}-{ye}" if ys and ye else (str(ys) if ys else None)
+
+    write_provenance(_COUNTRIES_DIR, WaveProvenance(
+        country=country,
+        wave=wave,
+        source=SOURCE_WORLDBANK,
+        catalog_id=cat_id,
+        idno=idno,
+        title=(entry or {}).get("title") or None,
+        years=years,
+        repository=(entry or {}).get("repository") or None,
+        url=catalog_url,
+        method="add-wave",
+    ))
     log(f"Created {country}/{wave}/ directory structure")
 
     # --- Download -----------------------------------------------------------

--- a/lsms_library/provenance.py
+++ b/lsms_library/provenance.py
@@ -1,0 +1,310 @@
+"""Per-wave provenance: which source dataset a wave directory actually holds.
+
+Every wave directory ``countries/{Country}/{wave}/`` records where its raw
+data came from in ``Documentation/SOURCE.org``.  Historically that file held
+nothing but a bare URL, which was enough for a human but not for code:
+
+* Roughly half the recorded URLs are **DOIs** (``https://doi.org/10.48529/…``)
+  rather than ``/catalog/{id}`` links, so no catalog id could be extracted.
+* Nothing tied a wave directory to a specific World Bank catalog **id**, so
+  :func:`lsms_library.data_access.discover_waves` had to guess which catalog
+  entries we already held by reconstructing a wave *label* from the entry's
+  year range (``year_start=2018, year_end=2019 -> "2018-19"``) and string-
+  matching it against directory names.  Labels collide: ``Nigeria/2018-19``
+  matched **both** the Living Standards Survey (id 3827) and the GHS-Panel
+  Wave 4 (id 3557).  We hold W4; the label heuristic reported that we held
+  the LSS.
+
+This module makes provenance explicit and machine-readable.  It **extends**
+``SOURCE.org`` (the file :func:`lsms_library.data_access.add_wave` already
+writes) rather than introducing a parallel mechanism, by appending org-mode
+``#+KEY: value`` keyword lines beneath the existing free-text URL body.  The
+bare URL stays as the first URL in the file, so the legacy reader
+(``data_access._read_source_url``, which greps the first ``http(s)://…``)
+keeps working unchanged.
+
+Example::
+
+    SOURCE
+
+    https://microdata.worldbank.org/index.php/catalog/3557
+
+    #+CATALOG_ID: 3557
+    #+CATALOG_IDNO: NGA_2018_GHSP-W4_v03_M
+    #+CATALOG_TITLE: General Household Survey, Panel 2018-2019, Wave 4
+    #+CATALOG_YEARS: 2018-2019
+    #+CATALOG_REPOSITORY: lsms
+    #+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/3557
+    #+PROVENANCE_SOURCE: worldbank
+    #+PROVENANCE_METHOD: source-url
+    #+PROVENANCE_RECORDED: 2026-07-12
+
+Three ``PROVENANCE_SOURCE`` values are possible, and the distinction between
+the last two matters:
+
+``worldbank``
+    The wave came from the WB Microdata Library and ``CATALOG_ID`` is the
+    numeric catalog id.
+``external``
+    The wave came from somewhere that is definitively *not* the WB catalog
+    (Ghana Statistical Service, Harvard Dataverse, …).  ``CATALOG_ID`` is
+    ``none`` — we know there is no WB id to record.
+``unknown``
+    We do **not** know where this wave came from.  ``CATALOG_ID`` is
+    ``unknown``.  This is recorded explicitly rather than left blank so that
+    a gap in our knowledge is visible and greppable instead of silently
+    defaulting to a confident-looking answer.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# DOI prefix of the World Bank Microdata Library.  A SOURCE.org whose URL is
+# a doi.org link with this prefix is a WB study whose numeric catalog id we
+# have to look up (the DOI does not contain it).
+WB_DOI_PREFIX = "10.48529"
+
+WB_HOSTS = ("microdata.worldbank.org",)
+
+# PROVENANCE_SOURCE values.
+SOURCE_WORLDBANK = "worldbank"
+SOURCE_EXTERNAL = "external"
+SOURCE_UNKNOWN = "unknown"
+
+# Sentinel CATALOG_ID values.  ``none`` = definitively not a WB catalog entry;
+# ``unknown`` = we have not determined it.  Kept distinct on purpose.
+_ID_NONE = "none"
+_ID_UNKNOWN = "unknown"
+
+_KEYWORD_RE = re.compile(r"^\s*#\+([A-Z_]+):\s*(.*?)\s*$", re.MULTILINE)
+_URL_RE = re.compile(r"https?://[^\s\]\)]+")
+_CATALOG_ID_RE = re.compile(r"/catalog/(\d+)")
+
+# Human-written prose in a legacy SOURCE.org (e.g. the EthiopiaRHS round map)
+# is preserved verbatim beneath this heading rather than being overwritten by
+# the structured record.  Parsing it back out again makes the writer
+# idempotent: re-running the backfill does not nest or duplicate the block.
+NOTES_HEADING = "* Notes (preserved from the original SOURCE.org)"
+
+# A line that carries no information beyond the URL itself: the literal
+# "SOURCE" banner, or a bare URL / org-mode [[link]].
+_BOILERPLATE_RE = re.compile(
+    r"^\s*(SOURCE|/?\[?\[?https?://[^\]\s]*\]?\]?)\s*$", re.IGNORECASE)
+
+
+def preserved_prose(text: str) -> str | None:
+    """Extract human-written prose from a SOURCE.org, dropping boilerplate.
+
+    Returns ``None`` when the file says nothing beyond its URL.  Idempotent:
+    text already rendered by :func:`render_source_org` yields back exactly the
+    prose it preserved.
+    """
+    if NOTES_HEADING in text:
+        text = text.split(NOTES_HEADING, 1)[1]
+    lines = [ln.rstrip() for ln in text.splitlines()]
+    keep = [ln for ln in lines
+            if ln.strip()
+            and not ln.lstrip().startswith("#+")
+            and not _BOILERPLATE_RE.match(ln)]
+    return "\n".join(keep) if keep else None
+
+
+@dataclass
+class WaveProvenance:
+    """Provenance record for one ``countries/{country}/{wave}/`` directory."""
+
+    country: str
+    wave: str
+    source: str = SOURCE_UNKNOWN          # worldbank | external | unknown
+    catalog_id: str | None = None         # WB numeric id, None if not WB/unknown
+    idno: str | None = None               # WB string idno, e.g. NGA_2018_GHSP-W4_v03_M
+    title: str | None = None
+    years: str | None = None              # "2018-2019"
+    repository: str | None = None         # WB collection, e.g. "lsms"
+    doi: str | None = None                # study DOI, when the catalog has one
+    url: str | None = None                # the source URL as recorded
+    method: str | None = None             # how the id was determined
+    recorded: str | None = None           # ISO date we wrote the record
+    note: str | None = None
+    superseded_url: str | None = None     # prior URL, when we corrected one
+    notes: str | None = None              # human prose preserved from the original
+    extra: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def is_worldbank(self) -> bool:
+        """True when this wave is a WB study with a known numeric catalog id."""
+        return self.source == SOURCE_WORLDBANK and bool(self.catalog_id)
+
+    @property
+    def is_resolved(self) -> bool:
+        """True when we know where this wave came from (WB id, or 'external').
+
+        ``False`` only for :data:`SOURCE_UNKNOWN` — i.e. a genuine gap.
+        """
+        return self.is_worldbank or self.source == SOURCE_EXTERNAL
+
+
+def source_org_path(countries_dir: Path, country: str, wave: str) -> Path:
+    """Return the path of a wave's ``Documentation/SOURCE.org``."""
+    return Path(countries_dir) / country / wave / "Documentation" / "SOURCE.org"
+
+
+def _classify_url(url: str | None) -> tuple[str, str | None]:
+    """Classify a source URL -> ``(provenance_source, catalog_id_or_None)``."""
+    if not url:
+        return SOURCE_UNKNOWN, None
+    if any(h in url for h in WB_HOSTS):
+        m = _CATALOG_ID_RE.search(url)
+        # A WB URL without /catalog/{id} (e.g. a bare host link) is still WB,
+        # but we do not know the id from the URL alone.
+        return SOURCE_WORLDBANK, (m.group(1) if m else None)
+    if WB_DOI_PREFIX in url:
+        # A WB Microdata DOI.  It IS a WB study, but the numeric id has to be
+        # resolved against the catalog -- the DOI does not encode it.
+        return SOURCE_WORLDBANK, None
+    return SOURCE_EXTERNAL, None
+
+
+def parse_source_org(text: str, country: str, wave: str) -> WaveProvenance:
+    """Parse ``SOURCE.org`` text into a :class:`WaveProvenance`.
+
+    Understands both the structured ``#+KEY: value`` form written by
+    :func:`render_source_org` and the legacy bare-URL form, so a wave that
+    has not been backfilled still yields a usable (if less precise) record.
+    """
+    kw = {k: v for k, v in _KEYWORD_RE.findall(text)}
+
+    url = kw.get("CATALOG_URL") or None
+    if not url:
+        m = _URL_RE.search(text)
+        url = m.group(0).rstrip("/") if m else None
+
+    raw_id = kw.get("CATALOG_ID")
+    if raw_id in (_ID_UNKNOWN, _ID_NONE, ""):
+        catalog_id = None
+    else:
+        catalog_id = raw_id or None
+
+    source = kw.get("PROVENANCE_SOURCE")
+    if not source:
+        # Legacy file: infer from the URL.
+        source, inferred_id = _classify_url(url)
+        catalog_id = catalog_id or inferred_id
+        method = "legacy-source-url" if url else None
+    else:
+        method = kw.get("PROVENANCE_METHOD")
+
+    known = {"CATALOG_ID", "CATALOG_IDNO", "CATALOG_TITLE", "CATALOG_YEARS",
+             "CATALOG_REPOSITORY", "CATALOG_DOI", "CATALOG_URL",
+             "PROVENANCE_SOURCE", "PROVENANCE_METHOD", "PROVENANCE_RECORDED",
+             "PROVENANCE_NOTE", "PROVENANCE_SUPERSEDED_URL"}
+
+    return WaveProvenance(
+        country=country,
+        wave=wave,
+        source=source or SOURCE_UNKNOWN,
+        catalog_id=catalog_id,
+        idno=kw.get("CATALOG_IDNO") or None,
+        title=kw.get("CATALOG_TITLE") or None,
+        years=kw.get("CATALOG_YEARS") or None,
+        repository=kw.get("CATALOG_REPOSITORY") or None,
+        doi=kw.get("CATALOG_DOI") or None,
+        url=url,
+        method=method,
+        recorded=kw.get("PROVENANCE_RECORDED") or None,
+        note=kw.get("PROVENANCE_NOTE") or None,
+        superseded_url=kw.get("PROVENANCE_SUPERSEDED_URL") or None,
+        notes=preserved_prose(text),
+        extra={k: v for k, v in kw.items() if k not in known},
+    )
+
+
+def render_source_org(prov: WaveProvenance) -> str:
+    """Render a :class:`WaveProvenance` as ``SOURCE.org`` text.
+
+    The recorded URL is emitted as the first ``http(s)://`` in the file so the
+    legacy reader (``data_access._read_source_url``) keeps finding it.
+    """
+    body = prov.url if prov.url else "(source URL not recorded)"
+    lines = ["SOURCE", "", body, ""]
+
+    if prov.is_worldbank:
+        cat_id = prov.catalog_id
+    elif prov.source == SOURCE_EXTERNAL:
+        cat_id = _ID_NONE
+    else:
+        cat_id = _ID_UNKNOWN
+    lines.append(f"#+CATALOG_ID: {cat_id}")
+
+    for key, val in (("CATALOG_IDNO", prov.idno),
+                     ("CATALOG_TITLE", prov.title),
+                     ("CATALOG_YEARS", prov.years),
+                     ("CATALOG_REPOSITORY", prov.repository),
+                     ("CATALOG_DOI", prov.doi),
+                     ("CATALOG_URL", prov.url)):
+        if val:
+            lines.append(f"#+{key}: {val}")
+
+    lines.append(f"#+PROVENANCE_SOURCE: {prov.source}")
+    if prov.method:
+        lines.append(f"#+PROVENANCE_METHOD: {prov.method}")
+    recorded = prov.recorded or _dt.date.today().isoformat()
+    lines.append(f"#+PROVENANCE_RECORDED: {recorded}")
+    # A superseded URL equal to the current one carries no information and
+    # would mask the URL it was meant to record.  Drop it.
+    if prov.superseded_url and (prov.superseded_url.rstrip("/")
+                                != (prov.url or "").rstrip("/")):
+        lines.append(f"#+PROVENANCE_SUPERSEDED_URL: {prov.superseded_url}")
+    if prov.note:
+        lines.append(f"#+PROVENANCE_NOTE: {prov.note}")
+
+    # Never silently drop human-written prose.
+    if prov.notes:
+        lines += ["", NOTES_HEADING, prov.notes]
+
+    return "\n".join(lines) + "\n"
+
+
+def read_provenance(countries_dir: Path, country: str,
+                    wave: str) -> WaveProvenance:
+    """Read one wave's provenance.
+
+    A missing or unreadable ``SOURCE.org`` yields a record with
+    ``source == 'unknown'`` -- never a guess.
+    """
+    path = source_org_path(countries_dir, country, wave)
+    if not path.exists():
+        return WaveProvenance(country=country, wave=wave,
+                              source=SOURCE_UNKNOWN, method="no-source-org")
+    try:
+        text = path.read_text()
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.debug("Could not read %s: %s", path, exc)
+        return WaveProvenance(country=country, wave=wave,
+                              source=SOURCE_UNKNOWN, method="unreadable")
+    return parse_source_org(text, country, wave)
+
+
+def write_provenance(countries_dir: Path, prov: WaveProvenance) -> Path:
+    """Write a wave's ``SOURCE.org``, creating ``Documentation/`` if needed."""
+    path = source_org_path(countries_dir, prov.country, prov.wave)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_source_org(prov))
+    return path
+
+
+def country_provenance(countries_dir: Path, country: str,
+                       waves: list[str]) -> dict[str, WaveProvenance]:
+    """Read provenance for every wave of *country*.
+
+    Every wave in *waves* gets an entry; waves with no ``SOURCE.org`` get an
+    explicit ``unknown`` record rather than being omitted.
+    """
+    return {w: read_provenance(countries_dir, country, w) for w in waves}

--- a/scripts/backfill_wave_provenance.py
+++ b/scripts/backfill_wave_provenance.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python
+"""Backfill each wave directory's WB catalog id into its ``SOURCE.org``.
+
+Every ``countries/{Country}/{wave}/`` directory should record *which* World
+Bank catalog entry (or which non-WB source) it actually holds, so that
+``discover_waves()`` can match on identity rather than on a wave label
+reconstructed from a year range.  See :mod:`lsms_library.provenance`.
+
+Resolution is evidence-based.  A wave is only marked resolved when the
+evidence is conclusive; otherwise it is recorded as ``unknown``.  **We never
+guess.**  In particular a wave with no ``SOURCE.org`` is *not* resolved by
+matching its directory name against a catalog year range -- that heuristic is
+exactly the bug this work exists to remove.
+
+Resolution ladder
+-----------------
+1. ``source-url``      -- ``SOURCE.org`` records a ``/catalog/{id}`` URL on a
+                          World Bank host.  The id is verified to exist in the
+                          WB catalog for this country.
+2. ``doi-lookup``      -- ``SOURCE.org`` records a WB Microdata DOI
+                          (``10.48529/…``).  The DOI does not encode the id,
+                          but the catalog row carries a ``doi`` field, so the
+                          id is recovered by exact DOI match.
+3. ``external-source`` -- ``SOURCE.org`` records a non-WB host (Ghana
+                          Statistical Service, Harvard Dataverse, …).  There
+                          is no WB id; recorded as ``external``.
+4. ``manual-override`` -- a small, explicitly justified table (below) for
+                          waves whose recorded URL is demonstrably wrong.
+5. otherwise           -- recorded as ``unknown``.
+
+Usage
+-----
+    python scripts/backfill_wave_provenance.py --dry-run      # report only
+    python scripts/backfill_wave_provenance.py                # write files
+    python scripts/backfill_wave_provenance.py --country Nigeria
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from lsms_library.data_access import (
+    _COUNTRY_CATALOG,
+    _local_waves,
+    _wb_catalog_search,
+)
+from lsms_library.paths import countries_root
+from lsms_library.provenance import (
+    SOURCE_EXTERNAL,
+    SOURCE_UNKNOWN,
+    SOURCE_WORLDBANK,
+    WB_DOI_PREFIX,
+    WaveProvenance,
+    read_provenance,
+    source_org_path,
+    write_provenance,
+)
+
+# ---------------------------------------------------------------------------
+# Manual overrides
+# ---------------------------------------------------------------------------
+# Each entry must cite the evidence that overrides what SOURCE.org records.
+# Keep this table tiny and justified; it is not a place to park guesses.
+
+_OVERRIDES: dict[tuple[str, str], dict] = {
+    ("Nigeria", "2018-19"): {
+        "catalog_id": "3557",
+        "note": (
+            "Corrected from catalog 3827 (NGA_2018_LSS, 'Living Standards "
+            "Survey 2018-2019').  The data files in this directory are "
+            "sect*_plantingw4 / sect*_harvestw4 / nga_*_y4 -- i.e. General "
+            "Household Survey Panel Wave 4 (NGA_2018_GHSP-W4, catalog 3557). "
+            "Both studies span 2018-2019, so the previously recorded id was "
+            "the wrong one of the two.  Every sibling Nigeria wave is also "
+            "GHS-Panel (W1=1002, W2=1952, W3=2734, W5=6410)."
+        ),
+    },
+}
+
+
+def _wave_dirs(root: Path, country: str) -> list[str]:
+    return _local_waves(country)
+
+
+def _declared_waves(country: str) -> set[str] | None:
+    """Waves the library itself recognises, or ``None`` if it cannot say."""
+    try:
+        import lsms_library as ll
+        return set(ll.Country(country).waves)
+    except Exception as exc:                      # noqa: BLE001 - best effort
+        print(f"  ! {country}: could not read Country.waves ({exc!r}); "
+              "will only update wave dirs that already have a SOURCE.org")
+        return None
+
+
+def _may_write(country: str, wave: str, root: Path,
+               declared: set[str] | None) -> bool:
+    """May we write ``{country}/{wave}/Documentation/SOURCE.org``?
+
+    **SOURCE.org is load-bearing.**  ``Country.waves`` (country.py) falls back
+    to scanning for subdirectories that contain ``Documentation/SOURCE.org``
+    when the country declares no explicit wave list.  For such a country,
+    *creating* a SOURCE.org in a directory silently promotes that directory
+    into a wave -- changing what the library reports and what every
+    wave-iterating table must now cover.
+
+    That is exactly what happened to ``Benin/2018-2019/`` (a stray duplicate of
+    ``Benin/2018-19/``, same .dta files, no SOURCE.org): stamping it made it a
+    wave, and ``sample()`` did not cover it.
+
+    So: only ever *update* a SOURCE.org that already exists, or *create* one in
+    a directory the library already declares a wave.  Never let recording
+    provenance change ``Country.waves``.
+    """
+    if source_org_path(root, country, wave).exists():
+        return True                                # updating: always safe
+    if declared is None:
+        return False                               # cannot verify: don't risk it
+    return wave in declared                        # creating: only for real waves
+
+
+def _build_catalog_index(code: str) -> tuple[dict[str, dict], dict[str, dict]]:
+    """Return ``(by_id, by_doi)`` for a country, across *all* collections.
+
+    Searching every collection (not just ``lsms``) matters: a wave we hold may
+    be catalogued outside the LSMS collection.
+    """
+    rows = _wb_catalog_search(code, collection=None)
+    by_id = {str(r["id"]): r for r in rows}
+    by_doi: dict[str, dict] = {}
+    for r in rows:
+        doi = str(r.get("doi") or "")
+        if doi:
+            # Index by the bare DOI suffix so 'https://doi.org/10.48529/x'
+            # and '10.48529/x' both match.
+            by_doi[doi.split("doi.org/")[-1].strip().rstrip("/")] = r
+    return by_id, by_doi
+
+
+def _years(entry: dict) -> str | None:
+    ys, ye = entry.get("year_start"), entry.get("year_end")
+    if ys and ye:
+        return f"{ys}-{ye}"
+    return str(ys) if ys else None
+
+
+def _from_entry(country: str, wave: str, entry: dict, method: str,
+                today: str, note: str | None = None,
+                superseded: str | None = None,
+                notes: str | None = None) -> WaveProvenance:
+    return WaveProvenance(
+        country=country, wave=wave,
+        source=SOURCE_WORLDBANK,
+        catalog_id=str(entry["id"]),
+        idno=entry.get("idno") or None,
+        title=entry.get("title") or None,
+        years=_years(entry),
+        repository=entry.get("repository") or None,
+        doi=entry.get("doi") or None,
+        url=entry.get("url"),
+        method=method,
+        recorded=today,
+        note=note,
+        superseded_url=superseded,
+        notes=notes,
+    )
+
+
+def resolve(country: str, wave: str, root: Path,
+            by_id: dict[str, dict], by_doi: dict[str, dict],
+            today: str) -> tuple[WaveProvenance, str]:
+    """Resolve one wave's provenance.  Returns ``(record, outcome)``."""
+    existing = read_provenance(root, country, wave)
+    # Human-written prose in the original file is carried through verbatim.
+    keep = existing.notes
+
+    # --- 4. Manual override (evidence beats the recorded URL) ---------------
+    ov = _OVERRIDES.get((country, wave))
+    if ov:
+        entry = by_id.get(ov["catalog_id"])
+        if entry:
+            # Remember the URL we replaced -- but only the *original* one.  On
+            # a re-run ``existing.url`` is already the corrected URL, so an
+            # unguarded assignment would overwrite the record of the mistake
+            # with a self-reference and lose it.
+            prior = existing.superseded_url or existing.url
+            canonical = (entry.get("url") or "").rstrip("/")
+            superseded = (prior if prior and prior.rstrip("/") != canonical
+                          else None)
+            return _from_entry(country, wave, entry, "manual-override", today,
+                               note=ov["note"], superseded=superseded,
+                               notes=keep), "override"
+
+    url = existing.url or ""
+
+    # --- 1. A /catalog/{id} URL on a World Bank host ------------------------
+    if existing.source == SOURCE_WORLDBANK and existing.catalog_id:
+        entry = by_id.get(existing.catalog_id)
+        if entry:
+            # Re-running on an already-stamped tree must not rewrite history:
+            # once a DOI has been resolved we record a /catalog/{id} CATALOG_URL,
+            # so a naive second pass would come through here and relabel the
+            # record "source-url", erasing the fact that we learned the id by
+            # DOI lookup (or by manual override).  Keep the original method.
+            method = (existing.method
+                      if existing.method in ("doi-lookup", "manual-override",
+                                             "add-wave")
+                      else "source-url")
+            return _from_entry(country, wave, entry, method, today,
+                               notes=keep,
+                               superseded=existing.superseded_url), method
+        # Recorded an id the catalog does not have for this country.  Do not
+        # invent a replacement.
+        return WaveProvenance(
+            country=country, wave=wave, source=SOURCE_UNKNOWN, url=url,
+            method="unresolved", recorded=today, notes=keep,
+            note=(f"SOURCE.org records WB catalog id {existing.catalog_id}, "
+                  "but no such entry exists in this country's catalog. "
+                  "Needs human review."),
+        ), "unknown"
+
+    # --- 2. A WB Microdata DOI ---------------------------------------------
+    if WB_DOI_PREFIX in url:
+        suffix = url.split("doi.org/")[-1].strip().rstrip("/")
+        entry = by_doi.get(suffix)
+        if entry:
+            return _from_entry(country, wave, entry, "doi-lookup", today,
+                               notes=keep), "doi-lookup"
+        return WaveProvenance(
+            country=country, wave=wave, source=SOURCE_UNKNOWN, url=url,
+            method="unresolved", recorded=today, notes=keep,
+            note=(f"SOURCE.org records WB DOI {suffix}, which did not match "
+                  "any catalog entry for this country.  Needs human review."),
+        ), "unknown"
+
+    # --- 3. A non-WB host ---------------------------------------------------
+    if url and existing.source == SOURCE_EXTERNAL:
+        host = url.split("//")[-1].split("/")[0]
+        return WaveProvenance(
+            country=country, wave=wave, source=SOURCE_EXTERNAL,
+            url=url, method="external-source", recorded=today, notes=keep,
+            note=f"Obtained from {host}, not the World Bank Microdata Library.",
+        ), "external"
+
+    # --- 5. Unknown ---------------------------------------------------------
+    return WaveProvenance(
+        country=country, wave=wave, source=SOURCE_UNKNOWN, url=url or None,
+        method="unresolved", recorded=today, notes=keep,
+        note=("No source URL recorded for this wave; its World Bank catalog "
+              "id is unknown.  Deliberately NOT inferred from the directory "
+              "name -- year-range labels collide across distinct surveys."),
+    ), "unknown"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--country", action="append",
+                    help="limit to this country (repeatable)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report what would be written; change nothing")
+    args = ap.parse_args(argv)
+
+    root = countries_root()
+    today = dt.date.today().isoformat()
+
+    countries = args.country or sorted(
+        d.name for d in root.iterdir()
+        if d.is_dir() and not d.name.startswith((".", "_")) and _local_waves(d.name)
+    )
+
+    counts: dict[str, int] = defaultdict(int)
+    rows: list[tuple[str, str, str, str]] = []
+
+    for country in countries:
+        spec = _COUNTRY_CATALOG.get(country)
+        waves = _wave_dirs(root, country)
+        if not waves:
+            continue
+
+        declared = _declared_waves(country)
+
+        # Directories that are not declared waves must NOT be stamped -- doing
+        # so would newly declare them (see _may_write).
+        skipped = [w for w in waves if not _may_write(country, w, root, declared)]
+        waves = [w for w in waves if w not in skipped]
+        for wave in skipped:
+            counts["skipped"] += 1
+            rows.append((country, wave, "skipped",
+                         "not a declared wave; stamping would create one"))
+
+        if spec is None:
+            for wave in waves:
+                existing = read_provenance(root, country, wave)
+                prov = WaveProvenance(
+                    country=country, wave=wave, source=SOURCE_UNKNOWN,
+                    url=existing.url, method="unresolved", recorded=today,
+                    notes=existing.notes,
+                    note=("No entry in _COUNTRY_CATALOG (data_access.py), so "
+                          "this country's source is unrecorded."))
+                if not args.dry_run:
+                    write_provenance(root, prov)
+                counts["unknown"] += 1
+                rows.append((country, wave, "unknown", "no catalog mapping"))
+            continue
+
+        if not spec.discoverable or not spec.code:
+            # Explicitly non-WB (e.g. EthiopiaRHS, KenyaLPS).  Record what we
+            # DO know: it is external, and why.
+            for wave in waves:
+                existing = read_provenance(root, country, wave)
+                prov = WaveProvenance(
+                    country=country, wave=wave, source=SOURCE_EXTERNAL,
+                    url=existing.url, method="not-a-wb-dataset", recorded=today,
+                    note=spec.reason, notes=existing.notes)
+                if not args.dry_run:
+                    write_provenance(root, prov)
+                counts["external"] += 1
+                rows.append((country, wave, "external", "not a WB dataset"))
+            continue
+
+        by_id, by_doi = _build_catalog_index(spec.code)
+
+        for wave in waves:
+            prov, outcome = resolve(country, wave, root, by_id, by_doi, today)
+            if not args.dry_run:
+                write_provenance(root, prov)
+            counts[outcome] += 1
+            detail = (f"{prov.catalog_id} {prov.idno or ''}".strip()
+                      if prov.catalog_id else (prov.note or "")[:52])
+            rows.append((country, wave, outcome, detail))
+
+    # --- Report -------------------------------------------------------------
+    width = max((len(f"{c}/{w}") for c, w, _, _ in rows), default=20)
+    for country, wave, outcome, detail in rows:
+        print(f"  {country + '/' + wave:<{width}}  {outcome:<11} {detail}")
+
+    total = sum(counts.values())
+    stamped = total - counts["skipped"]
+    resolved = stamped - counts["unknown"]
+    print(f"\n{'DRY RUN -- nothing written' if args.dry_run else 'Written'}")
+    print(f"  wave dirs scanned : {total}")
+    print(f"  stamped           : {stamped}")
+    print(f"      resolved      : {resolved}")
+    for k in sorted(k for k in counts if k not in ("unknown", "skipped")):
+        if counts[k]:
+            print(f"          {k:<14}: {counts[k]}")
+    print(f"      unknown       : {counts['unknown']}")
+    print(f"  skipped           : {counts['skipped']}  "
+          "(not declared waves; stamping would create one -- see _may_write)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_wave_provenance.py
+++ b/tests/test_wave_provenance.py
@@ -1,0 +1,426 @@
+"""Wave provenance: recording which WB catalog entry a wave dir actually holds.
+
+The regression under test is that ``discover_waves`` used to decide whether we
+held a catalog entry by rebuilding a wave *label* from the entry's year range
+and string-matching it against directory names.  Labels collide across
+distinct surveys, so this was wrong in both directions:
+
+* *False positive* -- ``Nigeria/2018-19/`` holds GHS-Panel Wave 4 (id 3557).
+  The Living Standards Survey (id 3827) also spans 2018-2019, so it rendered
+  as the same label and was reported as already held.  It is not.
+* *False negative* -- WB id 1001 (``UGA_2005-2009_UNPS``) renders as
+  ``"2005-10"``, matching no directory, so it looked missing even though we
+  hold it, split across ``2005-06/`` and ``2009-10/``.
+
+Matching is now on the catalog id recorded in each wave's SOURCE.org.
+
+All tests here are hermetic: the WB catalog is mocked, no network is touched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lsms_library import provenance as pv
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _write_source(root, country, wave, text):
+    p = root / country / wave / "Documentation"
+    p.mkdir(parents=True, exist_ok=True)
+    (p / "SOURCE.org").write_text(text)
+
+
+def _mkwave(root, country, wave):
+    """Create a wave dir with no SOURCE.org."""
+    (root / country / wave / "Data").mkdir(parents=True, exist_ok=True)
+
+
+# Catalog rows mirroring the real WB entries these tests are about.
+NGA_ROWS = [
+    {"id": "1002", "idno": "NGA_2010_GHSP-W1_v03_M", "title": "GHS Panel W1",
+     "year_start": 2010, "year_end": 2011, "doi": "", "repository": "lsms",
+     "url": "https://microdata.worldbank.org/index.php/catalog/1002"},
+    {"id": "3557", "idno": "NGA_2018_GHSP-W4_v03_M", "title": "GHS Panel W4",
+     "year_start": 2018, "year_end": 2019, "doi": "", "repository": "lsms",
+     "url": "https://microdata.worldbank.org/index.php/catalog/3557"},
+    {"id": "3827", "idno": "NGA_2018_LSS_v01_M", "title": "Living Standards Survey",
+     "year_start": 2018, "year_end": 2019, "doi": "", "repository": "lsms",
+     "url": "https://microdata.worldbank.org/index.php/catalog/3827"},
+]
+
+UGA_ROWS = [
+    {"id": "1001", "idno": "UGA_2005-2009_UNPS_v03_M", "title": "UNPS 2005-2009",
+     "year_start": 2005, "year_end": 2010, "doi": "", "repository": "lsms",
+     "url": "https://microdata.worldbank.org/index.php/catalog/1001"},
+]
+
+GHA_ROWS = [
+    {"id": "2313", "idno": "GHA_1987_GLSS_v02_M", "title": "GLSS I",
+     "year_start": 1987, "year_end": 1988, "doi": "", "repository": "lsms",
+     "url": "https://microdata.worldbank.org/index.php/catalog/2313"},
+    {"id": "2534", "idno": "GHA_2009_GSPS_v01_M", "title": "GSPS 2009-2010",
+     "year_start": 2009, "year_end": 2010, "doi": "", "repository": "lsms",
+     "url": "https://microdata.worldbank.org/index.php/catalog/2534"},
+]
+
+
+@pytest.fixture()
+def countries(tmp_path, monkeypatch):
+    """A temp countries tree wired into data_access."""
+    from lsms_library import data_access as da
+    root = tmp_path / "countries"
+    root.mkdir()
+    monkeypatch.setattr(da, "_COUNTRIES_DIR", root)
+    return root
+
+
+def _mock_catalog(monkeypatch, rows):
+    from lsms_library import data_access as da
+    monkeypatch.setattr(da, "_wb_catalog_search",
+                        lambda code, collection="lsms": list(rows))
+
+
+# ---------------------------------------------------------------------------
+# SOURCE.org parsing / rendering
+# ---------------------------------------------------------------------------
+
+class TestSourceOrgFormat:
+    def test_legacy_bare_url_yields_catalog_id(self):
+        """A pre-existing SOURCE.org (bare /catalog/{id} URL) still parses."""
+        prov = pv.parse_source_org(
+            "SOURCE\n\nhttps://microdata.worldbank.org/index.php/catalog/3557",
+            "Nigeria", "2018-19")
+        assert prov.source == pv.SOURCE_WORLDBANK
+        assert prov.catalog_id == "3557"
+        assert prov.is_worldbank
+
+    def test_legacy_wb_doi_is_worldbank_but_id_unknown(self):
+        """A WB DOI identifies a WB study but does not encode the numeric id."""
+        prov = pv.parse_source_org(
+            "SOURCE\n\nhttps://doi.org/10.48529/q9zx-4b28]]", "Albania", "2002")
+        assert prov.source == pv.SOURCE_WORLDBANK
+        assert prov.catalog_id is None
+        assert not prov.is_worldbank  # no id -> cannot match on identity
+
+    def test_non_wb_host_is_external(self):
+        prov = pv.parse_source_org(
+            "SOURCE\n\nhttps://doi.org/10.7910/DVN/T8G8IV", "EthiopiaRHS", "1989")
+        assert prov.source == pv.SOURCE_EXTERNAL
+        assert prov.catalog_id is None
+
+    def test_missing_file_is_unknown_never_a_guess(self, tmp_path):
+        prov = pv.read_provenance(tmp_path, "Bulgaria", "1995")
+        assert prov.source == pv.SOURCE_UNKNOWN
+        assert prov.catalog_id is None
+        assert not prov.is_resolved
+
+    def test_round_trip(self):
+        orig = pv.WaveProvenance(
+            country="Nigeria", wave="2018-19", source=pv.SOURCE_WORLDBANK,
+            catalog_id="3557", idno="NGA_2018_GHSP-W4_v03_M",
+            title="General Household Survey, Panel 2018-2019, Wave 4",
+            years="2018-2019", repository="lsms",
+            url="https://microdata.worldbank.org/index.php/catalog/3557",
+            method="manual-override", recorded="2026-07-12")
+        back = pv.parse_source_org(pv.render_source_org(orig),
+                                   "Nigeria", "2018-19")
+        for f in ("source", "catalog_id", "idno", "title", "years",
+                  "repository", "url", "method", "recorded"):
+            assert getattr(back, f) == getattr(orig, f), f
+
+    def test_unknown_is_recorded_explicitly(self):
+        """Silence must not masquerade as knowledge: 'unknown' is written out."""
+        text = pv.render_source_org(pv.WaveProvenance(
+            country="Bulgaria", wave="1995", source=pv.SOURCE_UNKNOWN))
+        assert "#+CATALOG_ID: unknown" in text
+        assert "#+PROVENANCE_SOURCE: unknown" in text
+
+    def test_external_records_none_not_unknown(self):
+        """'no WB id exists' is distinct from 'we do not know the WB id'."""
+        text = pv.render_source_org(pv.WaveProvenance(
+            country="EthiopiaRHS", wave="1989", source=pv.SOURCE_EXTERNAL,
+            url="https://doi.org/10.7910/DVN/T8G8IV"))
+        assert "#+CATALOG_ID: none" in text
+
+    def test_human_prose_is_preserved_not_overwritten(self):
+        """Legacy SOURCE.org files carry hand-written notes (the EthiopiaRHS
+        round map, for one).  Stamping provenance must not destroy them."""
+        original = (
+            "SOURCE\n\nhttps://doi.org/10.7910/DVN/T8G8IV\n\n"
+            "Ethiopian Rural Household Survey (ERHS) -- 1989 wave.\n"
+            "All ERHS rounds share one Dataverse deposit; see "
+            "../../_/CONTENTS.org\nfor the round->file map.\n")
+
+        prose = pv.preserved_prose(original)
+        assert "round->file map" in prose
+        assert "SOURCE" not in prose            # boilerplate dropped
+        assert "doi.org" not in prose           # the bare URL is not prose
+
+        rendered = pv.render_source_org(pv.WaveProvenance(
+            country="EthiopiaRHS", wave="1989", source=pv.SOURCE_EXTERNAL,
+            url="https://doi.org/10.7910/DVN/T8G8IV", notes=prose))
+        assert "round->file map" in rendered
+        assert "All ERHS rounds share one Dataverse deposit" in rendered
+
+    def test_rendering_is_idempotent(self):
+        """Re-stamping an already-stamped file must not nest or duplicate the
+        preserved-notes block."""
+        prov = pv.WaveProvenance(
+            country="EthiopiaRHS", wave="1989", source=pv.SOURCE_EXTERNAL,
+            url="https://doi.org/10.7910/DVN/T8G8IV",
+            notes="All ERHS rounds share one Dataverse deposit.")
+        once = pv.render_source_org(prov)
+        twice = pv.render_source_org(
+            pv.parse_source_org(once, "EthiopiaRHS", "1989"))
+        assert once == twice
+        assert twice.count(pv.NOTES_HEADING) == 1
+
+    def test_superseded_url_never_self_references(self):
+        """Guard for a bug this work introduced and then fixed: on a re-run the
+        'URL we replaced' must not be overwritten with the current URL, which
+        would silently erase the record of the correction."""
+        text = pv.render_source_org(pv.WaveProvenance(
+            country="Nigeria", wave="2018-19", source=pv.SOURCE_WORLDBANK,
+            catalog_id="3557",
+            url="https://microdata.worldbank.org/index.php/catalog/3557",
+            superseded_url="https://microdata.worldbank.org/index.php/catalog/3557"))
+        assert "PROVENANCE_SUPERSEDED_URL" not in text
+
+        # A genuinely different prior URL IS recorded.
+        text = pv.render_source_org(pv.WaveProvenance(
+            country="Nigeria", wave="2018-19", source=pv.SOURCE_WORLDBANK,
+            catalog_id="3557",
+            url="https://microdata.worldbank.org/index.php/catalog/3557",
+            superseded_url="https://microdata.worldbank.org/index.php/catalog/3827"))
+        assert "PROVENANCE_SUPERSEDED_URL: " \
+               "https://microdata.worldbank.org/index.php/catalog/3827" in text
+
+    def test_url_stays_first_url_for_legacy_reader(self):
+        """data_access._read_source_url greps the first http(s):// in the file.
+
+        The structured record must not displace it, or the WB download path
+        breaks for every backfilled wave.
+        """
+        from lsms_library.data_access import _read_source_url
+        from lsms_library import data_access as da
+
+        prov = pv.WaveProvenance(
+            country="Nigeria", wave="2018-19", source=pv.SOURCE_WORLDBANK,
+            catalog_id="3557", idno="NGA_2018_GHSP-W4_v03_M",
+            url="https://microdata.worldbank.org/index.php/catalog/3557")
+        text = pv.render_source_org(prov)
+
+        import re
+        first = re.search(r"https?://[^\s\]\)]+", text).group(0)
+        assert first == "https://microdata.worldbank.org/index.php/catalog/3557"
+
+
+# ---------------------------------------------------------------------------
+# discover_waves: identity matching
+# ---------------------------------------------------------------------------
+
+class TestDiscoverWavesMatchesOnCatalogId:
+
+    def test_nigeria_lss_reported_missing_not_held(self, countries, monkeypatch):
+        """THE regression: Nigeria/2018-19 holds GHS-Panel W4 (3557), not the
+        LSS (3827).  Both span 2018-2019.  The LSS must report as MISSING."""
+        from lsms_library.data_access import discover_waves
+        _mock_catalog(monkeypatch, NGA_ROWS)
+
+        _write_source(countries, "Nigeria", "2018-19", pv.render_source_org(
+            pv.WaveProvenance(country="Nigeria", wave="2018-19",
+                              source=pv.SOURCE_WORLDBANK, catalog_id="3557",
+                              idno="NGA_2018_GHSP-W4_v03_M",
+                              url="https://microdata.worldbank.org"
+                                  "/index.php/catalog/3557")))
+        _write_source(countries, "Nigeria", "2010-11", pv.render_source_org(
+            pv.WaveProvenance(country="Nigeria", wave="2010-11",
+                              source=pv.SOURCE_WORLDBANK, catalog_id="1002",
+                              url="https://microdata.worldbank.org"
+                                  "/index.php/catalog/1002")))
+
+        by_id = {e["id"]: e for e in discover_waves("Nigeria")}
+
+        # The survey we actually hold.
+        assert by_id["3557"]["local"] is True
+        assert by_id["3557"]["local_status"] == "yes"
+        assert by_id["3557"]["local_waves"] == ["2018-19"]
+
+        # The survey we do NOT hold, whose label collides with the one we do.
+        assert by_id["3827"]["local"] is False
+        assert by_id["3827"]["local_status"] == "no"
+        assert by_id["3827"]["local_waves"] == []
+
+        # Both still render to the same colliding label -- which is precisely
+        # why label matching could not tell them apart.
+        assert by_id["3557"]["wave"] == by_id["3827"]["wave"] == "2018-19"
+
+    def test_one_catalog_id_can_back_several_wave_dirs(self, countries,
+                                                       monkeypatch):
+        """WB 1001 (UNPS 2005-2009) backs BOTH Uganda/2005-06 and /2009-10.
+
+        Its year range renders as '2005-10', which matches no directory, so
+        label matching called it missing.  Identity matching finds it."""
+        from lsms_library.data_access import discover_waves
+        _mock_catalog(monkeypatch, UGA_ROWS)
+
+        for wave in ("2005-06", "2009-10"):
+            _write_source(countries, "Uganda", wave, pv.render_source_org(
+                pv.WaveProvenance(country="Uganda", wave=wave,
+                                  source=pv.SOURCE_WORLDBANK, catalog_id="1001",
+                                  url="https://microdata.worldbank.org"
+                                      "/index.php/catalog/1001")))
+
+        entry = discover_waves("Uganda")[0]
+        assert entry["wave"] == "2005-10"          # matches no directory
+        assert entry["local"] is True              # ... yet we hold it
+        assert entry["local_status"] == "yes"
+        assert entry["local_waves"] == ["2005-06", "2009-10"]
+
+    def test_unprovenanced_wave_is_unknown_not_a_confident_claim(
+            self, countries, monkeypatch):
+        """A dir with no SOURCE.org falls back to the label heuristic, but the
+        result is marked 'unknown' -- never a confident True."""
+        from lsms_library.data_access import discover_waves
+        _mock_catalog(monkeypatch, NGA_ROWS)
+
+        _mkwave(countries, "Nigeria", "2018-19")   # no SOURCE.org at all
+
+        by_id = {e["id"]: e for e in discover_waves("Nigeria")}
+        for cid in ("3557", "3827"):
+            assert by_id[cid]["local_status"] == "unknown", cid
+            # An unverified claim must not read as "held".
+            assert by_id[cid]["local"] is False, cid
+
+        # A label matching no directory is still a confident "no".
+        assert by_id["1002"]["local_status"] == "no"
+
+    def test_local_remains_a_bool_for_existing_callers(self, countries,
+                                                       monkeypatch):
+        """Backwards compatibility: `local` keeps its type and truthiness."""
+        from lsms_library.data_access import discover_waves
+        _mock_catalog(monkeypatch, NGA_ROWS)
+        _mkwave(countries, "Nigeria", "2018-19")
+
+        for e in discover_waves("Nigeria"):
+            assert isinstance(e["local"], bool)
+            assert {"wave", "local", "id", "idno", "title"} <= set(e)
+
+
+class TestSharedIsoCodeDisambiguation:
+    """GHA and TZA each back two distinct survey series in this repo."""
+
+    def test_ghana_lss_does_not_see_the_panel_surveys_waves(self, countries,
+                                                            monkeypatch):
+        from lsms_library.data_access import discover_waves
+        _mock_catalog(monkeypatch, GHA_ROWS)
+        _mkwave(countries, "GhanaLSS", "1987-88")
+
+        idnos = {e["idno"] for e in discover_waves("GhanaLSS")}
+        assert idnos == {"GHA_1987_GLSS_v02_M"}
+        assert "GHA_2009_GSPS_v01_M" not in idnos
+
+    def test_ghana_sps_does_not_see_the_living_standards_waves(self, countries,
+                                                               monkeypatch):
+        from lsms_library.data_access import discover_waves
+        _mock_catalog(monkeypatch, GHA_ROWS)
+        _mkwave(countries, "GhanaSPS", "2009-10")
+
+        idnos = {e["idno"] for e in discover_waves("GhanaSPS")}
+        assert idnos == {"GHA_2009_GSPS_v01_M"}
+
+    def test_tanzania_and_kagera_are_separate_series(self):
+        from lsms_library.data_access import _COUNTRY_CATALOG
+        nps = _COUNTRY_CATALOG["Tanzania"]
+        khds = _COUNTRY_CATALOG["Tanzania_Kegera"]
+        assert nps.code == khds.code == "TZA"
+
+        npsrow = {"idno": "TZA_2020_NPS-R5_v02_M"}
+        khdsrow = {"idno": "TZA_2010_KHDS_v01_M"}
+        assert nps.matches(npsrow) and not nps.matches(khdsrow)
+        assert khds.matches(khdsrow) and not khds.matches(npsrow)
+
+
+class TestSourceOrgIsLoadBearing:
+    """SOURCE.org's *presence* declares a directory to be a wave.
+
+    Country.waves (country.py) falls back to scanning for subdirectories
+    containing Documentation/SOURCE.org when the country declares no explicit
+    wave list.  So creating a SOURCE.org in a directory that is not a wave
+    silently promotes it into one.
+
+    This bit us for real: Benin/2018-2019/ is a stray duplicate of
+    Benin/2018-19/ (identical .dta files, no SOURCE.org).  Stamping it made it
+    a wave, and sample() did not cover it -- breaking
+    test_sample.py::test_covers_all_waves[Benin].
+
+    The backfill must therefore only ever UPDATE an existing SOURCE.org, or
+    CREATE one in a directory the library already declares a wave.
+    """
+
+    def test_backfill_refuses_to_create_source_org_in_an_undeclared_dir(
+            self, tmp_path):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "backfill", Path(__file__).resolve().parents[1]
+            / "scripts" / "backfill_wave_provenance.py")
+        backfill = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(backfill)
+
+        root = tmp_path / "countries"
+        # A declared wave that already has a SOURCE.org.
+        _write_source(root, "Benin", "2018-19", "SOURCE\n\nhttps://x/catalog/4291")
+        # A stray duplicate directory: data, but no SOURCE.org, not declared.
+        (root / "Benin" / "2018-2019" / "Data").mkdir(parents=True)
+
+        declared = {"2018-19"}
+        assert backfill._may_write("Benin", "2018-19", root, declared) is True
+        assert backfill._may_write("Benin", "2018-2019", root, declared) is False
+
+        # An undeclared dir stays undeclared: no Documentation/ is created.
+        assert not (root / "Benin" / "2018-2019" / "Documentation").exists()
+
+    def test_may_write_is_conservative_when_waves_cannot_be_read(self, tmp_path):
+        """If we cannot determine the declared waves, never create a new
+        SOURCE.org -- only update ones that already exist."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "backfill", Path(__file__).resolve().parents[1]
+            / "scripts" / "backfill_wave_provenance.py")
+        backfill = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(backfill)
+
+        root = tmp_path / "countries"
+        _write_source(root, "Benin", "2018-19", "SOURCE\n\nhttps://x/catalog/4291")
+        (root / "Benin" / "2018-2019" / "Data").mkdir(parents=True)
+
+        assert backfill._may_write("Benin", "2018-19", root, None) is True
+        assert backfill._may_write("Benin", "2018-2019", root, None) is False
+
+
+class TestCountryCatalogRegistry:
+    def test_serbia_and_montenegro_has_a_code(self):
+        """SCG returns catalog ids 80 and 81, matching our 2002/ and 2003/."""
+        from lsms_library.data_access import _COUNTRY_CATALOG, _COUNTRY_CODES
+        assert _COUNTRY_CATALOG["Serbia and Montenegro"].code == "SCG"
+        assert _COUNTRY_CODES["Serbia and Montenegro"] == "SCG"
+
+    def test_ethiopia_rhs_is_explicitly_not_discoverable(self, countries):
+        """EthiopiaRHS is an IFPRI/Dataverse study, not a WB one.  It must be
+        marked not-discoverable, not merely left out of the registry."""
+        from lsms_library.data_access import _COUNTRY_CATALOG, discover_waves
+        spec = _COUNTRY_CATALOG["EthiopiaRHS"]
+        assert spec.discoverable is False
+        assert spec.reason and "Dataverse" in spec.reason
+        # Returns empty without erroring, and without hitting the network.
+        assert discover_waves("EthiopiaRHS") == []
+
+    def test_unregistered_country_returns_empty(self, countries):
+        from lsms_library.data_access import discover_waves
+        assert discover_waves("Atlantis") == []


### PR DESCRIPTION
## First: two corrections to the diagnosis

**1. `SOURCE.org` was NOT missing — 117 of the 136 wave dirs already had one.**
The brief said `find lsms_library/countries -maxdepth 3 -name SOURCE.org` returns 0, and concluded "no pre-existing wave has one." The file actually lives at `{Country}/{wave}/Documentation/SOURCE.org` — **depth 4**. `-maxdepth 3` cannot reach it. With `-maxdepth 4` you get **117**.

This makes the fix *easier* (there was real provenance to harvest, not a blank slate), but the root cause is not "nothing records the id."

**2. The recorded provenance was sometimes WRONG, not merely absent — which is worse.**
`Nigeria/2018-19/Documentation/SOURCE.org` records catalog **3827** (the LSS). The directory actually holds `sect*_plantingw4` / `sect*_harvestw4` / `nga_*_y4` — i.e. **GHS-Panel Wave 4 (3557)**. So the file didn't just fail to disambiguate a label collision; it affirmatively recorded the wrong survey. (Every sibling Nigeria wave is GHS-Panel: W1=1002, W2=1952, W3=2734, W5=6410.) **A backfill that trusted `SOURCE.org` blindly would have cemented the error** — so the backfill validates rather than trusts, and this one wave is corrected via an explicit, evidence-citing override.

Everything else in the diagnosis held up; I verified each claim against the live WB API:
- 3827 = `NGA_2018_LSS_v01_M`, 3557 = `NGA_2018_GHSP-W4_v03_M` — **both** span 2018–2019 and both render to the label `"2018-19"`. Confirmed.
- Ethiopia 2671 (`ETH_2013_LASER`) is masked by 2247 (`ETH_2013_ESS`) — both render `"2013-14"`. Confirmed.
- GhanaLSS/GhanaSPS both map to `GHA`; each saw the other's waves. Confirmed.
- `SCG` returns ids 80 and 81, matching `2002/` and `2003/`. Confirmed.

I also found a **third failure mode the brief didn't mention**: one catalog entry can legitimately back *two* wave dirs. WB **1001** (`UGA_2005-2009_UNPS`, years 2005–2010) renders as `"2005-10"`, matching **no** directory — so it was reported MISSING even though we hold it, split across `Uganda/2005-06/` and `Uganda/2009-10/`. (Same class: Tanzania_Kegera id 79 is labeled `"2004"` but lives in `2004-05/`.)

---

## Provenance format, and why

**Extended `SOURCE.org`** — the file `add_wave()` already writes — rather than a new mechanism or a field in `data_info.yml`.

```org
SOURCE

https://microdata.worldbank.org/index.php/catalog/3557

#+CATALOG_ID: 3557
#+CATALOG_IDNO: NGA_2018_GHSP-W4_v03_M
#+CATALOG_TITLE: General Household Survey, Panel 2018-2019, Wave 4
#+CATALOG_YEARS: 2018-2019
#+CATALOG_REPOSITORY: lsms
#+CATALOG_URL: https://microdata.worldbank.org/index.php/catalog/3557
#+PROVENANCE_SOURCE: worldbank
#+PROVENANCE_METHOD: manual-override
#+PROVENANCE_RECORDED: 2026-07-12
#+PROVENANCE_SUPERSEDED_URL: https://microdata.worldbank.org/index.php/catalog/3827
#+PROVENANCE_NOTE: Corrected from catalog 3827 ...
```

Why this shape:
- **The bare URL stays the file's first URL**, so the legacy reader `data_access._read_source_url()` (which greps the first `http(s)://`) is untouched. There's a test pinning this.
- Provenance lives *next to the data it describes*, and `add_wave()` already owned this file — no parallel mechanism to keep in sync.
- `data_info.yml` was rejected: it is the *config* tree keyed by table/columns, and it feeds the v0.8.0 cache content-hash. Putting provenance there would churn the hash and rebuild caches for a change with no bearing on any built table.
- `PROVENANCE_SOURCE` ∈ `{worldbank, external, unknown}`, and `CATALOG_ID: none` (definitively not a WB entry) is kept **distinct** from `CATALOG_ID: unknown` (we don't know). Silence is recorded explicitly, not left blank.
- **Human prose is preserved verbatim** under a `* Notes (preserved from the original SOURCE.org)` heading. My first pass clobbered the hand-written EthiopiaRHS round-map notes; that was a bug, now covered by a test. The writer is idempotent (re-running does not nest or duplicate).

## The `discover_waves` fix

Matches on the recorded **catalog id**. Falls back to the label heuristic **only** for wave dirs with no recorded WB id, and marks those `local_status='unknown'`.

Return contract is backward compatible — I grepped for callers first (only `.claude/skills/add-wave/SKILL.md` + docs; no code callers in-repo):
- `local` stays a **`bool`**. Unknown rows get `local=False`: an unverified claim must not read as "held", because wrongly believing we hold a survey is the failure mode that hides missing data.
- New: `local_status` (`"yes"`/`"no"`/`"unknown"`) and `local_waves` (the dirs backing the entry).

Also fixed:
- `_COUNTRY_CODES` → a `_COUNTRY_CATALOG` registry (`_COUNTRY_CODES` retained as a derived, backward-compatible view).
- **`Serbia and Montenegro` → `SCG`** (previously: no code → `[]` + error log).
- **Shared-ISO disambiguation** via `idno_pattern`: `GhanaLSS` → `_GLSS`, `GhanaSPS` → `_GSPS` (both GHA); `Tanzania` → `_NPS`, `Tanzania_Kegera` → `_KHDS` (both TZA).
- **`EthiopiaRHS` marked `discoverable=False`** with a reason (IFPRI / Harvard Dataverse, `doi:10.7910/DVN/T8G8IV`) — explicitly not-discoverable, not merely omitted. Same for **`KenyaLPS`** (verified: a `KEN`/`lsms` catalog query returns zero entries).
- `_wb_catalog_search` now pages, can search all collections, and returns the catalog's `doi` field.

## A trap I fell into: `SOURCE.org` is load-bearing

`Country.waves` (country.py:1452) falls back to **scanning for subdirectories that contain `Documentation/SOURCE.org`** when a country declares no explicit wave list. So *creating* a `SOURCE.org` silently **promotes a directory into a wave**.

My first pass stamped all 136 dirs and broke `test_sample.py::test_covers_all_waves[Benin]`: `Benin/2018-2019/` is a **stray duplicate** of `Benin/2018-19/` (identical `.dta` files, no `SOURCE.org`), and stamping it made it a wave that `sample()` doesn't cover. Caught by the full suite, diagnosed, fixed.

The backfill now only ever **updates** an existing `SOURCE.org`, or **creates** one in a directory the library already declares a wave (`_may_write`). 13 dirs that are *not* declared waves are reported and left untouched: the stray `Benin/2018-2019/`, `Bulgaria` ×5, `Afghanistan` ×2, `Brazil/1996-97`, `KenyaLPS` ×4. **Verified: `Country.waves` is byte-identical to pristine for all 47 countries.** Two regression tests pin this.

## Backfill: 123 stamped (118 resolved / 5 unknown), 13 skipped, of 136 dirs

`scripts/backfill_wave_provenance.py` (`--dry-run`, `--country`). Evidence-based ladder; **nothing is guessed**.

| method | n | how |
|---|---|---|
| `source-url` | 52 | `SOURCE.org` had a `/catalog/{id}` URL; verified to exist in the catalog |
| `doi-lookup` | 48 | `SOURCE.org` had a WB DOI (`10.48529/…`), which does **not** encode the id — recovered by exact match against the catalog row's `doi` field |
| `external` | 17 | non-WB host (Ghana Statistical Service, Rwanda NISR, Harvard Dataverse) |
| `manual-override` | 1 | Nigeria 2018-19 (see above) |
| **unknown** | **5** | declared waves with no `SOURCE.org`: GhanaSPS ×2, Nepal/2003-04, Niger/2011-12, Senegal/2021-22 |
| *skipped* | *13* | *not declared waves — stamping would create one* |

Niger/2011-12 is *temptingly* easy (exactly one 2011–2012 LSMS candidate, `NER_2011_ECVMA`) — but inferring an id from a directory name is precisely the heuristic this PR exists to delete. Recorded `unknown`, left for a human. Unknowns degrade gracefully to `local_status='unknown'`.

Verified across all 117 pre-existing files: **0 prose lines lost, 0 original catalog ids lost** (Nigeria's 3827 is retained as `PROVENANCE_SUPERSEDED_URL`). The writer is **idempotent** — proven byte-for-byte across two consecutive runs of all 123 files.

## Before / after

**Nigeria — the headline. Does `discover_waves` now report the LSS as MISSING? Yes.**

| id | idno | label | before | after |
|---|---|---|---|---|
| 3557 | `NGA_2018_GHSP-W4` | 2018-19 | `LOCAL` | `local=True`, `status=yes`, dirs=`2018-19` |
| **3827** | **`NGA_2018_LSS`** | **2018-19** | **`LOCAL` ← false positive** | **`local=False`, `status=no`** ✅ |

**Ethiopia** — 2671 (`ETH_2013_LASER`) was `LOCAL`; now `local=False, status=no`. 2247 (ESS) correctly held.

**Uganda** — 1001 was `MISSING` (label `"2005-10"` matched nothing); now `local=True`, `local_waves=['2005-06','2009-10']` ✅ (impossible under label matching).

**Ghana** — `GhanaSPS` used to list GLSS I–IV as its own missing waves (4 spurious rows) and `GhanaLSS` listed GSPS 2009-10. Now each sees only its own series.

**Tanzania_Kegera** / **Serbia and Montenegro** — previously `[]` + `No ISO country code` error. Now resolve correctly (Kagera 79→`2004-05/`, 2251→`2010-11/`; SCG 80→`2002/`, 81→`2003/`). Note Kagera 79 is *labeled* `"2004"` but lives in `2004-05/` — matched by id, which label matching could never do.

**EthiopiaRHS** — was `No ISO country code` error; now returns `[]` with an explanatory log and no network call.

## Tests

New `tests/test_wave_provenance.py` — **23 tests, hermetic** (WB catalog mocked, no network):
- **`test_nigeria_lss_reported_missing_not_held`** — *the* regression. Provenances `Nigeria/2018-19` as 3557, asserts 3827 → `local=False`/`status=no` and 3557 → `local=True`, and asserts both still render to the same colliding label (so the test would fail under label matching).
- `test_one_catalog_id_can_back_several_wave_dirs` — Uganda 1001 → both dirs.
- `test_unprovenanced_wave_is_unknown_not_a_confident_claim` — no `SOURCE.org` ⇒ `status='unknown'`, `local=False`.
- `test_local_remains_a_bool_for_existing_callers` — backward compat.
- `test_url_stays_first_url_for_legacy_reader` — pins `_read_source_url` compat.
- `test_human_prose_is_preserved_not_overwritten`, `test_rendering_is_idempotent`, `test_superseded_url_never_self_references` — guards for two bugs I introduced and fixed mid-flight.
- **`test_backfill_refuses_to_create_source_org_in_an_undeclared_dir`** + `test_may_write_is_conservative_when_waves_cannot_be_read` — pin the `Country.waves` trap above.
- Ghana / Tanzania idno disambiguation; SCG code; EthiopiaRHS not-discoverable.

**Full suite: 3570 passed, 130 skipped, 4 xfailed, 1 xpassed**, with `test_currency.py::test_feature_ghana_per_wave` deselected — I confirmed that one **fails identically on pristine `development`** (pre-existing, unrelated). `test_sample.py` (33 tests incl. Benin) passes.

## Not done / follow-ups
- The 14 unknowns need a human to confirm their catalog ids (or confirm they are non-WB). `--dry-run` lists them.
- `Benin/2018-19/` and `Benin/2018-2019/` are **duplicate directories with identical data files**. The second is not a declared wave and is now left unstamped; I did not delete it (out of scope), but it looks stray and probably should be removed.
- Some `GhanaLSS` waves were downloaded from Ghana Statistical Service rather than the WB, so they report `status='unknown'` against the WB GLSS entries. That is the honest answer: we know the dir exists and which series it is, but nothing recorded a WB id for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtARb9se2un1DLFJrrpjHe
