### PR TITLE
fix(#323): Benin + Togo plot_inputs — injective seed-crop map recovers 236 destroyed rows

### DIFF
--- a/.coder/ledger/323-benin-togo.md
+++ b/.coder/ledger/323-benin-togo.md
@@ -1,0 +1,157 @@
+# Prior-Art Ledger — GH #323 (Benin, Togo)
+
+**Search tier used:** ripgrep + git floor (gitnexus not consulted; the work is
+config-scoped to two countries and the framework symbol was read directly).
+The decisive prior art was found by `git diff origin/development...fix/323-cotedivoire`.
+
+## §1 Task, restated
+
+`_normalize_dataframe_index` (`lsms_library/country.py`) reorders a table's index
+to the levels declared in the country's `_/data_scheme.yml`, and when the result
+is NOT unique it collapses it with `groupby().first()` — silently discarding the
+dropped rows. Benin and Togo both trip this on **`plot_inputs`**, and in exactly
+one way, the same way CotedIvoire did (its case B):
+
+`plot_inputs` declares `index: (t, i, input, crop, u)`. `harmonize_input` maps
+**every** seed label onto the single `input` value `Seed`, so `crop` is the only
+level left to tell two seed line-items apart. But `harmonize_seed_crop` was
+**non-injective**: four labels shared one `Autre crop` catch-all bucket, and
+*three* of them actually occur in the EHCVM `s16b` roster of both countries. When
+a household reports two of them in the same unit, both rows land on one index
+tuple and `groupby().first()` throws one away.
+
+Measured (2026-07-13, `LSMS_NO_CACHE=1`, wave frame vs. API):
+
+| country | wave    | wave rows | API rows (pre-fix) | destroyed | conflicting groups |
+|---------|---------|-----------|--------------------|-----------|--------------------|
+| Benin   | 2018-19 | 10,605    | 10,534             | **71**    | 64                 |
+| Togo    | 2018    | 13,733    | 13,565             | **168**   | 162                |
+
+Of Togo's 168, **165** are #323 destruction; the other **3** are *hollow* rows
+(`Quantity`, `Purchased`, `Quantity_purchased` all `<NA>`) removed by the
+framework's deliberate `dropna(how='all')` safety net — see §4.
+
+(The issue text quotes 68/61 and 156/153. Those are the same defect counted more
+conservatively: they exclude the groups whose duplicate rows carry *identical*
+values, where `first()` loses no information. Benin 64−3=61 groups / 71−3=68 rows;
+Togo 162−9=153 / 165−9=156. Both accountings go to **0**.)
+
+## §2 Existing machinery (this task's area)
+
+| symbol | path:line | what it does | tested? | reuse / extend / new |
+|--------|-----------|--------------|---------|----------------------|
+| `_normalize_dataframe_index` | `lsms_library/country.py` | reorders to the declared index; `groupby().first()` collapse when non-unique — **the silent row-eater** | — | **untouched** (owned centrally by PR #614) |
+| `dropna(how='all')` | `lsms_library/country.py:2217` | universal safety net: drops rows where every non-index column is NaN | — | untouched; explains Togo's residual 3 |
+| `harmonize_seed_crop` | `lsms_library/countries/{Benin,Togo}/_/categorical_mapping.org` | EHCVM seed-type label → the seed's crop (the `s16b` roster has no crop column) | now yes | **extend** — split the catch-all |
+| `harmonize_input` | same files | `s16bq01` label → canonical `input`; maps **all** seed labels to `Seed` | — | reuse as-is (correct: `input` is the input *identity*, the crop lives in `crop`) |
+| `_finish_plot_inputs` | `Benin/2018-19/_/plot_inputs.py`, `Togo/2018/_/plot_inputs.py` | coerces dtypes, fills `CROP_NA` / `UNIT_NA` sentinels, sets the declared index | now yes | **extend** — add the uniqueness guard |
+| CotedIvoire #323 fix | `fix/323-cotedivoire` (`origin`) | the identical defect + fix on the sibling EHCVM country | `tests/test_gh323_cotedivoire.py` | **the pattern followed here** |
+
+**Prior art is decisive.** CotedIvoire is EHCVM, the `s16b` labels are
+standardized across EHCVM countries, and Benin's and Togo's
+`harmonize_seed_crop` tables were copied *verbatim* from the Niger EHCVM
+reference — so they inherited the identical bug. The fix here is CIV's fix,
+label-for-label (`Autre céréale`, `Autre tubercule`), so the EHCVM family stays
+consistent.
+
+## §3 Definitions & conventions in force
+
+- **The #323 doctrine**: duplicates on a declared index mean **the identifier is
+  broken or a level is missing** — *never* that a reducer should be declared.
+  Fix the index. (`docs/323-grain-collapse-sites`; `fix/323-cotedivoire` ledger.)
+- **EHCVM index conventions**: `v: grappe`, `i: [grappe, menage]` — per
+  `CLAUDE.md` §"Gotchas with Teeth". Benin and Togo are both EHCVM 2018-19.
+- **`plot_inputs` grain**: `(t, i, input, crop, u)` per each country's
+  `_/data_scheme.yml`. EHCVM records inputs at **household × input**, not
+  plot × input (no parcel-level input question), so `plot` is deliberately not a
+  level. `plot_inputs` is *not* registered in `data_info.yml`'s `index_info`.
+- **Automatic categorical mappings** apply on a name match (`CLAUDE.md`). There
+  is **no** table named `crop`, `input` or `u` in either country's
+  `categorical_mapping.org`, so those index levels are **not** remapped at API
+  time; the wave script's values are final. (The library-level
+  `lsms_library/categorical_mapping/u.org` *does* canonicalize `u` at API time —
+  `Kilogramme`→`Kg`. It is injective over the units in use, so it neither causes
+  nor hides this defect.)
+- Everything else: `STANDING.md` §3.
+
+## §4 Invariants & assumptions
+
+- **`harmonize_seed_crop` must stay INJECTIVE over the labels actually present.**
+  This is the invariant the defect violated, and it is now *enforced*, not merely
+  documented: a uniqueness assertion on the declared index at the end of each
+  wave script fails the build loudly. Verified by re-widening the bucket and
+  watching both builds die (Benin: 47 dup tuples; Togo: 59).
+- **`Purchased` is NOT an index level and must not become one.** Togo's colliding
+  rows differ in `Purchased` (grappe 101 / menage 9: 16 Charrette purchased vs.
+  3 Charrette own-production), which makes adding it to the index look tempting.
+  It is wrong: `Purchased` is a measured *attribute* of a line-item, not part of
+  its identity — it would not separate two distinct seeds that were both
+  purchased, and it would corrupt the declared grain. Evidence that the
+  identifier (not a missing level) is the fault: **0** of the 226 colliding
+  groups across both countries repeat the *same* raw `s16bq01` label — every
+  single collision is between two **distinct** reported items pooled by the lossy
+  crop map. A counterfactually fully-injective crop map drives destroyed rows to
+  0 in both countries. See §6 for the residual.
+- **Hollow rows are dropped by design.** `country.py:2217` `dropna(how='all')`
+  removes rows where every non-index column is NaN. Three Togo rows qualify
+  (`529004`/Fungicide, `169011`×2/Seed — the household named the input and
+  reported nothing about it). This is table-agnostic framework behaviour, it
+  destroys no reported value, and it is **not** this fix's business.
+- **`lsms_library/*.py` is off-limits here** — the core `_normalize_dataframe_index`
+  fix is owned by PR #614 and a separate Site-2 PR. This change is config/script
+  only.
+- Repo-wide landmines: `STANDING.md` §4.
+
+## §5 Reuse decision
+
+| quantity | decision | reason |
+|----------|----------|--------|
+| the collapse itself (`_normalize_dataframe_index`) | **reuse, untouched** | owned centrally (PR #614); a per-country patch is exactly the failure mode this task was scoped to avoid |
+| seed → crop resolution | **extend `harmonize_seed_crop`** | the table already exists and is the right place; it was merely lossy |
+| making the map injective | **reuse the CIV pattern** (`Autre céréale` / `Autre tubercule`) | identical defect on a sibling EHCVM country; same source labels; keeps the EHCVM family label-consistent |
+| the build-time guard | **reuse the CIV pattern** (index-uniqueness assert at the tail of the wave script) | prose does not enforce; this fails the build loudly on any future re-widening |
+| a reducer / `groupby().agg()` on plot_inputs | **rejected** | violates the #323 doctrine (§3) — fix the identifier, never declare a reducer |
+| adding `Purchased` to the index | **rejected** | see §4 — attribute, not identifier; 0 same-label collisions prove the crop map is the whole fault |
+
+## §6 Open questions for the human
+
+- **Residual (guarded) non-injectivity, inherited from CIV.** Two label pairs
+  still share a Preferred Label, and both have **0 rows today** in both
+  countries, so neither can collide:
+  - the bare code `20` → `Autre crop` (an unlabelled category that leaked into
+    the label column), alongside `Autres semences`;
+  - `Semences de sésame` → `Sésame`, alongside the source's typo
+    `Semences de césame` (13 rows Benin / 103 Togo — the *only* variant that
+    occurs). These two ARE the same crop, so pooling them is correct, not lossy.
+
+  CIV made the same call. If a future EHCVM wave ships rows under `20`
+  co-occurring with `Autres semences`, the build assertion fires — loudly, by
+  design — rather than silently eating a row. Flagging it so the choice is
+  visible rather than implicit.
+- **`Autre céréale` / `Autre tubercule` have no `harmonize_food` counterpart.**
+  `Autre crop` does (`Autre (à préciser)` → `Autre crop`). The other two are new
+  labels living only in `harmonize_seed_crop`. There is no runtime coupling (the
+  `crop` level is not auto-mapped, and `plot_inputs` is not in `index_info`), and
+  CIV did the same. If `plot_inputs` is ever registered in `index_info` and its
+  `crop` level harmonized against `harmonize_food` cross-country, these two
+  labels will need homes there.
+
+---
+### Phase 3 — verification
+
+- `harmonize_seed_crop` (Benin, Togo `_/categorical_mapping.org`) — **OK (anchored on §2, §4, §5)**: extends the existing table rather than adding new machinery; the split labels are CIV's, so no divergence inside the EHCVM family.
+- uniqueness assertion in `Benin/2018-19/_/plot_inputs.py`, `Togo/2018/_/plot_inputs.py` — **OK (anchored on §4, §5)**: reuses the CIV guard pattern verbatim; negative-tested (re-widening the bucket fails both builds).
+- **no reducer declared, no index level added** — **OK (anchored on §3, §4)**: the #323 doctrine is honoured; the identifier was lossy and the identifier is what changed.
+- **no `lsms_library/*.py` touched** — **OK (anchored on §4)**: `git diff --stat` confirms the change is confined to `lsms_library/countries/{Benin,Togo}/**` plus a new test.
+- **REINVENTION check** — none. The one thing this task could have reinvented is the CIV fix; it was found first (`git diff origin/development...fix/323-cotedivoire`) and followed rather than re-derived.
+
+**Result (2026-07-13, `LSMS_NO_CACHE=1`):**
+
+| country | wave rows | API rows before | API rows after | destroyed before → after |
+|---------|-----------|-----------------|----------------|--------------------------|
+| Benin   | 10,605    | 10,534          | **10,605**     | 71 → **0** |
+| Togo    | 13,733    | 13,565          | **13,730**     | 165 → **0** (+3 hollow rows dropped by design, §4) |
+
+Duplicate tuples on the declared index: **0** in both. Rows were **recovered**
+(+71 Benin, +165 Togo), never lost. Both worked examples now carry distinct crop
+keys and both line-items survive.

--- a/lsms_library/countries/Benin/2018-19/_/plot_inputs.py
+++ b/lsms_library/countries/Benin/2018-19/_/plot_inputs.py
@@ -130,4 +130,30 @@ df = pd.DataFrame({
 df = _finish_plot_inputs(df, '2018-19')
 
 assert len(df) > 0, 'plot_inputs 2018-19 produced no rows'
+
+# GH #323 -- ENFORCE the declared grain.  `crop` is an index level and
+# harmonize_input collapses every seed label onto the single input 'Seed', so a
+# NON-INJECTIVE harmonize_seed_crop makes two DISTINCT reported seed line-items
+# land on one index tuple, whereupon the framework's groupby().first() silently
+# discards one.  That is what happened until 2026-07-13: four labels shared an
+# 'Autre crop' catch-all and 71 rows -- real reported quantities, e.g. the 6 kg
+# of "Plants/boutures de tubercules" that grappe 133 / menage 53 reported
+# alongside 9 kg of "Autres semences" -- vanished with no warning.  The CROP_NA
+# sentinel above shows the author knew the framework drops rows on a duplicated
+# index and guarded the NaN case; the catch-all bucket has the identical effect
+# and was missed.
+#
+# A comment is not a guard.  This assertion is: if any future label (or a
+# re-widened bucket) re-introduces a collision, the BUILD FAILS here, loudly,
+# instead of quietly shipping short.
+dups = df.index[df.index.duplicated()]
+assert dups.empty, (
+    f"plot_inputs 2018-19: {len(dups)} duplicate tuple(s) on the declared index "
+    f"(t, i, input, crop, u) -- e.g. {list(dups[:3])}.  Two distinct reported "
+    f"input line-items are colliding on one key; the framework would silently "
+    f"drop one via groupby().first().  Most likely a non-injective "
+    f"harmonize_seed_crop in _/categorical_mapping.org (see the note there). "
+    f"Split the offending Preferred Label rather than letting a row disappear."
+)
+
 to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Benin/_/categorical_mapping.org
+++ b/lsms_library/countries/Benin/_/categorical_mapping.org
@@ -241,8 +241,31 @@
 # s16b input roster has NO crop column — the crop is encoded in the seed-type
 # label ('Semences de petit mil').  This table resolves each EHCVM seed-type
 # label to the crop's harmonize_food `Preferred Label`, so seed rows carry the
-# SAME `crop` value a grown crop would.  Catch-all seed slots resolve to
-# 'Autre crop'.  Copied VERBATIM from the Niger EHCVM reference.
+# SAME `crop` value a grown crop would.  Copied from the Niger EHCVM reference.
+#
+# harmonize_seed_crop MUST STAY INJECTIVE over the labels actually present
+# (GH #323).  `crop` is an INDEX level of plot_inputs (t, i, input, crop, u),
+# and harmonize_input maps every seed label onto the single `input` value
+# 'Seed' — so any two DISTINCT reported seed items sharing a Preferred Label
+# collide on one index tuple, whereupon the framework's groupby().first()
+# silently DISCARDS one of them.  Until 2026-07-13 four labels shared one
+# 'Autre crop' catch-all bucket; THREE of them actually occur in Benin's s16b
+# ("Plants/boutures de tubercules" 655 rows, "Autres semences" 330,
+# "Semences d'autres céréales" 79), they co-occur within a household 64 times,
+# and 71 reported line-items were destroyed.  e.g. grappe 133 / menage 53
+# reported "Autres semences" 9 kg AND "Plants/boutures de tubercules" 6 kg;
+# the 6 kg row vanished.  The three are now split — which is also what the
+# source MEANS: one is specifically "other cereals", one is specifically tuber
+# cuttings (planting material, not grain seed at all).  The bare code '20' (an
+# unlabelled category that leaked through) keeps 'Autre crop'; it has 0 rows
+# today, as does the correctly-spelled "Semences de sésame" whose only
+# occurring variant is the source's typo "Semences de césame" (13 rows) — the
+# two ARE the same crop, so pooling them is correct, not lossy.
+#
+# This comment is NOT the enforcement: prose does not enforce.  The guard is
+# the uniqueness assertion on the declared index at the end of
+# 2018-19/_/plot_inputs.py, which fails the build loudly if any future label
+# (or a re-widened bucket) re-introduces a collision.
 
 #+NAME: harmonize_seed_crop
 | Original Label                | Preferred Label     |
@@ -255,8 +278,8 @@
 | Semences de sésame            | Sésame              |
 | Semences de césame            | Sésame              |
 | Semences de haricots/niébé    | Niébé/Haricots secs |
-| Semences d'autres céréales    | Autre crop          |
-| Plants/boutures de tubercules | Autre crop          |
+| Semences d'autres céréales    | Autre céréale       |
+| Plants/boutures de tubercules | Autre tubercule     |
 | Autres semences               | Autre crop          |
 | 20                            | Autre crop          |
 

--- a/lsms_library/countries/Togo/2018/_/plot_inputs.py
+++ b/lsms_library/countries/Togo/2018/_/plot_inputs.py
@@ -143,4 +143,31 @@ df = pd.DataFrame({
 df = _finish_plot_inputs(df, '2018')
 
 assert len(df) > 0, 'plot_inputs 2018 produced no rows'
+
+# GH #323 -- ENFORCE the declared grain.  `crop` is an index level and
+# harmonize_input collapses every seed label onto the single input 'Seed', so a
+# NON-INJECTIVE harmonize_seed_crop makes two DISTINCT reported seed line-items
+# land on one index tuple, whereupon the framework's groupby().first() silently
+# discards one.  That is what happened until 2026-07-13: four labels shared an
+# 'Autre crop' catch-all and 165 rows -- real reported quantities, e.g. the
+# 16 Charrette of market-purchased "Plants/boutures de tubercules" that grappe
+# 101 / menage 9 reported alongside 3 Charrette of own-production "Autres
+# semences" -- vanished with no warning.  The CROP_NA / UNIT_NA sentinels above
+# show the author knew the framework drops rows on a duplicated index and
+# guarded the NaN case; the catch-all bucket has the identical effect and was
+# missed.
+#
+# A comment is not a guard.  This assertion is: if any future label (or a
+# re-widened bucket) re-introduces a collision, the BUILD FAILS here, loudly,
+# instead of quietly shipping short.
+dups = df.index[df.index.duplicated()]
+assert dups.empty, (
+    f"plot_inputs 2018: {len(dups)} duplicate tuple(s) on the declared index "
+    f"(t, i, input, crop, u) -- e.g. {list(dups[:3])}.  Two distinct reported "
+    f"input line-items are colliding on one key; the framework would silently "
+    f"drop one via groupby().first().  Most likely a non-injective "
+    f"harmonize_seed_crop in _/categorical_mapping.org (see the note there). "
+    f"Split the offending Preferred Label rather than letting a row disappear."
+)
+
 to_parquet(df, 'plot_inputs.parquet')

--- a/lsms_library/countries/Togo/_/categorical_mapping.org
+++ b/lsms_library/countries/Togo/_/categorical_mapping.org
@@ -127,9 +127,12 @@
 # harmonize_input — s16bq01 input-type label -> canonical input identity.
 # harmonize_seed_crop — EHCVM seed-type label -> the seed's crop.  The
 #   s16b roster has NO crop column; the crop is embedded in the seed-type
-#   label ('Semences de petit mil'), resolved here.  Catch-all seed slots
-#   ('Semences d'autres céréales', 'Autres semences', 'Plants/boutures de
-#   tubercules', the bare '20' slot) -> 'Autre crop'.
+#   label ('Semences de petit mil'), resolved here.  The residual seed slots
+#   each get their OWN label — 'Semences d'autres céréales' -> 'Autre
+#   céréale', 'Plants/boutures de tubercules' -> 'Autre tubercule',
+#   'Autres semences' (and the bare '20' slot) -> 'Autre crop' — because a
+#   shared catch-all makes the map non-injective and silently destroys rows
+#   on the plot_inputs index (GH #323; see the note above the table).
 
 #+NAME: harmonize_input
 | Original Label                            | Preferred Label     |
@@ -176,6 +179,44 @@
 | Autres semences                           | Seed                |
 | 20                                        | Seed                |
 
+# harmonize_seed_crop (GAP 2 plot_inputs).  EHCVM-only helper.  The EHCVM
+# s16b input roster has NO crop column — the crop is encoded in the seed-type
+# label ('Semences de petit mil').  This table resolves each EHCVM seed-type
+# label to the crop's harmonize_food `Preferred Label`, so seed rows carry the
+# SAME `crop` value a grown crop would.  Copied from the Niger EHCVM reference.
+#
+# harmonize_seed_crop MUST STAY INJECTIVE over the labels actually present
+# (GH #323).  `crop` is an INDEX level of plot_inputs (t, i, input, crop, u),
+# and harmonize_input maps every seed label onto the single `input` value
+# 'Seed' — so any two DISTINCT reported seed items sharing a Preferred Label
+# collide on one index tuple, whereupon the framework's groupby().first()
+# silently DISCARDS one of them.  Until 2026-07-13 four labels shared one
+# 'Autre crop' catch-all bucket; THREE of them actually occur in Togo's s16b
+# ("Plants/boutures de tubercules" 780 rows, "Autres semences" 591,
+# "Semences d'autres céréales" 370), they co-occur within a household 162
+# times, and 165 reported line-items were destroyed.  e.g. grappe 101 /
+# menage 9 reported "Plants/boutures de tubercules" 16 Charrette (market-
+# purchased) AND "Autres semences" 3 Charrette (own-production); one of the
+# two vanished.  The three are now split — which is also what the source
+# MEANS: one is specifically "other cereals", one is specifically tuber
+# cuttings (planting material, not grain seed at all).  The bare code '20' (an
+# unlabelled category that leaked through) keeps 'Autre crop'; it has 0 rows
+# today, as does the correctly-spelled "Semences de sésame" whose only
+# occurring variant is the source's typo "Semences de césame" (103 rows) — the
+# two ARE the same crop, so pooling them is correct, not lossy.
+#
+# NB the colliding rows often differ in `Purchased` (as above), which invites
+# the wrong fix: adding `Purchased` to the index.  Do NOT.  `Purchased` is a
+# measured ATTRIBUTE of a line-item, not part of its identity — it would not
+# separate two distinct seeds that were both purchased, and it would corrupt
+# the declared grain.  The identifier (`crop`) was lossy; the identifier is
+# what gets fixed.
+#
+# This comment is NOT the enforcement: prose does not enforce.  The guard is
+# the uniqueness assertion on the declared index at the end of
+# 2018/_/plot_inputs.py, which fails the build loudly if any future label (or
+# a re-widened bucket) re-introduces a collision.
+
 #+NAME: harmonize_seed_crop
 | Original Label                | Preferred Label     |
 |-------------------------------+---------------------|
@@ -187,8 +228,8 @@
 | Semences de sésame            | Sésame              |
 | Semences de césame            | Sésame              |
 | Semences de haricots/niébé    | Niébé/Haricots secs |
-| Semences d'autres céréales    | Autre crop          |
-| Plants/boutures de tubercules | Autre crop          |
+| Semences d'autres céréales    | Autre céréale       |
+| Plants/boutures de tubercules | Autre tubercule     |
 | Autres semences               | Autre crop          |
 | 20                            | Autre crop          |
 

--- a/tests/test_gh323_benin_togo.py
+++ b/tests/test_gh323_benin_togo.py
@@ -1,0 +1,152 @@
+"""GH #323 -- Benin / Togo must not silently collapse a non-unique declared index.
+
+`_normalize_dataframe_index` reduces a non-unique DECLARED index with
+groupby().first(), silently discarding the dropped rows.  Benin and Togo trip it
+in exactly one way, and it is the same way CotedIvoire did (see
+`tests/test_gh323_cotedivoire.py`, case B):
+
+  plot_inputs -- INDEX_INCOMPLETE.  `crop` is an index level of
+  (t, i, input, crop, u), and harmonize_input maps EVERY seed label onto the
+  single input 'Seed'.  A non-injective harmonize_seed_crop therefore lands two
+  DISTINCT reported seed line-items on one index tuple.  Four labels shared an
+  'Autre crop' catch-all bucket; THREE of them actually occur in the EHCVM s16b
+  roster of both countries, and they co-occur within a household often enough to
+  destroy 71 reported rows in Benin and 165 in Togo.
+
+THE FIX IS TO THE IDENTIFIER, NOT TO A REDUCER.  Per the #323 doctrine,
+duplicates on a declared index mean the identifier is broken or a level is
+missing -- never that a reducer should be declared.  Here the identifier was
+lossy: `crop` threw away the distinction between "other cereals", "tuber
+cuttings" and "other seeds".  Splitting the bucket restores injectivity and the
+rows come back.
+
+DO NOT "FIX" THIS BY ADDING `Purchased` TO THE INDEX.  The colliding Togo rows
+happen to differ in `Purchased` (grappe 101 / menage 9: 16 Charrette purchased
+vs 3 Charrette own-production), which makes that look tempting.  It is wrong:
+`Purchased` is a measured ATTRIBUTE of a line-item, not part of its identity --
+it would not separate two distinct seeds that were both purchased, and it would
+corrupt the declared grain.  The two rows are two different planting materials,
+not a purchase-status split of one.
+
+INSTRUMENT NOTE (inherited from the CotedIvoire tests -- do not undo it).  Do
+NOT assert that the API's returned index is unique: `_normalize_dataframe_index`
+collapses it, so API-level uniqueness holds BY CONSTRUCTION and such a test
+passes even with the bug fully present.  The bug is that ROWS DISAPPEAR.  So
+these tests assert on exact row counts, on the specific rows that were being
+eaten, and on the injectivity of the mapping -- never on post-collapse
+uniqueness.
+"""
+import pandas as pd
+import pytest
+
+from lsms_library.country import Country
+
+# Row counts the API must return.
+#
+# Benin:  the wave script emits 10,605 reported line-items and ALL of them must
+#         survive.  Pre-fix the API returned 10,534 -- 71 destroyed.
+BENIN_ROWS = 10605
+#
+# Togo:   the wave script emits 13,733 reported line-items.  Pre-fix the API
+#         returned 13,565 -- 168 missing.  165 of those were destroyed by the
+#         #323 collapse and are recovered here.  The remaining 3 are HOLLOW rows
+#         (Quantity, Purchased and Quantity_purchased ALL <NA> -- the household
+#         named an input but reported nothing about it) and are dropped by the
+#         framework's deliberate, table-agnostic `dropna(how='all')` safety net
+#         in country.py.  That is not a #323 collapse: it destroys no reported
+#         value, and it is not this fix's business to change it.
+TOGO_ROWS = 13730
+
+# The three seed labels that actually occur in the s16b roster of BOTH
+# countries.  harmonize_seed_crop must keep them apart.
+LABELS_IN_USE = ["Autres semences",
+                 "Semences d'autres céréales",
+                 "Plants/boutures de tubercules"]
+
+
+@pytest.fixture(scope='module', params=['Benin', 'Togo'])
+def country(request):
+    try:
+        return Country(request.param)
+    except Exception as exc:                                   # pragma: no cover
+        pytest.skip(f'{request.param} unavailable: {exc}')
+
+
+def _plot_inputs(c):
+    try:
+        return c.plot_inputs()
+    except Exception as exc:                                   # pragma: no cover
+        pytest.skip(f'{c.name} plot_inputs could not be built: '
+                    f'{type(exc).__name__}: {exc}')
+
+
+def test_plot_inputs_keeps_every_reported_row(country):
+    """Every reported input line-item must survive to the API."""
+    expected = {'Benin': BENIN_ROWS, 'Togo': TOGO_ROWS}[country.name]
+    df = _plot_inputs(country)
+    assert len(df) == expected, (
+        f'{country.name}/plot_inputs has {len(df)} rows, expected {expected}. '
+        f'{expected - len(df)} reported line-item(s) are being silently '
+        f'discarded by the framework collapse (GH #323) -- most likely a '
+        f'non-injective harmonize_seed_crop merging distinct seed items into '
+        f'one crop bucket.'
+    )
+
+
+def test_harmonize_seed_crop_is_injective_over_labels_in_use(country):
+    """harmonize_seed_crop must be injective over the labels actually present.
+
+    `crop` is an index level and harmonize_input maps EVERY seed label onto the
+    single input 'Seed', so two seed labels sharing a Preferred Label collide on
+    one index tuple and the framework's groupby().first() eats one of them.
+    """
+    m = country.categorical_mapping.get('harmonize_seed_crop')
+    if m is None:                                              # pragma: no cover
+        pytest.skip('harmonize_seed_crop absent')
+    m = m.set_index('Original Label')['Preferred Label']
+    present = [lab for lab in LABELS_IN_USE if lab in m.index]
+    assert len(present) == len(LABELS_IN_USE), (
+        f'expected all of {LABELS_IN_USE} in harmonize_seed_crop; '
+        f'got {present}'
+    )
+    crops = [m[lab] for lab in present]
+    assert len(set(crops)) == len(crops), (
+        f'{country.name}: harmonize_seed_crop is NON-INJECTIVE over the seed '
+        f'labels that actually occur in s16b: {dict(zip(present, crops))}. '
+        f'Two distinct reported seed items will collide on the plot_inputs '
+        f'index (t, i, input, crop, u) and one will be silently discarded '
+        f'(GH #323).  Give each label its own Preferred Label.'
+    )
+
+
+@pytest.mark.parametrize('cname,hh,pairs', [
+    # Benin grappe 133 / menage 53 reported BOTH
+    #   "Autres semences"                9 kg   (own production)
+    #   "Plants/boutures de tubercules"  6 kg   (own production)  <- was eaten
+    # Both mapped to crop 'Autre crop', colliding on (i, Seed, Autre crop, Kg).
+    ('Benin', '133053', {('Autre crop', 9.0), ('Autre tubercule', 6.0)}),
+    # Togo grappe 101 / menage 9 reported BOTH
+    #   "Plants/boutures de tubercules" 16 Charrette  (market-purchased)
+    #   "Autres semences"                3 Charrette  (own production)
+    # Both mapped to crop 'Autre crop', colliding on (i, Seed, Autre crop,
+    # Charrette).  NB assert the exact (crop, Quantity) PAIR: merely checking
+    # that 3.0 appears among this household's seed rows passes even with the bug
+    # present, because it separately reports 1.0 and 6.0 for other crops.
+    ('Togo', '101009', {('Autre tubercule', 16.0), ('Autre crop', 3.0)}),
+])
+def test_plot_inputs_recovers_the_discarded_line_item(country, cname, hh, pairs):
+    """The exact rows the catch-all bucket used to eat."""
+    if country.name != cname:
+        pytest.skip(f'case is for {cname}')
+    flat = _plot_inputs(country).reset_index()
+    seeds = flat[(flat['i'] == hh) & (flat['input'] == 'Seed')]
+    if seeds.empty:                                            # pragma: no cover
+        pytest.skip(f'household {hh} not present')
+    got = {(r['crop'], float(r['Quantity']))
+           for _, r in seeds.iterrows() if pd.notna(r['Quantity'])}
+    missing = pairs - got
+    assert not missing, (
+        f'{cname} household {hh}: {missing} still discarded -- '
+        f'harmonize_seed_crop is merging distinct seed labels into one '
+        f'"Autre crop" bucket (GH #323).  got {got}'
+    )


### PR DESCRIPTION
Fixes the GH #323 defect in **Benin** and **Togo** `plot_inputs`. Config/script only — **zero changes to `lsms_library/*.py`.**

Part of the #323 consolidation (`slurm_logs/DESIGN_grain_collapse_sites_2026-07-13.org`). These two countries were never fixed in the original sweep — their agents died before committing.

## The bug

`plot_inputs` declares `(t, i, input, crop, u)`. `harmonize_input` maps *every* seed label onto the single `input` value `Seed`, so `crop` is the only level left to separate two seed line-items. And `harmonize_seed_crop` was **non-injective**: four labels shared one `Autre crop` catch-all, and **three of them actually occur** in the EHCVM `s16b` roster of both countries. Two distinct reported items collided on one index tuple, and `groupby().first()` ate one.

Both tables were copied verbatim from the Niger EHCVM reference, which is how they inherited it — the same route as CotedIvoire.

## The fix

Follows `fix/323-cotedivoire` label-for-label; no new approach invented. In each country's `_/categorical_mapping.org`:

- `Semences d'autres céréales` → `Autre céréale`
- `Plants/boutures de tubercules` → `Autre tubercule`
- `Autres semences` → `Autre crop` (unchanged)

Each wave script now **asserts the declared index is unique** before writing its parquet. Negative-tested: re-widening the bucket fails both builds loudly (Benin 47 dup tuples, Togo 59).

## Identifier broken — not a missing level

Per the #323 doctrine, duplicates on a declared index mean the identifier is broken *or* a level is missing. This is the former, and the evidence is decisive: of the **226 colliding groups across both countries, 0 repeat the same raw `s16bq01` label** — every collision is between two *distinct* reported items pooled by the lossy crop map. An injective crop map drives destroyed rows to zero in both.

Togo's `Purchased` difference is a red herring: grappe 101 / menage 9 reported *tuber cuttings* 16 Charrette (purchased) and *other seeds* 3 Charrette (own-production) — two different planting materials that happen to differ in purchase status, not a purchase-status split of one item. Adding `Purchased` to the index would be wrong: it is a measured attribute, not part of a line-item's identity, and it would not separate two distinct seeds that were both purchased.

## Before → after (`LSMS_NO_CACHE=1`)

| Country | Wave rows | API before | API after | Destroyed |
|---|---|---|---|---|
| Benin 2018-19 | 10,605 | 10,534 | **10,605** | 71 → **0** |
| Togo 2018 | 13,733 | 13,565 | **13,730** | 165 → **0** |

Duplicate tuples on the declared index: **0** in both. Rows are **recovered**, never lost.

## Two things a reviewer should know

1. **Togo's API is 3 rows short of its 13,733-row wave frame, and that is not #323.** Those rows are *hollow* — `Quantity`, `Purchased`, `Quantity_purchased` all `<NA>` (the household named an input and reported nothing about it). They are removed by the framework's deliberate, table-agnostic `dropna(how='all')` at `country.py:2217`. No reported value is destroyed. Flagged rather than quietly reporting "13,730 = success."
2. **Residual, guarded, inherited from CotedIvoire**: `20` → `Autre crop` and `Semences de sésame` → `Sésame` remain non-injective pairs, but both have **zero rows today**, so neither can collide — and the new build assertion fires if that ever changes. Matched CotedIvoire's call rather than diverging; worth a maintainer's eyes.

Tests: `tests/test_gh323_benin_togo.py` (6 passed). Ledger: `.coder/ledger/323-benin-togo.md`.

Refs #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
