### PR TITLE
fix(#323): Nigeria — the bare 'ea' is unique only within an LGA; 500 W1 clusters were conflated into 411

### DIFF
--- a/.coder/ledger/323-nigeria.md
+++ b/.coder/ledger/323-nigeria.md
@@ -1,0 +1,200 @@
+# Prior-Art Ledger — GH #323 (Nigeria)
+
+**Search tier used:** ripgrep + git floor (the GitNexus MCP server is not mounted
+in this subagent; blast radius established by direct call-site enumeration
+instead — `_normalize_dataframe_index` has 4 call sites, all internal to
+`country.py`).
+
+## §1 Task, restated
+
+`_normalize_dataframe_index` collapses a non-unique DECLARED index with
+`groupby().first()`, silently discarding the dropped rows. For Nigeria the audit
+reports 10 affected cells: `cluster_features` in all 8 W1–W4 quarters, and
+`assets` in 2012Q3 + 2013Q1. The task is to fix the *cause* in Nigeria's config,
+not to paper over the symptom, and to leave the collapse either impossible or
+explicitly DECLARED.
+
+Two independent root causes, both `INDEX_INCOMPLETE`:
+
+1. **`v = ea` is not a cluster id.** In the GHS-Panel, `ea` is a serial unique
+   only *within* an LGA. W1's design is 500 EAs × 10 HH = 5,000 households, but
+   `nunique(ea) = 411`; `nunique(state, lga, ea) = 500`. So the key MERGES
+   distinct clusters, and the household→cluster collapse then stamps one
+   arbitrary EA's Region/District/Rural onto every household in the merged group
+   (890/5000 wrong District in W1 alone; 1283/5263 by W4). Class-1, silently
+   WRONG — and it leaks everywhere, because `sample()` publishes the same key and
+   `_join_v_from_sample()` stamps it onto every household table.
+2. **`assets` W2 drops `item_seq`.** `sect5b_plantingw2` is a PER-UNIT roster
+   (one row per individual unit owned, each with its own age and resale value);
+   `dup(hhid,item_cd) = 14,493`, `dup(hhid,item_cd,item_seq) = 0`. `.first()`
+   kept unit #1 and discarded the rest: **₦147,297,485 (25.6%)** of reported
+   asset value, in each of the wave's two quarters.
+
+Two defects sat on top of (1): the `dfs:` block merged two HOUSEHOLD-level frames
+on `v` (a cartesian product within each EA — W2's `cluster_features` was 62,538
+rows from 4,859 households), and the geo sub-df was silently dropped in 3 of 4
+waves (wrong column casing in W1/W3; W4's geovars file has no `ea` column at
+all), so Latitude/Longitude were simply MISSING.
+
+## §2 Existing machinery (this task's area)
+
+| symbol | path:line | what it does | tested? | reuse / extend / new |
+|--------|-----------|--------------|---------|----------------------|
+| `_normalize_dataframe_index` | `country.py:4100` | reorders/drops index levels, then collapses duplicates with `.first()` (or `sum` for `_ADDITIVE_MEASURE_COLUMNS`) | yes | **leave unchanged** (D1: core does not aggregate). The composite key makes its collapse lossless for Region/District/Rural |
+| `aggregation:` key | `Albania/_/data_scheme.yml:83` + 7 others | **DEAD**: appears only in the `_skip` meta-key sets (`country.py:2387`, `diagnostics.py:230`); parsed and discarded, never enforced | no | **do NOT use** — D1 rejects making it real; it stays dead config, so Nigeria declares none |
+| `Wave.cluster_features` | `country.py:1168` | GH #161: when `i` is in the index, collapses HH→cluster with `.first()` / **`.mean()` for Lat/Lon** | partly | **leave unchanged** — this is #323 Site 2, owned centrally (PR #617), not per-country |
+| `_join_v_from_sample` | `country.py:~1620` | left-merges `sample().v` onto every household table | yes | reuse unchanged (but see §4) |
+| `community_prices_for_wave` | `nigeria.py:~1990` | builds `v = format_id(ea)` from the community questionnaire | yes | **extend** — same keyspace or the join dies |
+| `df_data_grabber` "Trickier" form | `local_tools.py:1034` | `{newvar: ([cols], fn)}` → row-wise transform; auto-bound by NAME (Benin's `i()`) | yes | **reuse** — one `nigeria.v()` serves sample + cluster_features |
+| `converted_categoricals:` | `country.py:933` | per-sub-df flag; when set, `get_dataframe(convert_categoricals=False)` → raw CODES | yes (EthiopiaRHS, Albania) | **reuse** — needed for the code-space key |
+
+## §3 Definitions & conventions in force
+
+- `sample` is the single source of truth for household→cluster; `v` lives there
+  and is joined at API time. Per `CLAUDE.md` "`sample()` and Cluster Identity".
+- Canonical `assets` grain is **`(t, i, j)`** — `lsms_library/data_info.yml`,
+  `Index Info > index_info`. A 4-level Nigeria would break `Feature('assets')`
+  assembly against every 3-level country (the same hazard CLAUDE.md documents for
+  `food_expenditures`' `s` level).
+- Canonical `cluster_features` grain is `(t, v)`; `cluster_features` OWNS `v`.
+- class-2 (silently MISSING) is strictly safer than class-1 (silently WRONG).
+
+## §4 Invariants & assumptions
+
+- **A NaN `v` is NOT a safe "missing" value.** `_join_v_from_sample` left-merges,
+  so rows survive — but the guard at `country.py:~1272` documents that the
+  downstream `groupby()` in `roster_to_characteristics` / the food-derivation
+  pipeline **drops NaN keys**, silently swallowing those households from every
+  derived table. So the `ea == 0` "Moved" households cannot be given `v = NA`;
+  that would trade one silent-data-loss bug for another. They get an explicit
+  singleton (`moved-{hhid}`) instead — present, never pooled, never dropped.
+- **The keyspace must be built from CODES, not labels.** Measured: in W2 the
+  community questionnaire's `state`/`lga` carry no Stata value labels while the
+  household file's do, so a label-built composite gives **0%** overlap between
+  `community_prices.v` and `sample.v`; a code-built one gives **100%**. A
+  label-built key would have silently severed community prices from their
+  households.
+- `_finalize_result` does `df.dropna(how='all')` (`country.py:2217`): a row whose
+  every column the `unique` reducer NA's out disappears entirely. Harmless with a
+  correct key (Region/District are functions of the key), but it is why a
+  half-migrated state showed W2 at 377 instead of 410 groups.
+- `@build_transform()` (`_build_registry.py:69`) folds the decorated function's
+  SOURCE into every table's cache fingerprint. Editing `_normalize_dataframe_index`
+  invalidates **all** cached parquets → the next build rebuilds from source. Any
+  before/after comparison must therefore rebuild both sides from source, or it
+  compares fresh output against a stale cache and reports phantom regressions.
+
+## §5 Reuse decision
+
+| quantity | decision | why |
+|---|---|---|
+| cluster id `v` | **new** (`nigeria.cluster_id` / `nigeria.v`) | no existing composite-key helper; auto-bound by name so `sample`, `cluster_features` and `community_prices` cannot drift apart |
+| HH→cluster collapse | **leave to core** | Ethan's D1 (2026-07-13): core does NOT aggregate on declaration. The composite key makes the existing `.first()` collapse *provably lossless* for Region/District/Rural, which is the whole point — fix the KEY, don't declare a reducer over a broken one |
+| `assets` item_seq | **not fixed here** — reported instead | needs two CORE edits (canonical `index_info` + `feature.py`); see §7 |
+| Lat/Lon reducer | **leave to core (Site 2)** | `mean()` is retained; auditing the HH→cluster collapse is owned centrally, not per-country |
+
+## §6 What was built  *(config only — `lsms_library/*.py` is UNTOUCHED)*
+
+This branch is the **config-only port** of `fix/323-nigeria`, off `origin/development`.
+The original branch's +139-line `country.py` patch (`_aggregation_policy`,
+`_apply_aggregation_policy`, `_unique_or_na`, and a `Wave.cluster_features` hunk)
+was **stripped** under D1, together with both `aggregation:` keys it fed
+(`cluster_features`, `assets`) — with core stripped those are dead config, since
+`aggregation:` lives only in core's `_skip` meta-key set.
+
+- **`nigeria.py`** — `cluster_id(state, lga, ea, hhid)` + the auto-bound `v(row)`;
+  `community_prices_for_wave` builds `v` through the same helper.
+- **wave YAMLs (all 5)** — `v: [state, lga, ea, hhid]` via a `converted_categoricals`
+  `df_key` sub-df (raw codes) alongside the labelled `df_main`; geo joined on `i`
+  (not `v`) — un-cartesianing the merge; per-wave geo column casing corrected.
+  W5's `sample` is fixed too: it has no `cluster_features`, but its `sample.v` is
+  stamped on every household table and was equally broken.
+- **`data_scheme.yml`** — no `aggregation:` key. Comments record *why* the collapse
+  is now sound (the key, not a reducer), and carry the `assets` open defect.
+
+### Measured, per round (`LSMS_NO_CACHE=1`, vs. a real `development` baseline build)
+
+`v` nunique in `sample`, **development → this branch**:
+
+| wave | pp quarter | ph quarter |
+|---|---|---|
+| 2010-11 | 2010Q3: 411 → **500** | 2011Q1: 411 → **500** |
+| 2012-13 | 2012Q3: 408 → 647 | 2013Q1: 408 → 647 |
+| 2015-16 | 2015Q3: 402 → 792 | 2016Q1: 402 → 792 |
+| 2018-19 | 2018Q3: 405 → 685 | 2019Q1: 405 → 685 |
+| 2023-24 | 2023Q3: 404 → 911 | 2024Q1: 404 → 911 |
+
+W1's 500-EA design is recovered **in both rounds**. (Post-W1 counts include the
+`moved-{hhid}` singletons: e.g. W3 = 486 real clusters + 306 movers = 792.)
+
+`cluster_features` Latitude present, **development → this branch**: 2010Q3 0 → 500,
+2012Q3 409 → 645, 2015Q3 0 → 784, 2018Q3 0 → 671 (and identically in each wave's
+ph quarter). Coordinates recovered in 3 of the 4 waves that declare the table.
+
+### Round safety (the pp/ph question)
+
+- **`v` is round-invariant**: 0 households change cluster between the pp and ph
+  quarter, in all 5 waves. It holds *by construction* — a wave folder has ONE
+  `data_info.yml` and both `Wave(t)`s read the SAME post-planting cover page, so
+  there is no second geo-coding to drift from.
+- Against the *raw* cover pages the only pp/ph disagreement is the `Moved`
+  sentinel: 0 / 17 / 41 / 66 / 64 households (W1…W5) are in a real EA at planting
+  and coded `ea == 0` at harvest, i.e. they relocated between the two visits.
+  **Zero** real-EA→real-EA disagreements — so no geo-recode, no label/code drift,
+  no `.0` float-suffix artefact. Using the planting frame's cluster for the whole
+  wave is the right call: `v` is the *sampling* cluster, fixed by the frame.
+- The `Moved` sentinel fires when it should and **only** when it should: 0 times in
+  W1 (nobody can have moved out of a frame they were just drawn from), and
+  152/306/166/393 times in W2–W5.
+- `cluster_features` carries **both** quarters with identical cluster sets and zero
+  attribute mismatches — neither round overwrites the other. 0 duplicate `(t,v)`.
+- `community_prices` is correctly post-harvest-only. Structurally verified: across
+  all 5 waves there are **11 `sectc8*` files and every one is `_harvest`** — no
+  `sectc8*_planting*` exists. The planting community files that *do* carry
+  `item_cd` (`sectc2_plantingw1`, `sectc2a/b_plantingw3`) have **no price column**;
+  C2 is an availability module. No planting-round price data is being dropped.
+- `sample` grain is unchanged by the rekey: 49,770 rows on `development` and on this
+  branch — one row per (household, round), 0 duplicate `(i,t)`.
+
+## §7 Residuals / honest gaps
+
+- **`assets` item_seq is NOT fixed and is still broken.** W2's per-unit roster
+  (`sect5b_plantingw2`, `item_seq` 1..15) is collapsed by `groupby().first()`,
+  keeping unit #1: true ₦576,299,043 → kept ₦429,001,558 → **₦147,297,485 (25.6%)
+  destroyed**, in *each* of 2012Q3 and 2013Q1. The original branch fixed this with
+  an `aggregation:` reducer, which D1 rejects. Declaring `item_seq` in Nigeria's
+  index does **not** close it either — *verified*: the canonical assets grain is
+  `(t,i,j)`, so `Feature('assets')` calls `_harmonize_country_frame`, drops the
+  extra level, and `_collapse_duplicate_index` re-reduces with `first()` (assets is
+  not in `_ADDITIVE_MEASURE_COLUMNS`). A 4-level Nigeria would fix
+  `Country.assets()`, leave `Feature('assets')` destroying the identical ₦147M, and
+  make Nigeria the library's only non-canonical assets grain. The real fix is two
+  CORE edits and belongs on its own PR:
+  1. `lsms_library/data_info.yml` → `index_info: assets: (t, i, j, item_seq)`
+  2. `lsms_library/feature.py` → `_ADDITIVE_MEASURE_COLUMNS['assets'] = ('Value',)`
+     (`Quantity` must stay `first` — it comes from the clean `sect5a` hh×item grid
+     and is merely repeated across the `item_seq` rows; `Age` wants `mean`.)
+  Recorded as a KNOWN OPEN DEFECT block in `Nigeria/_/data_scheme.yml`.
+- **Lat/Lon still collapse with `.mean()`** (core's Site-2 default). 5 / 24 / 50
+  clusters in W2 / W3 / W4 span more than one coordinate — the panel keeps a moved
+  household's ORIGINAL `ea` in the frame while the geovariables record its CURRENT
+  dwelling, so households up to ~890 km apart get a centroid in neither place. The
+  original branch NA'd these via a `unique` reducer; under D1 that is core's Site 2
+  to own, not Nigeria's. Behaviour here is the historical one, not a regression.
+- **`moved-` singletons inflate `cluster_features` row counts** (e.g. W3: 792 rows =
+  486 real clusters + 306 one-household "clusters"). Deliberate: a NaN `v` would be
+  dropped by the downstream `groupby()` and delete those households from every
+  derived table. Analysts computing cluster-level means should be aware.
+- **`v` is wave-local, not panel-stable.** LGA codes are recoded between waves, so
+  the composite is comparable within a wave, not across. The previous `v = ea` was
+  numerically comparable across waves but *meaningless* (it conflated clusters), so
+  no real cross-wave linkage is lost.
+- **~0.2–0.4% of `community_prices` clusters do not match a `sample` cluster** in
+  W2/W3 (join rate 99.6% / 99.8%; 100% in W1/W4/W5) — community questionnaires
+  administered in EAs where no sampled household resolved. Left visible rather than
+  force-matched.
+- **W5 declares no `cluster_features`**, so `community_prices` at 2024Q1 joins
+  `sample.v` at 100% but `cluster_features` at 0%. Pre-existing gap, not a
+  regression from this port.
+- W1 `assets` still has no `Value`/`Age` (the W1 YAML never extracted them; the
+  source section has no such columns). Pre-existing, unrelated to #323.

--- a/lsms_library/countries/Nigeria/2010-11/_/community_prices.py
+++ b/lsms_library/countries/Nigeria/2010-11/_/community_prices.py
@@ -3,8 +3,8 @@
 
 Item-level reported community food prices at grain (t, v, j, u) from the
 post-harvest COMMUNITY questionnaire's food-price module (Section C8,
-sectc8_harvestw1.csv).  CLUSTER-level (no household i); v = format_id(ea)
-is the community EA id, the SAME keyspace as sample().v.  W1 uses the
+sectc8_harvestw1.csv).  CLUSTER-level (no household i); v = cluster_id(state, lga, ea) is the
+COMPOSITE community EA id (GH #323), the SAME keyspace as sample().v.  W1 uses the
 community questionnaire's OWN item-code scheme (mapped by name to canonical
 harmonize_food Preferred Labels) and carries no unit column (the unit is the
 per-item fixed questionnaire unit).  t = 2011Q1 (post-harvest quarter).

