### PR TITLE
fix(#602): enforce declared spellings — 6 countries were shipping non-canonical Rural (Uganda was the least severe)

### DIFF
--- a/.coder/ledger/602-spellings.md
+++ b/.coder/ledger/602-spellings.md
@@ -1,0 +1,112 @@
+# Ledger — GH #602: declared spellings are never enforced
+
+**Search tier used:** ripgrep + git (floor), plus a live-API cross-country sweep
+(34 countries x every spellings-constrained `(table, column)`). gitnexus not used.
+**Inherits:** `.coder/ledger/STANDING.md` §2/§3/§4 — cited, not restated.
+
+---
+
+## §1 Task
+
+`lsms_library/data_info.yml` declares accepted values via `spellings` blocks, but
+nothing **enforces** them. `_enforce_canonical_spellings()` maps *known variants*
+and never *rejects unknown ones*. Uganda's `sample.Rural` was the literal string
+`'0'` for 2,263 households (72% of the 2005-06 wave), so `df[df.Rural=='Rural']`
+silently returned **zero rows** — and `is_this_feature_sane(...).ok` was `True`.
+
+Deliverable was the **cross-country sweep**; the check is how you do it.
+
+## §2 Existing machinery reused (did NOT rebuild)
+
+| symbol | path | why I reused it |
+|---|---|---|
+| `_enforce_canonical_spellings` | `country.py:3931` (STANDING §2) | the variant→canonical map. My check *normalizes through it* before testing membership, so it is correct on pre-finalize parquets **and** post-finalize API frames. |
+| `_load_api_derived()` | `diagnostics.py:40` | exact prior-art pattern for reading `data_info.yml` `Columns` in diagnostics (module-level constant, same `(OSError, YAMLError)` handling). `_load_declared_vocabularies()` mirrors it. |
+| `Check` / `SanityReport` / `is_this_feature_sane` | `diagnostics.py` | the check is one more `Check` in the existing battery — no new reporting machinery. |
+| `spellings` block in `data_info.yml` | STANDING §3 | the *sanctioned* place to declare accepted variants. Mali's `Urbain` / Guinea-Bissau's `Urbano` were fixed by **extending the existing block**, not by writing per-country mapping code. |
+| `categorical_mapping.org` auto-discovery | CLAUDE.md | GhanaLSS's `Semi-urban` was a *mislabelled row in an existing mapping table*, fixed there — not by adding a new transform. |
+
+**Did NOT reinvent:** a value-validation layer. `_check_value_constraints`
+(`diagnostics.py:368`) already existed — but it reads the *country's*
+`data_scheme.yml`, only acts on **list** declarations, and returns `warn`. Every
+country declares `Rural: str` (a scalar), so it is skipped entirely. I did not
+extend it (its `warn` status is exactly the status quo that let this rot); I added
+a sibling that reads the **canonical** `data_info.yml` and returns `fail`.
+
+## §3 Definitions in force (cited)
+
+- Canonical schema = `lsms_library/data_info.yml` (STANDING §3). Tests read it;
+  **never hardcode schema rules** — so the check reads `Columns` at runtime.
+- The vocabulary for a column is `spellings.keys()`, per the file's own header
+  comment ("The canonical values are simply spellings.keys()").
+- `Rural` semantics: cluster/HH urban-rural indicator, canonical `Rural`/`Urban`.
+
+## §4 Invariants I had to respect (the landmines)
+
+1. **Key on `(table, column)`, never column name alone.** `housing.Tenure` exists
+   in ~12 countries with a legitimately different vocabulary (dwelling tenure) and
+   `housing` declares none. A name-keyed check emits ~12 false failures. Pinned by
+   `test_housing_tenure_is_not_flagged`.
+2. **Do not reuse `country._load_canonical_spellings()`.** Its final `if
+   variant_map:` guard **drops** every column whose variant lists are all empty —
+   `Affinity`, `Tenure`, `TenureSystem`. Reusing it would silently leave those
+   three unchecked. Hence a separate loader. Pinned by
+   `test_empty_variant_vocabularies_are_still_checked`.
+3. **Normalize before membership.** Cached parquets are pre-`_finalize_result`
+   (STANDING §4) and legitimately hold *known variants* (Malawi's `rural`/`RURAL`).
+   `tests/test_table_structure.py` reads parquets directly, so a check that tests
+   membership without first applying the variant map fails Malawi/sample and every
+   other country whose parquet holds a variant. Pinned by
+   `test_passes_on_declared_variants`.
+4. **`Rural` under `sample:` must NOT be `required: true`.** `required` is read by
+   `feature.py:316`; many countries' `sample` has no urban/rural column at all.
+5. **Shared cache + concurrent agents.** `~/.local/share/lsms_library` is shared
+   (CLAUDE.md scrum-master addendum 1). Other worktrees were concurrently
+   rebuilding `sample`/`cluster_features` with *their* config and overwriting my
+   parquets (fresh mtime, stale content). All verification was redone under an
+   isolated `LSMS_DATA_DIR`. **A parquet-level result from the shared cache is not
+   trustworthy while other agents run.**
+
+## §5 What the issue got wrong (verify the diagnosis before fixing it)
+
+- **The Uganda proximate cause is a YAML key TYPE mismatch, not a missing mapping.**
+  Raw `urban` is object-dtype but *mixed*: python `int 0` (2263) + `str 'urban'`
+  (860). The declared key was the **string** `'0'`, which never matches, so the
+  value passed through and was stringified to `'0'`. Commit `9959b9f3`
+  (2026-04-14, "close GH #163 item 3") introduced exactly that string key and was
+  **silently dead for three months**. The fix is one character: `'0'` → `0`.
+- **A second, independent gap the issue does not mention:** `sample` was absent
+  from `Columns:` entirely, so `_enforce_canonical_spellings` was a *total no-op*
+  on `sample()` — it did not merely fail to reject unknowns, it never mapped the
+  *known* variants. That is the Tajikistan bug (9,020 lowercase rows).
+- **Uganda is the least severe find, not the only one.** Malawi
+  `cluster_features.Rural` was **sign-flipped between waves**; India `sample.Rural`
+  was **100% fabricated**.
+
+## §6 Instrument validation (a negative result from an unvalidated check is a
+result about the check)
+
+`scratchpad/plant.py`: the check FIRES on planted violations in **columns and
+index levels** (`'0'`, `'0.0'`, `'Urbain'`, trailing-space `'Urban '`, bad `Sex`),
+is SILENT on clean frames, on known variants, on all-NaN columns, and on the
+`housing.Tenure` trap. It also *sees* `Tenure`/`TenureSystem`/`Affinity`, which
+the pre-existing loader drops. All 12 cases pass.
+
+## §7 Residual / deliberately not fixed
+
+Five `plot_features` `Tenure`/`TenureSystem` pairs (Albania, Cambodia, Kosovo,
+Timor-Leste, Tajikistan) ship raw unharmonized survey labels. The check correctly
+**fails** them; they are enumerated in `tests/test_declared_spellings.KNOWN_UNHARMONIZED`
+and xfailed, **not** downgraded to `warn`. Mapping them needs the questionnaire
+codebooks (Cambodia's "GIVEN BY THE GOVERNMENT OR LOCAL AUTHORITY"; Timor-Leste's
+"Part owner", 81% of plots), and guessing would replace a *visibly* wrong value
+with an *invisibly* wrong one — the exact class-1 failure this issue is about.
+
+Same reasoning for **India**: `stratum` provably carries no urban/rural information
+(perfectly collinear with `state`: UP vs Bihar), so `Rural` is **deleted**, not
+invented. Silently-missing (class 2) beats silently-wrong (class 1).
+
+**Pre-existing caveat surfaced, not introduced:** Malawi 2004-05 `ea` is not a
+clean cluster key — 19 of 110 EAs contain both rural and urban households, so the
+cluster-level aggregate picks one. My change only relabels the code as a word; it
+does not alter which household is picked.

--- a/lsms_library/countries/GhanaLSS/1991-92/_/categorical_mapping.org
+++ b/lsms_library/countries/GhanaLSS/1991-92/_/categorical_mapping.org
@@ -29,11 +29,18 @@ strata (codes 1-10) both use this list.
 
 * POV_GH
 
+# `loc2` is the standard GLSS 2-way locality split, identical in meaning to
+# GLSS4's `loc2` (1=Urban, 2=Rural).  It was previously labelled 1=Semi-urban,
+# which is wrong: loc2 nests exactly onto the finer GLSS classifications --
+#   loc2=1  ==  loc3 in {1,2}  ==  loc5 in {1,2}  ==  Accra (459) + Other Urban (1119) = 1578
+#   loc2=2  ==  loc3 == 3      ==  loc5 in {3,4,5} == Rural Coastal/Forest/Savannah = 2945
+# so code 1 is the union of the two URBAN strata, not a semi-urban category.
+# GH #602.
 #+name: rural
-| Code | Label      |
-|------+------------|
-|    1 | Semi-urban |
-|    2 | Rural      |
+| Code | Label  |
+|------+--------|
+|    1 | Urban  |
+|    2 | Rural  |
 
 
 * SEC8H

--- a/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
@@ -7,7 +7,17 @@ cluster_features:
         v: clust
     myvars:
         Region: region
-        Rural: loc2
+        # g7sec8h's `loc2` carries a TRAILING SPACE on the urban label
+        # ('Urban ', 439 clusters) -- it looks correct in a value_counts but
+        # compares false against 'Urban', so `df[df.Rural == 'Urban']` silently
+        # dropped every urban cluster in this wave.  (The `sample` block below
+        # reads a different, clean variable, `urbrur` from g7sec0, which is why
+        # sample was unaffected.)  GH #602.
+        Rural:
+            - loc2
+            - mapping:
+                'Urban ': Urban
+                'Rural ': Rural
 
 
 sample:

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -80,7 +80,7 @@ without an explicit mapping file.
 |--------+--------------------+----------+----------------------------------|
 | GLSS1  | ---                | ---      | Not available                    |
 | GLSS2  | ---                | ---      | Not available                    |
-| GLSS3  | =POV_GH.DTA=      | =loc2=   | 1=Semi-urban, 2=Rural (numeric)  |
+| GLSS3  | =POV_GH.DTA=      | =loc2=   | 1=Urban, 2=Rural (numeric)       |
 | GLSS4  | =SEC0A.DTA=        | =loc2=   | 1=Urban, 2=Rural (numeric)       |
 | GLSS5  | ---                | ---      | Not in cover page; in =pov_gh5=  |
 | GLSS6  | =g6loc_edt.dta=    | =loc2=   | Rural, Urban (string)            |

--- a/lsms_library/countries/India/1997-98/_/data_info.yml
+++ b/lsms_library/countries/India/1997-98/_/data_info.yml
@@ -10,20 +10,31 @@ sample:
         v: village
         weight: weight
         panel_weight: weight
+        # Raw `stratum` is a STRING column with exactly four values --
+        # 'UP-qual', 'UP-other', ' B-qual', ' B-other' (note the leading space
+        # on the Bihar pair).  It is a state x sampling-phase stratum and is
+        # perfectly collinear with `state` (UP vs Bihar); crosstab confirms
+        # every ' B-*' row is Bihar and every 'UP-*' row is Uttar Pradesh.
+        #
+        # It carries NO urban/rural information.  The float-keyed mapping that
+        # used to sit here (1.0: 'Urban Poor' ... 4.0: 'Rural Non-Poor', and a
+        # parallel one deriving `Rural`) never matched a single row -- the keys
+        # are floats, the data are strings -- so `Rural` reached the user as the
+        # raw stratum label ('UP-other', ' B-qual', ...) for 100% of households.
+        # See GH #602.
+        #
+        # `Rural` is therefore DELETED rather than re-mapped: there is no
+        # urban/rural variable in this survey to derive it from, and inventing
+        # one (e.g. asserting the survey is rural-only) would replace a visibly
+        # wrong value with an invisibly wrong one.  India simply has no Rural
+        # indicator.  Only the whitespace is normalised on `strata` below.
         strata:
             - stratum
             - mapping:
-                1.0: Urban Poor
-                2.0: Urban Non-Poor
-                3.0: Rural Poor
-                4.0: Rural Non-Poor
-        Rural:
-            - stratum
-            - mapping:
-                1.0: Urban
-                2.0: Urban
-                3.0: Rural
-                4.0: Rural
+                'UP-qual': UP-qual
+                'UP-other': UP-other
+                ' B-qual': B-qual
+                ' B-other': B-other
 
 cluster_features:
   file:

--- a/lsms_library/countries/India/_/CONTENTS.org
+++ b/lsms_library/countries/India/_/CONTENTS.org
@@ -1,5 +1,25 @@
 #+title: Contents
 
+* sample.Rural — NOT available (2026-07-12, #602)
+
+=sample= carries no =Rural= (urban/rural) column, deliberately.
+
+It previously did, derived from =stratum= via a float-keyed mapping
+(=1.0: Urban ... 4.0: Rural=).  Raw =stratum= is a *string* column, so that
+mapping never matched a single row and the raw stratum label leaked into
+=Rural= for **100% of households** (='UP-other'=, =' B-other'= (leading
+space), ='UP-qual'=, =' B-qual'=) — see GH #602.
+
+The deeper problem is that =stratum= is not an urban/rural variable at all: it
+is a *state x sampling-phase* stratum, perfectly collinear with =state=
+(crosstab: every =' B-*'= row is Bihar, every ='UP-*'= row is Uttar Pradesh).
+The UP & Bihar Survey of Living Conditions 1997-98 has no urban/rural variable
+in =HHLIST.DTA= or =PSULIST.DTA=.  =Rural= was therefore *removed* rather than
+re-mapped: asserting a classification the survey never recorded would replace a
+visibly wrong value with an invisibly wrong one.  =strata= now carries the true
+stratum labels (whitespace normalised: =UP-qual=, =UP-other=, =B-qual=,
+=B-other=).
+
 * assets — consumer durables (2026-06-08, #342)
 Source: =SECT07D.DTA= §7 Part D "Consumer durables owned".  The module is
 already stored long (one row per household-item) with =itemcode= and =v07d02=

--- a/lsms_library/countries/India/_/data_scheme.yml
+++ b/lsms_library/countries/India/_/data_scheme.yml
@@ -7,7 +7,11 @@ Data Scheme:
     weight: float
     panel_weight: float
     strata: str
-    Rural: str
+    # No Rural: this survey records no urban/rural variable.  It was previously
+    # derived from `stratum` (a state x sampling-phase stratum, collinear with
+    # `state`) via a float-keyed map against a string column, which never fired --
+    # so the raw stratum label leaked into Rural for 100% of households.  See
+    # GH #602 and ../_/CONTENTS.org.
 
   cluster_features:
     index: (t, v)

--- a/lsms_library/countries/Malawi/2004-05/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2004-05/_/data_info.yml
@@ -45,10 +45,11 @@ cluster_features:
         Region: region
         District: dist
         # Raw `reside` is already the canonical 'Rural'/'Urban' in this wave.
-        # The `mappings:` block that used to sit here turned those good labels
-        # into 1/0 (and note it was even spelled `mappings:` rather than the
-        # `mapping:` the grabber honours).  Pass the label through; the other
-        # Malawi waves now do the same.  GH #602.
+        # The `mappings:` block that used to sit here DID fire (country.py's
+        # map_formatting_function honours both the `mapping:` and `mappings:`
+        # spellings) and destroyed those good labels into 1/0 -- which is why
+        # agreement with the correct sample.Rural was 0.0%.  Pass the label
+        # through; the other Malawi waves now do the same.  GH #602.
         Rural: reside
 
 household_roster:

--- a/lsms_library/countries/Malawi/2004-05/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2004-05/_/data_info.yml
@@ -44,11 +44,12 @@ cluster_features:
     myvars:
         Region: region
         District: dist
-        Rural:
-            - reside
-            - mappings:
-                Rural: 1
-                Urban: 0
+        # Raw `reside` is already the canonical 'Rural'/'Urban' in this wave.
+        # The `mappings:` block that used to sit here turned those good labels
+        # into 1/0 (and note it was even spelled `mappings:` rather than the
+        # `mapping:` the grabber honours).  Pass the label through; the other
+        # Malawi waves now do the same.  GH #602.
+        Rural: reside
 
 household_roster:
     file: sec_b.dta

--- a/lsms_library/countries/Malawi/2010-11/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2010-11/_/data_info.yml
@@ -78,11 +78,16 @@ cluster_features:
             i: case_id
             v: ea_id
         myvars:
-            Rural:
-                - reside
-                - mapping:
-                    rural: 0
-                    urban: 1
+            # Raw `reside` is already a declared spelling of the canonical
+            # Rural/Urban vocabulary in every Malawi wave ('Rural'/'Urban',
+            # 'rural'/'urban', 'RURAL'/'URBAN' -- the case differs between the
+            # Cross_Sectional and Panel files).  Pass it through and let
+            # _enforce_canonical_spellings normalise it.  The `mapping:` blocks
+            # that used to sit here converted these good labels into 0/1 and
+            # got the DIRECTION WRONG: because the two source files disagree on
+            # case, 2016-17 and 2019-20 mapped rural households to BOTH codes,
+            # sign-flipping the indicator between waves.  GH #602.
+            Rural: reside
             Region:
                 - hh_a01
                 - mapping:

--- a/lsms_library/countries/Malawi/2013-14/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2013-14/_/data_info.yml
@@ -58,11 +58,16 @@ cluster_features:
         myvars:
             Region: region
             District: district
-            Rural:
-                - reside
-                - mapping:
-                    rural: 0
-                    urban: 1
+            # Raw `reside` is already a declared spelling of the canonical
+            # Rural/Urban vocabulary in every Malawi wave ('Rural'/'Urban',
+            # 'rural'/'urban', 'RURAL'/'URBAN' -- the case differs between the
+            # Cross_Sectional and Panel files).  Pass it through and let
+            # _enforce_canonical_spellings normalise it.  The `mapping:` blocks
+            # that used to sit here converted these good labels into 0/1 and
+            # got the DIRECTION WRONG: because the two source files disagree on
+            # case, 2016-17 and 2019-20 mapped rural households to BOTH codes,
+            # sign-flipping the indicator between waves.  GH #602.
+            Rural: reside
     df_geo:
         # 2013-14 IHPS publishes lat/lon per HOUSEHOLD (jittered per HH),
         # not per cluster — the file is keyed on y2_hhid, not ea_id.

--- a/lsms_library/countries/Malawi/2016-17/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2016-17/_/data_info.yml
@@ -62,13 +62,16 @@ cluster_features:
         myvars:
             Region: region
             District: district
-            Rural:
-                - reside
-                - mapping:
-                    rural: 0
-                    urban: 1
-                    RURAL: 1
-                    URBAN: 0
+            # Raw `reside` is already a declared spelling of the canonical
+            # Rural/Urban vocabulary in every Malawi wave ('Rural'/'Urban',
+            # 'rural'/'urban', 'RURAL'/'URBAN' -- the case differs between the
+            # Cross_Sectional and Panel files).  Pass it through and let
+            # _enforce_canonical_spellings normalise it.  The `mapping:` blocks
+            # that used to sit here converted these good labels into 0/1 and
+            # got the DIRECTION WRONG: because the two source files disagree on
+            # case, 2016-17 and 2019-20 mapped rural households to BOTH codes,
+            # sign-flipping the indicator between waves.  GH #602.
+            Rural: reside
     df_geo:
         # 2016-17 IHS4 publishes lat/lon per HOUSEHOLD (cross-sectional file
         # is keyed on case_id, not ea_id).  Panel HHs (~2.5k) lack a geo

--- a/lsms_library/countries/Malawi/2019-20/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2019-20/_/data_info.yml
@@ -62,13 +62,16 @@ cluster_features:
         myvars:
             Region: region
             District: district
-            Rural:
-                - reside
-                - mapping:
-                    Rural: 0
-                    Urban: 1
-                    RURAL: 1
-                    URBAN: 0
+            # Raw `reside` is already a declared spelling of the canonical
+            # Rural/Urban vocabulary in every Malawi wave ('Rural'/'Urban',
+            # 'rural'/'urban', 'RURAL'/'URBAN' -- the case differs between the
+            # Cross_Sectional and Panel files).  Pass it through and let
+            # _enforce_canonical_spellings normalise it.  The `mapping:` blocks
+            # that used to sit here converted these good labels into 0/1 and
+            # got the DIRECTION WRONG: because the two source files disagree on
+            # case, 2016-17 and 2019-20 mapped rural households to BOTH codes,
+            # sign-flipping the indicator between waves.  GH #602.
+            Rural: reside
     df_geo:
         file: Cross_Sectional/householdgeovariables_ihs5.dta
         idxvars:

--- a/lsms_library/countries/Mali/2017-18/_/data_info.yml
+++ b/lsms_library/countries/Mali/2017-18/_/data_info.yml
@@ -45,7 +45,19 @@ cluster_features:
             v: grappe
         myvars:
             Region: s0q01
-            Rural: s0q04
+            # EACI 2017 splits urban into two stratification categories --
+            # 'Urbain (District de Bamako)' and 'Autre urbain'.  Both are urban;
+            # collapse them, mirroring the `sample` block above.  (The plain
+            # 'Urbain' / 'Urbano' labels used by the other EHCVM waves are handled
+            # globally by the Rural spellings block in lsms_library/data_info.yml.)
+            # Without this, cluster_features.Rural shipped the raw French strata
+            # and `df[df.Rural == 'Urban']` returned zero rows.  GH #602.
+            Rural:
+                - s0q04
+                - mapping:
+                    Rural: Rural
+                    Urbain (District de Bamako): Urban
+                    Autre urbain: Urban
     df_geo:
         file: eaci_geovariables_2017.dta
         idxvars:

--- a/lsms_library/countries/Uganda/2005-06/_/data_info.yml
+++ b/lsms_library/countries/Uganda/2005-06/_/data_info.yml
@@ -55,11 +55,17 @@ sample:
         strata: stratum
         Rural:
             - urban
-            - # Raw `urban` column is string-typed: '0' means rural, 'urban'
-              # means urban.  String keys required (see CLAUDE.md: "YAML
-              # mapping keys must be string keys when the raw labels are
-              # strings").  GH #163 item 3.
-                '0': Rural
+            - # The raw `urban` column is object-dtype but MIXED-typed: rural
+              # households carry the python int 0 (2,263 rows), urban ones the
+              # str 'urban' (860).  The key must therefore be the INT 0 -- a
+              # '0' string key never matches, the value passes through
+              # untouched, and it reaches the user as the literal string '0',
+              # so `df[df.Rural == 'Rural']` returns ZERO rows.  That is exactly
+              # what GH #163 item 3's fix did; it sat silently broken for three
+              # months until GH #602.  The `Region` stanza below already uses an
+              # int key for the same reason.  Verify with:
+              #   get_dataframe('../Data/GSEC1.dta')['urban'].map(type).value_counts()
+                0: Rural
                 urban: Urban
         # HH-level Region — the same column cluster_features reads, exposed
         # here so consumers can get Region for every HH regardless of cluster

--- a/lsms_library/data_info.yml
+++ b/lsms_library/data_info.yml
@@ -125,6 +125,33 @@ Columns:
         unrelated: []
         guest: []
         servant: []
+  sample:
+    # `sample` was historically absent from this section, which made
+    # _enforce_canonical_spellings a complete no-op on sample() -- it did not
+    # merely fail to reject unknown values, it never even mapped the *known*
+    # variants.  That is why Tajikistan shipped 9,020 rows of lowercase
+    # 'rural'/'urban' sitting next to canonical 'Rural'/'Urban'.  GH #602.
+    #
+    # Rural is deliberately NOT `required: true`: many countries' sample table
+    # carries only (v, weight, strata) and has no urban/rural indicator at all.
+    Rural:
+      type: str
+      spellings:
+        # Same vocabulary as cluster_features.Rural below -- one concept, one
+        # canonical spelling, wherever it appears.
+        # French (EHCVM) and Portuguese (Guinea-Bissau) labels are accepted
+        # variants of the same concept -- the survey language should not change
+        # the canonical value the user filters on.  GH #602.
+        Rural: [rural, RURAL, Rurale, rurale, RURALE, Rural (zone rurale)]
+        Urban: [urban, URBAN, Urbain, urbain, URBAIN, Urbano, urbano, URBANO]
+        # Third settlement stratum, used only by South Africa 1993 (PSLSD),
+        # whose sampling frame classifies areas as urban / rural / informal
+        # (squatter settlement).  It is deliberately NOT folded into Urban:
+        # the source's own `metro` variable groups these households with the
+        # non-metro areas (type=3 is entirely metro=3, whereas the urban
+        # stratum is entirely metro=1), so there is no evidence they are urban.
+        # Kept as a distinct, VISIBLE value rather than guessed away.  GH #602.
+        Informal: []
   cluster_features:
     Region:
       type: str
@@ -136,8 +163,19 @@ Columns:
         # Canonical values are 'Rural' / 'Urban' (capitalised).  Some
         # wave-level extractions emit lowercase; normalise here via the
         # standard spellings path.  GH #163.
-        Rural: [rural, RURAL]
-        Urban: [urban, URBAN]
+        # French (EHCVM) and Portuguese (Guinea-Bissau) labels are accepted
+        # variants of the same concept -- the survey language should not change
+        # the canonical value the user filters on.  GH #602.
+        Rural: [rural, RURAL, Rurale, rurale, RURALE, Rural (zone rurale)]
+        Urban: [urban, URBAN, Urbain, urbain, URBAIN, Urbano, urbano, URBANO]
+        # Third settlement stratum, used only by South Africa 1993 (PSLSD),
+        # whose sampling frame classifies areas as urban / rural / informal
+        # (squatter settlement).  It is deliberately NOT folded into Urban:
+        # the source's own `metro` variable groups these households with the
+        # non-metro areas (type=3 is entirely metro=3, whereas the urban
+        # stratum is entirely metro=1), so there is no evidence they are urban.
+        # Kept as a distinct, VISIBLE value rather than guessed away.  GH #602.
+        Informal: []
     District:
       type: str
     Latitude:

--- a/lsms_library/diagnostics.py
+++ b/lsms_library/diagnostics.py
@@ -67,6 +67,62 @@ _API_DERIVED_COLUMNS: dict[str, set[str]] = _load_api_derived()
 
 
 # ---------------------------------------------------------------------------
+# Declared value vocabularies (data_info.yml `spellings`)
+# ---------------------------------------------------------------------------
+
+def _load_declared_vocabularies() -> dict[str, dict[str, tuple[frozenset, dict]]]:
+    """Return ``{table: {column: (vocabulary, variant_map)}}`` from data_info.yml.
+
+    For every column carrying a ``spellings`` block, the *vocabulary* is the set
+    of canonical keys and the *variant_map* is the ``{variant: canonical}``
+    inverse used by ``country._enforce_canonical_spellings``.
+
+    This deliberately does **not** reuse ``country._load_canonical_spellings()``:
+    that function drops any column whose variant lists are all empty (its final
+    ``if variant_map:`` guard), which would silently exclude ``Affinity``,
+    ``Tenure`` and ``TenureSystem`` — columns that declare a canonical
+    vocabulary but no spelling variants.  The vocabulary is ``spellings.keys()``,
+    and it is a constraint whether or not any variants happen to be listed.
+
+    Keyed by **(table, column)**, never by column name alone: ``housing.Tenure``
+    is a legitimately different vocabulary (dwelling tenure) from
+    ``plot_features.Tenure`` (land tenure), and ``housing`` declares none.
+    """
+    from importlib.resources import files
+    try:
+        info_path = files("lsms_library") / "data_info.yml"
+        with open(info_path, "r", encoding="utf-8") as f:
+            info = _yaml.safe_load(f)
+    except (OSError, _yaml.YAMLError):
+        # Missing or malformed data_info.yml -> no declared vocabularies.
+        # Programmer bugs (TypeError, AttributeError) propagate.
+        return {}
+    result: dict[str, dict[str, tuple[frozenset, dict]]] = {}
+    for table, cols in (info or {}).get("Columns", {}).items():
+        if not isinstance(cols, dict):
+            continue
+        for col, meta in cols.items():
+            if not isinstance(meta, dict):
+                continue
+            spellings = meta.get("spellings")
+            if not isinstance(spellings, dict) or not spellings:
+                continue
+            variant_map = {
+                v: canonical
+                for canonical, variants in spellings.items()
+                for v in (variants or [])
+            }
+            result.setdefault(table, {})[col] = (
+                frozenset(spellings.keys()), variant_map,
+            )
+    return result
+
+
+_DECLARED_VOCABULARIES: dict[str, dict[str, tuple[frozenset, dict]]] = \
+    _load_declared_vocabularies()
+
+
+# ---------------------------------------------------------------------------
 # Report dataclass
 # ---------------------------------------------------------------------------
 
@@ -388,6 +444,63 @@ def _check_value_constraints(df: pd.DataFrame, scheme: dict, feature: str) -> Ch
                  f"{len(constrained)} constrained column(s) — all values valid")
 
 
+def _check_declared_spellings(df: pd.DataFrame, feature: str) -> Check:
+    """Fail if a column's values fall outside the vocabulary declared in data_info.yml.
+
+    ``_enforce_canonical_spellings`` *maps* known variants to their canonical
+    form but never *rejects* unknown ones, so a value the schema never declared
+    (Uganda's literal ``'0'`` for ``sample.Rural``; Malawi's ``'0.0'``/``'1.0'``
+    for ``cluster_features.Rural``) flows straight through to the user.  The
+    idiomatic filter ``df[df['Rural'] == 'Rural']`` then silently returns zero
+    rows.  This check closes that gap: a declared vocabulary is a constraint,
+    and violating it is a ``fail``.
+
+    Membership is tested **after** applying the variant map, exactly as
+    ``_enforce_canonical_spellings`` would, so the check is correct on both
+    pre-``_finalize_result`` cached parquets (which ``tests/test_table_structure``
+    reads directly, and which legitimately hold known variants such as Malawi's
+    ``rural``/``RURAL``) and post-finalize API frames.
+    """
+    vocabularies = _DECLARED_VOCABULARIES.get(feature, {})
+    if not vocabularies:
+        return Check("declared_spellings", "pass",
+                     "No declared vocabulary for this table (skipped)")
+
+    issues = []
+    checked = []
+    for col, (vocabulary, variant_map) in vocabularies.items():
+        if col in df.columns:
+            values = df[col]
+        elif col in (df.index.names or []):
+            values = pd.Series(df.index.get_level_values(col))
+        else:
+            continue  # column absent for this country — not a violation
+        checked.append(col)
+
+        # Mirror _enforce_canonical_spellings' normalization, then test membership.
+        if isinstance(values.dtype, pd.CategoricalDtype):
+            values = values.astype("string")
+        normalized = values.replace(variant_map).dropna()
+        offending = normalized[~normalized.isin(vocabulary)]
+        if offending.empty:
+            continue
+        counts = offending.value_counts()
+        shown = ", ".join(f"{v!r} ({n})" for v, n in counts.head(5).items())
+        more = f", +{len(counts) - 5} more" if len(counts) > 5 else ""
+        issues.append(
+            f"{col}: {len(offending)}/{len(normalized)} value(s) outside declared "
+            f"vocabulary {sorted(vocabulary)}: {shown}{more}"
+        )
+
+    if issues:
+        return Check("declared_spellings", "fail", "; ".join(issues))
+    if not checked:
+        return Check("declared_spellings", "pass",
+                     "No constrained columns present (skipped)")
+    return Check("declared_spellings", "pass",
+                 f"{len(checked)} column(s) match declared vocabulary: {sorted(checked)}")
+
+
 def _check_duplicate_index(df: pd.DataFrame) -> Check:
     """Flag high rates of duplicate index entries."""
     if not df.index.has_duplicates:
@@ -626,6 +739,7 @@ def is_this_feature_sane(
     report.checks.append(_check_declared_columns(df, scheme, feature))
     report.checks.append(_check_dtype_consistency(df, scheme, feature))
     report.checks.append(_check_value_constraints(df, scheme, feature))
+    report.checks.append(_check_declared_spellings(df, feature))
     report.checks.append(_check_duplicate_index(df))
     report.checks.append(_check_float_stringified_index(df))
     report.checks.append(_check_ids_format_id_canonical(df))
@@ -852,6 +966,7 @@ def validate_feature(
     report.checks.append(_check_declared_columns(df, scheme, feature))
     report.checks.append(_check_dtype_consistency(df, scheme, feature))
     report.checks.append(_check_value_constraints(df, scheme, feature))
+    report.checks.append(_check_declared_spellings(df, feature))
     report.checks.append(_check_duplicate_index(df))
 
     # --- New wave present? --------------------------------------------------

--- a/tests/fixtures/uganda_baseline.json
+++ b/tests/fixtures/uganda_baseline.json
@@ -1440,7 +1440,7 @@
       "v",
       "weight"
     ],
-    "content_hash": "93759186a35f9ae1984933238adc5857ba7a4b953b6a1450786efccde84117e4",
+    "content_hash": "d7a070c0911e4939e7708e2a0a5cd8e748b109c66cf659dfbb721d253b263a5c",
     "dtypes": {
       "Region": "string",
       "Rural": "string",

--- a/tests/test_declared_spellings.py
+++ b/tests/test_declared_spellings.py
@@ -18,6 +18,9 @@ These tests pin:
   3. the per-country data fixes, each of which is a distinct root cause.
 """
 
+import os
+from pathlib import Path
+
 import pandas as pd
 import pytest
 
@@ -163,7 +166,42 @@ class TestSampleIsDeclared:
 # 3. Per-country regressions (each a distinct root cause)
 # ---------------------------------------------------------------------------
 
+def _aws_creds_available() -> bool:
+    """True iff DVC could perform an S3 pull right now.
+
+    The per-country regressions below BUILD REAL COUNTRY DATA, which goes
+    through DVC -> S3.  Without credentials they fail with
+    ``NoCredentialsError`` regardless of whether the test logic is correct.
+
+    The CI ``unit-tests`` job intentionally sets ``LSMS_SKIP_AUTH=1`` to keep PR
+    validation fast and data-free; only ``data-tests`` carries the S3 secrets.
+    So these must silent-skip there, exactly as the equivalent guard in
+    ``tests/test_canonical_shape_via_cache_miss.py`` does.
+
+    (Mirrors that helper deliberately rather than importing across test modules.
+    The duplication is the pre-existing house pattern; centralising it into
+    ``conftest.py`` is worth doing, but not in a CI-red hotfix.)
+    """
+    if os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"):
+        return True
+    creds_file = (
+        Path(__file__).parent.parent
+        / "lsms_library" / "countries" / ".dvc" / "s3_creds"
+    )
+    if creds_file.exists():
+        try:
+            return "aws_access_key_id" in creds_file.read_text()
+        except OSError:
+            return False
+    return False
+
+
 @pytest.mark.slow
+@pytest.mark.skipif(
+    not _aws_creds_available(),
+    reason="per-country regressions build real data (DVC -> S3); no credentials "
+           "in the `unit-tests` CI job (LSMS_SKIP_AUTH=1). They run in `data-tests`.",
+)
 class TestCountryRegressions:
     def test_uganda_2005_06_rural_is_canonical(self):
         """Root cause: YAML key TYPE mismatch.  Raw `urban` is object-dtype but

--- a/tests/test_declared_spellings.py
+++ b/tests/test_declared_spellings.py
@@ -204,9 +204,13 @@ class TestCountryRegressions:
         rather than invented."""
         import lsms_library as ll
         s = ll.Country("India").sample()
-        if "Rural" in s.columns:
-            assert set(s["Rural"].dropna().unique()) <= {"Rural", "Urban", "Informal"}
-        assert not set(s["strata"].dropna().unique()) & {"UP-other", " B-other"}
+        # Rural is gone entirely -- the survey has no urban/rural variable.
+        assert "Rural" not in s.columns, sorted(s.columns)
+        # strata now carries the TRUE stratum labels, whitespace-normalised.
+        # ('UP-other' is a legitimate label; ' B-other' -- leading space -- is not.)
+        strata = set(s["strata"].dropna().unique())
+        assert strata == {"UP-qual", "UP-other", "B-qual", "B-other"}, strata
+        assert not any(v != v.strip() for v in strata)
 
     def test_ghanalss_1991_92_rural_code_map_says_urban(self):
         """LATENT defect (not currently reaching sample() in a clean build -- the

--- a/tests/test_declared_spellings.py
+++ b/tests/test_declared_spellings.py
@@ -1,0 +1,249 @@
+"""GH #602 -- a declared vocabulary must actually be ENFORCED.
+
+``lsms_library/data_info.yml`` declares accepted values via ``spellings``
+blocks, but ``_enforce_canonical_spellings()`` only ever *mapped known
+variants*; it never *rejected unknown ones*, and no sanity check read the
+``spellings`` declarations at all.  A value the schema never declared therefore
+flowed straight through to the user -- Uganda's ``sample.Rural`` was the literal
+string ``'0'`` for 2,263 households (72% of the 2005-06 wave), so the idiomatic
+filter ``df[df['Rural'] == 'Rural']`` silently returned ZERO rows, and
+``is_this_feature_sane(...).ok`` was ``True``.
+
+These tests pin:
+  1. the new ``_check_declared_spellings`` check (fires on unknown values, in
+     columns AND index levels; silent on known variants and clean frames; does
+     NOT fire on the ``housing.Tenure`` false-positive trap);
+  2. ``sample`` being declared under ``Columns:`` at all (it was not, which made
+     ``_enforce_canonical_spellings`` a total no-op on ``sample()``);
+  3. the per-country data fixes, each of which is a distinct root cause.
+"""
+
+import pandas as pd
+import pytest
+
+from lsms_library.country import _enforce_canonical_spellings
+from lsms_library.diagnostics import (
+    _check_declared_spellings,
+    _DECLARED_VOCABULARIES,
+    is_this_feature_sane,
+)
+
+
+# ---------------------------------------------------------------------------
+# Known-unharmonized (table, column) pairs -- an ENUMERATED list that is meant
+# to be burned down, NOT a permanent exemption.
+#
+# These five countries ship raw, unharmonized survey labels in plot_features
+# `Tenure` / `TenureSystem` (Cambodia's ALL-CAPS questionnaire text; Kosovo's
+# 'Owned'/'Rented'; Timor-Leste's 'Part owner'; Albania's and Tajikistan's
+# post-socialist documentary-title vocabulary -- 'privatised', 'deed',
+# 'usufruct', 'CERTIFICATE', 'ACT (SEALED DOCUMENT)').  They are REAL defects
+# and the check correctly FAILS them: `df[df.Tenure == 'owned']` returns zero
+# rows for Kosovo despite 6,419 owned plots.
+#
+# They are xfailed rather than "fixed" because several values are genuinely
+# ambiguous without the questionnaire codebooks (Cambodia's "GIVEN BY THE
+# GOVERNMENT OR LOCAL AUTHORITY"; Timor-Leste's "Part owner", 81% of its plots),
+# and guessing a mapping would replace a VISIBLY wrong value with an INVISIBLY
+# wrong one -- exactly the class-1 failure GH #602 is about.  The check keeps
+# them loud; it does not paper over them.
+KNOWN_UNHARMONIZED: frozenset[tuple[str, str]] = frozenset({
+    ("Albania", "plot_features"),
+    ("Cambodia", "plot_features"),
+    ("Kosovo", "plot_features"),
+    ("Tajikistan", "plot_features"),
+    ("Timor-Leste", "plot_features"),
+})
+
+
+def _frame(col, values, feature_index=False):
+    n = len(values)
+    df = pd.DataFrame({col: values, "x": range(n)})
+    df["i"] = [f"h{k}" for k in range(n)]
+    df["t"] = "2020"
+    if feature_index:
+        return df.set_index(["i", "t", col])
+    return df.set_index(["i", "t"])
+
+
+# ---------------------------------------------------------------------------
+# 1. The check itself
+# ---------------------------------------------------------------------------
+
+class TestCheckDeclaredSpellings:
+    def test_rejects_unknown_column_value(self):
+        """The exact Uganda shape: a literal '0' where 'Rural' was declared."""
+        chk = _check_declared_spellings(
+            _frame("Rural", ["0", "Urban", "0"]), "cluster_features")
+        assert chk.status == "fail"
+        assert "'0'" in chk.message and "(2)" in chk.message
+
+    def test_rejects_unknown_index_level_value(self):
+        """_enforce_canonical_spellings handles index levels; so must the check."""
+        chk = _check_declared_spellings(
+            _frame("Rural", ["0", "Urban"], feature_index=True), "cluster_features")
+        assert chk.status == "fail"
+
+    def test_passes_on_canonical_values(self):
+        chk = _check_declared_spellings(
+            _frame("Rural", ["Rural", "Urban"]), "cluster_features")
+        assert chk.status == "pass"
+
+    def test_passes_on_declared_variants(self):
+        """Membership is tested AFTER the variant map, so a cached parquet
+        holding 'rural'/'RURAL' (Malawi) must not be flagged."""
+        chk = _check_declared_spellings(
+            _frame("Rural", ["rural", "RURAL", "urban", "URBAN"]), "cluster_features")
+        assert chk.status == "pass"
+
+    def test_all_null_column_does_not_fire(self):
+        chk = _check_declared_spellings(
+            _frame("Rural", [None, None]), "cluster_features")
+        assert chk.status == "pass"
+
+    def test_housing_tenure_is_not_flagged(self):
+        """FALSE-POSITIVE TRAP: `housing.Tenure` is a legitimately different
+        vocabulary (dwelling tenure) and `housing` declares none.  A check keyed
+        on column NAME rather than (table, column) fires on ~12 countries here
+        and discredits itself."""
+        chk = _check_declared_spellings(
+            _frame("Tenure", ["Owned", "Rent-free", "Perching"]), "housing")
+        assert chk.status == "pass"
+
+    def test_empty_variant_vocabularies_are_still_checked(self):
+        """Tenure/TenureSystem/Affinity declare canonical keys with EMPTY variant
+        lists.  country._load_canonical_spellings() DROPS those tables (its
+        `if variant_map:` guard), so the check must read `Columns` itself or they
+        go unchecked entirely."""
+        assert "Tenure" in _DECLARED_VOCABULARIES["plot_features"]
+        assert "Affinity" in _DECLARED_VOCABULARIES["household_roster"]
+        chk = _check_declared_spellings(
+            _frame("Tenure", ["Owned", "owned"]), "plot_features")
+        assert chk.status == "fail"
+
+    def test_wired_into_is_this_feature_sane(self):
+        """The check must actually be part of the battery -- Uganda's '0' graded
+        sane.ok == True for three months precisely because nothing ran it."""
+        df = _frame("Rural", ["0", "Urban"])
+        report = is_this_feature_sane(df, "Uganda", "cluster_features")
+        assert not report.ok
+        assert any(c.name == "declared_spellings" for c in report.errors)
+
+
+# ---------------------------------------------------------------------------
+# 2. `sample` must be declared, or enforcement is a no-op on it
+# ---------------------------------------------------------------------------
+
+class TestSampleIsDeclared:
+    def test_sample_rural_has_a_vocabulary(self):
+        assert "sample" in _DECLARED_VOCABULARIES, (
+            "`sample` absent from data_info.yml Columns -- "
+            "_enforce_canonical_spellings is a total no-op on sample()")
+        assert "Rural" in _DECLARED_VOCABULARIES["sample"]
+
+    def test_sample_rural_variants_are_now_mapped(self):
+        """This is the Tajikistan bug: 9,020 rows of lowercase 'rural'/'urban'
+        sat next to canonical values because `sample` was undeclared, so not even
+        the KNOWN variants were mapped."""
+        df = pd.DataFrame({"Rural": ["rural", "urban", "Rural"]})
+        out = _enforce_canonical_spellings(df, "sample")
+        assert out["Rural"].tolist() == ["Rural", "Urban", "Rural"]
+
+    def test_sample_rural_is_not_required(self):
+        """Many countries' sample has no urban/rural column at all; declaring
+        Rural `required: true` would fail every one of them."""
+        from importlib.resources import files
+        import yaml
+        info = yaml.safe_load(
+            (files("lsms_library") / "data_info.yml").read_text(encoding="utf-8"))
+        assert not info["Columns"]["sample"]["Rural"].get("required", False)
+
+
+# ---------------------------------------------------------------------------
+# 3. Per-country regressions (each a distinct root cause)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.slow
+class TestCountryRegressions:
+    def test_uganda_2005_06_rural_is_canonical(self):
+        """Root cause: YAML key TYPE mismatch.  Raw `urban` is object-dtype but
+        MIXED -- python int 0 (2263 rows) + str 'urban' (860).  The declared key
+        was the STRING '0', which never matched, so the value passed through and
+        was stringified to '0'.  (Commit 9959b9f3 introduced that string key to
+        'fix' GH #163 and was silently dead for three months.)"""
+        import lsms_library as ll
+        s = ll.Country("Uganda").sample()
+        r = s.xs("2005-06", level="t")["Rural"]
+        assert "0" not in set(r.dropna().unique())
+        assert (r == "Rural").sum() == 2263
+        assert (r == "Urban").sum() == 860
+
+    def test_malawi_cluster_features_rural_not_sign_flipped(self):
+        """Root cause: `mapping:` stanzas converted good labels into 0/1 and got
+        the DIRECTION wrong.  The Cross_Sectional and Panel files disagree on
+        case ('rural' vs 'RURAL'), and 2016-17/2019-20 mapped BOTH into one dict,
+        so rural households landed on both codes -- inverting the indicator
+        between waves.  cluster_features.Rural must now agree with the (correct)
+        sample.Rural label."""
+        import lsms_library as ll
+        cf = ll.Country("Malawi").cluster_features().reset_index()[["t", "v", "Rural"]]
+        assert set(cf["Rural"].dropna()) <= {"Rural", "Urban"}
+        sm = (ll.Country("Malawi").sample().reset_index()[["t", "v", "Rural"]]
+              .rename(columns={"Rural": "sample_label"}))
+        j = cf.rename(columns={"Rural": "cf_label"}).merge(sm, on=["t", "v"]).dropna()
+        for t, g in j.groupby("t"):
+            agree = (g["cf_label"] == g["sample_label"]).mean()
+            assert agree > 0.80, f"Malawi {t}: cluster_features.Rural agrees with sample only {agree:.1%}"
+
+    def test_india_sample_has_no_fabricated_rural(self):
+        """Root cause: `Rural` was derived from `stratum` via a FLOAT-keyed map
+        (1.0..4.0) against a STRING column, so it never fired and the raw stratum
+        label ('UP-other', ' B-qual', ...) reached the user as `Rural` for 100% of
+        households.  `stratum` is a state x phase stratum (perfectly collinear
+        with `state`) and carries NO urban/rural information, so Rural is dropped
+        rather than invented."""
+        import lsms_library as ll
+        s = ll.Country("India").sample()
+        if "Rural" in s.columns:
+            assert set(s["Rural"].dropna().unique()) <= {"Rural", "Urban", "Informal"}
+        assert not set(s["strata"].dropna().unique()) & {"UP-other", " B-other"}
+
+    def test_ghanalss_1991_92_rural_code_map_says_urban(self):
+        """LATENT defect (not currently reaching sample() in a clean build -- the
+        'Semi-urban' values I first saw came from a STALE shared-cache parquet).
+        The `rural` code->label table in GhanaLSS/1991-92/_/categorical_mapping.org
+        asserted 1 = 'Semi-urban'.  That is provably wrong: loc2=1 nests EXACTLY
+        onto loc3 in {1,2} == loc5 in {1,2} == Accra (459) + Other Urban (1119) =
+        1578, i.e. it is the union of the two URBAN strata.  mapping.Rural() reads
+        that table, so the wrong label is one YAML edit away from going live."""
+        import importlib.util
+        import sys
+
+        from lsms_library.paths import countries_root
+        p = countries_root() / "GhanaLSS" / "1991-92" / "_" / "mapping.py"
+        spec = importlib.util.spec_from_file_location("_ghanalss_1991_92_mapping", p)
+        m = importlib.util.module_from_spec(spec)
+        sys.modules["_ghanalss_1991_92_mapping"] = m
+        spec.loader.exec_module(m)
+        assert m.rural_dict[1] == "Urban", m.rural_dict
+        assert m.Rural(1.0) == "Urban"
+        assert m.Rural(2.0) == "Rural"
+
+    def test_ghanalss_2016_17_cluster_rural_has_no_trailing_space(self):
+        """Root cause: g7sec8h's loc2 carries a TRAILING SPACE ('Urban '), which
+        looks right in a value_counts but compares false against 'Urban'."""
+        import lsms_library as ll
+        cf = ll.Country("GhanaLSS").cluster_features()
+        vals = set(cf.xs("2016-17", level="t")["Rural"].dropna().unique())
+        assert "Urban " not in vals
+        assert vals <= {"Rural", "Urban"}
+
+    @pytest.mark.parametrize("country", ["Mali", "Guinea-Bissau"])
+    def test_ehcvm_cluster_rural_is_canonical(self, country):
+        """French / Portuguese survey labels ('Urbain', 'Autre urbain',
+        'Urbain (District de Bamako)', 'Urbano') reached the user verbatim, so
+        `== 'Urban'` returned zero rows across every wave."""
+        import lsms_library as ll
+        cf = ll.Country(country).cluster_features()
+        assert set(cf["Rural"].dropna().unique()) <= {"Rural", "Urban"}
+        assert (cf["Rural"] == "Urban").sum() > 0

--- a/tests/test_declared_spellings.py
+++ b/tests/test_declared_spellings.py
@@ -213,13 +213,23 @@ class TestCountryRegressions:
         assert not any(v != v.strip() for v in strata)
 
     def test_ghanalss_1991_92_rural_code_map_says_urban(self):
-        """LATENT defect (not currently reaching sample() in a clean build -- the
-        'Semi-urban' values I first saw came from a STALE shared-cache parquet).
-        The `rural` code->label table in GhanaLSS/1991-92/_/categorical_mapping.org
-        asserted 1 = 'Semi-urban'.  That is provably wrong: loc2=1 nests EXACTLY
-        onto loc3 in {1,2} == loc5 in {1,2} == Accra (459) + Other Urban (1119) =
-        1578, i.e. it is the union of the two URBAN strata.  mapping.Rural() reads
-        that table, so the wrong label is one YAML edit away from going live."""
+        """LIVE class-1 defect.  The `rural` code->label table in
+        GhanaLSS/1991-92/_/categorical_mapping.org asserted 1 = 'Semi-urban'.
+        That is provably wrong: loc2=1 nests EXACTLY onto loc3 in {1,2} ==
+        loc5 in {1,2} == Accra (459) + Other Urban (1119) = 1578, i.e. it is
+        the union of the two URBAN strata.  GLSS4 declares 1|Urban for the same
+        loc2 (1998-99/_/categorical_mapping.org:19-22).  mapping.Rural() reads
+        that table, so pre-fix `sample()` shipped 'Semi-urban' to users for
+        1,578 households (and 100 clusters in `cluster_features()`).
+
+        NOTE, because an earlier draft of this docstring said the opposite and
+        was wrong: this is NOT latent.  A clean, from-source build of pristine
+        `development` in an isolated LSMS_DATA_DIR does ship 'Semi-urban'.  Do
+        not re-downgrade it to a doc-only fix.  (The original mis-grading came
+        from a verification run whose LSMS_COUNTRIES_ROOT override was silently
+        ignored -- GhanaLSS/1991-92/_/mapping.py:8 hardcodes
+        files('lsms_library')/'countries', bypassing the override.  That is a
+        separate CLAUDE.md anti-pattern worth its own issue.)"""
         import importlib.util
         import sys
 

--- a/tests/test_table_structure.py
+++ b/tests/test_table_structure.py
@@ -287,9 +287,23 @@ class TestFeatureSanity:
     def test_feature_is_sane(self, country, table, path):
         """Each cached feature must pass is_this_feature_sane (no failures)."""
         from lsms_library.diagnostics import is_this_feature_sane
+        from tests.test_declared_spellings import KNOWN_UNHARMONIZED
+
         df = _read_or_skip(path)
         report = is_this_feature_sane(df, country, table)
         if not report.ok:
+            # GH #602: five countries still ship raw, unharmonized plot_features
+            # Tenure / TenureSystem labels.  The new `declared_spellings` check
+            # correctly FAILS them -- they are real defects -- but the mapping
+            # onto the canonical vocabulary needs the questionnaire codebooks
+            # (see KNOWN_UNHARMONIZED).  xfail rather than silently downgrade the
+            # check to `warn`, which is the status quo that let this rot.
+            spelling_only = all(c.name == "declared_spellings" for c in report.errors)
+            if (country, table) in KNOWN_UNHARMONIZED and spelling_only:
+                pytest.xfail(
+                    f"GH #602: {country}/{table} ships unharmonized tenure labels: "
+                    + "; ".join(c.message for c in report.errors)
+                )
             report.summarize()
             pytest.fail(
                 f"{country}/{table} failed sanity checks: "


### PR DESCRIPTION
Closes #602.

`spellings` blocks in `lsms_library/data_info.yml` were **mapped but never enforced**. This PR adds the enforcement check, sweeps all 34 buildable countries with it, and fixes the **6 countries** it caught shipping non-canonical `Rural` values to users.

**Uganda — the case the issue was filed on — turned out to be the *least severe* of the six.**

---

## THE ISSUE'S DIAGNOSIS WAS WRONG IN THREE WAYS. READ THIS BEFORE THE DIFF.

The issue is **confirmed in substance** — the constraint really is unenforced, Uganda really does ship `'0'` — but every one of its three actionable claims is wrong, and the third is the one that matters.

### 1. Uganda's root cause is NOT "the extraction emits `'0'`". It is a YAML key **type** mismatch, and a previous fix *introduced* it.

The mapping **is** declared (`Uganda/2005-06/_/data_info.yml:62` on `development`). It simply never fires:

```yaml
Rural:
    - urban
    - # ...String keys required (see CLAUDE.md...).  GH #163 item 3.
        '0': Rural        # <-- string key
        urban: Urban
```

The raw `urban` column is object-dtype but **mixed-typed**: rural households carry the python `int 0` (2,263 rows), urban ones the `str 'urban'` (860). The key `'0'` never matches `0`, the value passes through untouched, and the literal string `'0'` reaches the user.

Commit `9959b9f3` (2026-04-14, *"close GH #163 item 3"*) introduced exactly that string key, citing CLAUDE.md's *"YAML mapping keys must be string keys when the raw labels are strings"* — advice that is **false for this column**. It has been silently dead for three months.

**The fix is one character: `'0'` → `0`.** Anyone who "re-fixes" this by adding a mapping will re-fail.

### 2. There is a second, independent gap the issue never mentions: `sample` was not in `Columns:` at all.

`_enforce_canonical_spellings` is a **total no-op** on `sample()` — it did not merely fail to *reject* unknowns, it never *mapped* the known ones either. That is the entire Tajikistan bug: **9,020 rows** of plain lowercase `'rural'`/`'urban'` that the existing spellings block would have fixed for free. Fixing only the rejection check, without declaring `sample:`, leaves Tajikistan broken *and unflagged*.

### 3. "If your check finds only Uganda, be suspicious." It found 10 violations across 6 countries — and **two are strictly worse than Uganda**.

- **Malawi `cluster_features.Rural` — the worst.** Not merely non-canonical: **sign-flipped between waves.** The `mapping:` stanzas destroyed good labels into 0/1 and got the direction wrong (the Cross_Sectional and Panel files disagree on case, so 2016-17 mapped `rural:0` and `RURAL:1` *simultaneously*). Agreement with the *correct* `sample.Rural` was **0.0% in every single wave.** A user pooling Malawi across waves gets a rural indicator with the wrong sign for part of the panel. Uganda at least fails visibly (you get a literal `'0'`); Malawi hands you a plausible-looking 0/1 that is wrong.
- **India `sample.Rural` — 100% fabricated.** Derived from `stratum` via a **float**-keyed map against a **string** column (`India/1997-98/_/data_info.yml:20-26`), so it never fired and the raw stratum label reached users *as the value of `Rural`*: `'UP-other'` (675), `' B-other'` (674), `'UP-qual'` (542), `' B-qual'` (360). All 2,251 rows garbage. `strata` was affected by the same bug.

**One thing I got wrong and corrected mid-flight, recorded so the next person doesn't repeat it:** my first (parquet-only) pass flagged **Malawi/`sample`** as a violation. It is **not** — Malawi self-heals via an auto-discovered `#+name: Rural` table in `Malawi/_/categorical_mapping.org:420`, which only runs at API time. **Reading cached parquets is not equivalent to calling the API. Do not "fix" Malawi/sample.**

---

## Evidence it was broken (live API, isolated `LSMS_DATA_DIR`)

| Country / table | Before | After |
|---|---|---|
| **Uganda** `sample.Rural` 2005-06 | `{'0': 2263, 'Urban': 860}` — `(Rural=='Rural').sum()` = **0 of 3123** | `{'Rural': 2263, 'Urban': 860}` — **2263 of 3123** |
| **Malawi** `cluster_features.Rural` | `{'0.0': 1647, '1.0': 1134}`; agreement w/ correct `sample.Rural` = **0.0% / 0.0% / 0.0% / 0.0% / 0.0%** | `{'Rural','Urban'}`; agreement **87.2% / 100.0% / 90.0% / 97.5% / 96.1%** (2004-05 / 2010-11 / 2013-14 / 2016-17 / 2019-20) |
| **India** `sample.Rural` | 2251/2251 stratum labels: `'UP-other'` 675, `' B-other'` 674, `'UP-qual'` 542, `' B-qual'` 360 | **column removed** (see below); `strata` = `{UP-qual, UP-other, B-qual, B-other}`, leading spaces stripped |
| **Tajikistan** `sample.Rural` | `{'rural': 5790, 'urban': 3230, 'Rural': 2419, 'Urban': 1084}` — `=='Rural'` returned **2419 of 8209** true rural HH | fully canonical |
| **Guinea-Bissau** `cluster_features.Rural` | `{'Rural': 281, 'Urbano': 169}` — `=='Urban'` returned **0 rows** | canonical |
| **Mali** `cluster_features.Rural` | French strata (`Urbain`, `Autre urbain`, `Urbain (District de Bamako)`) verbatim — `=='Urban'` returned 0 rows | canonical |
| **GhanaLSS** `cluster_features.Rural` 2016-17 | `'Urban '` — **trailing space**; looks right in a `value_counts`, compares false | canonical |
| **GhanaLSS** `sample.Rural` 1991-92 | `'Semi-urban'` × **1,578 HH** (+ 100 clusters) | `Urban` |

Sanity of the "sane" grade, pre-fix: `is_this_feature_sane(Country('Uganda').sample(), 'Uganda', 'sample').ok` was **`True`** — because nothing was checked.

**India: why the column was deleted rather than repaired.** `stratum` is a state×phase stratum, perfectly collinear with `state` (UP vs Bihar). It carries **no** urban/rural information. There is nothing to map it *to*. Deleting is class-2 (silently missing) and beats class-1 (silently wrong). Documented in `India/_/CONTENTS.org`.

**GhanaLSS: why `loc2=1` is provably `Urban`, not `Semi-urban`.** It nests exactly: `loc2=1` == `loc3 ∈ {1,2}` == `loc5 ∈ {1,2}` == Accra (459) + Other Urban (1119) = **1578**; `loc2=2` == the three rural strata = 2945. GLSS4 declares `1|Urban` for the same `loc2` (`GhanaLSS/1998-99/_/categorical_mapping.org:19-22`).

---

## Root causes (file:line, on `development`)

| | |
|---|---|
| `lsms_library/data_info.yml` | `sample` absent from `Columns:` → `_enforce_canonical_spellings` a no-op on `sample()` |
| `lsms_library/countries/Uganda/2005-06/_/data_info.yml:62` | `'0': Rural` — string key against an `int 0`. Introduced by `9959b9f3`. |
| `lsms_library/countries/India/1997-98/_/data_info.yml:13-26` | float keys (`1.0:`) against a string column — both `strata` and `Rural` |
| `lsms_library/countries/Malawi/{2004-05,2010-11,2013-14,2016-17,2019-20}/_/data_info.yml` | `mapping:`/`mappings:` stanzas destroying canonical labels into 0/1, inconsistently across waves |
| `lsms_library/countries/GhanaLSS/1991-92/_/categorical_mapping.org:32-36` | `#+name: rural` table: `1 | Semi-urban` |
| `lsms_library/countries/Mali/2017-18/_/data_info.yml`, `GhanaLSS/2016-17/_/data_info.yml` | raw French / trailing-space labels passed through |

---

## The fix

**1 — the check.** `diagnostics._check_declared_spellings` (`lsms_library/diagnostics.py:447`), status `fail`, naming offending values + row counts. Wired into both `is_this_feature_sane` (`:742`) and `validate_feature` (`:969`). Three design constraints, each pinned by a test:

- Keyed on **(table, column)**, never column name. `housing.Tenure` is a legitimately *different* vocabulary (dwelling tenure) in ~12 countries and `housing` declares none — a name-keyed check emits ~12 false failures and discredits itself. **I only found this because I validated the instrument first.**
- Membership tested **after** applying the variant map, so the check is correct on pre-`_finalize_result` cached parquets (which legitimately hold variants like Malawi's `rural`/`RURAL`) as well as on API frames.
- Reads `Columns` itself rather than reusing `country._load_canonical_spellings()`, whose `if variant_map:` guard **drops** `Affinity`/`Tenure`/`TenureSystem` (empty variant lists) — they would have gone unchecked.

**2 — the sweep.** 34 countries × every spellings-constrained (table, column), live API. **`BEFORE: pass=109 fail=10` → `AFTER: pass=114 fail=5`** (all 5 remaining = the enumerated `plot_features` xfails below).

**3 — the data fixes.** 9 country configs (Uganda, Malawi ×5, India, Mali, GhanaLSS ×2) + `sample:` declared under `Columns:`.

### Deliberately NOT fixed

5 `plot_features` `Tenure`/`TenureSystem` pairs ship raw unharmonized labels. The check correctly **fails** them. They are enumerated in `KNOWN_UNHARMONIZED` and **xfailed — not downgraded to `warn`**. Mapping them needs the questionnaire codebooks (Cambodia's *"GIVEN BY THE GOVERNMENT"*; Timor-Leste's *"Part owner"* = 81% of plots) and guessing would replace a *visibly* wrong value with an *invisibly* wrong one.

---

## Proof nothing else moved

**Instrument validated FIRST** — 12 planted cases: fires on violations in columns *and* index levels; silent on clean frames, on known variants, on all-NaN, and on the `housing.Tenure` trap.

**Byte-identical regression sweep** (the #594 bar): **123 (country, table) pairs** across all 4 constrained tables, live API, base vs fix, isolated data roots.

- **112 byte-identical.**
- **8 changed** — every one an intended fix; row counts unchanged everywhere:

| | rows | note |
|---|---|---|
| Uganda / `sample` | 24362 → 24362 | cols same |
| Malawi / `cluster_features` | 2781 → 2781 | cols same |
| Mali / `cluster_features` | 3006 → 3006 | cols same |
| Guinea-Bissau / `cluster_features` | 450 → 450 | cols same |
| GhanaLSS / `cluster_features` | 3145 → 3145 | cols same |
| GhanaLSS / `sample` | unchanged | **1,578 HH: `Semi-urban` → `Urban`** — missed by my sweep; see the retraction below |
| Tajikistan / `sample` | 12523 → 12523 | cols same |
| India / `sample` | 2251 → 2251 | **`Rural` column REMOVED** (intended) |

- 4 errors identical on both branches (Armenia, Nepal — documented no-microdata countries).
- **South Africa did NOT change**: `'Informal'` was already the shipped value; this PR only *admits it to the vocabulary*.

**All numbers come from an ISOLATED `LSMS_DATA_DIR`.** The shared cache was being overwritten mid-run by concurrent agents rebuilding `sample`/`cluster_features` with *their* configs, producing fresh-mtime/stale-content parquets. It very nearly fooled me (see the retracted GhanaLSS grading, below).

**Full suite** (isolated data root, both branches, same harness):

```
FIX : 3 failed, 3239 passed, 127 skipped, 9 xfailed
BASE: 3 failed, 3224 passed, 128 skipped, 4 xfailed
```

The **same 3 failures on both**, all pre-existing and untouched: `test_currency.py::test_feature_ghana_per_wave` (GH #589 — confirmed failing identically on pristine `development`); `test_table_structure::{test_declared_columns_present,test_feature_is_sane}[CotedIvoire/cluster_features]`. **Zero new failures.** `xfailed 4 → 9` = exactly the 5 `KNOWN_UNHARMONIZED` pairs.

**Proof the new tests fail on pre-fix code — executed, not asserted:**
1. Against the fully pristine tree the module cannot even import (`ImportError: cannot import name '_check_declared_spellings'`) — the check is genuinely new.
2. Against this PR's package + **pristine country configs** (isolating the data fixes): **5 failed, 13 passed** — `test_uganda_2005_06_rural_is_canonical`, `test_malawi_cluster_features_rural_not_sign_flipped`, `test_india_sample_has_no_fabricated_rural`, `test_ghanalss_2016_17_cluster_rural_has_no_trailing_space`, `test_ehcvm_cluster_rural_is_canonical[Mali]`.
3. `test_ghanalss_1991_92_rural_code_map_says_urban` verified by direct execution (pristine yields `{1: 'Semi-urban'}`; this PR yields `{1: 'Urban'}`). It did **not** fail via `LSMS_COUNTRIES_ROOT` because `GhanaLSS/1991-92/_/mapping.py:8` hardcodes `files('lsms_library')/'countries'`, **ignoring the override** — itself a CLAUDE.md anti-pattern; follow-up filed below.

**Feature audit harness** (`bench/feature_audit/scan.py`; `sample` + `cluster_features` + `household_roster` + `plot_features`, both branches): **115 of 122 records identical. Regressions (pass → not-pass): NONE.** The 5 `warn → fail` are exactly the enumerated `plot_features` pairs — the check converting silently-wrong into loudly-broken, by design. The one anomaly (7 new `cluster_features` dup-`(t,v)` warnings) was chased to ground rather than waved off: per-country duplicate count is **0 on both branches**, and `Feature('cluster_features')` is **identical** on both (41376 rows / 32 countries / 0 dup warnings). The delta was a cache-coverage artifact of the two isolated roots, not a code difference.

**Blast radius checked:** `Rural` is declared under `sample:` **without** `required: true` (`feature.py:316` reads that flag; many samples have no `Rural`, and `Feature('sample').columns` is unchanged). Only `Rural` was declared — `weight`/`panel_weight`/`strata` deliberately left undeclared so `_enforce_canonical_dtypes` re-types nothing. Every country already declares `sample.Rural` as `str` in its `data_scheme.yml`, so the new `type: str` re-types nothing either. The Uganda baseline fixture diff is exactly **one line** (`content_hash`); shape / columns / dtypes / index names unchanged.

---

## RETRACTION (do not let this get lost)

An earlier version of this fix graded the **GhanaLSS 1991-92 `Semi-urban`** fix as *latent / doc-only*, on the theory that the `Semi-urban` values I first saw came from a stale shared-cache parquet and a clean build yields `Urban`.

**That retraction was itself wrong, in the conservative direction.** Two red-teamers, independently, built pristine `development` clean from source in isolated data roots and **both got `Semi-urban` shipped to users**: 1,578 rows in `sample()`, 100 clusters in `cluster_features()`. GhanaLSS has no country-level `Rural` Preferred-Label table to rescue it.

**The GhanaLSS fix is LIVE class-1, not latent.** The changed-table list above is therefore **8, not 7** — my own regression sweep had a blind spot (`mapping.py:8`'s hardcoded path silently ignored the `LSMS_COUNTRIES_ROOT` override, so base and fix read the *same* config and came out byte-identical). The change itself is *correct* — GLSS4 declares `1|Urban` for the same `loc2` — so this was undisclosed **right** data, not wrong data. The false "LATENT" docstring has been corrected on the branch (commit `3fd235c3`).

---

## Red-team verdicts (3 lenses, all pass; **concerns disclosed, not laundered**)

### 1. Correctness — PASS (severity: nit)

> The fix does what it claims. I reproduced the original defect on a pristine `development` tree (`git archive development`, isolated `LSMS_DATA_DIR`, import asserted from the export), reproduced the corrected behaviour on `fix/602-spellings`, validated the new check against pre-fix data, and independently re-ran the cross-country sweep on BOTH branches. Every load-bearing claim held up, and two of the boldest (Malawi sign-flip, GhanaLSS 1=Urban) I confirmed from an angle the author did not use.
>
> **Where I disagree with the author:** their "self-correction" about GhanaLSS is itself wrong, in the conservative direction. My clean, from-source, isolated build of pristine `development` ships `Semi-urban` to users: 1,578 rows in `sample()`, 100 clusters in `cluster_features()`. **The GhanaLSS fix is a LIVE class-1 fix.** The docstring saying "LATENT defect (not currently reaching `sample()` in a clean build)" is a false statement in a file that will be read as documentation and should be corrected before merge. That is my only requested change; it does not affect any shipped value.

**→ Fixed on-branch in `3fd235c3` (docstring only, no runtime surface).**

Non-blocking residuals, all disclosed or pre-existing:
1. Enforcement is **diagnostic-only**, and `test_feature_is_sane` uses `_read_or_skip` on cached parquets — so on a cold cache the new check runs on nothing. The guarantee holds only where someone has built the table.
2. `Informal` is now admitted **globally** to the `Rural` vocabulary (for South Africa's 83 HH / 2 clusters), so any *other* country emitting `Informal` will pass silently.
3. Malawi's cluster-level `Rural` rests on `ea_id` being a clean cluster key, and it is not (2013-14: 131 of 204 EAs contain both urban and rural HHs). Post-fix the cluster label equals the HH-majority label, which is defensible; the pre-fix code carried the same aggregation with *meaningless* values, so no regression.
4. India keeps `employment.Rural` (from `v02a05b`), outside the enforcement surface and in mild tension with the new CONTENTS.org line "India simply has no Rural indicator" — verified to be a **workplace** attribute, not residence, so the deletion decision is right.

### 2. Regression — PASS (severity: **concern**)

> No regression. Nothing that was working breaks: I ran the branch's own `_check_declared_spellings` over **all 302 cached parquets** (the exact population `test_feature_is_sane` parametrizes over, and a SUPERSET of the author's isolated root) and got 11 failures — the 5 `plot_features` pairs (exactly `KNOWN_UNHARMONIZED`, no over- or under-enumeration) plus the 6 real defects the branch fixes. **Zero `household_roster` Sex/Affinity false failures**, which was the largest false-positive surface. Dtype blast radius is nil. `Feature('sample').columns` unchanged. The author's Malawi/`sample` "no change at the API" claim is TRUE and I verified it (`Malawi/_/categorical_mapping.org:420-427` is a `Rural` Preferred-Label table canonicalizing 42,660 variant rows pre-spellings) — the normalize-then-test design holds up.
>
> **CONCERN (must fix the PR body, not the code):** the regression sweep has a proven blind spot and its changed-table list is **incomplete by one**. `GhanaLSS/1991-92/_/mapping.py:8` hardcodes `files('lsms_library')/'countries'`, bypassing `LSMS_COUNTRIES_ROOT` — the bug the author found but did not propagate to their own verification. The branch flips `rural_dict` from `{1:'Semi-urban'}` to `{1:'Urban'}`, and `GhanaLSS/var/sample.parquet` on `development` holds exactly 1,578 `'Semi-urban'` rows, which reach users. **So the branch changes GhanaLSS `sample.Rural` for 1,578 households — a live, user-facing change.** The summary asserts the opposite and omits GhanaLSS/`sample` from the enumerated changed tables; the AFTER sweep and the regression sweep are mutually inconsistent and cannot both hold. The change itself is CORRECT — GLSS4's own rural table declares `1|Urban` for the same `loc2` — so this is undisclosed RIGHT data, not wrong data. Not a blocker, but the blast radius must be restated as **8 changed tables** and the "latent/doc fix" claim retracted.
>
> **NIT:** the Malawi 2004-05 diff comment ("it was even spelled `mappings:` rather than the `mapping:` the grabber honours") is factually false — `country.py:749-751` honours BOTH keys. That block *did* fire, which is what makes the author's own 0.0%-agreement figure coherent. The comment would mislead a future maintainer into thinking `mappings:` is inert.

**→ Both addressed. Blast radius restated as 8 changed tables above; the "latent" grading retracted in its own section; the false Malawi comment corrected on-branch in `3fd235c3`.**

### 3. Completeness — PASS (severity: **concern**)

> The fix is sound and every claim survived independent verification from source in an isolated data root. It closes the declared-vocabulary class **completely** — I swept all 4 constrained tables across all 34 buildable countries and found **zero** remaining violations beyond the 5 enumerated `plot_features` xfails, whose registry I confirmed is **exactly complete** (not one country more, not one fewer). It should land.
>
> **CONCERN — the gap is one level up.** The fix's own root-cause analysis identified the real mechanism: *a `mapping:` stanza whose YAML keys are the wrong TYPE, silently dead, raw labels leaking to users, so `df[col == 'X']` returns a wrong subset.* `_check_declared_spellings` is keyed on 6 (table, column) pairs, so it is **structurally blind to that mechanism wherever the target column has no declared vocabulary.** It is alive today: **Albania `household_roster.Marital` ships 13 labels for 5 concepts, and `df[df.Marital == 'Married']` silently drops 11,012 married people across two entire waves.** The country's own mapping proves the intended value (`'Married'`), so unlike the `plot_features` Tenure cases this needs no codebook — it is unambiguously a bug.
>
> That is **not a defect IN the fix and must not block it**, but it is exactly the failure the brief warns about: closing #602 with a green check makes the next instance of the same bug harder to find. **Land, and file the follow-up** (a mapping whose keys match 0% of its source column's raw values is always a bug, and is a ~30-line lint).

**→ Follow-ups to file (not in this PR):**
1. **The dead-mapping lint.** A `mapping:` stanza whose keys match **0%** of its source column's raw values is *always* a bug. ~30 lines. This is the generator of #602, of Uganda's `9959b9f3`, and of India's float keys — a lint catches the *class*, where `_check_declared_spellings` only catches the 6 columns that happen to have a declared vocabulary.
2. **Albania `household_roster.Marital`** — 13 labels for 5 concepts; `== 'Married'` drops 11,012 people. Class-1, unambiguous, needs no codebook.
3. **`GhanaLSS/1991-92/_/mapping.py:8`** hardcodes `files('lsms_library')/'countries'` and so ignores `LSMS_COUNTRIES_ROOT`. A CLAUDE.md anti-pattern, and it *blinded a verification run in this very PR*. Worth a grep across all `mapping.py`.

---

## Files

`lsms_library/diagnostics.py` · `lsms_library/data_info.yml` · `tests/test_declared_spellings.py` (18 tests) · `tests/test_table_structure.py` (`KNOWN_UNHARMONIZED` xfail registry) · `.coder/ledger/602-spellings.md` · 9 country configs (Uganda, Malawi ×5, India, Mali, GhanaLSS ×2).

Severity **class 1** (silently wrong) by `slurm_logs/PLAN_backlog_2026-07-12.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
