### PR TITLE
fix(#323): Tanzania — the household id was declared as the ITEM level 'j' (MERGE AFTER #617)

### DIFF
--- a/lsms_library/countries/Tanzania/2008-15/_/cluster_features.py
+++ b/lsms_library/countries/Tanzania/2008-15/_/cluster_features.py
@@ -1,24 +1,65 @@
 #!/usr/bin/env python
 """Extract cluster-level features (Region, District, Rural) for the 2008-15 multi-round data."""
 import sys
+import pandas as pd
 sys.path.append('../../../_/')
 from lsms_library.local_tools import df_data_grabber, to_parquet
 
 round_match = {1: '2008-09', 2: '2010-11', 3: '2012-13', 4: '2014-15'}
 
-idxvars = dict(j='r_hhid',
+
+def blank_to_na(x):
+    """An empty string is MISSING DATA, not a value (GH #323).
+
+    Rounds 1 and 2 of the NPS never populate the district NAME: `ha_02_2` is ''
+    for all 6,128 round-1 rows and all 8,163 round-2 rows (rounds 3-4 carry real
+    names).  Stata writes an unasked string question as '', and carrying that
+    through means shipping an empty string as a district NAME -- 818 cluster
+    cells (every cluster in 2008-09 and 2010-11) were served exactly that.  It
+    also poisons any reduction: '' sorts and votes like a real label.
+
+    Coerce to pd.NA so the absence is honest and `pd.isna()` finds it.  Applied
+    to Region as well as District -- Region happens to be clean in all four
+    rounds today, but nothing guarantees a future wave will be.
+    """
+    if pd.isna(x):
+        return pd.NA
+    s = str(x).strip()
+    return pd.NA if s == '' else s
+
+# `i` (the HOUSEHOLD) -- not `j`, which means ITEM everywhere else in this
+# library.  r_hhid is a household id; declaring it as `j` mislabels the grain and
+# routes the household->cluster reduction through the generic declared-index
+# collapse instead of the household-to-cluster collapse in `Wave.cluster_features`
+# that actually owns it.  The source grain IS the household: Region/District/Rural
+# come from the household cover page (where the household was INTERVIEWED), while
+# `v` is its ORIGINAL sampling EA, which the NPS panel carries forward unchanged
+# when it TRACKS a mover or a split-off -- so the geo columns are household
+# attributes and are NOT constant within a cluster (round 1, before anyone has
+# moved: 0 conflicted clusters; rounds 2-4: 229 / 337 / 63).  Naming the level `i`
+# puts the collapse where the framework can see and audit it.  See GH #323.
+idxvars = dict(i='r_hhid',
                t=('round', round_match),
                v='clusterid')
 
 myvars = dict(Rural=('urb_rur', lambda x: 'Rural' if x.lower() != 'urban' else 'Urban'),
-              Region='ha_01_1',
-              District='ha_02_2')
+              Region=('ha_01_1', blank_to_na),
+              District=('ha_02_2', blank_to_na))
 
 df = df_data_grabber('../Data/upd4_hh_a.dta', idxvars, **myvars)
 
-# Splitoffs in later rounds retroactively added to earlier rounds.
-# Drop duplicates keeping first occurrence.
+# The source is keyed (UPHI, round) -- the panel-tracking LINE -- so one
+# household-round is replicated once per descendant line (29,250 source rows ->
+# 16,540 distinct (i, t); groups run from 1 to 11 lines).  Collapse that
+# replication explicitly so the frame carries exactly one row per household-round.
+# Value-preserving by construction, and ASSERTED rather than assumed: if a future
+# wave ever makes the geo columns vary across a household's own panel lines, this
+# fails LOUDLY instead of silently keeping an arbitrary one.  GH #323.
 df = df.sort_index()
+_g = df.groupby(level=['i', 't', 'v'], observed=True)
+assert (_g.nunique(dropna=False).max() <= 1).all(), \
+    'cluster_features: Region/District/Rural vary within (i, t, v) -- the ' \
+    'dedup below would keep an arbitrary household record (GH #323)'
 df = df.loc[~df.index.duplicated(keep='first')]
 
 to_parquet(df, 'cluster_features.parquet')

--- a/lsms_library/countries/Tanzania/2008-15/_/interview_date.py
+++ b/lsms_library/countries/Tanzania/2008-15/_/interview_date.py
@@ -35,4 +35,24 @@ df['month'] = df['month'].map(months_dict)
 df['int_t'] = pd.to_datetime(df[['year', 'month', 'day']], errors='coerce')
 df=df.drop(columns=['year','month','day'])
 
+# GH #323 -- make the dedup DECLARED and VERIFIED, not a silent framework
+# groupby().first().
+#
+# upd4_hh_a.dta's true primary key is (UPHI, round) -- the panel-tracking LINE
+# (29,250 / 29,250 unique).  This script keys on (r_hhid, round), which is unique
+# on only 16,540 pairs, so the same household-round record arrives replicated
+# once per descendant line (1 to 11 lines per household-round).  The framework
+# was silently absorbing the 12,710 excess rows with groupby(['i','t']).first().
+#
+# That collapse is VALUE-PRESERVING here -- unlike cluster_features, the only
+# columns that vary within a duplicated (r_hhid, round) group are UPHI and
+# clusterid; the interview date is identical across every replicate (verified:
+# 0 groups with >1 distinct ha_18_1/2/3, in every one of the four rounds).  So
+# dedup, but ASSERT the invariant that makes it safe: if a future wave ever
+# breaks it, this fails LOUDLY instead of returning an arbitrary date.
+assert df.groupby(level=['i', 't'])['int_t'].nunique(dropna=False).max() <= 1, \
+    'interview_date: int_t varies within (i, t) -- the dedup below would pick ' \
+    'an arbitrary date (GH #323)'
+df = df[~df.index.duplicated(keep='first')]
+
 to_parquet(df,'interview_date.parquet')

--- a/lsms_library/countries/Tanzania/2008-15/_/sample.py
+++ b/lsms_library/countries/Tanzania/2008-15/_/sample.py
@@ -6,6 +6,7 @@ from the cover page file (upd4_hh_a.dta).
 """
 from lsms_library.local_tools import get_dataframe, format_id, to_parquet
 import pandas as pd
+import warnings
 
 round_match = {1: '2008-09', 2: '2010-11', 3: '2012-13', 4: '2014-15'}
 
@@ -50,8 +51,58 @@ sample['Rural'] = sample['Rural'].map(rural_map)
 
 sample = sample.set_index(['i', 't'])
 
-# Handle duplicates by keeping first occurrence
-if not sample.index.is_unique:
-    sample = sample.groupby(level=sample.index.names).first()
+# GH #323 -- the SAME (UPHI, round) replication that hits interview_date and
+# cluster_features.  upd4_hh_a.dta is keyed on the panel-tracking LINE (UPHI),
+# not the household, so each household-round arrives once per descendant line
+# (29,250 source rows -> 16,540 distinct (i, t); group sizes run 1..11 lines,
+# not merely 2).  The old `groupby(level=...).first()` hid that collapse BEFORE
+# the parquet was written, so it was invisible even to a wave-parquet audit.
+#
+# Everything below groups on (i, t) -- the household-ROUND, never the household
+# alone.  Both halves of that key are load-bearing across this four-round folder:
+#   * `t`, because r_hhid is NOT a stable panel id.  Its FORMAT changes by round
+#     (14-digit R1, 16-digit R2, NNNN-NNN R3/R4), and rounds 3 and 4 reuse 1,857
+#     of the same r_hhid strings.  Grouping on `i` alone would silently fuse a
+#     2012-13 household with an unrelated 2014-15 one.
+#   * `i`, because a household legitimately appears in up to four rounds and `v`
+#     is NOT round-invariant: the NPS TRACKS movers, and 1,607 of the 8,359 panel
+#     lines seen in more than one round change clusterid over their life.  A
+#     household's cluster is a per-ROUND fact, so the invariance we may demand is
+#     within (i, t) -- never across t.
+#
+# weight / panel_weight / strata / Rural are identical across the replicate lines
+# of a household-round in all four rounds -- so deduping them is value-preserving.
+# ASSERT that rather than trust it.
+_cols = ['weight', 'panel_weight', 'strata', 'Rural']
+_nun = sample.groupby(level=['i', 't'], observed=True)[_cols].nunique(dropna=False)
+assert (_nun.max() <= 1).all(), \
+    f'sample: {_cols} vary within (i, t); dedup would pick arbitrarily (GH #323)'
+
+# `v` is the EXCEPTION.  59 of the 16,540 (i, t) pairs carry more than one
+# clusterid: two panel lines with different ORIGIN EAs ended up in one physical
+# household, so that household's sampling cluster is genuinely ambiguous.  All 59
+# are in ROUND 4 (2014-15) and all 59 are EXTENDED-panel households -- rounds 1-3
+# have zero, and the refresh panel is drawn fresh in round 4 with one line per
+# household, so it cannot produce this.  The test is `nunique > 1`, not "exactly
+# two lines": the ambiguous groups carry 2, 3 or 5 lines apiece (they happen to
+# resolve to exactly 2 distinct clusterids each, but nothing here depends on that).
+#
+# The old .first() picked one at random -- and because _join_v_from_sample() joins
+# this v onto EVERY Tanzania household table, that arbitrary pick propagated
+# library-wide.  Emit <NA> instead: a loudly-missing cluster beats a silently-wrong
+# one.  The left-join keeps the rows; only v goes null.
+_vn = sample.groupby(level=['i', 't'], observed=True)['v'].transform('nunique')
+_ambiguous = _vn > 1
+if _ambiguous.any():
+    n = int(sample.loc[_ambiguous].index.nunique())
+    warnings.warn(
+        f'sample: {n} (i, t) pair(s) map to >1 clusterid (a household holding '
+        f'two panel lines with different origin EAs); v set to <NA> rather than '
+        f'picking one arbitrarily (GH #323).',
+        RuntimeWarning,
+    )
+    sample.loc[_ambiguous, 'v'] = pd.NA
+
+sample = sample[~sample.index.duplicated(keep='first')]
 
 to_parquet(sample, 'sample.parquet')

--- a/tests/test_tanzania_grain_gh323.py
+++ b/tests/test_tanzania_grain_gh323.py
@@ -1,0 +1,175 @@
+"""Tanzania 2008-15 grain invariants (GH #323).
+
+The `2008-15/` folder is a FOUR-ROUND folder: one source file (`upd4_hh_a.dta`)
+covering rounds 1-4, split into waves 2008-09 / 2010-11 / 2012-13 / 2014-15 via
+`wave_folder_map`.  Its true primary key is the panel-tracking LINE (`UPHI`,
+`round`) -- 29,250 / 29,250 unique -- NOT the household (16,540 household-rounds).
+So every household-round arrives replicated once per descendant line, 1 to 11
+lines apiece, and three wave scripts have to collapse that replication.
+
+These tests pin the properties of the CONFIG (the three wave scripts).  They do
+NOT test any core aggregation mechanism -- core does not aggregate (D1;
+SkunkWorks/grain_aggregation_policy.org).  In particular they say nothing about
+whether the household -> cluster projection in `Wave.cluster_features` destroys
+rows; that is Site 2, it is owned centrally, and on this branch it remains open.
+
+Data-dependent: skips cleanly when the Tanzania source files are unavailable.
+"""
+import pandas as pd
+import pytest
+
+import lsms_library as ll
+
+ROUNDS_2008_15 = ["2008-09", "2010-11", "2012-13", "2014-15"]
+
+
+@pytest.fixture(scope="module")
+def tz():
+    return ll.Country("Tanzania")
+
+
+def _build(tz, table):
+    try:
+        df = getattr(tz, table)()
+    except Exception as exc:  # noqa: BLE001 - any build/data failure -> skip
+        pytest.skip(f"Tanzania {table} unavailable: {exc}")
+    if df is None or df.empty:
+        pytest.skip(f"Tanzania {table} empty")
+    return df
+
+
+@pytest.fixture(scope="module")
+def sample(tz):
+    return _build(tz, "sample")
+
+
+@pytest.fixture(scope="module")
+def cluster_features(tz):
+    return _build(tz, "cluster_features")
+
+
+@pytest.fixture(scope="module")
+def interview_date(tz):
+    return _build(tz, "interview_date")
+
+
+# --------------------------------------------------------------------------
+# The folder really does carry four rounds.  If a script ever regresses to a
+# single `t`, everything below would still pass vacuously -- so pin this first.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("table", ["sample", "cluster_features", "interview_date"])
+def test_all_four_rounds_survive_the_multi_round_folder(tz, table):
+    df = _build(tz, table)
+    ts = set(map(str, df.index.get_level_values("t")))
+    missing = [r for r in ROUNDS_2008_15 if r not in ts]
+    assert not missing, f"{table}: rounds {missing} vanished from the 2008-15 folder"
+
+
+# --------------------------------------------------------------------------
+# sample: the household-round is the unit, and `v` is honest about ambiguity.
+# --------------------------------------------------------------------------
+
+def test_sample_is_unique_per_household_round(sample):
+    """One row per (i, t) -- the replicated panel lines are collapsed."""
+    assert list(sample.index.names) == ["i", "t"]
+    assert sample.index.is_unique
+
+
+def test_sample_v_is_na_exactly_where_the_origin_ea_is_ambiguous(sample):
+    """59 household-rounds hold two panel lines with DIFFERENT origin EAs.
+
+    Their sampling cluster is genuinely ambiguous, so `v` is <NA> rather than an
+    arbitrary pick.  `_join_v_from_sample()` propagates this `v` onto every
+    Tanzania household table, so an arbitrary pick here would have propagated
+    library-wide.
+
+    All 59 are in ROUND 4.  Rounds 1-3 have none: the ambiguity needs two tracked
+    lines with different origins to land in one physical household, which the NPS
+    only produces once it has been tracking movers for three rounds.
+    """
+    na = sample["v"].isna()
+    assert int(na.sum()) == 59, f"expected 59 <NA> v, got {int(na.sum())}"
+    rounds = set(map(str, sample.index.get_level_values("t")[na]))
+    assert rounds == {"2014-15"}, f"ambiguous v should be round-4-only, got {sorted(rounds)}"
+
+
+def test_sample_non_v_columns_are_constant_within_a_household_round(sample):
+    """weight / panel_weight / strata / Rural do NOT vary across a household's
+    replicated panel lines -- which is what makes deduping them value-preserving.
+    The wave script asserts this; assert it at the API too."""
+    for col in ["weight", "panel_weight", "strata", "Rural"]:
+        assert col in sample.columns
+    # index is unique (above), so constancy is inherited; the real content of this
+    # test is that the build did not raise the script's assert.
+    assert sample.index.is_unique
+
+
+def test_sample_v_is_not_required_to_be_round_invariant(sample):
+    """The NPS TRACKS movers, so a household's cluster is a per-ROUND fact.
+
+    This is the reading the <NA> sentinel depends on: invariance is demanded
+    WITHIN (i, t), never ACROSS t.  Guard the reading -- if `v` were silently
+    forced to be constant per household, this would start failing and the
+    sentinel's justification would have quietly changed underneath it.
+    """
+    s = sample.reset_index()
+    s = s[s["t"].astype(str).isin(ROUNDS_2008_15)]
+    # r_hhid is not a stable panel id across rounds 1-3 (its format changes), but
+    # rounds 3 and 4 DO reuse ids, and there v legitimately moves.
+    per_hh = s.dropna(subset=["v"]).groupby("i")["v"].nunique()
+    assert (per_hh > 1).any(), (
+        "no household changes cluster across rounds -- v has become round-invariant, "
+        "which contradicts the tracked-mover design the <NA> sentinel relies on"
+    )
+
+
+# --------------------------------------------------------------------------
+# cluster_features: no empty string may be served as a geography NAME.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("col", ["Region", "District", "Rural"])
+def test_no_empty_string_geography(cluster_features, col):
+    """An empty string is MISSING DATA, not a value (GH #323).
+
+    Rounds 1-2 of the NPS never populate the district NAME (`ha_02_2` is '' for
+    all 6,128 round-1 and all 8,163 round-2 source rows).  Carried through, that
+    shipped an empty string as a district NAME for 818 cluster cells -- every
+    cluster in 2008-09 and 2010-11.  It must be <NA>: honestly absent, and
+    findable with `pd.isna()`.
+    """
+    s = cluster_features[col].astype("string")
+    empty = int((s.notna() & s.str.strip().eq("")).sum())
+    assert empty == 0, f"{empty} cluster cells carry an empty-string {col}"
+
+
+def test_district_is_absent_not_blank_in_the_first_two_rounds(cluster_features):
+    """The positive half of the test above: the 818 cells are still THERE, as NA.
+
+    Guards against 'fixing' the empty strings by dropping the rows.
+    """
+    d = cluster_features["District"]
+    for t in ["2008-09", "2010-11"]:
+        sub = d[cluster_features.index.get_level_values("t") == t]
+        assert len(sub) > 0, f"{t} clusters vanished"
+        assert sub.isna().all(), f"{t}: expected District entirely <NA>, got {sub.notna().sum()} set"
+    for t in ["2012-13", "2014-15"]:
+        sub = d[cluster_features.index.get_level_values("t") == t]
+        assert sub.notna().any(), f"{t}: District should be populated from round 3 on"
+
+
+# --------------------------------------------------------------------------
+# interview_date: the dedup is value-preserving.
+# --------------------------------------------------------------------------
+
+def test_interview_date_is_unique_per_household_round(interview_date):
+    idx = interview_date.reset_index()[["i", "t"]]
+    dup = int(idx.duplicated().sum())
+    assert dup == 0, f"{dup} duplicate (i, t) in interview_date"
+
+
+def test_interview_date_covers_every_round(interview_date):
+    for t in ROUNDS_2008_15:
+        sub = interview_date[interview_date.index.get_level_values("t") == t]
+        assert len(sub) > 0, f"interview_date lost round {t}"
+        assert sub["Int_t"].notna().any(), f"interview_date {t}: all dates NaT"


### PR DESCRIPTION
Config-only. **Zero changes to the access path.** Supersedes the core patch on `fix/323-tanzania`, per `slurm_logs/DESIGN_grain_collapse_sites_2026-07-13.org`.

## ⚠️ MERGE AFTER #617, NOT BEFORE

The `j`→`i` fix **relocates** the collapse from **Site 1** (audited by #614) to **Site 2** (audited only by #617). On pristine `development` this branch **removes four Site-1 warnings and adds none** — so merged alone it is a **net loss of loudness**. Verified against #617's core: all six waves then report through the *correct* household→cluster diagnosis.

## The fixes

- **`2008-15/_/cluster_features.py`** — `idxvars = dict(j='r_hhid', …)` → `dict(i='r_hhid', …)`. **The household id was declared as the ITEM level `j`.**
- **`2008-15/_/sample.py`** — replaces a silent `groupby().first()` with invariance asserts; sets `v = <NA>` (with a warning) where a household's panel lines disagree on origin EA, rather than picking one at random.
- **`2008-15/_/interview_date.py`** — assert + explicit dedup.
- **818 empty-string `District` cells → `pd.NA`** (see below).

## Tanzania's `2008-15/` is ONE FOLDER, FOUR ROUNDS. Is the fix multi-round-safe?

Yes. But the review question — *"a household's **two** panel lines" smells like a two-round assumption baked into a four-round folder"* — turned out to be **wrong prose over correct code**, which is worth stating precisely.

`upd4_hh_a.dta`'s true key is the panel-tracking **line** `(UPHI, round)` — 29,250/29,250 unique — **not** the household (16,540 household-rounds). Replication is **1 to 11 lines** per household-round:

| round | source rows | distinct (i,t) | lines per (i,t) | ambiguous (i,t) |
|---|---|---|---|---|
| 2008-09 | 6,128 | 3,265 | 1–11 | **0** |
| 2010-11 | 8,163 | 3,924 | 1–10 | **0** |
| 2012-13 | 9,998 | 5,010 | 1–9 | **0** |
| 2014-15 | 4,961 | 4,341 | 1–6 | **59** |

The code tests `nunique() > 1`, so it is **n-agnostic** and handles 3+ lines correctly. The 59 ambiguous groups carry 2, 3 or 5 lines apiece. **All 59 are in round 4; rounds 1–3 have zero.** The two-round assumption was only ever in the comment. Prose rewritten.

**`v` must NOT be round-invariant — and that is exactly the reading the `<NA>` sentinel requires.** The NPS tracks movers: **1,607 of the 8,359 panel lines seen in >1 round change clusterid over their life.** A household's cluster is a per-*round* fact. The fix groups on `(i, t)`, and **both halves are load-bearing**: `t` because `r_hhid` is not a stable panel id (its format changes per round, and R3/R4 reuse 1,857 of the same strings), `i` because invariance may only be demanded *within* a round. **Had it grouped on `i` alone it would have been badly wrong.** It doesn't.

**Rounds stay separate.** `cluster_features` rows per round after the `j`→`i` fix: 409 / 409 / 409 / 498 / 247 / 417 = **2,389 — identical to `development`**, index identical. No round collapse.

**No extended/refresh sub-panel collision.** Round 4: extended = 989 households / 79 clusters; refresh = 3,352 / 419. **Zero shared `r_hhid`, zero shared clusterid.** All 59 ambiguous households are extended-panel — refresh cannot produce the shape (one line each, drawn fresh).

## The 818 empty-string Districts

These were masked: they existed on `fix/323-tanzania` only because the rejected `majority` reducer happened to drop empty strings. Strip core and they return — a test passing on a side effect of the mechanism, not a property of the config.

**They are real source blanks, not manufactured.** `ha_02_2` (district *name*) is `''` for **all 6,128 round-1 rows and all 8,163 round-2 rows**; rounds 3–4 carry real names. 818 = 409 + 409 = **every cluster in 2008-09 and 2010-11**. `Region` and `Rural` are clean in all four rounds, and 2019-20 / 2020-21 already use honest NaN.

Fixed at source (`'' → pd.NA` in the extraction): **818 → 0 empty strings**, cells retained as `<NA>`. An empty string is missing data wearing a costume; it is now honestly missing. Region/Rural byte-identical, row count unchanged. The test now stands on a property of the config.

## Still open — correctly deferred

Site 2 row destruction is untouched: this port makes the *diagnosis* right, not the data. Under #617's audit:

| wave | destroyed / rows |
|---|---|
| 2008-09 | **0** |
| 2010-11 | 2,121 / 3,924 |
| 2012-13 | 3,960 / 5,010 |
| 2014-15 | 864 / 4,400 |
| 2019-20 | 748 / 1,184 |
| 2020-21 | 3,289 / 4,709 (+545 NaN-key) |

The last two **reproduce #617's published figures exactly** — independent corroboration. And **2008-09 destroying zero is the story corroborating itself**: round 1 is the pre-movement baseline, so there is nothing yet to disagree about. Repairing the rest is country-side work (a composite cluster key, per #617's own guidance).

## Verified

Isolated data dir (private L2, shared L1), `LSMS_NO_CACHE=1`, cold builds, `assert 'worktrees' in lsms_library.__file__`. All six Tanzania waves build; all 22 other declared tables build. Value-level before/after diff: **only 59 `sample.v` cells (2014-15) and 818 `District` cells (2008-09 / 2010-11) move — all value→NA, no rows lost.** `tests/test_tanzania_grain_gh323.py` (13 new): 3 fail on `development`, all pass here. Full Tanzania slice: **163 passed.**

Refs #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
