### PR TITLE
fix(#323): cluster_features collapses household grain unchecked — enforce it (Tajikistan: 11,540 rows collapsed, 0 lost; the same assertion is FALSE in 10 other countries)

### DIFF
--- a/.coder/ledger/323-tajikistan.md
+++ b/.coder/ledger/323-tajikistan.md
@@ -1,0 +1,135 @@
+# Prior-Art Ledger — GH #323 (Tajikistan `cluster_features`)
+
+**Search tier used:** ripgrep + git floor. GitNexus MCP tools were NOT available in
+this environment (`ToolSearch` returned no `gitnexus_*` tools), so the CLAUDE.md
+"run `gitnexus_impact` before editing a symbol" rule was satisfied by an explicit
+call-graph grep instead — recorded in §2. Flagging this rather than silently
+skipping the mandated step.
+
+## §1 Task, restated
+
+`Country('Tajikistan').cluster_features()` returns 767 rows while the underlying
+L2-wave parquets hold 2000 / 4160 / 4644 / 1503 household rows. The task was to
+determine whether ~11.5k rows are being silently DESTROYED (as in Mali's roster,
+where 86% of people vanish) or losslessly DEDUPLICATED, and to make whichever is
+true be *enforced* rather than assumed.
+
+Answer: **Tajikistan is a FALSE POSITIVE for data loss and a TRUE POSITIVE for
+"undeclared silent collapse."** `rows_recovered = 0`. All four waves read
+`cluster_features` from the HOUSEHOLD cover file with a superfluous `i: <hhid>`
+in `idxvars`, so the extraction lands at household grain for a table whose
+canonical grain is the cluster `(t, v)`. The "duplicates" are exactly the
+two-stage sampling take.
+
+## §2 Existing machinery
+
+| symbol | path:line | what it does | tested? | reuse / extend / new |
+|--------|-----------|--------------|---------|----------------------|
+| `Wave.cluster_features` | `lsms_library/country.py:1168` | **THE ACTUAL COLLAPSE SITE.** Unguarded `groupby(keep_levels).agg({'first', GPS:'mean'})` dropping `i` | no | **extend (guarded)** |
+| `_normalize_dataframe_index` | `country.py:~4100` | generic index reduce; GH #323 `RuntimeWarning` on `groupby().first()` | yes | extend (`aggregation:`) |
+| `_declared_index_levels` | `country.py:3723` | parses `index: (t, v)` | yes | reuse |
+| `Country._materialization_entry` | `country.py:1335` | raw `data_scheme.yml` entry (incl. `aggregation`) | yes | reuse |
+| `_ADDITIVE_MEASURE_COLUMNS` | `feature.py` | vetted sum-allowlist for `food_acquired` | yes | reuse (untouched) |
+| `aggregation:` key | 9 countries' `data_scheme.yml` | **INERT** — see §4 | n/a | **make it enforcing** |
+
+Call-graph impact (grep, in lieu of `gitnexus_impact`): `_normalize_dataframe_index`
+has exactly **4 call sites**, all inside `country.py` (2115, 2715, 2929, 2983), all
+passing `scheme_entry`. It runs for *every table of every country*, so the blast
+radius is repo-wide — which is why the new branch is strictly additive (fires only
+when `aggregation:` names an ELIMINATED level). Verified byte-identical output on
+all 17 affected countries (§Phase 3).
+
+## §3 Definitions & conventions in force
+
+- `cluster_features` canonical index is `(t, v)` — `lsms_library/data_info.yml`
+  (`Index Info > index_info`); also `CLAUDE.md` ("`cluster_features` owns `v`").
+- `sample` is the single source of truth for the household→cluster map —
+  `CLAUDE.md` §"`sample()` and Cluster Identity". Tajikistan's `sample` block
+  carries `v` per household in all four waves, so `cluster_features` has no
+  business re-deriving it.
+- "NO AGGREGATION IN CORE" contract — `SkunkWorks/grain_aggregation_policy.org`.
+  The composition path must not *implicitly* reduce grain. This fix does not add
+  a reduction; it makes an existing, hidden one explicit and checked.
+- class-1 (silently WRONG) vs class-2 (silently MISSING): when in doubt, fail
+  loudly rather than guess — per the task standard.
+
+## §4 Invariants & assumptions
+
+- **PSU-constancy (the load-bearing invariant).** `Region` / `Rural` are
+  PSU-level attributes replicated across the households of a cluster. Verified on
+  the RAW NUMERIC CODES in the source `.dta` (so no code→label mapping collision
+  can hide a conflict): **0 of all 767 cluster-waves** carry more than one
+  distinct `(Region, Rural)`. Also 0 NaN in `hhid` and in the PSU var, which
+  rules out PHANTOM_NAN_ROWS. The ambiguous set is EMPTY, so `.first()` provably
+  picks the only value there is.
+- **`aggregation:` was INERT.** Declared in Senegal, Niger, Togo, Benin,
+  CotedIvoire, Guinea-Bissau, Burkina_Faso, Malawi, Albania — but a repo-wide grep
+  for it in `*.py` returned only two hits (`country.py:2387`,
+  `diagnostics.py:230`), both `_skip = {...}` sets that merely exclude it from
+  COLUMN parsing. **Nothing read it as a policy.** So "just declare `aggregation:`"
+  was, before this change, a NO-OP. Prose is not enforcement — and neither was
+  this key.
+- All nine pre-existing declarations are `visit: first` where `visit` is IN the
+  declared index (e.g. `interview_date`, `(t, i, visit)`). Such a level is never
+  eliminated, so `_declared_reducer` returns `None` for them and they stay
+  no-ops. This is what makes the change safe for those nine countries.
+- **GPS must be exempt.** `Latitude`/`Longitude` are household-level BY DESIGN and
+  are averaged to a cluster centroid (`country.py:1177`), so they are *expected*
+  to vary within a cluster. Checking them would false-positive every GPS country.
+
+## §5 Reuse decision
+
+| quantity | decision | reason |
+|----------|----------|--------|
+| household→cluster map | **reuse** `sample()` | already the single source of truth (§3); do NOT re-derive |
+| collapse of `i` in `cluster_features` | **extend** `Wave.cluster_features` | that is where the collapse actually happens; the guard belongs at the collapse |
+| policy vocabulary | **extend** `aggregation:` | the key already exists and is declared in 9 countries; make it read rather than invent a second mechanism |
+| `unique` reducer | **new** | no existing reducer *enforces* losslessness; `first`/`sum` both decide silently |
+| `sum` reducer | **NOT added** | `food_acquired` already sums via the vetted `_ADDITIVE_MEASURE_COLUMNS` allowlist; a generic `sum` would happily add region codes and sampling weights |
+
+### Why `unique` and not `first`
+
+`first` is provably correct for Tajikistan *today* (0/767 conflicting clusters), so
+`unique` is a guaranteed no-op on the data. That is precisely the point: it converts
+an unchecked assumption into an invariant **re-verified on every build**. If a future
+wave, a recode, or a PSU straddling two oblasts ever breaks PSU-constancy, `unique`
+FAILS LOUDLY instead of quietly keeping whichever household sorted first. The #323
+warning goes quiet for Tajikistan for a *reason that is checked*, rather than because
+a poisoned cache stopped asking.
+
+### Why `i` STAYS in `idxvars` (a deliberate departure from the dispatch brief)
+
+The brief's Part 1 proposed dropping `i: hhid` from all four wave `data_info.yml`s and
+deduping at the wave level. I did **not** do that, for a reason worth recording: `i` is
+what *names* the level being eliminated. Remove it and the row multiplicity becomes
+**anonymous** — a bare 1875-row duplicate blob over `(t, v)` with no level to attach a
+policy to, i.e. exactly the undeclarable shape of the bug. Keeping `i` is what makes the
+collapse expressible as `aggregation: {i: unique}` and therefore enforceable. Dropping it
+would also have removed the enforcement point while leaving the class untouched.
+
+## §6 Open questions for the human
+
+- **The class is much wider than Tajikistan.** 17 countries carry household grain in
+  `cluster_features`; on a cold build the "invariant by construction" comment is
+  actually **FALSE in ten of them** — Albania (18 clusters), Guatemala (8), Guyana
+  (23), Kazakhstan (2), Liberia, Malawi, Niger, Pakistan, Tanzania, Uganda. This
+  change makes all of them WARN (data unchanged). Each needs its own triage: is the
+  conflict a genuine multi-region PSU, a `v` that is not actually a cluster id, or a
+  bad mapping? Filed as follow-up, not silently "fixed" — guessing there is exactly
+  the class-1 error this issue is about.
+
+---
+### Phase 3 — verification
+
+- `Wave.cluster_features` — **OK (anchored on §2, §4)**: the collapse is now checked;
+  GPS exempted per §4; data byte-identical on all 17 affected countries.
+- `_declared_reducer` / `_apply_declared_reducer` — **OK (anchored on §4)**: reducer is
+  consulted only for ELIMINATED levels, so the nine `visit: first` declarations remain
+  no-ops (pinned by `test_reducer_ignored_for_a_level_that_survives_in_the_index`).
+- `_nonconstant_groups` / `_assert_constant_within_groups` — **OK (anchored on §5)**: not a
+  REINVENTION of `_ADDITIVE_MEASURE_COLUMNS` — that path *sums* a vetted column list for
+  `food_acquired`; this one *proves a collapse is lossless* and refuses to guess otherwise.
+- `aggregation: {i: unique}` (Tajikistan `data_scheme.yml`) — **OK (anchored on §4)**: no
+  longer inert; `test_aggregation_key_is_read_not_inert` fails on a pre-fix tree.
+- No CONTRADICTION with `SkunkWorks/grain_aggregation_policy.org` (§3): no new grain
+  reduction is introduced — an existing hidden one is surfaced and enforced.

--- a/lsms_library/countries/Tajikistan/_/data_scheme.yml
+++ b/lsms_library/countries/Tajikistan/_/data_scheme.yml
@@ -34,6 +34,32 @@ Data Scheme:
     index: (t, v)
     Region: str
     Rural: str
+    # All four waves read Region/Rural from the HOUSEHOLD cover file
+    # (1999 SHLDDTA, 2003 interview, 2007 r1m0, 2009 m0), so the extraction
+    # lands at household grain -- one row per household, `i` alongside `v`.
+    # The canonical grain of cluster_features is the CLUSTER, (t, v), so `i`
+    # is collapsed away.  The row multiplicity is exactly the two-stage
+    # sampling take (households sampled per PSU):
+    #
+    #   wave   HH rows   PSUs   collapsed   HH per PSU
+    #   1999      2000    125        1875      14-18
+    #   2003      4160    208        3952      exactly 20
+    #   2007      4644    267        4377      exactly 9..20
+    #   2009      1503    167        1336      exactly 9
+    #
+    # Region and Rural are PSU-level attributes REPLICATED across the
+    # households of a cluster, so the collapse is lossless: 0 of all 767
+    # cluster-waves carry more than one distinct (Region, Rural) -- verified on
+    # the raw numeric codes in the source .dta, so no code->label mapping
+    # collision can hide a conflict.
+    #
+    # `unique` (not `first`) is the reducer precisely BECAUSE it is a no-op
+    # today: it converts that fact from an unchecked assumption into an
+    # invariant re-verified on every build.  If a recode or a new wave ever
+    # puts a PSU across two oblasts, this RAISES instead of silently keeping
+    # whichever household happened to sort first (GH #323).
+    aggregation:
+      i: unique
 
   housing:
     # TLSS dwelling module.  1999 (SSEC2) and 2007 (r1m7a/b/c) field a full

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -1184,6 +1184,47 @@ class Wave:
                     c: ('mean' if c in ('Latitude', 'Longitude') else 'first')
                     for c in df.columns
                 }