--- a/lsms_library/countries/Nigeria/2010-11/_/data_info.yml
+++ b/lsms_library/countries/Nigeria/2010-11/_/data_info.yml
@@ -1,33 +1,63 @@
 Country: Nigeria
 Wave: 2010-11
 
+# `v` is the COMPOSITE cluster id (state/lga/ea), not the bare `ea` serial --
+# see the GH #323 note in _/nigeria.py.  `df_key` re-reads the same file with
+# `converted_categoricals` set (which makes get_dataframe skip the Stata label
+# decode) so the key is built from raw numeric CODES: the community
+# questionnaire that community_prices reads has no value labels on state/lga,
+# so a label-built key would not join it.  `df_main` keeps the decoded labels
+# for the human-readable Region / District / Rural columns.
 sample:
-    file: Post Planting Wave 1/Household/secta_plantingw1.dta
-    idxvars:
-        i: hhid
-    myvars:
-        v: ea
-        weight: wt_wave1
-        panel_weight: wt_wave1
-        strata: zone
-        Rural:
-            - sector
-            - mapping:
-                rural: Rural
-                Rural: Rural
-                RURAL: Rural
-                urban: Urban
-                Urban: Urban
-                URBAN: Urban
-
-cluster_features:
     dfs:
+        - df_key
         - df_main
-        - df_geo
+    df_key:
+        file: Post Planting Wave 1/Household/secta_plantingw1.dta
+        converted_categoricals: true
+        idxvars:
+            i: hhid
+        myvars:
+            v: [state, lga, ea, hhid]
     df_main:
         file: Post Planting Wave 1/Household/secta_plantingw1.dta
         idxvars:
-            v: ea
+            i: hhid
+        myvars:
+            weight: wt_wave1
+            panel_weight: wt_wave1
+            strata: zone
+            Rural:
+                - sector
+                - mapping:
+                    rural: Rural
+                    Rural: Rural
+                    RURAL: Rural
+                    urban: Urban
+                    Urban: Urban
+                    URBAN: Urban
+    merge_on:
+        - i
+    final_index:
+        - t
+        - i
+
+cluster_features:
+    dfs:
+        - df_key
+        - df_main
+        - df_geo
+    df_key:
+        file: Post Planting Wave 1/Household/secta_plantingw1.dta
+        converted_categoricals: true
+        idxvars:
+            i: hhid
+        myvars:
+            v: [state, lga, ea, hhid]
+    df_main:
+        file: Post Planting Wave 1/Household/secta_plantingw1.dta
+        idxvars:
+            i: hhid
         myvars:
             Region: zone
             District: state
