### PR TITLE
data(CotedIvoire): DVC-track the GPS file — Latitude/Longitude are REQUIRED again (follow-up to #624)

### DIFF
--- a/lsms_library/countries/CotedIvoire/2018-19/Data/Menage/ehcvm_individu_CIV2018.dta.dvc
+++ b/lsms_library/countries/CotedIvoire/2018-19/Data/Menage/ehcvm_individu_CIV2018.dta.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 6f12fbec180ba0fe92a265ea4632c1cc
+  size: 4663408
+  hash: md5
+  path: ehcvm_individu_CIV2018.dta

--- a/lsms_library/countries/CotedIvoire/2018-19/Data/Menage/ehcvm_ponderations_CIV2018.dta.dvc
+++ b/lsms_library/countries/CotedIvoire/2018-19/Data/Menage/ehcvm_ponderations_CIV2018.dta.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 30ab9a8250251ec6b41e7e54e26dbcb8
+  size: 7018
+  hash: md5
+  path: ehcvm_ponderations_CIV2018.dta

--- a/lsms_library/countries/CotedIvoire/2018-19/Data/Menage/grappe_gps_CIV2018.dta.dvc
+++ b/lsms_library/countries/CotedIvoire/2018-19/Data/Menage/grappe_gps_CIV2018.dta.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: e60e23ca44544440a43d8f74fd5ad8f3
+  size: 60134
+  hash: md5
+  path: grappe_gps_CIV2018.dta

--- a/lsms_library/countries/CotedIvoire/_/data_scheme.yml
+++ b/lsms_library/countries/CotedIvoire/_/data_scheme.yml
@@ -10,32 +10,20 @@ Data Scheme:
     Rural: str
 
   cluster_features:
-    # Latitude / Longitude are `optional:` because the source they come from is
-    # NOT in the shipped distribution -- NOT because CotedIvoire lacks cluster
-    # GPS.  It has it: 2018-19/_/data_info.yml wires `df_geo` to
-    # Menage/grappe_gps_CIV2018.dta (1084 grappes; columns grappe,
-    # coordonnes_gps__Latitude, coordonnes_gps__Longitude), and that wiring is
-    # correct -- the column names match the file exactly.  The problem is that
-    # this one file was never `dvc add`ed: it carries no .dvc sidecar, whereas
-    # every EHCVM sibling (Senegal / Mali / Niger / Burkina_Faso / Benin / Togo
-    # / Guinea-Bissau) has grappe_gps_<iso>2018.dta.dvc.  So in any clean
-    # checkout the file is simply absent, the GH #515 optional-sub-df fallback
-    # in country.py swallows the resulting PathMissingError, and Lat/Lon drop
-    # out silently.
-    #
-    # REMEDY (needs a human with S3 write creds -- it publishes a new blob to
-    # the shared dataset): `dvc add` + `dvc push` the GPS file, then delete the
-    # two `optional:` markers below.  No other change is required; the columns
-    # will flow through the existing df_geo merge as soon as the file resolves.
+    # Latitude / Longitude come from the df_geo merge wired in
+    # 2018-19/_/data_info.yml -> Menage/grappe_gps_CIV2018.dta (1084 grappes;
+    # columns grappe, coordonnes_gps__Latitude, coordonnes_gps__Longitude).
+    # Until 2026-07-13 that one file carried NO .dvc sidecar -- unlike every
+    # EHCVM sibling -- so in a clean checkout it was simply absent, the GH #515
+    # optional-sub-df fallback swallowed the PathMissingError, and Lat/Lon
+    # dropped out silently.  It is now DVC-tracked, so they are REQUIRED again.
     index: (t, v)
     Region: str
     Rural: str
     Latitude:
       type: float
-      optional: true
     Longitude:
       type: float
-      optional: true
 
   household_roster:
     index: (t, i, pid)


### PR DESCRIPTION
Commits the sidecars for the three CotedIvoire source files Ethan `dvc add`ed + pushed, and **reverses the temporary `optional:` markers** PR #624 had to add.

Blobs verified present in S3 (`dvcbucket0/LSMS`): `grappe_gps` `e60e23ca…`, `ehcvm_individu` `6f12fbec…`, `ehcvm_ponderations` `30ab9a82…`.

## Why the markers existed

`grappe_gps_CIV2018.dta` was the **only** EHCVM cluster-GPS file in the library with **no `.dvc` sidecar** — every sibling (Senegal, Mali, Niger, Burkina Faso, Benin, Togo, Guinea-Bissau) had one.

Its wiring was always correct: `2018-19/_/data_info.yml` wires `df_geo` to it, and the column names (`coordonnes_gps__Latitude` / `_Longitude`) match the file exactly. But in any clean checkout the file was simply **absent** → `PathMissingError` → the GH #515 optional-sub-df fallback **swallowed it** → `Latitude`/`Longitude` dropped out with only a warning.

#624 marked them `optional:` to get the suite green **without deleting a real feature**, and deliberately stopped short of the `dvc add` — that publishes a blob to the shared dataset every downstream user pulls, and *"looks right" is not provenance*. That was the right call, and it's now resolved.

## Verified end-to-end

Built from a **clean worktree with no raw `.dta` present**, so the sidecar alone had to resolve the file from S3:

```
columns: ['Region', 'Rural', 'Latitude', 'Longitude']
Latitude: 967 non-null of 1484 clusters
```

And the two tests #624 had to work around now pass **on their own merits**, with the `optional:` markers gone:

- `test_declared_columns_present[CotedIvoire/cluster_features]` ✅
- `test_feature_is_sane[CotedIvoire/cluster_features]` ✅

The 6 `optional:` markers elsewhere in `CotedIvoire/_/data_scheme.yml` (other tables) are untouched.

Refs #515, #323. Follow-up to #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
