### PR TITLE
feat(#323): explicit, country-invoked reducers — lossless or loud (unblocks Senegal + Burkina Faso)

### DIFF
--- a/lsms_library/build_transforms.py
+++ b/lsms_library/build_transforms.py
@@ -14,10 +14,16 @@ written parquet:
   - ``apply_derived`` (+ ``fill_v_with_coord_bin`` and the
     ``_DERIVED_TRANSFORMERS`` registry): the ``derived:`` block applied by
     ``Wave.grab_data`` during extraction.
+  - ``reduce_to_agreed`` / ``collapse_to_cluster_grain`` / ``add_visit_level``:
+    the EXPLICIT grain helpers (GH #323).  A country's ``mapping.py`` calls
+    them BY NAME; core never dispatches them.
 
 These names are re-exported from ``lsms_library.transformations`` for
 backward compatibility with the country scripts that import them from there.
 """
+import os
+import warnings
+
 import numpy as np
 import pandas as pd
 
@@ -336,3 +342,239 @@ def apply_derived(df, derived_spec):
             )
         df = fn(df, target=output_col, **step)
     return df
+
+
+# ---------------------------------------------------------------------------
+# Explicit grain helpers (GH #323)
+#
+# POLICY.  ``SkunkWorks/grain_aggregation_policy.org`` puts the boundary at the
+# ACCESS PATH: ``country.py`` / ``feature.py`` / ``local_tools.py`` NEVER reduce
+# grain -- they return the maximal grain the instruments support.  Aggregation
+# is always EXPLICITLY invoked, by the analyst or by the country.  The helpers
+# below are the country's instrument: a wave's ``_/mapping.py`` imports one BY
+# NAME and hands it the frame.  That is the country aggregating, visibly, at
+# build time -- not core aggregating behind the caller's back.
+#
+# They are therefore NOT a declared-reducer mechanism.  There is no
+# ``aggregation:`` YAML key and no dispatch table; core cannot reach these
+# functions.  A country that wants a collapse writes the call.
+#
+# The contract every reducer here upholds: a reduction that would DESTROY an
+# observed value is not performed quietly.  It raises, or (when the caller has
+# explicitly accepted the loss) it NAs the conflicted cells and warns loudly.
+# A helper that quietly picks a winner would only relocate the #323 bug.
+#
+# CACHE NOTE.  These run at build time, so their output is baked into the L2
+# parquet and their CODE must be versioned by the content hash.  It is, via
+# ``_build_registry.framework_imports_fingerprint``: ``Wave._input_hash`` /
+# ``Country._table_cache_hash`` parse every ``_/ *.py`` build module (mapping.py
+# included), resolve its ``from lsms_library... import`` targets, and fold their
+# closures in -- so editing a reducer invalidates exactly the waves that call
+# it.  ``add_visit_level`` additionally carries a ``@build_transform`` tag (it is
+# food_acquired-scoped, like its sibling ``food_acquired_to_canonical``); the
+# generic reducers deliberately do NOT, because an all-tables tag would fold
+# them into EVERY table's fingerprint in every country -- invalidating the whole
+# library's cache for a helper most countries never call, with no correctness
+# gain over the import-closure fold above.
+# ---------------------------------------------------------------------------
+
+_GRAIN_STRICT_ENV = 'LSMS_GRAIN_STRICT'
+
+
+class GrainConflict(ValueError):
+    """Rows sharing an index tuple carry DIFFERENT values; collapsing them
+    would destroy an observed value.  A ``ValueError`` subclass, so a caller
+    that catches ``ValueError`` still catches this."""
+
+
+class GrainConflictWarning(UserWarning):
+    """A reducer was told to proceed through a conflict (``on_conflict='na'``)
+    and blanked the conflicted cells.  Loud by construction: the values it
+    dropped are real data (GH #323)."""
+
+
+def _grain_strict() -> bool:
+    return os.environ.get(_GRAIN_STRICT_ENV, '').strip().lower() not in ('', '0', 'false', 'no')
+
+
+def _conflict_message(conflicts: pd.DataFrame, levels: list, verb: str) -> str:
+    """Human-readable, actionable account of a grain conflict.
+
+    ``conflicts`` is a boolean frame (group x column): True where a group holds
+    more than one distinct value.  Names the columns, the counts and a handful
+    of offending group keys -- enough to go look at the source.
+    """
+    per_col = {c: int(conflicts[c].sum()) for c in conflicts.columns if conflicts[c].any()}
+    bad = conflicts.any(axis=1)
+    examples = [tuple(k) if isinstance(k, tuple) else (k,) for k in conflicts.index[bad][:5]]
+    return (
+        f"grain conflict on {levels}: {int(bad.sum())} of {len(conflicts)} group(s) "
+        f"carry more than one distinct value.  Conflicted groups per column: "
+        f"{per_col}.  Offending groups e.g. {examples}.  {verb}  "
+        f"Either the payload is genuinely finer-grained than the declared index "
+        f"(it does not belong in this table), the identifier is broken / a level "
+        f"is missing, or the source needs cleaning.  If the loss is understood and "
+        f"accepted, pass on_conflict='na' to blank exactly these cells (and say why "
+        f"at the call site).  GH #323; SkunkWorks/grain_aggregation_policy.org."
+    )
+
+
+def reduce_to_agreed(df: pd.DataFrame, *, on_conflict: str = 'raise',
+                     na_is_conflict: bool = False) -> pd.DataFrame:
+    """Collapse rows sharing an index tuple, keeping ONLY values they AGREE on.
+
+    The honest reducer for a table whose declared grain is COARSER than the
+    source it is extracted from -- e.g. ``cluster_features``, declared ``(t, v)``
+    but read off a household-level cover page, where each cluster's attributes
+    are meant to be redundant copies across its households.
+
+    Call it from the country's ``_/mapping.py`` instead of letting the frame
+    reach core's duplicate-index fallback (``groupby().first()``), which is
+    silent, takes the first NON-NULL value PER COLUMN (so where the "redundant"
+    copies disagree it can synthesise a row that exists in no source), and hides
+    the loss behind the cache it poisons (GH #323).
+
+    Contract
+    --------
+    * **Lossless or loud.**  A group whose rows agree collapses to that agreed
+      row.  A group whose rows DISAGREE is never resolved by picking a winner:
+      by default this RAISES :class:`GrainConflict`, naming the columns and the
+      offending groups.  With ``on_conflict='na'`` the conflicted cells are set
+      missing (loudly missing beats quietly wrong) and a
+      :class:`GrainConflictWarning` is emitted -- the caller has to have asked
+      for that, in writing, at the call site.  ``LSMS_GRAIN_STRICT=1`` in the
+      environment escalates ``'na'`` back to a raise.
+    * **NaN is absence, not contradiction** (default).  A group where one row
+      says ``Dakar`` and another says nothing keeps ``Dakar``: no observed value
+      is discarded, so the completion is lossless.  Pass ``na_is_conflict=True``
+      for the stricter reading (a missing report is itself a disagreement).
+    * **NaN index keys survive.**  The groupby uses ``dropna=False``, so a row
+      whose declared index level is NaN is not deleted here.  (What core does
+      with it downstream is core's business -- see #323 Site 3.)
+    * **A unique index is returned untouched** -- same rows, same order, same
+      dtypes.  Nothing to collapse.
+
+    Args:
+        df: the frame as extracted, indexed by the declared (possibly
+            non-unique) levels.
+        on_conflict: ``'raise'`` (default) or ``'na'``.
+        na_is_conflict: treat a NaN alongside an observed value as a
+            disagreement rather than as a missing report.
+
+    Returns:
+        One row per index tuple.
+
+    Raises:
+        GrainConflict: on disagreement, unless ``on_conflict='na'``.
+        ValueError: on an unknown ``on_conflict``, or a non-empty frame with no
+            named index levels (a caller who forgot to set the index would
+            otherwise get a silent no-op).
+    """
+    if on_conflict not in ('raise', 'na'):
+        raise ValueError(f"on_conflict must be 'raise' or 'na', not {on_conflict!r}")
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError(f"reduce_to_agreed expects a DataFrame, got {type(df).__name__}")
+    if df.empty:
+        return df                       # e.g. grab_data's "no data loaded" frame
+    levels = [n for n in df.index.names if n is not None]
+    if not levels:
+        raise ValueError(
+            "reduce_to_agreed needs the declared index set (df.index has no named "
+            "levels); set_index the declared levels before reducing."
+        )
+    if df.index.is_unique:
+        return df                       # nothing to collapse -- keep rows/order/dtypes
+
+    cols = list(df.columns)
+    grouped = df.groupby(level=levels, observed=True, dropna=False)
+    # GroupBy.first() == first NON-NULL per column, which IS the agreed value
+    # wherever nunique <= 1.  We never rely on it where nunique > 1.
+    reduced = grouped[cols].first()
+    nunique = grouped[cols].nunique(dropna=not na_is_conflict).reindex(
+        index=reduced.index, columns=cols)
+    conflicts = nunique > 1
+
+    if bool(conflicts.to_numpy().any()):
+        if on_conflict == 'raise' or _grain_strict():
+            raise GrainConflict(_conflict_message(
+                conflicts, levels,
+                "Collapsing would silently discard the difference." if on_conflict == 'raise'
+                else f"on_conflict='na' was requested but {_GRAIN_STRICT_ENV} is set.",
+            ))
+        warnings.warn(
+            _conflict_message(conflicts, levels,
+                              "on_conflict='na': blanking those cells rather than "
+                              "picking an arbitrary winner."),
+            GrainConflictWarning, stacklevel=2)
+        reduced = reduced.mask(conflicts)
+
+    return reduced
+
+
+def collapse_to_cluster_grain(df: pd.DataFrame, *, on_conflict: str = 'raise',
+                              na_is_conflict: bool = False) -> pd.DataFrame:
+    """Reduce a HOUSEHOLD-grain ``cluster_features`` extraction to CLUSTER grain.
+
+    The named, discoverable case of :func:`reduce_to_agreed` -- and by far the
+    commonest: many countries source ``cluster_features`` from the household
+    cover file (one row per HOUSEHOLD) while the table is declared at ``(t, v)``,
+    so the frame arrives ~12x inflated and core used to collapse it with a silent
+    ``groupby().first()``, correct only by the ACCIDENT that the attributes
+    happen to be constant within the cluster (GH #323).
+
+    This makes the correction explicit and ENFORCES the invariant its
+    correctness rests on -- every attribute single-valued within a cluster.  A
+    cluster code that is unique only WITHIN a district, a re-coded region, a
+    grappe straddling urban and rural: any of these now raises and names the
+    offending clusters instead of keeping one row's value at random.  ("Invariant
+    by construction of the sampling design" is prose; prose is not enforcement.)
+
+    Use it as a wave-module ``df_edit`` hook::
+
+        # countries/<C>/<wave>/_/mapping.py
+        from lsms_library.transformations import (
+            collapse_to_cluster_grain as cluster_features,
+        )
+
+    See :func:`reduce_to_agreed` for the full contract (including
+    ``on_conflict='na'`` and ``LSMS_GRAIN_STRICT``).  Policy:
+    ``SkunkWorks/grain_aggregation_policy.org``.
+    """
+    return reduce_to_agreed(df, on_conflict=on_conflict, na_is_conflict=na_is_conflict)
+
+
+@build_transform(tables=['food_acquired'])
+def add_visit_level(df: pd.DataFrame, visit: int = 1) -> pd.DataFrame:
+    """Append a constant ``visit`` (recall-occasion) level to a food_acquired frame.
+
+    For a country whose ``food_acquired`` index carries a ``visit`` level because
+    SOME wave repeats the consumption recall, but whose OTHER waves ask it
+    exactly once.  Those single-recall waves get ``visit = 1`` so every wave
+    shares one index shape and the country-level concat aligns.
+
+    Motivating case (GH #323): Burkina Faso's 2014 EMC wave is a CONTINUOUS
+    survey that revisits the same 10,800 households in four quarterly passages,
+    each with its own independent 7-day recall (``visit = 1..4``); its EHCVM
+    waves (2018-19, 2021-22) field the module once.  Without the level, the four
+    passages collide on one ``(t, v, i, j, u, s)`` tuple and the additive
+    reducer SUMS them into a single bogus "7-day" figure.
+
+    This ADDS a level -- it never reduces grain -- which is exactly the
+    union-of-levels direction the grain policy asks for: carry the finer
+    instrument's detail, let the analyst collapse it.
+
+    Note ``visit`` is NOT EHCVM's ``vague``, which is a sample split (which
+    households are surveyed when), not a repeated measure;
+    ``food_acquired_to_canonical`` drops that upstream, and reusing it as
+    ``visit`` would falsely imply a second recall.
+
+    Raises:
+        ValueError: if ``visit`` is already present (in the index or the
+            columns) -- silently stamping a second one would corrupt the index.
+    """
+    if 'visit' in (df.index.names or []) or 'visit' in df.columns:
+        raise ValueError(
+            "add_visit_level: 'visit' is already present on this frame; stamping "
+            "a constant over an existing recall-occasion level would corrupt it."
+        )
+    return df.assign(visit=visit).set_index('visit', append=True)

--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -20,6 +20,19 @@ from .build_transforms import (  # noqa: F401  (re-export for back-compat)
     fill_v_with_coord_bin,
     apply_derived,
     _DERIVED_TRANSFORMERS,
+    # Explicit grain helpers (GH #323).  They live in build_transforms because
+    # a country's mapping.py calls them at BUILD time and their output is baked
+    # into the L2 parquet; they are re-exported here because that is where the
+    # country scripts import from, and because the grain policy
+    # (SkunkWorks/grain_aggregation_policy.org) names transformations.py as the
+    # home of caller-invoked aggregation.  Both modules are caller-invoked; only
+    # the ACCESS PATH (country.py / feature.py / local_tools.py) is forbidden to
+    # reduce grain, and none of these is reachable from it.
+    reduce_to_agreed,
+    collapse_to_cluster_grain,
+    add_visit_level,
+    GrainConflict,
+    GrainConflictWarning,
 )
 
 

--- a/tests/test_build_transform_hash.py
+++ b/tests/test_build_transform_hash.py
@@ -29,6 +29,20 @@ EXPECTED_ENTRY_POINTS = {
     "lsms_library.build_transforms._finalize_canonical_food_acquired",
     "lsms_library.build_transforms.fill_v_with_coord_bin",
     "lsms_library.build_transforms.apply_derived",
+    # GH #323: stamps the constant `visit` (recall-occasion) level on the
+    # single-recall waves of a country whose food_acquired index carries one.
+    # food_acquired-scoped, like its sibling food_acquired_to_canonical.
+    #
+    # NOT tagged, deliberately: build_transforms.reduce_to_agreed /
+    # .collapse_to_cluster_grain.  They are table-GENERIC, so the only honest
+    # tag is the all-tables one -- which would fold them into every table's
+    # fingerprint in every country and invalidate the whole library's cache on
+    # any edit, for a helper most countries never call.  Their build-path code
+    # is already versioned precisely by framework_imports_fingerprint, which
+    # folds the import closure of each wave's _/ *.py (mapping.py included) --
+    # i.e. of exactly the waves that call them.  See the CACHE NOTE in
+    # build_transforms.py.
+    "lsms_library.build_transforms.add_visit_level",
     "lsms_library.country._normalize_dataframe_index",
     "lsms_library.country.Wave.grab_data",
     "lsms_library.country.Country._aggregate_wave_data",

--- a/tests/test_gh323_explicit_reducers.py
+++ b/tests/test_gh323_explicit_reducers.py
@@ -1,0 +1,231 @@
+"""GH #323 -- the EXPLICIT grain helpers a country's mapping.py calls by name.
+
+The #323 policy (design note ``slurm_logs/DESIGN_grain_collapse_sites_2026-07-13.org``,
+decision D1) is that **core does not aggregate**: the access path (``country.py``,
+``feature.py``, ``local_tools.py``) never reduces grain.  A reducer a country
+invokes EXPLICITLY, at build time, from its own ``_/mapping.py`` is a different
+animal -- that is the country aggregating, visibly -- and is what these helpers
+are.  See ``SkunkWorks/grain_aggregation_policy.org``.
+
+The tests that matter here are the LOUD ones.  A reducer that quietly picks a
+winner among disagreeing rows would just relocate the #323 bug into a new
+function, so every path that would destroy an observed value must raise (or,
+when the caller has explicitly accepted the loss, blank the cell and warn).
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from lsms_library.transformations import (   # imported the way a country script does
+    reduce_to_agreed,
+    collapse_to_cluster_grain,
+    add_visit_level,
+    GrainConflict,
+    GrainConflictWarning,
+)
+
+
+def _cluster_frame(regions=('Dakar', 'Dakar', 'Dakar', 'Thies', 'Thies', 'Thies')):
+    """Two clusters x three households, as read off a household cover page."""
+    idx = pd.MultiIndex.from_tuples(
+        [('2018-19', '01')] * 3 + [('2018-19', '02')] * 3, names=['t', 'v'])
+    return pd.DataFrame({'Region': list(regions),
+                         'Rural': [False] * 3 + [True] * 3}, index=idx)
+
+
+# --------------------------------------------------------------------------
+# reduce_to_agreed -- the lossless path
+# --------------------------------------------------------------------------
+
+def test_agreeing_rows_collapse_losslessly():
+    out = reduce_to_agreed(_cluster_frame())
+    assert len(out) == 2
+    assert out.loc[('2018-19', '01'), 'Region'] == 'Dakar'
+    assert out.loc[('2018-19', '02'), 'Region'] == 'Thies'
+    assert out.loc[('2018-19', '02'), 'Rural'] is True or out.loc[('2018-19', '02'), 'Rural']
+    assert list(out.index.names) == ['t', 'v']
+
+
+def test_unique_index_is_returned_untouched():
+    """Nothing to collapse -> same rows, same order, same dtypes."""
+    df = _cluster_frame().iloc[[0, 3]]              # one household per cluster
+    out = reduce_to_agreed(df)
+    pd.testing.assert_frame_equal(out, df)
+
+
+def test_nan_is_absence_not_contradiction():
+    """One row reports Dakar, another reports nothing: no OBSERVED value is
+    discarded by keeping Dakar, so the completion is lossless and silent."""
+    df = _cluster_frame(regions=('Dakar', np.nan, 'Dakar', 'Thies', 'Thies', 'Thies'))
+    out = reduce_to_agreed(df)                       # must not raise
+    assert out.loc[('2018-19', '01'), 'Region'] == 'Dakar'
+
+
+def test_nan_index_key_rows_are_not_deleted():
+    """groupby(dropna=False): a row whose declared index level is NaN is not
+    annihilated by the reduce itself (#323 Site 3 is core's business, not ours)."""
+    idx = pd.MultiIndex.from_tuples(
+        [('2018-19', '01'), ('2018-19', '01'),
+         ('2018-19', np.nan), ('2018-19', np.nan)], names=['t', 'v'])
+    df = pd.DataFrame({'Region': ['Dakar', 'Dakar', 'Fatick', 'Fatick']}, index=idx)
+    out = reduce_to_agreed(df)
+    assert len(out) == 2, out
+    assert 'Fatick' in set(out['Region'])
+
+
+def test_empty_frame_passes_through():
+    """grab_data hands the df_edit hook an empty, unnamed-index frame when no
+    source file loaded; that must not become a hard failure."""
+    empty = pd.DataFrame()
+    pd.testing.assert_frame_equal(reduce_to_agreed(empty), empty)
+
+
+# --------------------------------------------------------------------------
+# reduce_to_agreed -- the must-be-loud path
+# --------------------------------------------------------------------------
+
+def test_disagreement_raises_by_default():
+    df = _cluster_frame(regions=('Dakar', 'Diourbel', 'Dakar', 'Thies', 'Thies', 'Thies'))
+    with pytest.raises(GrainConflict) as exc:
+        reduce_to_agreed(df)
+    msg = str(exc.value)
+    assert 'Region' in msg                       # names the offending column
+    assert "('2018-19', '01')" in msg            # names the offending group
+    assert 'GH #323' in msg
+    assert 'Rural' not in msg                    # the clean column is not accused
+
+
+def test_disagreement_is_never_resolved_by_picking_a_winner():
+    """The whole point: no mode of this helper returns 'Dakar' (or 'Diourbel')
+    for a cluster whose households disagree."""
+    df = _cluster_frame(regions=('Dakar', 'Diourbel', 'Dakar', 'Thies', 'Thies', 'Thies'))
+    with pytest.raises(GrainConflict):
+        reduce_to_agreed(df)                                   # default
+    with pytest.warns(GrainConflictWarning):
+        out = reduce_to_agreed(df, on_conflict='na')           # opt-in
+    assert pd.isna(out.loc[('2018-19', '01'), 'Region'])
+
+
+def test_on_conflict_na_blanks_only_the_conflicted_cells_and_warns():
+    df = _cluster_frame(regions=('Dakar', 'Diourbel', 'Dakar', 'Thies', 'Thies', 'Thies'))
+    with pytest.warns(GrainConflictWarning, match='Region'):
+        out = reduce_to_agreed(df, on_conflict='na')
+    assert len(out) == 2
+    assert pd.isna(out.loc[('2018-19', '01'), 'Region'])       # the conflict -> NA
+    assert out.loc[('2018-19', '02'), 'Region'] == 'Thies'     # the clean cluster survives
+    assert not out.loc[('2018-19', '01'), 'Rural']             # the clean COLUMN survives
+
+
+def test_na_is_conflict_flag_treats_a_missing_report_as_disagreement():
+    df = _cluster_frame(regions=('Dakar', np.nan, 'Dakar', 'Thies', 'Thies', 'Thies'))
+    with pytest.raises(GrainConflict):
+        reduce_to_agreed(df, na_is_conflict=True)
+
+
+def test_grain_strict_env_escalates_na_to_raise(monkeypatch):
+    monkeypatch.setenv('LSMS_GRAIN_STRICT', '1')
+    df = _cluster_frame(regions=('Dakar', 'Diourbel', 'Dakar', 'Thies', 'Thies', 'Thies'))
+    with pytest.raises(GrainConflict, match='LSMS_GRAIN_STRICT'):
+        reduce_to_agreed(df, on_conflict='na')
+
+
+def test_grain_conflict_is_a_valueerror():
+    """A country script catching ValueError still catches it."""
+    assert issubclass(GrainConflict, ValueError)
+
+
+def test_unnamed_index_on_a_nonempty_frame_raises():
+    """A caller who forgot to set the declared index gets an error, not a
+    silent no-op that would leave the collapse to core."""
+    df = pd.DataFrame({'Region': ['Dakar', 'Dakar']})
+    with pytest.raises(ValueError, match='named'):
+        reduce_to_agreed(df)
+
+
+def test_unknown_on_conflict_raises():
+    with pytest.raises(ValueError, match='on_conflict'):
+        reduce_to_agreed(_cluster_frame(), on_conflict='first')
+
+
+# --------------------------------------------------------------------------
+# collapse_to_cluster_grain -- the named cluster case
+# --------------------------------------------------------------------------
+
+def test_collapse_to_cluster_grain_dedups_identical_household_rows():
+    out = collapse_to_cluster_grain(_cluster_frame())
+    assert len(out) == 2
+    assert out.loc[('2018-19', '01'), 'Region'] == 'Dakar'
+
+
+def test_collapse_to_cluster_grain_raises_when_an_attribute_conflicts():
+    """'Invariant by construction of the sampling design' is prose.  This is
+    the enforcement: a cluster code unique only within a district merges two
+    real clusters, and the collapse must not silently keep one Region."""
+    df = _cluster_frame(regions=('Dakar', 'Diourbel', 'Dakar', 'Thies', 'Thies', 'Thies'))
+    with pytest.raises(GrainConflict):
+        collapse_to_cluster_grain(df)
+
+
+def test_collapse_to_cluster_grain_works_as_a_bare_df_edit_hook():
+    """Country scripts alias-import it (`... as cluster_features`), so it must
+    be callable with the single positional frame grab_data passes."""
+    hook = collapse_to_cluster_grain
+    assert len(hook(_cluster_frame())) == 2
+
+
+# --------------------------------------------------------------------------
+# add_visit_level -- widens the index, never reduces it
+# --------------------------------------------------------------------------
+
+def _food_frame():
+    idx = pd.MultiIndex.from_tuples(
+        [('2018-19', 'h1', 'Rice', 'kg', 'purchased'),
+         ('2018-19', 'h1', 'Maize', 'kg', 'produced')],
+        names=['t', 'i', 'j', 'u', 's'])
+    return pd.DataFrame({'Quantity': [2.0, 3.0], 'Expenditure': [500.0, np.nan]}, index=idx)
+
+
+def test_add_visit_level_appends_the_recall_occasion():
+    out = add_visit_level(_food_frame(), visit=1)
+    assert list(out.index.names) == ['t', 'i', 'j', 'u', 's', 'visit']
+    assert set(out.index.get_level_values('visit')) == {1}
+    assert len(out) == 2                       # widens the index; loses no rows
+    assert out['Quantity'].tolist() == [2.0, 3.0]
+
+
+def test_add_visit_level_takes_a_nondefault_passage():
+    out = add_visit_level(_food_frame(), visit=3)
+    assert set(out.index.get_level_values('visit')) == {3}
+
+
+def test_add_visit_level_refuses_to_stamp_over_an_existing_visit():
+    already = add_visit_level(_food_frame(), visit=2)
+    with pytest.raises(ValueError, match='already present'):
+        add_visit_level(already, visit=1)
+    with pytest.raises(ValueError, match='already present'):
+        add_visit_level(_food_frame().assign(visit=4))
+
+
+# --------------------------------------------------------------------------
+# The policy itself: core must not be able to reach these behind the caller
+# --------------------------------------------------------------------------
+
+def test_core_does_not_dispatch_the_reducers():
+    """D1: core does not aggregate.  These helpers are called BY NAME from
+    country scripts; the access path must not import, reference, or dispatch
+    them (and no ``aggregation:`` YAML key may drive them).  A grep, because
+    the thing being guarded is precisely that no such wiring exists.
+    """
+    from pathlib import Path
+    import lsms_library
+
+    root = Path(lsms_library.__file__).parent
+    banned = ('reduce_to_agreed', 'collapse_to_cluster_grain', 'add_visit_level')
+    offenders = []
+    for mod in ('country.py', 'feature.py', 'local_tools.py'):
+        src = (root / mod).read_text()
+        offenders += [f"{mod}:{name}" for name in banned if name in src]
+    assert not offenders, (
+        f"the access path references an explicit reducer: {offenders} -- that is "
+        "core aggregating behind the caller's back (GH #323 D1)"
+    )


### PR DESCRIPTION
Lands the **explicit, country-invoked reducers** that Senegal and Burkina Faso need, so their branches can be stripped of core patches and rebased cleanly. Part of the GH #323 consolidation (`slurm_logs/DESIGN_grain_collapse_sites_2026-07-13.org`).

**The access path is untouched** — no `country.py`, `feature.py`, `local_tools.py`. Verified by a test that greps them and fails if any ever references a reducer.

## Why this is not the rejected Design A

D1 says *core does not aggregate*. It does not say *nothing may aggregate*. The policy draws the line at **core-implicit vs. caller-explicit**: a reducer that core auto-dispatches from an `aggregation:` YAML key, behind the caller's back, is rejected. A reducer a country's own `_/mapping.py` calls **by name** is the country aggregating, *visibly*, at build time — which is what the contract asks for.

Without this, stripping the core patches from `fix/323-senegal` and `fix/323-burkina-faso` turns both countries into **ImportErrors at wave load**: their `mapping.py` files already call these helpers.

## Where they live, and why not `transformations.py`

Everything is in **`build_transforms.py`**, re-exported from `transformations.py` (so both branches' existing `from lsms_library.transformations import ...` lines work unchanged).

The policy doc says "aggregation lives in `transformations.py`" — but that line **predates the PR #531 build/read split**. The operative distinction now is *build-time vs. read-time*: these helpers are called from a country's `_/mapping.py`, so they run at **build** time and their output is **baked into the L2 parquet**. That is precisely what `build_transforms.py` holds. `transformations.py` is documented as the *read path* — re-applied on every API call, never cached. Filing a build-time reducer there would misfile it and corrupt the cache-hash reasoning.

## The contracts — lossless or loud

- **`reduce_to_agreed(df, *, on_conflict='raise', na_is_conflict=False)`** — collapses rows sharing an index tuple, keeping only values they *agree* on. Disagreement raises `GrainConflict` (a `ValueError`), naming the offending columns and groups. `on_conflict='na'` blanks exactly the conflicted cells and warns; `LSMS_GRAIN_STRICT=1` escalates that back to a raise. **No mode picks a winner** — a test asserts that directly. NaN is treated as *absence, not contradiction* (filling from a unanimous sibling discards no observed value); `na_is_conflict=True` takes the strict reading. NaN index keys survive (`dropna=False`).
- **`collapse_to_cluster_grain(...)`** — the named cluster case, usable as a bare `df_edit` hook. "Invariant by construction of the sampling design" is prose; this is the enforcement.
- **`add_visit_level(df, visit=1)`** — *widens* the index, never reduces it; refuses to stamp over an existing `visit` level.

## The salvaged default was itself a quiet #323, and the fix caught it

**I changed the default from NA-on-conflict to raise-on-conflict.** Burkina Faso's original helper silently NA'd conflicts — which is still quiet destruction, just with a different corpse. A country must now write `on_conflict='na'` *at the call site* to accept a loss.

That change immediately earned itself. Real-data check (`LSMS_NO_CACHE=1`, hook simulated on the actual pre-collapse cover-page frame):

- **Senegal 2018-19**: collapses **losslessly**, 7,156 → 598 clusters. ✅
- **Burkina Faso 2018-19**: **RAISES.** Its `cluster_features` YAML declares `i: menage` as an idxvar while the table's final index is `(t, v)` — so the household id rides in as a *column* and disagrees in **585 of 585 clusters**.

Under the salvaged NA default, that column would have been **silently blanked to all-NA and nobody would ever have noticed**.

**Action for the Burkina Faso rebase**: drop `i` from the `cluster_features` extraction — a config fix, in their scope. Do **not** paper over it with `on_conflict='na'`.

## Verification

- `tests/test_gh323_explicit_reducers.py` — **22 tests**: lossless path, must-raise path, NA-mode-warns path, NaN semantics both ways, NaN-key retention, unique-index identity, `LSMS_GRAIN_STRICT` escalation, `add_visit_level` guards, and the policy test that fails if the access path ever gains a reducer reference.
- Full suite: **3,496 passed, 2 failed, 140 skipped**. Both failures reproduce identically on unmodified `origin/development` — neither is from this branch:
  - `test_currency.py::test_feature_ghana_per_wave` — compares a list to a set (`assert ['GHC'] == {'GHC'}`); pandas 3 unwraps `agg(lambda s: set(...))`. Test bug.
  - `test_table_structure.py::…[CotedIvoire/cluster_features]` — declared column `Latitude` missing (the GH #515 optional-`df_geo` drop).

## One decision worth a maintainer's eye: cache-hash tagging

`add_visit_level` carries `@build_transform(tables=['food_acquired'])` and the pinned `EXPECTED_ENTRY_POINTS` drift guard is updated. The **generic** reducers are deliberately **not** tagged: they are table-generic, so the only honest tag is all-tables — which would fold them into every table's fingerprint in every country and invalidate the entire library's cache for a helper most countries never call. `framework_imports_fingerprint` already versions them precisely, by folding the import closure of each wave's `_/*.py` (including `mapping.py`) — i.e. of exactly the waves that call them. Flip it by adding a bare `@build_transform()` if you'd rather have the blunt instrument.

## Unverified

No country calls these helpers *on this branch* (configs are untouched by design), so the end-to-end path through `grab_data` is exercised only by the simulated-hook probe, not by a real cached build. That closes when Senegal and Burkina Faso rebase.

Refs #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
