### PR TITLE
fix: get development to green — and CotedIvoire's GPS is real, just never dvc-added

### DIFF
--- a/lsms_library/countries/CotedIvoire/_/data_scheme.yml
+++ b/lsms_library/countries/CotedIvoire/_/data_scheme.yml
@@ -10,11 +10,32 @@ Data Scheme:
     Rural: str
 
   cluster_features:
+    # Latitude / Longitude are `optional:` because the source they come from is
+    # NOT in the shipped distribution -- NOT because CotedIvoire lacks cluster
+    # GPS.  It has it: 2018-19/_/data_info.yml wires `df_geo` to
+    # Menage/grappe_gps_CIV2018.dta (1084 grappes; columns grappe,
+    # coordonnes_gps__Latitude, coordonnes_gps__Longitude), and that wiring is
+    # correct -- the column names match the file exactly.  The problem is that
+    # this one file was never `dvc add`ed: it carries no .dvc sidecar, whereas
+    # every EHCVM sibling (Senegal / Mali / Niger / Burkina_Faso / Benin / Togo
+    # / Guinea-Bissau) has grappe_gps_<iso>2018.dta.dvc.  So in any clean
+    # checkout the file is simply absent, the GH #515 optional-sub-df fallback
+    # in country.py swallows the resulting PathMissingError, and Lat/Lon drop
+    # out silently.
+    #
+    # REMEDY (needs a human with S3 write creds -- it publishes a new blob to
+    # the shared dataset): `dvc add` + `dvc push` the GPS file, then delete the
+    # two `optional:` markers below.  No other change is required; the columns
+    # will flow through the existing df_geo merge as soon as the file resolves.
     index: (t, v)
     Region: str
     Rural: str
-    Latitude: float
-    Longitude: float
+    Latitude:
+      type: float
+      optional: true
+    Longitude:
+      type: float
+      optional: true
 
   household_roster:
     index: (t, i, pid)

--- a/tests/test_currency.py
+++ b/tests/test_currency.py
@@ -215,15 +215,23 @@ def test_feature_ghana_per_wave():
     if g.empty or CURRENCY_LEVEL not in g.index.names:
         pytest.skip("GhanaLSS food_expenditures unavailable")
     flat = g.reset_index()
-    by_wave = flat.groupby("t")[CURRENCY_LEVEL].agg(
-        lambda s: set(s.dropna().unique())
-    )
-    if "2005-06" in by_wave.index:
-        assert by_wave.loc["2005-06"] == {"GHC"}
-    post = [w for w in ("2012-13", "2016-17") if w in by_wave.index]
+    # Build the per-wave code sets directly rather than via groupby().agg():
+    # a reducer returning a ``set`` is a list-like, which pandas unwraps back
+    # into a Series element (``{'GHC'}`` -> ``['GHC']``), so the assertions
+    # below would compare a list against a set and fail on type alone.  A plain
+    # dict comprehension keeps the values honest ``set`` objects.
+    by_wave = {
+        wave: set(grp[CURRENCY_LEVEL].dropna().unique())
+        for wave, grp in flat.groupby("t")
+    }
+    # Set equality (not membership) is the point: a wave carrying *two* codes,
+    # or the wrong one, or none, must still fail.
+    if "2005-06" in by_wave:
+        assert by_wave["2005-06"] == {"GHC"}
+    post = [w for w in ("2012-13", "2016-17") if w in by_wave]
     for w in post:
-        assert by_wave.loc[w] == {"GHS"}
-    assert post or "2005-06" in by_wave.index, "no GhanaLSS waves materialized"
+        assert by_wave[w] == {"GHS"}
+    assert post or "2005-06" in by_wave, "no GhanaLSS waves materialized"
 
 
 def test_feature_non_monetary_unaffected():


### PR DESCRIPTION
`development` is currently **red** — 3 failing tests, all pre-existing and unrelated to the GH #323 work in flight. This gets it to green.

**Result: `3462 passed, 157 skipped, 4 xfailed, 1 xpassed, 0 failed`** (full suite, no `-x`).

## Fix 1 — `test_currency.py::test_feature_ghana_per_wave`