@@ -40,17 +70,26 @@ cluster_features:
                     urban: Urban
                     Urban: Urban
                     URBAN: Urban
+    # Geovariables are HOUSEHOLD-level, so they join on `i`.  Joining them on
+    # `v` (as this block used to) is a many-to-many merge between two
+    # household-level frames -- a cartesian product within each EA, which is
+    # what inflated W2's cluster_features to 62,538 rows.  This file's columns
+    # are lowercase; W2/W3's are uppercase.  Asking for the wrong casing makes
+    # df_data_grabber raise KeyError, which the GH #515 handler catches by
+    # DROPPING the sub-df -- which is why Latitude/Longitude were missing from
+    # 3 of the 4 waves.
     df_geo:
         file: nga_householdgeovariables_y1.csv
         idxvars:
-            v: ea
+            i: hhid
         myvars:
-            Latitude: LAT_DD_MOD
-            Longitude: LON_DD_MOD
+            Latitude: lat_dd_mod
+            Longitude: lon_dd_mod
     merge_on:
-        - v
+        - i
     final_index:
         - t
+        - i
         - v
 
 assets:

--- a/lsms_library/countries/Nigeria/2012-13/_/community_prices.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/community_prices.py
@@ -3,7 +3,7 @@
 
 Item-level reported community food prices at grain (t, v, j, u) from the
 post-harvest COMMUNITY questionnaire's food-price module (Section C8,
-sectc8_harvestw2.csv).  CLUSTER-level (no household i); v = format_id(ea).
+sectc8_harvestw2.csv).  CLUSTER-level (no household i); v = cluster_id(state, lga, ea).
 W2 shares W1's community item-code scheme (mapped by name to canonical
 harmonize_food labels) and carries no unit column (per-item fixed unit).
 t = 2013Q1 (post-harvest quarter).  See the W1 wave script for why this is a

--- a/lsms_library/countries/Nigeria/2012-13/_/data_info.yml
+++ b/lsms_library/countries/Nigeria/2012-13/_/data_info.yml
@@ -1,33 +1,58 @@
 Country: Nigeria
 Wave: 2012-13
 
+# `v` = composite cluster id (state/lga/ea) built from raw CODES; see the
+# GH #323 note in _/nigeria.py and the W1 data_info.yml for the full rationale.
 sample:
-    file: Post Planting Wave 2/Household/secta_plantingw2.dta
-    idxvars:
-        i: hhid
-    myvars:
-        v: ea
-        weight: wt_wave2
-        panel_weight: wt_combined
-        strata: zone
-        Rural:
-            - sector
-            - mapping:
-                rural: Rural
-                Rural: Rural
-                RURAL: Rural
-                urban: Urban
-                Urban: Urban
-                URBAN: Urban
-
-cluster_features:
     dfs:
+        - df_key
         - df_main
-        - df_geo
+    df_key:
+        file: Post Planting Wave 2/Household/secta_plantingw2.dta
+        converted_categoricals: true
+        idxvars:
+            i: hhid
+        myvars:
+            v: [state, lga, ea, hhid]
     df_main:
         file: Post Planting Wave 2/Household/secta_plantingw2.dta
         idxvars:
-            v: ea
+            i: hhid
+        myvars:
+            weight: wt_wave2
+            panel_weight: wt_combined
+            strata: zone
+            Rural:
+                - sector
+                - mapping:
+                    rural: Rural
+                    Rural: Rural
+                    RURAL: Rural
+                    urban: Urban
+                    Urban: Urban
+                    URBAN: Urban
+    merge_on:
+        - i
+    final_index:
+        - t
+        - i
+
+cluster_features:
+    dfs:
+        - df_key
+        - df_main
+        - df_geo
+    df_key:
+        file: Post Planting Wave 2/Household/secta_plantingw2.dta
+        converted_categoricals: true
+        idxvars:
+            i: hhid
+        myvars:
+            v: [state, lga, ea, hhid]
+    df_main:
+        file: Post Planting Wave 2/Household/secta_plantingw2.dta
+        idxvars:
+            i: hhid
         myvars:
             Region: zone
             District: state
@@ -40,17 +65,22 @@ cluster_features:
                     urban: Urban
                     Urban: Urban
                     URBAN: Urban
+    # Joined on `i`, not `v`: both frames are household-level, so merging them
+    # on the cluster key was a cartesian product within each EA -- that is what
+    # made this wave's cluster_features 62,538 rows from 4,859 households.
+    # This file's lat/lon columns are UPPERCASE (W1's and W4's are lowercase).
     df_geo:
         file: nga_householdgeovars_y2.csv
         idxvars:
-            v: ea
+            i: hhid
         myvars:
             Latitude: LAT_DD_MOD
             Longitude: LON_DD_MOD
     merge_on:
-        - v
+        - i
     final_index:
         - t
+        - i
         - v
 
 assets:

--- a/lsms_library/countries/Nigeria/2015-16/_/community_prices.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/community_prices.py
@@ -4,7 +4,7 @@
 Item-level reported community food prices at grain (t, v, j, u) from the
 post-harvest COMMUNITY questionnaire's food-price module (Section C8).  W3
 splits the module across sectc8a_harvestw3.dta and sectc8b_harvestw3.dta
-(different item ranges).  CLUSTER-level (no household i); v = format_id(ea).
+(different item ranges).  CLUSTER-level (no household i); v = cluster_id(state, lga, ea).
 W3 item_cd is the consumption-module scheme already in harmonize_food
 (resolved via Code); c8q2 is the per-row unit label, c8q3 the reported price.
 t = 2016Q1 (post-harvest quarter).

--- a/lsms_library/countries/Nigeria/2015-16/_/data_info.yml
+++ b/lsms_library/countries/Nigeria/2015-16/_/data_info.yml
@@ -1,37 +1,62 @@
 Country: Nigeria
 Wave: 2015-16
 
+# `v` = composite cluster id (state/lga/ea) built from raw CODES; see the
+# GH #323 note in _/nigeria.py and the W1 data_info.yml for the full rationale.
 sample:
-    file: secta_plantingw3.dta
-    idxvars:
-        i: hhid
-    myvars:
-        v: ea
-        weight: wt_wave3
-        panel_weight: wt_w1_w2_w3
-        strata: zone
-        Rural:
-            - sector
-            - mapping:
-                1. URBAN: Urban
-                2. RURAL: Rural
-                1. Urban: Urban
-                2. Rural: Rural
-                rural: Rural
-                Rural: Rural
-                RURAL: Rural
-                urban: Urban
-                Urban: Urban
-                URBAN: Urban
-
-cluster_features:
     dfs:
+        - df_key
         - df_main
-        - df_geo
+    df_key:
+        file: secta_plantingw3.dta
+        converted_categoricals: true
+        idxvars:
+            i: hhid
+        myvars:
+            v: [state, lga, ea, hhid]
     df_main:
         file: secta_plantingw3.dta
         idxvars:
-            v: ea
+            i: hhid
+        myvars:
+            weight: wt_wave3
+            panel_weight: wt_w1_w2_w3
+            strata: zone
+            Rural:
+                - sector
+                - mapping:
+                    1. URBAN: Urban
+                    2. RURAL: Rural
+                    1. Urban: Urban
+                    2. Rural: Rural
+                    rural: Rural
+                    Rural: Rural
+                    RURAL: Rural
+                    urban: Urban
+                    Urban: Urban
+                    URBAN: Urban
+    merge_on:
+        - i
+    final_index:
+        - t
+        - i
+
+cluster_features:
+    dfs:
+        - df_key
+        - df_main
+        - df_geo
+    df_key:
+        file: secta_plantingw3.dta
+        converted_categoricals: true
+        idxvars:
+            i: hhid
+        myvars:
+            v: [state, lga, ea, hhid]
+    df_main:
+        file: secta_plantingw3.dta
+        idxvars:
+            i: hhid
         myvars:
             Region: zone
             District: state
@@ -48,17 +73,22 @@ cluster_features:
                     urban: Urban
                     Urban: Urban
                     URBAN: Urban
+    # Joined on `i` (household), not `v`.  This file's lat/lon columns are
+    # UPPERCASE; asking for the lowercase names made df_data_grabber raise
+    # KeyError, which the GH #515 handler swallows by dropping the sub-df --
+    # which is why W3 had no Latitude/Longitude at all.
     df_geo:
         file: NGA_HouseholdGeovars_Y3.dta
         idxvars:
-            v: ea
+            i: hhid
         myvars:
-            Latitude: lat_dd_mod
-            Longitude: lon_dd_mod
+            Latitude: LAT_DD_MOD
+            Longitude: LON_DD_MOD
     merge_on:
-        - v
+        - i
     final_index:
         - t
+        - i
         - v
 
 assets:

--- a/lsms_library/countries/Nigeria/2018-19/_/community_prices.py
+++ b/lsms_library/countries/Nigeria/2018-19/_/community_prices.py
@@ -3,7 +3,7 @@
 
 Item-level reported community food prices at grain (t, v, j, u) from the
 post-harvest COMMUNITY questionnaire's food-price module (Section C8,
