### PR TITLE
fix(#323): Benin cluster_features — project in the extraction, enforce the invariant (config-only)

### DIFF
--- a/.coder/ledger/323-benin.md
+++ b/.coder/ledger/323-benin.md
@@ -1,0 +1,186 @@
+# Prior-Art Ledger — GH #323 (Benin): the residue after PR #615
+
+**Search tier used:** ripgrep + git floor (gitnexus not consulted; the change is
+config-scoped to one country/one wave and the framework symbols were read
+directly). The decisive prior art was found with
+`git log --all --grep=323 -- lsms_library/countries/Benin` and
+`git show fc3be203` (CotedIvoire).
+
+> **Companion ledger, not a replacement.** `.coder/ledger/323-benin-togo.md`
+> owns Benin's `plot_inputs` defect and its fix, which **merged on 2026-07-19**
+> (PR #615, commits `36170a57` + `ef45231e`). This ledger owns what was left
+> over: the `cluster_features` extraction grain, the `food_acquired`
+> non-defect, and the dead `aggregation:` key. Read that one first for the
+> `harmonize_seed_crop` story.
+
+## §1 Task, restated
+
+The task as briefed was "fix GH #323 for Benin", listing two deliverables: the
+`cluster_features` extraction hook salvaged from
+`rescue/2026-07-21/323-benin`, and an injective `harmonize_seed_crop` for
+`plot_inputs`.
+
+**The second was already done.** `origin/development` at `53ef3a5d` already
+carries the split (`Semences d'autres céréales → Autre céréale`,
+`Plants/boutures de tubercules → Autre tubercule`), the uniqueness assertion in
+`Benin/2018-19/_/plot_inputs.py`, the ledger, and `tests/test_gh323_benin_togo.py`
+— all merged via PR #615. Re-deriving it would have produced a no-op diff and,
+worse, an invented second account of the same numbers. **Verified rather than
+assumed**: a cold rebuild returns 10,605 rows with 0 duplicate index tuples
+(§Phase 3).
+
+So this task reduces to three things, and they are three *different* things —
+conflating them is exactly how #323 survived elsewhere:
+
+| table | dup rows on the declared index | what it is | action |
+|---|---|---|---|
+| `plot_inputs` | 71 | broken identifier — **real loss** | none — merged in PR #615 |
+| `cluster_features` | 7,342 | **wrong extraction grain** — no loss | fix the extraction + enforce the invariant |
+| `food_acquired` | 1,382 | **intended bucketing** — no loss | none — core already SUMs; document it |
+
+`cluster_features` declares `(t, v)`, but `df_main` in
+`Benin/2018-19/_/data_info.yml` reads `Region`/`Rural` from the **household**-level
+cover page `s00_me_ben2018.dta` while declaring only `v: grappe`. Each grappe's
+attributes are broadcast across its 8,012 households and handed to
+`_normalize_dataframe_index` as 8,012 rows on a 670-cluster grain.
+
+## §2 Existing machinery (this task's area)
+
+| symbol | path:line | what it does | tested? | reuse / extend / new |
+|--------|-----------|--------------|---------|----------------------|
+| `_normalize_dataframe_index` | `lsms_library/country.py` (~L4550) | reorders to the declared index; `groupby().first()` when non-unique, `sum` for `_ADDITIVE_MEASURE_COLUMNS`; audits first (#614) | yes | **untouched** (D1: core is not this PR's business) |
+| `_audit_index_collapse` | `lsms_library/country.py:4214` | pre-collapse audit; `GrainCollapseWarning` on destruction, **silent when lossless**, stamped into the parquet and replayed warm | yes | reuse as the oracle — its silence on Benin is a *result*, not an absence |
+| `_collapse_to_cluster_grain` (Site 2) | `lsms_library/country.py:~4453` | the *other* household→cluster collapse, for countries declaring `i:` in `cluster_features` idxvars | yes | **N/A for Benin** — Benin declares only `v`, so Site 2 never fires here; the collapse lands on Site 1 |
+| `_ADDITIVE_MEASURE_COLUMNS` | `lsms_library/country.py` / `feature.py` | the one surviving reduction: `food_acquired` measures are SUMMED | yes | reuse — it is why `food_acquired`'s 1,382 collisions lose nothing |
+| df_edit hook dispatch | `lsms_library/country.py:1054` (`dfs:` branch) | a `mapping.py` function named after a declared table runs on the merged, **already-indexed** frame | — | **reuse** — the hook sees `(t, v)`, which is what the salvaged code assumes |
+| `Wave.formatting_functions` | `lsms_library/country.py:692` | loads `{wave_folder}.py` + `mapping.py` into the hook namespace | — | reuse (also the test's handle on the hook) |
+| CotedIvoire case A | `fix/323-cotedivoire` `fc3be203`, `CotedIvoire/_/cotedivoire.py` | same defect: household-grain source, `v`-only declaration; projects in the extraction | `tests/test_gh323_cotedivoire.py` | **the pattern followed here** |
+| `.coder/ledger/323-benin-togo.md` | — | Benin/Togo `plot_inputs` | `tests/test_gh323_benin_togo.py` | **cite, do not re-derive** |
+
+## §3 Definitions & conventions in force
+
+- **D1, "core does not aggregate"** — `slurm_logs/DESIGN_grain_collapse_sites_2026-07-13.org`,
+  §"Decisions (Ethan, 2026-07-13)"; upheld in `SkunkWorks/grain_aggregation_policy.org`
+  §3a and now summarised in `CLAUDE.md` §"Grain Collapse". Consequence for this
+  PR: **no file under `lsms_library/*.py` is touched.**
+- **`aggregation:` is dead config** — same doc, same section: the key survives
+  only in core's "skip these meta-keys" sets, a test pins that the collapse does
+  not honour it, and it now contradicts the policy it was written to serve.
+  Cited in `CLAUDE.md` §"Grain Collapse".
+- **Duplicates on a declared index mean the identifier is broken or a level is
+  missing** — `CLAUDE.md` §"Grain Collapse"; the Mali `pid` case is the proof
+  that no reducer can be correct in general.
+- **EHCVM key convention**: each `grappe` is visited in exactly one `vague`, so
+  `v: grappe` and `i: [grappe, menage]` — `CLAUDE.md` §"Gotchas with Teeth",
+  `Benin/_/CONTENTS.org` §"Sampling Design".
+- **`cluster_features` owns `v`** — `CLAUDE.md` §"`sample()` and Cluster
+  Identity"; `Benin/_/data_scheme.yml` declares `index: (t, v)`.
+
+## §4 Invariants & assumptions
+
+- **The collapse hides behind the cache it poisoned.** The L2-country parquet is
+  written *post*-collapse, so a warm read shows a clean unique index. Every
+  number in this ledger is a cold build: `LSMS_NO_CACHE=1` **plus** an isolated
+  `LSMS_DATA_DIR` (with `dvc-cache` symlinked to the shared L1 so no blob is
+  re-fetched). `LSMS_NO_CACHE` alone is **not** sufficient — it is *soft* for
+  script-path L2-wave parquets, and a stale pre-PR-#615 `plot_inputs.parquet`
+  in the shared cache did in fact report 71 duplicates on the first attempt.
+- **Config-tree identity.** `LSMS_COUNTRIES_ROOT=<worktree>/lsms_library/countries`,
+  plus `PYTHONPATH=<worktree>` and an `assert 'worktrees' in lsms_library.__file__`
+  in every measurement script (`CLAUDE.md` scrum-master addendum 3).
+- **`groupby().first()` skips NA per column**, so a conflicting group collapses
+  to a *composite* row assembled from different source rows — a cluster that
+  exists nowhere in the survey. This is why "one household is missing Region"
+  must count as a straddle, not as a tolerable gap; a test pins it.
+- **`nunique(dropna=False)` counts NaN as a value**, so a cluster whose
+  attribute is *uniformly* missing is one distinct value, not two. Also pinned.
+- **Benin's `cluster_features` collapse is value-lossless today** (0 of 670
+  grappes straddle; GPS is already grappe-level at 670/670) — so the #614 audit
+  is correctly silent and **this fix recovers zero rows**. Saying otherwise
+  would be a false claim of recovered data.
+- **No `dvc` CLI.** All source reads go through `get_dataframe()` /
+  `_ensure_dvc_pulled()` (lock-free direct-S3); this PR needs no write path.
+
+## §5 Reuse decision
+
+| quantity | decision | reason |
+|----------|----------|--------|
+| `plot_inputs` injectivity | **reuse (already merged)** | PR #615 landed it on `development`; re-deriving would fork the account of the same numbers |
+| `cluster_features` grain | **reuse the CotedIvoire pattern** (project in the extraction) | same defect on a sibling EHCVM country; keeps the family consistent |
+| the straddle policy | **new — RAISE**, not CIV's strict-majority-with-warning | CIV *had* a conflict (grappe 648: 11 Rural vs 1 Urbain) and so needed a resolution rule. Benin has **zero**, so a resolution rule would be dead code that quietly licenses a future guess. Raising is the strictly safer no-op. Noted as a deliberate divergence in §6. |
+| duplicate-collapse policy | **reuse core as-is** | D1 — core is PR #614's; a country may not patch it |
+| `food_acquired` collisions | **reuse `_ADDITIVE_MEASURE_COLUMNS`** | already lossless (totals verified identical); the only deliverable is prose so the next reader does not mistake a sum for a drop |
+| `aggregation: {visit: first}` on `interview_date` | **delete** | dead config that contradicts D1, and nonsense on its own terms (`visit` is an index *level*, not a measure) |
+
+## §6 Decisions worth flagging
+
+1. **The hook RAISES; CotedIvoire's warns and takes a strict majority.** A
+   deliberate divergence, argued in §5. If Benin ever acquires a straddling
+   grappe the build stops with the offending clusters named — which is the
+   outcome we want, because we would then have to decide *what the right answer
+   is*, and the framework must not decide it for us in the meantime.
+2. **`food_acquired` was left alone.** It is tempting to "fix" 1,382 colliding
+   rows by splitting the residual food buckets the way `plot_inputs`' seed
+   bucket was split. That would be wrong: `Autres poissons fumés` is the
+   harmonized taxonomy's *own* residual category, the pooling is intended, and
+   `u` and `s` are both in the index so the sum is commensurable. The two cases
+   look identical at the level of "duplicates on a declared index" and are
+   opposite at the level of what the data means. Hence the table in §1.
+3. **A pre-existing `aggregation:` key was deleted, slightly widening the diff.**
+   It was in the file this PR edits, it is dead, and leaving it would have left
+   a Benin-shaped counterexample to the very policy the rest of the diff
+   documents.
+
+## §7 Open questions for the human
+
+- None blocking. One observation for whoever owns Site 4: Benin's
+  `cluster_features` uses a `dfs:` **outer** merge (`df_main` ⋈ `df_geo` on
+  `v`) with no cardinality guard — the Site-4 pattern. Here it is benign
+  (`df_geo` is 670/670 unique on `v`, so the merge cannot fan out) and the
+  hook now runs downstream of it regardless, but it is the same construct.
+
+---
+### Phase 3 — verification
+
+Cold builds, `LSMS_NO_CACHE=1` + isolated `LSMS_DATA_DIR` (L1 shared via a
+`dvc-cache` symlink), `LSMS_COUNTRIES_ROOT` + `PYTHONPATH` pinned to the
+worktree and asserted in-process.
+
+| measure | before | after |
+|---|---|---|
+| `cluster_features` wave-frame rows | 8,012 | **670** |
+| `cluster_features` duplicate `(t, v)` tuples | 7,342 | **0** |
+| `cluster_features` API rows | 670 | 670 (frames byte-identical) |
+| `food_acquired` wave rows → API rows | 190,618 → 189,236 | unchanged; `Quantity` 576,293.81 and `Expenditure` 87,287,926.96 identical on both tiers |
+| `plot_inputs` wave rows / dups / API rows | 10,605 / 0 / 10,605 | unchanged (PR #615 already landed) |
+
+**Regression re-verification of PR #615** (cold, counterfactually re-widening
+the split buckets back to one `Autre crop`): the landed fix holds — 10,605 API
+rows, 0 duplicate index tuples. The counterfactual destroys **71** rows across
+**64** conflicting groups, carrying **11,445.25** units of reported `Quantity`
+and flipping **4** households' `Purchased` True→False. The issue text's **68**
+is the same defect counted conservatively: it drops the 3 pairs whose *measured*
+payload is coincidentally equal, where `first()` loses no measurement — but
+those two rows still name two *different* crops, so 71 is the honest figure.
+Both accountings go to 0.
+| `GrainCollapseWarning`s across all 21 Benin tables | 0 | **0** |
+
+- `Benin/2018-19/_/mapping.py::cluster_features` — **OK (anchored on §2, §5)**:
+  it is the CotedIvoire case-A pattern (project in the extraction), running in
+  the documented df_edit slot, with the straddle policy divergence recorded in
+  §6.1.
+- `Benin/_/data_scheme.yml` + `Benin/_/CONTENTS.org` prose — **OK (anchored on
+  §3)**: documents the three grain cases and cites the policy; declares no
+  `aggregation:` key and says why.
+- Deletion of `interview_date`'s `aggregation:` — **OK (anchored on §3, §5)**:
+  the key is dead by the cited authority; `interview_date` returns 24,035 rows
+  with zero grain reports either way.
+- No `lsms_library/*.py` in the diff — **OK (anchored on §3, D1)**.
+- `tests/test_gh323_benin_cluster_features.py` — **OK (anchored on §4)**: 6 of
+  its 8 tests fail/error on the pre-fix tree; the 2 that pass are the ones that
+  *should* (the invariant holds in the raw data, and the API row count was
+  already right) — which is the honest instrument, per the CotedIvoire note
+  that a post-collapse-uniqueness assertion passes with the bug fully present.
+- **No REINVENTION found** against `.coder/ledger/323-benin-togo.md`: this PR
+  contains no `harmonize_seed_crop` change. That ledger's account of
+  `plot_inputs` stands unmodified and is cited, not restated.

--- a/lsms_library/countries/Benin/2018-19/_/mapping.py
+++ b/lsms_library/countries/Benin/2018-19/_/mapping.py
@@ -61,6 +61,51 @@ def Age(value):
     return result
 
 
+def cluster_features(df):
+    '''Reduce the broadcast household-level cover page to CLUSTER grain (GH #323).
+
+    ``df_main`` extracts Region/Rural from ``s00_me_ben2018.dta``, which is
+    HOUSEHOLD-level (8,012 rows = 8,012 distinct (grappe, menage) pairs over
+    670 grappes), but declares only ``v: grappe`` as its index var.  Each
+    grappe's attributes are therefore broadcast across all its households,
+    handing the framework 8,012 rows on a (t, v) index with 7,342 duplicate
+    tuples -- which ``_normalize_dataframe_index`` (GH #323 Site 1) then
+    reduces with ``groupby().first()``.
+
+    That reduction is VALUE-LOSSLESS today, so no data has ever been lost here
+    and the framework's #323 audit is correctly silent about it: measured
+    against the raw source under ``LSMS_NO_CACHE=1``, 0 of the 670 grappes
+    carry more than one distinct ``s00q01`` (Region) or ``s00q04`` (Rural),
+    and ``grappe_gps_ben2018.dta`` is already grappe-level at 670/670.
+
+    But "lossless today" is a property of the 2018-19 data, not of the
+    extraction, and relying on it MASKS the defect class: if a grappe ever
+    straddled two regions, ``first()`` would silently pick one -- and, because
+    it skips NA per COLUMN, it would in general hand back a composite row
+    assembled from different households, a cluster that exists nowhere in the
+    survey.  So fix the grain at the source and ENFORCE the invariant rather
+    than describing it: assert every cluster carries exactly one distinct
+    value per attribute, and RAISE if that ever stops being true, instead of
+    quietly choosing a winner.
+
+    This changes no returned value (670 rows before and after); it makes the
+    670 correct BY CONSTRUCTION rather than by luck.
+    '''
+    levels = list(df.index.names)
+    spread = df.groupby(level=levels, observed=True).nunique(dropna=False)
+    straddling = spread[(spread > 1).any(axis=1)]
+    if len(straddling):
+        raise ValueError(
+            f'Benin cluster_features: {len(straddling)} cluster(s) carry more '
+            f'than one distinct value for a cluster attribute, so reducing the '
+            f'household-level cover page to cluster grain would have to GUESS. '
+            f'Offending clusters (nunique per column):\n{straddling.head(10)}'
+        )
+    # Exact-duplicate rows by construction (the assertion above proves it), so
+    # keeping one row per cluster discards only redundancy.
+    return df[~df.index.duplicated(keep='first')]
+
+
 def household_roster(df):
     '''
     Recover Age from date-of-birth components when s01q04a is null.

--- a/lsms_library/countries/Benin/_/CONTENTS.org
+++ b/lsms_library/countries/Benin/_/CONTENTS.org
@@ -39,6 +39,106 @@ food_quantities.)
 
 * Data Quality Notes
 
+** Grain: the three ways Benin's declared indexes go non-unique (GH #323)
+
+Three Benin tables hand the framework a non-unique declared index, and
+they are *three different things*.  Conflating them is how #323 stayed
+alive elsewhere, so they are separated here.  All figures are cold
+builds under =LSMS_NO_CACHE=1= into an isolated =LSMS_DATA_DIR=; never
+read them off =var/=, which is written *post*-collapse and therefore
+cannot show you the loss.
+
+| table            | dup rows | what it is                      | fixed by                        |
+|------------------+----------+---------------------------------+---------------------------------|
+| =plot_inputs=    |       71 | broken identifier — REAL LOSS   | injective =harmonize_seed_crop= |
+| =cluster_features= |    7,342 | wrong extraction grain — no loss | extraction hook + invariant     |
+| =food_acquired=  |    1,382 | intended bucketing — no loss    | nothing; core already SUMs      |
+
+*** =plot_inputs= — the identifier was broken (fixed 2026-07-13)
+
+=harmonize_input= maps every seed label onto the single =input= value
+=Seed=, so =crop= is the only index level left to tell two seed
+line-items apart — and =harmonize_seed_crop= was non-injective: four
+labels shared one =Autre crop= catch-all, three of which occur in
+Benin's =s16b=.  A household reporting both "Autres semences" (9 kg)
+and "Plants/boutures de tubercules" (6 kg) landed both on
+=(Seed, Autre crop, Kilogramme)= and =groupby().first()= discarded
+one.  71 rows destroyed, 11,445.25 units of reported input quantity,
+and 4 households' =Purchased= flag flipped True→False.
+
+Two accountings circulate for this number and both are right, so say
+which you mean.  *71* counts every non-first row on a duplicated index
+tuple, across 64 conflicting groups.  *68* is the conservative count
+used in the issue text: it drops the 3 pairs whose *measured* payload
+(=Quantity= / =Purchased= / =Quantity_purchased=) happens to be equal,
+where =first()= loses no measurement.  Those 3 are still real losses —
+the two rows name two *different* crops — which is why 71 is the figure
+used here.  Both accountings go to **0** after the fix.
+
+Tuber cuttings are not cereal seed, so *summing* them would have been
+as wrong as dropping one.  The catch-all is split instead (see the
+note above =harmonize_seed_crop= in =categorical_mapping.org=), and
+=2018-19/_/plot_inputs.py= now asserts its declared index is unique
+before writing.  API rows 10,534 → 10,605 = every reported line-item.
+Same defect, same fix, as sibling EHCVM CotedIvoire and Togo — the
+tables were copied verbatim from the Niger reference and inherited the
+bug with it.
+
+*** =cluster_features= — the extraction grain was wrong (fixed 2026-07-21)
+
+=df_main= reads Region/Rural from the *household*-level cover page
+=s00_me_ben2018.dta= while declaring only =v: grappe=, so each
+grappe's attributes are broadcast across its households: 8,012 rows on
+a 670-cluster grain, 7,342 of them duplicate =(t, v)= tuples.
+
+*No value was ever lost*: 0 of 670 grappes carry more than one
+distinct =s00q01= (Region) or =s00q04= (Rural), and
+=grappe_gps_ben2018.dta= is already grappe-level at 670/670.  The
+#323 audit is correctly silent, and it should stay silent.
+
+But that is a fact about the 2018-19 data, not about the extraction.
+=groupby().first()= skips NA *per column*, so a grappe that ever
+straddled two regions would not collapse to one of its households — it
+would collapse to a composite row assembled column-by-column from
+different households, a cluster that exists nowhere in the survey.  So
+=2018-19/_/mapping.py= now carries a =cluster_features(df)= hook that
+projects to cluster grain in the *extraction* and RAISES if any
+cluster straddles two values.  8,012 → 670 rows reach the framework;
+the API result is byte-identical.  This buys
+correctness-by-construction, not rows.
+
+*** =food_acquired= — the bucketing is intended, and core sums it
+
+1,382 rows collide, and here that is *correct*.  The raw source has no
+duplicates (=s07b_me_ben2018.dta=: 187,672 rows, unique on
+=(grappe, menage, s07bq01)=); =harmonize_food= is deliberately
+many-to-one (160 Original Labels → 146 Preferred Labels, 14 buckets
+taking 2 originals each).  Seven of the 14 merely pool an alternate or
+mis-encoded spelling of the same item ("Maïs" with "MaÃ¯s en grain");
+the five that actually collide in the data are the taxonomy's own
+residual categories — =Autres légumes en feuilles= (1,830 rows),
+=Autres poissons fumés= (712), =Riz importé non parfumé= (120),
+=Autre Riz local= (66), =Autres poissons frais= (36).
+
+=food_acquired= is in core's =_ADDITIVE_MEASURE_COLUMNS=, so these are
+SUMMED, not =first()=-ed, which is why the audit is silent.  Colliding
+rows necessarily share =u= *and* =s= (both are in the index), so the
+sums are commensurable by construction.  Verified: wave-frame and API
+totals agree exactly — Quantity 576,293.81, Expenditure 87,287,926.96
+— across the 190,618 → 189,236 row reduction.
+
+*** No =aggregation:= keys, deliberately
+
+An =aggregation: {visit: first}= block sat on =interview_date= until
+2026-07-21.  It was deleted: nothing reads the key (it appears in core
+only inside "skip these meta-keys" sets, and a test pins that the
+collapse does not honour it), the #323 consolidation decided the core
+never aggregates (D1, 2026-07-13), and =visit= is an index *level*
+anyway, so "reduce it with first" named no operation.  Do not add such
+a key back — declaring a reducer only puts a signature on the corpse.
+Where a declared index goes non-unique, the identifier is broken or a
+level is missing; fix that.
+
 ** shocks: at most 2 coping strategies per household in 2018-19
 
 The 2018-19 instrument's shock module captures up to 26 distinct

--- a/lsms_library/countries/Benin/_/data_scheme.yml
+++ b/lsms_library/countries/Benin/_/data_scheme.yml
@@ -9,6 +9,32 @@ Data Scheme:
     strata: str
     Rural: str
   cluster_features:
+    # GRAIN (GH #323).  The declared grain is the cluster, (t, v) -- 670
+    # grappes in 2018-19 -- but `df_main` in 2018-19/_/data_info.yml reads
+    # Region/Rural from the HOUSEHOLD-level cover page s00_me_ben2018.dta
+    # while declaring only `v: grappe`.  Each grappe's attributes were
+    # therefore broadcast across its households, handing the framework 8,012
+    # rows carrying 7,342 duplicate (t, v) tuples for it to reduce.
+    #
+    # The reduction was value-lossless (measured cold under LSMS_NO_CACHE=1:
+    # 0 of 670 grappes carry more than one distinct s00q01/Region or
+    # s00q04/Rural; grappe_gps_ben2018.dta is already grappe-level at
+    # 670/670), so the framework's #323 audit was correctly silent and no
+    # number here has ever been wrong.  But that is a property of the 2018-19
+    # data, not of the extraction -- a grappe that ever straddled two regions
+    # would have been resolved by groupby().first(), which skips NA per
+    # COLUMN and so returns a composite cluster assembled from different
+    # households.
+    #
+    # Fixed at the source rather than at the collapse: the
+    # `cluster_features(df)` hook in 2018-19/_/mapping.py projects to cluster
+    # grain in the EXTRACTION and RAISES if any cluster straddles two values,
+    # so the 670 rows are right by construction instead of by luck.  8,012 ->
+    # 670 rows reach the framework; the API result is byte-identical.
+    #
+    # No `aggregation:` key: per the #323 consolidation (D1, 2026-07-13) the
+    # core never aggregates, the key is not read by anything, and declaring
+    # one would be prose masquerading as enforcement.
     index: (t, v)
     Region: str
     Rural: str
@@ -63,6 +89,30 @@ Data Scheme:
     # `visit` (vague) is dropped: in EHCVM 2018-19 it's a sample split
     # (each grappe surveyed in exactly one vague), not a repeated measure,
     # so households are uniquely keyed by (t, v, i, j, u, s) without it.
+    #
+    # GRAIN (GH #323).  1,382 rows collide on the declared index, and the
+    # collision is CORRECT here -- unlike plot_inputs below, nothing is being
+    # destroyed.  The raw source has no duplicates (s07b_me_ben2018.dta:
+    # 187,672 rows, all unique on (grappe, menage, s07bq01)); the collisions
+    # are created downstream by harmonize_food, which is deliberately
+    # many-to-one (160 Original Labels -> 146 Preferred Labels; 14 buckets
+    # take 2 originals each).  Seven of those 14 merely pool an alternate
+    # spelling or a mis-encoded variant of the SAME item ('Maïs' with
+    # 'MaÃ¯s en grain'); the five that actually collide in the data are the
+    # taxonomy's own residual categories -- 'Autres légumes en feuilles'
+    # (1,830 rows), 'Autres poissons fumés' (712), 'Riz importé non parfumé'
+    # (120), 'Autre Riz local' (66), 'Autres poissons frais' (36).
+    #
+    # Two distinct items landing in one residual bucket is a genuine, intended
+    # aggregation, and core already handles it correctly: food_acquired is in
+    # `_ADDITIVE_MEASURE_COLUMNS`, so the measures are SUMMED rather than
+    # first()-ed, which is why the #323 audit is silent about this cell.
+    # Colliding rows necessarily share `u` AND `s` (both are IN the index), so
+    # the sums are commensurable BY CONSTRUCTION.  Verified cold under
+    # LSMS_NO_CACHE=1: wave-frame and API totals agree exactly -- Quantity
+    # 576,293.81, Expenditure 87,287,926.96 -- over a 190,618 -> 189,236 row
+    # reduction.  Nothing to fix; recorded so the next reader does not
+    # mistake a lossless sum for a silent drop.
     index: (t, v, i, j, u, s)
     Quantity: float
     Expenditure: float
@@ -80,11 +130,20 @@ Data Scheme:
     Floor: str
 
   interview_date:
+    # An `aggregation: {visit: first}` block used to sit here.  Removed
+    # 2026-07-21 (GH #323): NOTHING READS IT.  `aggregation` appears in core
+    # only inside "skip these meta-keys" sets, a test pins that the collapse
+    # does not honour it, and per the #323 consolidation (D1, 2026-07-13) the
+    # core never aggregates -- so the key was prose wearing the costume of
+    # enforcement.  It was also nonsense on its own terms: `visit` is an INDEX
+    # LEVEL here, not a measure, and "reduce the index level with first" names
+    # no operation.  Benin's interview_date has no duplicate-index problem
+    # to reduce (24,035 rows, zero grain reports on a cold build), so deleting
+    # it changes no returned value.
     index: (t, i, visit)
     Interview start: datetime
     Interview end: datetime
-    aggregation:
-      visit: first
+
   shocks:
     index: (t, i, Shock)
     AffectedIncome: bool
@@ -179,6 +238,23 @@ Data Scheme:
     # the framework's canonical NaN-key de-dup collapse).  `u` is in the index
     # and a missing unit is filled with 'Manquant' for the same non-null
     # reason.
+    #
+    # GRAIN (GH #323, fixed 2026-07-13).  71 rows -- 11,445.2 units of
+    # reported input quantity, and 4 households' Purchased flag flipped
+    # True->False -- used to be DESTROYED here, and unlike food_acquired above
+    # the loss was real.  `crop` is an index level and harmonize_input maps
+    # every seed label onto the single input 'Seed', so `crop` was the only
+    # level left to tell two seed line-items apart; harmonize_seed_crop was
+    # NON-INJECTIVE (four labels shared one 'Autre crop' catch-all, three of
+    # which occur in Benin's s16b), so a household reporting BOTH 'Autres
+    # semences' (9 kg) and 'Plants/boutures de tubercules' (6 kg) landed both
+    # on (Seed, Autre crop, Kilogramme) and one was dropped.  Tuber cuttings
+    # and cereal seed are not the same thing and summing them would be as
+    # wrong as dropping one: THE IDENTIFIER WAS BROKEN.  The catch-all is now
+    # split (see the note above harmonize_seed_crop in _/categorical_mapping.org)
+    # and 2018-19/_/plot_inputs.py ASSERTS the declared index is unique before
+    # writing, so a re-widened bucket fails the build instead of shipping
+    # short.  API rows 10,534 -> 10,605 = every reported line-item.
     index: (t, i, input, crop, u)
     Quantity: float
     Purchased: bool

--- a/tests/test_gh323_benin_cluster_features.py
+++ b/tests/test_gh323_benin_cluster_features.py
@@ -1,0 +1,192 @@
+"""GH #323 -- Benin cluster_features must reach the framework at CLUSTER grain.
+
+Companion to ``tests/test_gh323_benin_togo.py``, which covers Benin's *other*
+#323 site (``plot_inputs``, where the identifier was broken and 71 reported
+rows were genuinely destroyed).  This file covers a different failure mode, and
+the difference is the whole point:
+
+  ``cluster_features`` declares ``(t, v)`` -- 670 grappes -- but ``df_main`` in
+  ``2018-19/_/data_info.yml`` reads Region/Rural from the HOUSEHOLD-level cover
+  page ``s00_me_ben2018.dta`` while declaring only ``v: grappe``.  Each
+  grappe's attributes are broadcast across its households, so 8,012 rows with
+  7,342 duplicate ``(t, v)`` tuples were handed to
+  ``_normalize_dataframe_index`` to reduce.
+
+NO VALUE WAS EVER LOST HERE, and these tests must not pretend otherwise.  Zero
+of the 670 grappes carry more than one distinct Region or Rural, and the GPS
+file is already grappe-level -- so the reduction was value-lossless and the
+framework's #323 audit is correctly SILENT about this cell.  Fixing the
+extraction recovers zero rows.
+
+What it buys is that the 670 rows are right BY CONSTRUCTION rather than by
+luck.  ``groupby().first()`` skips NA *per column*, so a grappe that ever
+straddled two regions would not collapse to one of its households -- it would
+collapse to a composite row assembled column-by-column from different
+households, a cluster that exists nowhere in the survey.  The
+``cluster_features(df)`` hook in ``2018-19/_/mapping.py`` projects to cluster
+grain in the EXTRACTION and RAISES if any cluster straddles two values.
+
+INSTRUMENT NOTE (inherited from the CotedIvoire / Benin-Togo tests -- do not
+undo it).  Do NOT assert that the API's returned index is unique: the collapse
+makes it unique BY CONSTRUCTION, so such a test passes with the bug fully
+present.  These tests assert on the PRE-collapse wave frame, on the invariant
+itself, and -- because prose is not enforcement -- on the hook actually raising
+when the invariant is violated.
+"""
+import pandas as pd
+import pytest
+
+from lsms_library.country import Country
+
+# 2018-19 EHCVM: 670 grappes, 8,012 households.
+N_CLUSTERS = 670
+
+
+@pytest.fixture(scope='module')
+def benin():
+    try:
+        return Country('Benin')
+    except Exception as exc:                                   # pragma: no cover
+        pytest.skip(f'Benin unavailable: {exc}')
+
+
+@pytest.fixture(scope='module')
+def wave_frame(benin):
+    """The PRE-collapse wave-level frame -- the only tier that can show this."""
+    try:
+        return benin['2018-19'].grab_data('cluster_features')
+    except Exception as exc:                                   # pragma: no cover
+        pytest.skip(f'Benin cluster_features could not be built: '
+                    f'{type(exc).__name__}: {exc}')
+
+
+@pytest.fixture(scope='module')
+def hook(benin):
+    fns = benin['2018-19'].formatting_functions
+    fn = fns.get('cluster_features')
+    if fn is None:                                             # pragma: no cover
+        pytest.fail('Benin 2018-19 mapping.py declares no cluster_features hook; '
+                    'the household-level cover page will be broadcast onto the '
+                    'cluster grain again (GH #323).')
+    return fn
+
+
+def test_wave_frame_is_at_cluster_grain(wave_frame):
+    """The extraction must emit one row per cluster, not one per household."""
+    assert len(wave_frame) == N_CLUSTERS, (
+        f'Benin/cluster_features emits {len(wave_frame)} wave-level rows for '
+        f'{N_CLUSTERS} clusters.  The household-level cover page is being '
+        f'broadcast onto the (t, v) grain and left for the framework to reduce '
+        f'with groupby().first() (GH #323).  Project to cluster grain in the '
+        f'extraction instead.'
+    )
+
+
+def test_wave_frame_has_no_duplicate_cluster_tuples(wave_frame):
+    """No manufactured duplicates for the framework collapse to eat."""
+    n_dup = int(wave_frame.index.duplicated().sum())
+    assert n_dup == 0, (
+        f'Benin/cluster_features hands the framework {n_dup} duplicate (t, v) '
+        f'tuple(s).  The fix for a manufactured duplicate is to stop '
+        f'manufacturing it, not to choose a survivor (GH #323).'
+    )
+
+
+def test_every_cluster_carries_one_value_per_attribute(wave_frame):
+    """The invariant the hook enforces -- asserted here on real data too.
+
+    "Region/Rural are invariant within a cluster" is exactly the kind of claim
+    that was licensed by a comment elsewhere in the library and turned out to
+    be false.  Check it rather than believe it.
+    """
+    spread = wave_frame.groupby(level=list(wave_frame.index.names),
+                                observed=True).nunique(dropna=False)
+    straddling = spread[(spread > 1).any(axis=1)]
+    assert straddling.empty, (
+        f'{len(straddling)} Benin cluster(s) carry more than one distinct value '
+        f'for a cluster attribute:\n{straddling.head(10)}\n'
+        f'Reducing to cluster grain would have to GUESS.'
+    )
+
+
+def test_api_row_count_is_the_cluster_count(benin):
+    """Regression guard: the API result is unchanged by the grain fix.
+
+    This fix recovers no rows -- it was value-lossless before and is
+    value-lossless now.  A change here means something else moved.
+    """
+    df = benin.cluster_features()
+    assert len(df) == N_CLUSTERS, (
+        f'Benin/cluster_features API returned {len(df)} rows, expected '
+        f'{N_CLUSTERS} (one per grappe).'
+    )
+
+
+def test_hook_raises_when_a_cluster_straddles_two_values(hook):
+    """Prose is not enforcement.  Prove the guard actually fires.
+
+    Without this, the hook could silently degrade into
+    ``drop_duplicates()``-with-extra-steps -- picking a winner exactly as
+    ``first()`` did -- and every other test here would still pass.
+    """
+    idx = pd.MultiIndex.from_tuples(
+        [('2018-19', '1'), ('2018-19', '1')], names=['t', 'v'])
+    straddling = pd.DataFrame(
+        {'Region': ['alibori', 'atlantique'],
+         'Rural': ['Rural', 'Rural'],
+         'Latitude': [11.29, 11.29],
+         'Longitude': [2.43, 2.43]},
+        index=idx)
+    with pytest.raises(ValueError, match='more than one distinct value'):
+        hook(straddling)
+
+
+def test_hook_is_a_no_op_on_a_frame_already_at_cluster_grain(hook):
+    """A well-formed frame must pass through untouched."""
+    idx = pd.MultiIndex.from_tuples(
+        [('2018-19', '1'), ('2018-19', '2')], names=['t', 'v'])
+    clean = pd.DataFrame(
+        {'Region': ['alibori', 'atlantique'],
+         'Rural': ['Rural', 'Urban'],
+         'Latitude': [11.29, 6.52],
+         'Longitude': [2.43, 2.36]},
+        index=idx)
+    out = hook(clean)
+    pd.testing.assert_frame_equal(out, clean)
+
+
+def test_hook_tolerates_a_cluster_whose_attribute_is_uniformly_missing(hook):
+    """All-NaN within a cluster is ONE distinct value, not two.
+
+    ``nunique(dropna=False)`` counts NaN as a value; a cluster where every
+    household is missing Region must not be reported as straddling.
+    """
+    idx = pd.MultiIndex.from_tuples(
+        [('2018-19', '1'), ('2018-19', '1')], names=['t', 'v'])
+    frame = pd.DataFrame(
+        {'Region': [pd.NA, pd.NA],
+         'Rural': ['Rural', 'Rural'],
+         'Latitude': [11.29, 11.29],
+         'Longitude': [2.43, 2.43]},
+        index=idx)
+    out = hook(frame)
+    assert len(out) == 1
+
+
+def test_hook_rejects_a_cluster_that_is_missing_a_value_in_one_household(hook):
+    """One household has Region, another does not -- that is a straddle.
+
+    This is the case that makes ``first()`` FABRICATE: it skips NA per column,
+    so it would take Region from one household and Rural from another and hand
+    back a cluster that exists in no survey record.  The guard must refuse.
+    """
+    idx = pd.MultiIndex.from_tuples(
+        [('2018-19', '1'), ('2018-19', '1')], names=['t', 'v'])
+    frame = pd.DataFrame(
+        {'Region': [pd.NA, 'alibori'],
+         'Rural': ['Urban', pd.NA],
+         'Latitude': [11.29, 11.29],
+         'Longitude': [2.43, 2.43]},
+        index=idx)
+    with pytest.raises(ValueError, match='more than one distinct value'):
+        hook(frame)


### PR DESCRIPTION
Closes the Benin half of the "still owed a fix" list in
`slurm_logs/DESIGN_grain_collapse_sites_2026-07-13.org`. References GH #323.

**This is CONFIG-ONLY.** No file under `lsms_library/*.py` is touched, per **D1**
of the consolidation doc ("core does not aggregate"), and **no `aggregation:` key
is added** — the key is dead config and now contradicts the policy it was written
to serve. The diff is one country's `_/` tree, one ledger, one test file.

## What the brief asked for vs. what was actually left to do

The brief listed two deliverables. **The second was already merged.**
`origin/development` at `53ef3a5d` already carries the injective
`harmonize_seed_crop`, the uniqueness assertion in `plot_inputs.py`, a ledger and
tests — PR #615, commits `36170a57` + `ef45231e`, merged 2026-07-19. Nothing here
re-implements it; a second, differently-shaped fix on top of the landed one would
be worse than nothing. It is **re-verified** below as a regression check.

So the real scope was `cluster_features`, plus writing down two things that were
being conflated with it.

| table | dup rows on the declared index | what it is | action |
|---|---|---|---|
| `plot_inputs` | 71 | broken identifier — **real loss** | none (PR #615) |
| `cluster_features` | 7,342 | **wrong extraction grain** — no loss | fixed here |
| `food_acquired` | 1,382 | **intended bucketing** — no loss | documented |

## `cluster_features` — the fix

`cluster_features` declares `(t, v)` — 670 grappes — but `df_main` in
`2018-19/_/data_info.yml` reads Region/Rural from the **household**-level cover
page `s00_me_ben2018.dta` while declaring only `v: grappe`. Each grappe's
attributes were broadcast across its 8,012 households and handed to
`_normalize_dataframe_index` as 8,012 rows on a 670-cluster grain.

**No rows are recovered, and this PR does not pretend otherwise.** Measured cold:
0 of 670 grappes carry more than one distinct `s00q01`/Region or `s00q04`/Rural,
and `grappe_gps_ben2018.dta` is already grappe-level at 670/670. The reduction
was value-lossless, PR #614's audit is **correctly silent**, and the API returned
— and still returns — the right 670 rows.

What changes is *why* they are right. `groupby().first()` skips NA **per column**,
so a grappe that ever straddled two regions would not collapse to one of its
households; it would collapse to a *composite* row assembled column-by-column
from different households — a cluster that exists nowhere in the survey. The new
`cluster_features(df)` hook in `2018-19/_/mapping.py` projects to cluster grain in
the **extraction** and **RAISES** if any cluster straddles two values, naming the
offenders. Correctness by construction, not by luck.

This is CotedIvoire's case-A pattern (`fc3be203`) on a sibling EHCVM country,
with **one deliberate divergence**: CIV resolves a straddle by strict majority
with a warning, because CIV *has* one (grappe 648: 11 Rural vs 1 Urbain). Benin
has zero, so a resolution rule here would be dead code that quietly licenses a
future guess. Raising is the strictly safer no-op. Argued in ledger §5/§6.1.

## Measured before / after

Cold builds: `LSMS_NO_CACHE=1` **plus** an isolated `LSMS_DATA_DIR` (with
`dvc-cache` symlinked to the shared L1 so no blob is re-fetched);
`LSMS_COUNTRIES_ROOT` + `PYTHONPATH` pinned to the worktree and asserted
in-process. `LSMS_NO_CACHE` **alone was not sufficient** — it is *soft* for
script-path L2-wave parquets, and a stale pre-#615 `plot_inputs.parquet` in the
shared cache did in fact report 71 duplicates on the first attempt.

| measure | before | after |
|---|---|---|
| `cluster_features` wave-frame rows | 8,012 | **670** |
| `cluster_features` duplicate `(t, v)` tuples | 7,342 | **0** |
| `cluster_features` API rows | 670 | 670 — frames **byte-identical** |
| `GrainCollapseWarning`s across all 21 Benin tables | 0 | **0** |

## Documented, not changed

**`food_acquired` — 1,382 rows collide and that is CORRECT.** The raw source has
no duplicates (`s07b_me_ben2018.dta`: 187,672 rows, verified unique on
`(grappe, menage, s07bq01)`). `harmonize_food` is deliberately many-to-one (160
Original Labels → 146 Preferred; 14 two-label buckets, 7 of which merely pool a
mis-encoded spelling of the *same* item, e.g. `Maïs` with `MaÃ¯s en grain`). The
five that actually collide are the taxonomy's own residual categories
(`Autres légumes en feuilles` 1,830 rows, `Autres poissons fumés` 712, …).
`food_acquired` is in `_ADDITIVE_MEASURE_COLUMNS`, so core **SUMS** rather than
`first()`-ing, and `u` *and* `s` are both in the index, so the sums are
commensurable by construction. Verified identical on both tiers — Quantity
576,293.81, Expenditure 87,287,926.96 — across 190,618 → 189,236 rows.

It is tempting to "fix" this the way `plot_inputs`' seed bucket was fixed. That
would be wrong; the two cases look identical at the level of "duplicates on a
declared index" and are opposite at the level of what the data means. The table
in `CONTENTS.org` exists to stop the next reader.

**`plot_inputs` — re-verified regression check.** 10,605 API rows, 0 duplicate
index tuples. Counterfactually re-widening the split buckets back to one
`Autre crop` destroys **71** rows across **64** conflicting groups, carrying
**11,445.25** units of reported `Quantity` and flipping **4** households'
`Purchased` True→False. The issue text's **68** is the same defect counted
conservatively — it drops the 3 pairs whose *measured* payload is coincidentally
equal, where `first()` loses no measurement — but those rows still name two
**different** crops, so 71 is the honest figure. Both accountings go to **0**.

## Also removed: a dead `aggregation:` key

`interview_date` carried a pre-existing `aggregation: {visit: first}`. Deleted:
nothing reads the key, a test pins that the collapse does not honour it, and
`visit` is an index **level**, not a measure — "reduce it with first" named no
operation. `interview_date` returns 24,035 rows with zero grain reports either
way. This slightly widens the diff, but it sat in the file this PR edits and
would have left a Benin-shaped counterexample to the policy the rest of the diff
documents.

## Tests

`tests/test_gh323_benin_cluster_features.py` — 8 new tests. **6 of the 8
fail/error on the pre-fix tree**; the 2 that pass are the ones that *should* (the
invariant genuinely holds in the raw data, and the API row count was already
right) — the honest instrument. Per the CotedIvoire instrument note, none of them
assert post-collapse index uniqueness, which holds **by construction** and passes
with the bug fully present. Four are negative tests on the hook itself, including
the two NaN cases: uniformly-missing is one value, but one-household-missing is a
straddle (it is exactly the case where `first()` fabricates).

`tests/test_gh323_benin_togo.py` still passes unchanged (14 passed, 2 skipped
across both files).

**Pre-existing failure, unrelated and untouched:**
`test_gh323_explicit_reducers.py::test_core_does_not_dispatch_the_reducers`
(`assert not ['country.py:collapse_to_cluster_grain']`) fails **identically on
pristine `origin/development`** — verified by stashing this branch's changes. It
greps `country.py`, which this PR does not modify.

## Deferred, not implemented

Nothing in Benin's defect required a core change, so none was made. One
observation for whoever owns **Site 4**: Benin's `cluster_features` uses a `dfs:`
**outer** merge (`df_main` ⋈ `df_geo` on `v`) with no cardinality guard — the
Site-4 construct. Here it is benign (`df_geo` is 670/670 unique on `v`, so the
merge cannot fan out) and the new hook runs downstream of it regardless, but the
primitive that would close it generally is a cardinality assertion on that merge,
which belongs in the Site-4 PR, not here.

Ledger: `.coder/ledger/323-benin.md` (companion to `.coder/ledger/323-benin-togo.md`,
which owns the `plot_inputs` story and is cited rather than restated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
