### PR TITLE
docs(#637): EHCVM people_last7days (t, i, pid) key review -- no key is broken

### DIFF
--- a/lsms_library/countries/Benin/2018-19/_/people_last7days.py
+++ b/lsms_library/countries/Benin/2018-19/_/people_last7days.py
@@ -97,6 +97,28 @@ def _finish_people_last7days(df, t):
     keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
             'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
     df = df[keep]
+    # --- (t, i, pid) key soundness reviewed 2026-07-21 -- GH #637 ----------
+    # This collapse is a NO-OP on the shipped Benin data: there is nothing to
+    # collapse, so `.first()`'s per-column skipna=True can form no composite
+    # row here.  Measured on the SOURCE directly (this table is
+    # `materialize: make`, so it builds out-of-process and an in-process
+    # groupby probe cannot see it -- see the #637 thread):
+    #   s04_me_ben2018 rows 35,042; duplicate (grappe, menage, s01q00a)
+    #     groups 0
+    #   s01_me_ben2018 rows 42,343; duplicate person-key groups 0
+    #     -> the how='left' merge fans out 0 rows (merged == 35,042)
+    #   benin.i() is INJECTIVE: 8,012 distinct (grappe, menage) pairs in the
+    #     full roster -> 8,012 distinct ids (menage runs to 562, so the
+    #     zero-padded-3 form is exercised; no collision)
+    #   groups on (t, i, pid) 35,042 == rows 35,042  ->  0 duplicate groups
+    # So the key merges no distinct persons -- the ONLY situation in which the
+    # composite would be wrong (GH #637 correction thread; GH #323 D1: the fix
+    # for a merged entity is the identifier, never a reducer).
+    # Do NOT "fix" this to `.first(skipna=False)`: in this codebase NaN is
+    # absence, not contradiction, and skipna=False would return <NA> for
+    # values the survey actually recorded.
+    # `dropna=False` governs NA *group keys* only; rows with NA i/pid are
+    # already dropped above and `t` is a literal, so it too is inert here.
     df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
     df = df.set_index(['t', 'i', 'pid'])
     return df

--- a/lsms_library/countries/Burkina_Faso/2018-19/_/people_last7days.py
+++ b/lsms_library/countries/Burkina_Faso/2018-19/_/people_last7days.py
@@ -90,6 +90,29 @@ def _finish_people_last7days(df, t):
     keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
             'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
     df = df[keep]
+    # --- (t, i, pid) key soundness reviewed 2026-07-21 -- GH #637 ----------
+    # This collapse is a NO-OP on the shipped Burkina Faso data: there is
+    # nothing to collapse, so `.first()`'s per-column skipna=True can form no
+    # composite row here.  Measured on the SOURCE directly (this table is
+    # `materialize: make`, so it builds out-of-process and an in-process
+    # groupby probe cannot see it -- see the #637 thread):
+    #   s04_me_bfa2018 rows 45,612; duplicate (grappe, menage, s01q00a)
+    #     groups 0
+    #   s01_me_bfa2018 rows 45,612; duplicate person-key groups 0
+    #     -> the how='left' merge fans out 0 rows (merged == 45,612)
+    #   ehcvm_i() is INJECTIVE: 7,010 distinct (grappe, menage) pairs ->
+    #     7,010 distinct ids (menage runs to 527, i.e. the three-digit case
+    #     that broke the older `i()`, and the '0'-separated form collides on
+    #     none of it)
+    #   groups on (t, i, pid) 45,612 == rows 45,612  ->  0 duplicate groups
+    # So the key merges no distinct persons -- the ONLY situation in which the
+    # composite would be wrong (GH #637 correction thread; GH #323 D1: the fix
+    # for a merged entity is the identifier, never a reducer).
+    # Do NOT "fix" this to `.first(skipna=False)`: in this codebase NaN is
+    # absence, not contradiction, and skipna=False would return <NA> for
+    # values the survey actually recorded.
+    # `dropna=False` governs NA *group keys* only; rows with NA i/pid are
+    # already dropped above and `t` is a literal, so it too is inert here.
     df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
     df = df.set_index(['t', 'i', 'pid'])
     return df

--- a/lsms_library/countries/CotedIvoire/2018-19/_/people_last7days.py
+++ b/lsms_library/countries/CotedIvoire/2018-19/_/people_last7days.py
@@ -96,6 +96,30 @@ def _finish_people_last7days(df, t):
     keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
             'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
     df = df[keep]
+    # --- (t, i, pid) key soundness reviewed 2026-07-21 -- GH #637 ----------
+    # This collapse is a NO-OP on the shipped CotedIvoire data: there is
+    # nothing to collapse, so `.first()`'s per-column skipna=True can form no
+    # composite row here.  Measured on the SOURCE directly (this table is
+    # `materialize: make`, so it builds out-of-process and an in-process
+    # groupby probe cannot see it -- see the #637 thread):
+    #   s04_me_CIV2018 rows 61,116; duplicate (grappe, menage, s01q00a)
+    #     groups 0
+    #   s01_me_CIV2018 rows 61,116; duplicate person-key groups 0
+    #     -> the how='left' merge fans out 0 rows (merged == 61,116)
+    #   _i() is INJECTIVE: 12,992 distinct (grappe, menage) pairs -> 12,992
+    #     distinct ids.  Worth stating why, since _i() concatenates with NO
+    #     separator: menage tops out at 30, so zeropadding=3 always yields
+    #     exactly three characters and the split point is unambiguous.  A
+    #     future CotedIvoire wave with menage > 999 would break that.
+    #   groups on (t, i, pid) 61,116 == rows 61,116  ->  0 duplicate groups
+    # So the key merges no distinct persons -- the ONLY situation in which the
+    # composite would be wrong (GH #637 correction thread; GH #323 D1: the fix
+    # for a merged entity is the identifier, never a reducer).
+    # Do NOT "fix" this to `.first(skipna=False)`: in this codebase NaN is
+    # absence, not contradiction, and skipna=False would return <NA> for
+    # values the survey actually recorded.
+    # `dropna=False` governs NA *group keys* only; rows with NA i/pid are
+    # already dropped above and `t` is a literal, so it too is inert here.
     df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
     df = df.set_index(['t', 'i', 'pid'])
     return df

--- a/lsms_library/countries/Guinea-Bissau/2018-19/_/people_last7days.py
+++ b/lsms_library/countries/Guinea-Bissau/2018-19/_/people_last7days.py
@@ -106,6 +106,29 @@ def _finish_people_last7days(df, t):
     keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
             'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
     df = df[keep]
+    # --- (t, i, pid) key soundness reviewed 2026-07-21 -- GH #637 ----------
+    # This collapse is a NO-OP on the shipped Guinea-Bissau data: there is
+    # nothing to collapse, so `.first()`'s per-column skipna=True can form no
+    # composite row here.  Measured on the SOURCE directly (this table is
+    # `materialize: make`, so it builds out-of-process and an in-process
+    # groupby probe cannot see it -- see the #637 thread):
+    #   s04_me_gnb2018 rows 42,839; duplicate (grappe, menage, s01q00a)
+    #     groups 0
+    #   s01_me_gnb2018 rows 42,839; duplicate person-key groups 0
+    #     -> the how='left' merge fans out 0 rows (merged == 42,839)
+    #   i() is INJECTIVE: 5,351 distinct (grappe, menage) pairs -> 5,351
+    #     distinct ids.  Note Guinea-Bissau's grappe is a wide code (max
+    #     27,711,109, not a 3-digit cluster number as in the other EHCVM
+    #     countries); the '0'-separated form still collides on none of it.
+    #   groups on (t, i, pid) 42,839 == rows 42,839  ->  0 duplicate groups
+    # So the key merges no distinct persons -- the ONLY situation in which the
+    # composite would be wrong (GH #637 correction thread; GH #323 D1: the fix
+    # for a merged entity is the identifier, never a reducer).
+    # Do NOT "fix" this to `.first(skipna=False)`: in this codebase NaN is
+    # absence, not contradiction, and skipna=False would return <NA> for
+    # values the survey actually recorded.
+    # `dropna=False` governs NA *group keys* only; rows with NA i/pid are
+    # already dropped above and `t` is a literal, so it too is inert here.
     df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
     df = df.set_index(['t', 'i', 'pid'])
     return df

--- a/lsms_library/countries/Senegal/2018-19/_/people_last7days.py
+++ b/lsms_library/countries/Senegal/2018-19/_/people_last7days.py
@@ -103,6 +103,31 @@ def _finish_people_last7days(df, t):
     keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
             'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
     df = df[keep]
+    # --- (t, i, pid) key soundness reviewed 2026-07-21 -- GH #637 ----------
+    # This collapse is a NO-OP on the shipped Senegal data: there is nothing
+    # to collapse, so `.first()`'s per-column skipna=True can form no
+    # composite row here.  Measured on the SOURCE directly (this table is
+    # `materialize: make`, so it builds out-of-process and an in-process
+    # groupby probe cannot see it -- see the #637 thread):
+    #   s04_me_sen2018 rows 66,120; duplicate (grappe, menage, s01q00a)
+    #     groups 0
+    #   s01_me_sen2018 rows 66,119; duplicate person-key groups 0
+    #     -> the how='left' merge fans out 0 rows (merged == 66,120)
+    #   i() is INJECTIVE: 7,156 distinct (grappe, menage) pairs -> 7,156
+    #     distinct ids
+    #   groups on (t, i, pid) 66,120 == rows 66,120  ->  0 duplicate groups
+    # Separate, non-key observation from the same probe: exactly ONE s04
+    # person-key -- (grappe 481, menage 9, line 17) -- has no s01 roster row,
+    # so that person's Age (and hence working_age) is NA.  A one-row roster
+    # gap, not a key defect; recorded so it is not rediscovered as one.
+    # So the key merges no distinct persons -- the ONLY situation in which the
+    # composite would be wrong (GH #637 correction thread; GH #323 D1: the fix
+    # for a merged entity is the identifier, never a reducer).
+    # Do NOT "fix" this to `.first(skipna=False)`: in this codebase NaN is
+    # absence, not contradiction, and skipna=False would return <NA> for
+    # values the survey actually recorded.
+    # `dropna=False` governs NA *group keys* only; rows with NA i/pid are
+    # already dropped above and `t` is a literal, so it too is inert here.
     df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
     df = df.set_index(['t', 'i', 'pid'])
     return df

--- a/lsms_library/countries/Togo/2018/_/people_last7days.py
+++ b/lsms_library/countries/Togo/2018/_/people_last7days.py
@@ -107,6 +107,27 @@ def _finish_people_last7days(df, t):
     keep = ['t', 'i', 'pid', 'farm_work', 'SOB_work', 'wage_work',
             'farm_hrs', 'SB_hrs', 'wage_hrs', 'Industry', 'working_age']
     df = df[keep]
+    # --- (t, i, pid) key soundness reviewed 2026-07-21 -- GH #637 ----------
+    # This collapse is a NO-OP on the shipped Togo data: there is nothing to
+    # collapse, so `.first()`'s per-column skipna=True can form no composite
+    # row here.  Measured on the SOURCE directly (this table is
+    # `materialize: make`, so it builds out-of-process and an in-process
+    # groupby probe cannot see it -- see the #637 thread):
+    #   s04_me_tgo2018 rows 25,282; duplicate (grappe, menage, s01q00a)
+    #     groups 0
+    #   s01_me_tgo2018 rows 27,480; duplicate person-key groups 0
+    #     -> the how='left' merge fans out 0 rows (merged == 25,282)
+    #   i() is INJECTIVE: 6,171 distinct (grappe, menage) pairs in the full
+    #     roster -> 6,171 distinct ids
+    #   groups on (t, i, pid) 25,282 == rows 25,282  ->  0 duplicate groups
+    # So the key merges no distinct persons -- the ONLY situation in which the
+    # composite would be wrong (GH #637 correction thread; GH #323 D1: the fix
+    # for a merged entity is the identifier, never a reducer).
+    # Do NOT "fix" this to `.first(skipna=False)`: in this codebase NaN is
+    # absence, not contradiction, and skipna=False would return <NA> for
+    # values the survey actually recorded.
+    # `dropna=False` governs NA *group keys* only; rows with NA i/pid are
+    # already dropped above and `t` is a literal, so it too is inert here.
     df = (df.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first())
     df = df.set_index(['t', 'i', 'pid'])
     return df


### PR DESCRIPTION
Key-soundness review of the six copy-pasted EHCVM `people_last7days` sites named in #637.

## Verdict: no key is broken. No fix warranted.

The `.groupby(['t', 'i', 'pid'], dropna=False, as_index=False).first()` line is a **strict no-op in all six countries** — there are **zero** duplicate `(t, i, pid)` groups, so `.first()`'s per-column `skipna=True` can form no composite row at all. Not "the composites it forms are benign": it forms none.

This PR therefore adds **only the evidence** — a comment at each site recording that the key was reviewed, what was checked, and the counts. **No behaviour change.**

## How it was measured

Directly on the **source**, not by instrumenting the build. These tables are `materialize: make`, so they run out-of-process via `subprocess.run(make_cmd, …)`; the earlier in-process `DataFrameGroupBy.first` monkeypatch never entered those subprocesses, which is why it reported a meaningless `0` for these sites (per the #637 correction thread, all 38 country-script sites were unmeasured).

For each country: load `s04_me_*` (7-day module) and `s01_me_*` (roster) with `get_dataframe()`, reproduce the merge and the `i()`/`pid` construction exactly as the site does, then count duplicate groups on the built key and classify each.

## Per-country verdict

| country | s04 rows | s01 rows | dup groups on `(grappe, menage, s01q00a)` in s04 / s01 | merge fan-out | groups on `(t,i,pid)` | **dup groups** | exact | complementary | **conflicting** |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| Benin 2018-19 | 35,042 | 42,343 | 0 / 0 | 0 | 35,042 | **0** | 0 | 0 | **0** |
| Burkina Faso 2018-19 | 45,612 | 45,612 | 0 / 0 | 0 | 45,612 | **0** | 0 | 0 | **0** |
| CotedIvoire 2018-19 | 61,116 | 61,116 | 0 / 0 | 0 | 61,116 | **0** | 0 | 0 | **0** |
| Guinea-Bissau 2018-19 | 42,839 | 42,839 | 0 / 0 | 0 | 42,839 | **0** | 0 | 0 | **0** |
| Senegal 2018-19 | 66,120 | 66,119 | 0 / 0 | 0 | 66,120 | **0** | 0 | 0 | **0** |
| Togo 2018 | 25,282 | 27,480 | 0 / 0 | 0 | 25,282 | **0** | 0 | 0 | **0** |

`groups == rows` in every row of that table. There is no conflicting group to quote evidence for, because there is no duplicate group of any kind.

## Why the key cannot merge two people

Three independent facts, each checked:

1. **`s04` is already one row per person.** Zero duplicate `(grappe, menage, s01q00a)` groups in the 7-day module itself.
2. **The roster merge does not fan out.** `s01` also has zero duplicate person-key groups, so the `how='left'` merge adds zero rows in all six countries (`merged == len(s04)` exactly).
3. **Every household-id formatter is injective**, over the *full* roster — not just the households that reach `s04`:

| country | formatter | distinct `(grappe, menage)` pairs | distinct `i` | collisions |
|---|---|---:|---:|---:|
| Benin | `grappe + zeropad3(menage)` | 8,012 | 8,012 | 0 |
| Burkina Faso | `ehcvm_i`: `grappe + '0' + zeropad2(menage)` | 7,010 | 7,010 | 0 |
| CotedIvoire | `grappe + zeropad3(menage)` | 12,992 | 12,992 | 0 |
| Guinea-Bissau | `grappe + '0' + zeropad2(menage)` | 5,351 | 5,351 | 0 |
| Senegal | `grappe + '0' + zeropad2(menage)` | 7,156 | 7,156 | 0 |
| Togo | `grappe + '0' + zeropad2(menage)` | 6,171 | 6,171 | 0 |

Two of these are worth naming because they are the ones that *could* have collided:

- **Burkina Faso** `menage` runs to **527** — the three-digit case that broke the older `i()` (the GAP-4 livestock i-key bug documented in `ehcvm_i`'s docstring). `ehcvm_i`'s `'0'` separator survives it with zero collisions.
- **CotedIvoire** concatenates with **no separator at all**. It is injective only because `menage` tops out at 30, so `zeropadding=3` always yields exactly three characters and the split point is unambiguous. A future wave with `menage > 999` would break that. Recorded in the comment at the site.
- **Guinea-Bissau**'s `grappe` is a wide code (max 27,711,109), not a 3-digit cluster number as elsewhere; the separated form still collides on none of it.

## End-to-end confirmation

Cold rebuilds under an isolated `LSMS_DATA_DIR` (`dvc-cache` symlinked; no `dvc` CLI invoked anywhere in this work). The wave parquets carry exactly the pre-groupby row counts, with zero duplicate index entries:

```
Togo    wave-parquet rows 25282  dup idx 0
Benin   wave-parquet rows 35042  dup idx 0
Senegal wave-parquet rows 66120  dup idx 0
```

## Deliberately NOT changed

- **`.first()` is left as-is.** `.first(skipna=False)` was withdrawn on #637 as a regression — NaN is absence, not contradiction, and it would return `<NA>` for values the survey recorded. Each site comment says so, so the attractive-but-wrong fix is not re-derived here.
- **No `aggregation:` YAML key** (GH #323 D1 forbids it).
- No file under `lsms_library/*.py` is touched.

## Three side observations, recorded so they are not rediscovered as defects

1. **`dropna=False` is inert at all six sites.** It governs NA *group keys* only. Rows with NA `i`/`pid` are already filtered out on the line immediately above, and `t` is a literal. If the author believed it preserved NAs in the *values*, that belief was mistaken — and harmless here.
2. **Senegal has one orphan person.** Exactly one `s04` person-key — `(grappe 481, menage 9, line 17)` — has no `s01` roster row, so that person's `Age` (hence `working_age`) is NA. A one-row roster gap, not a key defect.
3. **Senegal's API row count is 65,723, not the parquet's 66,120.** I chased this 397-row gap because a silent row loss is exactly what a broken key looks like. It is neither the key nor the v-join: all 7,156 wave households are present in `sample()` at `t='2018-19'` with zero NA `v`, `_join_v_from_sample` drops nothing, and `id_walk` drops nothing (Senegal's `updated_ids['2018-19']` is empty). It is the universal hollow-row safety net `df.dropna(how='all')` at `country.py:2243`, removing exactly 397 persons whose every declared column is NA (unknown age *and* non-1/2 codes on all three dummies). Benin and Togo have 0 such rows. Working as designed; unrelated to #637.

Refs #637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