-sectc8_harvestw4.dta).  CLUSTER-level (no household i); v = format_id(ea).
+sectc8_harvestw4.dta).  CLUSTER-level (no household i); v = cluster_id(state, lga, ea).
 W4 item_cd is the consumption-module scheme already in harmonize_food
 (resolved via Code); c8q2 is the per-row unit label, c8q3 the reported price.
 t = 2019Q1 (post-harvest quarter).

--- a/lsms_library/countries/Nigeria/2018-19/_/data_info.yml
+++ b/lsms_library/countries/Nigeria/2018-19/_/data_info.yml
@@ -1,37 +1,62 @@
 Country: Nigeria
 Wave: 2018-19
 
+# `v` = composite cluster id (state/lga/ea) built from raw CODES; see the
+# GH #323 note in _/nigeria.py and the W1 data_info.yml for the full rationale.
 sample:
-    file: secta_plantingw4.dta
-    idxvars:
-        i: hhid
-    myvars:
-        v: ea
-        weight: wt_wave4
-        panel_weight: wt_longpanel
-        strata: strata
-        Rural:
-            - sector
-            - mapping:
-                1. URBAN: Urban
-                2. RURAL: Rural
-                1. Urban: Urban
-                2. Rural: Rural
-                rural: Rural
-                Rural: Rural
-                RURAL: Rural
-                urban: Urban
-                Urban: Urban
-                URBAN: Urban
-
-cluster_features:
     dfs:
+        - df_key
         - df_main
-        - df_geo
+    df_key:
+        file: secta_plantingw4.dta
+        converted_categoricals: true
+        idxvars:
+            i: hhid
+        myvars:
+            v: [state, lga, ea, hhid]
     df_main:
         file: secta_plantingw4.dta
         idxvars:
-            v: ea
+            i: hhid
+        myvars:
+            weight: wt_wave4
+            panel_weight: wt_longpanel
+            strata: strata
+            Rural:
+                - sector
+                - mapping:
+                    1. URBAN: Urban
+                    2. RURAL: Rural
+                    1. Urban: Urban
+                    2. Rural: Rural
+                    rural: Rural
+                    Rural: Rural
+                    RURAL: Rural
+                    urban: Urban
+                    Urban: Urban
+                    URBAN: Urban
+    merge_on:
+        - i
+    final_index:
+        - t
+        - i
+
+cluster_features:
+    dfs:
+        - df_key
+        - df_main
+        - df_geo
+    df_key:
+        file: secta_plantingw4.dta
+        converted_categoricals: true
+        idxvars:
+            i: hhid
+        myvars:
+            v: [state, lga, ea, hhid]
+    df_main:
+        file: secta_plantingw4.dta
+        idxvars:
+            i: hhid
         myvars:
             Region: zone
             District: state
@@ -48,17 +73,22 @@ cluster_features:
                     urban: Urban
                     Urban: Urban
                     URBAN: Urban
+    # This wave's geovariables file has NO `ea` column at all (hhid, lat, lon
+    # only), so the old `merge_on: [v]` could not join it and W4 silently lost
+    # Latitude/Longitude.  Joining on `i` (household) is both correct and the
+    # only thing that works here.
     df_geo:
         file: nga_householdgeovars_y4.dta
         idxvars:
-            v: ea
+            i: hhid
         myvars:
             Latitude: lat_dd_mod
             Longitude: lon_dd_mod
     merge_on:
-        - v
+        - i
     final_index:
         - t
+        - i
         - v
 
 assets:

