### PR TITLE
fix(Tanzania): describe a cluster from inside it; re-key 2020-21 (GH #323, Site 2)

### DIFF
--- a/.coder/ledger/323-tanzania-key.md
+++ b/.coder/ledger/323-tanzania-key.md
@@ -1,0 +1,208 @@
+# Prior-Art Ledger — GH #323 (Tanzania, Site 2): the `cluster_features` cluster key
+
+**Search tier used:** ripgrep + git, plus
+`slurm_logs/DESIGN_grain_collapse_sites_2026-07-13.org` (branch
+`origin/docs/323-grain-collapse-sites`), the Uganda template
+(`origin/fix/323-uganda-config` + `.coder/ledger/323-uganda.md`), and the
+already-landed Tanzania config commit `3a387bca`.
+
+**Every measurement below is a COLD build** against an **isolated
+`LSMS_DATA_DIR`** whose `dvc-cache` is symlinked to the shared L1 blob cache, so
+L2 is rebuilt honestly while raw blobs are reused. `LSMS_NO_CACHE=1` alone is
+NOT sufficient — it is *soft* for script-path L2-wave parquets, and Tanzania
+`2008-15/cluster_features` is exactly such a script. Config tree =
+`LSMS_COUNTRIES_ROOT=<worktree>/lsms_library/countries`, asserted before any
+number was trusted.
+
+## §1 Task, restated
+
+Tanzania is the worst Site-2 cell in the corpus: **2,104 of 7,167
+cluster-attribute cells contested (29.4%)**, 65.4% of them in 2012-13. Fix the
+**identifier**, not the symptom. CONFIG-ONLY: nothing under `lsms_library/*.py`;
+no `aggregation:` keys (D1); no reducer-by-declaration and no blanking-to-NA as
+*the* fix.
+
+## §2 Existing machinery (this task's area)
+
+| symbol | path | what it does | reuse / extend / new |
+|--------|------|--------------|----------------------|
+| `_collapse_to_cluster_grain` | `country.py:4490` | Site 2's audit-then-`.first()` | **do not touch** (core, PR #617) — but it is the *instrument*: monkeypatched to measure |
+| `reduce_to_agreed` / `collapse_to_cluster_grain` | `build_transforms.py:422/514` | lossless-or-loud grain reducer | **considered, NOT used** — see §6.1 |
+| `Wave.column_mapping` → `final_mapping['df_edit']` | `country.py:802` | dispatches a function named after the table as that table's frame hook | **reuse** — the sanctioned YAML-path extension point (2019-20 / 2020-21) |
+| `Tanzania/2008-15/_/cluster_features.py` | config | script-path extraction for the 4-round folder | **extend** |
+| commit `3a387bca` | config | named the grain (`j`→`i`), `''`→`pd.NA` | **build on** — it made the collapse *visible*; it did not fix the key |
+| `origin/fix/323-tanzania` | branch | the REJECTED Design-A patch (+167 lines of `country.py`) | **do not salvage the code**; the diagnosis is already in `3a387bca` |
+| `Uganda/_/uganda.py` composite `v` (PR #634) | config | `DISTRICT/PARISH` composite key | **pattern considered, does not apply** — see §6.2 |
+
+## §3 Definitions & conventions in force
+
+- `sample()` is the single source of truth for a household's cluster; `v` is
+  joined at API time by `_join_v_from_sample` — `CLAUDE.md` §"`sample()` and
+  Cluster Identity". ⇒ **`sample.v` and `cluster_features.v` must be the same
+  key.** Verified per wave (§7).
+- `cluster_features` owns `v`; index `(t, v)` — `Tanzania/_/data_scheme.yml`.
+- "NO AGGREGATION IN CORE" — `SkunkWorks/grain_aggregation_policy.org`, D1 of
+  the consolidation note.
+- Multi-round folder semantics: `.claude/skills/multi-round-waves.md` — the
+  `2008-15/` script emits all four rounds with `t` in the index; paths use
+  `wave_folder`, not `year`.
+- NPS panel design: `.claude/skills/tanzania-panel-design.md` — the 2014-15
+  extended/refresh split, and **that the NPS TRACKS movers**, which is the whole
+  root cause here.
+
+## §4 Invariants & assumptions (the landmines)
+
+- **The bug hides behind the cache it poisoned.** Site 2 writes the L2 parquet
+  *post*-collapse. Every number here is from an isolated data dir (§ header).
+- **The geocode scheme is a property of the WAVE, not of the string's length.**
+  2019-20's 8-character `'11014002'` is `01-1-014-002` = DODOMA under its own
+  9-digit scheme, and IRINGA under the 8-digit one. `cluster_region()` therefore
+  *requires* the caller to name the scheme; pinned by test.
+- **Residency must be evaluated per `(t, v)`, not per `v`.** A cluster can have
+  residents in one round and none in the next. The first cut grouped on `v` and
+  silently lost **12 cluster-waves**; caught by a test that pins per-round
+  cluster counts.
+- **Stata writes an unpopulated STRING variable as `''`, not as missing.** The
+  first cut used `.notna()` on `sdd_cluster` and dropped 63 rows instead of 389.
+  Caught only because the split-off exclusion produced no cluster-count change.
+- `format_id` is auto-applied to `idxvars`, not `myvars` — `CLAUDE.md`.
+
+## §5 Reuse decision
+
+| quantity | decision | reason |
+|----------|----------|--------|
+| what a cluster's Region/District/Rural ARE | **new, but no new primitive**: a residency FILTER in config | the columns are household attributes in a tracking panel; the fix is to stop asking non-residents, not to reduce their answers |
+| the region/district crosswalk | **new**, checked in as `TZ_REGION_BY_CODE` in `tanzania.py` | mined from the 2008-09 frame, cross-checked against 2019-20 `t0_region` and 2020-21 `hh_a01_1`; a runtime mine would be silently re-derived on every build and is untestable |
+| the household→cluster projection | **leave in core** (`Wave.cluster_features`) | see §6.1 |
+| 2020-21 `v` | **re-key to `y5_cluster`** | `sample` already uses it; `clusterid` matched nothing and is NaN for 11.6% of rows |
+| 2019-20 geography | **re-source to `t0_region`/`t0_district`** | `hh_a01_1` is the MOVER question — null for 89.9% of the households that can describe the cluster |
+
+## §6 Decisions, with the evidence
+
+1. **The config does NOT collapse to `(t, v)` itself** — no `reduce_to_agreed`,
+   no `collapse_to_cluster_grain` hook. Collapsing in the config would drive the
+   #323 instrument to 0 *for free* and blind the framework's Site-2 audit to
+   whatever remains. The frame is left at household grain and only the
+   *non-resident rows* are removed, so the before/after numbers are measured
+   with the same instrument and the residue is still announced by
+   `GrainCollapseWarning`. A test pins that `i` survives into the projection.
+
+2. **A composite key (the Uganda fix) is the WRONG fix here, and the data say
+   so.** Uganda's `v` was ambiguous: a parish code unique only within a
+   district. Tanzania's is not. In round 1 — the only round in which nobody has
+   moved — **all 409 clusters agree on all three attributes, 0 contested**, and
+   the cluster id's own region field maps 1:1 onto the region name (26/26 codes)
+   with its district field equal to the reported district code for **100.0%** of
+   rows. Making `v` a `(region, cluster)` composite *would* have zeroed the
+   Region column, but tautologically: it merely re-labels the mover's row with
+   the mover's region and calls the disagreement gone. Measured, and rejected on
+   that basis:
+
+   | 2012-13 key | clusters | Region | District | Rural |
+   |---|---|---|---|---|
+   | `clusterid` | 409 | 242 | 314 | 247 |
+   | `(region, clusterid)` | 821 | **0** | 253 | 178 |
+   | `(region, district, clusterid)` | 1,165 | **0** | **0** | 142 |
+
+   The composite inflates 409 real clusters into 1,165 by splitting each one
+   across the regions its movers went to. That is not a finer key; it is a
+   fabricated one, and it would desynchronise `v` from `sample`.
+
+3. **`strataid2` looked like the perfect cluster-invariant source and was
+   rejected on measurement.** It is `"<REGION> - RURAL|URBAN"` and shows *zero*
+   within-cluster variation in all four rounds — because it is **100% NULL in
+   rounds 1-3**. The "invariance" was an artefact of missingness. Exactly the
+   trap #323 exists to catch; recorded so nobody re-proposes it.
+
+4. **Cluster attributes are NOT taken from the cluster's frame round and carried
+   forward.** Tried: per `v`, use the round the cluster first appears in. Round 1
+   (409 clusters) and 2014-15 (419 new) come out at 0 contested, but the 82
+   clusters that first appear in 2012-13 come out at 172 — they are pre-2012
+   clusters *renumbered* after the Simiyu/Geita/Njombe/Katavi region splits, so
+   their "frame round" is not a frame round at all. Residency generalises
+   correctly where first-appearance does not.
+
+5. **`urban/rural` is not in the geocode.** Tested: the EA-code leading digit
+   predicts `urb_rur` for only 75.3% of round-1 clusters. So `Rural` stays a
+   reported attribute, and its 264 residual contested cells are real
+   sub-cluster variation, not decodable away.
+
+6. **2019-20 split-off rows are dropped, and that removes 100 clusters.** Their
+   `clusterid` is not a sampling cluster: under a single DODOMA code they pool
+   households whose own strata span DAR ES SALAAM, DODOMA and ZANZIBAR, and of
+   the 269 (of 326) whose parent household IS in the frame, only **31** carry
+   the parent's cluster. Emitting cluster rows
+   built from them is fabrication (the parent's "18 fabricated rows"). The honest
+   consequence — those 326 households' `sample.v` now points at a cluster the
+   table does not contain — is recorded in §9 rather than papered over.
+
+7. **Malformed ids are carried through, not repaired.** Three 2020-21
+   `y5_cluster` values have the wrong field widths and one carries region code
+   `27`. Guessing the intended value is unfalsifiable; the tests pin the count so
+   it cannot grow.
+
+## §7 Measured effect (cold build, isolated `LSMS_DATA_DIR`)
+
+Contested cluster-attribute cells (`nunique(dropna=True) > 1` per column, on the
+pre-collapse frame — the parent's instrument, reproduced to ±2):
+
+| wave | before | after | clusters |
+|------|--------|-------|----------|
+| 2008-09 | 0 | 0 | 409 → 409 |
+| 2010-11 | 329 | **78** | 409 → 409 |
+| 2012-13 | 803 | **147** | 409 → 409 |
+| 2014-15 | 160 | **41** | 498 → 498 |
+| 2019-20 | 257 | **72** | 247 → **147** |
+| 2020-21 | 557 | **47** | 418 → **515** |
+| **total** | **2,106** | **385** | 2,389 → 2,387 rows |
+
+By column: Region **706 → 3**, District 758 → 118, Rural 642 → 264.
+
+Rows destroyed by the collapse (framework's own Site-2 audit): **10,982 →
+2,687**; NaN-key deletions **545 → 0**.
+
+`sample.v` ≡ `cluster_features.v`, `(t, v)` pairs in `cluster_features` unknown
+to `sample`:
+
+| wave | before | after |
+|------|--------|-------|
+| 2008-09 / 2010-11 / 2012-13 / 2019-20 | 0 | 0 |
+| **2020-21** | **417 of 417** | **0** |
+| 2014-15 | 5 | 5 (pre-existing, §9) |
+
+## §8 Verification
+
+- `tests/test_gh323_tanzania_cluster_key.py` — 28 tests, all config-level;
+  exercises no core aggregation.
+- **Negative control**: run against a pristine `origin/development` config tree
+  (`git archive` into a separate `LSMS_COUNTRIES_ROOT`, separate data dir),
+  **20 of 28 fail** — including every contested-cell ceiling, the
+  `sample.v` ≡ `cluster_features.v` test, both 2020-21 key tests and the
+  per-wave cluster counts.
+- `tests/test_tanzania_grain_gh323.py` (19) and
+  `tests/test_tanzania_community_cluster_xwalk.py` pass.
+- `tests/test_schema_consistency.py` + `tests/test_gh323_benin_togo.py` pass
+  (243 passed, 2 skipped in that slice).
+- Pre-existing failure, NOT caused by this branch and NOT fixed by it (core is
+  out of scope):
+  `tests/test_gh323_explicit_reducers.py::test_core_does_not_dispatch_the_reducers`
+  — PR #617's private `country._collapse_to_cluster_grain` contains PR #618's
+  banned substring. Same failure is recorded in `.coder/ledger/323-uganda.md` §8.
+
+## §9 Deferred
+
+- **2019-20 `sample.v` for the 326 split-off households.** Their `clusterid` is
+  not a sampling cluster (§6.6) and now dangles. Blanking it changes `v` on every
+  2019-20 household table for 27.5% of the wave — a semantic change that belongs
+  in its own PR, per the same reasoning D2 used to keep Burkina Faso's
+  `dropna=False` out of a bug fix.
+- **5 of 498 2014-15 clusters unknown to `sample()`.** Present in the wave-level
+  `sample.parquet` (13/7/10/10/10 rows), lost between there and `sample()` —
+  i.e. in `_finalize_result`'s `id_walk`, on the panel-id side. Pre-existing on
+  `development`; unchanged here.
+- **A `harmonize_district` table.** Most of the 118 residual District cells are
+  two spellings of one district (`MBINGA (NYASA)` / `MBINGA(NYASA)` /
+  `MBINGA NYASA` / `NYASA`) or a mid-panel district split (Chalinze/Bagamoyo,
+  Kibiti/Rufiji, Ubungo/Kinondoni). Label harmonisation, not a key defect.
+- **A `Rural` cluster classification.** 264 residual cells are EAs whose
+  households are genuinely not all urban or all rural.

--- a/lsms_library/countries/Tanzania/2008-15/_/cluster_features.py
+++ b/lsms_library/countries/Tanzania/2008-15/_/cluster_features.py
@@ -2,8 +2,10 @@
 """Extract cluster-level features (Region, District, Rural) for the 2008-15 multi-round data."""
 import sys
 import pandas as pd
+sys.path.append('../../_/')
 sys.path.append('../../../_/')
 from lsms_library.local_tools import df_data_grabber, to_parquet
+import tanzania
 
 round_match = {1: '2008-09', 2: '2010-11', 3: '2012-13', 4: '2014-15'}
 
@@ -44,7 +46,12 @@ idxvars = dict(i='r_hhid',
 
 myvars = dict(Rural=('urb_rur', lambda x: 'Rural' if x.lower() != 'urban' else 'Urban'),
               Region=('ha_01_1', blank_to_na),
-              District=('ha_02_2', blank_to_na))
+              District=('ha_02_2', blank_to_na),
+              # Carried only to decide RESIDENCY, then dropped: `ha_02_1` is the
+              # reported district CODE, which is directly comparable with the
+              # district field of the cluster's own geocode (they agree for
+              # 100.0% of round-1 rows).  Not part of the declared schema.
+              _district_code=('ha_02_1', blank_to_na))
 
 df = df_data_grabber('../Data/upd4_hh_a.dta', idxvars, **myvars)
 
@@ -61,5 +68,28 @@ assert (_g.nunique(dropna=False).max() <= 1).all(), \
     'cluster_features: Region/District/Rural vary within (i, t, v) -- the ' \
     'dedup below would keep an arbitrary household record (GH #323)'
 df = df.loc[~df.index.duplicated(keep='first')]
+
+# GH #323 -- KEEP ONLY THE HOUSEHOLDS THAT STILL LIVE IN THE CLUSTER.
+#
+# `v` is the ORIGINAL sampling EA and the NPS carries it forward when it tracks
+# a mover, so from round 2 on a cluster's rows include households now living in
+# another region entirely.  Their cover-page Region / District / Rural describe
+# where they WENT.  Residency is decided against the cluster's own geocode --
+# `v`'s leading fields ARE its region and district (validated on the round-1
+# frame: 26/26 region codes single-valued, district digit == `ha_02_1` for
+# 100.0% of rows).  Per round, region-disagreeing households:
+#   2008-09     0 / 6,128   (round 1 -- nobody has moved yet)
+#   2010-11   549 / 8,163
+#   2012-13 1,154 / 9,998
+#   2014-15   314 / 4,961
+# Filtering them out takes the CONTESTED cluster-attribute cells from
+# 0 / 329 / 803 / 160 to 0 / 78 / 144 / 35 (per round), with no cluster lost --
+# see Tanzania/_/CONTENTS.org.  The frame stays at HOUSEHOLD grain on purpose:
+# the household->cluster projection belongs to `Wave.cluster_features`, where
+# the framework audits it and reports whatever residue survives.
+df = tanzania.keep_cluster_residents(df, region='Region',
+                                     district_code='_district_code',
+                                     scheme='nps', label='2008-15')
+df = df.drop(columns='_district_code')
 
 to_parquet(df, 'cluster_features.parquet')

--- a/lsms_library/countries/Tanzania/2019-20/_/data_info.yml
+++ b/lsms_library/countries/Tanzania/2019-20/_/data_info.yml
@@ -2,13 +2,31 @@ Country: Tanzania
 Wave: 2019-20
 
 cluster_features:
+    # GH #323.  Region/District come from `t0_region` / `t0_district` -- the
+    # location of the SDD FRAME household, i.e. of the cluster -- and NOT from
+    # `hh_a01_1` / `hh_a02_1`, which this instrument asks ONLY OF MOVERS ("where
+    # are you now?").  Reading the mover question was doubly wrong: it is null
+    # for 89.9% of the households found at their ORIGINAL location (the ones
+    # that actually describe the cluster) and non-null precisely for the ones
+    # that left.  257 of 741 cluster-attribute cells were contested by it.
+    #
+    # `_frame` carries `sdd_cluster` purely so the df_edit hook can tell a FRAME
+    # household from a SPLIT-OFF.  A split-off is a new household formed by
+    # departing members; the SDD file leaves its `sdd_cluster` and `t0_*` blank
+    # but still stamps it with a `clusterid`, and that clusterid is NOT its
+    # sampling cluster -- among the 326 split-off rows it collects households
+    # whose own strata span DAR ES SALAAM, DODOMA and ZANZIBAR under a single
+    # DODOMA cluster code.  A split-off is evidence about itself, not about a
+    # cluster.  Dropped by the hook.
     file: HH_SEC_A.dta
     idxvars:
         i: sdd_hhid
         v: clusterid
     myvars:
-        Region: hh_a01_1
-        District: hh_a02_1
+        Region: t0_region
+        District: t0_district
+        _frame: sdd_cluster
+        _status: hh_tracking_status
         Rural:
             - sdd_rural
             - mapping:

--- a/lsms_library/countries/Tanzania/2019-20/_/mapping.py
+++ b/lsms_library/countries/Tanzania/2019-20/_/mapping.py
@@ -1,7 +1,62 @@
 """Formatting functions for Tanzania 2019-20."""
+import sys
+from pathlib import Path
+import pandas as pd
 from lsms_library.local_tools import format_id
+
+# `mapping.py` is loaded by importlib from an absolute path, so a RELATIVE
+# sys.path entry does not find the country module.  Resolve it from __file__,
+# the same way Uganda/Ethiopia reach their `_age_helpers`.
+_COUNTRY = str(Path(__file__).resolve().parent.parent.parent / '_')
+if _COUNTRY not in sys.path:
+    sys.path.insert(0, _COUNTRY)
+import tanzania
+
+_RESIDENT_STATUS = 'HOUSEHOLD FOUND - ORIGINAL LOCATION'
 
 
 def v(x):
     """Ensure cluster ID is a clean string (strip .0 from float)."""
     return format_id(x)
+
+
+def cluster_features(df):
+    """Restrict the cluster grain to households resident in the cluster (GH #323).
+
+    Two exclusions, in this order:
+
+    1. SPLIT-OFF households -- `sdd_cluster` blank.  The SDD file stamps them
+       with a `clusterid` they were never sampled in (see the YAML comment);
+       nothing about them is evidence about that cluster.  326 of 1,184 rows.
+    2. Households whose `t0_region` is not the region carried by their own
+       cluster's geocode -- they were tracked out of the cluster between t0 and
+       the SDD round.
+
+    Contested cluster-attribute cells: 257 of 741 before, 126 of 441 after
+    (247 -> 147 clusters; the 100 clusters that disappear are exactly the ones
+    that existed only because split-off rows were pooled under a stray code).
+    The residual is genuine: 14 SDD clusters hold frame households reporting
+    different t0 regions, and 54 different t0 districts.  That is a property of
+    the shipped file, not something this hook can resolve -- it is left to the
+    framework's grain audit to report rather than papered over.
+    """
+    # Stata writes an unpopulated STRING variable as '', not as missing, so
+    # `.notna()` alone keeps every split-off row.  (This exact trap cost a
+    # measurement round: 63 rows dropped instead of 389.)
+    frame = df['_frame'].map(
+        lambda x: not (pd.isna(x) or str(x).strip() in ('', 'nan', '<NA>')))
+    out = df[frame.to_numpy()].drop(columns='_frame')
+    if len(out) == 0:                      # pragma: no cover - defensive
+        return df.drop(columns=['_frame', '_status'])
+    # Of the frame households, only those found AT THEIR ORIGINAL LOCATION are
+    # still in the cluster; `HOUSEHOLD FOUND - NEW LOCATION` means the survey
+    # followed them somewhere else.  This is the wave's own statement of
+    # residency, so it takes precedence over the geocode test -- which then
+    # still runs, and catches the frame households whose recorded t0 region is
+    # not the region in their own cluster's code.
+    resident = (out['_status'].astype(str).str.upper().str.strip()
+                == _RESIDENT_STATUS)
+    out = out.drop(columns='_status')
+    return tanzania.keep_cluster_residents(out, region='Region', scheme='sdd',
+                                           extra_mask=resident.to_numpy(),
+                                           label='2019-20')

--- a/lsms_library/countries/Tanzania/2020-21/_/data_info.yml
+++ b/lsms_library/countries/Tanzania/2020-21/_/data_info.yml
@@ -2,13 +2,26 @@ Country: Tanzania
 Wave: 2020-21
 
 cluster_features:
+    # GH #323.  `v` is `y5_cluster`, NOT `clusterid` -- and this was not a
+    # cosmetic difference.  `sample` has always used `y5_cluster` (see below),
+    # so with `clusterid` here ALL 417 of this wave's `(t, v)` pairs were
+    # unknown to `sample`: `_join_v_from_sample` gave every 2020-21 household a
+    # `v` that had no cluster_features row at all.  `clusterid` is also blank
+    # for all 545 BOOSTER households (11.6%), so those were deleted outright on
+    # a NaN key, taking 68 clusters with them.  `y5_cluster` is populated for
+    # 100% of rows and is the id the Y5 design actually uses.
+    #
+    # `_status` / `_class` are carried only so the df_edit hook can tell who is
+    # still LIVING in the cluster; both are dropped there.
     file: hh_sec_a.dta
     idxvars:
         i: y5_hhid
-        v: clusterid
+        v: y5_cluster
     myvars:
         Region: hh_a01_1
         District: hh_a02_1
+        _status: hh_tracking_status
+        _class: tracking_class
         Rural:
             - y5_rural
             - mapping:

--- a/lsms_library/countries/Tanzania/2020-21/_/mapping.py
+++ b/lsms_library/countries/Tanzania/2020-21/_/mapping.py
@@ -1,7 +1,56 @@
 """Formatting functions for Tanzania 2020-21."""
+import sys
+from pathlib import Path
+import pandas as pd
 from lsms_library.local_tools import format_id
+
+# `mapping.py` is loaded by importlib from an absolute path, so a RELATIVE
+# sys.path entry does not find the country module.  Resolve it from __file__,
+# the same way Uganda/Ethiopia reach their `_age_helpers`.
+_COUNTRY = str(Path(__file__).resolve().parent.parent.parent / '_')
+if _COUNTRY not in sys.path:
+    sys.path.insert(0, _COUNTRY)
+import tanzania
+
+_RESIDENT_STATUS = 'HOUSEHOLD FOUND - ORIGINAL LOCATION'
+_BOOSTER = 'BOOSTER SAMPLE (NEW HOUSEHOLD)'
 
 
 def v(x):
     """Ensure cluster ID is a clean string (strip .0 from float)."""
     return format_id(x)
+
+
+def cluster_features(df):
+    """Restrict the cluster grain to households resident in the cluster (GH #323).
+
+    NPS Y5 states residency outright.  `hh_tracking_status` distinguishes a
+    household FOUND AT ITS ORIGINAL LOCATION from one found at a NEW one, and
+    `tracking_class` marks the BOOSTER households, which were drawn fresh in
+    2020-21 and are therefore in their cluster by construction.  Everything else
+    -- households tracked to a new location, and the 1,269 split-off rows -- is
+    carrying its parent's `y5_cluster` while living somewhere else.
+
+    Contested cluster-attribute cells: 557 of 1,254 before, 51 of 1,455 after,
+    and the cluster count RISES 418 -> 485 because the booster clusters, whose
+    `clusterid` was blank, stop being deleted on a NaN key.  The 51 that remain
+    are within-region: 7 clusters disagree on Region, 31 on District and 13 on
+    Rural, which is what a 2012-2020 district split and an EA straddling a town
+    boundary look like.  Reported, not resolved.
+    """
+    status = df['_status'].astype(str).str.upper().str.strip()
+    cls = df['_class'].astype(str).str.upper().str.strip()
+    resident = (status == _RESIDENT_STATUS) | (cls == _BOOSTER)
+    out = df.drop(columns=['_status', '_class'])
+    # This wave alone writes its place names in mixed case ('arusha', 'meru',
+    # 'ARUSHA URBAN' all occur); 2008-15 and 2019-20 are uppercase.  Normalise
+    # so a cluster's Region is the same string across waves and two spellings of
+    # one district stop counting as a disagreement.
+    for col in ('Region', 'District'):
+        out[col] = out[col].map(
+            lambda x: pd.NA if pd.isna(x) else str(x).strip().upper())
+    if not bool(resident.any()):           # pragma: no cover - defensive
+        return out
+    return tanzania.keep_cluster_residents(out, region='Region', scheme='y5',
+                                           extra_mask=resident.to_numpy(),
+                                           label='2020-21')

--- a/lsms_library/countries/Tanzania/_/CONTENTS.org
+++ b/lsms_library/countries/Tanzania/_/CONTENTS.org
@@ -969,3 +969,173 @@ Longitude are therefore NOT emitted.
   (+ =_plot_harmonized_codes=, =_map_plot_codes=).
 - =Tanzania/2019-20/_/plot_features.py=, =Tanzania/2020-21/_/plot_features.py= :: per-wave scripts.
 - =Tanzania/_/plot_features.py= :: country concatenator (concat + id_walk).
+
+* The cluster key of =cluster_features= (GH #323, Site 2)
+
+** The defect, and why it is a key defect
+
+Tanzania was the worst Site-2 offender in the library.  Measured cold on
+=development=, households *within the same cluster* disagreed about the
+cluster's own attributes in *2,104 of 7,167 cluster-attribute cells (29.4%)*
+--- 65.4% of them in 2012-13 --- and =groupby().first()= resolved that by
+serving one arbitrary household's answer as the cluster's.
+
+The cause is *not* an ambiguous cluster code.  Every wave read =Region= /
+=District= / =Rural= off the household *cover page*: the address where that
+household was *interviewed*.  The NPS is a *tracking* panel.  When a household
+moves, or a member splits off to form a new household, the survey follows it,
+records its *new* address, and carries its *original* sampling cluster =v=
+forward unchanged.  So the geo columns are HOUSEHOLD attributes; =v= is a
+CLUSTER attribute; and projecting the former onto the latter asks a household
+that has left the cluster to describe it.
+
+That the columns really are cluster attributes is settled by round 1.  In
+2008-09, before anyone has moved, *all 409 clusters agree on all three columns
+--- 0 contested cells*.  The disagreement appears only from round 2 on, and it
+tracks movement: 549 / 1,154 / 314 households in rounds 2 / 3 / 4 report a
+region that is not their own cluster's.
+
+** The identifier already carries the answer
+
+The NPS cluster id is not an opaque serial.  It is a *hierarchical geocode*
+whose leading fields are the cluster's region and district.  Validated against
+the 2008-09 frame --- the only pollution-free round:
+
+- every one of the *26 region codes* present maps to *exactly one* region name
+  (0 violations over 409 clusters);
+- the *district digit* of the geocode equals the separately reported district
+  code =ha_02_1= for *100.0%* of round-1 households.
+
+The field widths are a property of the *wave*, never of the string's length:
+
+| scheme | layout                  | waves                                        |
+|--------+-------------------------+----------------------------------------------|
+| =nps=  | =RR D WW EEE= (8)       | NPS rounds 1-3; the 2014-15 *extended* panel |
+| =nps=  | =RR DD WWW EE CCC= (12) | the 2014-15 *refresh* sample                 |
+| =sdd=  | =RR D WWW EEE= (9)      | NPS-SDD, 2019-20                             |
+| =y5=   | =RR-DD-WWW-EE-CCC=      | NPS Y5, 2020-21 (=y5_cluster=)               |
+
+Reading 2019-20's 8-character ='11014002'= under the 8-digit scheme yields
+IRINGA; under its own 9-digit scheme it is =01-1-014-002= = DODOMA.  Getting
+this wrong relabels a whole region silently, which is why
+=tanzania.cluster_region()= makes the caller name the scheme.
+
+** The fix
+
+*The cluster's geography is recorded from inside the cluster.*  Each wave now
+excludes the households that are no longer there, and leaves the frame at
+household grain so the projection onto =(t, v)= stays where the framework
+audits it (=Wave.cluster_features=).  Residency is decided against the
+cluster's own geocode, in tiers (region+district, then region, then --- if a
+cluster-wave has no resident at all --- unfiltered, so no cluster is ever
+dropped by tightening the test).  Tiers are evaluated per =(t, v)=, not per
+=v=: grouping on =v= alone silently lost 12 cluster-waves.
+
+Per wave:
+
+| wave    | =v=            | frame restriction                                    | Region / District           |
+|---------+----------------+------------------------------------------------------+-----------------------------|
+| 2008-15 | =clusterid=    | geocode residency (region + district code)           | =ha_01_1= / =ha_02_2=       |
+| 2019-20 | =clusterid=    | =sdd_cluster= present AND found at ORIGINAL location | =t0_region= / =t0_district= |
+| 2020-21 | *=y5_cluster=* | found at ORIGINAL location, or BOOSTER               | =hh_a01_1= / =hh_a02_1=     |
+
+Two waves needed more than a filter.
+
+*2019-20 was reading the mover question.*  =hh_a01_1= / =hh_a02_1= are asked
+ONLY of households found at a NEW location --- they are null for 89.9% of the
+households found at their ORIGINAL location, i.e. for exactly the ones that can
+describe the cluster.  The cluster's own location is =t0_region= /
+=t0_district=.  Separately, the 326 SPLIT-OFF rows (=sdd_cluster= blank) carry
+a =clusterid= they were never sampled in: under a single DODOMA code they
+collect households whose own strata are DAR ES SALAAM, DODOMA and ZANZIBAR.
+Pooling them manufactured *100 clusters that do not exist* (247 -> 147).
+
+*2020-21's key was simply wrong.*  =cluster_features= keyed on =clusterid=
+while =sample= has always keyed on =y5_cluster=, so *all 417 of its =(t, v)=
+pairs were unknown to =sample=* --- =_join_v_from_sample= matched nothing and
+every 2020-21 household got a =v= with no cluster_features row.  =clusterid= is
+also blank for all *545 booster households* (11.6%), which were therefore
+deleted outright on a NaN key, taking 68 clusters with them.  Keying on
+=y5_cluster= fixes both: 418 -> 515 clusters, 0 unknown to =sample=.
+
+** Measured effect (cold build, isolated =LSMS_DATA_DIR=, L2 rebuilt)
+
+Contested cluster-attribute cells (households in a cluster disagree),
+before -> after:
+
+| wave    | Region     | District     | Rural        | total          | clusters         |
+|---------+------------+--------------+--------------+----------------+------------------|
+| 2008-09 | 0 -> 0     | 0 -> 0       | 0 -> 0       | 0 -> 0         | 409 -> 409       |
+| 2010-11 | 152 -> 0   | 0 -> 0       | 177 -> 78    | 329 -> 78      | 409 -> 409       |
+| 2012-13 | 242 -> 0   | 314 -> 34    | 247 -> 113   | 803 -> 147     | 409 -> 409       |
+| 2014-15 | 52 -> 0    | 62 -> 17     | 46 -> 24     | 160 -> 41      | 498 -> 498       |
+| 2019-20 | 61 -> 1    | 99 -> 35     | 97 -> 36     | 257 -> 72      | 247 -> 147       |
+| 2020-21 | 199 -> 2   | 283 -> 32    | 75 -> 13     | 557 -> 47      | 418 -> 515       |
+| *total* | *706 -> 3* | *758 -> 118* | *642 -> 264* | *2,106 -> 385* | *2,389 -> 2,387* |
+
+*Region is essentially solved*: 706 contested clusters -> 3.
+
+Rows destroyed by the collapse, as reported by the framework's own Site-2
+audit: *10,982 -> 2,687* (2010-11 2,121 -> 605; 2012-13 3,960 -> 1,304;
+2014-15 864 -> 404; 2019-20 748 -> 197; 2020-21 3,289 -> 177), and the *545
+NaN-key deletions in 2020-21 -> 0*.
+
+** The residue, honestly
+
+385 cells still contested.  None of it is a key defect and none of it is forced
+to zero.
+
+*District (118).*  Overwhelmingly *two names for one place*.  Spelling and
+transliteration variants --- ='MBINGA (NYASA)'= / ='MBINGA(NYASA)'= /
+='MBINGA NYASA'= / ='NYASA'= / ='MBINGA'=; ='SONGEA VIJIJINI'= / ='SONGEA
+(V)'=; typos ='MUFINDI'= / ='MFINDI'=, ='IRINGA MJINI'= / ='IRINGA MJINI1'=.
+And genuine *district splits* that happened mid-panel: Chalinze out of
+Bagamoyo, Kibiti out of Rufiji, Ubungo out of Kinondoni.  These are
+label-harmonisation problems (a =harmonize_district= table would close most of
+them); they are not evidence that =v= is ambiguous.
+
+*Rural (264).*  EAs whose households are not all classified alike.  =urb_rur= /
+=sdd_rural= / =y5_rural= are recorded per HOUSEHOLD, and an EA on a town
+boundary genuinely contains both; modal share within a contested cluster is
+0.75-0.88.  This is real sub-cluster variation, not a merge of two clusters.
+
+*Region (3).*  Two 2020-21 clusters and one 2019-20 cluster sit across a
+post-2012 region boundary (SINGIDA/SIMIYU, GEITA/SHINYANGA, and a Pemba/Unguja
+pair).
+
+*Ids that contradict their own households (13).*  After the collapse, 13 of
+2,387 clusters carry a Region that is not the one their geocode encodes.  Four
+are 2014-15 SIMIYU clusters still wearing their pre-2012 SHINYANGA code --- the
+households are right and the id is stale, and the config lets the residents
+win.  Three are 2020-21 ids that are *malformed in the source*
+(='12-06-05-101-005'=, ='12-072-02-24-001'=, ='55-01-02-251-005'= carry the
+wrong field widths); one more carries region code =27=, which is not a Tanzania
+region code.  These are carried through as-is rather than repaired by guesswork.
+
+** Known, NOT fixed here
+
+- *2019-20 =sample.v= for the 326 split-off households.*  Those households are
+  still assigned the =clusterid= the file stamps on them, which is not a
+  sampling cluster --- and now that =cluster_features= no longer manufactures
+  rows for it, their =v= points at a cluster the table does not contain.
+  Blanking it would change =v= on every 2019-20 household table for 27.5% of
+  the wave; that is a semantic change that belongs in its own PR, not inside a
+  cluster-key fix.  Recorded rather than done.
+- *5 of 498 2014-15 clusters are unknown to =sample()=* (='17201000'=,
+  ='21408000'=, ='52104012'=, ='53119012'=, ='53206000'=).  They ARE present in
+  the wave-level =sample.parquet= (13 / 7 / 10 / 10 / 10 rows) and are lost
+  between there and =sample()= --- i.e. in =_finalize_result='s =id_walk=, on
+  the panel-id side.  Pre-existing on =development=; unchanged by this work.
+- =Rural= label harmonisation, and a =harmonize_district= table for the
+  district spellings above.
+
+** Files
+
+- =Tanzania/_/tanzania.py= :: =TZ_REGION_BY_CODE=, =cluster_region()=,
+  =cluster_district_code()=, =normalize_place()=, =keep_cluster_residents()=.
+- =Tanzania/2008-15/_/cluster_features.py= :: residency filter for rounds 1-4.
+- =Tanzania/2019-20/_/data_info.yml= + =_/mapping.py= :: =t0_*= geography,
+  frame-and-original-location restriction.
+- =Tanzania/2020-21/_/data_info.yml= + =_/mapping.py= :: =v= = =y5_cluster=,
+  original-or-booster restriction, place-name case normalisation.
+- =tests/test_gh323_tanzania_cluster_key.py= :: 28 tests.

--- a/lsms_library/countries/Tanzania/_/tanzania.py
+++ b/lsms_library/countries/Tanzania/_/tanzania.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 import warnings
 import json
+import re
 import sys
 sys.path.append('../../_')
 sys.path.append('../../../_')
@@ -154,6 +155,216 @@ Waves = {'2008-15': ('upd4_hh_a.dta', ['r_hhid', 'round', 'UPHI'], map_08_15),
 
 waves = ['2008-09', '2010-11', '2012-13', '2014-15', '2019-20', '2020-21']
 wave_folder_map = {'2008-09':'2008-15', '2010-11':'2008-15', '2012-13':'2008-15', '2014-15':'2008-15', '2019-20':'2019-20', '2020-21':'2020-21'}
+
+
+# ---------------------------------------------------------------------------
+# GH #323 -- the NPS cluster geocode, and who is RESIDENT in a cluster.
+#
+# THE DEFECT.  `cluster_features` is declared at `(t, v)`, but every Tanzania
+# wave extracts it from the household COVER PAGE -- one row per household,
+# carrying the address where that household was INTERVIEWED.  The NPS is a
+# TRACKING panel: when a household moves, or a member splits off to form a new
+# household, the survey follows it and records its NEW address while carrying
+# its ORIGINAL sampling cluster `v` forward unchanged.  So the geo columns are
+# HOUSEHOLD attributes and the cluster is a CLUSTER attribute, and projecting
+# the former onto the latter with `.first()` hands the analyst one mover's
+# doormat as the cluster's location.  Measured cold, 2,104 of 7,167
+# cluster-attribute cells (29.4%) were contested this way -- 65.4% in 2012-13.
+#
+# WHY THIS IS AN IDENTIFIER FIX AND NOT A REDUCER.  The NPS cluster id is not an
+# opaque serial: it is a HIERARCHICAL GEOCODE whose leading fields ARE the
+# cluster's region and district.  Verified on the 2008-09 frame -- round 1, the
+# only pollution-free round, because nobody has moved yet:
+#
+#   * every one of the 26 region codes present maps to EXACTLY ONE region name
+#     (0 violations, 409 clusters); and
+#   * the district digit of the geocode equals the separately reported district
+#     code `ha_02_1` for 100.0% of rows.
+#
+# The cluster's own geography is therefore recoverable from `v` itself.  What
+# these helpers do is USE it -- to decide which households are actually
+# RESIDENT in the cluster they are being asked to describe.  A household whose
+# reported region is not the region in its own cluster's code has moved out; it
+# is evidence about where it went, not about the cluster.
+#
+# The codes below are the Tanzania NBS standard region codes, MINED from the
+# 2008-09 frame and cross-checked against 2019-20 (`t0_region`) and 2020-21
+# (`hh_a01_1`) -- the modal name agrees across all three sources for every code.
+# 22 NJOMBE / 23 KATAVI / 24 SIMIYU / 25 GEITA are the regions created in 2012
+# and appear only from 2012-13 on.  (SONGWE, split from MBEYA in 2016, has no
+# cluster code of its own: its clusters keep the 12 = MBEYA prefix they were
+# drawn under.)
+# ---------------------------------------------------------------------------
+
+TZ_REGION_BY_CODE = {
+    '01': 'DODOMA',        '02': 'ARUSHA',      '03': 'KILIMANJARO',
+    '04': 'TANGA',         '05': 'MOROGORO',    '06': 'PWANI',
+    '07': 'DAR ES SALAAM', '08': 'LINDI',       '09': 'MTWARA',
+    '10': 'RUVUMA',        '11': 'IRINGA',      '12': 'MBEYA',
+    '13': 'SINGIDA',       '14': 'TABORA',      '15': 'RUKWA',
+    '16': 'KIGOMA',        '17': 'SHINYANGA',   '18': 'KAGERA',
+    '19': 'MWANZA',        '20': 'MARA',        '21': 'MANYARA',
+    '22': 'NJOMBE',        '23': 'KATAVI',      '24': 'SIMIYU',
+    '25': 'GEITA',
+    '51': 'KASKAZINI UNGUJA', '52': 'KUSINI UNGUJA',
+    '53': 'MJINI MAGHARIBI UNGUJA',
+    '54': 'KASKAZINI PEMBA',  '55': 'KUSINI PEMBA',
+}
+
+# Field widths of the geocode, by the scheme the wave was coded under.  The
+# scheme is a property of the WAVE, never of the string's length -- 2019-20's
+# 8-character '11014002' is the 9-digit '011014002' (= DODOMA), NOT the 8-digit
+# '11014002' (= IRINGA).  Getting this wrong silently relabels a whole region,
+# which is why the caller must name the scheme.
+#
+#   'nps' : RR D WW EEE       (9 digits) -- NPS rounds 1-3 and the 2014-15
+#           RR DD WWW EE CCC (12 digits)    EXTENDED panel keep the 8-digit
+#                                           form; the 2014-15 REFRESH sample is
+#                                           drawn under the 12-digit form, so
+#                                           this scheme picks by length.
+#   'sdd' : RR D WWW EEE      (9 digits) -- NPS-SDD, 2019-20.
+#   'y5'  : RR-DD-WWW-EE-CCC             -- NPS Y5, 2020-21 (`y5_cluster`,
+#                                           already hyphen-delimited).
+_GEOCODE_SCHEMES = {
+    'nps': ((8, 2, 1), (12, 2, 2)),   # (width, region width, district width)
+    'sdd': ((9, 2, 1),),
+}
+
+
+def _geocode_fields(v, scheme='nps'):
+    """(region_code, district_code) from an NPS cluster id.  ``(pd.NA, pd.NA)``
+    if ``v`` is missing or does not fit the scheme."""
+    if v is None or (not isinstance(v, str) and pd.isna(v)):
+        return pd.NA, pd.NA
+    c = str(v).strip()
+    if c in ('', 'nan', '<NA>', 'None'):
+        return pd.NA, pd.NA
+    if c.endswith('.0'):
+        c = c[:-2]
+    if scheme == 'y5' or '-' in c:
+        bits = c.split('-')
+        if len(bits) < 2:
+            return pd.NA, pd.NA
+        return bits[0].zfill(2), bits[1].lstrip('0') or '0'
+    for width, rw, dw in _GEOCODE_SCHEMES.get(scheme, _GEOCODE_SCHEMES['nps']):
+        if len(c) <= width:
+            p = c.zfill(width)
+            return p[:rw], p[rw:rw + dw].lstrip('0') or '0'
+    return pd.NA, pd.NA
+
+
+def cluster_region_code(v, scheme='nps'):
+    """The region code carried by the cluster id itself."""
+    return _geocode_fields(v, scheme)[0]
+
+
+def cluster_district_code(v, scheme='nps'):
+    """The district code carried by the cluster id itself (leading zeros stripped)."""
+    return _geocode_fields(v, scheme)[1]
+
+
+def cluster_region(v, scheme='nps'):
+    """The cluster's OWN region name, decoded from its id.  ``pd.NA`` if the id
+    is missing or carries a region code we have no name for."""
+    rc = cluster_region_code(v, scheme)
+    if pd.isna(rc):
+        return pd.NA
+    return TZ_REGION_BY_CODE.get(rc, pd.NA)
+
+
+def normalize_place(x):
+    """Case- and punctuation-insensitive form of a place name, for COMPARISON
+    only -- never stored.  The same region is written 'MJINI/MAGHARIBI UNGUJA'
+    in 2008-15, 'MJINI MAGHARIBI UNGUJA' in 2019-20 and 'arusha' in 2020-21."""
+    if x is None or (not isinstance(x, str) and pd.isna(x)):
+        return pd.NA
+    s = re.sub(r'[^A-Z0-9]+', ' ', str(x).upper()).strip()
+    return s if s else pd.NA
+
+
+def _norm_series(s):
+    return s.map(normalize_place)
+
+
+def keep_cluster_residents(df, region='Region', district_code=None,
+                           scheme='nps', v='v', extra_mask=None, label=''):
+    """Keep only the households RESIDENT in the cluster they describe.
+
+    ``cluster_features`` asks what a CLUSTER looks like.  Only a household that
+    still lives in the cluster can answer; a tracked mover answers about
+    somewhere else.  Residency is decided against the cluster's OWN geocode (see
+    the module comment): a household is resident when its reported region is the
+    region in its cluster's id, and -- where the source also reports a district
+    CODE comparable with the geocode's -- when its district matches too.
+
+    Applied in TIERS, finest first, so that tightening the test can never empty
+    a cluster-WAVE and drop it from the table:
+
+      1. region AND district code agree with the geocode;
+      2. else region alone agrees;
+      3. else keep that cluster-wave's households unfiltered (nothing in the
+         wave places anyone in it -- the residual disagreement is then reported
+         by the framework's grain audit rather than papered over).
+
+    The tiers are evaluated per ``(t, v)``, not per ``v``: the declared grain is
+    ``(t, v)``, and a cluster can have residents in one round and none in the
+    next.  Grouping on ``v`` alone silently dropped 12 cluster-waves.
+
+    Args:
+        df: household-grain frame with ``v`` in the index (or columns).
+        region: name of the reported-region column.
+        district_code: name of a reported district-CODE column comparable with
+            the geocode's district field, or None if the wave has none.
+        scheme: geocode scheme -- 'nps', 'sdd' or 'y5'.
+        v: name of the cluster-id level/column.
+        extra_mask: optional boolean Series, ANDed into tier 1 and tier 2 --
+            for waves whose instrument states residency directly (NPS-SDD's
+            `sdd_cluster`, NPS Y5's `hh_tracking_status`).
+        label: wave label, for the diagnostic warning only.
+
+    Returns:
+        The subset of ``df`` describing each cluster from inside it.
+    """
+    flat = df.reset_index() if v not in df.columns else df.copy()
+    vs = flat[v]
+    if 't' in flat.columns:
+        grain = flat['t'].astype(str).str.cat(vs.astype(str), sep='|')
+    else:
+        grain = vs
+    geo_region = vs.map(lambda x: cluster_region(x, scheme))
+    ok_region = _norm_series(geo_region) == _norm_series(flat[region])
+    if district_code is not None and district_code in flat.columns:
+        geo_dist = vs.map(lambda x: cluster_district_code(x, scheme))
+        rep = flat[district_code].map(
+            lambda x: pd.NA if pd.isna(x) else str(x).split('.')[0].lstrip('0') or '0')
+        ok_fine = ok_region & (geo_dist == rep)
+    else:
+        ok_fine = ok_region
+    if extra_mask is not None:
+        extra = pd.Series(np.asarray(extra_mask), index=flat.index).fillna(False)
+        ok_fine = ok_fine & extra
+        ok_region = ok_region & extra
+    ok_fine = ok_fine.fillna(False).astype(bool)
+    ok_region = ok_region.fillna(False).astype(bool)
+
+    n_clusters = int(grain.nunique(dropna=False))
+    has_fine = ok_fine.groupby(grain, dropna=False).transform('max')
+    has_coarse = ok_region.groupby(grain, dropna=False).transform('max')
+    keep = ok_fine | (~has_fine & ok_region) | (~has_fine & ~has_coarse)
+
+    n_drop = int((~keep).sum())
+    n_unresolved = int((~has_fine & ~has_coarse).groupby(grain, dropna=False).max().sum())
+    if n_drop or n_unresolved:
+        warnings.warn(
+            f'cluster_features{" " + label if label else ""}: {n_drop} of '
+            f'{len(flat)} household rows describe a cluster they no longer live '
+            f'in (the NPS tracks movers and split-offs but carries their '
+            f'ORIGINAL cluster forward) and are excluded from the cluster grain; '
+            f'{n_unresolved} of {n_clusters} clusters have no resident '
+            f'household at all and are left unfiltered.  GH #323.',
+            RuntimeWarning, stacklevel=2)
+    return df[keep.to_numpy()]
+
 
 def harmonized_food_labels(fn='../../_/categorical_mapping.org', name='harmonize_food'):
     # Harmonized food labels.  Reads the canonical harmonize_food table

--- a/tests/test_gh323_tanzania_cluster_key.py
+++ b/tests/test_gh323_tanzania_cluster_key.py
@@ -1,0 +1,351 @@
+"""Tanzania `cluster_features` cluster key (GH #323, Site 2).
+
+Tanzania was the worst Site-2 offender in the corpus: 2,104 of 7,167
+cluster-attribute cells contested (29.4%), 65.4% of them in 2012-13.  The cause
+was not an ambiguous cluster code.  It was that every wave read the cluster's
+Region / District / Rural off the household COVER PAGE -- the address where the
+household was INTERVIEWED -- while the NPS is a TRACKING panel that follows
+movers and split-offs and carries their ORIGINAL cluster `v` forward unchanged.
+So a household that left the cluster was still being asked to describe it.
+
+Two things are pinned here.
+
+1.  **The identifier decodes.**  The NPS cluster id is a hierarchical geocode
+    whose leading fields ARE the cluster's region and district.  Every test of
+    residency rests on that, so it is asserted directly against the 2008-09
+    frame -- round 1, the only pollution-free round, because nobody has moved
+    yet.
+2.  **The cluster grain is described from inside the cluster.**  Contested
+    cells per wave, and the key agreements that make the table joinable.
+
+These are CONFIG-level tests.  They exercise no core aggregation mechanism --
+core does not aggregate (D1, SkunkWorks/grain_aggregation_policy.org).
+
+Data-dependent: skips cleanly when the Tanzania source files are unavailable.
+"""
+import re
+import warnings
+
+import pandas as pd
+import pytest
+
+import lsms_library as ll
+
+WAVES = ["2008-09", "2010-11", "2012-13", "2014-15", "2019-20", "2020-21"]
+ATTRS = ["Region", "District", "Rural"]
+
+# Contested-cell ceilings, per wave, measured cold (isolated LSMS_DATA_DIR,
+# L2 rebuilt) on this branch.  The BEFORE column is what `development` produces.
+#
+#   wave      before   after
+#   2008-09        0       0
+#   2010-11      329      78
+#   2012-13      803     147
+#   2014-15      160      41
+#   2019-20      257      72
+#   2020-21      557      47
+#
+# The ceilings are the measured values.  They are upper bounds, not equalities:
+# a change that lowers them further should not fail, but a regression toward the
+# `development` numbers must.  The residue is characterised in
+# Tanzania/_/CONTENTS.org -- district RENAMINGS and SPLITS carrying two names for
+# one place, and EAs whose households are not all classified alike on urban /
+# rural.  Neither is a key defect and neither is forced to zero here.
+CONTESTED_CEILING = {
+    "2008-09": 0,
+    "2010-11": 78,
+    "2012-13": 147,
+    "2014-15": 41,
+    "2019-20": 72,
+    "2020-21": 47,
+}
+
+# Cluster counts per wave.  2019-20 FALLS 247 -> 147 (100 of its "clusters"
+# existed only because split-off rows were pooled under a stray code) and
+# 2020-21 RISES 418 -> 515 (the booster clusters stop being deleted on a NaN
+# `clusterid` key).
+CLUSTERS = {
+    "2008-09": 409,
+    "2010-11": 409,
+    "2012-13": 409,
+    "2014-15": 498,
+    "2019-20": 147,
+    "2020-21": 515,
+}
+
+
+@pytest.fixture(scope="module")
+def tz():
+    return ll.Country("Tanzania")
+
+
+def _build(tz, table):
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            df = getattr(tz, table)()
+    except Exception as exc:  # noqa: BLE001 - any build/data failure -> skip
+        pytest.skip(f"Tanzania {table} unavailable: {exc}")
+    if df is None or df.empty:
+        pytest.skip(f"Tanzania {table} empty")
+    return df
+
+
+@pytest.fixture(scope="module")
+def cluster_features(tz):
+    return _build(tz, "cluster_features")
+
+
+@pytest.fixture(scope="module")
+def sample(tz):
+    return _build(tz, "sample")
+
+
+@pytest.fixture(scope="module")
+def geocode():
+    """The country module's geocode helpers, loaded the way the config does."""
+    import importlib.util
+    from lsms_library.paths import countries_root
+
+    path = countries_root() / "Tanzania" / "_" / "tanzania.py"
+    if not path.exists():           # pragma: no cover - config always shipped
+        pytest.skip("Tanzania country module unavailable")
+    spec = importlib.util.spec_from_file_location("_tz_geocode_probe", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------
+# 1.  The identifier decodes.  Everything else rests on this.
+# --------------------------------------------------------------------------
+
+def test_geocode_region_field_is_documented_for_every_scheme(geocode):
+    """The scheme is a property of the WAVE, never of the string's length.
+
+    2019-20's 8-character '11014002' is the 9-digit '011014002' (DODOMA), NOT
+    the 8-digit '11014002' (IRINGA).  Reading it under the wrong scheme
+    relabels a whole region silently, so pin both readings.
+    """
+    assert geocode.cluster_region("11014002", scheme="sdd") == "DODOMA"
+    assert geocode.cluster_region("11014002", scheme="nps") == "IRINGA"
+    assert geocode.cluster_region("02-02-033-04-004", scheme="y5") == "ARUSHA"
+    # The 2014-15 refresh sample is drawn under the 12-digit form, and the
+    # 'nps' scheme has to pick by length within the same wave.
+    assert geocode.cluster_region("20203304004", scheme="nps") == "ARUSHA"
+    assert pd.isna(geocode.cluster_region(None))
+    assert pd.isna(geocode.cluster_region(float("nan")))
+
+
+def test_geocode_district_field(geocode):
+    assert geocode.cluster_district_code("11014002", scheme="sdd") == "1"
+    assert geocode.cluster_district_code("02-02-033-04-004", scheme="y5") == "2"
+
+
+def test_every_region_code_has_exactly_one_name(geocode):
+    """A code that named two regions would make the residency test meaningless."""
+    names = list(geocode.TZ_REGION_BY_CODE.values())
+    assert len(names) == len(set(names)), "a region name is claimed by two codes"
+    assert all(re.fullmatch(r"\d{2}", c) for c in geocode.TZ_REGION_BY_CODE)
+
+
+def test_the_geocode_agrees_with_the_pollution_free_frame(geocode):
+    """Round 1 is the ground truth: nobody has moved, so every household's
+    reported region IS its cluster's region.  If the crosswalk were wrong this
+    would be the first thing to know."""
+    from lsms_library.local_tools import get_dataframe
+    from lsms_library.paths import countries_root
+
+    fn = countries_root() / "Tanzania" / "2008-15" / "Data" / "upd4_hh_a.dta"
+    try:
+        raw = get_dataframe(str(fn))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"Tanzania 2008-15 source unavailable: {exc}")
+    r1 = raw[raw["round"] == 1]
+    cid = r1["clusterid"].astype(str).str.replace(r"\.0$", "", regex=True)
+    decoded = cid.map(lambda x: geocode.cluster_region(x, "nps"))
+    reported = r1["ha_01_1"].map(geocode.normalize_place)
+    agree = (decoded.map(geocode.normalize_place) == reported)
+    assert agree.mean() == 1.0, (
+        f"the cluster geocode disagrees with the round-1 frame for "
+        f"{int((~agree).sum())} of {len(agree)} households"
+    )
+
+
+# --------------------------------------------------------------------------
+# 2.  The cluster grain is described from inside the cluster.
+# --------------------------------------------------------------------------
+
+def _contested(flat):
+    """Cluster-attribute cells whose households DISAGREE -- the #323 instrument.
+
+    Counted on the PRE-COLLAPSE frame, because that is the only place the
+    evidence exists: one line later `.first()` has reduced it and the parquet is
+    written from the reduced frame.  Reading the finished table instead would
+    report 0 unconditionally and prove nothing.
+    """
+    flat = flat.reset_index()
+    for col in ["v"] + ATTRS:
+        if col not in flat.columns:
+            flat[col] = pd.NA
+        flat[col] = flat[col].astype(str).str.strip().replace(
+            {"nan": pd.NA, "None": pd.NA, "<NA>": pd.NA, "": pd.NA})
+    g = flat.groupby("v", dropna=False)
+    return {a: int((g[a].nunique(dropna=True) > 1).sum()) for a in ATTRS}
+
+
+@pytest.fixture(scope="module")
+def pre_collapse(tz):
+    """Household-grain `cluster_features`, per wave, exactly as it reaches
+    `Wave.cluster_features`'s projection onto `(t, v)`."""
+    out = {}
+    for wave in WAVES:
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                out[wave] = tz[wave].grab_data("cluster_features")
+        except Exception as exc:  # noqa: BLE001
+            pytest.skip(f"Tanzania {wave} cluster_features unavailable: {exc}")
+    return out
+
+
+@pytest.mark.parametrize("wave", WAVES)
+def test_cluster_features_is_one_row_per_cluster(cluster_features, wave):
+    sub = cluster_features.xs(wave, level="t")
+    assert sub.index.is_unique, f"{wave}: duplicate v in cluster_features"
+    assert len(sub) == CLUSTERS[wave], (
+        f"{wave}: {len(sub)} clusters, expected {CLUSTERS[wave]}")
+
+
+@pytest.mark.parametrize("wave", WAVES)
+def test_contested_cells_stay_below_the_measured_ceiling(pre_collapse, wave):
+    per_col = _contested(pre_collapse[wave])
+    total = sum(per_col.values())
+    assert total <= CONTESTED_CEILING[wave], (
+        f"{wave}: {total} contested cluster-attribute cells "
+        f"({per_col}), ceiling {CONTESTED_CEILING[wave]} -- households in a "
+        f"cluster are disagreeing about the cluster again"
+    )
+
+
+def test_2008_09_is_the_uncontested_baseline(pre_collapse):
+    """Round 1, before anyone has moved.  Every cluster's households agree on
+    every attribute -- which is what makes them CLUSTER attributes, and what
+    makes the later rounds' disagreement a movement artefact rather than an
+    ambiguous code."""
+    assert sum(_contested(pre_collapse["2008-09"]).values()) == 0
+
+
+def test_the_frame_reaching_the_projection_is_still_household_grain(pre_collapse):
+    """The mover exclusion is a ROW FILTER, not an early collapse.
+
+    If the config reduced to `(t, v)` itself, every measurement above would read
+    0 for free and the framework's grain audit would see nothing at all.  Keep
+    the projection where it is audited.
+    """
+    for wave in WAVES:
+        idx = pre_collapse[wave].index.names
+        assert "i" in idx, f"{wave}: `i` is gone -- the config collapsed early"
+
+
+# --------------------------------------------------------------------------
+# 3.  The two keys must be the SAME key, or `_join_v_from_sample` matches
+#     nothing.  This is what was broken outright in 2020-21.
+# --------------------------------------------------------------------------
+
+def test_cluster_features_v_is_a_key_sample_knows(cluster_features, sample):
+    """Before this branch, ALL 417 of 2020-21's `(t, v)` pairs were unknown to
+    `sample`: `cluster_features` keyed on `clusterid` while `sample` keyed on
+    `y5_cluster`, so every 2020-21 household got a cluster with no row.
+
+    The 2014-15 residue is PRE-EXISTING and lives on the sample side: 5 clusters
+    are present in the wave-level `sample.parquet` but do not survive `id_walk`
+    into `sample()`.  Pinned at its measured value so it cannot grow.
+    """
+    known = set(map(tuple, sample.reset_index()[["t", "v"]].astype(str).values))
+    cv = cluster_features.reset_index()[["t", "v"]].astype(str).drop_duplicates()
+    per_wave = {}
+    for wave in WAVES:
+        rows = cv[cv["t"] == wave]
+        per_wave[wave] = sum(tuple(r) not in known for r in rows.values)
+    expected = {w: 0 for w in WAVES}
+    expected["2014-15"] = 5
+    assert per_wave == expected, per_wave
+
+
+def test_2020_21_is_keyed_on_y5_cluster(cluster_features):
+    """`y5_cluster` is hyphen-delimited `RR-DD-WWW-EE-CCC`; `clusterid` is a
+    bare number and is BLANK for all 545 booster households.  A regression to
+    `clusterid` shows up as the wrong shape and 68 missing clusters.
+
+    Three of the 515 ids are MALFORMED IN THE SOURCE -- '12-06-05-101-005',
+    '12-072-02-24-001' and '55-01-02-251-005' carry the wrong field widths.
+    They are carried through as-is rather than repaired by guesswork; the point
+    of this test is the KEY, and every id still has a hyphen.
+    """
+    v = cluster_features.xs("2020-21", level="t").index.astype(str)
+    assert v.str.contains("-").all(), (
+        "2020-21 cluster ids are not in y5_cluster form: "
+        f"{[x for x in v if '-' not in x][:5]}"
+    )
+    well_formed = v.str.fullmatch(r"\d{2}-\d{2}-\d{3}-\d{2}-\d{3}")
+    assert int((~well_formed).sum()) <= 3, (
+        f"more malformed y5_cluster ids than the 3 known: "
+        f"{[x for x, ok in zip(v, well_formed) if not ok]}"
+    )
+
+
+def test_2020_21_booster_clusters_are_present(cluster_features):
+    """`clusterid` is NaN for every booster household, so keying on it deleted
+    them outright on a NaN key.  Keying on `y5_cluster` keeps them."""
+    n = len(cluster_features.xs("2020-21", level="t"))
+    assert n == 515, f"2020-21 has {n} clusters, expected 515"
+
+
+# --------------------------------------------------------------------------
+# 4.  The mover exclusion must not silently drop a cluster.
+# --------------------------------------------------------------------------
+
+def test_no_cluster_wave_is_lost_from_the_2008_15_folder(cluster_features):
+    """Residency is tested per `(t, v)`, not per `v`: a cluster can have
+    residents in one round and none in the next, and grouping on `v` alone lost
+    12 cluster-waves.  Pin the per-round counts."""
+    for wave in ["2008-09", "2010-11", "2012-13", "2014-15"]:
+        n = len(cluster_features.xs(wave, level="t"))
+        assert n == CLUSTERS[wave], f"{wave}: {n} clusters, expected {CLUSTERS[wave]}"
+
+
+# Clusters whose finished Region is not the one their own id encodes.  The
+# geocode decides RESIDENCY; it is never written into the table, so where the
+# two part company the residents win -- which is what makes these exceptions
+# legible instead of hidden:
+#
+#   2014-15  4  -- 2 are SIMIYU clusters still carrying their pre-2012 SHINYANGA
+#                  code (Simiyu was carved out of Shinyanga in 2012, so the
+#                  households are RIGHT and the id is stale); 2 are ids whose
+#                  region field contradicts every household in them.
+#   2020-21  9  -- 3 malformed ids (see above) plus 6 whose region field
+#                  contradicts their households.
+#   others   0.
+REGION_VS_GEOCODE_CEILING = {
+    "2008-09": 0, "2010-11": 0, "2012-13": 0, "2014-15": 4,
+    "2019-20": 0, "2020-21": 9,
+}
+
+
+@pytest.mark.parametrize("wave", WAVES)
+def test_region_is_the_region_the_cluster_id_claims(cluster_features, geocode, wave):
+    """The end-to-end statement of the fix: after the collapse, a cluster's
+    Region is the region carried by its own id -- for 2,374 of 2,387 clusters,
+    and for ALL of them in four of the six waves.  Before this branch the
+    finished Region was whichever household `.first()` happened to reach."""
+    scheme = {"2019-20": "sdd", "2020-21": "y5"}.get(wave, "nps")
+    sub = cluster_features.xs(wave, level="t").reset_index()
+    decoded = sub["v"].map(lambda x: geocode.cluster_region(x, scheme))
+    left = decoded.map(geocode.normalize_place)
+    right = sub["Region"].map(geocode.normalize_place)
+    mismatch = int(((left.notna()) & (right.notna()) & (left != right)).sum())
+    assert mismatch <= REGION_VS_GEOCODE_CEILING[wave], (
+        f"{wave}: {mismatch} clusters carry a Region that is not the one in "
+        f"their own geocode (ceiling {REGION_VS_GEOCODE_CEILING[wave]})"
+    )


### PR DESCRIPTION
Fixes the Tanzania `cluster_features` cluster key — the worst Site-2 cell in the
corpus (**2,104 of 7,167 cluster-attribute cells contested, 29.4%**; 65.4% in
2012-13). **Config only**: nothing under `lsms_library/*.py`, no `aggregation:`
keys (D1).

## The cause is not an ambiguous cluster code

Every wave read `Region` / `District` / `Rural` off the household **cover
page** — the address where the household was **interviewed**. The NPS is a
**tracking** panel: it follows movers and split-offs, records their *new*
address, and carries their *original* sampling cluster `v` forward unchanged. So
the geo columns are HOUSEHOLD attributes, `v` is a CLUSTER attribute, and the
projection onto `(t, v)` asks a household that has left the cluster to describe
it.

Round 1 settles that these really are cluster attributes: in **2008-09, before
anyone has moved, all 409 clusters agree on all three columns — 0 contested**.
Disagreement appears only from round 2 and tracks movement (549 / 1,154 / 314
households in rounds 2/3/4 report a region that is not their cluster's).

## The identifier already carries the answer

The NPS cluster id is a **hierarchical geocode** whose leading fields *are* the
cluster's region and district. Validated on the 2008-09 frame:

- all **26** region codes present map to **exactly one** region name (0 violations);
- the geocode's district digit equals the reported district code `ha_02_1` for
  **100.0%** of rows.

Field widths are a property of the **wave**, never of the string's length —
2019-20's 8-character `'11014002'` is `01-1-014-002` = DODOMA under its own
9-digit scheme and IRINGA under the 8-digit one. `cluster_region()` therefore
makes the caller name the scheme, and a test pins both readings.

## The fix

Each wave excludes the households that no longer live in the cluster, in tiers
against the cluster's own geocode (region+district → region → unfiltered, so
tightening the test can never drop a cluster). Tiers are evaluated per `(t, v)`,
not per `v` — grouping on `v` alone silently lost 12 cluster-waves.

The frame **stays at household grain on purpose**: the projection belongs to
`Wave.cluster_features` where the framework audits it, and collapsing in config
would drive the #323 instrument to 0 for free. A test pins that `i` survives
into the projection.

Two waves needed more than a filter:

- **2019-20 was reading the mover question.** `hh_a01_1` / `hh_a02_1` are asked
  only of households found at a NEW location — null for **89.9%** of those found
  at their ORIGINAL location, i.e. exactly the ones that can describe the
  cluster. Re-sourced to `t0_region` / `t0_district`. Separately the 326
  SPLIT-OFF rows (`sdd_cluster` blank) carry a `clusterid` they were never
  sampled in — under one DODOMA code they pool households whose own strata span
  DAR ES SALAAM, DODOMA and ZANZIBAR — which manufactured **100 clusters that do
  not exist** (247 → 147).
- **2020-21's key was simply wrong.** `cluster_features` keyed on `clusterid`
  while `sample` has always keyed on `y5_cluster`, so **all 417 of its `(t, v)`
  pairs were unknown to `sample`** — `_join_v_from_sample` matched nothing.
  `clusterid` is also blank for all **545 booster households**, deleted outright
  on a NaN key. `v` → `y5_cluster`: **418 → 515 clusters, 0 unknown to sample**.

## Numbers

Cold build, isolated `LSMS_DATA_DIR` with `dvc-cache` symlinked to the shared L1
(`LSMS_NO_CACHE=1` alone is *not* enough — it is soft for the script-path
2008-15 L2-wave parquet).

| wave | contested before | after | clusters |
|---|---|---|---|
| 2008-09 | 0 | 0 | 409 → 409 |
| 2010-11 | 329 | **78** | 409 → 409 |
| 2012-13 | 803 | **147** | 409 → 409 |
| 2014-15 | 160 | **41** | 498 → 498 |
| 2019-20 | 257 | **72** | 247 → **147** |
| 2020-21 | 557 | **47** | 418 → **515** |
| **total** | **2,106** | **385** | 2,389 → 2,387 rows |

By column: **Region 706 → 3**, District 758 → 118, Rural 642 → 264. Rows
destroyed by the collapse (the framework's own Site-2 audit) **10,982 → 2,687**;
NaN-key deletions **545 → 0**.

`sample.v` ≡ `cluster_features.v`: pairs unknown to `sample` are **0 in every
wave** except 2014-15's 5, which are **pre-existing** — present in the
wave-level `sample.parquet`, lost in `_finalize_result`'s `id_walk`.

## Rejected, on evidence

Full write-up in `.coder/ledger/323-tanzania-key.md`.

- **A composite key** (Uganda's fix) — zeroes Region *tautologically* by
  splitting each real cluster across the regions its movers went to: 2012-13 goes
  409 clusters → 1,165, and `v` desynchronises from `sample`.
- **`strataid2` as the cluster-invariant source** — shows zero within-cluster
  variation in all four rounds *because it is 100% NULL in rounds 1-3*. The
  invariance was an artefact of missingness.
- **Carrying attributes from each cluster's first-appearance round** — the 82
  clusters first appearing in 2012-13 are pre-2012 clusters *renumbered* after
  the Simiyu/Geita/Njombe/Katavi region splits, so it is not a frame round.
- **Decoding urban/rural from the geocode** — predicts `urb_rur` for only 75.3%
  of round-1 clusters.

## Residue, not forced to zero

- **District (118)** — overwhelmingly two names for one place: `MBINGA (NYASA)` /
  `MBINGA(NYASA)` / `MBINGA NYASA` / `NYASA`, typos `MUFINDI`/`MFINDI`, and
  mid-panel district splits (Chalinze/Bagamoyo, Kibiti/Rufiji, Ubungo/Kinondoni).
  A `harmonize_district` table would close most of it.
- **Rural (264)** — EAs whose households are genuinely not all urban or all
  rural; modal share 0.75–0.88.
- **Region (3)** — post-2012 region boundaries.
- **13 of 2,387 clusters** end up with a Region that is not the one their geocode
  encodes: 4 are Simiyu clusters still wearing a pre-2012 Shinyanga code (the
  households are right, the id is stale) and 3 are `y5_cluster` ids **malformed
  in the source**, carried through rather than repaired by guesswork.

## Deferred

- **2019-20 `sample.v` for the 326 split-offs now dangles.** Their `clusterid` is
  not a sampling cluster; blanking it changes `v` on every 2019-20 household
  table for 27.5% of the wave — a semantic change that belongs in its own PR.
- `harmonize_district`; a cluster-level `Rural` classification.

## Tests

`tests/test_gh323_tanzania_cluster_key.py` — 28 tests, config-level only.

**Negative control**: against a pristine `origin/development` config tree
(`git archive` into a separate `LSMS_COUNTRIES_ROOT` + data dir), **20 of 28
fail** — every contested-cell ceiling, the `sample.v` ≡ `cluster_features.v`
test, both 2020-21 key tests, and the per-wave cluster counts.

`test_tanzania_grain_gh323.py` (19), `test_tanzania_community_cluster_xwalk.py`,
`test_schema_consistency.py` and `test_gh323_benin_togo.py` all pass.

Pre-existing and untouched:
`test_gh323_explicit_reducers.py::test_core_does_not_dispatch_the_reducers`
fails on pristine `development` too (core's private
`_collapse_to_cluster_grain` contains a banned substring) — also recorded in
`.coder/ledger/323-uganda.md` §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
