### PR TITLE
fix(GhanaLSS): GH #323 — make the silent index collapse declared-and-CHECKED (one instance; class stays open)

### DIFF
--- a/.coder/ledger/323-ghanalss.md
+++ b/.coder/ledger/323-ghanalss.md
@@ -1,0 +1,184 @@
+# Prior-Art Ledger — GH #323 (GhanaLSS)
+
+**Search tier used:** ripgrep + git (gitnexus MCP tools were not available in this
+environment; call-graph established manually — `_normalize_dataframe_index` has
+exactly four call sites, all in `country.py`: 2115, 2715, 2929, 2983).
+
+## §1 Task, restated
+
+`_normalize_dataframe_index` (`lsms_library/country.py`) reduces a wave/country
+frame to its DECLARED index (`data_scheme.yml` → `index:`). When that index is
+non-unique it collapses the duplicates with `groupby().first()`, keeping one row
+per tuple and silently discarding the rest. GhanaLSS was reported with 7
+affected cells (~982k duplicate rows). The task: fix GhanaLSS's instances
+*without* leaving the class alive, and without moving any other country.
+
+GhanaLSS turns out to exhibit **both** failure modes the same line of code
+enables — which is why one uniform fix would have been wrong:
+
+* **(A) benign-but-silent** — `cluster_features`, 5 waves. The source is
+  household-grain; the projected columns are cluster-invariant. The collapse is
+  a correct de-duplication, arrived at silently.
+* **(B) silently WRONG** — `cluster_features`, 1987-88 + 1988-89. `Region` is
+  wired to a person-level **region of birth**. `.first()` fabricates a cluster's
+  region from its first-listed person.
+* **(C) phantom NaN keys** — `food_security`, 2016-17. 110 households with
+  NaN `clust`/`nh` collapse onto one NaN tuple and are dropped.
+
+## §2 Existing machinery
+
+| symbol | path:line | what it does | tested? | reuse / extend / new |
+|--------|-----------|--------------|---------|----------------------|
+| `_normalize_dataframe_index` | `country.py:4100` | reorders/reduces to declared index; `groupby().first()` on duplicates | partly | **extend** (checked reducer) |
+| `_ADDITIVE_MEASURE_COLUMNS` | `feature.py:101` | `food_acquired` → sum, not first (GH #501) | yes | precedent for a per-table policy |
+| `aggregation:` block | 9 × `data_scheme.yml` | declared `{visit: first}` | **no** | **was INERT — never read by any code** |
+| `_finalize_result` `dropna(how='all')` | `country.py:2217` | drops all-NA rows | yes | explains why (C) recovers 0 API rows |
+| `get_categorical_mapping` | `local_tools.py:1138` | org-table → dict | yes | returns `{}` for 1988-89 (separate bug) |
+
+**Key prior-art finding:** `aggregation:` was already *declared* by 9 countries
+and *skipped* as a scheme meta-key (`country.py:2387`, `diagnostics.py:230`) —
+but **grep for its consumption returns zero**. It was pure prose. Adding
+`aggregation:` to GhanaLSS without implementing it would have been precisely the
+"prose is not enforcement" failure. See `SkunkWorks/grain_aggregation_policy.org`
+(item #4, "not yet built").
+
+## §3 Definitions & conventions in force
+
+- Design contract, `SkunkWorks/grain_aggregation_policy.org`: *"the
+  composition/access path — `country.py` (`_normalize_dataframe_index`) — NEVER
+  reduces grain."* Item #3 of its implementation order names this exact line:
+  *"Both core `.first()` collapses are the GH #323 / #325 silent-data-loss
+  footguns."* The full union+sentinel rewrite is a framework-wide change and is
+  **not** attempted here (it would move every country); this task implements the
+  narrower "declared or fatal" half.
+- `cluster_features` owns `v`; declared index `(t, v)` — `CLAUDE.md`, canonical
+  `lsms_library/data_info.yml`.
+- class-1 (silently WRONG) vs class-2 (silently MISSING): class-2 is strictly
+  safer. Drop loudly rather than guess.
+
+## §4 Invariants & assumptions
+
+- `groupby(level=…)` defaults to `dropna=True` → **NaN-keyed rows are dropped
+  outright, not merged into a phantom**. Verified: `food_security` 2016-17 loses
+  all 110.
+- `_finalize_result`'s `dropna(how='all')` (`country.py:2217`) drops any row
+  whose every non-index column is NA. This is why **rows recovered = 0** (§6).
+- The `.pth` trap is real: `PYTHONPATH` does **not** redirect `lsms_library` to a
+  worktree — `sys.path[0]` (cwd) wins. Verified empirically; defeated with an
+  explicit `sys.path.insert(0, WT)` + assert.
+
+## §5 Reuse decision
+
+Extend the existing, already-declared-but-inert `aggregation:` block rather than
+invent a parallel key. New reducer `invariant`, keyed on **columns** (per the
+design doc's `{column: reducer}` shape). All 9 existing blocks are
+`{visit: first}` — `visit` is an index *level*, never a column, and `first` ≠
+`invariant`, so they are doubly unaffected. Proven: §6.
+
+## §6 Evidence
+
+**Instrument validated first** (the brief's trap): scanner reproduced Mali
+`household_roster` 2014-15 dup = **32,026** and Guyana `housing` 1992 dup =
+**311** exactly, then all 7 reported GhanaLSS cells exactly.
+
+### (B) `Region` is birthplace — five independent strands
+
+1. `mapping.py`'s `Region()` and `Birthplace()` are **byte-identical function
+   bodies** over the same `region_dict`; both waves map `REGION` as the roster's
+   `Birthplace`.
+2. The waves' own `categorical_mapping.org` `region` code list runs 1..17 and
+   includes **11=Nigeria, 12=Ivory Coast, 13=Togo, 14=Burkina Faso, 15=Mali,
+   16=Other Africa**. A Ghanaian enumeration area cannot be *located* in Nigeria.
+3. `REGION` varies **within a single household** — 1,019/3,192 HH (1988-89) and
+   1,033/3,136 (1987-88), up to **6 distinct values in one household**.
+4. It varies within a cluster in 167/170 (1988-89) and 174/176 (1987-88).
+5. `Y01A.DCT` order: MAR, SCOHAB, SID, **REGION, NAT**(ionality), LODGE — the
+   classic birthplace→nationality pair.
+
+**Averted fabrication** (decoding REGION as the repaired `region_dict` would):
+
+| wave | clusters labelled **"Nigeria"** | disagree with modal birthplace |
+|------|-------------------------------:|-------------------------------:|
+| 1987-88 | **7** of 176 | 49 of 176 |
+| 1988-89 | **9** of 170 | 53 of 170 |
+
+**The landmine.** `Region` is currently **100 % NaN** (0/14,924) because
+`get_categorical_mapping` returns `{}` for 1988-89 — an *unrelated* defect. So
+the class-1 fabrication is **armed behind a class-2 bug**: repair `region_dict`
+(a plausible future fix, since it also breaks `Birthplace`) and the fabrication
+goes live. Dropping `Region` costs **zero** information today and defuses it.
+
+### (A) cluster-invariance — verified, all 5 waves
+
+`region` / `loc2` / `ez`: max distinct value per cluster = **1**; clusters with
+>1 = **0**. So `.first()` returns the right answer; it was silent, not wrong.
+
+| wave | source | rows | clusters |
+|------|--------|-----:|---------:|
+| 1991-92 | POV_GH.DTA | 4,523 | 365 |
+| 1998-99 | SEC0A.DTA | 5,998 | 300 |
+| 2005-06 | aggregates/pov_gh5 | 8,687 | 580 |
+| 2012-13 | PARTA/g6loc_edt | 16,772 | 1,200 |
+| 2016-17 | g7sec8h.dta | 934,584 | 1,000 |
+
+### (C) `food_security` 2016-17
+
+110 tail rows (13,899–14,008): `clust`=NaN, `nh`=NaN, **all 8 FIES items NaN**,
+but a valid `hid`. `hid == f"{clust}/{nh:02d}"` with **100.00 %** fidelity on the
+13,899 good rows, and is byte-identical to the id the framework builds from
+`[clust, nh]`. The 110 parse to **110 distinct households, disjoint** from the
+answered set, and **all 110 are present in `sample()`**. `FIES_score()` already
+returns `pd.NA` when all 8 items are missing, so recovery does **not** fabricate
+a food-secure 0.
+
+### The guard actually bites — validated where validation is NEEDED
+
+Testing the guard against the *live* 1988-89 tree is **vacuous** (Region is
+all-NA → `nunique` = 0 → passes trivially). That would be validating where it is
+free. Fed the **real birth-region values** (the world where `region_dict` is
+repaired), it RAISES:
+
+```
+1987-88: 'Region' non-constant in 174 of 176 group(s)  -> ValueError
+1988-89: 'Region' non-constant in 167 of 170 group(s)  -> ValueError
+```
+
+### Nothing else moved
+
+757 real (country × wave × table) cells pushed through **both** the BASE and FIX
+`_normalize_dataframe_index` on real cached data: **0 differ**, 0 non-GhanaLSS
+deltas. The change is data-inert everywhere else; it alters only *warnings*.
+
+## §7 Honest accounting — rows recovered = 0
+
+The API row count does **not** move, and saying otherwise would be a vanity
+metric:
+
+- (A) one row per cluster **is** the correct grain — nothing to recover.
+- (B) 1988-89's `cluster_features` was already contributing **0 API rows**
+  (all-NA → `dropna(how='all')`). Removing it is a 0-row change.
+- (C) the 110 recovered households are all-NA in every declared column, so
+  `_finalize_result`'s `dropna(how='all')` drops them — exactly as it already
+  drops 7 all-NA households that *did* have `clust`/`nh` populated.
+
+The value is **correctness**: a fabricated cluster `Region` deleted, a silent
+967k-row collapse made declared-and-checked, and a 110-household phantom killed.
+
+## §8 Left undone (deliberately, not fixed)
+
+1. **`sample` 2 duplicate `(i, t)` tuples** — pre-existing, fires identically on
+   pristine base. Root cause is **different**: `panel_ids` is many-to-one —
+   1988-89 HH `204922` **and** `204932` both map to `1987-88,101332`; `255718`
+   **and** `255728` both map to `1987-88,114008`. Two *distinct* households
+   collapse onto one id. My `invariant` reducer cannot apply (weight/strata
+   genuinely differ between two different households), and choosing the "true"
+   match is a guess I refuse to make. **Reported, not guessed.**
+2. **`get_categorical_mapping` returns `{}` for GhanaLSS 1988-89** — both
+   `region_dict` and `relationship_dict` are empty, so `Birthplace` *and*
+   `Relationship` are all-NA for that wave. Separate defect; **not fixed here on
+   purpose** — fixing it would *arm* the (B) fabrication, which is precisely why
+   (B) is being removed first. 1998-99's `cluster_features` Region/Rural are
+   likewise all-NA (0/5,998), so that wave contributes 0 API rows today.
+3. The framework-wide union+sentinel rewrite (`grain_aggregation_policy.org`
+   item #3). Out of scope for a single-country fix; the `invariant` reducer is
+   the "declared or fatal" half and is available to every country now.

--- a/lsms_library/countries/GhanaLSS/1987-88/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1987-88/_/data_info.yml
@@ -1,13 +1,36 @@
 Country: GhanaLSS
 Wave: 1987-88
 
-cluster_features:
-    file: Y01A.DAT
-    idxvars:
-        v: CLUST
-    myvars:
-        Region: REGION
-        Age: AGEY
+# cluster_features: DELIBERATELY NOT WIRED (GH #323).
+#
+# Identical defect to 1988-89 (see that wave's data_info.yml for the full
+# argument), and it was NOT in the originally-reported affected-cell list only
+# because this wave's cluster_features parquet had never been built -- fixing
+# 1988-89 alone would have closed the instance and left the class.
+#
+# The block that used to live here read `Region: REGION` and `Age: AGEY` from
+# Y01A.DAT, the PERSON-LEVEL ROSTER (15,492 persons / 3,136 households / 176
+# clusters):
+#
+#   * `Region: REGION` is the person's REGION OF BIRTH, not the cluster's region.
+#     REGION varies WITHIN a household in 1,033 of 3,136 households (up to 6
+#     distinct values in ONE household), and within a cluster in 174 of 176.  The
+#     wave's own `region` code list includes 11=Nigeria, 12=Ivory Coast,
+#     13=Togo, 14=Burkina Faso -- foreign countries a Ghanaian enumeration area
+#     cannot be located in.  mapping.py's Region() and Birthplace() are the same
+#     function body over the same region_dict, and REGION is mapped as the
+#     roster's `Birthplace` below.
+#   * `Age: AGEY` is a PERSON's age.  Collapsed to one row per cluster it made a
+#     cluster's "Age" the age of its first-listed person (range 17-80) -- a
+#     category error, meaningless as a cluster feature.
+#
+# No cluster-invariant region source exists in this wave (Y00A.DAT's LOC is a
+# plausible Rural indicator but varies within cluster in 3 of 170 clusters, so it
+# is NOT wired without verification).  Dropping is safer than guessing: silently
+# MISSING (class-2) beats silently WRONG (class-1).
+#
+# Enforced by `aggregation: {Region: invariant}` in `_/data_scheme.yml`:
+# re-adding either column here RAISES at build time.
 
 sample:
     file: Y00A.DAT

--- a/lsms_library/countries/GhanaLSS/1988-89/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1988-89/_/data_info.yml
@@ -1,12 +1,44 @@
 Country: GhanaLSS
 Wave: 1988-89
 
-cluster_features:
-    file: Y01A.DAT
-    idxvars:
-        v: CLUST
-    myvars:
-        Region: REGION
+# cluster_features: DELIBERATELY NOT WIRED (GH #323).
+#
+# This wave has NO cluster-level region variable.  The block that used to live
+# here read `Region: REGION` from Y01A.DAT -- but Y01A.DAT is the PERSON-LEVEL
+# ROSTER (14,924 persons / 3,192 households / 170 clusters) and its REGION column
+# is the person's REGION OF BIRTH, not the cluster's region.  Four independent
+# strands establish this:
+#
+#   1. The same column of the same file is ALSO mapped, correctly, as the
+#      roster's `Birthplace: REGION` below -- and mapping.py's Region() and
+#      Birthplace() are literally the same function body over the same
+#      region_dict.
+#   2. The `region` code list in this wave's categorical_mapping.org runs 1..17
+#      and includes 11=Nigeria, 12=Ivory Coast, 13=Togo, 14=Burkina Faso,
+#      15=Mali, 16=Other Africa.  A Ghanaian enumeration area cannot be located
+#      "in Nigeria"; only a BIRTHPLACE can take those values.
+#   3. REGION varies WITHIN a household in 1,019 of 3,192 households, with up to
+#      6 distinct values in a single household.  No household straddles 6
+#      regions; its members can be BORN in 6.  (It varies within a CLUSTER in
+#      167 of 170 clusters.)
+#   4. Y01A.DCT's variable order -- MAR, SCOHAB, SID, REGION, NAT (nationality),
+#      LODGE, MON, MEMB -- is the classic birthplace->nationality questionnaire pair.
+#
+# Because the declared cluster_features index is (t, v), the framework collapsed
+# these 14,924 person-rows to 170 clusters via groupby().first(), which silently
+# took the birth-region of the FIRST-LISTED PERSON of the FIRST-LISTED HOUSEHOLD
+# and called it the cluster's region.
+#
+# There is no valid substitute: a sweep of all 93 .DAT files in this wave's Data/
+# found no cluster-invariant region-like column, and CLUST does not encode region.
+# Taking the cluster's MODAL birthplace would be a guess that fails precisely
+# where it matters (migrant-receiving clusters: Greater Accra, mining/cocoa
+# areas), so we DROP the column rather than fabricate one: silently MISSING
+# (class-2) is strictly safer than silently WRONG (class-1).
+#
+# This is now enforced, not merely documented: `_/data_scheme.yml` declares
+# `aggregation: {Region: invariant}` for cluster_features, so re-adding
+# `Region: REGION` here RAISES at build time instead of collapsing quietly.
 
 sample:
     file: Y00A.DAT

--- a/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/2016-17/_/data_info.yml
@@ -73,9 +73,35 @@ food_security:
     # (binarized by the same-named formatting fn in mapping.py).
     file: g7sec9c.dta
     idxvars:
-        i:
-            - clust
-            - nh
+        # GH #323: key on `hid`, NOT on the [clust, nh] pair.
+        #
+        # g7sec9c.dta has 14,009 rows.  The first 13,899 are unique on
+        # (clust, nh); the last 110 (rows 13,899-14,008) have clust=NaN AND
+        # nh=NaN -- but a perfectly valid `hid` -- and every one of their eight
+        # FIES items is NaN.  Those are GLSS7 households that never answered
+        # Section 9C; the numeric clust/nh columns were simply left unpopulated
+        # where `hid` was.  It is a defect in the World Bank source file.
+        #
+        # Keyed on [clust, nh], all 110 collapsed onto a single (t, NaN) tuple,
+        # so they were dropped outright by the duplicate-collapse (groupby's
+        # dropna) -- 110 distinct households silently vanishing into one phantom.
+        #
+        # `hid` is complete and reconstructs the compound key exactly: on all
+        # 13,899 well-keyed rows, hid == f"{clust}/{nh:02d}" with 100.00%
+        # fidelity, which is byte-identical to the id the framework builds from
+        # [clust, nh] (e.g. '70001/01').  So keying on `hid` leaves those 13,899
+        # ids unchanged and additionally recovers the 110 as the distinct
+        # households they are (all 110 are present in sample(), and their 110
+        # ids are disjoint from the 13,899).
+        #
+        # Their answers stay all-NA -- the truthful representation of "did not
+        # answer Section 9C".  FIES_score() already returns pd.NA when all eight
+        # items are missing, so this does NOT fabricate a food-secure score of 0.
+        # (_finalize_result's dropna(how='all') then drops these all-NA rows from
+        # the API, exactly as it already does for 7 all-NA households that DID
+        # have clust/nh populated.  The fix removes the phantom at the source; it
+        # is not expected to move the API row count.)
+        i: hid
     myvars:
         Worried: s9cq1
         HealthyDiet: s9cq2

--- a/lsms_library/countries/GhanaLSS/_/data_scheme.yml
+++ b/lsms_library/countries/GhanaLSS/_/data_scheme.yml
@@ -19,9 +19,39 @@ Index Info:
 
 Data Scheme:
   cluster_features:
+    # GH #323 -- DECLARED de-duplication, not a silent collapse.
+    #
+    # Every wired wave points `file:` at a HOUSEHOLD-grain source (the poverty
+    # aggregates / cover page / Section-8H food module) and projects columns that
+    # describe the CLUSTER, not the household.  So the source carries one row per
+    # household (2016-17: one row per household x food item -- 934,584 rows for
+    # 1,000 clusters) while the declared index (t, v) is one row per cluster.
+    # Collapsing to (t, v) is therefore a DE-DUPLICATION of a cluster-invariant
+    # projection -- the right answer -- but before #323 it happened SILENTLY via
+    # groupby().first(), which is the same line of code that would happily
+    # fabricate a value if the column were NOT cluster-invariant.
+    #
+    # `invariant` makes that assumption CHECKED rather than assumed: the build
+    # RAISES if any of these columns ever varies within a (t, v) group.  Verified
+    # cluster-invariant in all five wired waves at the time of writing (max
+    # distinct value per cluster = 1; zero clusters with >1):
+    #   1991-92 POV_GH.DTA          4,523 HH ->   365 clusters
+    #   1998-99 SEC0A.DTA           5,998 HH ->   300 clusters
+    #   2005-06 aggregates/pov_gh5  8,687 HH ->   580 clusters
+    #   2012-13 PARTA/g6loc_edt    16,772 HH -> 1,200 clusters
+    #   2016-17 g7sec8h.dta       934,584 rows-> 1,000 clusters
+    #
+    # 1987-88 / 1988-89 are deliberately NOT wired: their only candidate source
+    # (Y01A.DAT REGION) is the person's REGION OF BIRTH, not the cluster's region
+    # -- see those waves' data_info.yml for the full argument.
     index: (t, v)
     Region: str
     Rural: str
+    Ecological_zone: str
+    aggregation:
+      Region: invariant
+      Rural: invariant
+      Ecological_zone: invariant
   household_roster:
     index: (t, i, pid)
     Sex: str

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -4196,8 +4196,38 @@ def _normalize_dataframe_index(
             if 'Price' in df.columns and {'Expenditure', 'Quantity'} <= set(df.columns):
                 df['Price'] = df['Expenditure'] / df['Quantity'].where(df['Quantity'] != 0)
         else:
+            # GH #323: a DECLARED `aggregation:` policy in data_scheme.yml makes
+            # the collapse explicit instead of silent.  The `invariant` reducer
+            # says: "the source is FINER-grained than the declared index, but this
+            # column is CONSTANT within each index group, so collapsing is a
+            # verified DE-DUPLICATION -- not a merge of distinct entities."
+            # It is CHECKED, not asserted in prose: _assert_invariant_within_index
+            # RAISES if the column is ever non-constant within a group, which turns
+            # a silently-WRONG collapse (class-1) into a loud failure.
+            #
+            # Worked example -- GhanaLSS cluster_features: every wave points `file:`
+            # at a HOUSEHOLD-grain source and projects cluster-invariant columns
+            # (region/loc2), so 934,584 rows legitimately de-duplicate to 1,000
+            # clusters.  The SAME line of code, pointed at a person-level BIRTHPLACE
+            # column (GhanaLSS 1987-88/1988-89), instead fabricated a cluster's
+            # "Region" from the first-listed person -- this check would have caught it.
+            policy = (schema_entry or {}).get("aggregation") or {}
+            if not isinstance(policy, dict):
+                policy = {}
+            invariant_cols = [
+                col for col, reducer in policy.items()
+                if reducer == "invariant" and col in df.columns
+            ]
+            if invariant_cols:
+                _assert_invariant_within_index(
+                    df, invariant_cols, present_levels, table_name
+                )
+
             df = df.groupby(level=present_levels, observed=True).first()
-            if n_dropped:
+            # Only DECLARED columns are exempt from the warning; anything the
+            # policy does not cover is still a silent drop and must be surfaced.
+            undeclared = [c for c in df.columns if c not in invariant_cols]
+            if n_dropped and undeclared:
                 # No aggregation policy for this table -- surface the loss
                 # loudly rather than drop rows quietly (a table whose source
                 # legitimately has multiple rows per index tuple needs an
@@ -4205,8 +4235,59 @@ def _normalize_dataframe_index(
                 warnings.warn(
                     f"Canonical index over {present_levels} had {n_dropped} "
                     f"duplicate tuple(s); collapsed via groupby().first(), dropping "
-                    f"those rows (possible silent data loss — GH #323).",
+                    f"those rows (possible silent data loss — GH #323). "
+                    f"Columns without an aggregation policy: {undeclared}.",
                     RuntimeWarning,
                 )
 
     return df
+
+
+def _assert_invariant_within_index(
+    df: pd.DataFrame,
+    columns: list[str],
+    levels: list[str],
+    table_name: str | None = None,
+) -> None:
+    """Verify each column is constant within every declared-index group.
+
+    Backs the ``aggregation: {col: invariant}`` policy (GH #323).  A column
+    declared ``invariant`` is one the survey records at a FINER grain than the
+    declared index but whose value does not vary within an index group (e.g. a
+    cluster's region, recorded once per household).  Collapsing such a column
+    with ``.first()`` is a lossless de-duplication.
+
+    Raises ``ValueError`` naming the offending groups if the invariant does not
+    hold -- a non-constant column means ``.first()`` would silently pick one
+    value from several distinct ones (class-1: silently WRONG).
+    """
+    offenders: dict[str, pd.Series] = {}
+    for col in columns:
+        counts = df.groupby(level=levels, observed=True)[col].nunique(dropna=True)
+        bad = counts[counts > 1]
+        if len(bad):
+            offenders[col] = bad
+
+    if not offenders:
+        return
+
+    where = f" in {table_name!r}" if table_name else ""
+    lines = [
+        f"aggregation policy declares these column(s){where} INVARIANT within "
+        f"{levels}, but they are NOT constant within their index group -- "
+        f"collapsing would silently pick one value from several (GH #323):"
+    ]
+    for col, bad in offenders.items():
+        examples = ", ".join(
+            f"{lvl}={cnt} distinct values" for lvl, cnt in bad.head(3).items()
+        )
+        lines.append(
+            f"  {col!r}: non-constant in {len(bad)} of "
+            f"{df.groupby(level=levels, observed=True).ngroups} group(s); e.g. {examples}"
+        )
+    lines.append(
+        "Either the column is wired to the WRONG source variable (one recorded at "
+        "a finer grain -- e.g. a person-level attribute mapped as a cluster "
+        "attribute), or it needs a real reducer instead of `invariant`."
+    )
+    raise ValueError("\n".join(lines))

--- a/tests/test_declared_aggregation_gh323.py
+++ b/tests/test_declared_aggregation_gh323.py
@@ -1,0 +1,184 @@
+"""
+Regression tests for GH #323 -- ``_normalize_dataframe_index`` silently
+collapsing a non-unique DECLARED index with ``groupby().first()``.
+
+The collapse has two failure modes, and GhanaLSS exhibits BOTH from the same
+line of code:
+
+* **Benign but silent.**  ``cluster_features`` sources are HOUSEHOLD-grain files
+  whose projected columns (region, urban/rural) are genuinely cluster-invariant,
+  so collapsing 934,584 rows to 1,000 clusters is a lossless de-duplication --
+  the right answer, arrived at silently.
+* **Silently WRONG.**  GhanaLSS 1987-88 / 1988-89 wired ``Region`` to Y01A.DAT's
+  ``REGION`` column, which is the person's REGION OF BIRTH.  Collapsed with
+  ``.first()``, a cluster inherits the birth-region of its first-listed person --
+  labelling 9 of 170 (1988-89) and 7 of 176 (1987-88) Ghanaian enumeration areas
+  as being located in **Nigeria**, and disagreeing with even the cluster's modal
+  birthplace in 53 / 49 clusters respectively.
+
+The fix makes the collapse DECLARED and CHECKED rather than silent: a
+``data_scheme.yml`` table may declare ``aggregation: {column: invariant}``,
+which asserts the column is constant within every declared-index group and
+RAISES if it is not.  The same mechanism that blesses the benign case is the one
+that catches the wrong case.
+
+NOTE on why the guard is tested against *synthetic* birthplace values below: in
+the live 1988-89 tree ``Region`` is currently all-NA (an unrelated defect --
+``get_categorical_mapping`` returns an empty dict for that wave), so the guard
+passes there *trivially*.  Testing only that would be validating where
+validation is free.  The case that matters is the one where that masking bug is
+repaired and the real birth-region values reach the collapse -- so the tests
+below feed the guard exactly that shape.
+"""
+import warnings
+
+import pandas as pd
+import pytest
+import yaml
+
+from lsms_library.country import _normalize_dataframe_index
+from lsms_library.paths import countries_root
+
+
+class _SchemeLoader(yaml.SafeLoader):
+    """data_scheme.yml carries ``!make`` tags; ignore them for these tests."""
+
+
+_SchemeLoader.add_multi_constructor('!', lambda loader, suffix, node: None)
+
+
+def _scheme(country):
+    path = countries_root() / country / '_' / 'data_scheme.yml'
+    return yaml.load(path.read_text(), Loader=_SchemeLoader)
+
+
+def _data_info(country, wave):
+    path = countries_root() / country / wave / '_' / 'data_info.yml'
+    return yaml.load(path.read_text(), Loader=_SchemeLoader)
+
+
+# --------------------------------------------------------------------------
+# The framework guard (the CLASS-level fix)
+# --------------------------------------------------------------------------
+
+_SCHEMA = {
+    'index': '(t, v)',
+    'Region': 'str',
+    'aggregation': {'Region': 'invariant'},
+}
+
+
+def test_invariant_reducer_raises_when_column_is_not_constant():
+    """A column declared `invariant` that VARIES within its index group must raise.
+
+    This is the 1988-89 shape: one row per PERSON, `Region` holding the person's
+    birthplace, collapsed to one row per cluster.  Pre-fix this silently returned
+    the first person's birthplace as the cluster's region.
+    """
+    df = pd.DataFrame({
+        't': ['1988-89'] * 5,
+        'v': ['2001', '2001', '2001', '2002', '2002'],
+        # cluster 2001 holds three people born in three different regions
+        'Region': ['Ashanti', 'Nigeria', 'Volta', 'Central', 'Central'],
+    }).set_index(['t', 'v'])
+
+    with pytest.raises(ValueError, match='invariant|INVARIANT'):
+        _normalize_dataframe_index(df, _SCHEMA, '1988-89', 'cluster_features')
+
+
+def test_invariant_reducer_collapses_silently_when_column_is_constant():
+    """A genuinely cluster-invariant column de-duplicates without warning.
+
+    This is the 1991-92..2016-17 shape: a household-grain source projecting a
+    cluster-level attribute.  The collapse is correct, and now DECLARED, so it
+    must not emit the GH #323 warning.
+    """
+    df = pd.DataFrame({
+        't': ['2016-17'] * 5,
+        'v': ['7001', '7001', '7001', '7002', '7002'],
+        'Region': ['Ashanti', 'Ashanti', 'Ashanti', 'Volta', 'Volta'],
+    }).set_index(['t', 'v'])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        out = _normalize_dataframe_index(df, _SCHEMA, '2016-17', 'cluster_features')
+
+    assert len(out) == 2, 'should de-duplicate to one row per cluster'
+    assert out.loc[('2016-17', '7001'), 'Region'] == 'Ashanti'
+    assert not [w for w in caught if 'GH #323' in str(w.message)], \
+        'a DECLARED + verified de-duplication must not warn'
+
+
+def test_undeclared_collapse_still_warns():
+    """Without an `aggregation:` policy the collapse must still be surfaced.
+
+    Guards against the fix accidentally silencing the warning for every table.
+    """
+    df = pd.DataFrame({
+        't': ['x'] * 3,
+        'v': ['1', '1', '2'],
+        'Region': ['a', 'b', 'c'],
+    }).set_index(['t', 'v'])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        _normalize_dataframe_index(df, {'index': '(t, v)'}, 'x', 'cluster_features')
+
+    assert [w for w in caught if 'GH #323' in str(w.message)], \
+        'an UNDECLARED collapse must still warn'
+
+
+# --------------------------------------------------------------------------
+# The GhanaLSS instances
+# --------------------------------------------------------------------------
+
+def test_ghanalss_cluster_features_declares_its_aggregation():
+    """The de-duplication must be DECLARED, not left silent."""
+    entry = _scheme('GhanaLSS')['Data Scheme']['cluster_features']
+    policy = entry.get('aggregation')
+    assert policy, 'cluster_features collapses a household-grain source; declare it'
+    assert policy.get('Region') == 'invariant'
+    assert policy.get('Rural') == 'invariant'
+
+
+@pytest.mark.parametrize('wave', ['1987-88', '1988-89'])
+def test_ghanalss_early_waves_do_not_map_birthplace_as_cluster_region(wave):
+    """Y01A.DAT's REGION is a person's BIRTHPLACE -- never a cluster's region.
+
+    mapping.py's ``Region()`` and ``Birthplace()`` are the same function body over
+    the same ``region_dict``, and the wave's own code list runs to 11=Nigeria,
+    12=Ivory Coast, 13=Togo, 14=Burkina Faso -- values a Ghanaian enumeration
+    area cannot take.  These waves must therefore not declare cluster_features
+    at all (no cluster-invariant region variable exists in their 93 source files).
+    """
+    info = _data_info('GhanaLSS', wave)
+    cf = info.get('cluster_features')
+    if cf is None:
+        return  # correct: not wired
+    myvars = cf.get('myvars', {}) or {}
+    assert myvars.get('Region') != 'REGION', (
+        f'GhanaLSS {wave}: cluster_features.Region is wired to Y01A.DAT REGION, '
+        'the person-level region of BIRTH (varies within a single household in '
+        '~1/3 of households, up to 6 distinct values).  Collapsed to one row per '
+        'cluster this fabricates the cluster region -- GH #323.'
+    )
+    assert 'Age' not in myvars, (
+        f'GhanaLSS {wave}: `Age` is a PERSON attribute; as a cluster feature it '
+        "becomes the age of the cluster's first-listed person."
+    )
+
+
+def test_ghanalss_food_security_keys_on_complete_hid():
+    """2016-17 food_security must key on `hid`, not the incomplete [clust, nh].
+
+    The last 110 rows of g7sec9c.dta have clust=NaN AND nh=NaN (with all eight
+    FIES items NaN) but a valid `hid`.  Keyed on [clust, nh] those 110 distinct
+    households collapse onto a single NaN tuple and are dropped outright.
+    """
+    info = _data_info('GhanaLSS', '2016-17')
+    idx = info['food_security']['idxvars']
+    assert idx.get('i') == 'hid', (
+        'food_security must key on the complete `hid` column; keying on '
+        '[clust, nh] silently merges 110 NaN-keyed households into one phantom '
+        '(GH #323).'
+    )


### PR DESCRIPTION
## GH #323 — GhanaLSS instance (ONE instance; the class stays open)

`_normalize_dataframe_index` silently collapses a non-unique declared index with
`groupby().first()`. This PR fixes the **GhanaLSS** instance of that bug — 7 cells —
and adds the *first actual enforcement mechanism* for the `aggregation:` policy.

**It does NOT close #323.** #323 is a *class* (~14 countries / ~44 cells / ~150k rows;
Mali alone loses 32,026 of 37,175 roster rows). Closing the class on an instance fix is
precisely how this bug survived its first round. **#323 stays open until the framework fix
lands.**

---

### What was silently dropped, and how many rows

Measured at the **L2-wave parquet** (the truth layer). The L2-**country** parquet
(`var/`) is written POST-collapse, so scanning it returns a false zero — the instrument
was validated on the known positives first (Mali/2014-15 `household_roster` dup = 32,026
exactly; Guyana/1992 `housing` dup = 311 exactly) before any GhanaLSS number was trusted.

| table | wave | dup rows BEFORE | AFTER | root cause |
|---|---|---:|---:|---|
| `cluster_features` | 1988-89 | 14,754 | — | **EXTRACTION_BUG** → table removed |
| `cluster_features` | 1987-88 | *never built* | — | **EXTRACTION_BUG** → table removed |
| `cluster_features` | 1991-92 | 4,158 | 4,158 | INTENDED_AGGREGATION → declared + **checked** |
| `cluster_features` | 1998-99 | 5,698 | 5,698 | INTENDED_AGGREGATION → declared + checked |
| `cluster_features` | 2005-06 | 8,107 | 8,107 | INTENDED_AGGREGATION → declared + checked |
| `cluster_features` | 2012-13 | 15,572 | 15,572 | INTENDED_AGGREGATION → declared + checked |
| `cluster_features` | 2016-17 | 933,584 | 933,584 | INTENDED_AGGREGATION → declared + checked |
| `food_security` | 2016-17 | 109 (+110 NaN-keyed) | **0** | **PHANTOM_NAN_ROWS** → fixed |

Silent #323 warnings on a cold GhanaLSS build: **8 → 1** (the remaining one is `sample`,
pre-existing, a different root cause).

**Rows recovered at the API = 0, honestly.** One row per cluster *is* the correct grain for
(A)/(B); the 110 recovered `food_security` households are all-NA in every declared column
and are dropped by `_finalize_result`'s `dropna(how='all')` (country.py:2217) — exactly as
it already drops 7 all-NA households that *did* have `clust`/`nh` populated. Claiming a
110-row recovery would be a vanity metric. The value here is that the collapse is no longer
silent and the fabrication path is disarmed.

---

### Three root causes, fixed three different ways

One uniform fix would have baked in a wrong value.

**(A) `cluster_features`, 5 waves — INTENDED_AGGREGATION, now DECLARED *and ENFORCED*.**
Each wave points `file:` at a HOUSEHOLD-grain source and projects cluster-invariant columns.
Verified invariant in all five at the source (max distinct value per cluster = 1; zero
violations).

*Key finding:* `aggregation:` was already declared by **9 countries and read by ZERO lines of
code** — grep for its consumption returns nothing; `SkunkWorks/grain_aggregation_policy.org`
item #4 is literally "not yet built". Declaring it would have been **pure prose, and prose is
not enforcement.** So it is now implemented: a new `invariant` reducer in
`_normalize_dataframe_index` (+ `_assert_invariant_within_index`) that verifies constancy
within the index group and **RAISES** otherwise. Proven fatal end-to-end through `Country()`
(projected household-varying `nh` as a declared-invariant column → `ValueError`,
"non-constant in 1000 of 1000 groups") — i.e. it is not swallowed by the wave loop's
`except (KeyError, AttributeError)`. Guard cost: 0.30 s on the 934,584-row worst case.

**(B) `cluster_features`, 1987-88 + 1988-89 — EXTRACTION_BUG (silently WRONG).**
`Region` was wired to `Y01A.DAT REGION` = **the person's REGION OF BIRTH**. Confirmed 5 ways:
`mapping.py`'s `Region()` and `Birthplace()` are byte-identical bodies over the same
`region_dict`; the waves' own code list runs to 11=Nigeria / 12=Ivory Coast / 13=Togo /
14=Burkina Faso (a Ghanaian EA cannot be *located* in Nigeria); REGION varies **within one
household** in 1,019/3,192 and 1,033/3,136 HH (up to 6 distinct values in ONE household);
within-cluster in 167/170 and 174/176; `Y01A.DCT`'s variable order is the classic
birthplace→nationality pair. Collapsed, `.first()` labelled **9/170 and 7/176 clusters
"Nigeria"**.

No cluster-invariant region source exists in these waves → **DROPPED rather than guessed**
(class-2 silently-MISSING > class-1 silently-WRONG). Also dropped 1987-88's `Age: AGEY` (a
person's age, made into "the cluster's age"). 1987-88 was **not** in the reported cell list —
its parquet had never been built — so fixing only 1988-89 would have closed the instance and
left the class.

*Correction to the original diagnosis (it mattered):* the (B) fabrication is currently
**MASKED** — `Region` is 100% NaN (0/14,924) because `get_categorical_mapping` returns `{}`
for these waves (a separate bug). The first guard test was therefore **vacuous** (all-NA →
`nunique`=0 → passes trivially). Re-tested against the *real* birth-region values (the world
where `region_dict` is repaired — plausible, since that bug also breaks `Birthplace`) it
**RAISES**: non-constant in 174/176 and 167/170. A latent class-1 bug is armed behind a
class-2 bug; dropping `Region` costs zero rows today and defuses it.

**(C) `food_security` 2016-17 — PHANTOM_NAN_ROWS.**
110 tail rows have `clust`=NaN **and** `nh`=NaN (all 8 FIES items NaN) but a valid `hid`;
`groupby`'s `dropna` dropped all 110 outright. Re-keyed on `i: hid`, which reconstructs
`{clust}/{nh:02d}` with **100.00% fidelity on all 13,899 good rows** (byte-identical ids).

- BEFORE: 14,009 rows / 110 NaN `i` / 13,899 unique `i`
- AFTER: 14,009 rows / **0 NaN `i`** / 14,009 unique `i`
- ids lost = 0; ids recovered = 110; payload of the 13,899 pre-existing households
  **byte-identical** (`.equals() == True`); all 110 recovered hids present in `sample()`.
- `FIES_score()` already returns `pd.NA` when all 8 items are missing → **no fabricated
  food-secure 0.**

---

### Proof nothing else moved

1. **Dual-implementation byte-identity.** Loaded BASE and FIXED `_normalize_dataframe_index`
   into one process and pushed **every cached L2-wave parquet across all countries** through
   both, with each country's real schema entry — **757 (country × wave × table) cells: 0
   differ, 0 non-GhanaLSS deltas.** The framework change is data-inert everywhere else; it
   alters only warnings. (An independent red-team re-ran this over 729 cells / 32 countries:
   0 data differences, 0 raise/no-raise changes, 0 warnings gained; non-GhanaLSS #323 warning
   count 102 base / 102 fixed.)
2. **The 9 countries that already declare `aggregation:`** (Benin, CotedIvoire, Burkina_Faso,
   Senegal, Albania, Togo, Malawi, Guinea-Bissau, Niger) all declare `{visit: first}`.
   `visit` is an index *level*, never a column, and `first` ≠ `invariant` — doubly unaffected.
   Confirmed empirically in the sweep, not by grep.
3. **Tests fail pre-fix** (verified by stashing `lsms_library/` in the worktree): 6 of 7 FAIL
   on pristine base, 7/7 pass post-fix. The 1 that passes both ways
   (`test_undeclared_collapse_still_warns`) is a regression guard, not a fix-detector.
4. **Blast-radius suite**: `test_normalize_index_j_preserved.py`, `test_schema_consistency.py`,
   `test_table_structure.py`, `test_id_walk.py`, `test_add_market_index_dedup.py` + the new
   file = **2,198 passed, 2 skipped, 0 failed** (2,200 of the 3,427-test suite).
5. **GH #589**: `tests/test_currency.py::test_feature_ghana_per_wave` **FAILS IDENTICALLY** on
   pristine base and with this branch — same assertion, `AssertionError: assert ['GHC'] ==
   {'GHC'}` at `test_currency.py:222` (both diffed). Not touched, not "fixed".
6. **Shared parquet cache not poisoned**: every worktree-config build ran under an isolated
   `LSMS_DATA_DIR`. Verified the shared cache still holds the base-config GhanaLSS parquets.
7. **`.pth` trap defeated and asserted**: every verification script does
   `sys.path.insert(0, WT)` + asserts `'worktrees' in lsms_library.__file__` *and* in
   `countries_root()`.

**API level (unchanged, as predicted):** `cluster_features` 3,145 rows / 0 duplicate `(t,v)`;
`food_security` 13,892 rows / 0 duplicates / 0 NaN `i`. `Feature('cluster_features')(['GhanaLSS'])`
assembles, and the base `No rule to make target .../1987-88/_/cluster_features.parquet` error is gone.
Base-drift is nil (`git diff d572d8a9..development` on `country.py` is empty).

---

### Red-team verdicts — all three lenses, including the concerns that did NOT block

**[correctness] passes = true, severity = `concern`.**
Every load-bearing claim reproduces exactly under an independently-validated instrument.
Duplicate counts go to zero or to a declared, checked, non-vacuously verified aggregation.
The `invariant` guard is genuinely fatal through `Country()`. **ONE UNDISCLOSED HOLE (concern,
not blocker):** the new warning suppression at `country.py:4225` keys only on `undeclared`
being empty — but `groupby(level=...).first()` *also* silently drops **NaN-KEYED rows**
(`dropna=True`), and `_assert_invariant_within_index` is itself a `groupby`, so it cannot see
them either. **A table that declares all its columns `invariant` therefore loses NaN-keyed rows
with ZERO warning — which is exactly the phantom-NaN mechanism this same PR fixes in
`food_security` 2016-17.** Not live for GhanaLSS (`rows_with_NaN_key` = 0 on all five wired
waves; `invariant` is declared nowhere else), so this branch loses no data — **but it is a
regression in the #323 detector itself, inside the generic framework mechanism other fix-agents
are being pointed at.** Flagged loudly here rather than laundered into silence.

**[regression] passes = true, severity = `nit`.**
Nothing else moves (see the 729/757-cell differential above). The scanner was rebuilt after
catching its own instrument bug — `yaml.safe_load` silently skipped the 14 countries whose
`data_scheme.yml` uses `!make` tags, *including Mali and GhanaLSS themselves*, yielding a
clean-looking 333-cell sweep with zero GhanaLSS rows — then re-validated on both required
positives. The newly-declared `Ecological_zone: str` is a genuine no-op (base `var/` already
stored it as `StringDtype`). **Nit, not a blocker:** the warning gate changed from
`if n_dropped:` to `if n_dropped and undeclared:`, so a frame reaching the collapse with **zero
non-index columns** would suppress the #323 warning for *every* country regardless of
declaration — unreachable in all 729 cells today, but a new silent-drop path inside a #323 fix.

**[soundness] passes = true, severity = `concern`.**
The retained/re-keyed data is CORRECT, not merely present, and the fix guesses nowhere.
(C) `hid` **is** the framework's own composite id (`format_id(hid) == f"{clust}/{nh:02d}"` on
13,899/13,899, 0 mismatches; hid unique 14,009/14,009; the 110 are disjoint, all in `sample()`,
all 8 FIES items NaN in all 110). (A) the `invariant` declaration is true **at the source**.
(B) the `Region` drop is well-founded and refuses to guess. **CONCERN (one-line hardening):**
`_assert_invariant_within_index` uses `nunique(dropna=True)`, so a declared-invariant column
that is **100% NA at check time yields `nunique == 0` and passes vacuously** — and because
`undeclared` is then empty, the fix *also* suppresses the pre-existing #323 warning.
**GhanaLSS 1998-99 is a live instance:** its `cluster_features` L2-wave parquet is 5,998 rows
with `Region` 0/5,998 and `Rural` 0/5,998 non-null (the same `get_categorical_mapping → {}`
defect found in 1988-89); base warned "had 5698 duplicate tuple(s)", the fix checks nothing and
says nothing. So the exact configuration the PR exists to catch — a person-level column wired as
a cluster attribute in a wave whose categorical mapping is broken — is the one the guard cannot
see, *because the broken mapping NA-s out the evidence*. No wrong data today (the source is
genuinely invariant) and it is fail-safe if the mapping is repaired, but the `data_scheme.yml`
comment's "Verified cluster-invariant in all five wired waves (max distinct value per cluster =
1)" is **0, not 1**, at the layer the guard actually inspects.

*Both `concern`s are recorded here deliberately rather than fixed in this PR: hardening the
detector (NaN-keyed rows; vacuous all-NA `nunique`) belongs with the framework fix for the
**class**, where it can be validated against all ~44 cells rather than GhanaLSS's 7.*

---

Refs **GH #323** (do not close it). Do not merge without human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
