### PR TITLE
fix(Malawi): 2004-05's cluster key was an intra-TA sequence number (GH #323, config-only)

### DIFF
--- a/.coder/ledger/323-malawi-key.md
+++ b/.coder/ledger/323-malawi-key.md
@@ -1,0 +1,236 @@
+# Prior-Art Ledger — GH #323 (Malawi, Site 2): the cluster key
+
+**Search tier used:** ripgrep + git, plus PR #634 / `.coder/ledger/323-uganda.md`
+(the template for this task), the consolidation note
+`slurm_logs/DESIGN_grain_collapse_sites_2026-07-13.org` (branch
+`origin/docs/323-grain-collapse-sites`, Site 2 + D1/D2/D3), and PR #627's Site-4
+cartesian census. Every number below is a **cold** build against an *isolated*
+`LSMS_DATA_DIR` (fresh tree, `dvc-cache` symlinked to the shared L1) with
+`LSMS_COUNTRIES_ROOT` pointed at this worktree and asserted before any run.
+`LSMS_NO_CACHE=1` alone was **not** trusted — it is soft for script-path L2-wave
+parquets, and the collapse is baked into the cache it poisoned.
+
+## §1 Task, restated
+
+Malawi's `cluster_features` is declared `(t, v)` in `_/data_scheme.yml` but every
+one of the five waves extracts it from the household **cover page**, so the frame
+arrives at household grain and is projected onto the cluster by
+`Wave.cluster_features` → `country._collapse_to_cluster_grain` → `.first()`. Where
+the households of one `v` disagree about the cluster's own attributes, one
+arbitrary household's answer is served as the cluster's — and `.first()` skips NA
+per column, so the row it returns can be a **composite existing in no source
+record**. The task: find, empirically, what actually identifies a cluster in each
+wave and fix the identifier. Config only (`countries/Malawi/**`); no
+`lsms_library/*.py`, no `aggregation:` keys, no declared reducer, no blanking to
+`<NA>`.
+
+## §2 Existing machinery (this task's area)
+
+| symbol | path | what it does | tested? | reuse / extend / new |
+|--------|------|--------------|---------|----------------------|
+| `_collapse_to_cluster_grain` | `country.py:4490` | Site 2's audit-then-`.first()`; emits `GrainCollapseWarning` | yes | **do not touch** (core, PR #617) — monkeypatched *read-only* to capture the pre-collapse frame |
+| `_join_v_from_sample` | `country.py` | joins `cluster_features` onto household tables through `sample.v` | yes | the constraint: forces `sample.v` ≡ `cluster_features.v` |
+| `_enforce_canonical_spellings` | `country.py` (`_finalize_result`) | `rural`/`RURAL` → `Rural` at API time | yes | **reuse** — the reason no `Rural` mapping is needed in YAML |
+| auto-discovery categorical mapping | `country.py` (`_apply_categorical_mappings`) | column name ↔ `categorical_mapping.org` table name, case-insensitive | yes | **reuse**, and *also* apply the `region` table at extraction (§6.3) |
+| `mappings: [table, from, to]` in `myvars` | `country.py:760` `map_formatting_function` | pulls a `categorical_mapping.org` table into a dict | yes (used by Malawi `strata` in all 5 waves) | **reuse** for 2016-17 `Region` |
+| `psu` column | `Malawi/2004-05/Data/sec_a.dta` | the fully qualified 8-digit EA code, already in the file | — | **reuse** — no derivation, no composite, no new primitive |
+| `cs_i` | `Malawi/2016-17/_/mapping.py`, `2019-20/_/mapping.py` | `'cs-17-' + format_id(...)`, keeps CS ids apart from panel `y{3,4}_hhid` | — | **reuse** — `df_geo` must build `i` the same way `df_main` does |
+| `Rural: 0/1` inline `mapping:` blocks | all 5 waves | **already removed on `development`** by GH #602 | yes | nothing to do — do **not** re-add |
+| `aggregation:` block | `Malawi/_/data_scheme.yml` (`interview_date`) | dead config; nothing reads it | n/a | **forbidden** to add more (D1); the existing one is out of scope |
+
+## §3 Definitions & conventions in force
+
+- `sample()` is the single source of truth for a household's cluster; `v` is
+  joined from it at API time — `CLAUDE.md` "`sample()` and Cluster Identity".
+  ⇒ **`sample.v` and `cluster_features.v` must be the same key.**
+- `cluster_features` owns `v`; index `(t, v)` — `Malawi/_/data_scheme.yml`.
+- Canonical `Rural` is `str` with spellings `Rural: [rural, RURAL, …]` —
+  `lsms_library/data_info.yml`. **Not** a 0/1 indicator.
+- "NO AGGREGATION IN CORE" — `SkunkWorks/grain_aggregation_policy.org`, D1 of the
+  consolidation note.
+- D2: NaN-key rows are deleted and reported, never retained. (Malawi has none:
+  every wave's cover page populates its cluster column for every household.)
+- D3: Sites 2 and 4 get their own PRs. Site 4 is PR #627 — see §6.5.
+
+## §4 Invariants & assumptions
+
+- **The Malawi EA code is structured**: `region(1) + district(2) + TA(2) + EA(3)`,
+  8 digits. Verified by decoding: the leading digit reproduces the reported
+  region for 11,280/11,280 households in 2004-05.
+- **Frame vintage is not shared across the IHS2/IHS3 boundary.** 2004-05's 564
+  EA codes overlap 2010-11's 768 in only **3** codes (1998 vs 2008 census frame).
+  The *format* is common to all five waves; the *sets* are not. So a cross-wave
+  join on `v` is meaningful from 2010-11 on and not before — and the 2004-05 fix
+  does not, and cannot, create a spurious panel link.
+- **The IHPS waves are TRACKED panels.** `ea_id` in 2013-14 / the panel halves of
+  2016-17 and 2019-20 is the **IHS3 baseline EA**, and the panel EA sets nest
+  cleanly: 2019-20-PN = 2016-17-PN = 102 ⊂ 2013-14 = 204 ⊂ 2010-11 = 768. So a
+  cluster's households genuinely live in different districts. Dispersal, not
+  collision — see §6.2.
+- **The two halves of 2016-17 / 2019-20 do not collide.** `ea_id` is one national
+  keyspace; the single code shared between the 2016-17 CS and panel halves
+  (`30305580`) is the *same real EA* in the *same district*, sampled twice.
+- `format_id` is auto-applied to `idxvars`, not `myvars` — `CLAUDE.md`. `psu` is
+  already an 8-character string in the source, so `sample.myvars.v: psu` needs no
+  formatter.
+- **A cartesian merge cannot change a contested-cell count.** `nunique(dropna=True)`
+  per (cluster, column) is invariant to row repetition. Assumed by PR #627's
+  owner; **measured** here rather than assumed — §7.
+
+## §5 Reuse decision
+
+| quantity | decision | reason |
+|----------|----------|--------|
+| 2004-05 cluster key | **reuse the source's own `psu`** | Not a composite, not derived: the fully qualified code is already a column. 564 values, exactly 20 HH each, 0 contested cells. A `(dist, ta, ea)` composite would produce the identical partition (verified: 564 groups) with three columns instead of one, and would *not* be on the later waves' 8-digit keyspace. |
+| 2013-14 / 2019-20 panel keys | **no change** | The contest is dispersal. Uganda §6.5 set the precedent (`comm` not re-keyed): a structured code with zero collisions in its frame year, whose multi-district groups show a dispersal signature, must not be split by current district. Splitting 2013-14 on `(district, ea_id)` yields 626 groups of **median 1 household** — 422 singleton pseudo-clusters — and would desynchronise `v` from the IHS3 baseline. |
+| GPS reducer | **none** — no averaging, no median | Same argument that retired core's `.mean()` on 2026-07-13, and here it is decisive: the 2013-14 within-EA spread is *entirely* movers (§6.2), so a centroid would place a cluster in the middle of nowhere between an EA and the towns its emigrants moved to. |
+| categorical reducer | **none declared** | D1. The key fix removes the conflicts that were fixable; the rest are reported. |
+| `Rural` 0/1 mapping | **nothing** — already removed by GH #602 on `development` | A second implementation would fork the vocabulary. Canonical `spellings` already normalise the three cases. |
+| 2016-17 `Region` | **extend**: apply the existing `region` table at extraction | The auto-discovery mapping already collapses `South`/`Southern` at API time, so this is output-neutral; it just stops the *collapse* from reading a spelling difference as a disagreement about the cluster. |
+| 2016-17 `df_geo` merge key | **fix**: build `i` with `cs_i`, exactly as `df_main` does | Not a new mechanism — the transform already exists and `df_main` already uses it. The block simply failed to mirror it. |
+| 2010-11 / 2019-20 cartesian `df_geo` merges | **leave, and document in place** | Site 4, PR #627 owns it (D3). The one-line config fix was implemented, measured, and then **reverted** so #627's cardinality guard keeps these two cells as evidence. §6.5. |
+
+## §6 Decisions, with the evidence
+
+1. **2004-05's `ea` is not a cluster id — it is an intra-TA sequence number.**
+   110 distinct values for 564 EAs. Measured at source, contested cells by key:
+
+   | key | groups | region | district | reside |
+   |-----|--------|--------|----------|--------|
+   | `ea` | 110 | 66 | 79 | 19 |
+   | `(dist, ea)` | 447 | 0 | 0 | 8 |
+   | `(dist, ta, ea)` | 564 | 0 | 0 | 0 |
+   | **`psu`** | **564** | **0** | **0** | **0** |
+
+   `psu` ≡ `(dist, ta, ea)` exactly (each is unique within the other), with 20
+   households in every group. The `(dist, ea)` row is the instructive one: it is
+   the "make `v` a district composite" reflex, and it is *wrong here* — it still
+   merges EAs that share a district but sit in different TAs.
+
+2. **2013-14 is dispersal, and the GPS proves it.** 188 of 204 EAs have
+   households at different coordinates — the broken-key signature. But restrict
+   to households that did not move (`dist_to_IHS3location` ≤ 1 km) and **all 204
+   EAs collapse to exactly one coordinate**; `LAT_DD_MOD` is the EA-level
+   displaced fix of the household's *current* location, not per-household jitter.
+   Median within-EA spread 145 km, max 775 km — every kilometre of it a tracked
+   mover. Corroborated: 588/4,000 households report a district different from the
+   one encoded in their own `ea_id`, sitting a median **68 km** from their IHS3
+   location, against **0.03 km** for the 3,412 that match.
+
+   This is the finding that made the difference between fixing an identifier and
+   fabricating one. The brief's premise — "at 75%, the key is broken" — is right
+   about 2004-05 and wrong about 2013-14, and the reason is arithmetic: with ~20
+   households per EA and 13% of them district-movers, `1 − 0.87²⁰ ≈ 94%` of EAs
+   are *expected* to contain at least one mover. The high **cell** rate is a
+   property of the metric on a tracked panel, not evidence of a merged key.
+
+3. **The 2016-17 `Region` conflict was a spelling, not a collision.** EA
+   `30305580` is in both halves; the CS file writes `Southern`, the panel file
+   `South`. Same district, same real EA. Applying the `region` table at
+   extraction removes the cell. 1 → 0.
+
+4. **2016-17 had no GPS at all, and it was a merge key.** `df_main` builds
+   Cross_Sectional `i` as `cs_i(case_id)`; `df_geo` declared the raw `case_id`,
+   so the `how='outer'` join matched nothing — 12,447 orphan geo rows next to
+   14,955 coordinate-less main rows, and **0 of 880 clusters with GPS**. The two
+   files are exactly 1:1 on `case_id` (12,447 = 12,447, none on either side
+   alone), so mirroring the transform makes the join exact: **779 of 880**
+   clusters now carry coordinates (the other 101 are IHPS panel EAs, for which
+   IHS4 publishes no geovariables). Honest cost: 7 of those 779 EAs have
+   households whose `lat_modified` differs within the EA — IHS4's displacement is
+   nearly but not exactly EA-constant — so `Latitude`/`Longitude` show 7
+   contested cells where before there were none, *because before there was no
+   coordinate*.
+
+   This is **not** a Site-4 cardinality fix and 2016-17 is not on PR #627's
+   cartesian list. It is a non-matching key, which produces orphans, not a
+   product.
+
+5. **The two real cartesians were fixed, measured, and then reverted.** 2010-11
+   (196,083 rows from 12,271; 183,812 phantom) and 2019-20 (185,842 from 14,612;
+   171,230 phantom) merge a household-grain geo file on the cluster key `v`.
+   Collapsing both to `merge_on: [i]` was implemented and measured: contested
+   cells **0 and 250 — identical either way**, confirming §4's invariance claim
+   by measurement rather than by argument. The change was then reverted at the
+   coordinator's direction so PR #627's guard retains these cells as evidence;
+   the one-line fix is recorded in each wave's `data_info.yml` next to the
+   declaration that causes it, and in `CONTENTS.org`. #627 owns the decision.
+
+6. **`Rural` needed nothing.** The pre-#602 inline `mapping:` blocks were both
+   live and inverted (`rural: 0` in one file, `RURAL: 1` in another, in the *same
+   wave*), but GH #602 already removed all five on `development`. Verified
+   against the pre-collapse frames: `Rural` arrives as the raw label and
+   `_enforce_canonical_spellings` normalises it. Nothing added.
+
+## §7 Measured effect (cold build, isolated `LSMS_DATA_DIR`)
+
+Contested cells = clusters where `nunique(dropna=True) > 1` for that attribute,
+counted on the frame captured *inside* `_collapse_to_cluster_grain` before it
+runs — the only place the evidence still exists.
+
+| wave | before | after | clusters | note |
+|------|--------|-------|----------|------|
+| 2004-05 | 164 / 330 (49.7%) | **0 / 1,692** | 110 → **564** | Region 66→0, District 79→0, Rural 19→0 |
+| 2010-11 | 0 / 3,840 | 0 / 3,840 | 768 | already correct |
+| 2013-14 | 765 / 1,020 (75.0%) | 765 / 1,020 | 204 | dispersal — §6.2 |
+| 2016-17 | 78 / 4,405 | 89 / 4,400 | 880 | Region 1→**0**; Lat/Lon 1→7 *because GPS now exists*: 0 → **779** clusters with coordinates |
+| 2019-20 | 250 / 4,095 (6.1%) | 250 / 4,095 | 819 | dispersal — panel half only |
+| **total** | **1,257 / 13,690** | **1,104 / 15,047** | 2,782 → **3,235** | |
+
+(The brief's baseline was 1,255; the 2-cell difference is in 2004-05 and does not
+bear on anything. Its 424,607 source rows are 412,160 here — the 12,447 removed
+are 2016-17's orphan geo rows, and ~355k of what remains is the known cartesian.)
+
+At the API, what the 2004-05 fix restored: **20 → 26 districts**, and the
+settlement strata from `{Rural}` — every one of the 110 mega-clusters came out
+rural — back to `{Rural, Urban}`.
+
+Two of the five waves (2004-05, 2010-11) now emit **no `GrainCollapseWarning` at
+all**; before, four did.
+
+## §8 Verification
+
+- `sample.v` ≡ `cluster_features.v` in **every** wave: **0** `cluster_features`
+  `(t, v)` pairs unknown to `sample`, **0** orphaned `sample` clusters.
+- `tests/test_gh323_malawi_cluster_key.py` — 14 tests, all config-level;
+  exercises no core aggregation. **Negative control run**: 7 of the 14 fail
+  against a pristine `origin/development` config tree (exported with
+  `git archive`, cold data dir), including every load-bearing one.
+- Malawi-relevant slice (`-k "malawi or Malawi or 323 or schema or sample or
+  cluster"`): **680 passed, 58 skipped, 4 xfailed, 1 failed**.
+- The 1 failure is **pre-existing and untouched by this branch**:
+  `tests/test_gh323_explicit_reducers.py::test_core_does_not_dispatch_the_reducers`
+  greps `lsms_library/country.py` for the substring `collapse_to_cluster_grain`
+  and finds PR #617's private `_collapse_to_cluster_grain`. This branch is
+  config-only and does not touch `country.py`. Same failure is reported on PR
+  #634.
+
+## §9 Deferred (deliberately)
+
+- **Site 4 / PR #627**: 2010-11 and 2019-20's cartesian `df_geo` merges. §6.5.
+- **The `region`/`district` extraction-time harmonisation is applied only where
+  it removed a measured conflict** (2016-17 `Region`). Doing it everywhere is
+  output-neutral and tidier, but it is a diff across five waves and two tables
+  for zero measured gain, so it is not in this PR.
+- **2016-17's 101 panel clusters and 2019-20's 102 have no coordinates**, because
+  IHS4/IHS5 publish geovariables for the cross-sectional half only. Pre-existing,
+  unrelated to #323, recorded in `CONTENTS.org`.
+- **IHPS-2016 mixes baseline and current geography in one file** (`district`
+  baseline, `reside` current — 0 vs 277 households off their EA's mode). That is
+  the source's inconsistency; documented, not papered over.
+
+---
+### Phase 3 — verification
+
+- `Malawi/2004-05/_/data_info.yml` `sample.v` / `cluster_features.v` = `psu` —
+  **OK (anchored on §3, §5)**: same key in both, as `_join_v_from_sample`
+  requires; verified 0 unknown pairs.
+- `Malawi/2016-17/_/data_info.yml` `df_geo.idxvars.i` — **OK (anchored on §2)**:
+  reuses the existing `cs_i`, mirroring `df_main`; no new transform.
+- `Malawi/2016-17/_/data_info.yml` `Region` `mappings:` — **OK (anchored on §2)**:
+  same `mappings: [table, from, to]` form the wave's `strata` already uses; the
+  `region` table is unchanged.
+- 2013-14 / 2019-20 — **OK (anchored on §5, §6.2)**: no change is the decision,
+  and the decision is pinned by a test that fails if the evidence for it changes.
+- No `aggregation:` key added, no reducer declared, no value blanked to `<NA>`,
+  no file under `lsms_library/*.py` touched — **OK (anchored on §3, D1)**.

--- a/lsms_library/countries/Malawi/2004-05/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2004-05/_/data_info.yml
@@ -6,7 +6,23 @@ sample:
     idxvars:
         i: case_id
     myvars:
-        v: ea
+        # GH #323 SITE 2.  `ea` is NOT a cluster id: it is the EA's sequence
+        # number WITHIN its Traditional Authority, so it takes only 110
+        # distinct values for IHS2's 564 enumeration areas.  Keyed on `ea`,
+        # ~5 unrelated EAs -- in different TAs, districts and regions --
+        # merge into one `v`.  `psu` is the fully qualified 8-digit EA code
+        # (region 1 + district 2 + TA 2 + EA 3) that the same file already
+        # carries: 564 distinct values, exactly 20 households each, and it
+        # is the SAME 8-digit keyspace the later IHS3/IHS4/IHS5 waves use
+        # for `ea_id` (a different census frame vintage, hence only 3 codes
+        # in common with 2010-11 -- the FORMAT matches, the frame does not).
+        # Verified: keyed on `psu`, zero households in a cluster disagree
+        # about the cluster's region / district / urban-rural status; keyed
+        # on `ea`, 164 of 330 such cells are contested.
+        #
+        # `v` must be declared identically here and in cluster_features
+        # below or _join_v_from_sample matches nothing.
+        v: psu
         weight: hhwght
         panel_weight: hhwght
         strata:
@@ -40,7 +56,15 @@ cluster_features:
     file: sec_a.dta
     idxvars:
         i: case_id
-        v: ea
+        # GH #323 SITE 2 -- see the note on sample.v above.  `ea` is the EA's
+        # sequence number within its Traditional Authority (110 values for
+        # 564 EAs); `psu` is the fully qualified 8-digit EA code.  Keeping
+        # `ea` here merged ~5 real EAs per `v` and the household->cluster
+        # projection then served ONE arbitrary household's answer as the
+        # cluster's: 6 of Malawi's 26 districts vanished from
+        # cluster_features entirely and every one of the 110 surviving
+        # clusters came out `Rural` -- IHS2's whole urban stratum erased.
+        v: psu
     myvars:
         Region: region
         District: dist

--- a/lsms_library/countries/Malawi/2010-11/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2010-11/_/data_info.yml
@@ -129,6 +129,23 @@ cluster_features:
             # lookups for this wave.
             District: hh_a01
     df_geo:
+        # GH #323 SITE 4 -- KNOWN CARTESIAN, DELIBERATELY NOT FIXED HERE.
+        # `householdgeovariables.dta` is HOUSEHOLD grain (12,271 rows, one per
+        # case_id, across 768 EAs), and this block keys it on `ea_id` and merges
+        # on the CLUSTER key `v`.  `pd.merge` therefore pairs every household in
+        # df_main with every geo row sharing that `v`: 12,271 x ~16 = 196,083
+        # rows, 183,812 of them phantom, for a table that collapses to 768
+        # clusters.  It costs 16x the time and memory and manufactures the
+        # duplicates Site 2 then destroys.
+        #
+        # It does NOT corrupt any value: `lat_modified` is constant within every
+        # ea_id, and a cartesian repeats values rather than inventing them, so
+        # the contested-cell count is provably unchanged by it (measured: 0
+        # before and after collapsing the merge to household grain).  The
+        # one-line fix is `idxvars: {i: case_id}` + `merge_on: [i]` -- the two
+        # files are exactly 1:1 on case_id, no rows on either side alone.  Left
+        # in place so that PR #627's cardinality guard (core, Site 4) still has
+        # this cell as evidence; #627 owns the decision.
         file: Full_Sample/Geovariables/HH_level/householdgeovariables.dta
         idxvars:
             v: ea_id

--- a/lsms_library/countries/Malawi/2016-17/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2016-17/_/data_info.yml
@@ -60,7 +60,19 @@ cluster_features:
                 - mapping: cs_i
             v: ea_id
         myvars:
-            Region: region
+            # GH #323 SITE 2.  Harmonize the region label AT EXTRACTION, not
+            # only at API time.  The Cross_Sectional file spells the southern
+            # region 'Southern' and the Panel file spells it 'South'; EA
+            # 30305580 is sampled in BOTH halves (a genuine shared EA, same
+            # district -- not a code collision), so the household->cluster
+            # projection saw two spellings of one region and recorded a
+            # conflict that does not exist.  The auto-discovery `region`
+            # table already collapses them at API time, so applying it here
+            # is output-neutral -- it just stops the collapse from seeing a
+            # spelling difference as a disagreement about the cluster.
+            Region:
+                - region
+                - mappings: ['region', 'Alternate Spelling', 'Preferred Label']
             District: district
             # Raw `reside` is already a declared spelling of the canonical
             # Rural/Urban vocabulary in every Malawi wave ('Rural'/'Urban',
@@ -78,7 +90,18 @@ cluster_features:
         # file in this wave and end up with NaN lat/lon -- acceptable.
         file: Cross_Sectional/householdgeovariablesihs4.dta
         idxvars:
-            i: case_id
+            # `i` MUST be built exactly as df_main builds it.  df_main runs
+            # case_id through cs_i ('cs-17-' + format_id) to keep the
+            # Cross_Sectional ids apart from the Panel's y3_hhid; this block
+            # declared the RAW case_id, so the merge key never matched and
+            # the `how='outer'` join produced 12,447 orphan geo rows next to
+            # 14,955 main rows with no coordinates.  Result: 0 of 880
+            # clusters had GPS.  The two files are exactly 1:1 on case_id
+            # (12,447 = 12,447, no rows on either side alone), so mirroring
+            # the transform makes the join exact.
+            i:
+                - case_id
+                - mapping: cs_i
         myvars:
             Latitude: lat_modified
             Longitude: lon_modified

--- a/lsms_library/countries/Malawi/2019-20/_/data_info.yml
+++ b/lsms_library/countries/Malawi/2019-20/_/data_info.yml
@@ -73,6 +73,24 @@ cluster_features:
             # sign-flipping the indicator between waves.  GH #602.
             Rural: reside
     df_geo:
+        # GH #323 SITE 4 -- KNOWN CARTESIAN, DELIBERATELY NOT FIXED HERE.
+        # `householdgeovariables_ihs5.dta` is HOUSEHOLD grain (11,434 rows, one
+        # per case_id, across 717 EAs), and this block keys it on `ea_id` and
+        # merges on the CLUSTER key `v`: 14,612 households x 11,434 geo rows
+        # paired within `v` = 185,842 rows, 171,230 of them phantom, for a table
+        # that collapses to 819 clusters.
+        #
+        # It does NOT corrupt any value -- a cartesian repeats values rather
+        # than inventing them, and the contested-cell count is provably
+        # unchanged by it (measured: 250 before and after collapsing the merge
+        # to household grain).  The one-line fix is `idxvars: {i: [case_id,
+        # {function: cs_i}]}` + `merge_on: [i]`; the two files are exactly 1:1
+        # on case_id.  Left in place so PR #627's cardinality guard (core,
+        # Site 4) still has this cell as evidence; #627 owns the decision.
+        #
+        # Unrelated to the cardinality: the 102 IHPS Panel EAs share NO ea_id
+        # with the geo file, so those clusters have NaN coordinates either way
+        # -- IHS5 publishes no geovariables for the panel half.
         file: Cross_Sectional/householdgeovariables_ihs5.dta
         idxvars:
             v: ea_id

--- a/lsms_library/countries/Malawi/_/CONTENTS.org
+++ b/lsms_library/countries/Malawi/_/CONTENTS.org
@@ -465,8 +465,138 @@ District names vary slightly across waves (e.g., "Blanytyre" vs
 =strata= table in =categorical_mapping.org=.
 
 ** Cluster (PSU)
-- 2004-05: =ea= (numeric, 110 unique EAs)
+- 2004-05: =psu= (string, 564 unique EAs)  -- *was* =ea=; see below
 - 2010-11 onward: =ea_id= (string, 200--800 unique EAs per wave)
+
+Every wave's =v= is the same object in the same format: the *fully qualified
+8-digit Malawi enumeration-area code*, =region(1) + district(2) + TA(2) +
+EA(3)= -- e.g. =10101016= is EA 016 of TA 01 of district 01 (Chitipa) of
+region 1 (North).
+
+*** GH #323: 2004-05's cluster key was not a cluster key
+
+Until this was fixed, 2004-05 declared =v: ea=.  =ea= is *the EA's sequence
+number within its Traditional Authority*, so it takes only *110 distinct
+values for IHS2's 564 enumeration areas*.  Keyed on =ea=, roughly five
+unrelated EAs -- in different TAs, districts and regions -- merged into one
+=v=, and the household -> cluster projection in =Wave.cluster_features= then
+resolved the disagreement with =groupby().first()=: one arbitrary household's
+answer, served as the cluster's.
+
+What that destroyed, measured cold:
+
+| quantity                                            | =v: ea= | =v: psu= |
+|-----------------------------------------------------+---------+----------|
+| clusters                                            |     110 |      564 |
+| districts present in =cluster_features=             |      20 |       26 |
+| settlement strata present in =cluster_features=     | 1 (all =Rural=) |        2 |
+| contested cluster-attribute cells (of 330 / 1,692)  |     164 |    *0* |
+
+The urban stratum did not merely lose rows -- it disappeared.  All 110
+surviving clusters came out =Rural=, because =first()= happened to reach a
+rural household in every merged group.  Six of Malawi's 26 districts vanished
+from =cluster_features= entirely.  Both facts were invisible at the API: the
+table looked complete, it was just wrong.
+
+=psu= is the fully qualified code, already present in =sec_a.dta=: 564 values,
+*exactly 20 households each* (the IHS2 design), and *zero* households in a
+cluster disagreeing about their cluster's region, district or urban/rural
+status.  It is declared identically in =sample= and in =cluster_features=,
+because =_join_v_from_sample= joins the two through =v= and they cannot be
+allowed to drift.
+
+Note the *frame vintage*: 2004-05 shares only 3 codes with 2010-11.  IHS2 is
+drawn from the 1998 census frame and IHS3+ from the 2008 frame, so the code
+*format* is common across all five waves but the code *sets* are not.  A
+cross-wave join on =v= is meaningful from 2010-11 onward and not before.
+
+*** GH #323: what remains contested, and why it is NOT re-keyed
+
+After the fix, three waves still have clusters whose households disagree.  In
+every case the measurement says the identifier is *right* and the households
+have *moved* -- these are tracked panels, and re-keying on the current district
+would fracture real EAs, desynchronise =v= from =sample=, and sever the panel's
+link to its own baseline.
+
+| wave    | contested cells | of    | what they are                                |
+|---------+-----------------+-------+----------------------------------------------|
+| 2004-05 |           *0*   | 1,692 | --                                           |
+| 2010-11 |           *0*   | 3,840 | --                                           |
+| 2013-14 |             765 | 1,020 | IHPS tracked movers (see below)              |
+| 2016-17 |              75 | 4,400 | IHPS-2016 =reside= is current, not baseline  |
+| 2019-20 |             250 | 4,095 | IHPS tracked movers                          |
+
+**** 2013-14 (IHPS): the GPS is the proof
+=ea_id= here is the *IHS3 baseline EA* -- 204 of IHS3's 768, and =case_id= is
+literally =ea_id= + household number.  The survey tracks movers and split-off
+households wherever they go (4,000 interviewed households from 3,104 baseline
+households), and the file's =region= / =district= / =reside= / geovariables all
+describe the household's *current* location.
+
+188 of 204 EAs have households reporting different coordinates, which is
+exactly the broken-key signature.  It is not one.  Restrict to households that
+did *not* move (=dist_to_IHS3location= <= 1 km) and *every one of the 204 EAs
+collapses to exactly one coordinate* -- =LAT_DD_MOD= is the EA-level displaced
+fix of the household's current location, not per-household jitter.  All of the
+within-EA spread (median 145 km, max 775 km) is dispersal.
+
+Corroborating: 588 of 4,000 households report a district different from the one
+encoded in their own =ea_id=, and those 588 sit a *median 68 km* from their
+IHS3 location against *0.03 km* for the 3,412 that match.
+
+**** 2016-17 (IHS4 + IHPS4)
+The 75 remaining cells are all =Rural=, all in the panel half.  IHPS-2016
+records =district= / =region= at *baseline* (0 of 2,508 households sit outside
+their EA's modal district) but =reside= *currently* -- 277 households differ
+from their EA's modal =reside= and 246 of those are flagged =mover=.  So one
+file mixes baseline and current geography; that is the survey's inconsistency,
+not ours.
+
+EA =30305580= is sampled in *both* the Cross_Sectional and the Panel halves.
+That is a genuine shared EA (same district), not a code collision -- the two
+halves spelled its region =Southern= and =South=, which used to read as a
+disagreement.  The =region= table is now applied at extraction, so it does not.
+
+**** 2019-20 (IHS5 + IHPS5)
+All 250 cells are in the panel half.  Unlike 2016-17, IHPS-2019 records
+=district= / =region= *currently*: 747 of 3,178 households are outside their
+EA's modal district, and 652 of those are more than 1 km from their IHS3
+location.  The 102 panel EAs share no =ea_id= with the 717 cross-sectional
+ones, so there is no cross-half collision here at all.
+
+*** GH #323: 2016-17 had no GPS, and the reason was a merge key
+=cluster_features= builds =i= for the Cross_Sectional half by running =case_id=
+through =cs_i= (='cs-17-'= + =format_id=), to keep it apart from the Panel's
+=y3_hhid=.  The =df_geo= block declared the *raw* =case_id=, so its merge key
+never matched anything: the =how='outer'= join produced 12,447 orphan geo rows
+alongside 14,955 main rows with no coordinates, and *0 of 880 clusters had
+GPS*.  =df_geo= now builds =i= exactly as =df_main= does; the two files are
+1:1 on =case_id= (12,447 = 12,447), so the join is exact and *779 of 880*
+clusters carry coordinates.  The remaining 101 are the IHPS panel EAs, for
+which IHS4 publishes no geovariables file.
+
+Cost of that fix, stated plainly: 7 of the 779 EAs have households whose IHS4
+=lat_modified= differs within the EA (IHS4's displacement is *nearly* but not
+exactly EA-constant), so =Latitude= / =Longitude= now show 7 contested cells
+where before there were none -- because before there was no coordinate at all.
+
+*** Known, deliberately unfixed: two cartesian =df_geo= merges (Site 4, PR #627)
+2010-11 and 2019-20 key a *household-grain* geovariables file on =ea_id= and
+merge it on the *cluster* key =v=, so =pd.merge= pairs every household with
+every geo row sharing that =v=:
+
+| wave    | households | geo rows | merged rows | phantom |
+|---------+------------+----------+-------------+---------|
+| 2010-11 |     12,271 |   12,271 |     196,083 | 183,812 |
+| 2019-20 |     14,612 |   11,434 |     185,842 | 171,230 |
+
+A cartesian *repeats* values, it does not invent them, so it corrupts nothing
+and changes no contested-cell count -- verified by measuring both waves with
+the merge collapsed to household grain (=merge_on: [i]=, the two files are 1:1
+on =case_id=): 0 and 250 contested cells respectively, identical either way.
+It does cost roughly 16x the build time and memory.  The one-line config fix is
+noted in each wave's =data_info.yml= but *not applied here*, so that PR #627's
+cardinality guard keeps these cells as evidence.  #627 owns the decision.
 
 ** Weights
 | Wave    | Cross-section weight | Panel weight       | Source file                                |

--- a/tests/test_gh323_malawi_cluster_key.py
+++ b/tests/test_gh323_malawi_cluster_key.py
@@ -1,0 +1,299 @@
+"""Malawi cluster key (GH #323, Site 2).
+
+Malawi's `cluster_features` is declared at `(t, v)` but every wave extracts it
+from the household cover page, so it is projected from household grain onto the
+cluster.  Where the households of one `v` DISAGREE about the cluster's own
+attributes, core resolves it with `groupby().first()` -- one arbitrary
+household's answer, served as the cluster's.  These tests pin the CONFIG that
+makes `v` a real cluster id.  They exercise no core aggregation (D1: core does
+not aggregate).
+
+Two different diseases were measured, and only one of them is a broken key:
+
+* **2004-05 (IHS2) -- BROKEN KEY.**  `ea` is the EA's sequence number *within
+  its Traditional Authority*: 110 distinct values for 564 enumeration areas, so
+  ~5 unrelated EAs merged into one `v`.  Fixed by keying on `psu`, the fully
+  qualified 8-digit EA code (region + district + TA + EA) that the same file
+  already carries.  164 of 330 contested cells -> 0.
+
+* **2013-14 / 2019-20 (IHPS panel halves) -- NOT a broken key.**  `ea_id` is the
+  IHS3 baseline EA and the survey TRACKS movers, so a cluster's households
+  genuinely live in different districts.  The decisive evidence is the GPS: in
+  2013-14 the households of an EA that did NOT move share EXACTLY ONE
+  coordinate, in all 204 EAs.  Every kilometre of within-EA spread is a tracked
+  mover.  Re-keying on the current district would fracture real EAs, desynchronise
+  `v` from `sample`, and destroy the panel's link to its own baseline.  So the
+  residual contested cells are reported, not forced to zero.
+
+Data-dependent: skips cleanly when the Malawi source files are unavailable.
+"""
+import re
+
+import pandas as pd
+import pytest
+import yaml
+
+import lsms_library as ll
+from lsms_library.paths import countries_root
+
+WAVES = ["2004-05", "2010-11", "2013-14", "2016-17", "2019-20"]
+
+# The fully qualified Malawi EA code: region(1) + district(2) + TA(2) + EA(3).
+EA_CODE = re.compile(r"^\d{8}$")
+
+
+@pytest.fixture(scope="module")
+def mw():
+    return ll.Country("Malawi")
+
+
+def _build(mw, table):
+    try:
+        df = getattr(mw, table)()
+    except Exception as exc:  # noqa: BLE001 - any build/data failure -> skip
+        pytest.skip(f"Malawi {table} unavailable: {exc}")
+    if df is None or df.empty:
+        pytest.skip(f"Malawi {table} empty")
+    return df
+
+
+@pytest.fixture(scope="module")
+def sample(mw):
+    return _build(mw, "sample")
+
+
+@pytest.fixture(scope="module")
+def cluster_features(mw):
+    return _build(mw, "cluster_features")
+
+
+def _wave_config(wave):
+    path = countries_root() / "Malawi" / wave / "_" / "data_info.yml"
+    if not path.exists():
+        pytest.skip(f"Malawi {wave} data_info.yml missing")
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+# ---------------------------------------------------------------------------
+# 1.  2004-05: the broken key.
+# ---------------------------------------------------------------------------
+
+def test_2004_05_v_is_the_fully_qualified_ea_code_not_the_within_TA_sequence(sample):
+    """IHS2 drew 564 EAs of 20 households each.  `ea` collapses them to 110."""
+    s = sample.reset_index()
+    v = s.loc[s["t"].astype(str) == "2004-05", "v"].dropna().astype(str)
+    assert v.nunique() == 564, (
+        f"2004-05 should have 564 clusters (IHS2's EA count), got {v.nunique()}. "
+        "110 means `v` is still `ea`, the EA sequence number within its "
+        "Traditional Authority, which merges ~5 real EAs per cluster."
+    )
+    assert v.map(lambda x: bool(EA_CODE.match(x))).all(), (
+        "2004-05 `v` must be the 8-digit region+district+TA+EA code"
+    )
+
+
+def test_2004_05_cluster_features_keeps_every_district_and_the_urban_stratum(
+    cluster_features,
+):
+    """What the broken key actually destroyed, at the API.
+
+    Keyed on `ea`, `groupby().first()` served one household's answer for each of
+    110 mega-clusters: 6 of Malawi's 26 districts disappeared from
+    `cluster_features` outright, and every surviving cluster came out `Rural` --
+    IHS2's entire urban stratum erased from the cluster table.
+    """
+    cf = cluster_features.reset_index()
+    w = cf[cf["t"].astype(str) == "2004-05"]
+    assert len(w) == 564, f"expected 564 clusters, got {len(w)}"
+    assert w["District"].nunique() == 26, (
+        f"2004-05 covers 26 districts; cluster_features shows "
+        f"{w['District'].nunique()}"
+    )
+    assert set(w["Rural"].dropna().astype(str)) == {"Rural", "Urban"}, (
+        "2004-05 cluster_features must retain both settlement strata; "
+        f"got {sorted(set(w['Rural'].dropna().astype(str)))}"
+    )
+
+
+def test_2004_05_source_shows_ea_is_not_a_cluster_id(mw):
+    """The evidence, at source: `ea` merges districts, `psu` does not.
+
+    This is the measurement that decided the key.  It is pinned so that a future
+    reader does not have to take the diagnosis on trust, and so that a change of
+    source file cannot silently invalidate it.
+    """
+    from lsms_library.local_tools import get_dataframe
+
+    path = countries_root() / "Malawi" / "2004-05" / "Data" / "sec_a.dta"
+    try:
+        df = get_dataframe(str(path))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"Malawi 2004-05 sec_a.dta unavailable: {exc}")
+
+    assert df["ea"].nunique() == 110
+    assert df["psu"].nunique() == 564
+    # exactly 20 households per real EA -- the IHS2 design
+    assert set(df.groupby("psu").size().unique()) == {20}
+
+    def contested(key, cols):
+        g = df.assign(**{key: df[key].astype(str)}).groupby(key, observed=True)
+        return {c: int((g[c].nunique(dropna=True) > 1).sum()) for c in cols}
+
+    cols = ["region", "dist", "reside"]
+    assert contested("psu", cols) == {"region": 0, "dist": 0, "reside": 0}, (
+        "psu must be a real cluster id: no household disagrees about its cluster"
+    )
+    bad = contested("ea", cols)
+    assert sum(bad.values()) > 100, (
+        f"`ea` is expected to be badly contested (measured 164 cells); got {bad}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2.  The invariant that makes the join work at all.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("wave", WAVES)
+def test_sample_v_and_cluster_features_v_are_the_same_key(
+    wave, sample, cluster_features
+):
+    """`_join_v_from_sample` joins `cluster_features` onto every household table
+    through `sample.v`.  If the two `v` are built from different columns the
+    join silently matches nothing, so this must hold in EVERY wave -- it is the
+    reason the 2004-05 change had to be made in `sample` and `cluster_features`
+    together."""
+    s = sample.reset_index()
+    cf = cluster_features.reset_index()
+    sv = set(s.loc[s["t"].astype(str) == wave, "v"].dropna().astype(str))
+    cv = set(cf.loc[cf["t"].astype(str) == wave, "v"].dropna().astype(str))
+    if not sv and not cv:
+        pytest.skip(f"{wave} absent from this build")
+    assert cv - sv == set(), (
+        f"{wave}: {len(cv - sv)} cluster_features clusters unknown to sample: "
+        f"{sorted(cv - sv)[:5]}"
+    )
+    assert sv - cv == set(), (
+        f"{wave}: {len(sv - cv)} sample clusters have no cluster_features row: "
+        f"{sorted(sv - cv)[:5]}"
+    )
+
+
+def test_every_wave_uses_the_same_eight_digit_ea_keyspace(sample):
+    """One `v` vocabulary across the whole country.
+
+    IHS2's frame is a different census vintage from IHS3+ (only 3 codes in
+    common), so the SETS differ -- but the FORMAT must not, or `v` stops being
+    comparable and a cross-wave join silently produces nothing.
+    """
+    s = sample.reset_index()
+    for wave in WAVES:
+        v = s.loc[s["t"].astype(str) == wave, "v"].dropna().astype(str)
+        if v.empty:
+            continue
+        bad = sorted(set(v[~v.map(lambda x: bool(EA_CODE.match(x)))]))[:5]
+        assert not bad, f"{wave}: non-canonical cluster ids {bad}"
+
+
+# ---------------------------------------------------------------------------
+# 3.  The df_geo merges: no cartesian product, and the key actually matches.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("wave", ["2010-11", "2019-20"])
+def test_the_known_cartesian_geo_merges_are_documented_where_they_live(wave):
+    """2010-11 and 2019-20 merge a HOUSEHOLD-grain geo file on the CLUSTER key.
+
+    That pairs every household with every geo row sharing its `v`: 196,083 rows
+    from 12,271 (183,812 phantom) and 185,842 from 14,612 (171,230 phantom).
+    It is Site 4, it is owned centrally by PR #627's cardinality guard, and it
+    is deliberately NOT fixed here -- but it must not be silent either.  A
+    cartesian repeats values rather than inventing them, so it changes no
+    contested-cell count; see the paired test below, which is the load-bearing
+    claim.
+    """
+    cfg = _wave_config(wave)["cluster_features"]
+    assert cfg.get("merge_on") == ["v"], (
+        f"{wave}: if this now merges on `i` the cartesian has been fixed -- "
+        "update the note in data_info.yml and tell PR #627 it lost an example"
+    )
+    src = (countries_root() / "Malawi" / wave / "_" / "data_info.yml").read_text()
+    assert "SITE 4" in src and "CARTESIAN" in src, (
+        f"{wave}: the known cartesian df_geo merge must stay documented in "
+        "data_info.yml, next to the declaration that causes it"
+    )
+
+
+@pytest.mark.parametrize("wave", ["2016-17"])
+def test_geo_subframe_builds_i_exactly_as_the_main_frame_does(wave):
+    """Both halves of IHS4/IHS5 live in one table, so `i` for the
+    Cross_Sectional half is run through `cs_i` to keep it apart from the Panel's
+    y{3,4}_hhid.  The geo block declared the RAW case_id, so its merge key never
+    matched: 2016-17 ended up with GPS for 0 of its 880 clusters, plus 12,447
+    orphan geo rows manufactured by the outer join.  The two blocks must build
+    `i` identically or they drift apart again."""
+    cfg = _wave_config(wave)["cluster_features"]
+    main_i = cfg["df_main"]["idxvars"].get("i")
+    geo_i = cfg["df_geo"]["idxvars"].get("i")
+    assert geo_i is not None, f"{wave}: df_geo declares no `i` to merge on"
+    assert geo_i == main_i, (
+        f"{wave}: df_geo `i` ({geo_i!r}) must be built exactly like df_main's "
+        f"({main_i!r})"
+    )
+
+
+def test_2016_17_clusters_actually_have_coordinates(cluster_features):
+    """The consequence of the key fix above, measured at the API: 0 -> 779."""
+    cf = cluster_features.reset_index()
+    w = cf[cf["t"].astype(str) == "2016-17"]
+    if w.empty:
+        pytest.skip("2016-17 absent from this build")
+    have = int(w["Latitude"].notna().sum())
+    assert have >= 700, (
+        f"2016-17 should carry GPS for its 779 Cross_Sectional clusters "
+        f"(the 101 Panel clusters have no geovariables file); got {have}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4.  The residual, and why it is NOT re-keyed.
+# ---------------------------------------------------------------------------
+
+def test_2013_14_within_cluster_spread_is_tracked_movers_not_a_broken_key():
+    """The decisive measurement, pinned.
+
+    188 of 204 EAs have households reporting different coordinates, which looks
+    exactly like the broken-key signature.  It is not: restrict to households
+    that did NOT move (`dist_to_IHS3location` <= 1 km) and every one of the 204
+    EAs collapses to EXACTLY ONE coordinate.  `LAT_DD_MOD` is the EA-level
+    displaced fix of the household's CURRENT location, so all of the spread is
+    panel dispersal.  `ea_id` is a real cluster id and must be left alone.
+
+    If this ever fails, the diagnosis behind leaving 2013-14 / 2019-20 unre-keyed
+    has changed and the decision must be revisited.
+    """
+    from lsms_library.local_tools import get_dataframe
+
+    root = countries_root() / "Malawi" / "2013-14" / "Data"
+    try:
+        cover = get_dataframe(str(root / "HH_MOD_A_FILT_13.dta"))
+        geo = get_dataframe(str(root / "HouseholdGeovariables_IHPS_13.dta"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"Malawi 2013-14 sources unavailable: {exc}")
+
+    m = cover[["y2_hhid", "ea_id", "dist_to_IHS3location"]].merge(
+        geo[["y2_hhid", "LAT_DD_MOD", "LON_DD_MOD"]], on="y2_hhid", how="inner"
+    ).dropna(subset=["LAT_DD_MOD"])
+
+    stayers = m[m["dist_to_IHS3location"].fillna(0) <= 1]
+    per_ea = stayers.groupby("ea_id")[["LAT_DD_MOD", "LON_DD_MOD"]].apply(
+        lambda g: len(g.drop_duplicates())
+    )
+    assert per_ea.max() == 1, (
+        "households that did not move must share their EA's single displaced "
+        f"coordinate; {int((per_ea > 1).sum())} EAs do not"
+    )
+    # and the movers really are the whole story
+    movers = m[m["dist_to_IHS3location"].fillna(0) > 1]
+    assert len(movers) > 1000, (
+        f"expected ~1,340 tracked movers in IHPS 2013; got {len(movers)}"
+    )


### PR DESCRIPTION
Malawi's half of GH #323 Site 2, **config-only**. Refs #323.

No file under `lsms_library/*.py` is touched, no `aggregation:` key is added (dead config, forbidden by **D1**), no reducer is declared and nothing is blanked to `<NA>`. Every number below is a **cold** build against an *isolated* `LSMS_DATA_DIR` (fresh tree, `dvc-cache` symlinked to the shared L1) with `LSMS_COUNTRIES_ROOT` pointed at the worktree and asserted before any run — `LSMS_NO_CACHE=1` alone was not trusted, because the collapse is baked into the cache it poisoned.

---

## The finding: two different diseases, and only one is a broken key

`cluster_features` is declared `(t, v)` but all five waves extract it from the household **cover page**, so the frame arrives at household grain and `_collapse_to_cluster_grain` reduces it with `.first()`. Measured per column, per cluster, on the frame captured *inside* that function before it runs:

| wave | contested cells before | after | clusters | verdict |
|---|---|---|---|---|
| **2004-05** | **164 / 330 (49.7%)** | **0 / 1,692** | 110 → **564** | **broken key** |
| 2010-11 | 0 / 3,840 | 0 / 3,840 | 768 | already correct |
| 2013-14 | 765 / 1,020 (75.0%) | 765 / 1,020 | 204 | **tracked panel dispersal** |
| 2016-17 | 78 / 4,405 | 89 / 4,400 | 880 | Region 1→**0**; GPS 0→**779 clusters** |
| 2019-20 | 250 / 4,095 (6.1%) | 250 / 4,095 | 819 | **tracked panel dispersal** |
| **total** | **1,257 / 13,690** | **1,104 / 15,047** | 2,782 → **3,235** | |

Two of the five waves now emit **no `GrainCollapseWarning` at all**; before, four did.

*(The brief's baseline was 1,255 — the 2-cell difference is in 2004-05 and bears on nothing.)*

## 1. 2004-05 — `ea` is not a cluster id, it is a sequence number

`ea` is the EA's position **within its Traditional Authority**: **110 distinct values for IHS2's 564 enumeration areas**. Keyed on it, roughly five unrelated EAs — different TAs, different districts, different regions — merge into one `v`. Measured at source:

| key | groups | region | district | reside |
|---|---|---|---|---|
| `ea` | 110 | 66 | 79 | 19 |
| `(dist, ea)` | 447 | 0 | 0 | 8 |
| `(dist, ta, ea)` | 564 | 0 | 0 | 0 |
| **`psu`** | **564** | **0** | **0** | **0** |

The `(dist, ea)` row is the instructive one: it is the "make `v` a district composite" reflex — Uganda's fix — and here it is **wrong**, because it still merges EAs that share a district but sit in different TAs. The right key needed no composite at all: `psu` is already a column in `sec_a.dta`, the fully qualified **8-digit code** `region(1)+district(2)+TA(2)+EA(3)`, 564 values with **exactly 20 households each** (the IHS2 design). It is also the *same 8-digit keyspace* the IHS3/IHS4/IHS5 waves use for `ea_id`, so `v` now has one format across the whole country.

### What the broken key was actually doing, at the API

> | | `v: ea` | `v: psu` |
> |---|---|---|
> | clusters | 110 | **564** |
> | districts in `cluster_features` | **20** | **26** |
> | settlement strata in `cluster_features` | **1 — all `Rural`** | **2** |

`.first()` reached a rural household in every one of the 110 merged groups, so **IHS2's entire urban stratum was absent from `cluster_features`**, and **6 of Malawi's 26 districts had vanished outright**. Neither was visible at the API: the table looked complete.

Declared identically in `sample` and `cluster_features` — they cannot be allowed to drift, or `_join_v_from_sample` matches nothing.

*Frame vintage, stated so nobody reads too much into it:* 2004-05 shares only **3** codes with 2010-11 (1998 vs 2008 census frame). The format is common to all five waves; the code sets are not. A cross-wave join on `v` is meaningful from 2010-11 on and not before, and this change neither creates nor claims a panel link.

## 2. 2013-14 and 2019-20 — the residual is dispersal, and it is not re-keyed

`ea_id` in the IHPS waves is the **IHS3 baseline EA** (`case_id` is literally `ea_id` + household number), the panel EA sets nest cleanly — 2019-20-PN = 2016-17-PN = 102 ⊂ 2013-14 = 204 ⊂ 2010-11 = 768 — and the survey **tracks movers and split-offs wherever they go**.

**The GPS settles it.** 188 of 204 EAs in 2013-14 have households at different coordinates, which is exactly the broken-key signature. It is not one:

> Restrict to households that did **not** move (`dist_to_IHS3location` ≤ 1 km) and **every one of the 204 EAs collapses to exactly one coordinate.**

`LAT_DD_MOD` is the EA-level *displaced* fix of the household's **current** location — not per-household jitter — so all of the within-EA spread (median **145 km**, max **775 km**) is dispersal. Corroborating: 588 of 4,000 households report a district different from the one encoded in their own `ea_id`, and they sit a **median 68 km** from their IHS3 location against **0.03 km** for the 3,412 that match.

**Why the 75% headline is not what it looks like.** With ~20 households per EA and 13% of them district-movers, `1 − 0.87²⁰ ≈ 94%` of EAs are *expected* to contain at least one mover. A high **cell** rate is a property of the metric applied to a tracked panel, not evidence of a merged key.

**Why not re-key anyway.** Splitting 2013-14 on `(district, ea_id)` gives 626 groups of **median one household** — 422 singleton pseudo-clusters — desynchronises `v` from `sample` and from the IHS3 baseline, and destroys the panel's link to its own sampling design. Same precedent as Uganda's `comm` (PR #634 §6.5). So these residuals are **reported, not forced to zero**.

2019-20's 250 cells are all in the panel half, on the same mechanism (747 of 3,178 households off their EA's modal district, 652 of them >1 km from their IHS3 location). Its 102 panel EAs share **no** `ea_id` with the 717 cross-sectional ones — no cross-half collision.

## 3. 2016-17 had GPS for 0 of its 880 clusters, and the cause was a merge key

`df_main` builds Cross_Sectional `i` as `cs_i(case_id)` (`'cs-17-'` + `format_id`) to keep it apart from the Panel's `y3_hhid`. `df_geo` declared the **raw** `case_id`, so its merge key matched nothing: the `how='outer'` join produced **12,447 orphan geo rows** next to 14,955 coordinate-less main rows. The two files are exactly 1:1 on `case_id` (12,447 = 12,447, none on either side alone), so mirroring the transform makes the join exact — **779 of 880 clusters now carry coordinates** (the other 101 are IHPS panel EAs, for which IHS4 publishes no geovariables).

**Honest cost:** 7 of those 779 EAs have households whose IHS4 `lat_modified` differs within the EA — IHS4's displacement is *nearly* but not exactly EA-constant — so `Latitude`/`Longitude` show 7 contested cells where before there were 0, **because before there was no coordinate at all**. That is the whole of the `78 → 89` movement in the table above.

This is **not** a cardinality fix, and 2016-17 is not on PR #627's cartesian list: a non-matching key produces orphans, not a product.

Separately, 2016-17's single `Region` conflict was a **spelling**: EA `30305580` is sampled in both halves (a genuine shared EA, same district), and the CS file writes `Southern` where the Panel writes `South`. The existing `region` table — which already collapses them at API time, so this is output-neutral — is now applied at extraction, so the collapse stops reading a spelling difference as a disagreement about the cluster. 1 → 0.

## 4. Site 4: measured, and deliberately left alone — for #627

2010-11 and 2019-20 key a **household-grain** geovariables file on `ea_id` and merge it on the **cluster** key `v`, so `pd.merge` pairs every household with every geo row sharing that `v`:

| wave | households | geo rows | merged | phantom |
|---|---|---|---|---|
| 2010-11 | 12,271 | 12,271 | 196,083 | **183,812** |
| 2019-20 | 14,612 | 11,434 | 185,842 | **171,230** |

**The load-bearing claim, measured rather than argued:** a cartesian *repeats* values, it does not invent them, so it cannot change a contested-cell count. The one-line config fix (`idxvars: {i: case_id}` + `merge_on: [i]`; both file pairs are 1:1 on `case_id`) was implemented and measured — contested cells **0 and 250, identical either way** — and then **reverted**, so PR #627's cardinality guard keeps these two cells as evidence. #627 owns the decision. The fix is recorded in each wave's `data_info.yml` next to the declaration that causes it, and a test fails if either wave silently starts merging on `i` without telling #627.

## 5. `Rural` needed nothing

The pre-#602 inline `mapping:` blocks were both live and **inverted** — `rural: 0` in one file and `RURAL: 1` in another, *in the same wave*, so the two halves of 2016-17 and 2019-20 coded rural households with opposite values. **GH #602 already removed all five on `development`.** Verified against the pre-collapse frames: `Rural` arrives as the raw label and `_enforce_canonical_spellings` normalises it. Nothing added here; noted only so the next reader does not re-derive it.

## 6. The invariant

`sample.v` ≡ `cluster_features.v` in **every** wave after the change: **0** `cluster_features` `(t, v)` pairs unknown to `sample`, **0** orphaned `sample` clusters.

| wave | sample `v` | cluster_features `v` | unknown to sample | orphaned |
|---|---|---|---|---|
| 2004-05 | 564 | 564 | 0 | 0 |
| 2010-11 | 768 | 768 | 0 | 0 |
| 2013-14 | 204 | 204 | 0 | 0 |
| 2016-17 | 880 | 880 | 0 | 0 |
| 2019-20 | 819 | 819 | 0 | 0 |

## 7. Tests

`tests/test_gh323_malawi_cluster_key.py` — **14 tests, all config-level**; exercises no core aggregation. They pin the fix *and* the diagnosis: `test_2013_14_within_cluster_spread_is_tracked_movers_not_a_broken_key` fails if the evidence for leaving the IHPS waves un-re-keyed ever stops holding.

- On this branch: **14 passed**.
- **Negative control**: against a pristine `origin/development` config tree (exported with `git archive`, cold data dir), **7 of the 14 fail** — including every load-bearing one.
- Malawi-relevant slice (`-k "malawi or Malawi or 323 or schema or sample or cluster"`): **680 passed, 58 skipped, 4 xfailed, 1 failed**.

**Pre-existing failure, not caused or fixed here** (core is out of scope): `tests/test_gh323_explicit_reducers.py::test_core_does_not_dispatch_the_reducers` greps `lsms_library/country.py` for the substring `collapse_to_cluster_grain` and finds PR #617's private `_collapse_to_cluster_grain`. This branch is config-only and does not touch `country.py`. Same failure is reported on PR #634.

## 8. Deferred

- **Site 4 / PR #627** — §4 above.
- Extraction-time `region`/`district` harmonisation is applied **only** where it removed a measured conflict (2016-17 `Region`). Doing it everywhere is output-neutral and tidier, but it is a diff across five waves for zero measured gain.
- 2016-17's 101 and 2019-20's 102 panel clusters have **no coordinates**: IHS4/IHS5 publish geovariables for the cross-sectional half only. Pre-existing, unrelated to #323.
- **IHPS-2016 mixes baseline and current geography in one file** — `district` is baseline (0 of 2,508 households outside their EA's modal district) while `reside` is current (277 differ, 246 of them flagged `mover`). That is the source's inconsistency; it accounts for all 75 of 2016-17's remaining contested cells, and it is documented rather than papered over.

Diagnosis preserved in `Malawi/_/CONTENTS.org` and `.coder/ledger/323-malawi-key.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
