### PR TITLE
fix(#323): EthiopiaRHS double-punched food was SUMMED, not collapsed — 343 Birr of phantom value

### DIFF
--- a/.coder/ledger/323-ethiopiarhs.md
+++ b/.coder/ledger/323-ethiopiarhs.md
@@ -1,0 +1,194 @@
+# GH #323 — EthiopiaRHS: silent collapse of a non-unique declared index
+
+Branch `fix/323-ethiopiarhs`, base `development` @ `d572d8a9`.
+
+## §1 What the brief said, and where it was stale
+
+The dispatched diagnosis said `_normalize_dataframe_index` applies
+`groupby().first()` to EthiopiaRHS `food_acquired`, destroying 131 rows of real
+Quantity/Expenditure, and prescribed (1) a source-level dedup and (2) declaring
+`aggregation: sum`.
+
+**Half of that was already fixed and the sign of the other half was inverted.**
+`food_acquired` has been in `feature.py::_ADDITIVE_MEASURE_COLUMNS` since GH
+`#501`/`#514` (`899b89c6`, `d8ff08d5`), so the collapse already **SUMs** rather
+than `first()`s. Measured on the L2-wave parquets vs. the API:
+
+| wave  | L2-wave Qty | API Qty | Δ |
+|-------|-------------|---------|---|
+| 1989  | 14020.6 | 14020.6 | 0 |
+| 1994a | 116829.4 | 116829.4 | 0 |
+| 1994b | 70860.2 | 70860.2 | 0 |
+| 1997  | 86044.1 | 86044.1 | 0 |
+
+Mass **preserved** ⇒ the sum path is live ⇒ the 131 "destroyed" rows were
+already being folded in correctly. What the brief missed is the consequence:
+**`sum` DOUBLE-COUNTS a row that was punched twice.**
+
+## §2 What was actually broken
+
+Instrument validated first on the mandated positives (Mali/2014-15
+`household_roster` = 32,026 dup rows; Guyana/1992 `housing` = 311) before any
+EthiopiaRHS number was trusted.
+
+**Channel A — double-count (class-1, silently WRONG).** 90 rows across the five
+roster waves are byte-identical in the canonical grain *and* in both measures.
+The framework sums them, so they are counted twice: **514.9 Quantity and 343.1
+Birr of pure overstatement.**
+
+Smoking gun, end to end: `food89.dta` rows 865/866 are identical in *every*
+source column (hh 20120, foodcode 34, qty 2.0, unit 9, value 0.5). The API
+reported **Quantity 4.0 / Expenditure 1.0**. The source records one line.
+
+The other 127 colliding rows genuinely DIFFER (1997 hh 10_93 produced Berbere
+1.0 kg *and* 30.0 kg). Those are real repeat measurements and `sum` is right for
+them. So dedup and sum are a **matched pair** — neither is correct alone.
+
+**Channel B — NaN index keys silently DELETED (new; not in the brief).**
+`groupby(level=..., observed=True)` defaults to `dropna=True`, so any row with a
+NaN in an index level **vanishes** during the collapse. It only bites when the
+index is non-unique (otherwise no groupby runs), which is why it hid inside
+Channel A. EthiopiaRHS 1995 lost 11 rows (20.2 Qty, 23.7 Birr) this way — the
+wide melt path filtered missing `i` and `u` but forgot `j`.
+
+This model is **exactly predictive**: `rows − dup − nan_key` reproduces the
+observed API row count for all five waves (2068 / 12971 / 13333 / 11956 / 14365).
+
+## §3 The fix
+
+**Class level** (`country.py`) — the part that matters for #323.
+`SkunkWorks/grain_aggregation_policy.org` introduced an `aggregation:` block in
+`data_scheme.yml`; ten countries declare one; **nothing read it.** It was
+documentary prose while the code applied `.first()` regardless — the repo's own
+"prose is not enforcement" failure mode. `_normalize_dataframe_index` now
+**honours** it (`_declared_aggregation`), with precedence
+declared → hardcoded additive map → `first`. An unknown reducer raises rather
+than degrading to `first()`. Undeclared collapses stay loud, and
+`LSMS_STRICT_INDEX=1` turns them into an error — the enforcement lever.
+
+Proof it was inert on base: with `aggregation: {Quantity: sum}` declared and
+rows 1.0 + 30.0, base returns **1.0**.
+
+**Country level** (`EthiopiaRHS/_/ethiopiarhs.py`, `_/data_scheme.yml`).
+`_drop_double_punched()` drops rows indistinguishable in the canonical grain,
+*before* the framework sums; the wide path now also filters NaN `j`, converting
+an accidental pandas deletion into an intentional, symmetric drop.
+`aggregation: {Quantity: sum, Expenditure: sum}` is declared explicitly rather
+than inherited from the hardcoded map.
+
+## §4 Numbers
+
+Cold rebuild (`cache clear --country EthiopiaRHS`; the L2-country parquet is
+written POST-collapse, so a warm run shows the poisoned cache and appears to
+pass).
+
+| wave  | API rows before → after | Qty before → after | Exp before → after |
+|-------|-------------------------|--------------------|--------------------|
+| 1989  | 2068 → **2068** | 14020.6 → 14018.6 (−2.0) | 10094.8 → 10094.3 (−0.5) |
+| 1994a | 12971 → **12971** | 116829.4 → 116745.5 (−83.9) | 50267.6 → 50243.5 (−24.1) |
+| 1994b | 13333 → **13333** | 70860.2 → 70689.5 (−170.7) | 58759.7 → 58706.1 (−53.6) |
+| 1995  | 11956 → **11956** | 56950.9 → 56791.6 (−159.3) | 44405.8 → 44300.8 (−105.0) |
+| 1997  | 14365 → **14365** | 86044.1 → 85945.1 (−99.0) | 72176.8 → 72016.8 (−160.0) |
+
+Row counts unchanged (the grain did not move); the mass falls by *exactly* the
+double-counted amount. Byte-identical dupes 90 → **0**; the 127 real repeat
+measurements are retained and summed; NaN-`j` 11 → **0**. 1989 Fenugreek now
+reports **2.0 / 0.5**, matching source.
+
+**Regression.** `_normalize_dataframe_index` was run over every affected cell
+under old and new code, with the config tree *and* a frozen parquet snapshot
+pinned (the shared cache is being mutated by other agents — Panama/Niger cells
+appeared and vanished mid-run, which is what made a first, unpinned comparison
+untrustworthy): **719 cells / 31 countries / 27,085,429 rows → 0 output
+changes.** Includes the nine countries whose `interview_date: {visit: first}`
+policy is now live; `first`-for-every-column is byte-identical to the old
+`.first()` (NaN-skipping included, verified).
+
+## §5 Judgment call, stated plainly
+
+Treating the 90 byte-identical rows as double-punches rather than as genuine
+repeat acquisitions of identical amount+price+unit+source is **not settleable
+from the data** — the instrument records no axis on which the two rows differ.
+I took the conservative reading and drop.
+
+If that call is wrong, it **understates** by 90 rows (class-2, silently
+missing). Summing them **overstates** (class-1, silently wrong). Class-2 is the
+safer error, and for rows identical on every recorded axis, asserting "two
+distinct events" is the stronger and less defensible claim. The 1989 case is the
+tell: rows 865/866 are identical in *unrelated household-level fields too*,
+which is a data-entry signature, not an economic one.
+
+The load-bearing negative: **there is no missing level to name.** All 27 columns
+of the q36 module were enumerated — no line / transaction / occasion / visit id.
+`q36_1a` is a section flag (1.0/NaN/2.0), not a line number; adding it to the key
+moves 1994a's dup count only 213 → 212. Unlike Guyana (where `SN` was the missing
+level), `(t,i,j,u,s)` **is** the maximal grain the instrument supports, so a
+synthetic row-order id would be a meaningless axis and would break cross-country
+comparability.
+
+## §6 What I did NOT fix, and why
+
+**The class is only PARTLY closed. Do not close #323 on this branch.**
+
+1. **Channel B is repo-wide and unfixed: 710,845 rows** with a NaN index key are
+   silently deleted by `groupby(dropna=True)` across ~28 countries. The one-line
+   fix (`dropna=False`) would *restore* those rows and thereby change many
+   countries' outputs — it cannot be validated country-by-country from an
+   EthiopiaRHS remit, and shipping it here would violate "prove you broke nothing
+   else." **It needs its own issue.** I fixed only EthiopiaRHS's 11, at source.
+
+2. **The `first()` default still stands for undeclared tables.** A repo-wide scan
+   of L2-wave parquets on the full declared index finds **99 cells / 24 countries
+   where colliding rows genuinely DIFFER (477,499 rows silently wrong)**. Making
+   an undeclared collapse `raise` by default — which is the correct end state —
+   breaks all 24 at cold build. This branch ships the *mechanism* (declare a
+   policy) and the *lever* (`LSMS_STRICT_INDEX=1`); flipping the default requires
+   declaring a policy for each of those countries first. Per-country damage:
+   Burkina_Faso 184,308 · Mali 68,666 · Malawi 67,137 · Nigeria 58,782 · Uganda
+   20,317 · Tanzania 20,102 · Tajikistan 11,540 · Albania 9,514 · South Africa
+   8,454 · Kosovo 6,702 · India 6,194 · Guyana 4,545 · Liberia 2,954 · Kazakhstan
+   1,861 · Niger 1,815 · Benin 1,302 · Cambodia 1,260 · China 758 · Togo 579 ·
+   Senegal 208 · Ethiopia 207 · Serbia 163 · EthiopiaRHS 127 · CotedIvoire 4.
+   (That scan does not separate *intended* level-drop aggregation from the bug;
+   it is an upper bound on the cells needing a declared policy, not on the bug.)
+
+## §7 Prior art consulted
+
+`SkunkWorks/grain_aggregation_policy.org` (the `aggregation:` contract and its
+"NO AGGREGATION IN CORE" direction — this change does not contradict it; it makes
+the *interim* collapse honest), `feature.py::_ADDITIVE_MEASURE_COLUMNS` +
+`_collapse_duplicate_index` (GH #501/#514 — reused as the fallback rather than
+duplicated), CLAUDE.md cache tiers (why verification must be cold).
+
+---
+
+## Stripped to config-only (2026-07-13, GH #323 consolidation)
+
+This branch (`fix/323-ethiopiarhs-config`, off `origin/development`) carries the
+country work from `fix/323-ethiopiarhs` and **nothing else**. Per
+`slurm_logs/DESIGN_grain_collapse_sites_2026-07-13.org`:
+
+* **Stripped: 129 lines of `lsms_library/country.py`** (the Design-A
+  `_declared_aggregation` reducer machinery) and `tests/test_index_collapse_policy.py`
+  (which exercised it). **D1: core does not aggregate** — Design B (PR #614) won.
+* **Stripped: the `aggregation: {Quantity: sum, Expenditure: sum}` block** in
+  `_/data_scheme.yml`. It was always a **NO-OP**: `food_acquired` is in
+  `feature.py`'s `_ADDITIVE_MEASURE_COLUMNS`, so core *already* sums those two
+  columns when the canonical index is non-unique. Prose in `CONTENTS.org`,
+  `data_scheme.yml` and the `_drop_double_punched` docstring that described the
+  sum as *declared* has been corrected to say it is *core's, and unconditional*.
+* **Kept, and it stands alone:** `_drop_double_punched()` and the `j.notna()`
+  filter in `_/ethiopiarhs.py`. The dedup is what makes core's (pre-existing) sum
+  *correct*; it does not depend on the stripped machinery in any way.
+
+Verified post-strip, cold build (`LSMS_NO_CACHE=1`), branch vs. `origin/development`:
+
+| | Quantity | Expenditure |
+|---|---|---|
+| development | 344,705.2 | 235,704.6 |
+| this branch | 344,190.4 | 235,361.5 |
+| **removed** | **514.8** | **343.1** |
+
+Exactly the claimed double-punch overstatement (90 rows). Row count is unchanged
+(54,693) because core was *summing* the punch-duplicates into the same index
+tuple, not adding rows — the defect inflated values, not the shape.

--- a/lsms_library/countries/EthiopiaRHS/_/CONTENTS.org
+++ b/lsms_library/countries/EthiopiaRHS/_/CONTENTS.org
@@ -260,6 +260,53 @@ files are the R6 slice.
   R6/R7 area_output PAs 21-23 (extra Debre-Birhan sub-sites not in the
   erhs_village_* Code tables -> NaN Region/Woreda/v).
 
+* food_acquired grain: repeat lines, double-punches (GH #323)
+
+The q36 food module is a ONE-ROW-PER-FOOD-ITEM roster.  All 27 source
+columns were enumerated: there is NO line / transaction / occasion /
+visit identifier (=q36_1a= is a section flag, 1.0/NaN/2.0, NOT a line
+number).  So =(t, i, j, u, s)= IS the maximal grain the instrument
+supports -- there is no finer axis to name, and none should be invented.
+
+The roster nevertheless carries MULTIPLE LINES per (household, item).
+Most differ in UNIT (=u= is in the index, so they do not collide and are
+preserved).  The rest split two ways, and the distinction is
+load-bearing:
+
+- 127 rows (1994a-1997) are a second acquisition of the SAME item, in
+  the SAME unit, from the SAME source, carrying DIFFERENT measurements
+  (1997 hh 10_93 produced Berbere 1.0 kg AND 30.0 kg).  These are REAL,
+  and core already handles them: =food_acquired= is in =feature.py='s
+  =_ADDITIVE_MEASURE_COLUMNS=, so the collapse to the canonical grain
+  SUMS Quantity and Expenditure.  (=first= would destroy ~50% of the
+  Quantity/Expenditure mass in the affected cells.)
+
+- 90 rows are byte-identical in the canonical grain AND in both measures
+  -- one measurement punched twice (food89.dta rows 865/866 are identical
+  in EVERY source column: hh 20120, foodcode 34, qty 2.0, unit 9, value
+  0.5).  Because the collapse SUMS, these are DOUBLE-COUNTED (the API
+  reported Fenugreek 4.0/1.0 for that household).
+  =ethiopiarhs.food_acquired= drops them via =_drop_double_punched()=
+  BEFORE the framework sums: 514.9 Quantity and 343.1 Birr of
+  overstatement removed.
+
+The dedup is what makes the sum correct.  The sum is unconditional (it is
+core's, not this country's, and it is right for the 127 real repeats);
+without the dedup, the 90 punch-duplicates are counted twice.
+
+JUDGMENT CALL: a household *could* genuinely acquire the same item, same
+unit, same source, same amount, same price, twice in a recall week; the
+instrument records no axis on which such rows differ, so the data cannot
+settle it.  We drop (conservative).  Being wrong understates by 90 rows
+(silently missing); summing overstates (silently wrong), and the latter
+is the worse failure.
+
+Also: the wide melt path now filters missing =j= (as the 1989 path always
+did).  11 NaN-j rows (1995) were previously deleted by accident --
+=groupby(level=...)= defaults to =dropna=True=, so a NaN index key
+silently vanishes during the collapse.  The item is unidentifiable, so
+the row is now dropped deliberately rather than by pandas' default.
+
 * Food security (non-FIES families, GH #332) --- not wired
 
 ERHS carries only bespoke, non-standardized food-stress items (IFPRI

--- a/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
+++ b/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
@@ -151,6 +151,27 @@ Data Scheme:
   # Mali-style clean YAML: extract wide per-source columns; the
   # `food_acquired` df_edit hook in _/ethiopiarhs.py melts them to
   # canonical long form on s. Price is API-derived (food_prices).
+  #
+  # GRAIN (GH #323).  The ERHS q36 food module is a ONE-ROW-PER-FOOD-ITEM
+  # roster: all 27 source columns were enumerated and there is NO line /
+  # transaction / occasion / visit identifier (q36_1a is a section flag, not a
+  # line number).  So (t,i,j,u,s) IS the maximal grain the instrument supports
+  # -- there is no finer axis to name, and none should be invented.
+  #
+  # The roster nevertheless carries MULTIPLE LINES per (i,j).  Most differ in
+  # UNIT (u is in the index, so they do not collide).  Of the rest, 127 rows
+  # across 1994a-1997 are a second acquisition of the SAME item, in the SAME
+  # unit, from the SAME source, carrying DIFFERENT measurements (e.g. 1997 hh
+  # 10_93 produced Berbere 1.0 kg AND 30.0 kg).  Those are real quantities, and
+  # core ALREADY sums them: `food_acquired` is in feature.py's
+  # `_ADDITIVE_MEASURE_COLUMNS`, so the collapse to the canonical grain SUMs
+  # Quantity and Expenditure.  Nothing needs declaring here.
+  #
+  # But `sum` DOUBLE-COUNTS a row punched twice.  So the `food_acquired` hook in
+  # _/ethiopiarhs.py drops rows that are indistinguishable in the canonical
+  # grain (`_drop_double_punched`) BEFORE the framework sums: 90 rows, 514.9
+  # Quantity and 343.1 Birr of pure overstatement.  The dedup is what makes the
+  # (already unconditional) sum correct.
   food_acquired:
     index: (t, i, j, u, s)
     Quantity: float

--- a/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
+++ b/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
@@ -87,6 +87,48 @@ def i(value):
     return tools.format_id(value)
 
 
+#: Canonical grain of `food_acquired` (less `t`, which the framework prepends).
+_FOOD_GRAIN = ['i', 'j', 'u', 's']
+#: The measures that ride on that grain.
+_FOOD_MEASURES = ['Quantity', 'Expenditure']
+
+
+def _drop_double_punched(flat):
+    """Drop food rows that are INDISTINGUISHABLE in the canonical grain.
+
+    GH #323.  The ERHS q36 food module is a one-row-per-food-item roster with
+    NO line / transaction / occasion identifier -- all 27 source columns were
+    enumerated; q36_1a is a section flag, not a line number.  So two rows equal
+    on (i, j, u, s) AND on Quantity AND on Expenditure are not a second,
+    distinguishable acquisition: they are the SAME measurement recorded twice
+    (a data-entry double-punch -- e.g. food89.dta rows 865/866 are identical in
+    EVERY source column, incl. unrelated household-level fields).
+
+    This must happen BEFORE the framework collapses the canonical index, because
+    that collapse SUMS the additive measures: `food_acquired` is in feature.py's
+    `_ADDITIVE_MEASURE_COLUMNS`, so the sum is unconditional core behaviour (GH
+    #501/#514) -- not something this country opts into.  Left in, these rows are
+    silently DOUBLE-COUNTED: 1989 hh 20120 Fenugreek reports Quantity 4.0 / 1.0
+    Birr where the source recorded 2.0 / 0.5.  Across the five roster waves that
+    is 90 rows, 514.9 Quantity and 343.1 Birr of pure overstatement.
+
+    Rows that DIFFER in Quantity or Expenditure are NOT touched -- those are
+    real repeat measurements (a household that produced Berbere 1.0 kg and
+    30.0 kg) and core's `sum` correctly folds them together.
+
+    JUDGMENT CALL, stated plainly: a household *could* genuinely acquire the
+    same item, same unit, same source, same amount, at the same price, twice in
+    one recall week; the instrument cannot rule it out, because it records no
+    axis on which the two rows differ.  We take the conservative reading and
+    drop.  If that call is wrong we UNDERSTATE by these rows (class-2, silently
+    missing); summing them OVERSTATES (class-1, silently wrong) -- and for rows
+    that are identical on every recorded axis, asserting "two distinct events"
+    is the stronger, less defensible claim.
+    """
+    subset = [c for c in _FOOD_GRAIN + _FOOD_MEASURES if c in flat.columns]
+    return flat.drop_duplicates(subset=subset)
+
+
 def food_acquired(df):
     """Melt ERHS wide per-source food columns into canonical long form.
 
@@ -127,6 +169,7 @@ def food_acquired(df):
         # would need Codeunit1.SPS).
         if 'u' in flat.columns:
             flat['u'] = flat['u'].astype('string').str.strip()
+        flat = _drop_double_punched(flat)
         return flat.set_index(idx)
 
     w = df.reset_index()
@@ -160,6 +203,17 @@ def food_acquired(df):
     out['u'] = out['u'].astype('string').str.strip()
     out = out[out['i'].notna()]
     out = out[out['u'].notna() & (out['u'] != '')]
+    # Drop rows with no FOOD id.  `j` is an index level, so a NaN here cannot be
+    # placed on the item axis at all.  The 1989 path above already filters j;
+    # this path did not, leaking 11 NaN-j rows (1995) that pandas then deleted
+    # by accident -- groupby(level=...) defaults to dropna=True, so any row with
+    # a NaN index key silently VANISHES during the canonical-index collapse
+    # (GH #323, and it only bites when the index happens to be non-unique).
+    # Dropping them here makes an accident an intentional, symmetric decision:
+    # the item is unidentifiable, so the row is dropped LOUDLY rather than
+    # guessed at.  Output is unchanged; the honesty is the point.
+    out = out[out['j'].notna()]
+    out = _drop_double_punched(out)
     out = out.set_index(['i', 'j', 'u', 's'])
     return out
 

--- a/tests/test_ethiopiarhs_double_punch.py
+++ b/tests/test_ethiopiarhs_double_punch.py
@@ -1,0 +1,87 @@
+"""EthiopiaRHS food_acquired -- the data-entry double-punch (GH #323).
+
+`food_acquired` is in ``feature.py``'s ``_ADDITIVE_MEASURE_COLUMNS``, so when
+the canonical ``(t, i, j, u, s)`` index is non-unique core ALREADY SUMS Quantity
+and Expenditure.  That is right for the 127 rows (1994a-1997) that are a genuine
+second acquisition of the same item in the same unit from the same source, with
+DIFFERENT measurements (1997 hh 10_93 produced Berbere 1.0 kg AND 30.0 kg).
+
+It is wrong for a row punched twice.  The ERHS q36 module is a
+one-row-per-food-item roster with NO line / transaction / occasion identifier
+(all 27 source columns were enumerated; q36_1a is a section flag, not a line
+number), so two rows equal on the canonical grain AND on both measures are one
+measurement recorded twice -- and the sum DOUBLE-COUNTS them.  Across the five
+roster waves: 90 rows, 514.9 Quantity and 343.1 Birr of pure overstatement.
+
+``ethiopiarhs._drop_double_punched()`` removes them BEFORE core sums.  These
+tests exercise that country-level helper directly -- they assert a property of
+the EthiopiaRHS data and its hook, not of any core collapse mechanism.
+"""
+import importlib.util
+
+import pandas as pd
+
+from lsms_library.paths import countries_root
+
+
+def _erhs():
+    spec = importlib.util.spec_from_file_location(
+        'erhs_mod', countries_root() / 'EthiopiaRHS' / '_' / 'ethiopiarhs.py')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_drops_double_punched_rows():
+    """The 1989 smoking gun: food89.dta rows 865/866 are identical in EVERY
+    source column (hh 20120, foodcode 34, qty 2.0, unit 9, value 0.5).  They are
+    one measurement punched twice.  Core's sum reports 4.0 / 1.0 -- a pure
+    overstatement.  The hook must collapse them to one row.
+    """
+    erhs = _erhs()
+    punched = pd.DataFrame({
+        'i': ['20120', '20120'],
+        'j': ['Fenugreek (Abish)', 'Fenugreek (Abish)'],
+        'u': ['9', '9'],
+        's': ['purchased', 'purchased'],
+        'Quantity': [2.0, 2.0],
+        'Expenditure': [0.5, 0.5],
+    })
+    out = erhs._drop_double_punched(punched)
+    assert len(out) == 1, 'byte-identical double-punch was not dropped'
+    assert out['Quantity'].iloc[0] == 2.0
+    assert out['Expenditure'].iloc[0] == 0.5
+
+
+def test_keeps_rows_that_differ_in_measurement():
+    """The other half: rows that DIFFER are real repeat acquisitions (1997 hh
+    10_93 produced Berbere 1.0 kg AND 30.0 kg).  The dedup must NOT touch them
+    -- core's sum correctly folds them together."""
+    erhs = _erhs()
+    real = pd.DataFrame({
+        'i': ['10_93', '10_93'],
+        'j': ['Berbere', 'Berbere'],
+        'u': ['kg', 'kg'],
+        's': ['produced', 'produced'],
+        'Quantity': [1.0, 30.0],
+        'Expenditure': [float('nan'), float('nan')],
+    })
+    out = erhs._drop_double_punched(real)
+    assert len(out) == 2, 'real repeat measurements were destroyed'
+
+
+def test_dedup_is_keyed_on_the_canonical_grain_plus_both_measures():
+    """A row differing on ANY of (i, j, u, s, Quantity, Expenditure) survives.
+
+    Guards the subset: dropping a measure from the key would silently discard
+    real repeat acquisitions; dropping a grain level would merge distinct items.
+    """
+    erhs = _erhs()
+    base = dict(i='1', j='Teff', u='kg', s='purchased',
+                Quantity=1.0, Expenditure=2.0)
+    for field, other in [('i', '2'), ('j', 'Maize'), ('u', 'g'),
+                         ('s', 'produced'), ('Quantity', 9.0),
+                         ('Expenditure', 9.0)]:
+        rows = pd.DataFrame([base, {**base, field: other}])
+        out = erhs._drop_double_punched(rows)
+        assert len(out) == 2, f'rows differing only in {field!r} were merged'


### PR DESCRIPTION
Config-only. **Zero changes to the access path.** Supersedes the core patch on `fix/323-ethiopiarhs`, per `slurm_logs/DESIGN_grain_collapse_sites_2026-07-13.org`.

## The fix — food was being DOUBLE-COUNTED

Core **already** sums `food_acquired` duplicates (`_ADDITIVE_MEASURE_COLUMNS` in `feature.py`, since GH #501). So EthiopiaRHS's data-entry **double-punches** were not being collapsed — they were being **summed**, i.e. counted twice.

`_/ethiopiarhs.py` gains `_drop_double_punched()`, removing 90 duplicate-punch rows at source, plus an explicit `j.notna()` filter (11 NaN-`j` rows).

**Verified against `development` (cold):**

| | dev | this branch | delta |
|---|---|---|---|
| Quantity | 344,705.2 | 344,190.4 | **−514.8** |
| Expenditure | 235,704.6 | 235,361.5 | **−343.1 Birr** |

Exactly the claimed 90-row overstatement. This is pure phantom value removed.

Its `aggregation: {Quantity: sum, Expenditure: sum}` block was a **no-op** — it restated what core has done since #501 — and is stripped with zero effect. (Independent evidence for D1: the agent reached for a new config mechanism rather than finding the one already there.)

## Structural check — the near-miss worth recording

**EthiopiaRHS is round-structured** (R1–R7; `_present` / `_drop_all_nan_value_rows` round-population filters; `1994a` / `1994b` directories). A keyword census scored it *clean*; reading `CONTENTS.org` found the rounds.

That matters, because `_drop_double_punched()` dedups on `['i','j','u','s'] + measures` — **without `t`**. Had any single wave directory carried two rounds, it would have silently collapsed across them: **the Tanzania bug.** It does not: `food_acquired` is wired for 5 directories (1989, 1994a, 1994b, 1995, 1997) and **each was verified to yield exactly one distinct `t`** — 1994a/1994b are separate dirs, not one dir with a round column. The round machinery belongs to `sample` / `cluster_features` / the 2004–2009 aggregates, untouched here.

Row math confirms: 54,820 wave rows − 54,693 country rows = **127**, the documented real repeat-acquisitions that core correctly sums.

Tests: 3 passed + 41 structural.

Refs #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