+                # GH #323.  The comment above ASSERTS that the ``first``-reduced
+                # columns are cluster-invariant -- but nothing checked it, and an
+                # unchecked ``.first()`` over a household grain is exactly the
+                # silent-collapse bug (it is indistinguishable from merging
+                # distinct entities).  Prose is not enforcement, so check it.
+                #
+                # GPS is excluded: Latitude/Longitude are HH-level BY DESIGN and
+                # are averaged to a cluster centroid, so they are *expected* to
+                # vary within a cluster and must not be flagged.
+                #
+                # A country may declare the policy in data_scheme.yml:
+                #     cluster_features:
+                #       aggregation:
+                #         i: unique     # enforce losslessness; RAISE on conflict
+                # ``unique``/``constant`` turns the assumption into an invariant
+                # re-verified on every build.  ``first`` declares the discard
+                # deliberate.  Undeclared keeps the historical collapse (data
+                # byte-identical) but WARNS when the assertion is actually false,
+                # so the class surfaces instead of hiding.
+                reduced = [c for c in df.columns if c not in ('Latitude', 'Longitude')]
+                entry = self.country._materialization_entry('cluster_features')
+                reducer = _declared_reducer(entry, ['i'])
+                where = f"{self.name} cluster_features"
+                if reducer in ('unique', 'constant'):
+                    _assert_constant_within_groups(
+                        df, keep_levels, reduced, ['i'], where, reducer,
+                    )
+                elif reducer is None:
+                    offenders, bad_cols = _nonconstant_groups(df, keep_levels, reduced)
+                    if len(offenders):
+                        warnings.warn(
+                            f"{where}: collapsing household grain `i` to the "
+                            f"canonical (t, v) cluster index via .first(), but "
+                            f"{len(offenders)} cluster(s) carry conflicting values "
+                            f"in {bad_cols} -- one value is being kept and the "
+                            f"others silently DISCARDED (GH #323).  Declare "
+                            f"`aggregation: {{i: unique}}` once the conflict is "
+                            f"resolved, or add the finer level to the index.  "
+                            f"First offending cluster(s): {offenders[:5].tolist()}.",
+                            RuntimeWarning,
+                        )
                 df = df.groupby(level=keep_levels).agg(agg)
             else:
                 df = df.groupby(level=keep_levels).first()