--- a/lsms_library/countries/Nigeria/2023-24/_/community_prices.py
+++ b/lsms_library/countries/Nigeria/2023-24/_/community_prices.py
@@ -4,7 +4,7 @@
 Item-level reported community food prices at grain (t, v, j, u) from the
 post-harvest COMMUNITY questionnaire's food-price module (Section C8,
 Post Harvest Wave 5/Community/sectc8_harvestw5.dta).  CLUSTER-level (no
-household i); v = format_id(ea).  W5 item_cd is the consumption-module scheme
+household i); v = cluster_id(state, lga, ea).  W5 item_cd is the consumption-module scheme
 already in harmonize_food (resolved via Code); the per-row unit label is
 c8aq2_b, the reported price c8aq3.  t = 2024Q1 (post-harvest quarter).
 """

--- a/lsms_library/countries/Nigeria/2023-24/_/data_info.yml
+++ b/lsms_library/countries/Nigeria/2023-24/_/data_info.yml
@@ -7,36 +7,57 @@ Wave: 2023-24
 # The script handles the pp/ph concat and t-value assignment
 # (2023Q3 / 2024Q1) per the pp-ph skill.
 
+# `v` = composite cluster id (state/lga/ea) built from raw CODES; see the
+# GH #323 note in _/nigeria.py.  This wave has no cluster_features table, but
+# sample.v is what _join_v_from_sample() stamps onto every household table, so
+# the bare `ea` key is just as wrong here: it collapses the wave's 719 real
+# (state, lga, ea) clusters into 404 `ea` codes.  393 households carry the
+# ea == 0 'Moved' sentinel and become singletons.
 sample:
-    file: Post Planting Wave 5/Household/secta_plantingw5.dta
-    idxvars:
-        i: hhid
-    myvars:
-        v: ea
-        weight: wt_cross_wave5
-        panel_weight: wt_longpanel_wave5
-        strata:
-            - strata
-            - mapping:
-                1: North Central
-                2: North East
-                3: North West
-                4: South East
-                5: South South
-                6: South West
-        Rural:
-            - sector
-            - mapping:
-                1. URBAN: Urban
-                2. RURAL: Rural
-                1. Urban: Urban
-                2. Rural: Rural
-                rural: Rural
-                Rural: Rural
-                RURAL: Rural
-                urban: Urban
-                Urban: Urban
-                URBAN: Urban
+    dfs:
+        - df_key
+        - df_main
+    df_key:
+        file: Post Planting Wave 5/Household/secta_plantingw5.dta
+        converted_categoricals: true
+        idxvars:
+            i: hhid
+        myvars:
+            v: [state, lga, ea, hhid]
+    df_main:
+        file: Post Planting Wave 5/Household/secta_plantingw5.dta
+        idxvars:
+            i: hhid
+        myvars:
+            weight: wt_cross_wave5
+            panel_weight: wt_longpanel_wave5
+            strata:
+                - strata
+                - mapping:
+                    1: North Central
+                    2: North East
+                    3: North West
+                    4: South East
+                    5: South South
+                    6: South West
+            Rural:
+                - sector
+                - mapping:
+                    1. URBAN: Urban
+                    2. RURAL: Rural
+                    1. Urban: Urban
+                    2. Rural: Rural
+                    rural: Rural
+                    Rural: Rural
+                    RURAL: Rural
+                    urban: Urban
+                    Urban: Urban
+                    URBAN: Urban
+    merge_on:
+        - i
+    final_index:
+        - t
+        - i
 
 individual_education:
     # GH #171: highest education level completed per household member.

--- a/lsms_library/countries/Nigeria/_/CONTENTS.org
+++ b/lsms_library/countries/Nigeria/_/CONTENTS.org
@@ -46,7 +46,49 @@ this rotating panel design.
 
 ** Cluster (PSU) identifier
 
-=ea= is consistent across all five waves.
+*=ea= ALONE IS NOT THE CLUSTER ID* (GH #323).  It is a serial number unique
+only /within/ an LGA, so the same =ea= value recurs in different LGAs and
+states.  Wave 1 is the proof --- the GHS-Panel design is 500 EAs x 10
+households = 5,000 households, but
+
+| key                          | distinct values |
+|------------------------------+-----------------|
+| =ea=                         |             411 |
+| =(state, lga, ea)=           |             500 |
+
+and the household geovariables confirm it independently: lat/lon is constant
+within all 500 =(state, lga, ea)= groups, but /varies/ inside 76 of the 411
+bare =ea= codes.  Keying on =ea= therefore merges distinct clusters; the
+household -> cluster collapse in =cluster_features= then hands one arbitrary
+EA's Region/District/Rural to every household in the merged group (890/5000
+households got the wrong District in W1; 1283/5263 by W4).
+
+=v= is therefore the *composite* id =state/lga/ea=, built from the raw numeric
+CODES by =nigeria.cluster_id()= and published identically by =sample=,
+=cluster_features= and =community_prices= (one keyspace --- see the note at the
+top of =_/nigeria.py=).  It is built from codes, not labels, because the
+community questionnaire carries no value labels on =state=/=lga=: a
+label-built key matches the household side 0% of the time in W2, a code-built
+one 100%.
+
+*The =Moved= sentinel.*  From W2 on, a tracked household that left its original
+EA is recorded with =ea == 0= --- surfacing as the label =Moved= (W2),
+=0. Moved= (W3), or a bare =0= (W4).  It is a missing-value sentinel, not a
+cluster: pooling it welds unrelated households from across the country into
+fake clusters like =(Lagos, ETI-OSA, Moved)=.  Such households have no sampling
+cluster and each gets its own singleton =v= (=moved-{hhid}=): 152 / 306 / 166 /
+393 households in W2 / W3 / W4 / W5.  They are deliberately NOT given a NaN
+=v=, which the downstream =groupby()= would silently drop from every derived
+table.
+
+Cluster counts after the fix (real clusters + moved singletons):
+
+| Wave    | real clusters | moved singletons |
+|---------+---------------+------------------|
+| 2010-11 |           500 |                0 |
+| 2012-13 |           495 |              152 |
+| 2015-16 |           486 |              306 |
+| 2018-19 |           519 |              166 |
 
 ** Strata
 

--- a/lsms_library/countries/Nigeria/_/community_prices.py
+++ b/lsms_library/countries/Nigeria/_/community_prices.py
@@ -3,8 +3,9 @@
 
 Item-level reported community food prices at grain (t, v, j, u) from the
 post-harvest COMMUNITY questionnaire's food-price module (Section C8).
-CLUSTER-level (no household i); v = format_id(ea) is the community EA id,
-the SAME keyspace as sample().v, so prices join households via their cluster.
+CLUSTER-level (no household i); v = cluster_id(state, lga, ea) is the community EA id -- the COMPOSITE key
+(GH #323: the bare `ea` serial is unique only within an LGA), the SAME
+keyspace as sample().v, so prices join households via their cluster.
 Stores the REPORTED surveyed Price ONLY -- no index, no cross-cluster
 median/mean, no HH-median imputation (those are transformations).
 

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -10,6 +10,27 @@ Data Scheme:
     Rural: str
 
   cluster_features:
+    # Built from the HOUSEHOLD cover page (one row per household), so the frame
+    # arrives at household grain and Wave.cluster_features() collapses it to
+    # the (t, v) cluster grain.  What makes that collapse SOUND is the key:
+    # `v` is the composite cluster id (state/lga/ea -- see the GH #323 note in
+    # _/nigeria.py), not the bare `ea` serial.  `ea` is unique only WITHIN an
+    # LGA, so keying on it merged distinct clusters and the collapse then
+    # stamped one arbitrary EA's Region/District onto the other's households
+    # (890/5000 W1 households got the wrong District).  With the composite key,
+    # Region/District/Rural are constant within the group BY CONSTRUCTION
+    # (state and lga are IN the key; zone and sector are functions of them), so
+    # the collapse is provably lossless for them.
+    #
+    # Latitude/Longitude are the exception and are NOT invariant from W2 on:
+    # the panel follows households that move while keeping their ORIGINAL ea in
+    # the sampling frame, so a mover's current coordinates differ from its
+    # cluster's.  Core reduces these with .mean() (the cluster centroid).  That
+    # is the historical behaviour and it is retained here deliberately: core
+    # does not aggregate on declaration (GH #323 D1), and auditing this
+    # household->cluster collapse is Site 2, owned centrally rather than
+    # per-country.  Measured spread: 5 / 24 / 50 clusters in W2 / W3 / W4 span
+    # more than one coordinate.  W1 is clean (0 of 500 groups disagree).
     index: (t, v)
     Region: str
     District: str
@@ -75,6 +96,55 @@ Data Scheme:
     index: (t, i)
     previous_i: str
   assets:
+    # KNOWN OPEN DEFECT (GH #323, Site 1) -- NOT fixed here; recorded so it is
+    # not rediscovered.  Wave 2 (t = 2012Q3 / 2013Q1) is the only wave whose
+    # asset module carries a PER-UNIT roster: sect5b_plantingw2 has one row per
+    # individual unit owned, enumerated by `item_seq` (1..15), each with its own
+    # age (s5q3) and its own resale value (s5q4).  A household owning 5 hoes
+    # gets 5 rows.  (dup on (hhid,item_cd) = 14,493; dup on
+    # (hhid,item_cd,item_seq) = 0 -- item_seq is precisely the level the
+    # canonical (t,i,j) grain drops.)  W1/W3/W4 have no such roster and are
+    # already unique on (t,i,j).
+    #
+    # Core collapses the per-unit rows with groupby().first(), which keeps unit
+    # #1 and DISCARDS the rest.  MEASURED (2026-07-13, LSMS_NO_CACHE=1):
+    #
+    #   true total (sum s5q4 over ALL units) : N576,299,043
+    #   what first() keeps (unit #1 only)    : N429,001,558
+    #   DESTROYED                            : N147,297,485  = 25.6%
+    #
+    # and it is destroyed in EACH of the two quarters the wave is tagged on
+    # (2012Q3 and 2013Q1 both return the same truncated N429,001,558).
+    #
+    # `item_seq` is exactly the missing level -- but declaring it here does NOT
+    # close the bug, and that was verified rather than assumed:
+    #
+    #   * the canonical assets grain (lsms_library/data_info.yml, Index Info >
+    #     index_info) is (t, i, j).  Feature('assets') calls
+    #     _harmonize_country_frame, which DROPS any level a country adds beyond
+    #     the canonical set, then _collapse_duplicate_index reduces the
+    #     resulting duplicates with first() -- because 'assets' is not listed in
+    #     feature.py's _ADDITIVE_MEASURE_COLUMNS (only 'food_acquired' is).
+    #   * so a 4-level Nigeria would repair Country('Nigeria').assets() and
+    #     Feature('assets') would re-destroy the identical N147M, while leaving
+    #     Nigeria the only country in the library with a non-canonical assets
+    #     grain.  A half-fix that also breaks cross-country consistency.
+    #
+    # The complete fix is therefore TWO edits, both outside this file and both
+    # with cross-country blast radius (they belong on their own PR):
+    #   1. lsms_library/data_info.yml : index_info assets -> (t, i, j, item_seq)
+    #   2. lsms_library/feature.py    : _ADDITIVE_MEASURE_COLUMNS['assets'] =
+    #                                   ('Value',)   [Quantity must stay first --
+    #                                   it comes from the clean sect5a hh x item
+    #                                   grid and is merely repeated across the
+    #                                   item_seq rows; summing it would multiply
+    #                                   it by the unit count.  Age wants mean.]
+    #
+    # Declaring a per-column reducer in THIS file was tried and REJECTED (GH
+    # #323 D1: core does not aggregate on declaration -- duplicates on a declared
+    # index nearly always mean the identifier is broken or a level is missing,
+    # not "reduce me").  An `aggregation:` key here would be dead config: core
+    # never reads it.  So nothing in this file pretends to fix it.
     index: (t, i, j)
     Quantity: float
     Age: float
@@ -356,7 +426,8 @@ Data Scheme:
     # it across sectc8a / sectc8b; W5 under Post Harvest Wave 5/Community/).
     # There is NO household i, so _join_v_from_sample does NOT apply -- `v`
     # is declared in the index here and carried NATIVELY: it is the
-    # community questionnaire's EA id (v = format_id(ea)), the SAME keyspace
+    # community questionnaire's EA id (v = cluster_id(state, lga, ea) -- the
+    # COMPOSITE key; GH #323), the SAME keyspace
     # as sample().v, so community_prices.v joins households via their
     # cluster.  Country-level script (_/community_prices.py) maps each wave
     # -> materialize: make.

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -1,5 +1,6 @@
 
 import os
+import re
 import pandas as pd
 import numpy as np
 
@@ -31,6 +32,109 @@ wave_folder_map = {
     '2023Q3': '2023-24',
     '2024Q1': '2023-24',
 }
+
+
+# =====================================================================
+# Cluster identity `v`  (GH #323)
+# =====================================================================
+# `ea` ALONE IS NOT A CLUSTER ID.  In the GHS-Panel it is a serial number
+# unique only *within* an LGA, so the same `ea` value recurs in different
+# LGAs and states.  Wave 1 is the proof: the design is 500 EAs x 10
+# households = 5,000 households, but
+#
+#     nunique(ea)                = 411      <- 89 real EAs conflated away
+#     nunique(state, lga, ea)    = 500      <- the design, recovered
+#
+# and the household geovariables confirm it independently: lat/lon is
+# constant within all 500 (state, lga, ea) groups (0 groups span >1
+# coordinate) but VARIES inside 76 of the 411 bare `ea` codes.  Keying on
+# `ea` therefore MERGES DISTINCT CLUSTERS, and the household->cluster
+# collapse in cluster_features then stamps one arbitrary EA's
+# Region/District/Rural onto every household in the merged group:
+# 890/5000 households got the wrong District in W1 alone (17.8%), rising
+# to 1283/5263 (24.4%) by W4.  That is a class-1 SILENTLY-WRONG defect,
+# and it leaks everywhere, because sample() publishes the same broken key
+# and _join_v_from_sample() stamps it onto every household table.
+#
+# THE KEYSPACE IS BUILT FROM CODES, NOT LABELS.  The community
+# questionnaire (community_prices) must land in the SAME keyspace as the
+# household files so a cluster's prices join its households.  In W2 the
+# community file's state/lga carry no Stata value labels while the
+# household file's do, so a LABEL-built key gives 0% overlap between the
+# two sides; a CODE-built key gives 100%.  Hence every consumer of these
+# helpers reads its geography with convert_categoricals=False (the YAML
+# path does this with `converted_categoricals:` on the sub-df) and the
+# composite is assembled from the raw numeric codes.
+#
+# THE `Moved` SENTINEL.  From W2 on, a tracked household that left its
+# original EA is recorded with ea == 0 -- surfacing as the label 'Moved'
+# (W2), '0. Moved' (W3), or a bare 0 (W4).  It is a MISSING-VALUE
+# SENTINEL, not a cluster: pooling those households would weld unrelated
+# households from across the country into fake clusters like
+# (Lagos, ETI-OSA, 'Moved').  They have no sampling cluster, so each is
+# given its own singleton id.  A NaN `v` was rejected deliberately: the
+# downstream groupby() in roster_to_characteristics / the food-derivation
+# pipeline DROPS NaN keys, which would silently delete these households
+# (152 / 306 / 166 in W2 / W3 / W4) from every derived table -- trading
+# one silent-data-loss bug for another.  An explicit singleton keeps them
+# present, keeps their true Region/District/Rural, and can never merge
+# them with anyone else.
+_MOVED_EA_CODE = 0
+
+
+def _geo_code(x):
+    """Normalize one geographic component to its numeric CODE as a string.
+
+    Handles every rendering the GHS files use for the same underlying code:
+    a raw numeric (``1690`` / ``1690.0``), a Stata code-prefixed label
+    (``'102. ABA SOUTH'`` -> ``'102'``), and the bare ``'Moved'`` label,
+    which is code 0.  Returns ``None`` when the value is missing.
+    """
+    if pd.isna(x):
+        return None
+    s = str(x).strip()
+    if not s:
+        return None
+    m = re.match(r'^(\d+)\s*\.\s*\D', s)   # '102. ABA SOUTH' -> '102'
+    if m:
+        return m.group(1)
+    if re.fullmatch(r'-?\d+(\.0*)?', s):   # 1690 / '1690' / '1690.0'
+        return str(int(float(s)))
+    if s.lower().lstrip('0. ').startswith('moved'):
+        return str(_MOVED_EA_CODE)
+    return ' '.join(s.upper().split())     # last-resort: a bare label
+
+
+def cluster_id(state, lga, ea, hhid=None):
+    """The composite EA identity for one household.  See the note above.
+
+    Real EA        -> ``'{state}/{lga}/{ea}'`` (codes)
+    'Moved' (ea=0) -> ``'moved-{hhid}'``: no sampling cluster; a singleton
+                      that can never be pooled with another household.
+    """
+    ea_c = _geo_code(ea)
+    if ea_c is None:
+        return None
+    if ea_c == str(_MOVED_EA_CODE):
+        hh = format_id(hhid)
+        return f'moved-{hh}' if hh is not None else None
+    state_c, lga_c = _geo_code(state), _geo_code(lga)
+    if state_c is None or lga_c is None:
+        return None
+    return f'{state_c}/{lga_c}/{ea_c}'
+
+
+def v(row):
+    """`v` formatting function, auto-bound by df_data_grabber.
+
+    Declared in the wave YAML as ``v: [state, lga, ea, hhid]`` (idxvars for
+    cluster_features, myvars for sample), so BOTH tables -- and
+    community_prices, via cluster_id() -- share one keyspace by
+    construction.  They must: sample.v is what _join_v_from_sample() stamps
+    onto every household table, and community_prices.v has to join it.
+    """
+    return cluster_id(row.get('state'), row.get('lga'), row.get('ea'),
+                      row.get('hhid'))
 
 
 # ---------------------------------------------------------------------
@@ -1766,7 +1870,7 @@ def people_last7days_from_s4aq(t, df, hhid='hhid', indiv='indiv'):
 # sectc8a / sectc8b; W5 lives under Post Harvest Wave 5/Community/).  This
 # is a CLUSTER-level table: there is no household i.  `v` is the native
 # community-questionnaire EA id (`ea`), which maps to the SAME keyspace as
-# sample().v (sample joins v = format_id(ea) too), so community_prices.v
+# sample().v (sample publishes the same composite cluster_id; GH #323), so community_prices.v
 # joins households via their cluster.  Item-level REPORTED prices only --
 # NOT an index, NOT a median/mean across clusters, NOT an HH-median
 # imputation (those are transformations over these rows).
@@ -1901,7 +2005,9 @@ def community_prices_for_wave(t, frames, mode, crop_labels=None):
         Each dict describes one source price frame:
             df     raw DataFrame (convert_categoricals=False)
             dec    decoded-label DataFrame (for unit / item decode)
-            ea     EA id column name (-> v = format_id(ea))
+            ea     EA id column name (-> v = cluster_id(state, lga, ea))
+            state  state column name (default 'state')
+            lga    LGA column name   (default 'lga')
             item   item_cd column name
             price  reported-price column name
             unit   unit column name (W3-W5; None for W1/W2)
@@ -1925,7 +2031,19 @@ def community_prices_for_wave(t, frames, mode, crop_labels=None):
     for fr in frames:
         df = fr['df']
         dec = fr['dec']
-        v = df[fr['ea']].apply(format_id)
+        # v must land in the SAME keyspace as sample().v, or a cluster's prices
+        # join no households at all.  That means the COMPOSITE (state/lga/ea)
+        # id, not the bare `ea` serial (GH #323), and it means building it from
+        # raw CODES: `df` here is read with convert_categoricals=False, and the
+        # community questionnaire carries no value labels on state/lga anyway,
+        # so a label-built key would not match the household side (measured: 0%
+        # overlap in W2, 100% on codes).  A community record with no usable EA
+        # yields v = None and is dropped by the notna() filter below.
+        state_col = fr.get('state', 'state')
+        lga_col = fr.get('lga', 'lga')
+        v = df.apply(
+            lambda r: cluster_id(r.get(state_col), r.get(lga_col), r[fr['ea']]),
+            axis=1)
         code = pd.to_numeric(df[fr['item']], errors='coerce')
         price = pd.to_numeric(df[fr['price']], errors='coerce')
 

--- a/tests/test_nigeria_cluster_identity.py
+++ b/tests/test_nigeria_cluster_identity.py
@@ -27,14 +27,58 @@ destroyed by groupby().first(), in each of the wave's two quarters), but no
 change to Nigeria's config can fix it; see the KNOWN OPEN DEFECT note in
 Nigeria/_/data_scheme.yml for the two core edits that would.
 """