A bug in the **test's assertion**, not the library. It built per-wave code sets with `groupby().agg(lambda s: set(...))` — but a reducer returning a `set` is a *list-like*, so pandas unwraps it back into a Series element, and `{'GHC'}` came back as `['GHC']`. The comparison failed on **type alone**; the value was right all along.

Replaced the `agg` with a plain dict comprehension over `flat.groupby("t")`, so the values are honest `set` objects. Assertions remain set **equality** (`== {"GHC"}`), not membership — a wave carrying two codes, the wrong code, or none still fails. Not weakened into a tautology.

## Fixes 2 & 3 — CotedIvoire `cluster_features`: the GPS is REAL and was being silently swallowed

`data_scheme.yml:16-17` declares `Latitude` / `Longitude`; the country returns only `['Region', 'Rural']`. The obvious reading is that the declaration is stale. **It is not, and deleting it would have destroyed a live feature.**

- `2018-19/_/data_info.yml` **already** wires a `df_geo` sub-df to `Menage/grappe_gps_CIV2018.dta`, requesting `coordonnes_gps__Latitude` / `coordonnes_gps__Longitude`.
- The actual file has **1084 grappes** and columns `grappe, coordonnes_gps__Latitude, coordonnes_gps__Longitude, …`. The YAML names match **exactly** — so this is *not* the Ethiopia `lat_dd_mod` / `LAT_DD_MOD` casing bug.
- **The real defect: the file was never `dvc add`ed.** It has **no `.dvc` sidecar**, while all seven EHCVM siblings do:

```
CotedIvoire    .../Menage/grappe_gps_CIV2018.dta        <- raw file, NO sidecar
Senegal        .../grappe_gps_sen2018.dta.dvc           <- tracked
Mali           .../grappe_gps_mli2018.dta.dvc           <- tracked
Niger          .../grappe_gps_ner2018.dta.dvc           <- tracked
Burkina_Faso   .../grappe_gps_bfa2018.dta.dvc           <- tracked
Benin          .../grappe_gps_ben2018.dta.dvc           <- tracked
Togo           .../grappe_gps_tgo2018.dta.dvc           <- tracked
Guinea-Bissau  .../grappe_gps_gnb2018.dta.dvc           <- tracked
```

It exists only as a stray, gitignored, untracked artifact on one machine. So in **any clean checkout** the file is absent → `PathMissingError` → the GH #515 optional-sub-df fallback (`country.py:995-1022`) **eats it** → Lat/Lon vanish with only a warning. That warning was captured in a cold rebuild.

The columns are therefore **unavailable in the shipped distribution, but not unavailable in reality.**

### What this PR does

Marks them `optional: true` — the mechanism that **already exists** (honored by `_check_declared_columns` and `test_declared_columns_present`). This **keeps** the declaration and the `df_geo` merge intact, so **the columns light up automatically the moment the file is tracked.** Nothing is deleted. The YAML comment records the evidence and the remedy.

### What this PR deliberately does NOT do — needs a maintainer

**The actual fix is `dvc add` + `dvc push` on that GPS file.** Write credentials are present (`.dvc/s3_write_creds`), so it is mechanically possible. It was deliberately not done, because it would publish an **unverified stray blob of unknown provenance** into the shared dataset that every downstream user pulls — a permanent, irreversible write, well outside a get-to-green diff.

It looks right. But *"looks right" is not provenance.*

**Once you confirm the file is the genuine WB EHCVM extract: `dvc add` + `dvc push` it and drop the two `optional:` markers.** No other change is required — the wiring is already there and will start working.

## Verification

Full suite, **no `-x`**, 32 workers, `PYTHONPATH` + `LSMS_COUNTRIES_ROOT` pinned to the worktree (asserted `'worktrees' in lsms_library.__file__`). **3,624 tests collected** — more than the 3,471 baseline, not fewer, so the suite genuinely ran end to end.

Diff is confined to `tests/test_currency.py` and `CotedIvoire/_/data_scheme.yml`. **No library code touched**, so GH #323 Sites 1/2/4 are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