@@ -3737,6 +3778,142 @@ def _declared_index_levels(schema_entry: dict[str, Any] | None) -> list[str]:
     return [str(level) for level in declared_levels]
 
 
+#: Reducers accepted by the ``aggregation:`` block in a country's
+#: ``data_scheme.yml``.  Deliberately small (GH #323):
+#:
+#: ``unique`` / ``constant``
+#:     Collapse a group ONLY when every retained column holds exactly one
+#:     distinct value; RAISE otherwise.  Use when the eliminated level is a
+#:     finer grain over which the retained columns are *replicated* (e.g.
+#:     Tajikistan's cluster_features, read from the household cover file: the
+#:     ~9-20 households sampled per PSU each repeat their PSU's Region/Rural).
+#:     The collapse is then provably lossless rather than a silent guess.
+#:
+#: ``first``
+#:     Keep the first row per group, DISCARDING the rest.  Lossy, but a
+#:     deliberate, declared choice (the #323 warning is suppressed) rather than
+#:     the silent fallback.
+#:
+#: ``sum`` is intentionally NOT offered here: the one table whose source
+#: legitimately repeats rows per index tuple (``food_acquired``) is summed via
+#: the vetted ``_ADDITIVE_MEASURE_COLUMNS`` allowlist, which names the columns
+#: that may be added.  A generic ``sum`` would happily add up region codes and
+#: sampling weights.
+_DECLARED_REDUCERS = ("unique", "constant", "first")
+
+
+def _declared_reducer(
+    schema_entry: dict[str, Any] | None,
+    eliminated_levels: list[str],
+) -> str | None:
+    """Return the reducer declared for an eliminated index level, if any.
+
+    The ``aggregation:`` block maps an index level to a reducer.  Only levels
+    actually being *collapsed away* here are consulted -- a reducer declared for
+    a level that survives in the canonical index (e.g. ``visit`` in Senegal's
+    ``interview_date``, index ``(t, i, visit)``) describes how a downstream
+    consumer should collapse it and is correctly a no-op for us.
+    """
+    if not schema_entry or not eliminated_levels:
+        return None
+
+    policy = schema_entry.get("aggregation")
+    if not isinstance(policy, dict):
+        return None
+
+    chosen = {
+        str(policy[lvl]).strip().lower()
+        for lvl in eliminated_levels
+        if lvl in policy and policy[lvl] is not None
+    }
+    if not chosen:
+        return None
+    if len(chosen) > 1:
+        raise ValueError(
+            f"Conflicting `aggregation:` reducers {sorted(chosen)} declared for "
+            f"index levels {eliminated_levels} being collapsed together; a single "
+            f"group cannot be reduced two ways.  Declare one reducer."
+        )
+
+    reducer = chosen.pop()
+    if reducer not in _DECLARED_REDUCERS:
+        raise ValueError(
+            f"Unknown `aggregation:` reducer {reducer!r} in data_scheme.yml; "
+            f"supported reducers are {list(_DECLARED_REDUCERS)}."
+        )
+    return reducer
+
+
+def _nonconstant_groups(
+    df: pd.DataFrame,
+    group_levels: list[str],
+    cols: list[str],
+) -> tuple[pd.Index, list[str]]:
+    """Groups where some column in ``cols`` carries >1 distinct value.
+
+    This is *the ambiguous set*: the rows for which a ``.first()`` collapse is a
+    GUESS rather than a lossless dedup.  Empty ambiguous set => ``.first()``
+    provably picks the only value there is.
+    """
+    cols = [c for c in cols if c in df.columns]
+    if not cols:
+        return df.index[:0], []
+    nun = df[cols].groupby(level=group_levels, observed=True).nunique(dropna=True)
+    bad_cols = [c for c in cols if (nun[c] > 1).any()]
+    if not bad_cols:
+        return nun.index[:0], []
+    return nun[(nun[bad_cols] > 1).any(axis=1)].index, bad_cols
+
+
+def _assert_constant_within_groups(
+    df: pd.DataFrame,
+    group_levels: list[str],
+    cols: list[str],
+    eliminated_levels: list[str],
+    where: str,
+    reducer: str = "unique",
+) -> None:
+    """Raise unless collapsing ``eliminated_levels`` is provably LOSSLESS.
+
+    A wrong-but-quiet answer (class-1) is strictly worse than a loud failure, so
+    when the declared invariant does not hold we refuse to guess (GH #323).
+    """
+    offenders, bad_cols = _nonconstant_groups(df, group_levels, cols)
+    if not len(offenders):
+        return
+    raise ValueError(
+        f"{where}: `aggregation: {{{eliminated_levels[0]}: {reducer}}}` in "
+        f"data_scheme.yml asserts that collapsing {eliminated_levels} leaves every "
+        f"column constant within {group_levels} -- but {len(offenders)} group(s) "
+        f"carry conflicting values in {bad_cols}.  Collapsing would silently keep "
+        f"whichever row sorted first.  First offending group(s): "
+        f"{offenders[:5].tolist()}.  Either the source grain is genuinely finer "
+        f"than the declared index (add the level to the index), or the declared "
+        f"reducer is wrong."
+    )
+
+
+def _apply_declared_reducer(
+    df: pd.DataFrame,
+    reducer: str,
+    present_levels: list[str],
+    eliminated_levels: list[str],
+    table_name: str | None,
+    wave: str | None,
+) -> pd.DataFrame:
+    """Collapse ``df`` to ``present_levels`` under a DECLARED aggregation policy.
+
+    ``unique``/``constant`` verifies the collapse is lossless and raises if it is
+    not -- turning a silent guess into an enforced invariant (GH #323).
+    """
+    if reducer in ("unique", "constant"):
+        where = f"{table_name or '<table>'}" + (f" (wave {wave})" if wave else "")
+        _assert_constant_within_groups(
+            df, present_levels, list(df.columns), eliminated_levels, where, reducer,
+        )
+    return df.groupby(level=present_levels, observed=True).first()
+
+
 _SCHEME_DTYPE_MAP = {
     'bool': pd.BooleanDtype(),
     'int': pd.Int64Dtype(),
@@ -4162,6 +4339,7 @@ def _normalize_dataframe_index(
 
     # Drop any unexpected index levels (but keep at least one, and only on MultiIndex)
     extra_levels = [lvl for lvl in df.index.names if lvl not in declared]
+    eliminated_levels: list[str] = []
     if (
         extra_levels
         and isinstance(df.index, pd.MultiIndex)
@@ -4169,6 +4347,10 @@ def _normalize_dataframe_index(
     ):
         try:
             df = df.droplevel(extra_levels)
+            # Remember which levels we removed: an `aggregation:` policy in
+            # data_scheme.yml names the ELIMINATED level (the grain being
+            # collapsed away), so we need this to look the policy up below.
+            eliminated_levels = [str(lvl) for lvl in extra_levels]
         except ValueError:
             pass  # Cannot drop levels; keep original index
 
@@ -4190,7 +4372,19 @@ def _normalize_dataframe_index(
         from .feature import _ADDITIVE_MEASURE_COLUMNS
         additive = _ADDITIVE_MEASURE_COLUMNS.get(table_name) if table_name else None
         present_additive = [c for c in (additive or ()) if c in df.columns]
-        if present_additive:
+
+        # GH #323: an explicitly DECLARED aggregation policy beats every
+        # default below.  `aggregation:` in data_scheme.yml maps an ELIMINATED
+        # index level (the grain being collapsed away) to a reducer.  Until now
+        # the key was inert -- parsed only to be *excluded* from column parsing
+        # -- so a country could describe its intended collapse and still get the
+        # silent groupby().first() fallback.  Declaring it now ENFORCES it.
+        reducer = _declared_reducer(schema_entry, eliminated_levels)
+        if reducer is not None:
+            df = _apply_declared_reducer(
+                df, reducer, present_levels, eliminated_levels, table_name, wave,
+            )
+        elif present_additive:
             agg = {c: ('sum' if c in present_additive else 'first') for c in df.columns}
             df = df.groupby(level=present_levels, observed=True).agg(agg)
             if 'Price' in df.columns and {'Expenditure', 'Quantity'} <= set(df.columns):

--- a/tests/test_gh323_cluster_features_aggregation.py
+++ b/tests/test_gh323_cluster_features_aggregation.py
@@ -1,0 +1,222 @@
+"""GH #323 -- the silent ``groupby().first()`` collapse in ``cluster_features``.
+
+``Wave.cluster_features()`` collapses a household-grain extraction (``i`` in
+``idxvars``) down to the canonical ``(t, v)`` cluster index.  It did so with an
+unguarded ``.first()`` whose comment *asserted* that the reduced columns are
+"invariant within a cluster by construction of the LSMS-ISA sampling design" --
+but nothing ever checked that assertion.  An unchecked ``.first()`` over a
+household grain is indistinguishable from merging genuinely distinct entities,
+and it is SILENT: it never reaches the guarded branch in
+``_normalize_dataframe_index``, so the GH #323 warning never fired for it.
+
+17 countries carry household grain in ``cluster_features``; on a cold build the
+assertion is actually FALSE in ten of them.
+
+These tests pin the enforcement:
+
+* a DECLARED ``aggregation: {i: unique}`` RAISES when the invariant is violated
+  (rather than silently keeping whichever household sorted first);
+* an UNDECLARED collapse WARNS when the invariant is violated;
+* Tajikistan's collapse is lossless, so declaring ``unique`` is a pure no-op.
+
+The private helpers are imported INSIDE the unit tests, so that on a pre-fix
+tree this module still collects and the behavioural tests below fail on
+BEHAVIOUR (no raise / no warning) rather than on an ImportError.
+"""
+import pandas as pd
+import pytest
+
+import lsms_library.country as C
+from lsms_library import Country
+
+# Tajikistan clusters per wave (the two-stage sampling take).
+TAJIK_PSUS = {'1999': 125, '2003': 208, '2007': 267, '2009': 167}
+
+
+def _poison_region(monkeypatch, wave_suffix):
+    """Make one household inside a cluster disagree about its Region.
+
+    dtype-safe: swaps in another value ALREADY PRESENT in the column rather than
+    a sentinel string.  ``Region`` is int8 raw codes in some countries (Guyana)
+    and mapped labels in others (Tajikistan); a string sentinel raises
+    ``LossySetitemError`` on the former.
+    """
+    real = C.Wave.grab_data
+
+    def poisoned(self, request):
+        df = real(self, request)
+        if request == 'cluster_features' and self.name.endswith(wave_suffix):
+            df = df.copy()
+            col = df['Region']
+            current = col.iloc[0]
+            alt = next((v for v in col.dropna().unique() if v != current), None)
+            assert alt is not None, "need >=2 distinct Regions to build a conflict"
+            df.iloc[0, df.columns.get_loc('Region')] = alt
+        return df
+
+    monkeypatch.setattr(C.Wave, 'grab_data', poisoned)
+
+
+def _aggregation_of(country):
+    entry = Country(country)._materialization_entry('cluster_features')
+    return (entry.get('aggregation') or {}).get('i')
+
+
+# --------------------------------------------------------------------------
+# BEHAVIOUR (these fail on a pre-fix tree: no raise, no warning)
+# --------------------------------------------------------------------------
+
+def test_declared_unique_raises_when_a_cluster_straddles_two_regions(monkeypatch):
+    """The point of the whole exercise: a conflict must FAIL LOUDLY, not be
+    quietly resolved in favour of whichever household sorted first.
+
+    Pre-fix this silently returned 125 rows with one Region invented."""
+    assert _aggregation_of('Tajikistan') == 'unique', \
+        "Tajikistan must DECLARE its household->cluster collapse"
+    _poison_region(monkeypatch, '1999')
+    with pytest.raises(ValueError, match='conflicting values'):
+        Country('Tajikistan')['1999'].cluster_features()
+
+
+def test_undeclared_country_warns_instead_of_collapsing_silently(monkeypatch):
+    """The CLASS, not just the instance: a country with NO declared policy must
+    still surface the conflict rather than discard rows in silence."""
+    assert _aggregation_of('Guyana') is None, \
+        "Guyana must have NO declared policy for this test to mean anything"
+    _poison_region(monkeypatch, '1992')
+    with pytest.warns(RuntimeWarning, match='GH #323'):
+        Country('Guyana')['1992'].cluster_features()
+
+
+def test_tajikistan_collapse_is_lossless_no_op():
+    """0 of 767 cluster-waves carry a conflicting (Region, Rural), so enforcing
+    ``unique`` must change nothing about the returned data."""
+    for wave, n_clusters in TAJIK_PSUS.items():
+        df = Country('Tajikistan')[wave].cluster_features()
+        assert list(df.index.names) == ['t', 'v']
+        assert len(df) == n_clusters, f"{wave}: expected {n_clusters}, got {len(df)}"
+
+
+def test_tajikistan_country_level_row_count():
+    df = Country('Tajikistan').cluster_features()
+    assert len(df) == sum(TAJIK_PSUS.values()) == 767
+    assert list(df.index.names) == ['t', 'v']
+
+
+# --------------------------------------------------------------------------
+# The `aggregation:` key must actually be READ.  It used to be inert: declared
+# in nine countries' data_scheme.yml, but referenced in *.py only to be
+# EXCLUDED from column parsing.  Nothing consumed it as a policy.
+# --------------------------------------------------------------------------
+
+def test_aggregation_key_is_read_not_inert():
+    from lsms_library.country import _declared_reducer
+    entry = Country('Tajikistan')._materialization_entry('cluster_features')
+    assert _declared_reducer(entry, ['i']) == 'unique'
+
+
+def test_reducer_ignored_for_a_level_that_survives_in_the_index():
+    # Senegal-style: `visit` is IN the declared index, so it is never collapsed
+    # and its reducer must not fire.  This is what keeps the nine pre-existing
+    # `visit: first` declarations no-ops.
+    from lsms_library.country import _declared_reducer
+    entry = {'index': '(t, i, visit)', 'aggregation': {'visit': 'first'}}
+    assert _declared_reducer(entry, []) is None
+
+
+def test_unknown_reducer_is_rejected():
+    from lsms_library.country import _declared_reducer
+    with pytest.raises(ValueError, match='Unknown `aggregation:` reducer'):
+        _declared_reducer({'aggregation': {'i': 'average'}}, ['i'])
+
+
+# --------------------------------------------------------------------------
+# The guard itself
+# --------------------------------------------------------------------------
+
+def _frame(regions):
+    idx = pd.MultiIndex.from_tuples(
+        [('1999', 'psu1', f'hh{n}') for n in range(len(regions))],
+        names=['t', 'v', 'i'],
+    )
+    return pd.DataFrame(
+        {'Region': regions, 'Latitude': [1.0, 2.0, 3.0][:len(regions)]}, index=idx,
+    )
+
+
+def test_constant_group_is_lossless_and_passes():
+    from lsms_library.country import _assert_constant_within_groups, _nonconstant_groups
+    df = _frame(['Sogd', 'Sogd', 'Sogd'])
+    offenders, bad = _nonconstant_groups(df, ['t', 'v'], ['Region'])
+    assert len(offenders) == 0 and bad == []
+    _assert_constant_within_groups(df, ['t', 'v'], ['Region'], ['i'], 'test')
+
+
+def test_conflicting_group_is_detected_and_raises():
+    from lsms_library.country import _assert_constant_within_groups, _nonconstant_groups
+    df = _frame(['Sogd', 'Khatlon', 'Sogd'])
+    offenders, bad = _nonconstant_groups(df, ['t', 'v'], ['Region'])
+    assert len(offenders) == 1 and bad == ['Region']
+    with pytest.raises(ValueError, match='conflicting values'):
+        _assert_constant_within_groups(df, ['t', 'v'], ['Region'], ['i'], 'test')
+
+
+def test_gps_columns_are_exempt_from_the_constancy_check():
+    # Latitude/Longitude are HH-level BY DESIGN (averaged to a cluster
+    # centroid), so they must be allowed to vary.  Were GPS checked, every
+    # GPS-carrying country would false-positive.
+    from lsms_library.country import _nonconstant_groups
+    df = _frame(['Sogd', 'Sogd', 'Sogd'])          # Latitude varies 1/2/3
+    offenders, _ = _nonconstant_groups(df, ['t', 'v'], ['Region'])
+    assert len(offenders) == 0, "GPS must not be in the checked column set"
+
+
+# --------------------------------------------------------------------------
+# The second collapse site: `_normalize_dataframe_index`.  No country routes a
+# cluster_features collapse through it today (Wave.cluster_features pre-collapses),
+# but the `aggregation:` policy is wired there too -- so pin it rather than ship
+# an unexercised branch.
+# --------------------------------------------------------------------------
+
+def _flat_frame(regions, lat):
+    idx = pd.MultiIndex.from_tuples(
+        [('1999', 'psu1')] * len(regions), names=['t', 'v'],
+    )
+    return pd.DataFrame({'Region': regions, 'Latitude': lat}, index=idx)
+
+
+def test_apply_declared_reducer_unique_collapses_when_lossless():
+    from lsms_library.country import _apply_declared_reducer
+    df = _flat_frame(['Sogd', 'Sogd', 'Sogd'], [1.0, 1.0, 1.0])
+    out = _apply_declared_reducer(df, 'unique', ['t', 'v'], ['i'], 'cluster_features', '1999')
+    assert len(out) == 1
+    assert out['Region'].iloc[0] == 'Sogd'
+
+
+def test_apply_declared_reducer_checks_every_column_including_gps():
+    """The GENERIC reducer has NO GPS exemption, deliberately.
+
+    ``unique`` means "collapsing this level loses nothing" -- so a varying
+    Latitude IS a loss and must raise.  The mean-centroid exemption is a rule
+    specific to ``Wave.cluster_features`` (where GPS is averaged on purpose),
+    and it must not leak into the generic path.
+    """
+    from lsms_library.country import _apply_declared_reducer
+    df = _flat_frame(['Sogd', 'Sogd', 'Sogd'], [1.0, 2.0, 3.0])
+    with pytest.raises(ValueError, match='Latitude'):
+        _apply_declared_reducer(df, 'unique', ['t', 'v'], ['i'], 'cluster_features', '1999')
+
+
+def test_apply_declared_reducer_unique_raises_when_lossy():
+    from lsms_library.country import _apply_declared_reducer
+    df = _flat_frame(['Sogd', 'Khatlon', 'Sogd'], [1.0, 1.0, 1.0])
+    with pytest.raises(ValueError, match='conflicting values'):
+        _apply_declared_reducer(df, 'unique', ['t', 'v'], ['i'], 'cluster_features', '1999')
+
+
+def test_apply_declared_reducer_first_is_a_declared_discard():
+    """`first` is lossy BY DECLARATION: it collapses without raising."""
+    from lsms_library.country import _apply_declared_reducer
+    df = _flat_frame(['Sogd', 'Khatlon', 'Sogd'], [1.0, 1.0, 1.0])
+    out = _apply_declared_reducer(df, 'first', ['t', 'v'], ['i'], 'cluster_features', '1999')
+    assert len(out) == 1


### PR DESCRIPTION
Fixes **one instance** of **GH #323**. **#323 (the class) MUST STAY OPEN** — see *Scope* at the bottom. Closing the class on an instance fix is precisely how this bug survived once already.

## TL;DR — an honest headline

Tajikistan is a **FALSE POSITIVE for data loss** and a **TRUE POSITIVE for undeclared silent collapse**.

**`rows_recovered = 0`.** That is the correct answer, not an evasion. 11,540 household rows *are* silently collapsed away — but the collapse is provably **lossless**, so no row is *recoverable*. The defect here is not lost data; it is that the collapse was **unchecked and undeclared**, and the unchecked assumption behind it is **actually FALSE in 10 other countries**.

The main finding is that **the diagnosis pointed at the wrong function**, and the class is far broader than one country.

## What is silently dropped, and how many rows

All four Tajikistan waves read `cluster_features` from the **household cover file** with a superfluous `i: <hhid>` in `idxvars`, so extraction lands at **household grain** for a table whose canonical grain is the **cluster `(t, v)`**. `i` is then collapsed away. The multiplicity is exactly the two-stage sampling take:

| wave | HH rows | PSUs | rows collapsed away | HH per PSU |
|---|---|---|---|---|
| 1999 | 2,000 | 125 | **1,875** | 14–18 |
| 2003 | 4,160 | 208 | **3,952** | exactly 20 |
| 2007 | 4,644 | 267 | **4,377** | ≤18 |
| 2009 | 1,503 | 167 | **1,336** | exactly 9 |
| **total** | **12,307** | **767** | **11,540** | |

HH−PSU reproduces every reported duplicate count **to the row**. Zero NaN in `hhid` and `psu` (rules out phantom rows).

**The collapse is LOSSLESS:** **0 of all 767 cluster-waves** carry more than one distinct `(Region, Rural)` — verified on the **raw numeric codes in the source `.dta`**, so no code→label mapping collision can hide a conflict. The ambiguous set is empty, so `.first()` provably picks the only value there is.

## Root cause — the diagnosis pointed at the WRONG function

The collapse does **NOT** occur in `_normalize_dataframe_index`. That is why its GH #323 warning **never fired** for `cluster_features` (measured: **0 warnings on a cold pristine build**).

It occurs in **`Wave.cluster_features()` (`country.py:1180`)**, via an unguarded `groupby().agg('first')` whose own comment **ASSERTS** the reduced columns are *"invariant within a cluster by construction of the LSMS-ISA sampling design"* — an assertion **nothing ever checked**.

**Prose is not enforcement.**

**The class is broad:** **17 countries** carry household grain in `cluster_features`, and on a cold build that "invariant by construction" comment is **FALSE in 10 of them**.

## The fix (2 parts)

1. **`Wave.cluster_features()` now CHECKS the assertion.** GPS (`Latitude`/`Longitude`) is exempt — household-level *by design*, averaged to a cluster centroid. Declared conflict → **RAISE**; undeclared conflict → loud **`RuntimeWarning`** (data unchanged).

2. **`aggregation:` made ENFORCING.** It was **INERT**: declared in 9 countries' `data_scheme.yml` but referenced in `*.py` only by two `_skip` sets that *excluded* it from COLUMN parsing — nothing read it as policy, so "just declare `aggregation:`" was a no-op. (Malawi's own YAML comment says so out loud: *"nothing reads this yet"*.) It is now consulted at **both** collapse sites, with a new `unique`/`constant` reducer that collapses only when every retained column has exactly one distinct value, and **RAISES otherwise**.

Tajikistan declares `aggregation: {i: unique}`.

- **`unique`, not `first`, PRECISELY BECAUSE it is a no-op today** (0/767 conflicts): it converts an unchecked assumption into an **invariant re-verified on every build**.
- **`i` deliberately STAYS in `idxvars`.** It *names* the eliminated level, which is what makes the collapse **declarable**. Drop it and the multiplicity becomes an anonymous duplicate blob with no level to attach a policy to.
- **`sum` deliberately NOT added.** `food_acquired` already sums via the vetted `_ADDITIVE_MEASURE_COLUMNS` allowlist; a generic `sum` would happily add up region codes and sampling weights.

## Before / after

- **API rows: 767 → 767** (per-wave 125 / 208 / 267 / 167 — unchanged).
- `assert_frame_equal(check_exact=True)` BEFORE vs AFTER: **IDENTICAL**.
- **`rows_recovered = 0`.**

**The guard has teeth (negative control).** Injecting one household with a conflicting `Region` into a PSU → `ValueError` raised. On the **real data path**, BASE silently kept the injected wrong `Region` and **propagated it to the whole PSU with zero warnings** (a class-1 silently-WRONG failure, demonstrated); FIX raises. Re-run with the frame **reversed** so the conflicting row sorts first: still raises. It is a genuine group-wise `nunique`, not a peek at row 0.

## Proof nothing else moved

**DATA BYTE-IDENTICAL across all 17 countries** that carry household grain in `cluster_features` (worktree@BASE vs worktree@FIX, cold `LSMS_NO_CACHE=1` builds, `assert_frame_equal(check_exact=True)` on every frame):

> Albania 1829, Burkina_Faso 2035, Cambodia 252, China 30, Guatemala 8, Guyana 130, Kazakhstan 135, Kosovo 360, Liberia 32, Malawi 2781, Niger 1599, Pakistan 301, Serbia and Montenegro 919, South Africa 355, Tajikistan 767, Tanzania 2389, Uganda 4409

**→ ALL 17 IDENTICAL. Zero rows moved anywhere.** The only behavioural delta is **+14 new `RuntimeWarning`s** — loud, not silent, and data-neutral.

**Blast radius is provably small (static, exhaustive, and re-derived independently at landing).** `grep -rn -A4 '^\s*aggregation:' lsms_library/countries/*/_/data_scheme.yml` returns **exactly 10** declarations library-wide: `visit: first` on `interview_date` in 9 countries — **all** of which declare `index: (t, i, visit)`, so `visit` **survives** and is never an *eliminated* level, hence `_declared_reducer` returns `None` for all 9 (verified individually) — plus Tajikistan's new `i: unique`. **The reducer key space is exhausted; no third country can be hit.** Confirmed empirically with a spy monkeypatched over `_apply_declared_reducer` (fired = 0 for all 9 `interview_date` countries).

## Warnings surfaced (the class, made loud)

**+14 new GH #323 warnings across 10 countries** where the unchecked "invariant by construction" comment is **actually FALSE** — Albania (18 clusters), Guyana (23), Guatemala (8), Kazakhstan (2), Liberia, Malawi (4), Niger, Pakistan, Tanzania (2), Uganda.

These are deliberately left as **loud warnings rather than guessed resolutions** — under *class-2 (silently MISSING) beats class-1 (silently WRONG)*, we refuse to guess. **Tajikistan warns 0**, because its declared `unique` invariant **holds and is now checked**.

## Tests

`tests/test_gh323_cluster_features_aggregation.py` — 14 tests.

- **POST-FIX: 14 passed.**
- **PRE-FIX control (source reverted to BASE, test file kept): 12 failed, 2 passed.** The 2 that pass on both sides are the no-op row-count guards (767 total; 125/208/267/167 per wave) — they *should* pass either way, since the data legitimately does not change. Behavioural failures for behavioural reasons: declared-`unique` did **not** raise; undeclared country did **not** warn (`Emitted warnings: []`).

*(The authoring agent reported this control as "8 failed, 2 passed"; I measured 12 failed / 2 passed because I reverted `country.py` wholesale, so several failures surface at import. Reporting my own measured numbers.)*

## Red-team verdicts — all three, verbatim on the concerns

Survived a three-lens adversarial red-team. **All three PASS. Reporting the non-blocking findings rather than laundering them into silence.**

### correctness — PASSES, severity: nit
Every load-bearing claim reproduced independently. Instrument validated on the known positives **before** trusting any zero (Mali/2014-15 `household_roster` = 32,026 dups; Guyana/1992 `housing` = 311 — exact). All 9 Tajikistan declared tables × 4 waves scanned against the **full declared index**: dups appear **only** in `cluster_features`. Root-cause re-pointing confirmed (cold BASE build emits 0 #323 warnings).

> **The hard one:** BASE and FIX both give 767 rows / 0 dups / 0 warnings, so *"guard works"* and *"guard never engaged"* look identical. Disambiguated: (a) `_declared_reducer(entry, ['i'])` → `'unique'` (**guard engaged**); (b) poisoned negative control on the real data path → BASE silently propagated the wrong Region, FIX raised.

**Nits (non-blocking):** (a) the precedence footgun below; (b) **merge hazard** — see *Merge order*; (c) the new warning fires only on **cold** builds, so warm users will not see the 14 conflicts in the other 10 countries — the class-surfacing is weaker than the summary implies (for Tajikistan's `unique` guard this is sound: the cache hash covers `data_scheme.yml` + sources, so the invariant is re-checked exactly when inputs change); (d) full suite not run.

### regression — PASSES, severity: none
> "Nothing else moves. I re-derived the claim independently rather than trusting it, and it holds."

Every reachable table byte-identical BASE vs FIX; the reducer branch in `_normalize_dataframe_index` never fires anywhere in the library; the only behavioural delta is the +14 `RuntimeWarning`s.

**Nits (non-blocking):** (1) `Country._market_lookup` (`country.py:1611-1631`) catches `(FileNotFoundError, KeyError, ValueError)` around `w.cluster_features()`. The new guard raises `ValueError`, so on the `market=` / `_add_market_index` path a declared-`unique` conflict **degrades from RAISE to "wave silently dropped from the market lookup"**. Still class-2 (missing + warned), not class-1, and unreachable today (Tajikistan has 0 conflicts) — but the RAISE teeth are blunted on exactly that one path. (2) 1 `xpassed` in the FIX suite, not baselined — not plausibly reachable from this diff.

### soundness — PASSES, severity: **CONCERN** (non-blocking, but NOT silent)

> "The fix survives my attempts to break it."

Verified the "false positive" verdict is real: chased the two API-vs-wave row deltas a naive scan would miss (`individual_education` 70,286 → 59,790; `housing` 8,147 → 8,146) — **neither is a #323 collapse** (exactly 10,496 rows have NaN `Educational Attainment`; exactly 1 housing row is all-NaN — the all-NaN `dropna`, not `groupby().first()`). Verified the collapse attributes rows to the **right** cluster, not merely a distinct one: on raw `.dta` codes, `distinct(psu) == distinct(psu, region, rural)` in all four waves, and post-collapse HH-per-PSU stays at clean design takes (9–20, not a doubled ~32–40).

**THE CONCERN — `country.py:4376-4390` precedence footgun (raised by two reviewers):**

> The new `if reducer is not None:` branch **PREEMPTS** `elif present_additive:`. If any country ever declares an `aggregation:` reducer on a level that gets eliminated in `food_acquired`, `Quantity`/`Expenditure` silently switch from **`sum` to `.first()`** and `Price` is never re-derived — **reintroducing the exact silent loss #323 is about, through the key introduced to prevent it.**

**Inert today** (all 9 existing declarations are `visit: first` on a *surviving* level; `sum` is deliberately not in `_DECLARED_REDUCERS`, so a declarer cannot even opt out) and **verified never to engage**. The reviewer notes a two-line `raise if present_additive and reducer` closes it. **Left unresolved in this PR by the landing agent** rather than making an unreviewed edit to a red-teamed diff — flagged here for the merger's decision.

**Further nits:** (a) `nunique(dropna=True)` + groupby's NaN-key drop mean the `unique` invariant is *"columns constant within SURVIVING groups"*, not *"no rows dropped"* — a household with a NaN `v` would vanish unseen (Tajikistan has 0 NaN `psu`/`hhid`, so no live impact); (b) the guard only runs on a cold build, and `LSMS_CACHE_SCHEMA` is **not** bumped, so the 14 new warnings will not reach anyone with a warm cache; (c) `aggregation:` is now overloaded three ways — worth one line in `SkunkWorks/grain_aggregation_policy.org`, since prose/code drift is how #323 survived the first time.

### Separate pre-existing defect found (file separately; does NOT block)
`Country('Tajikistan').sample()['v']` is float-stringified (`'1.0'`, `'10.0'`) while every other Tajikistan table's `v` is `'1'`, `'10'` — **0 of 270 sample cluster ids join to `cluster_features`**. Cause: `v: pop_pt` sits under `myvars` in `sample`'s `data_info`, and `format_id` is applied to `idxvars` only (the documented CLAUDE.md gotcha). **Present on `development`, untouched by this branch.**

## Landing verification (independent, this PR)

- **Instrument validated first**, on the known positives, before trusting any zero: Mali/2014-15 `household_roster` = **32,026** dups; Guyana/1992 `housing` = **311**. Exact.
- **Blast radius re-derived from scratch** — all 10 `aggregation:` declarations enumerated; all 9 `visit` levels confirmed *surviving* (`index: (t, i, visit)`).
- **`.pth` trap**: asserted `'worktrees' in lsms_library.__file__` and `hasattr(country, '_declared_reducer')` — every number above was produced by **worktree** code, not the main checkout.
- **Tests re-run**: 14 passed on FIX; **12 failed / 2 passed on BASE** (teeth confirmed).
- **GH #589**: `test_currency.py::test_feature_ghana_per_wave` **fails identically on pristine base `2d3d5f71`** and on this branch — pre-existing, **not** regressed here. (The red-team left this unverified; now confirmed.)
- **Full suite NOT run to completion** by the author, the red-team, or me. The regression reviewer ran a 2,348-test relevant subset: all pass. Stating this rather than claiming a green suite nobody got.
- Merges cleanly into `development` (`country.py` untouched on `development` since the merge-base).

## Merge order — READ BEFORE MERGING

**`fix/323-albania` rewrites the SAME `Wave.cluster_features` block (`country.py:1172-1229`)** with a semantically equivalent guard and the same diagnosis (independent corroboration of the root cause — but a textual conflict). **These two WILL conflict.** A careless resolution could **drop one guard**, which is precisely the *"class gets re-hidden"* failure mode. Merge one, then rebase the other and re-run both test files.

## Scope — READ THIS

This fixes **ONE INSTANCE**. **GH #323 — the class — STAYS OPEN.**

The framework half here is genuinely class-level (it checks all 17 household-grain countries and makes `aggregation:` enforcing), but it **does not resolve** the 14 newly-surfaced conflicts in 10 other countries, and it **does not touch** the `_normalize_dataframe_index` collapse that is the original #323 (~14 countries / ~44 cells / ~150k rows, incl. Mali's 32,026 dropped people). Those remain live.

**A fix that closes one instance of a systemic bug and leaves the class is worse than no fix**, because the issue closes and the bug gets harder to find. That is literally how #323 got closed the first time. Do not do it again.

Ledger: `.coder/ledger/323-tajikistan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