+import os
 import warnings
+from pathlib import Path
 
 import pandas as pd
 import pytest
 
 from lsms_library.country import Country
 
-pytestmark = pytest.mark.slow
+
+def _aws_creds_available() -> bool:
+    """True iff DVC could perform an S3 pull right now.
+
+    Every test in this module BUILDS REAL NIGERIA DATA, which goes through
+    DVC -> S3.  Without credentials they raise ``NoCredentialsError`` regardless
+    of whether the test logic is correct -- which is exactly what happened: this
+    file turned the PR red with 27 errors while 649 other data-dependent tests
+    skipped cleanly around it.
+
+    The CI ``unit-tests`` job intentionally sets ``LSMS_SKIP_AUTH=1`` to keep PR
+    validation fast and data-free; only ``data-tests`` carries the S3 secrets.
+    So these must silent-skip there, exactly as the equivalent guards in
+    ``tests/test_canonical_shape_via_cache_miss.py`` and
+    ``tests/test_declared_spellings.py`` do.
+
+    (Mirrors those helpers deliberately rather than importing across test
+    modules -- the duplication is the pre-existing house pattern.  Centralising
+    it into ``conftest.py`` is worth doing, and is now wanted in at least three
+    places, but not inside a CI-red fix.)
+    """
+    if os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"):
+        return True
+    creds_file = (
+        Path(__file__).parent.parent
+        / "lsms_library" / "countries" / ".dvc" / "s3_creds"
+    )
+    if creds_file.exists():
+        try:
+            return "aws_access_key_id" in creds_file.read_text()
+        except OSError:
+            return False
+    return False
+
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not _aws_creds_available(),
+        reason="needs S3 credentials to build Nigeria; the unit-tests job is "
+               "deliberately data-free (see data-tests for the credentialed run)",
+    ),
+]
 
 # The GHS-Panel W1 design: 500 EAs x 10 households.  Independently confirmed by
 # the household geovariables, which carry exactly 500 distinct coordinates.

