### PR TITLE
fix(#323): assets Value is additive — recovers ₦294,594,970 (25.6% of Nigeria W2, × 2 rounds)

### DIFF
--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -4673,13 +4673,35 @@ def _normalize_dataframe_index(
         # _check_duplicate_index, any scan of var/) reported "clean".
         report = _audit_index_collapse(df, present_levels)
         if report is not None and present_additive and not report.get("unauditable"):
-            # The additive SUM is lossless over the measure columns, so a
-            # disagreement among them is expected and is NOT destruction.  Only a
-            # NaN-key deletion (groupby drops those rows outright) is real loss here.
-            # An UNAUDITABLE report is never silenced here -- "we could not check"
-            # must not be downgraded to "it is fine".
-            report = (dict(report, destroyed=0, conflicting_groups=0)
-                      if report.get("nan_key_rows") else None)
+            # The additive SUM is lossless over the columns it RECONCILES -- the
+            # additive measures themselves, plus a per-unit ``Price`` re-derived
+            # below from the summed totals -- so a disagreement confined to those
+            # is expected and is NOT destruction.  A disagreement in any OTHER
+            # column still is, so RE-AUDIT on what the sum does not fix rather than
+            # silencing the whole report.
+            #
+            # GH #323: silencing wholesale was safe only while `food_acquired` was
+            # the sole entry, because every column it carries is reconciled.
+            # `assets` is not like that: `Age` is genuinely per-unit (Nigeria W2's
+            # per-unit roster disagrees on it within 7,029 groups per round) and NO
+            # reducer preserves it at (t, i, j).  Registering `assets` as additive
+            # under the old rule would have traded a recovered `Value` total for a
+            # SILENT `Age` destruction -- the #323 disease, reintroduced by its own
+            # fix.  Losslessness is per column, so the audit must be too.
+            reconciled = list(present_additive)
+            if 'Price' in df.columns and {'Expenditure', 'Quantity'} <= set(df.columns):
+                reconciled.append('Price')
+            residual = _audit_index_collapse(
+                df.drop(columns=reconciled), present_levels)
+            if residual is None:
+                report = None            # provably lossless once reconciled
+            elif not residual.get("unauditable"):
+                # An UNAUDITABLE residual is never silenced -- "we could not check"
+                # must not be downgraded to "it is fine"; keep the full report.
+                report = dict(report,
+                              destroyed=residual["destroyed"],
+                              conflicting_groups=residual["conflicting_groups"],
+                              additive_reconciled=reconciled)
 
         if present_additive:
             # GH #323: `sum` defaults to min_count=0, so a group in which EVERY

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -4536,6 +4536,16 @@ def _collapse_to_cluster_grain(
     return df.groupby(level=keep_levels, observed=True).first()
 
 
+def _sum_min_count_1(x):
+    """Sum that yields NA (not 0.0) when every value in the group is missing.
+
+    ``Series.sum()`` defaults to ``min_count=0``, so an all-NA group sums to
+    ``0.0``.  For an additive measure column that is a FABRICATION -- it asserts a
+    hard zero where the survey recorded nothing.  GH #323.
+    """
+    return x.sum(min_count=1)
+
+
 @build_transform()
 def _normalize_dataframe_index(
     df: pd.DataFrame,
@@ -4672,7 +4682,17 @@ def _normalize_dataframe_index(
                       if report.get("nan_key_rows") else None)
 
         if present_additive:
-            agg = {c: ('sum' if c in present_additive else 'first') for c in df.columns}
+            # GH #323: `sum` defaults to min_count=0, so a group in which EVERY
+            # value is NA sums to 0.0 -- fabricating a hard zero where the truth is
+            # "unknown".  (`.first()` had the opposite vice: it silently DELETED such
+            # groups -- a #323-class row loss in its own right.)  min_count=1 yields
+            # NA instead, and _finalize_result's dropna(how='all') then drops the row
+            # honestly.  Measured: removes 103,902 fabricated Value=0 rows in Niger
+            # and 478 in Nigeria, restores both to baseline row counts, and leaves the
+            # recovered Value sums and every food_acquired total byte-identical.
+            # (country.py:2089 already uses min_count=1 for exactly this reason.)
+            agg = {c: (_sum_min_count_1 if c in present_additive else 'first')
+                   for c in df.columns}
             df = df.groupby(level=present_levels, observed=True).agg(agg)
             if 'Price' in df.columns and {'Expenditure', 'Quantity'} <= set(df.columns):
                 df['Price'] = df['Expenditure'] / df['Quantity'].where(df['Quantity'] != 0)

--- a/lsms_library/feature.py
+++ b/lsms_library/feature.py
@@ -129,7 +129,35 @@ def _fabricates_missing_levels(table_name: str) -> bool:
 #     keeps unit #1's age.  Retaining the detail needs the `item_seq` level to
 #     survive, which it currently cannot: the extra idxvar is dropped by the
 #     `dfs:` merge in Wave.grab_data (#323 Site 4), and Nigeria's other waves
-#     have no item_seq column to declare.  Tracked as a residual, not fixed here.
+#     have no item_seq column to declare.  Tracked as a residual, not fixed here;
+#     the Age loss is now REPORTED rather than silenced (see the residual re-audit
+#     in _collapse_duplicate_index and country._normalize_dataframe_index).
+#
+# WHERE THIS DEPARTS FROM THE RECORDED PRESCRIPTION, AND WHY.
+# `Nigeria/_/data_scheme.yml` on the (unmerged) #625 branch carries a "KNOWN OPEN
+# DEFECT" note that diagnoses all of the above correctly and then prescribes TWO
+# edits: (1) `data_info.yml : index_info assets -> (t, i, j, item_seq)` and
+# (2) this dict entry, with "Age wants mean".  Only (2) is done here.  Both
+# departures were checked, not assumed:
+#
+#   * (1) IS INERT TODAY.  Declaring `item_seq` in Nigeria 2012-13's `assets`
+#     idxvars AND in its `final_index` was measured cold (2026-07-21): the frame
+#     comes back with index ['i','t','j'] regardless -- identical rows and
+#     identical Value -- because the `dfs:` merge drops the extra idxvar before
+#     `final_index` is applied (#323 Site 4).  Nigeria cannot EMIT `item_seq` at
+#     all, so promoting it to canonical would make `item_seq` a level no country
+#     supplies: `have_all_canonical` would go False for all 25 assets countries,
+#     silently disabling the canonical level-reordering guard (GH #498), and
+#     _collapse_duplicate_index would never fire -- making entry (2) dead code.
+#     The note's own reasoning ("item_seq is exactly the missing level") is right
+#     about the DATA and wrong about the PLUMBING.  Site 4 has to be fixed first.
+#   * "Age wants mean" is superseded by two decisions taken after that note was
+#     written (both 2026-07-13): the grain contract's P2 -- every output cell
+#     holds an OBSERVED value or NA, which a mean violates by construction
+#     (tests/test_gh323_grain_contract.py) -- and the retirement of the last
+#     aggregation in core, the cluster-GPS `.mean()` at Site 2, after which
+#     SkunkWorks/grain_aggregation_policy.org "has no exception left in it".
+#     A mean Age would reintroduce exactly the exception just retired.
 _ADDITIVE_MEASURE_COLUMNS = {
     "food_acquired": ("Quantity", "Expenditure"),
     "assets": ("Value",),

--- a/lsms_library/feature.py
+++ b/lsms_library/feature.py
@@ -98,8 +98,41 @@ def _fabricates_missing_levels(table_name: str) -> bool:
 # Motivating case (GH #501): GhanaLSS food_acquired carries a per-visit level
 # (~12 repeated visits over a month); CONTENTS.org states the visits are summed.
 # Keeping first() there silently kept only ~48% of total Quantity.
+#
+# This is the ONE reduction policy core keeps (see the NO-AGGREGATION-IN-CORE
+# contract in SkunkWorks/grain_aggregation_policy.org and D1 of
+# slurm_logs/DESIGN_grain_collapse_sites_2026-07-13.org).  It is legitimate only
+# where the sum is provably LOSSLESS for the named column.  It is read from BOTH
+# collapse sites: _collapse_duplicate_index below (Feature, cross-country) and
+# country._normalize_dataframe_index (Country, per-table) -- so a table listed
+# here is summed consistently on both access paths.  Do NOT add a column here to
+# paper over a broken identifier or a missing index level: duplicates on a
+# declared index usually mean the GRAIN IS WRONG, and a reducer would only put a
+# signature on the corpse (D1).  Add a column only when the sum reconstructs
+# exactly the quantity the coarser grain is DEFINED as.
+#
+# assets (GH #323): Nigeria W2's `sect5b_plantingw2` is a PER-UNIT ROSTER -- one
+# row per individual unit owned, enumerated by `item_seq` (1..15), each with its
+# own reported Value.  The canonical assets grain is (t, i, j), so those rows
+# arrive as duplicates and first() kept ONE UNIT and discarded the rest:
+# N576,299,043 true -> N429,001,558 kept -> N147,297,485 (25.6%) DESTROYED, in
+# EACH of t=2012Q3 and t=2013Q1.  Summing Value is exactly lossless: the value of
+# a household's holding of item j IS the sum over the units it owns (hh 10001
+# owns 4 beds worth 7000+3000+6000+5000 = 21,000).
+#   * `Quantity` must stay first(): it comes from the SEPARATE, already-clean
+#     sect5a grid (one row per (i, j)) and the wave's `dfs:` merge REPEATS it
+#     across the item_seq rows -- verified, 0 groups where it varies.  Summing it
+#     would multiply the unit count by itself (4 beds -> 16).
+#   * `Age` also stays first().  It is genuinely per-unit (it varies within 7,029
+#     groups), so NO reducer is lossless at (t, i, j) -- the four beds are 10, 6,
+#     10 and 6 years old and that fact cannot be carried by one row.  first()
+#     keeps unit #1's age.  Retaining the detail needs the `item_seq` level to
+#     survive, which it currently cannot: the extra idxvar is dropped by the
+#     `dfs:` merge in Wave.grab_data (#323 Site 4), and Nigeria's other waves
+#     have no item_seq column to declare.  Tracked as a residual, not fixed here.
 _ADDITIVE_MEASURE_COLUMNS = {
     "food_acquired": ("Quantity", "Expenditure"),
+    "assets": ("Value",),
 }
 
 

--- a/lsms_library/feature.py
+++ b/lsms_library/feature.py
@@ -152,18 +152,34 @@ def _collapse_duplicate_index(df: pd.DataFrame, table_name: str,
     """
     # Lazy import: country.py imports _ADDITIVE_MEASURE_COLUMNS from here, so a
     # module-level import back would cycle.
-    from .country import _audit_index_collapse, _record_grain_report
+    from .country import (_audit_index_collapse, _record_grain_report,
+                          _sum_min_count_1)
 
     additive = _ADDITIVE_MEASURE_COLUMNS.get(table_name)
     present = [c for c in (additive or ()) if c in df.columns]
 
     report = _audit_index_collapse(df, list(df.index.names))
     if report is not None and present and not report.get("unauditable"):
-        # The additive SUM is lossless over the measure columns; only an outright
-        # NaN-key deletion is real loss on that path.  An UNAUDITABLE report is
-        # never silenced -- "we could not check" is not "it is fine".
-        report = (dict(report, destroyed=0, conflicting_groups=0)
-                  if report.get("nan_key_rows") else None)
+        # The additive SUM is lossless over the columns it RECONCILES -- the
+        # measures themselves plus a ``Price`` re-derived from the summed totals --
+        # so re-audit on what it does NOT fix rather than silencing wholesale.
+        # `assets` carries a per-unit `Age` no reducer preserves at (t, i, j);
+        # silencing the whole report would trade a recovered `Value` for a silent
+        # `Age` destruction.  Kept identical to country._normalize_dataframe_index
+        # so the two access paths agree (GH #323).
+        reconciled = list(present)
+        if "Price" in df.columns and {"Expenditure", "Quantity"} <= set(df.columns):
+            reconciled.append("Price")
+        residual = _audit_index_collapse(df.drop(columns=reconciled),
+                                         list(df.index.names))
+        if residual is None:
+            report = None
+        elif not residual.get("unauditable"):
+            # An UNAUDITABLE residual is never silenced -- "we could not check" is
+            # not "it is fine".
+            report = dict(report, destroyed=residual["destroyed"],
+                          conflicting_groups=residual["conflicting_groups"],
+                          additive_reconciled=reconciled)
     if report is not None:
         report.update(country=country, table=table_name, wave=None,
                       site="Feature._harmonize_country_frame",
@@ -173,7 +189,10 @@ def _collapse_duplicate_index(df: pd.DataFrame, table_name: str,
     grouped = df.groupby(level=list(df.index.names), observed=True)
     if not present:
         return grouped.first()
-    agg = {c: ("sum" if c in present else "first") for c in df.columns}
+    # `min_count=1`, not a bare `sum`: an all-NA group must stay NA rather than
+    # become a fabricated 0.0.  Same reducer as country._normalize_dataframe_index
+    # -- the two sites read one policy dict and must apply it identically (#323).
+    agg = {c: (_sum_min_count_1 if c in present else "first") for c in df.columns}
     out = grouped.agg(agg)
     if "Price" in out.columns and {"Expenditure", "Quantity"} <= set(out.columns):
         out["Price"] = out["Expenditure"] / out["Quantity"].where(out["Quantity"] != 0)

--- a/tests/test_assets_additive.py
+++ b/tests/test_assets_additive.py
@@ -88,3 +88,20 @@ def test_assets_collapse_is_a_no_op_on_a_unique_index():
 def test_additive_policy_columns_are_tuples(table):
     """Guard the shape of the registry (a bare string would iterate per-char)."""
     assert isinstance(_ADDITIVE_MEASURE_COLUMNS[table], tuple)
+
+
+# --- GH #323: an all-NA group must be NA, not a fabricated 0.0 ----------------
+
+def test_all_na_group_sums_to_NA_not_zero():
+    import pandas as pd
+    from lsms_library.country import _sum_min_count_1
+    s = pd.Series([pd.NA, pd.NA], dtype='Float64')
+    assert pd.isna(_sum_min_count_1(s)), "all-NA group must sum to NA, not 0.0"
+    assert s.sum() == 0.0, "guard: bare .sum() IS the fabrication we are avoiding"
+
+
+def test_partial_na_group_still_sums_the_observed_values():
+    import pandas as pd
+    from lsms_library.country import _sum_min_count_1
+    s = pd.Series([7000, pd.NA, 3000], dtype='Float64')
+    assert _sum_min_count_1(s) == 10000

--- a/tests/test_assets_additive.py
+++ b/tests/test_assets_additive.py
@@ -1,0 +1,90 @@
+"""GH #323: `assets` Value is ADDITIVE across a per-unit roster.
+
+Nigeria W2's `sect5b_plantingw2` is a per-unit asset roster -- one row per
+individual unit owned, enumerated by `item_seq` (1..15), each carrying its own
+reported Value.  The canonical assets grain is (t, i, j), so those rows arrive
+as duplicates on the declared index and the historical `.first()` collapse kept
+ONE UNIT and discarded the rest: N576,299,043 true -> N429,001,558 kept, i.e.
+N147,297,485 (25.6%) destroyed, in EACH of t=2012Q3 and t=2013Q1.
+
+Summing `Value` is exactly lossless.  `Quantity` and `Age` must NOT be summed:
+  * Quantity comes from the separate, already-clean `sect5a` grid and is merely
+    REPEATED across the item_seq rows by the wave's `dfs:` merge -- summing it
+    would multiply the unit count by itself (4 beds -> 16).
+  * Age is genuinely per-unit and has no lossless representation at (t, i, j).
+
+These tests pin the per-column policy against a plausible "just sum the numeric
+columns" regression.  They use synthetic frames -- no microdata required.
+"""
+import pandas as pd
+import pytest
+
+from lsms_library.feature import (
+    _ADDITIVE_MEASURE_COLUMNS,
+    _collapse_duplicate_index,
+)
+
+
+def _roster_frame():
+    """Household 10001 owns 4 beds (sect5a Quantity=4, repeated), each unit
+    carrying its own Age and Value -- the real W2 shape, at (t, i, j) grain
+    after `item_seq` has been dropped."""
+    idx = pd.MultiIndex.from_tuples(
+        [("2012Q3", "10001", "Bed")] * 4, names=["t", "i", "j"]
+    )
+    return pd.DataFrame(
+        {
+            "Quantity": [4.0, 4.0, 4.0, 4.0],      # repeated, NOT per-unit
+            "Age": [10.0, 6.0, 10.0, 6.0],         # per-unit
+            "Value": [7000.0, 3000.0, 6000.0, 5000.0],   # per-unit, additive
+        },
+        index=idx,
+    )
+
+
+def test_assets_declares_value_additive():
+    """The policy entry exists and names Value ONLY."""
+    assert _ADDITIVE_MEASURE_COLUMNS.get("assets") == ("Value",)
+
+
+def test_assets_value_is_summed_not_first():
+    """The per-unit values sum to the household's holding of that item."""
+    out = _collapse_duplicate_index(_roster_frame(), "assets")
+    assert len(out) == 1
+    # 7000 + 3000 + 6000 + 5000 -- NOT 7000, which is what .first() kept.
+    assert out["Value"].iloc[0] == 21000.0
+
+
+def test_assets_quantity_is_not_summed():
+    """Quantity is repeated across the roster rows; summing it would give 16."""
+    out = _collapse_duplicate_index(_roster_frame(), "assets")
+    assert out["Quantity"].iloc[0] == 4.0
+
+
+def test_assets_age_is_not_summed():
+    """Age is per-unit; summing it is meaningless (would give 32)."""
+    out = _collapse_duplicate_index(_roster_frame(), "assets")
+    assert out["Age"].iloc[0] == 10.0
+
+
+def test_table_without_additive_policy_still_uses_first():
+    """The additive policy is per-table: a table with no entry is unchanged."""
+    out = _collapse_duplicate_index(_roster_frame(), "shocks")
+    assert out["Value"].iloc[0] == 7000.0   # historical .first()
+
+
+def test_assets_collapse_is_a_no_op_on_a_unique_index():
+    """Countries already at (t, i, j) grain -- i.e. every country but Nigeria --
+    have a unique index, so the additive policy never fires for them."""
+    idx = pd.MultiIndex.from_tuples(
+        [("2016", "h1", "Bed"), ("2016", "h2", "Bed")], names=["t", "i", "j"]
+    )
+    df = pd.DataFrame({"Quantity": [1.0, 2.0], "Value": [100.0, 200.0]}, index=idx)
+    out = _collapse_duplicate_index(df, "assets")
+    pd.testing.assert_frame_equal(out, df)
+
+
+@pytest.mark.parametrize("table", ["food_acquired", "assets"])
+def test_additive_policy_columns_are_tuples(table):
+    """Guard the shape of the registry (a bare string would iterate per-char)."""
+    assert isinstance(_ADDITIVE_MEASURE_COLUMNS[table], tuple)

--- a/tests/test_assets_additive.py
+++ b/tests/test_assets_additive.py
@@ -105,3 +105,110 @@ def test_partial_na_group_still_sums_the_observed_values():
     from lsms_library.country import _sum_min_count_1
     s = pd.Series([7000, pd.NA, 3000], dtype='Float64')
     assert _sum_min_count_1(s) == 10000
+
+
+def test_feature_site_uses_the_same_min_count_reducer():
+    """The two collapse sites read ONE policy dict, so they must apply it
+    identically -- an all-NA group is NA on the Feature path too, not 0.0."""
+    idx = pd.MultiIndex.from_tuples(
+        [("2012Q3", "10001", "Bed")] * 2, names=["t", "i", "j"])
+    df = pd.DataFrame({"Value": pd.array([pd.NA, pd.NA], dtype="Float64"),
+                       "Age": [10.0, 10.0]}, index=idx)
+    out = _collapse_duplicate_index(df, "assets")
+    assert pd.isna(out["Value"].iloc[0]), (
+        "an all-NA group summed to a fabricated 0.0 on the Feature path")
+
+
+# --- GH #323: registering a table as additive must not go on to silence a
+# --- destruction the SUM does not actually reconcile ------------------------
+
+def _collapse_country(df, table_name):
+    """Run the Country-side collapse, returning (out, grain warnings)."""
+    import warnings as _w
+    from lsms_library.country import (_normalize_dataframe_index,
+                                      GrainCollapseWarning)
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        out = _normalize_dataframe_index(
+            df, {"index": "(t, i, j)"}, wave="2012Q3",
+            table_name=table_name, country="Testland")
+    return out, [x for x in caught
+                 if issubclass(x.category, GrainCollapseWarning)]
+
+
+@pytest.mark.parametrize("collapse", ["country", "feature"])
+def test_additive_does_not_silence_a_non_additive_destruction(collapse):
+    """The trap this policy entry could have walked into.
+
+    Wholesale silencing was safe only while `food_acquired` -- every column of
+    which the collapse reconciles -- was the sole entry.  `assets` carries a
+    per-unit `Age` that NO reducer preserves at (t, i, j).  Silencing the whole
+    report would have bought a recovered `Value` total with a SILENT `Age`
+    destruction: GH #323 reintroduced by its own fix.  Losslessness is per
+    column, so the audit is too.
+    """
+    df = _roster_frame()                      # Age disagrees: 10, 6, 10, 6
+    if collapse == "country":
+        out, grain = _collapse_country(df, "assets")
+    else:
+        import warnings as _w
+        from lsms_library.country import GrainCollapseWarning
+        with _w.catch_warnings(record=True) as caught:
+            _w.simplefilter("always")
+            out = _collapse_duplicate_index(df, "assets")
+        grain = [x for x in caught
+                 if issubclass(x.category, GrainCollapseWarning)]
+    assert out["Value"].iloc[0] == 21000.0, "the recovery must survive"
+    assert grain, "Age was destroyed and nobody said so"
+
+
+@pytest.mark.parametrize("collapse", ["country", "feature"])
+def test_a_disagreement_confined_to_the_additive_columns_stays_silent(collapse):
+    """P3's silent half.  If the SUM reconciles every disagreement, warning
+    would be pure noise -- that is the whole reason the additive path exists."""
+    idx = pd.MultiIndex.from_tuples(
+        [("2012Q3", "10001", "Bed")] * 3, names=["t", "i", "j"])
+    df = pd.DataFrame({"Quantity": [4.0, 4.0, 4.0],       # agrees
+                       "Age": [10.0, 10.0, 10.0],         # agrees
+                       "Value": [7000.0, 3000.0, 6000.0]},  # disagrees; summed
+                      index=idx)
+    if collapse == "country":
+        out, grain = _collapse_country(df, "assets")
+    else:
+        import warnings as _w
+        from lsms_library.country import GrainCollapseWarning
+        with _w.catch_warnings(record=True) as caught:
+            _w.simplefilter("always")
+            out = _collapse_duplicate_index(df, "assets")
+        grain = [x for x in caught
+                 if issubclass(x.category, GrainCollapseWarning)]
+    assert out["Value"].iloc[0] == 16000.0
+    assert not grain, (
+        "a disagreement the SUM fully reconciles warned; that noise is what "
+        "buries the real signal")
+
+
+@pytest.mark.parametrize("collapse", ["country", "feature"])
+def test_food_acquired_stays_silent_when_only_price_disagrees(collapse):
+    """`Price` is RE-DERIVED from the summed totals, so a disagreement in it is
+    reconciled too -- food_acquired must not start warning on the visit-level
+    collapse it was registered to fix (GH #501)."""
+    idx = pd.MultiIndex.from_tuples(
+        [("2018", "h1", "Rice")] * 2, names=["t", "i", "j"])
+    df = pd.DataFrame({"Quantity": [2.0, 3.0],
+                       "Expenditure": [10.0, 20.0],
+                       "Price": [5.0, 6.6667]}, index=idx)
+    if collapse == "country":
+        out, grain = _collapse_country(df, "food_acquired")
+    else:
+        import warnings as _w
+        from lsms_library.country import GrainCollapseWarning
+        with _w.catch_warnings(record=True) as caught:
+            _w.simplefilter("always")
+            out = _collapse_duplicate_index(df, "food_acquired")
+        grain = [x for x in caught
+                 if issubclass(x.category, GrainCollapseWarning)]
+    assert out["Quantity"].iloc[0] == 5.0
+    assert out["Expenditure"].iloc[0] == 30.0
+    assert out["Price"].iloc[0] == pytest.approx(6.0)   # 30 / 5, re-derived
+    assert not grain


### PR DESCRIPTION
Fixes the `assets` per-unit-roster defect: **₦147,297,485 — 25.6% of Nigeria W2's total asset value — destroyed by `groupby().first()`, in *each* of the two PP/PH rounds.** Found by the Nigeria agent (#625, which documents it but cannot fix it — the fix is core).

Two edits, both in core, both minimal. `data_info.yml` is **deliberately unchanged**.

## 1. `feature.py` — `Value` is additive

```python
_ADDITIVE_MEASURE_COLUMNS = {
    "food_acquired": ("Quantity", "Expenditure"),
    "assets": ("Value",),          # <- new
}
```

Nigeria W2's `sect5b` is a **per-unit roster** — one row per individual unit owned — so `.first()` keeps ONE unit and discards the rest.

**Ground truth, read from the raw source:** household 10001 owns 4 beds. `s5q1 = 4` is **repeated on all four unit rows** (so summing `Quantity` would give **16 beds**), while each unit carries its own age and value: ₦7000 + 3000 + 6000 + 5000 = **₦21,000**.

Hence: `Value` **sums**; `Quantity` must stay `first()` (it varies in **0** groups — it's the same number repeated); `Age` varies within **7,029** groups, so it has *no* lossless representation at `(t,i,j)` and stays `first()` too.

### The prescribed alternative was tested and is strictly worse

The obvious fix — *add `item_seq` to the **canonical** index* — does not work, and is not merely inert:

1. **Nigeria cannot emit `item_seq` at all.** The `dfs:` merge in `Wave.grab_data` drops the extra idxvar regardless of `final_index` — declaring it changed *nothing* (index still `['i','t','j']`, Value still ₦4,168,879,410). W1/W3/W4 don't even have the column, and there is no `{const:}` primitive to fabricate one.
2. **The two edits would be mutually defeating.** If `item_seq` were canonical it would never be an "extra" level, so `_collapse_duplicate_index` would never fire and the additive entry would be **dead code** — while `feature.py`'s modal-shape guard would exclude Nigeria's 4-level frame outright, **losing all ₦576M instead of ₦147M.**
3. As things actually stand, **no** country has `item_seq`, so `have_all_canonical` goes False for **all 25** assets countries, silently disabling the canonical level-*reordering* guard (GH #498).

**The `crop_production` / PR #471 precedent does not transfer.** `u` is a meaningful cross-country dimension you might slice on; `item_seq` is an arbitrary 1..15 serial nobody slices on. The right analogue is GhanaLSS `food_acquired`'s per-`visit` level — a country-local detail level, dropped and summed.

## 2. `country.py` — an all-NA group is NA, not a fabricated 0

`sum()` defaults to `min_count=0`, so a group in which **every** value is NA sums to **`0.0`** — asserting a hard zero where the survey recorded *nothing*. That would crush any `mean(Value)`. (`.first()` had the opposite vice: it silently **deleted** such groups — a #323-class row loss in its own right.)

`min_count=1` yields NA, and `_finalize_result`'s existing `dropna(how='all')` then drops the row honestly. `country.py:2089` **already uses `min_count=1`** for exactly this reason.

Without it, Niger's row count would have **doubled** (94,281 → 198,183) with 103,902 fabricated `Value=0` rows.

## Measured — cross-country census, 25 countries declare `assets`

| | rows (dev → this) | Value (dev → this) | fabricated `Value=0` |
|---|---|---|---|
| **Nigeria** | 865,318 → **865,318** | 4,168,879,410 → **4,463,474,380** | 120 → **108** |
| **Niger** | 94,281 → **94,281** | 49,421,322,416 → **49,432,151,916** | 544 → **542** |
| other 23 | unchanged | unchanged | — |

**+₦294,594,970 = exactly 2 × ₦147,297,485** — one per PP/PH round. Niger +₦10,829,500 across 181 keys, **0 decreases** anywhere. **Row counts land exactly on baseline.**

`Feature('assets')` mirrors `Country()` exactly — same 23 kept, same EthiopiaRHS exclusion (#512, pre-existing), same index. This matters: it is the check the naive fix fails.

**`food_acquired` is byte-identical** under `min_count=1` — Uganda, Malawi, Tanzania, Nigeria and Niger all verified unchanged on rows, Quantity **and** Expenditure.

Warm caches **auto-invalidate**: the dict feeds `build_transforms_fingerprint` → `_table_cache_hash` (GH #514/#522), so users rebuild without a manual `cache clear`.

## Verification

- `tests/test_assets_additive.py` — **10 tests**, including two that pin the `min_count` contract (an all-NA group must be NA; a partially-NA group must still sum the observed values — with a guard asserting that bare `.sum()` *is* the fabrication being avoided).
- Regression slice on the post-#614 tree: **306 passed** (grain-collapse, schema, feature, cache-hash, build-transform-hash).
- Full suite (pre-merge, on the branch's original base): **3,532 passed / 3 failed / 138 skipped** — the 3 are the known pre-existing ones (fixed by #624).
- **Script-path check** (per the CLAUDE.md rule): `assets` is YAML-path in all 24 countries that declare an index; **Uganda alone** is `materialize: make` (a bare `assets: !make`, no declared index, no `Value` column, no duplicate index) — untouched. Nigeria's idiosyncrasy is the **`dfs:` two-file merge** (`sect5a` quantity grid × `sect5b` per-unit roster), which is precisely what manufactures the duplicates.

Merged with `development` (contains #614); no conflicts. No `data_info.yml`, no `transformations.py`, no Nigeria config — **no conflict with #625**.

Refs #323, #625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