--- a/tests/test_nigeria_cluster_identity.py
+++ b/tests/test_nigeria_cluster_identity.py
@@ -1,0 +1,270 @@
+"""GH #323 -- Nigeria: cluster identity `v`, and its behaviour ACROSS ROUNDS.
+
+Nigeria is a post-planting / post-harvest country: every wave FOLDER carries two
+quarters (2010-11 -> 2010Q3 planting + 2011Q1 harvest), and each quarter is a
+separate ``Wave``.  So every claim below has to hold in BOTH rounds, not just
+one -- a fix that is right for the planting quarter and silently wrong for the
+harvest quarter is not a fix.
+
+What these tests pin down (measured 2026-07-13 with LSMS_NO_CACHE=1; the
+"development" figures are from an actual baseline build of `development`, not
+from memory):
+
+  * `v` was the bare `ea` serial, which is unique only WITHIN an LGA.  W1's
+    500-EA design came back as 411 clusters -- IN BOTH ROUNDS (2010Q3: 411,
+    2011Q1: 411).  The composite cluster_id(state, lga, ea) recovers 500 in
+    both.
+  * Latitude/Longitude were absent from 3 of the 4 waves that declare
+    cluster_features (development: lat_notna = 0 / 409 / 0 / 0 for
+    2010Q3 / 2012Q3 / 2015Q3 / 2018Q3) -- wrong column casing, and a
+    household-level geo frame merged on `v`, which GH #515 then dropped.
+  * `ea == 0` is the 'Moved' sentinel, not a cluster; pooling it welds
+    unrelated households into fake clusters.
+
+Deliberately NOT tested here: the `assets` item_seq per-unit roster.  It is a
+real and large defect (N147,297,485 -- 25.6% of W2's reported asset value --
+destroyed by groupby().first(), in each of the wave's two quarters), but no
+change to Nigeria's config can fix it; see the KNOWN OPEN DEFECT note in
+Nigeria/_/data_scheme.yml for the two core edits that would.
+"""
+import warnings
+
+import pandas as pd
+import pytest
+
+from lsms_library.country import Country
+
+pytestmark = pytest.mark.slow
+
+# The GHS-Panel W1 design: 500 EAs x 10 households.  Independently confirmed by
+# the household geovariables, which carry exactly 500 distinct coordinates.
+W1_CLUSTERS = 500
+
+# (post-planting quarter, post-harvest quarter) for each wave folder.
+ROUNDS = [
+    ('2010Q3', '2011Q1'),   # 2010-11
+    ('2012Q3', '2013Q1'),   # 2012-13
+    ('2015Q3', '2016Q1'),   # 2015-16
+    ('2018Q3', '2019Q1'),   # 2018-19
+    ('2023Q3', '2024Q1'),   # 2023-24  (no cluster_features declared)
+]
+# Waves that declare cluster_features (W5 does not).
+CF_ROUNDS = ROUNDS[:4]
+CF_QUARTERS = [q for pair in CF_ROUNDS for q in pair]
+
+# community_prices comes from the COMMUNITY questionnaire's Section C8, which is
+# administered in the post-harvest round only.  Verified structurally: across all
+# five waves there are 11 `sectc8*` files and every one is a `_harvest` file --
+# there is no `sectc8*_planting*` anywhere.  The planting community files that do
+# carry an `item_cd` (sectc2_plantingw1, sectc2a/b_plantingw3) have no price
+# column at all; C2 is an availability module.  So no planting-round price data
+# is being dropped -- there is none to drop.
+PH_QUARTERS = ['2011Q1', '2013Q1', '2016Q1', '2019Q1', '2024Q1']
+
+
+@pytest.fixture(scope='module')
+def nigeria():
+    return Country('Nigeria')
+
+
+@pytest.fixture(scope='module')
+def sample(nigeria):
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        return nigeria.sample()
+
+
+@pytest.fixture(scope='module')
+def cf(nigeria):
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        return nigeria.cluster_features()
+
+
+# --------------------------------------------------------------------------
+# the cluster key itself
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('t', ['2010Q3', '2011Q1'])
+def test_w1_recovers_the_500_ea_design_in_both_rounds(cf, t):
+    """`ea` alone conflates 500 real EAs into 411 codes -- in BOTH rounds.
+
+    development returns 411 for 2010Q3 *and* 2011Q1; the composite key returns
+    500 for both.  Parametrised precisely so a fix that only lands on the
+    planting quarter cannot pass.
+    """
+    n = cf.loc[t].index.get_level_values('v').nunique()
+    assert n == W1_CLUSTERS, (
+        f'{t} has {n} clusters, expected {W1_CLUSTERS}.  A count near 411 means '
+        f'`v` is the bare `ea` serial again (GH #323).'
+    )
+
+
+def test_cluster_features_index_is_unique(cf):
+    """The canonical (t, v) grain must not need a duplicate-collapse at all."""
+    dups = int(cf.index.duplicated().sum())
+    assert dups == 0, f'{dups} duplicate (t, v) tuples in cluster_features'
+
+
+@pytest.mark.parametrize('t', CF_QUARTERS)
+def test_every_wave_has_coordinates_in_every_round(cf, t):
+    """Lat/Lon were silently missing from 3 of the 4 waves that declare
+    cluster_features -- and missing in both of each wave's quarters."""
+    wave = cf.loc[t]
+    assert wave['Latitude'].notna().any(), f'{t}: no Latitude at all'
+    assert wave['Longitude'].notna().any(), f'{t}: no Longitude at all'
+
+
+@pytest.mark.parametrize('t', ['2010Q3', '2011Q1'])
+def test_w1_every_cluster_has_a_coordinate(cf, t):
+    """W1's coordinates are genuinely invariant within cluster -> all 500 keep
+    one.  (development: 0.)"""
+    assert int(cf.loc[t]['Latitude'].notna().sum()) == W1_CLUSTERS
+
+
+def test_moved_households_are_singletons_never_a_shared_cluster(sample):
+    """`ea == 0` is the 'Moved' sentinel, not a cluster.
+
+    Pooling it welds unrelated households into fake clusters like
+    (Lagos, ETI-OSA, 'Moved').  Each moved household must get its own id -- and
+    must NOT get a NaN `v`, which the downstream groupby() would silently drop.
+    """
+    assert sample['v'].isna().sum() == 0, 'a NaN v is silently dropped downstream'
+
+    moved = sample[sample['v'].astype(str).str.startswith('moved-')]
+    assert len(moved) > 0, 'expected the Moved sentinel in the panel waves'
+    # one household per singleton, per wave
+    per = moved.reset_index().groupby(['t', 'v']).size()
+    assert int(per.max()) == 1, 'a "moved" id is shared by >1 household'
+
+
+def test_moved_sentinel_does_not_fire_in_the_baseline_wave(sample):
+    """W1 is the frame's own baseline: no household can have moved OUT of an EA
+    it was only just drawn from, and indeed `ea == 0` never occurs in W1's cover
+    page.  So the sentinel must fire ZERO times in 2010Q3/2011Q1 -- it must fire
+    when it should and ONLY when it should."""
+    s = sample.reset_index()
+    w1 = s[s.t.isin(['2010Q3', '2011Q1'])]
+    n_moved = w1['v'].astype(str).str.startswith('moved-').sum()
+    assert n_moved == 0, f'{n_moved} spurious moved-singletons in W1'
+
+    # ...and it DOES fire in the later panel waves.
+    later = s[s.t.isin(['2012Q3', '2015Q3', '2018Q3', '2023Q3'])]
+    assert later['v'].astype(str).str.startswith('moved-').sum() > 0
+
+
+# --------------------------------------------------------------------------
+# ROUND SAFETY -- the pp/ph question
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('pp,ph', ROUNDS)
+def test_v_is_round_invariant_within_a_wave(sample, pp, ph):
+    """A household must get the SAME cluster in the planting and the harvest
+    quarter of one wave.
+
+    It does, by construction: both quarters of a wave read the SAME post-planting
+    cover page (the wave folder has one data_info.yml and both Wave(t)s use it),
+    so there is no second geo-coding to drift from.  This test is the guard that
+    keeps it that way -- e.g. if someone later points the harvest quarter at
+    secta_harvest*.dta, 17/41/66/64 households in W2/W3/W4/W5 would flip to a
+    `moved-` singleton (they relocate BETWEEN the two visits) and `v` would stop
+    being a stable within-wave cluster key.
+    """
+    s = sample.reset_index()
+    a = s[s.t == pp][['i', 'v']].rename(columns={'v': 'v_pp'})
+    b = s[s.t == ph][['i', 'v']].rename(columns={'v': 'v_ph'})
+    m = a.merge(b, on='i', how='inner')
+    assert len(m) > 0, f'no households shared between {pp} and {ph}'
+    differs = m[m.v_pp != m.v_ph]
+    assert len(differs) == 0, (
+        f'{len(differs)} households change cluster between {pp} and {ph}; '
+        f'`v` must be constant within a wave.  e.g.\n{differs.head().to_string()}'
+    )
+
+
+@pytest.mark.parametrize('pp,ph', CF_ROUNDS)
+def test_cluster_features_carries_both_rounds_and_they_agree(cf, pp, ph):
+    """Both quarters must be present, with the same cluster set and identical
+    attributes -- neither round may overwrite or collide with the other."""
+    c = cf.reset_index()
+    A = c[c.t == pp].set_index('v').drop(columns='t')
+    B = c[c.t == ph].set_index('v').drop(columns='t')
+
+    assert len(A) > 0, f'{pp} missing from cluster_features'
+    assert len(B) > 0, f'{ph} missing from cluster_features'
+    assert set(A.index) == set(B.index), (
+        f'{pp} and {ph} disagree on the cluster set '
+        f'({len(A)} vs {len(B)} clusters)'
+    )
+    for col in ['Region', 'District', 'Rural', 'Latitude', 'Longitude']:
+        x, y = A[col], B.loc[A.index, col]
+        mismatched = int(((x != y) & ~(x.isna() & y.isna())).sum())
+        assert mismatched == 0, (
+            f'{col} differs between {pp} and {ph} for {mismatched} cluster(s)'
+        )
+
+
+def test_sample_is_one_row_per_household_per_round(sample):
+    """sample is keyed (i, t) with t the QUARTER, so a household in a pp/ph wave
+    has exactly two rows -- one per round.  The GH #323 rekey changed `v`'s
+    VALUE, and must not have changed this grain (development and this branch both
+    return 49,770 rows)."""
+    assert sample.index.names == ['i', 't'] or set(sample.index.names) == {'i', 't'}
+    assert int(sample.index.duplicated().sum()) == 0
+
+    s = sample.reset_index()
+    for pp, ph in ROUNDS:
+        n_pp = s[s.t == pp]['i'].nunique()
+        n_ph = s[s.t == ph]['i'].nunique()
+        assert n_pp == n_ph and n_pp > 0, (
+            f'{pp} has {n_pp} households but {ph} has {n_ph}; both rounds of a '
+            f'wave are populated from the same cover page and must match'
+        )
+
+
+# --------------------------------------------------------------------------
+# one keyspace: sample.v / cluster_features.v / community_prices.v
+# --------------------------------------------------------------------------
+
+def test_sample_and_cluster_features_share_one_keyspace(nigeria, cf, sample):
+    """sample.v is stamped onto every household table by _join_v_from_sample;
+    it must resolve against cluster_features -- in BOTH rounds."""
+    s = sample.reset_index()
+    s = s[s['t'].isin(CF_QUARTERS)]          # W5 declares no cluster_features
+    known = set(map(tuple, cf.reset_index()[['t', 'v']].drop_duplicates().values))
+    got = set(map(tuple, s[['t', 'v']].dropna().drop_duplicates().values))
+    orphans = got - known
+    assert not orphans, f'{len(orphans)} sample clusters absent from cluster_features'
+
+
+def test_community_prices_is_post_harvest_only(nigeria):
+    """Section C8 is asked in the post-harvest round only (there is no
+    sectc8*_planting* file in any wave), so community_prices must land on the PH
+    quarter -- and on NO planting quarter."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        cp = nigeria.community_prices()
+    ts = set(cp.reset_index()['t'].unique())
+    assert ts == set(PH_QUARTERS), (
+        f'community_prices t values {sorted(ts)}; expected exactly the '
+        f'post-harvest quarters {PH_QUARTERS}'
+    )
+
+
+def test_community_prices_joins_the_household_keyspace(nigeria, sample):
+    """A cluster's prices are useless if they join no households: community_prices
+    must be built from the SAME composite key as sample.  (On the bare-`ea` key,
+    and on any label-built key, this join silently degrades.)"""
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        cp = nigeria.community_prices()
+    cpr = cp.reset_index()
+    s = sample.reset_index()
+    for t, sub in cpr.groupby('t'):
+        vs = set(sub['v'].dropna())
+        known = set(s[s.t == t]['v'].dropna())
+        rate = len(vs & known) / max(len(vs), 1)
+        assert rate > 0.95, (
+            f'{t}: only {rate:.1%} of community_prices clusters join sample.v; '
+            f'the two sides are not in the same keyspace'
+        )


### PR DESCRIPTION
Config-only. **Zero changes to the access path.** Supersedes the core patch on `fix/323-nigeria`, per `slurm_logs/DESIGN_grain_collapse_sites_2026-07-13.org`.

## The fix — the cluster key was unique only *within* an LGA

`v` was the bare `ea` serial. It is unique only **within an LGA**, so it conflated real clusters: W1's **500 designed EAs collapsed into 411 codes** — two genuinely different clusters merged into one, and `.first()` then kept one Region at random.

Rekeyed to a composite `cluster_id(state, lga, ea)` across `sample`, `cluster_features` and `community_prices` in all 5 waves (`_/nigeria.py` gains `_geo_code` / `cluster_id`). This is the canonical #323 answer: *the identifier is broken, so fix the identifier.*

`v` nunique in `sample`, dev → branch: **411 → 500** (W1), 408 → 647, 402 → 792, 405 → 685, 404 → 911.
`cluster_features` Latitude present, dev → branch: **0 → 500** (2010Q3), 409 → 645, **0 → 784** (2015Q3), **0 → 671** (2018Q3) — the geo merge was also cartesian-ing; un-cartesianing it recovers GPS in 3 of 4 waves.

## Nigeria is PP/PH — so: is the fix round-safe?

Every Nigeria wave dir holds **two rounds** needing **distinct `t`** (2010-11 → `2010Q3` planting, `2011Q1` harvest). Per `.claude/skills/add-feature/pp-ph/SKILL.md`, this is "the single most common source of duplicate-index bugs in these countries." A cluster-key rekey that isn't round-invariant would silently move households between clusters across rounds.

**It is round-safe. 0 households change cluster between the pp and ph quarter, in all 5 waves.**

It holds *by construction* — a wave *folder* has one `data_info.yml`, and both `Wave('2010Q3')` and `Wave('2011Q1')` read it, so both quarters extract `v` from the **same post-planting cover page**. There is no second geo-coding to drift from.

But "invariant by construction" is exactly the prose #323 exists to distrust, so the raw PP and PH cover pages were checked **independently**:

- The only pp/ph disagreement is the **`Moved` sentinel** — 0 / 17 / 41 / 66 / 64 households (W1–W5) sit in a real EA at planting and are coded `ea == 0` at harvest. They genuinely relocated between visits.
- **Zero real-EA → real-EA disagreements.** No geo-recode, no label/code drift, no `.0` float-suffix artefact.

Using the planting frame's cluster for the whole wave is correct: `v` is the **sampling** cluster, fixed by the frame.

The `Moved` special-case (`ea == 0` → singleton `moved-{hhid}`, so a mover can never be pooled into a cluster it left) fires when it should and **only** when it should: **0 times in W1** — nobody can move out of a frame they were just drawn from — and 152 / 306 / 166 / 393 times in W2–W5.

**The other three round questions:**
- `cluster_features` — both quarters present, **identical cluster sets, zero attribute mismatches, 0 duplicate `(t,v)`**. Neither round overwrites the other.
- `community_prices` is post-harvest-only — structurally verified: across all 5 waves there are **11 `sectc8*` files and every one is `_harvest`**. And not just by filename: the planting community files that *do* carry `item_cd` (`sectc2_plantingw1`, `sectc2a/b_plantingw3`) have **no price column** — C2 is an availability module. No planting-round price data is being dropped; there is none.
- `sample` grain is one row per **(household, round)** — 49,770 rows, 0 duplicate `(i,t)` — and is **identical on `development` and on this branch.** The rekey changed `v`'s *value*, not the grain.

## The `v` rekey needs no propagation

The other `materialize: make` tables are keyed on `i` and never build `v`, so `_join_v_from_sample` stamps the new composite on for free. Verified empirically: `household_roster` / `food_acquired` / `plot_features` / `people_last7days` / `housing` / `interview_date` all carry the new `10/1014/80`-style ids; `livestock` / `shocks` / `assets` are correctly v-join exempt. Nothing was missed.

## ⚠️ A real defect this PR does NOT fix — and why

**W2 `assets`: ₦576,299,043 true → ₦429,001,558 kept → ₦147,297,485 (25.6%) destroyed**, in *each* of 2012Q3 and 2013Q1. `sect5b_plantingw2` carries a **per-unit roster** — one row per individual unit owned, enumerated by `item_seq` — and `.first()` keeps one unit and throws the rest away.

The original branch "fixed" this with an `aggregation:` block, which D1 rejects. The obvious replacement — *declare `item_seq` in Nigeria's index* — **was tested and does not close the bug**: the canonical assets grain is `(t, i, j)`, so `Feature('assets')` calls `_harmonize_country_frame`, drops the extra level, and `_collapse_duplicate_index` re-reduces with `first()` (assets is not in `_ADDITIVE_MEASURE_COLUMNS`). A 4-level Nigeria would fix `Country.assets()`, let `Feature('assets')` destroy the identical ₦147M, and make Nigeria the library's only non-canonical assets grain — a half-fix that also breaks cross-country consistency.

The real fix is **two core edits**, which are out of scope for a country PR:
1. `lsms_library/data_info.yml` → `index_info: assets: (t, i, j, item_seq)`
2. `lsms_library/feature.py` → `_ADDITIVE_MEASURE_COLUMNS['assets'] = ('Value',)` — `Quantity` must stay `first` (it comes from the clean `sect5a` grid and is merely repeated across the `item_seq` rows); `Age` wants `mean`.

Recorded as a **KNOWN OPEN DEFECT** block in `Nigeria/_/data_scheme.yml` and `.coder/ledger/323-nigeria.md` §7, with the numbers and the prescription, so it cannot vanish in the gap between "your fix was rejected" and "someone else covers it." **It needs its own PR.**

## Verification

Worktree import asserted, `LSMS_NO_CACHE=1`, cache cleared via `lsms-library cache clear --country Nigeria` (which enumerates Nigeria's round-name cache dirs). Imports and builds with core stripped.

`tests/test_nigeria_cluster_identity.py`: **28 pass on the branch, 12 FAIL on a real `development` baseline build** — the baseline was actually run, not quoted from the branch. Plus `test_schema_consistency.py` 218 passed, `test_sample.py -k Nigeria` 11 passed.

**Two tests that passed on `development` were dropped** rather than shipped: the "cartesian product" row-count test is vacuous, since the collapse hides the very explosion it claims to check. A green test that proves nothing is worse than no test.

Two residuals, pre-existing and not regressions: Lat/Lon still collapse via core (5/24/50 clusters in W2/W3/W4 span >1 coordinate — Site 2 / #617 owns that), and `moved-` singletons inflate `cluster_features` row counts (W3: 792 rows = 486 real clusters + 306 one-household "clusters") — deliberate, since a NaN `v` would delete those households from every derived table.

Refs #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
