### PR TITLE
fix(#323): add a `condition` index level to Uganda crop_production

### DIFF
--- a/.coder/ledger/323-uganda-crop-condition.md
+++ b/.coder/ledger/323-uganda-crop-condition.md
@@ -156,3 +156,97 @@ physically cleared Uganda cache: 10 passed.
   drops the level.
 - No `aggregation:` key added; no reducer; no edit under `lsms_library/*.py` except the
   config file `data_info.yml`.  `transformations.py` untouched.
+
+---
+
+## Phase 4 — post-review corrections (PR #649 adversarial review, 2026-07-21)
+
+Verdict was APPROVE-WITH-NOTES: the data path survived every attack, three
+comments were inaccurate, one test gap was real.  All measurements below were
+re-derived independently (isolated `LSMS_DATA_DIR` with only `dvc-cache`
+symlinked in, `LSMS_COUNTRIES_ROOT` pinned to the worktree and asserted,
+Uganda cache physically removed, no `dvc` CLI) — not copied from the review.
+
+### F1 (MEDIUM) — code 99's justification was false by ~100x
+
+Old claim: "only 3 rows in the whole panel and none after 2011-12".
+Measured: **381 raw source rows** carry code 99 with a reported measure and
+**340 built rows** carry `other_condition`; **219 of the 340 are after
+2011-12**.  Per wave (built): 1 / 0 / 120 / 32 / 32 / 32 / 123.
+
+Vintage semantics confirmed from Stata metadata: 99 = `Others` (2011-12),
+`Not Applicable` (2018-19, 2019-20), and **absent from the label set** in
+2013-14 / 2015-16 (both ship 19 codes, no 99) though 32 rows per wave use it.
+
+**Behaviour unchanged.**  The merge is kept and the *real* justification is
+now written down: `t` is an index level so no wave-crossing tuple exists and
+nothing is summed; 99 is the scheme's own residual slot in every vintage; and
+splitting would need a third value for 2013-14/2015-16 where no wave says
+what 99 means.  The alternative (split into `other_condition` /
+`not_applicable_condition`) is recorded as a follow-up that moves 340 rows
+and needs its own before/after.
+
+### F2 (LOW) — the sentinel rate, not the off-scheme rate
+
+`data_scheme.yml` said "~1%".  Measured sentinel share: **7 994 / 133 683 =
+6.0% panel-wide, 23.2% in 2009-10**.  "~1%" is right only for *off-scheme
+codes*: 297 = 1.1% of 2009-10, 192 = 0.9% of 2010-11, 492 panel-wide.
+`CONTENTS.org` already had the correct figures, so this was the summary
+drifting from the analysis; the summary now agrees.
+
+### F3 (LOW) — `Source Label` is not verbatim
+
+Of the 216 (code, wave, season) label pairs in the five labelled waves,
+**60 match the org column literally, 156 do not**.  It is the 2018-20 wording
+with whitespace collapsed, except **four codes — 24, 32, 42, 99** — which
+take the longer 2009-16 phrasing; 99's text ("Others / Not Applicable")
+appears in no wave at all.  Also documented: code 45's *Preferred* Label
+`dried_grain` is an inference from grid position (every wave writes only
+"Dry - grain"), covering 40 411 / 133 683 rows = 30%.
+
+### F4 (MEDIUM) — a mis-wired colmap must fail loudly
+
+Two independent guards, because they catch different mistakes.
+
+1. **`uganda._require` raises `CropColmapError`** when a colmap NAMES a column
+   the source lacks.  `None` stays the declared way to say "no such column".
+   Measured no-op: exactly one named column failed to resolve panel-wide
+   (2010-11's intercrop `flag: 'a4aq3'`, a column that does not exist in that
+   file — fixed to `None`, itself a no-op), and a cold rebuild is
+   byte-identical afterwards (133 683 rows; Quantity 317,005,989.0;
+   Quantity_sold 18,134,251.4; Value_sold 9,066,365,499.8; `intercropped`
+   non-null 75 625 on both sides; sorted frames `.equals()` True).
+2. **Three tests**, thresholds set from measurement:
+   `test_crop_colmap_columns_resolve_in_source` (S3-guarded),
+   `test_sentinel_share_bounded_per_wave_season` (ceiling 40%; worst honest
+   cell 25.7%), `test_condition_varies_within_every_wave_season` (floor 10
+   distinct; measured minimum 18).
+
+**Mutation proof** (Uganda cache physically cleared each run):
+
+| mutation | before | after |
+|---|---|---|
+| baseline | 10 passed | **13 passed** |
+| `condition: 'a5aq6b_TYPO'` (2018-19 A) | 10 passed | **1 failed, 4 passed, 8 errors** |
+| `condition: 's5aq06f_1'` (existing wrong column) | 10 passed | **1 failed, 12 passed** |
+
+The second mutation is the informative one: the build succeeds, the resolve
+test passes, and the sentinel share is only **33.7%** — *under* the 40%
+ceiling — so the variety test (2 distinct conditions vs a floor of 10) is what
+catches it.  Neither invariant alone suffices; both are kept.
+
+Also hardened: `test_fresh_and_dry_no_longer_collide`'s `skip`-on-empty is now
+an assert, and the `crop_production` fixture re-raises a build failure when S3
+credentials are present (still skips without them, so the data-free CI job is
+unaffected).
+
+### Found while doing F4, NOT raised by the review
+
+`crop_production.intercropped` is wired to the **seed-use question** in every
+wave that populates it (`a4aq3` / `a4aq16` / `s4aq16`, all labelled "did you
+use any seed/seedlings?", {1: Yes, 2: No}), not to the cropping-system
+question (`a4aq7` "Cropping system" {1: Pure Stand, 2: Inter cropped}, or
+`a4aq8` / `s4aq08` "What type of crop stand was on the plot?" {1: Pure Stand,
+2: Mixed Stand}).  Agreement between the wired flag and the true crop-stand
+question is 48.5–52.5% — a coin flip.  Rewiring moves data, so it is filed as
+a Known Issue in `Uganda/_/CONTENTS.org`, not fixed here.

--- a/.coder/ledger/323-uganda-crop-condition.md
+++ b/.coder/ledger/323-uganda-crop-condition.md
@@ -1,0 +1,158 @@
+# Prior-Art Ledger — #323 / #637: `condition` index level on Uganda `crop_production`
+
+**Search tier used:** ripgrep + git floor (gitnexus not exercised; no MCP index write attempted).
+
+## §1 Task, restated
+
+Uganda's `crop_production` is a script-path (`materialize: make`) table built by
+`lsms_library/countries/Uganda/_/uganda.py::crop_production_for_wave` from the UNPS
+post-harvest modules AGSEC5A (season A) / AGSEC5B (season B).  Its declared index in
+`Uganda/_/data_scheme.yml` is `(t, i, plot, j, u, season)`.  The UNPS harvest question
+6 records, per plot-crop-season, *how much was harvested **and in what condition***
+(green / fresh / dry-at-harvest / dried, crossed with the physical form: on the stalk,
+with shell/cob, in the cob, in pods, as grain).  The condition is not in the declared
+index, so two harvest records that differ **only** by condition — e.g. 240 kg dry
+coffee and 100 kg fresh coffee off the same plot — land on the same index tuple and are
+summed by the de-duplication block at the end of `crop_production_for_wave`.  Dry weight
+is added to fresh weight.  This ledger covers adding `condition` as an index level,
+sourced per vintage, on a shared vocabulary.
+
+## §2 Existing machinery (this task's area)
+
+| symbol | path:line | what it does | tested? | reuse / extend / new |
+|--------|-----------|--------------|---------|----------------------|
+| `crop_production_for_wave` | `Uganda/_/uganda.py:922` | builds one wave's canonical frame from AGSEC5A/5B + AGSEC4A; already loops over a per-season `conditions:` list of column-sets | via wave-script asserts | **extend** — the loop variable is already named `cond`; it just never emitted the condition label |
+| `CROP_COLMAPS` | `Uganda/_/uganda.py:1099` | per-wave, per-season source column map | no | **extend** — add a `condition:` key per condition dict |
+| `_harmonized_codes(table)` | `Uganda/_/uganda.py:517` | reads a `Code \| Preferred Label` org table from `Uganda/_/categorical_mapping.org` into `{int: str}` | no | **reuse** — same call shape as `_harvest_unit_map()` |
+| `harvest_units` org table | `Uganda/_/categorical_mapping.org:779` | the harvest **unit** code scheme (`1=Kg`, `10=Sack (100 kgs)`, …) | no | **model to copy** for a sibling `harvest_conditions` table |
+| `_enforce_canonical_spellings` | `lsms_library/country.py:3948` | rewrites variant→canonical values; **line 3962 handles INDEX levels** via `df.rename(index=…, level=col)` | `tests/test_schema_consistency.py` reads the same YAML | **reuse** — this is what makes a `Columns:` declaration reach an index level |
+| `_load_canonical_spellings` | `lsms_library/country.py:3921` | inverts `Columns.<table>.<col>.spellings` into `{variant: canonical}` | — | reuse (read-only) |
+| `Columns.plot_features.Tenure` | `lsms_library/data_info.yml:159` | the house model for a canonical **vocabulary declaration**: `type: str`, a prose `note:`, and `spellings:` with *empty* variant lists | — | **model to copy** |
+| `_normalize_dataframe_index` | `lsms_library/country.py:4099` | **drops any index level not in `data_scheme.yml`'s `index:`**, then collapses duplicates | — | constraint: the `index:` line MUST be updated or the level is silently dropped at API time |
+| `harvest_kg` | `lsms_library/transformations.py:1132` | `groupby(['t','i',plot,'j']).sum()` over whatever levels are present | — | **unaffected** — name-based groupby, and it sums, so splitting rows leaves the total identical |
+| `_canonical_index_levels` / modal-shape exclusion | `lsms_library/feature.py:58`, `:487` | `Feature()` drops per-country frames whose `tuple(index.names)` differs from the modal shape | — | constraint: `crop_production` is **not** in `index_info`; Uganda is already modal-excluded |
+| `Country._/crop_production.py` | `Uganda/_/crop_production.py` | concatenates wave parquets + `id_walk`; index-agnostic | — | no change needed (docstring only) |
+
+## §3 Definitions & conventions in force
+
+- **Canonical schema single source of truth**: `lsms_library/data_info.yml`;
+  `tests/test_schema_consistency.py` reads it — never hardcode schema rules in tests
+  (`CLAUDE.md`, "Canonical Schema").
+- **`spellings` is an inverse dict** (canonical → accepted variants);
+  "The canonical values are simply `spellings.keys()`" — `lsms_library/data_info.yml:71-76`.
+- **Index-level value *enumerations* are not schema-able**: "Acquisition source `s` is an
+  INDEX level, not a column. … Enforced in code (`lsms_library.transformations.S_VALUES`);
+  data_info.yml has no schema for index-level value enumerations."
+  — `lsms_library/data_info.yml:247-250`.  See §5 for how this and `_enforce_canonical_spellings`
+  line 3962 are both true.
+- **Countries extend, they do not force-fit**: "Countries may extend this list rather than
+  force-fit a local category" — `lsms_library/data_info.yml:170` (`Tenure`), and the same
+  stance for `TenureSystem` at `:188`.
+- **`crop_production` is deliberately NOT registered in `index_info`**: "the plot-level ag
+  features (plot_labor/crop_production/plot_inputs) are NOT here: their per-country index
+  NAMES diverge (plot vs plot_id, crop vs j) and need harmonizing before registration --
+  tracked separately." — `lsms_library/data_info.yml:32-34`.
+- **Never write an unevidenced "no module here" claim** — `CLAUDE.md`, "Adjudicating
+  `absent` cells".  Applied here to the `a5aq6b`/`a5aq6c` inversion comment: it was
+  checked per wave against Stata metadata rather than trusted.
+- **`sane` is not `blessed`** — `CLAUDE.md`, "Coverage Matrix".  No cell is blessed by
+  this PR; no human has read the per-condition numbers in analysis.
+
+## §4 Invariants & assumptions
+
+- **The declared `index:` in `data_scheme.yml` is load-bearing.**  `_normalize_dataframe_index`
+  (`country.py:4160`) drops undeclared index levels and then collapses duplicates.  Adding
+  `condition` to the parquet without adding it to `index:` would be a silent no-op that
+  still sums fresh onto dry.
+- **The de-dup collapse uses `groupby(level=…)` with pandas' default `dropna=True`**
+  (`uganda.py:1084`), so any row with `pd.NA` in an index level is **silently dropped**.
+  This already loses 431 rows / 7.1 M native units in 2009-10 (NaN `plot`) — see §6.
+  Consequence for this task: `condition` must carry a **sentinel**, never `pd.NA`, exactly
+  as `u` already does (`df['u'] = … .where(df['u'].notna(), 'Unknown')`, `uganda.py:1078`).
+- **`_harmonized_codes` returns `pd.NA` for a code whose `Preferred Label` is blank or for
+  a code absent from the table** (`uganda.py:534`, plus the `.get(c, pd.NA)` at the call
+  site).  So off-scheme codes must be sentinel-filled by the caller.
+- **`uganda.py` resolves `categorical_mapping.org` relative to CWD** (`../../_/`), i.e. it
+  assumes the wave-script working directory.  Any harness must `chdir` into a wave `_/`.
+- **`u`, `plot`, `j` and now `condition` are all *object* index levels**; the collapse's
+  `groupby` is on level names, so level ORDER in the tuple is not load-bearing for it —
+  but it is for anyone slicing positionally.
+- **`t` is a string wave label**; `season` is `'A'`/`'B'`.
+
+## §5 Reuse decision
+
+| quantity | decision | reason |
+|----------|----------|--------|
+| condition code → label decode | **reuse** `_harmonized_codes` + a new `harvest_conditions` org table | identical shape to `harvest_units`; one table serves every wave because the integer code scheme is bit-identical across vintages (see `CONTENTS.org`) |
+| per-vintage source column | **extend** `CROP_COLMAPS` with a `condition:` key per condition dict | the `conditions:` list already exists for the wide 2019-20 slots |
+| canonical cross-country vocabulary | **extend** `data_info.yml` `Columns:` with a `crop_production.condition` entry in the `Tenure` style | `_enforce_canonical_spellings` (`country.py:3962`) *does* reach index levels — verified in code and by an executed unit test, not assumed |
+| index-level value **enforcement** (reject an off-vocabulary value) | **deferred** — needs an `S_VALUES`-style constant in `transformations.py`, which is core and out of scope | see §6 |
+| `index_info` registration of `crop_production` | **not done** | blocked on cross-country level-NAME harmonisation (`plot` vs `plot_id`, `crop` vs `j`) across 14 countries; `data_info.yml:32-34` says so explicitly.  Uganda is already modal-excluded from `Feature('crop_production')` today, before and after this change. |
+| reducer / `aggregation:` YAML | **rejected** | #323 D1: a new index level or nothing; `aggregation:` is dead config |
+
+## §6 Open questions for the human
+
+- **Enforcement follow-up (core).**  `spellings:` *declares* the vocabulary and rewrites
+  known variants, but nothing rejects a value outside it.  A follow-up core PR should add
+  either (a) a `CONDITION_VALUES` constant in `transformations.py` alongside `S_VALUES`, or
+  (b) a generic index-level enumeration check driven from `data_info.yml` — which would
+  also let `s` stop being special-cased.  (b) is the better shape; (a) is the precedent.
+- **`crop_production` in `index_info`.**  Requires renaming `crop`→`j` (10 countries) and
+  `plot`→`plot_id` (or the reverse) before registration, and a decision on whether Uganda's
+  `season` and `condition` become canonical levels or get fabricated as NaN for the other
+  13.  Separate PR; sized in the report.
+- **Pre-existing NaN-key row loss in the collapse** (431 rows / 7.1 M units in 2009-10,
+  43 rows / 962.5 in 2011-12).  Rows whose `plot` id is `pd.NA` vanish in
+  `groupby(level=…).sum()`.  Not caused by, and not fixed by, this PR — it is a separate
+  defect and is unchanged by it.
+- **2009-10 sentinel quantities.**  2009-10's `Quantity` sums to 3.18e8 native units,
+  ~300× every other wave, because `99999` is used as a missing sentinel and never stripped.
+  Separate defect.
+- **Second condition slot dropped for 2019-20 season B and 2018-19 season B.**
+  `agsec5b.dta` carries `s5bq06a_2/b_2/c_2` labelled "(2019, condition2)" with 1 306
+  non-null conditions; `CROP_COLMAPS['2019-20']['B']` reads only slot 1, so those harvest
+  records are absent from the table entirely.  Deliberately NOT added here: it *adds mass*,
+  which would destroy the "totals unchanged" invariant this PR is verified against.
+  Separate issue.
+
+---
+### Measured outcome (cold, isolated `LSMS_DATA_DIR`, 2026-07-21)
+
+| wave | dup groups before | after | rows before | rows after | Quantity before = after |
+|---|---:|---:|---:|---:|---:|
+| 2009-10 | 670 | 181 | 24 997 | 25 485 | 310,664,565.8 |
+| 2010-11 | 608 | 81 | 20 442 | 20 970 | 708,149.5 |
+| 2011-12 | 653 | 55 | 19 552 | 20 152 | 1,128,560.3 |
+| 2013-14 | 589 | 61 | 17 053 | 17 585 | 1,098,713.5 |
+| 2015-16 | 764 | 63 | 18 874 | 19 576 | 1,050,367.4 |
+| 2018-19 | 0 | 0 | 14 194 | 14 194 | 1,180,031.7 |
+| 2019-20 | 370 | 18 | 15 369 | 15 721 | 1,175,600.8 |
+| **total** | **3 654** | **459** | **130 481** | **133 683** | **317,005,989.0** |
+
+`Quantity_sold` (18,134,251.4) and `Value_sold` (9,066,365,499.8) totals are
+likewise identical before and after.  The 130 481 "before" figure is independently
+corroborated by the pre-change `Feature('crop_production')` run.
+
+`Feature('crop_production')` is byte-identical before and after: 250 692 rows, the
+same 8 kept countries, the same modal index, and the same 6 excluded frames
+(`Ethiopia, EthiopiaRHS, Mali, Nigeria, Tanzania, Uganda`) — Uganda was already
+excluded.
+
+Negative control: on the pre-fix tree `tests/test_uganda_crop_condition.py` gives
+6 failed / 3 errors / 1 passed, including `expected the dry (240) and fresh (100)
+coffee records to stay separate, got quantities [340.0]`.  Post-fix, from a
+physically cleared Uganda cache: 10 passed.
+
+### Phase 3 — verification
+
+- `crop_production_for_wave` (condition decode + sentinel) — **OK (anchored on §4)**: uses
+  `_harmonized_codes` per §5, sentinel-fills per the `u` precedent at `uganda.py:1078`, so
+  no new `pd.NA` index keys and no new silent row loss.
+- `harvest_conditions` org table — **OK (anchored on §2)**: same `Code | Preferred Label`
+  shape as `harvest_units`; codes are the 20 that carry Stata value labels, nothing invented.
+- `data_info.yml Columns.crop_production.condition` — **OK (anchored on §3)**: `Tenure`
+  shape, empty variant lists, prose `note:` carrying the "countries may extend" stance.
+- `data_scheme.yml index:` — **OK (anchored on §4)**: required, else `_normalize_dataframe_index`
+  drops the level.
+- No `aggregation:` key added; no reducer; no edit under `lsms_library/*.py` except the
+  config file `data_info.yml`.  `transformations.py` untouched.

--- a/.coder/ledger/323-uganda-crop-condition.md
+++ b/.coder/ledger/323-uganda-crop-condition.md
@@ -250,3 +250,43 @@ question (`a4aq7` "Cropping system" {1: Pure Stand, 2: Inter cropped}, or
 2: Mixed Stand}).  Agreement between the wired flag and the true crop-stand
 question is 48.5–52.5% — a coin flip.  Rewiring moves data, so it is filed as
 a Known Issue in `Uganda/_/CONTENTS.org`, not fixed here.
+
+### Prior art missed on the first pass (coordinator correction, 2026-07-21)
+
+I applied F1–F3 without reading `Uganda/_/CONTENTS.org` end to end — only the
+sections PR #649 itself had added. Re-read in full afterwards. One piece of
+genuine, pre-existing prior art was missed, and it bears directly on F3.
+
+**§"Unit handling for `food_acquired`"** (pre-dates the `condition` work;
+untouched by `b28b5024`) records the house convention for cross-wave label
+drift: the `u` table carries **one column per wave** (`2005-06` … `2019-20`)
+holding that wave's raw questionnaire string, "unused at runtime but
+preserv[ing] the cross-wave provenance".
+
+`categorical_mapping.org` therefore holds three shapes for one job:
+
+| table | shape | per-wave drift |
+|---|---|---|
+| `u` | Code, Preferred Label, one col per wave | representable |
+| `harvest_units` | Code, Preferred Label | not recorded |
+| `harvest_conditions` | Code, Preferred Label, `Source Label` | **lossy** |
+
+This reframes F3. The single `Source Label` column is not merely *where* the
+"verbatim" claim went wrong — it is **why** it could: one cell cannot hold two
+vintages' wordings, so codes 24/32/42 silently took the 2009-16 text and 99
+became a hand-made composite. The `u` table has no such failure mode; it
+preserves each wave's string separately, typos and all (`Small cup wuth
+handle(Akendo)`).
+
+Recommended follow-up (documented, not done): give `harvest_conditions` the
+`u` table's shape. Runtime-inert — `get_categorical_mapping` reads only
+`Code` + `Preferred Label` — and the 216 measured label pairs above are
+exactly the data needed to populate it. Left to the maintainer because the
+review scoped F3 to a prose correction.
+
+No **contradiction** was found: nothing pre-existing in `CONTENTS.org` asserts
+anything about code 99's incidence, the sentinel rate, or the unlabelled
+2009-10/2010-11 codes, so none of the F1/F2/F3 numbers overwrote a recorded
+decision. Checked the LOGBOOK/status entries too — the only one is on
+"Missing panel weight for 2019-20" (weights, unrelated); no `WAITING` caveats
+anywhere in the file.

--- a/lsms_library/countries/Uganda/2009-10/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2009-10/_/crop_production.py
@@ -2,9 +2,11 @@
 """crop_production for Uganda UNPS 2009-10 (GAP 1 item-level build).
 
 Reads AGSEC5A (season 1), AGSEC5B (season 2) and AGSEC4A (intercrop
-flag) via get_dataframe and emits a canonical (t,i,plot,j,u,season)
+flag) via get_dataframe and emits a canonical (t,i,plot,j,u,condition,season)
 parquet of REPORTED harvest values.  Harvest unit is a5aq6c (the column
-whose labels decode to Kg/Sack/Bunch); a5aq6b is the Fresh/Dry condition.
+whose labels decode to Kg/Sack/Bunch); the harvest CONDITION is a5aq6b,
+now an index level in its own right (GH #323/#637) so fresh and dry
+records for one plot-crop no longer collide and get summed.
 See uganda.CROP_COLMAPS for the per-wave column map.
 """
 import sys

--- a/lsms_library/countries/Uganda/2010-11/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2010-11/_/crop_production.py
@@ -2,9 +2,11 @@
 """crop_production for Uganda UNPS 2010-11 (GAP 1 item-level build).
 
 Reads AGSEC5A (season 1), AGSEC5B (season 2) and AGSEC4A (intercrop
-flag) via get_dataframe and emits a canonical (t,i,plot,j,u,season)
+flag) via get_dataframe and emits a canonical (t,i,plot,j,u,condition,season)
 parquet of REPORTED harvest values.  Harvest unit is a5aq6c (the column
-whose labels decode to Kg/Sack/Bunch); a5aq6b is the Fresh/Dry condition.
+whose labels decode to Kg/Sack/Bunch); the harvest CONDITION is a5aq6b,
+now an index level in its own right (GH #323/#637) so fresh and dry
+records for one plot-crop no longer collide and get summed.
 See uganda.CROP_COLMAPS for the per-wave column map.
 """
 import sys

--- a/lsms_library/countries/Uganda/2011-12/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2011-12/_/crop_production.py
@@ -2,9 +2,11 @@
 """crop_production for Uganda UNPS 2011-12 (GAP 1 item-level build).
 
 Reads AGSEC5A (season 1), AGSEC5B (season 2) and AGSEC4A (intercrop
-flag) via get_dataframe and emits a canonical (t,i,plot,j,u,season)
+flag) via get_dataframe and emits a canonical (t,i,plot,j,u,condition,season)
 parquet of REPORTED harvest values.  Harvest unit is a5aq6c (the column
-whose labels decode to Kg/Sack/Bunch); a5aq6b is the Fresh/Dry condition.
+whose labels decode to Kg/Sack/Bunch); the harvest CONDITION is a5aq6b,
+now an index level in its own right (GH #323/#637) so fresh and dry
+records for one plot-crop no longer collide and get summed.
 See uganda.CROP_COLMAPS for the per-wave column map.
 """
 import sys

--- a/lsms_library/countries/Uganda/2013-14/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2013-14/_/crop_production.py
@@ -2,9 +2,11 @@
 """crop_production for Uganda UNPS 2013-14 (GAP 1 item-level build).
 
 Reads AGSEC5A (season 1), AGSEC5B (season 2) and AGSEC4A (intercrop
-flag) via get_dataframe and emits a canonical (t,i,plot,j,u,season)
+flag) via get_dataframe and emits a canonical (t,i,plot,j,u,condition,season)
 parquet of REPORTED harvest values.  Harvest unit is a5aq6c (the column
-whose labels decode to Kg/Sack/Bunch); a5aq6b is the Fresh/Dry condition.
+whose labels decode to Kg/Sack/Bunch); the harvest CONDITION is a5aq6b,
+now an index level in its own right (GH #323/#637) so fresh and dry
+records for one plot-crop no longer collide and get summed.
 See uganda.CROP_COLMAPS for the per-wave column map.
 """
 import sys

--- a/lsms_library/countries/Uganda/2015-16/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2015-16/_/crop_production.py
@@ -2,9 +2,11 @@
 """crop_production for Uganda UNPS 2015-16 (GAP 1 item-level build).
 
 Reads AGSEC5A (season 1), AGSEC5B (season 2) and AGSEC4A (intercrop
-flag) via get_dataframe and emits a canonical (t,i,plot,j,u,season)
+flag) via get_dataframe and emits a canonical (t,i,plot,j,u,condition,season)
 parquet of REPORTED harvest values.  Harvest unit is a5aq6c (the column
-whose labels decode to Kg/Sack/Bunch); a5aq6b is the Fresh/Dry condition.
+whose labels decode to Kg/Sack/Bunch); the harvest CONDITION is a5aq6b,
+now an index level in its own right (GH #323/#637) so fresh and dry
+records for one plot-crop no longer collide and get summed.
 See uganda.CROP_COLMAPS for the per-wave column map.
 """
 import sys

--- a/lsms_library/countries/Uganda/2018-19/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2018-19/_/crop_production.py
@@ -2,10 +2,17 @@
 """crop_production for Uganda UNPS 2018-19 (GAP 1 item-level build).
 
 Reads AGSEC5A (season 1), AGSEC5B (season 2) and AGSEC4A (intercrop
-flag) via get_dataframe and emits a canonical (t,i,plot,j,u,season)
-parquet of REPORTED harvest values.  Harvest unit is a5aq6c (the column
-whose labels decode to Kg/Sack/Bunch); a5aq6b is the Fresh/Dry condition.
-See uganda.CROP_COLMAPS for the per-wave column map.
+flag) via get_dataframe and emits a canonical (t,i,plot,j,u,condition,season)
+parquet of REPORTED harvest values.
+
+2018-19 is the odd wave.  AGSEC5A carries NO harvest-unit column at all
+(-> u='Unknown'); its condition is a5aq6b (labelled) -- a5aq6c holds the
+same 20-code condition scheme unlabelled and disagreeing on 158 of 7 144
+rows, so the labelled column wins.  AGSEC5B does carry a unit (a5bq6b,
+40 labels) with the condition in a5bq6c, but the unit is still wired as
+None here; wiring it is a separate defect (see Uganda/_/CONTENTS.org).
+The harvest CONDITION is now an index level in its own right
+(GH #323/#637).  See uganda.CROP_COLMAPS for the per-wave column map.
 """
 import sys
 sys.path.append('../../_/')

--- a/lsms_library/countries/Uganda/2019-20/_/crop_production.py
+++ b/lsms_library/countries/Uganda/2019-20/_/crop_production.py
@@ -3,8 +3,20 @@
 
 2019-20 keeps the WB column names (s5aq06b_1 = harvest unit, s5aq06c_1 =
 condition) and records two parallel harvest conditions (_1 / _2) per
-(plot, crop); both are emitted as separate reported rows.  Crop module
-lives under Data/Agric/.  See uganda.CROP_COLMAPS['2019-20'].
+(plot, crop); both are emitted as separate reported rows.  The _1/_2 slot
+number is NOT an ordinal "first/second harvest" -- the Stata variable
+labels read "(2018, full harvest, condition1/condition2)" and each slot
+carries its own 6c condition column drawing on the same 20-code scheme as
+the 2009-16 long-form waves.  That condition is now an index level
+(GH #323/#637).
+
+KNOWN GAP: season B's agsec5b.dta also carries a slot _2
+(s5bq06a_2 / s5bq06b_2 / s5bq06c_2, labelled "(2019, condition2)", 1 306
+non-null conditions) which CROP_COLMAPS does not read, so those harvest
+records are absent from the table entirely.  Adding them ADDS mass and so
+is deliberately left to a separate change; see Uganda/_/CONTENTS.org.
+
+Crop module lives under Data/Agric/.  See uganda.CROP_COLMAPS['2019-20'].
 """
 import sys
 sys.path.append('../../_/')

--- a/lsms_library/countries/Uganda/_/CONTENTS.org
+++ b/lsms_library/countries/Uganda/_/CONTENTS.org
@@ -238,7 +238,212 @@ concern from =u= label canonicalisation.  Its keys are the same
 
 For the cross-country canonical-=u= roadmap, see GH #223.
 
+* Harvest condition on =crop_production= (GH #323 / #637)
+
+** The defect
+
+The UNPS post-harvest module (AGSEC5A season A / AGSEC5B season B) asks
+question 6 as a single compound question: *how much did you harvest, in
+what unit, and in what condition/state*.  A household that took some of a
+crop off a plot fresh and the rest after drying it answers TWICE.  Both
+answers are separate source rows (2009-16) or separate parallel column
+slots (2018-20).
+
+=crop_production= was keyed =(t, i, plot, j, u, season)=, with no level
+for the condition, so those answers landed on the same index tuple and the
+de-duplication block at the end of =uganda.crop_production_for_wave= summed
+them.  Dry weight was added to fresh weight.  A measured example from
+2011-12:
+
+#+begin_example
+HH 1033000506  plot -1-6  Coffee  Kilogram (KG)
+   240 kg  "Dry after additional drying - in pods or shell/husks"  month 6
+   100 kg  "Fresh/raw harvested - in pods or shell/husks"          month 6
+   -> summed to 340 kg
+#+end_example
+
+340 is not a quantity of anything.  Across the panel this affected *3 654
+index groups*.
+
+The quietest instances were 2009-10 and 2010-11: those waves have no
+harvest-month column, so *every* one of their collisions looked like an
+exact duplicate of an identical record, while in fact fresh and dry
+weights were being added together.
+
+** Fix: =condition= is an index level
+
+The grain is now =(t, i, plot, j, u, condition, season)=.  Labels come
+from the =harvest_conditions= table in =_/categorical_mapping.org=, via
+=uganda._harvest_condition_map()=; the canonical cross-country vocabulary
+is declared in =lsms_library/data_info.yml= under
+=Columns > crop_production > condition=.
+
+*Quantities in different conditions are not commensurable.*  Do not sum
+across this level without a drying / shelling conversion.  =transformations.harvest_kg=
+groups by =(t, i, plot, j)= and therefore still sums across conditions —
+that is a *pre-existing* property of that transform, unchanged by this
+work, and it remains the caller's problem (its own docstring already warns
+that its unit coverage is a lower bound).
+
+** Which source column is the unit and which is the condition
+
+Decided by the VALUE-LABEL vocabulary, never by the variable label.  The
+unit column's labels decode to Kg / Sack (100 kgs) / Bunch (Big); the
+condition column's to Green / Fresh / Dry ....  Verified per wave against
+the Stata metadata on 2026-07-21:
+
+| wave    | file    | condition | unit      | note                                                    |
+|---------+---------+-----------+-----------+---------------------------------------------------------|
+| 2009-10 | AGSEC5A | a5aq6b    | a5aq6c    | no value labels at all; matched by code distribution     |
+| 2009-10 | AGSEC5B | a5bq6b    | a5bq6c    | ditto                                                    |
+| 2010-11 | AGSEC5A | a5aq6b    | a5aq6c    | ditto                                                    |
+| 2010-11 | AGSEC5B | a5bq6b    | a5bq6c    | ditto                                                    |
+| 2011-12 | AGSEC5A | a5aq6b    | a5aq6c    | variable + value labels agree                            |
+| 2011-12 | AGSEC5B | a5bq6b    | a5bq6c    | variable + value labels agree                            |
+| 2013-14 | AGSEC5A | a5aq6b    | a5aq6c    | *variable labels are swapped*; value labels are correct  |
+| 2013-14 | AGSEC5B | a5bq6b    | a5bq6c    | variable + value labels agree                            |
+| 2015-16 | AGSEC5A | a5aq6b    | a5aq6c    | variable + value labels agree                            |
+| 2015-16 | AGSEC5B | a5bq6b    | a5bq6c    | value labels mojibaked (=ï¿½= for the en-dash)           |
+| 2018-19 | AGSEC5A | a5aq6b    | (none)    | no unit column exists -> u='Unknown'                     |
+| 2018-19 | AGSEC5B | a5bq6c    | a5bq6b*   | *unit exists but is NOT wired; see Known Issues          |
+| 2019-20 | agsec5a | s5aq06c_1 | s5aq06b_1 | slot 1                                                   |
+| 2019-20 | agsec5a | s5aq06c_2 | s5aq06b_2 | slot 2                                                   |
+| 2019-20 | agsec5b | s5bq06c_1 | s5bq06b_1 | slot 1 (slot 2 not wired; see Known Issues)              |
+
+A comment previously in =uganda.py= claimed "the WB .do's A5aq6b/A5aq6c
+unit/condition rename is inverted for these actual UNPS files".  That is
+*true of exactly one file* — 2013-14 AGSEC5A, where =a5aq6b= is titled
+"Unit of quantity for the crop harvested" but carries the condition value
+labels, and =a5aq6c= is titled "Condition/state of the harvested crop" but
+carries the unit value labels.  Every other wave labels its variables
+correctly.  The wiring (=6c= = unit) was right in all cases; only the
+explanation was overstated.
+
+2018-19 AGSEC5A additionally carries an =a5aq6c= that holds the *same*
+20-code condition scheme, unlabelled, disagreeing with =a5aq6b= on 158 of
+7 144 rows.  The labelled column (=a5aq6b=) is used.
+
+** The two vintages encode the same vocabulary
+
+- *2009-16 (LONG)* — one column group per season; the condition is a VALUE
+  in =a5aq6b= / =a5bq6b=, with multiple source rows per plot-crop.
+- *2018-20 (WIDE)* — parallel =_1= / =_2= slots; the condition for each
+  slot is a value in that slot's own 6c column.  The slot number is *not*
+  an ordinal "first/second harvest": the 2019-20 Stata variable labels read
+  literally "6c. Condition/state of crop harvested (2018, full harvest,
+  condition1)" and "(… condition2)".
+
+They are the same vocabulary — in fact the same *integer codes*.  Every
+wave that carries value labels (2011-12, 2013-14, 2015-16, 2018-19,
+2019-20) uses the identical 20-code set; only the label TEXT drifts
+(en-dash vs hyphen, mojibake in 2015-16 AGSEC5B, and code 99 reading
+"Others" in 2011-12 but "Not Applicable" in 2018-20).  One
+=harvest_conditions= table therefore serves all vintages, and no
+harmonisation between them was needed or invented.
+
+Worked example, =agsec5a.dta= row index 3 (2019-20): same maize, same
+plot, same month; slot _1 = 80.0 Kilogram(KG) "Dry - grain", slot _2 = 2.0
+Plastic Basin(15 lts) "Fresh/raw harvested - in the cob".
+
+The scheme is a 2-D cross of a dryness family (tens digit: 1 green, 2
+fresh/raw, 3 dry at harvest, 4 dry after additional drying) with a
+physical form (units digit: 0 n/a, 1 with shell/cob and stalk, 2 with
+shell/cob without stalk, 3 in the cob, 4 in pods/shell/husks, 5 grain).
+The =Preferred Label= strings encode exactly that cross.
+
+*Hypothesis, deliberately not acted on*: the unlabelled 2009-10/2010-11
+codes 10, 15, 25, 30 and 34 fit the grid (=green n/a=, =green grain=,
+=fresh grain=, =dry-at-harvest n/a=, =dry-at-harvest in pods=) and account
+for roughly half of those waves' off-scheme rows.  No wave labels them, so
+they are NOT given Preferred Labels; they fall to =unknown_condition=.
+
+** Effect (cold rebuild, isolated data dir, 2026-07-21)
+
+| wave    | dup groups before | after | rows before | rows after | Quantity (unchanged) |
+|---------+-------------------+-------+-------------+------------+----------------------|
+| 2009-10 |               670 |   181 |       24997 |      25485 |        310,664,565.8 |
+| 2010-11 |               608 |    81 |       20442 |      20970 |            708,149.5 |
+| 2011-12 |               653 |    55 |       19552 |      20152 |          1,128,560.3 |
+| 2013-14 |               589 |    61 |       17053 |      17585 |          1,098,713.5 |
+| 2015-16 |               764 |    63 |       18874 |      19576 |          1,050,367.4 |
+| 2018-19 |                 0 |     0 |       14194 |      14194 |          1,180,031.7 |
+| 2019-20 |               370 |    18 |       15369 |      15721 |          1,175,600.8 |
+|---------+-------------------+-------+-------------+------------+----------------------|
+| total   |              3654 |   459 |      130481 |     133683 |        317,005,989.0 |
+
+Collisions fall 87.4%.  =Quantity=, =Quantity_sold= and =Value_sold= totals
+are *identical* per wave before and after — as they must be: summing is
+conservative, so a correct fix moves rows apart, it does not create or
+destroy mass.
+
+*Residual 459 groups.*  These are now all *commensurable*: same crop, same
+unit, same condition, so summing them is arithmetically valid, which is
+precisely what was not true before.  Breakdown: 50 groups' rows differ in
+=harvest_month= (two harvest events of the same crop in the same state);
+~320 differ only in =Quantity= (repeat entries within the module, or both
+2019-20 slots reporting the same condition); 49 are byte-identical rows
+(a genuinely duplicated source record — note the collapse SUMS these, so a
+repeated record still doubles; pre-existing behaviour, not addressed here);
+37 carry the =unknown_condition= sentinel in the key and so may still hide
+a real condition difference (28 of them in 2009-10).
+
+*=unknown_condition= incidence*: 7 994 of 133 683 rows (6.0%), concentrated
+in the two unlabelled waves — 2009-10 5 911, 2010-11 914, 2011-12 712,
+2013-14 409, 2015-16 26, 2018-19 9, 2019-20 13.  Most are rows where the
+condition column is simply null, not off-scheme codes (only ~500 rows in
+the whole panel carry a code outside the 20-code scheme).
+
+** Cross-country status
+
+=crop_production= is NOT registered in =lsms_library/data_info.yml=
+=Index Info > index_info=, by an explicit decision recorded there: the
+plot-level ag features' per-country index NAMES diverge (=plot= vs
+=plot_id=, =crop= vs =j=) and must be harmonised first.  Uganda was
+therefore *already* excluded from =Feature('crop_production')= before this
+change — its shape =['i','t','v','plot','j','u','season']= differs from the
+modal =['i','t','v','plot','crop','u']= — alongside Ethiopia, EthiopiaRHS,
+Mali, Nigeria and Tanzania.  Adding =condition= cannot and does not change
+the set of countries Feature keeps.
+
 * Known Issues
+** TODO 2018-19 AGSEC5B harvest unit is available but not wired
+
+=CROP_COLMAPS['2018-19']['B']= sets =unit: None=, so every 2018-19 season-B
+harvest row carries =u='Unknown'=.  But =a5bq6b= exists in that file,
+titled "6b. Unit", with the full 40-label =harvest_units= vocabulary and
+7 041 non-null values.  (Season A genuinely has no unit column; the
+long-standing note "2018-19's harvest side carries no unit label" is
+correct for 5A and wrong for 5B.)  Wiring it would move rows between =u=
+values, so it is a separate change with its own before/after.
+
+** TODO Second condition slot dropped for 2019-20 season B
+
+=agsec5b.dta= (2019-20) carries =s5bq06a_2= / =s5bq06b_2= / =s5bq06c_2=,
+labelled "(2019, condition2)", with 1 306 non-null conditions.
+=CROP_COLMAPS= reads only slot 1, so those harvest records are absent from
+=crop_production= entirely.  2018-19 AGSEC5B likewise has an =_2= slot, but
+there its variable label reads "during the second season of 2017" — i.e.
+it may be a SEASON slot rather than a condition slot, and needs the
+questionnaire before it is wired.  Adding either ADDS mass, so both are
+deliberately outside the #323 condition fix (which is verified against a
+"totals unchanged" invariant).
+
+** TODO Duplicate collapse silently drops rows with a null index key
+
+=crop_production_for_wave='s de-duplication uses
+=groupby(level=...)=, whose pandas default is =dropna=True=.  Any row with
+=pd.NA= in an index level therefore *vanishes*.  Measured: 431 rows /
+7 108 132 native units in 2009-10 and 43 rows / 962.5 in 2011-12, all with
+a null =plot= id (the =hhid-parcel-plot= concatenation propagates NA).
+Unrelated to and unchanged by the =condition= work; =condition= is
+sentinel-filled precisely so it does not add to this.
+
+** TODO 2009-10 harvest quantities carry an unstripped 99999 sentinel
+
+2009-10's =Quantity= sums to 3.18e8 native units, ~300x every other wave,
+because =99999= is used as a missing-value sentinel and never removed.
+Any analysis touching 2009-10 =crop_production= quantities must filter it.
+
 ** TODO Missing panel weight for 2019-20
 :LOGBOOK:
 - Note taken on [2026-04-09 Wed] \\

--- a/lsms_library/countries/Uganda/_/CONTENTS.org
+++ b/lsms_library/countries/Uganda/_/CONTENTS.org
@@ -333,13 +333,80 @@ explanation was overstated.
   literally "6c. Condition/state of crop harvested (2018, full harvest,
   condition1)" and "(… condition2)".
 
-They are the same vocabulary — in fact the same *integer codes*.  Every
-wave that carries value labels (2011-12, 2013-14, 2015-16, 2018-19,
-2019-20) uses the identical 20-code set; only the label TEXT drifts
-(en-dash vs hyphen, mojibake in 2015-16 AGSEC5B, and code 99 reading
-"Others" in 2011-12 but "Not Applicable" in 2018-20).  One
-=harvest_conditions= table therefore serves all vintages, and no
-harmonisation between them was needed or invented.
+They are the same vocabulary — in fact the same *integer codes*, with one
+documented exception: 2011-12, 2018-19 and 2019-20 label all 20 codes;
+2013-14 and 2015-16 label the same 19 *without 99*, although 32 rows in
+each of those waves use code 99.  Only the label TEXT otherwise drifts
+(en-dash vs hyphen, mojibake in 2015-16 AGSEC5B, collapsed double spaces
+in 2018-19, and code 99 reading "Others" in 2011-12 but "Not Applicable"
+in 2018-20).  One =harvest_conditions= table therefore serves all
+vintages, and no harmonisation between them was needed or invented.
+
+*** Code 99 is merged across vintages — the true incidence
+
+Corrected 2026-07-21 after adversarial review of PR #649.  The
+=categorical_mapping.org= comment used to justify the merge by asserting
+that code 99 was "only 3 rows in the whole panel and none after 2011-12".
+That was false by roughly 100x.  Measured on a cold rebuild (isolated
+=LSMS_DATA_DIR=, only =dvc-cache= symlinked in; Uganda cache physically
+removed; =LSMS_COUNTRIES_ROOT= pinned to the branch worktree):
+
+| wave                        | 2009-10 | 2010-11 | 2011-12 | 2013-14 | 2015-16 | 2018-19 | 2019-20 | total |
+|-----------------------------+---------+---------+---------+---------+---------+---------+---------+-------|
+| raw source rows, code 99    |       2 |       0 |     160 |      32 |      32 |      32 |     123 |   381 |
+| built rows, =other_condition= |     1 |       0 |     120 |      32 |      32 |      32 |     123 |   340 |
+
+So *219 of the 340 built rows are after 2011-12* — precisely the case the
+old comment said did not exist.  (Raw exceeds built because the
+duplicate-collapse merges commensurable rows and the =j=-null filter drops
+some.)  Code 99 means three different things across the panel: "Others"
+in 2011-12, "Not Applicable" in 2018-19/2019-20, and *nothing labelled at
+all* in 2013-14/2015-16.
+
+The merge onto one =other_condition= value is nonetheless kept, for
+reasons that survive the corrected numbers:
+
+1. =t= is an index level, so a 2011-12 "Others" tuple and a 2019-20 "Not
+   Applicable" tuple can never coincide.  Nothing is summed, aggregated or
+   de-duplicated across the vintage boundary — verified, no wave-crossing
+   collision exists.  The merge is a *naming* choice and the vintage stays
+   recoverable by the reader from =t=.
+2. 99 is the scheme's own residual slot in every vintage: the code the
+   instrument uses when the dryness x form grid does not apply.
+   =other_condition= names the slot without asserting which residual
+   reading applies.
+3. Splitting would need a THIRD value for 2013-14/2015-16, where no wave
+   says what 99 means — i.e. inventing a label the source does not carry.
+
+A future PR wanting finer semantics should split into =other_condition=
+(2011-12) / =not_applicable_condition= (2018-20), leaving 2009-10 /
+2013-14 / 2015-16 on the sentinel.  That MOVES 340 rows between index
+values, so it needs its own before/after and is out of scope for a
+comment correction.
+
+*** =Source Label= is a normalized representative, not a verbatim quote
+
+Also corrected 2026-07-21.  Of the 216 (code, wave, season) value-label
+pairs across the five labelled waves, *60 match the org file's
+=Source Label= column literally and 156 do not*.  The column is the
+2018-20 wording with whitespace runs collapsed, except for four codes
+where the two vintages differ in WORDING rather than punctuation and the
+column keeps the longer 2009-16 phrasing:
+
+| code | 2018-20 raw label                        | =Source Label=                                             |
+|------+------------------------------------------+------------------------------------------------------------|
+|   24 | Fresh/raw harvested - in pods            | Fresh/raw harvested - in pods or shell/husks               |
+|   32 | Dry at harvest - with shell              | Dry at harvest - with shell/cob without stalk              |
+|   42 | Dry after additional drying - with shell | Dry after additional drying - with shell and without stalk |
+|   99 | Not Applicable                           | Others / Not Applicable                                    |
+
+Code 99's entry is not a quote of anything: no wave writes "Others / Not
+Applicable".  Separately, code *45*'s PREFERRED label is an inference:
+every labelled wave writes exactly "Dry - grain", and =dried_grain= (the
+4x additional-drying family) is deduced from grid position — 35 already
+occupies "Dry at harvest - grain".  That code covers 40 411 of 133 683
+rows (30%), so the inference is load-bearing and is now stated rather
+than implied.
 
 Worked example, =agsec5a.dta= row index 3 (2019-20): same maize, same
 plot, same month; slot _1 = 80.0 Kilogram(KG) "Dry - grain", slot _2 = 2.0
@@ -388,10 +455,82 @@ repeated record still doubles; pre-existing behaviour, not addressed here);
 a real condition difference (28 of them in 2009-10).
 
 *=unknown_condition= incidence*: 7 994 of 133 683 rows (6.0%), concentrated
-in the two unlabelled waves — 2009-10 5 911, 2010-11 914, 2011-12 712,
-2013-14 409, 2015-16 26, 2018-19 9, 2019-20 13.  Most are rows where the
-condition column is simply null, not off-scheme codes (only ~500 rows in
-the whole panel carry a code outside the 20-code scheme).
+in the two unlabelled waves — 2009-10 5 911 (23.2% of that wave), 2010-11
+914 (4.4%), 2011-12 712 (3.5%), 2013-14 409 (2.3%), 2015-16 26 (0.1%),
+2018-19 9 (0.1%), 2019-20 13 (0.1%).  Most are rows where the condition
+column is simply null, not off-scheme codes: only 492 rows in the whole
+panel carry a code outside the 20-code scheme (297 = 1.1% of 2009-10, 192
+= 0.9% of 2010-11, 3 in 2011-12, none later).  *Do not read the ~1%
+off-scheme rate as the sentinel rate* — =data_scheme.yml= conflated the
+two until 2026-07-21.
+
+By (wave, season), the sentinel share is 25.7 / 20.5% (2009-10 A/B), 7.1 /
+1.0% (2010-11), 3.6 / 3.4% (2011-12), 0.3 / 4.4% (2013-14), 0.2 / 0.03%
+(2015-16), 0.13 / 0.00% (2018-19), 0.12 / 0.04% (2019-20); distinct
+non-sentinel conditions per cell range 18–20.  Those two ranges are what
+=tests/test_uganda_crop_condition.py= turns into per-cell invariants (see
+"A mis-wired colmap must fail loudly" below).
+
+** A mis-wired colmap must fail loudly
+
+Added 2026-07-21 after the PR #649 review demonstrated the gap by mutation.
+=crop_production_for_wave= used to guard every colmap lookup with
+=if cond.get(k) and cond[k] in df5.columns=, silently falling back when the
+named column was absent.  Every one of those fallbacks is *invisible in the
+output*: a mis-typed =condition= sentinels a whole wave-season to
+=unknown_condition=, a mis-typed =qty= drops the slot entirely, a mis-typed
+=unit= sets =u='Unknown'= everywhere.  The reviewer typo'd
+=CROP_COLMAPS['2018-19']['A']='s condition column, cleared the cache, and
+*all 10 tests passed* while that cell went to =unknown_condition= on 7 153
+of 7 153 rows.
+
+Two changes close it.
+
+1. *A NAMED column that does not resolve now raises =CropColmapError=*
+   (=uganda._require=).  =None= remains the declared, auditable way to say
+   "this wave records no such column" — 2018-19 season A genuinely has no
+   harvest unit.  A NAME is a claim about the source file, and it is now
+   checked.  *Measured no-op*: across all 7 waves x 2 seasons x every slot,
+   exactly one named column failed to resolve (see the 2010-11 intercrop
+   flag under Known Issues, fixed to =None= in the same change), and a cold
+   rebuild before/after is byte-identical — 133 683 rows, Quantity
+   317 005 989.0, Quantity_sold 18 134 251.4, Value_sold 9 066 365 499.8,
+   =intercropped= non-null 75 625 on both sides.
+
+2. *Three tests in =tests/test_uganda_crop_condition.py=*, deliberately
+   complementary because they catch different mistakes:
+   - =test_crop_colmap_columns_resolve_in_source= — a NAMED column must
+     exist in the file it is read from.  Catches typos and dropped columns.
+     Reads raw Stata, so it is S3-credential-guarded and skips in the
+     data-free CI job.
+   - =test_sentinel_share_bounded_per_wave_season= — no (wave, season) may
+     exceed 40% =unknown_condition=.  Worst honest cell measured is 2009-10
+     season A at 25.7%; a collapsed cell is ~100%.
+   - =test_condition_varies_within_every_wave_season= — every (wave,
+     season) must decode at least 10 distinct non-sentinel conditions.
+     Measured minimum is 18.
+
+   Mutation-proved both ways.  Typo =a5aq6b= -> =a5aq6b_TYPO=: the build
+   now raises and the module goes *1 failed + 8 errors* (was 10 passed).
+   Point the condition at an existing-but-wrong integer column
+   (=s5aq06f_1=, the harvest month — a plausible 6f/6b fat-finger): the
+   build succeeds, the resolve test passes, the sentinel share is only
+   33.7% so the *ceiling test also passes*, and the variety test catches it
+   at 2 distinct conditions.  Neither invariant alone is sufficient, which
+   is why both are kept.
+
+   The panel-wide checks cannot do this work: =test_condition_values_are_-
+   canonical= passes because =unknown_condition= IS canonical, and
+   =test_condition_actually_separates_records=' >1000 threshold survives
+   the loss of any single cell.
+
+3. Relatedly, =test_fresh_and_dry_no_longer_collide= no longer carries
+   =if sel.empty: pytest.skip(...)=.  A skip-on-empty escape hatch on the
+   fix's single most important regression test would let an id remapping
+   disarm it rather than fail it.  The =crop_production= fixture likewise
+   now re-raises a build failure when S3 credentials ARE present (it still
+   skips without them), so a config bug turns the module red instead of
+   reporting eight quiet skips.
 
 ** Cross-country status
 
@@ -406,6 +545,57 @@ Mali, Nigeria and Tanzania.  Adding =condition= cannot and does not change
 the set of countries Feature keeps.
 
 * Known Issues
+** TODO =crop_production.intercropped= is wired to the SEED-USE question
+
+Found 2026-07-21 while closing the "silent colmap" gap above, by reading
+the Stata variable labels of every column =CROP_COLMAPS[...]['intercrop']=
+names.  *Not* raised in the PR #649 review.
+
+=crop_production_for_wave= builds =intercropped= from
+=colmap['intercrop']['flag']=, recoding =2 -> True=.  In every wave that
+populates the column, that flag points at the *seed-use* question, whose
+value labels are {1: Yes, 2: No} — so =intercropped=True= currently means
+"did NOT use seed/seedlings for this crop":
+
+| wave    | wired flag | its variable label                            | its value labels |
+|---------+------------+-----------------------------------------------+------------------|
+| 2011-12 | =a4aq3=    | Did you use any seed or for this crop?        | 1 Yes, 2 No      |
+| 2013-14 | =a4aq16=   | A4AQ16: Did you use any seed or seedlings...  | 1 Yes, 2 No      |
+| 2015-16 | =a4aq16=   | A4aq16: did you use any seed or seedlings...  | 1 Yes, 2 No      |
+| 2018-19 | =s4aq16=   | 16. Did you use any seed/seedlings?           | 1 Yes, 2 No      |
+| 2019-20 | =s4aq16=   | 16. Did you use any seed/seedlings?           | 1 Yes, 2 No      |
+
+The actual cropping-system question is a different column in the same
+file, and it is present in *every* wave:
+
+| wave              | column            | variable label                              | value labels                    |
+|-------------------+-------------------+---------------------------------------------+---------------------------------|
+| 2009-10, 2010-11  | =a4aq7=           | Cropping system                             | 1 Pure Stand, 2 Inter cropped   |
+| 2011-12 … 2015-16 | =a4aq8=           | What type of crop stand was on the plot?    | 1 Pure Stand, 2 Mixed Stand     |
+| 2018-19, 2019-20  | =s4aq08=          | 8. What type of crop stand was on the plot? | 1 Pure Stand, 2 Mixed Stand     |
+
+The two are near-independent, so the current column is close to noise:
+=(wired == 2)= agrees with =(crop-stand == 2)= on 48.5% / 48.8% / 52.5% /
+51.8% / 52.5% of rows (2011-12 … 2019-20) — a coin flip.  The "yes"
+rates differ too (33–42% wired vs 50–58% true crop-stand).
+
+*Any analysis using =crop_production.intercropped= today is using the
+seed-purchase question.*  Rewiring MOVES data (and would newly populate
+2009-10 and 2010-11, which are 100% NaN today), so it is a separate change
+with its own before/after — not folded into a comment-and-tests PR.
+
+** DONE 2010-11 intercrop flag named a column that does not exist
+
+=CROP_COLMAPS['2010-11']['intercrop']['flag']= was ='a4aq3'=, but 2010-11
+AGSEC4A ships only =['HHID','prcid','pltid','cropID','a4aq7'..'a4aq14']= —
+there is no =a4aq3=.  The old =in df4a.columns= guard swallowed it, so
+=intercropped= was NaN on all 20 970 rows of that wave with nothing said.
+Set to =None= (a provable no-op: the build output is byte-identical), so
+the config now states what the build already did and the strict check
+above can be applied uniformly.  Note this wave DOES carry =a4aq7=
+"Cropping system" {1: Pure Stand, 2: Inter cropped}; wiring it belongs
+with the item above.
+
 ** TODO 2018-19 AGSEC5B harvest unit is available but not wired
 
 =CROP_COLMAPS['2018-19']['B']= sets =unit: None=, so every 2018-19 season-B

--- a/lsms_library/countries/Uganda/_/CONTENTS.org
+++ b/lsms_library/countries/Uganda/_/CONTENTS.org
@@ -408,6 +408,46 @@ occupies "Dry at harvest - grain".  That code covers 40 411 of 133 683
 rows (30%), so the inference is load-bearing and is now stated rather
 than implied.
 
+**** The house convention for per-wave label drift already exists, and this table does not follow it
+
+Noted 2026-07-21, while re-reading this file end to end.  *"Unit handling
+for =food_acquired="* above (a section that predates the =condition= work)
+records the established shape:
+
+#+begin_quote
+The =u= table also retains the per-wave variant columns (=2005-06=,
+=2009-10=, ..., =2019-20=) that document the raw label appearing in each
+wave's questionnaire.  These extra columns are unused at runtime but
+preserve the cross-wave provenance previously captured in the retired
+=_/unitlabels.py= file.
+#+end_quote
+
+So =categorical_mapping.org= holds *three different shapes* for the same
+job:
+
+| table                 | shape                                    | per-wave drift |
+|-----------------------+------------------------------------------+----------------|
+| =u=                   | Code, Preferred Label, one col PER WAVE  | representable  |
+| =harvest_units=       | Code, Preferred Label                    | not recorded   |
+| =harvest_conditions=  | Code, Preferred Label, =Source Label=    | *lossy*        |
+
+The single =Source Label= column is the **root cause of the defect
+corrected above**, not merely its location: one cell cannot hold two
+vintages' wordings, so codes 24 / 32 / 42 silently took the 2009-16 text
+and 99 became a hand-made composite.  The =u= table has no such problem —
+it carries each wave's raw string in its own column, typos and all
+(=Small cup wuth handle(Akendo)= is preserved verbatim in six waves).
+
+*Recommended follow-up*: give =harvest_conditions= the =u= table's shape —
+replace =Source Label= with one column per labelled wave (2011-12,
+2013-14, 2015-16, 2018-19, 2019-20; 2009-10 and 2010-11 stay blank, as
+they ship no value labels, exactly as the =u= table leaves blanks).  It is
+**runtime-inert** — =get_categorical_mapping= reads only =Code= +
+=Preferred Label= — and the measured per-wave strings needed to populate
+it are the 216 label pairs recorded above.  Not done here because the
+PR #649 review scoped this finding to a prose correction and a table
+reshape is the maintainer's call, not a side effect of one.
+
 Worked example, =agsec5a.dta= row index 3 (2019-20): same maize, same
 plot, same month; slot _1 = 80.0 Kilogram(KG) "Dry - grain", slot _2 = 2.0
 Plastic Basin(15 lts) "Fresh/raw harvested - in the cob".

--- a/lsms_library/countries/Uganda/_/categorical_mapping.org
+++ b/lsms_library/countries/Uganda/_/categorical_mapping.org
@@ -877,6 +877,16 @@
 # Applicable".  It is a composite, and it is the one place in this table
 # where reading the Source Label as a quotation would mislead.
 #
+# THE SINGLE `Source Label` COLUMN IS THE ROOT CAUSE, not just the place the
+# error sits: one cell cannot hold two vintages' wordings.  The `u` table
+# further up THIS FILE already solves exactly this, with one column PER WAVE
+# (2005-06 ... 2019-20) carrying that wave's raw string verbatim, typos
+# included -- see CONTENTS.org "Unit handling for food_acquired", which
+# predates this table and which `harvest_conditions` did not follow.  The
+# recommended fix is to adopt the `u` shape here (runtime-inert:
+# get_categorical_mapping reads only Code + Preferred Label); it is written
+# up under CONTENTS.org "The house convention for per-wave label drift".
+#
 # Code 45's PREFERRED Label is likewise an inference, not a reading.  Every
 # labelled wave writes exactly "Dry - grain"; `dried_grain` (i.e. dry AFTER
 # ADDITIONAL DRYING, the 4x family) is inferred from the code's position in

--- a/lsms_library/countries/Uganda/_/categorical_mapping.org
+++ b/lsms_library/countries/Uganda/_/categorical_mapping.org
@@ -849,23 +849,96 @@
 # canonical vocabulary is declared cross-country in
 # lsms_library/data_info.yml (Columns > crop_production > condition).
 #
-# Source Label is the VERBATIM Stata value label, for provenance; it is not
-# read at runtime (get_categorical_mapping selects Code + Preferred Label).
-# The label text drifts cosmetically across vintages -- 2009-16 uses an
-# en-dash, 2018-20 a hyphen, 2015-16 AGSEC5B is mojibaked, and code 99 is
-# "Others" in 2011-12 but "Not Applicable" in 2018-20 (recorded in the
-# Preferred Label as `other_condition`, the more conservative reading; only
-# 3 rows in the whole panel and none after 2011-12).  The CODES are
-# bit-identical in every wave that carries value labels (2011-12, 2013-14,
-# 2015-16, 2018-19, 2019-20), which is why one table serves all vintages.
+# Source Label is a NORMALIZED, CROSS-VINTAGE REPRESENTATIVE of the Stata
+# value label -- NOT a verbatim quote of any one wave.  (It is provenance
+# only; get_categorical_mapping reads Code + Preferred Label and never looks
+# at this column.)  Measured 2026-07-21 over all 216 (code, wave, season)
+# label pairs in the five labelled waves: 60 match this column literally,
+# 156 do not.  The column is the 2018-20 wording with runs of whitespace
+# collapsed, with four documented exceptions.  What was normalized away:
+#
+#   * en-dash -> hyphen           2011-12 / 2013-14 / 2015-16 write "Green
+#                                 harvested <en-dash> in the cob".
+#   * mojibake -> hyphen          2015-16 AGSEC5B writes the same separator
+#                                 as the literal bytes "ï¿½".
+#   * double space -> single      2018-19 writes "Green harvested  - ...".
+#
+# FOUR CODES take their text from a DIFFERENT WAVE than a 2018-20 row's own,
+# because there the two vintages differ in WORDING, not just punctuation --
+# this column keeps the longer 2009-16 phrasing:
+#
+#   | code | 2018-20 label                          | this column                                 |
+#   |   24 | Fresh/raw harvested - in pods          | Fresh/raw harvested - in pods or shell/husks |
+#   |   32 | Dry at harvest - with shell            | Dry at harvest - with shell/cob without stalk |
+#   |   42 | Dry after additional drying - with shell | Dry after additional drying - with shell and without stalk |
+#   |   99 | Not Applicable                         | Others / Not Applicable                     |
+#
+# Code 99's entry is not a quote at all: no wave writes "Others / Not
+# Applicable".  It is a composite, and it is the one place in this table
+# where reading the Source Label as a quotation would mislead.
+#
+# Code 45's PREFERRED Label is likewise an inference, not a reading.  Every
+# labelled wave writes exactly "Dry - grain"; `dried_grain` (i.e. dry AFTER
+# ADDITIONAL DRYING, the 4x family) is inferred from the code's position in
+# the grid -- 35 already occupies "Dry at harvest - grain", so 45 must be
+# the additional-drying counterpart.  It covers ~30% of all records, so the
+# inference is load-bearing; it is stated here rather than buried.
+#
+# The CODES are identical across the labelled waves with ONE exception:
+# 2011-12, 2018-19 and 2019-20 ship all 20; 2013-14 and 2015-16 ship the
+# same 19 without 99.  That is why one table serves all vintages.
+#
+# CODE 99 IS MERGED ACROSS VINTAGES, AND ITS MEANING GENUINELY DIFFERS.
+# Measured (cold rebuild, isolated LSMS_DATA_DIR, 2026-07-21): 381 raw
+# source rows carry code 99 with a reported measure, and 340 rows of the
+# built table carry `other_condition` --
+#
+#   | wave    | 2009-10 | 2010-11 | 2011-12 | 2013-14 | 2015-16 | 2018-19 | 2019-20 |
+#   | rows    |       1 |       0 |     120 |      32 |      32 |      32 |     123 |
+#
+# so 219 of the 340 are AFTER 2011-12.  (An earlier version of this comment
+# claimed "only 3 rows in the whole panel and none after 2011-12".  That was
+# false by ~100x and it was the stated basis for the merge; it is corrected
+# here rather than left to suppress scrutiny.)  Across those waves 99 means
+# three different things: "Others" (2011-12, the only wave that labels it
+# that way), "Not Applicable" (2018-19 / 2019-20), and NOTHING AT ALL in
+# 2013-14 / 2015-16, whose 19-code label sets omit 99 entirely although 32
+# rows per wave use it.
+#
+# Why one row here is nonetheless the right shape, on the corrected numbers:
+#   1. `t` is an index level of crop_production, so a 2011-12 "Others" tuple
+#      and a 2019-20 "Not Applicable" tuple can never coincide.  Nothing is
+#      summed, aggregated or de-duplicated across the vintage boundary; the
+#      merge is a naming choice, and the vintage stays recoverable by the
+#      reader from `t`.  (Verified: no wave-crossing collision exists.)
+#   2. 99 is the scheme's own residual slot in every vintage -- it is the
+#      code the instrument uses when the 2-D dryness x form grid does not
+#      apply.  `other_condition` names that slot without asserting which
+#      residual reading applies, which is what the evidence supports.
+#   3. Splitting it would require a THIRD value for 2013-14 / 2015-16, where
+#      no wave says what 99 means -- i.e. inventing a label the source does
+#      not carry, which is exactly what `unknown_condition` exists to avoid.
+# A future PR that wants finer semantics should split 99 into
+# `other_condition` (2011-12) / `not_applicable_condition` (2018-20) and
+# leave 2009-10 / 2013-14 / 2015-16 on the sentinel; that MOVES 340 rows
+# between index values, so it needs its own before/after and is deliberately
+# not done as part of a comment correction.
 #
 # 2009-10 and 2010-11 carry NO value labels at all; their condition codes were
 # matched to this scheme by distribution (their modes are 20 / 45 / 24, the
-# same as the labelled waves).  ~1.0-1.5% of their rows carry codes outside
-# the 20 below (data-entry noise plus, plausibly, the unlabelled grid cells
-# 10/15/25/30/34 -- a HYPOTHESIS, deliberately NOT given labels here).  Those
-# rows get the `unknown_condition` sentinel from uganda._CONDITION_UNKNOWN
-# rather than an invented label.
+# same as the labelled waves).  Measured 2026-07-21: 1.1% of 2009-10 rows
+# (297 / 26 085) and 0.9% of 2010-11 rows (192 / 21 051) carry a code outside
+# the 20 below -- 492 rows panel-wide (data-entry noise plus, plausibly, the
+# unlabelled grid cells 10/15/25/30/34 -- a HYPOTHESIS, deliberately NOT given
+# labels here).  Those rows get the `unknown_condition` sentinel from
+# uganda._CONDITION_UNKNOWN rather than an invented label.
+#
+# OFF-SCHEME CODES ARE THE SMALL PART OF THE SENTINEL.  The sentinel also
+# absorbs rows whose condition column is simply NULL, and those dominate:
+# 7 994 of 133 683 built rows (6.0%) carry `unknown_condition`, of which only
+# ~490 are off-scheme codes.  Per wave the sentinel share is 23.2% (2009-10),
+# 4.4%, 3.5%, 2.3%, 0.1%, 0.1%, 0.1%.  Do not read "~1%" as the sentinel rate;
+# it is the off-scheme rate in the two unlabelled waves only.
 #+name: harvest_conditions
 | Code | Preferred Label                     | Source Label                                              |
 |------+-------------------------------------+-----------------------------------------------------------|

--- a/lsms_library/countries/Uganda/_/categorical_mapping.org
+++ b/lsms_library/countries/Uganda/_/categorical_mapping.org
@@ -826,6 +826,70 @@
 |  119 | Nomi Tin (1kg)                    |
 |  120 | Nomi Tin (500g)                   |
 
+# harvest_conditions: harvest CONDITION/STATE code -> Preferred Label for the
+# `condition` index level of crop_production (GH #323 / #637).  UNPS question
+# 6c, "in what condition/state was the crop harvested" -- asked jointly with
+# the quantity and unit, so the SAME plot-crop-season yields one record per
+# state and the states must not be summed together (dry weight + fresh weight
+# is not a quantity of anything).
+#
+# The integer scheme is a 2-D cross of a DRYNESS family (tens digit) with a
+# physical FORM (units digit):
+#
+#     1x  Green harvested          x0  state not applicable
+#     2x  Fresh / raw harvested    x1  with shell/cob and with stalk
+#     3x  Dry at harvest           x2  with shell/cob, without stalk
+#     4x  Dry after additional     x3  in the cob
+#         drying                   x4  in pods or shell/husks
+#                                  x5  grain
+#
+# The Preferred Labels below encode exactly that cross in snake_case, so a
+# sibling LSMS-ISA country with a coarser instrument can reuse the family
+# tokens (`fresh`, `dried`) and a finer one can extend the list.  The
+# canonical vocabulary is declared cross-country in
+# lsms_library/data_info.yml (Columns > crop_production > condition).
+#
+# Source Label is the VERBATIM Stata value label, for provenance; it is not
+# read at runtime (get_categorical_mapping selects Code + Preferred Label).
+# The label text drifts cosmetically across vintages -- 2009-16 uses an
+# en-dash, 2018-20 a hyphen, 2015-16 AGSEC5B is mojibaked, and code 99 is
+# "Others" in 2011-12 but "Not Applicable" in 2018-20 (recorded in the
+# Preferred Label as `other_condition`, the more conservative reading; only
+# 3 rows in the whole panel and none after 2011-12).  The CODES are
+# bit-identical in every wave that carries value labels (2011-12, 2013-14,
+# 2015-16, 2018-19, 2019-20), which is why one table serves all vintages.
+#
+# 2009-10 and 2010-11 carry NO value labels at all; their condition codes were
+# matched to this scheme by distribution (their modes are 20 / 45 / 24, the
+# same as the labelled waves).  ~1.0-1.5% of their rows carry codes outside
+# the 20 below (data-entry noise plus, plausibly, the unlabelled grid cells
+# 10/15/25/30/34 -- a HYPOTHESIS, deliberately NOT given labels here).  Those
+# rows get the `unknown_condition` sentinel from uganda._CONDITION_UNKNOWN
+# rather than an invented label.
+#+name: harvest_conditions
+| Code | Preferred Label                     | Source Label                                              |
+|------+-------------------------------------+-----------------------------------------------------------|
+|   11 | green_with_shell_and_stalk          | Green harvested - with shell/cob and with stalk           |
+|   12 | green_with_shell                    | Green harvested - with shell/cob without stalk            |
+|   13 | green_in_cob                        | Green harvested - in the cob                              |
+|   14 | green_in_pods                       | Green harvested - in the pods                             |
+|   20 | fresh                               | Fresh/raw harvested - state not applicable                |
+|   21 | fresh_with_shell_and_stalk          | Fresh/raw harvested - with shell/cob and with stalk       |
+|   22 | fresh_with_shell                    | Fresh/raw harvested - with shell/cob without stalk        |
+|   23 | fresh_in_cob                        | Fresh/raw harvested - in the cob                          |
+|   24 | fresh_in_pods                       | Fresh/raw harvested - in pods or shell/husks              |
+|   31 | dry_at_harvest_with_shell_and_stalk | Dry at harvest - with shell/cob and with stalk            |
+|   32 | dry_at_harvest_with_shell           | Dry at harvest - with shell/cob without stalk             |
+|   33 | dry_at_harvest_in_cob               | Dry at harvest - in the cob                               |
+|   35 | dry_at_harvest_grain                | Dry at harvest - grain                                    |
+|   40 | dried                               | Dry after additional drying - state not applicable        |
+|   41 | dried_with_shell_and_stalk          | Dry after additional drying - with shell and with stalk   |
+|   42 | dried_with_shell                    | Dry after additional drying - with shell and without stalk |
+|   43 | dried_in_cob                        | Dry after additional drying - in the cob                  |
+|   44 | dried_in_pods                       | Dry after additional drying - In pods or shell/husks      |
+|   45 | dried_grain                         | Dry - grain                                               |
+|   99 | other_condition                     | Others / Not Applicable                                   |
+
 # harmonize_input: agricultural-input identity Code -> Preferred Label for
 # the plot_inputs feature (GAP 2).  One row per REPORTED input applied to a
 # plot, ``input`` axis.  The UNPS plot-input module (AGSEC3A/3B) records four

--- a/lsms_library/countries/Uganda/_/crop_production.py
+++ b/lsms_library/countries/Uganda/_/crop_production.py
@@ -1,7 +1,7 @@
 """Concatenate wave-level crop_production data for Uganda (GAP 1).
 
 Each wave's ``Uganda/<wave>/_/crop_production.py`` produces a parquet
-indexed ``(t, i, plot, j, u, season)`` with the REPORTED harvest columns
+indexed ``(t, i, plot, j, u, condition, season)`` with the REPORTED harvest columns
 (Quantity, Quantity_sold, Value_sold, harvest_month, intercropped,
 perennial, planting_month).  This script concatenates them across waves
 and applies cross-wave id_walk so the household index uses the panel

--- a/lsms_library/countries/Uganda/_/data_scheme.yml
+++ b/lsms_library/countries/Uganda/_/data_scheme.yml
@@ -130,7 +130,7 @@ Data Scheme:
     # (season 1) + AGSEC5B (season 2) of the UNPS post-harvest
     # questionnaire, joined to AGSEC4A for the intercropped flag.
     #
-    # Grain (t, i, plot, j, u, season):
+    # Grain (t, i, plot, j, u, condition, season):
     #   plot   — hhid-parcel-plot, mirroring the WB harmonised plot_id;
     #            its parcel component is the parcel plot_features keys on.
     #   j      — crop, on the shared 'harmonize_crop' Preferred Labels,
@@ -140,6 +140,20 @@ Data Scheme:
     #   u      — reported native harvest unit ('harvest_units' table);
     #            'Unknown' where a wave records no harvest unit label
     #            (e.g. 2018-19 harvest side).
+    #   condition — physical state of the crop when the Quantity was
+    #            measured ('harvest_conditions' table): green / fresh /
+    #            dry-at-harvest / dried, crossed with the form (on the
+    #            stalk, with shell, in the cob, in pods, as grain).  UNPS
+    #            asks quantity, unit AND condition together, so the same
+    #            plot-crop-season carries one record PER CONDITION; before
+    #            this level existed (GH #323/#637) those records collided
+    #            and their Quantity was summed — dry weight added to fresh
+    #            weight.  'unknown_condition' where the wave records no
+    #            condition code or an off-scheme one (~1% of 2009-10 and
+    #            2010-11 rows, which ship no value labels).
+    #            Quantities in different conditions are NOT commensurable;
+    #            do not sum across this level without a drying/shelling
+    #            conversion.
     #   season — 'A' (first season) / 'B' (second season).
     #
     # Columns are REPORTED values only — no harvest_kg / yield /
@@ -147,7 +161,7 @@ Data Scheme:
     # wave -> NaN.  2005-06 is excluded: its AGSEC5A is a crop-area
     # allocation matrix with no crop-level harvest quantities, and the
     # WB LSMS-ISA panel itself starts at wave 1 (2009-10).
-    index: (t, i, plot, j, u, season)
+    index: (t, i, plot, j, u, condition, season)
     Quantity: float
     Quantity_sold: float
     Value_sold: float

--- a/lsms_library/countries/Uganda/_/data_scheme.yml
+++ b/lsms_library/countries/Uganda/_/data_scheme.yml
@@ -149,8 +149,14 @@ Data Scheme:
     #            this level existed (GH #323/#637) those records collided
     #            and their Quantity was summed — dry weight added to fresh
     #            weight.  'unknown_condition' where the wave records no
-    #            condition code or an off-scheme one (~1% of 2009-10 and
-    #            2010-11 rows, which ship no value labels).
+    #            condition code or an off-scheme one: 7 994 of 133 683 rows
+    #            = 6.0% panel-wide, and 23.2% in 2009-10 (then 4.4 / 3.5 /
+    #            2.3 / 0.1 / 0.1 / 0.1% for 2010-11 … 2019-20).  A NULL
+    #            condition column is the bulk of that; only ~490 rows in the
+    #            whole panel carry a code OUTSIDE the 20-code scheme (1.1%
+    #            of 2009-10, 0.9% of 2010-11 — the two waves that ship no
+    #            value labels).  Measured cold 2026-07-21; the per-wave
+    #            breakdown is in _/CONTENTS.org.
     #            Quantities in different conditions are NOT commensurable;
     #            do not sum across this level without a drying/shelling
     #            conversion.

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -934,6 +934,36 @@ def _harvest_condition_map():
     return _harmonized_codes(_HARVEST_CONDITION_TABLE)
 
 
+class CropColmapError(KeyError):
+    """A ``CROP_COLMAPS`` entry names a source column that does not exist.
+
+    Raised rather than silently falling back, because every fallback in
+    ``crop_production_for_wave`` is *invisible in the output*: a mis-typed
+    condition column sentinels a whole wave-season to ``unknown_condition``,
+    a mis-typed quantity column drops the slot entirely, and a mis-typed unit
+    column sets ``u='Unknown'`` everywhere.  All three look exactly like
+    "this wave genuinely does not record that", which is a claim the config
+    is allowed to make — but only by writing ``None``, explicitly.
+    """
+
+
+def _require(df, name, where, why):
+    """Return ``df[name]``; raise ``CropColmapError`` if the column is absent.
+
+    ``name`` of ``None`` never reaches here — a ``None`` in the colmap is the
+    declared, auditable way to say "this wave has no such column".
+    """
+    if name not in df.columns:
+        near = [c for c in df.columns if str(c).lower().startswith(str(name)[:5].lower())]
+        raise CropColmapError(
+            f"CROP_COLMAPS[{where}] names {name!r} as the {why} column, but that "
+            f"column is not in the source file (columns starting similarly: "
+            f"{near or 'none'}).  Fix the colmap, or write None to declare "
+            f"explicitly that this wave records no {why}."
+        )
+    return df[name]
+
+
 def _to_int_code(series):
     """Coerce a (possibly categorical/float/str) code column to Int64."""
     if series is None:
@@ -982,6 +1012,17 @@ def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
             file_hhid, file_parcel, file_plot, flag, [perennial]
         describing how to read the intercropped flag from ``df4a``.
 
+    Raises
+    ------
+    CropColmapError
+        If the colmap NAMES a column that is not in the source file.  Every
+        fallback here is invisible in the output — a wrong condition column
+        sentinels a whole wave-season to ``unknown_condition``, a wrong
+        quantity column drops the slot — so a name that does not resolve is
+        a config bug, not a survey fact.  To state a survey fact ("this wave
+        records no unit"), write ``None``, which is checked and auditable.
+        See ``tests/test_uganda_crop_condition.py``.
+
     Returns
     -------
     pd.DataFrame indexed by ``(t, i, plot, j, u, condition, season)`` with columns
@@ -1005,22 +1046,24 @@ def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
         pa4 = df4a[ic['parcel']].apply(format_id)
         pl4 = df4a[ic['plot']].apply(format_id)
         key3 = list(zip(hh4, pa4, pl4))
-        if ic.get('flag') and ic['flag'] in df4a.columns:
-            flagcode = _to_int_code(df4a[ic['flag']])
+        w4 = f"{t!r}]['intercrop'"
+        if ic.get('flag'):
+            flagcode = _to_int_code(_require(df4a, ic['flag'], w4, 'intercrop flag'))
             # 1 = mono/No, 2 = Yes  (recode mirrors WB: 2 -> True)
             for k, c in zip(key3, flagcode):
                 if pd.notna(c):
                     inter_lookup[k] = bool(int(c) == 2)
-        if ic.get('crop') and ic['crop'] in df4a.columns:
-            crop4 = _to_int_code(df4a[ic['crop']])
+        if ic.get('crop'):
+            crop4 = _to_int_code(_require(df4a, ic['crop'], w4, 'intercrop crop'))
             key4 = list(zip(hh4, pa4, pl4, crop4))
-            if ic.get('perennial') and ic['perennial'] in df4a.columns:
-                per = _to_int_code(df4a[ic['perennial']])
+            if ic.get('perennial'):
+                per = _to_int_code(_require(df4a, ic['perennial'], w4, 'perennial'))
                 for k, c in zip(key4, per):
                     if pd.notna(c):
                         perennial_lookup[k] = bool(int(c) == 2)
-            if ic.get('planting_month') and ic['planting_month'] in df4a.columns:
-                pm = _to_int_code(df4a[ic['planting_month']])
+            if ic.get('planting_month'):
+                pm = _to_int_code(_require(df4a, ic['planting_month'], w4,
+                                           'planting month'))
                 for k, m in zip(key4, pm):
                     if pd.notna(m) and 1 <= int(m) <= 12:
                         planting_lookup[k] = int(m)
@@ -1033,30 +1076,33 @@ def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
         if cm is None:
             continue
 
-        hh = _format_agsec_hhid(df5[cm['hhid']], t)
-        parcel = df5[cm['parcel']].apply(format_id)
-        plot = df5[cm['plot']].apply(format_id) if cm.get('plot') and cm['plot'] in df5.columns else pd.Series(['']*len(df5), index=df5.index)
+        w = f"{t!r}][{season!r}"
+        hh = _format_agsec_hhid(_require(df5, cm['hhid'], w, 'household id'), t)
+        parcel = _require(df5, cm['parcel'], w, 'parcel id').apply(format_id)
+        plot = (_require(df5, cm['plot'], w, 'plot id').apply(format_id)
+                if cm.get('plot') else pd.Series(['']*len(df5), index=df5.index))
         plot_id = hh.astype(str) + '-' + parcel.astype(str) + '-' + plot.astype(str)
-        crop_code = _to_int_code(df5[cm['crop']])
+        crop_code = _to_int_code(_require(df5, cm['crop'], w, 'crop code'))
         j = crop_code.map(lambda c: crop_map.get(int(c), pd.NA) if pd.notna(c) else pd.NA)
 
-        for cond in cm['conditions']:
+        for n, cond in enumerate(cm['conditions']):
+            ws = f"{w}]['conditions'][{n}"
             qcol = cond.get('qty')
-            if not qcol or qcol not in df5.columns:
+            if not qcol:
                 continue
-            qty = pd.to_numeric(df5[qcol], errors='coerce')
+            qty = pd.to_numeric(_require(df5, qcol, ws, 'quantity'), errors='coerce')
 
             # reported native unit
-            if cond.get('unit') and cond['unit'] in df5.columns:
-                ucode = _to_int_code(df5[cond['unit']])
+            if cond.get('unit'):
+                ucode = _to_int_code(_require(df5, cond['unit'], ws, 'unit'))
                 u = ucode.map(lambda c: unit_map.get(int(c), pd.NA) if pd.notna(c) else pd.NA)
             else:
                 u = pd.Series([pd.NA]*len(df5), index=df5.index, dtype='object')
 
             # reported harvest CONDITION (UNPS q6c).  Sentinel-filled here
             # rather than left NA -- see _CONDITION_UNKNOWN.
-            if cond.get('condition') and cond['condition'] in df5.columns:
-                ccode = _to_int_code(df5[cond['condition']])
+            if cond.get('condition'):
+                ccode = _to_int_code(_require(df5, cond['condition'], ws, 'condition'))
                 condition = ccode.map(
                     lambda c: condition_map.get(int(c), pd.NA) if pd.notna(c) else pd.NA)
             else:
@@ -1064,11 +1110,15 @@ def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
             condition = condition.astype('object').where(
                 condition.notna(), _CONDITION_UNKNOWN)
 
-            qsold = pd.to_numeric(df5[cond['qty_sold']], errors='coerce') if cond.get('qty_sold') in df5.columns else pd.Series([pd.NA]*len(df5), index=df5.index)
-            vsold = pd.to_numeric(df5[cond['value_sold']], errors='coerce') if cond.get('value_sold') in df5.columns else pd.Series([pd.NA]*len(df5), index=df5.index)
+            qsold = (pd.to_numeric(_require(df5, cond['qty_sold'], ws, 'quantity sold'),
+                                   errors='coerce') if cond.get('qty_sold')
+                     else pd.Series([pd.NA]*len(df5), index=df5.index))
+            vsold = (pd.to_numeric(_require(df5, cond['value_sold'], ws, 'value sold'),
+                                   errors='coerce') if cond.get('value_sold')
+                     else pd.Series([pd.NA]*len(df5), index=df5.index))
 
-            if cond.get('month') and cond['month'] in df5.columns:
-                hm = _to_int_code(df5[cond['month']])
+            if cond.get('month'):
+                hm = _to_int_code(_require(df5, cond['month'], ws, 'harvest month'))
                 hm = hm.where((hm >= 1) & (hm <= 12), pd.NA)
             else:
                 hm = pd.Series([pd.NA]*len(df5), index=df5.index, dtype='Int64')
@@ -1173,6 +1223,21 @@ def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
 #                      below) — a separate defect, see CONTENTS.org.
 #   2019-20            WB names throughout: s5{a,b}q06b_{1,2} = unit,
 #                      s5{a,b}q06c_{1,2} = condition, one pair per slot.
+#
+# A NAMED column that is absent from the source now RAISES (`_require` ->
+# CropColmapError) instead of silently falling back.  Write `None` to declare
+# that a wave records no such column -- that is a survey fact and is auditable;
+# a name that does not resolve is a config bug and used to be invisible.
+#
+# KNOWN DEFECT, deliberately not fixed here: every `intercrop.flag` below
+# points at the SEED-USE question ("did you use any seed/seedlings?",
+# {1: Yes, 2: No}), not at the cropping-system question (`a4aq7` "Cropping
+# system" {1: Pure Stand, 2: Inter cropped} in 2009-10/2010-11, `a4aq8` /
+# `s4aq08` "What type of crop stand was on the plot?" {1: Pure Stand,
+# 2: Mixed Stand} from 2011-12 on).  So `intercropped` currently means "did
+# NOT use seed", and agrees with the true crop-stand answer on only 48-53%
+# of rows.  Rewiring MOVES data, so it needs its own before/after; see
+# CONTENTS.org "Known Issues".
 CROP_COLMAPS = {
     '2009-10': {
         'A': {'hhid': 'HHID', 'parcel': 'a5aq1', 'plot': 'a5aq3', 'crop': 'a5aq5',
@@ -1198,8 +1263,18 @@ CROP_COLMAPS = {
               'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c', 'condition': 'a5bq6b',
                               'qty_sold': 'a5bq7a', 'value_sold': 'a5bq8',
                               'month': None}]},
+        # `flag: None` is a MEASUREMENT, not a guess: 2010-11 AGSEC4A ships
+        # ['HHID','prcid','pltid','cropID','a4aq7'..'a4aq14'] and has no
+        # `a4aq3` at all, so the previous 'a4aq3' entry silently resolved to
+        # nothing and `intercropped` was NaN on all 20 970 rows of this wave.
+        # Writing None makes the config say what the build already did (a
+        # provable no-op) instead of naming a column that does not exist.
+        # NOTE the wave DOES carry a cropping-system question — a4aq7,
+        # "Cropping system", value-labelled {1: Pure Stand, 2: Inter cropped}.
+        # Wiring it would ADD data, so it is a separate change with its own
+        # before/after; see CONTENTS.org "Known Issues".
         'intercrop': {'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid',
-                      'flag': 'a4aq3', 'crop': 'cropID'},
+                      'flag': None, 'crop': 'cropID'},
     },
     '2011-12': {
         'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -876,18 +876,35 @@ def plot_features_for_wave(t, source_2a, source_2b, colmap):
 # crop_production  (GAP 1 — item-level post-harvest crop module)
 # ----------------------------------------------------------------------
 #
-# Grain: (t, i, plot, j, u, season).  One row per *reported* harvest
-# record for a crop on a plot.  Stores REPORTED values only — Quantity
-# (native harvest unit u), Quantity_sold, Value_sold, harvest_month and
-# the intercropped / perennial flags.  No harvest_kg / yield / main_crop /
-# value-share — those are transformations over these item rows.
+# Grain: (t, i, plot, j, u, condition, season).  One row per *reported*
+# harvest record for a crop on a plot.  Stores REPORTED values only —
+# Quantity (native harvest unit u, in state `condition`), Quantity_sold,
+# Value_sold, harvest_month and the intercropped / perennial flags.  No
+# harvest_kg / yield / main_crop / value-share — those are transformations
+# over these item rows.
 #
 # Source: AGSEC5A (season 1) + AGSEC5B (season 2), the UNPS post-harvest
-# crop module.  Column names AND the unit/condition column semantics drift
-# across waves (see slurm notes in the wave scripts), so each wave passes
-# an explicit colmap.  Some newer waves (2018-19, 2019-20) record two
-# harvest "conditions" per (plot, crop) in parallel _1 / _2 column sets;
-# we emit one row per non-empty condition rather than summing them.
+# crop module.  Column names drift across waves, so each wave passes an
+# explicit colmap.
+#
+# `condition` (GH #323 / #637) is the harvest CONDITION — UNPS question 6c,
+# "how much did you harvest AND IN WHAT STATE/CONDITION".  It is a real
+# level of the survey's grain, not a nuisance: the same plot-crop-season is
+# reported once per state, so 240 kg of dry coffee and 100 kg of fresh
+# coffee are two separate records.  Before it was indexed they collided and
+# were SUMMED, adding dry weight to fresh weight.  The two vintages encode
+# the same 20-code scheme differently:
+#
+#   2009-16 LONG   one column group per season; the condition is a VALUE in
+#                  a5aq6b / a5bq6b, with multiple source rows per plot-crop.
+#   2018-20 WIDE   parallel _1 / _2 slots; the condition for each slot is a
+#                  value in its own column (s5aq06c_1 / s5aq06c_2, ...).
+#                  The slot number is NOT an ordinal "first/second harvest"
+#                  — you read the condition label out of the slot's own 6c
+#                  column, which draws on the identical integer scheme.
+#
+# See Uganda/_/CONTENTS.org "Harvest condition on crop_production" for the
+# per-wave source columns, the evidence, and the residual collisions.
 #
 # plot id mirrors the WB harmonised plot_id = hhid-parcel-plot; its parcel
 # component (hhid-parcel) is the same parcel that plot_features keys on
@@ -895,6 +912,14 @@ def plot_features_for_wave(t, source_2a, source_2b, colmap):
 
 _CROP_TABLE = 'harmonize_crop'
 _HARVEST_UNIT_TABLE = 'harvest_units'
+_HARVEST_CONDITION_TABLE = 'harvest_conditions'
+
+# Sentinel for a harvest record whose condition code is missing or outside
+# the labelled scheme.  MUST be a real string, never pd.NA: the duplicate
+# collapse below uses ``groupby(level=...)``, whose default ``dropna=True``
+# silently DELETES rows with a null index key (this already costs 431 rows
+# in 2009-10 via a null `plot`).  Mirrors the 'Unknown' sentinel on `u`.
+_CONDITION_UNKNOWN = 'unknown_condition'
 
 
 def _crop_label_map():
@@ -903,6 +928,10 @@ def _crop_label_map():
 
 def _harvest_unit_map():
     return _harmonized_codes(_HARVEST_UNIT_TABLE)
+
+
+def _harvest_condition_map():
+    return _harmonized_codes(_HARVEST_CONDITION_TABLE)
 
 
 def _to_int_code(series):
@@ -942,6 +971,8 @@ def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
                          set, each with keys:
                 qty           — reported harvest quantity column
                 unit          — reported harvest unit code column (or None)
+                condition     — reported harvest CONDITION/state code column
+                                (UNPS q6c; None only if the wave has none)
                 qty_sold      — reported quantity sold column (or None)
                 value_sold    — reported sale value column (or None)
                 month         — harvest-end month code column (or None)
@@ -953,7 +984,7 @@ def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
 
     Returns
     -------
-    pd.DataFrame indexed by ``(t, i, plot, j, u, season)`` with columns
+    pd.DataFrame indexed by ``(t, i, plot, j, u, condition, season)`` with columns
         ``Quantity`` (Float64), ``Quantity_sold`` (Float64),
         ``Value_sold`` (Float64), ``harvest_month`` (Int64 1-12) and
         ``intercropped`` (boolean).  The ``perennial`` / ``planting_month``
@@ -962,6 +993,7 @@ def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
     """
     crop_map = _crop_label_map()
     unit_map = _harvest_unit_map()
+    condition_map = _harvest_condition_map()
 
     # --- intercropped / perennial / planting from AGSEC4A (plot-crop) ---
     inter_lookup = {}      # (hh, parcel, plot) -> bool   (plot-level flag)
@@ -1021,6 +1053,17 @@ def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
             else:
                 u = pd.Series([pd.NA]*len(df5), index=df5.index, dtype='object')
 
+            # reported harvest CONDITION (UNPS q6c).  Sentinel-filled here
+            # rather than left NA -- see _CONDITION_UNKNOWN.
+            if cond.get('condition') and cond['condition'] in df5.columns:
+                ccode = _to_int_code(df5[cond['condition']])
+                condition = ccode.map(
+                    lambda c: condition_map.get(int(c), pd.NA) if pd.notna(c) else pd.NA)
+            else:
+                condition = pd.Series([pd.NA]*len(df5), index=df5.index, dtype='object')
+            condition = condition.astype('object').where(
+                condition.notna(), _CONDITION_UNKNOWN)
+
             qsold = pd.to_numeric(df5[cond['qty_sold']], errors='coerce') if cond.get('qty_sold') in df5.columns else pd.Series([pd.NA]*len(df5), index=df5.index)
             vsold = pd.to_numeric(df5[cond['value_sold']], errors='coerce') if cond.get('value_sold') in df5.columns else pd.Series([pd.NA]*len(df5), index=df5.index)
 
@@ -1036,6 +1079,7 @@ def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
                 'plot':          plot_id.values,
                 'j':             j.values,
                 'u':             u.values,
+                'condition':     condition.values,
                 'season':        season,
                 'Quantity':      qty.values,
                 'Quantity_sold': qsold.values,
@@ -1077,12 +1121,17 @@ def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
     # with no unit).  Where there's no quantity at all, leave the unit
     # sentinel too.
     df['u'] = df['u'].astype('object').where(df['u'].notna(), 'Unknown')
+    # Belt-and-braces: `condition` was already sentinel-filled per condition
+    # slot above, but a slot that yields no rows must not reintroduce NA.
+    df['condition'] = df['condition'].astype('object').where(
+        df['condition'].notna(), _CONDITION_UNKNOWN)
 
-    df = df.set_index(['t', 'i', 'plot', 'j', 'u', 'season'])
-    # Collapse exact-duplicate index tuples (same plot/crop/unit/season
-    # reported twice) by summing the reported quantities — this is NOT an
-    # aggregation across distinct items, just de-duplication of repeated
-    # identical source rows so the index is unique.
+    df = df.set_index(['t', 'i', 'plot', 'j', 'u', 'condition', 'season'])
+    # Collapse exact-duplicate index tuples (same plot/crop/unit/condition/
+    # season reported twice) by summing the reported quantities — this is NOT
+    # an aggregation across distinct items, just de-duplication of repeated
+    # identical source rows so the index is unique.  Before `condition` was
+    # in the index this block also summed FRESH onto DRY weight (GH #323).
     if not df.index.is_unique:
         num = df[['Quantity', 'Quantity_sold', 'Value_sold']].groupby(level=df.index.names).sum(min_count=1)
         firstcols = df[['harvest_month', 'intercropped']].groupby(level=df.index.names).first()
@@ -1090,20 +1139,48 @@ def crop_production_for_wave(t, df5a, df5b, df4a, colmap):
     return df
 
 
-# Per-wave column maps for crop_production_for_wave.  The harvest UNIT is
-# the column whose value labels decode to Kg/Sack/Bunch (the harvest_units
-# scheme) — empirically a5aq6c for 2009-16 (NOT a5aq6b, which is the
-# Fresh/Dry condition; the WB .do's A5aq6b/A5aq6c unit/condition rename is
-# inverted for these actual UNPS files).  2018-19's harvest side carries
-# no unit label (-> u='Unknown'); 2019-20 keeps WB names s5aq06b_1.
+# Per-wave column maps for crop_production_for_wave.
+#
+# UNIT vs CONDITION.  The rule that decides which column is which is the
+# VALUE-LABEL vocabulary, never the variable label: the unit column's labels
+# decode to Kg / Sack (100 kgs) / Bunch (Big) (the `harvest_units` scheme);
+# the condition column's decode to Green/Fresh/Dry ... (`harvest_conditions`).
+# Verified per wave against the Stata metadata (2026-07-21, GH #323/#637):
+#
+#   2009-10, 2010-11   a5aq6b = condition, a5aq6c = unit.  Agrees with the
+#                      files' own variable labels ("Condition/State at
+#                      Harvest" / "Unit of Harvest").  NEITHER column carries
+#                      value labels in these two waves, so the mapping was
+#                      confirmed from the code DISTRIBUTIONS instead: 6b's
+#                      modes are 20/45/24 (the condition scheme's modes),
+#                      6c's are 22/1/10 (Plastic Basin / Kg / Sack 100kg).
+#   2011-12, 2015-16   a5aq6b = condition, a5aq6c = unit.  Variable labels
+#                      and value labels agree.
+#   2013-14 AGSEC5A    the VARIABLE labels really are swapped here — a5aq6b
+#                      is titled "Unit of quantity" but carries the CONDITION
+#                      value labels, and a5aq6c is titled "Condition/state"
+#                      but carries the UNIT value labels.  This single file
+#                      is the whole basis of the old "the WB .do's A5aq6b/
+#                      A5aq6c rename is inverted" comment, which overstated
+#                      the problem: 2013-14 AGSEC5B is labelled correctly.
+#                      Either way the wiring below (6c = unit) is right.
+#   2018-19 AGSEC5A    NO unit column at all (-> u='Unknown').  a5aq6b holds
+#                      the condition (labelled); a5aq6c holds the SAME 20-code
+#                      condition scheme unlabelled and differing on 158/7144
+#                      rows, so a5aq6b (the labelled one) is used.
+#   2018-19 AGSEC5B    a5bq6b = unit (labelled), a5bq6c = condition.  NOTE the
+#                      unit is available and is NOT yet wired (unit: None
+#                      below) — a separate defect, see CONTENTS.org.
+#   2019-20            WB names throughout: s5{a,b}q06b_{1,2} = unit,
+#                      s5{a,b}q06c_{1,2} = condition, one pair per slot.
 CROP_COLMAPS = {
     '2009-10': {
         'A': {'hhid': 'HHID', 'parcel': 'a5aq1', 'plot': 'a5aq3', 'crop': 'a5aq5',
-              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c',
+              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c', 'condition': 'a5aq6b',
                               'qty_sold': 'a5aq7a', 'value_sold': 'a5aq8',
                               'month': None}]},
         'B': {'hhid': 'HHID', 'parcel': 'a5bq1', 'plot': 'a5bq3', 'crop': 'a5bq5',
-              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c',
+              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c', 'condition': 'a5bq6b',
                               'qty_sold': 'a5bq7a', 'value_sold': 'a5bq8',
                               'month': None}]},
         # 2009-10 AGSEC4A uses a non-standard column layout (a4aq1/a4aq2/
@@ -1114,11 +1191,11 @@ CROP_COLMAPS = {
     },
     '2010-11': {
         'A': {'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid', 'crop': 'cropID',
-              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c',
+              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c', 'condition': 'a5aq6b',
                               'qty_sold': 'a5aq7a', 'value_sold': 'a5aq8',
                               'month': None}]},
         'B': {'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid', 'crop': 'cropID',
-              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c',
+              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c', 'condition': 'a5bq6b',
                               'qty_sold': 'a5bq7a', 'value_sold': 'a5bq8',
                               'month': None}]},
         'intercrop': {'hhid': 'HHID', 'parcel': 'prcid', 'plot': 'pltid',
@@ -1126,11 +1203,11 @@ CROP_COLMAPS = {
     },
     '2011-12': {
         'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
-              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c',
+              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c', 'condition': 'a5aq6b',
                               'qty_sold': 'a5aq7a', 'value_sold': 'a5aq8',
                               'month': 'a5aq6f'}]},
         'B': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
-              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c',
+              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c', 'condition': 'a5bq6b',
                               'qty_sold': 'a5bq7a', 'value_sold': 'a5bq8',
                               'month': 'a5bq6f'}]},
         'intercrop': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
@@ -1138,11 +1215,11 @@ CROP_COLMAPS = {
     },
     '2013-14': {
         'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
-              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c',
+              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c', 'condition': 'a5aq6b',
                               'qty_sold': 'a5aq7a', 'value_sold': 'a5aq8',
                               'month': 'a5aq6f'}]},
         'B': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
-              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c',
+              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c', 'condition': 'a5bq6b',
                               'qty_sold': 'a5bq7a', 'value_sold': 'a5bq8',
                               'month': 'a5bq6f'}]},
         'intercrop': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
@@ -1150,11 +1227,11 @@ CROP_COLMAPS = {
     },
     '2015-16': {
         'A': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
-              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c',
+              'conditions': [{'qty': 'a5aq6a', 'unit': 'a5aq6c', 'condition': 'a5aq6b',
                               'qty_sold': 'a5aq7a', 'value_sold': 'a5aq8',
                               'month': 'a5aq6f'}]},
         'B': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID', 'crop': 'cropID',
-              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c',
+              'conditions': [{'qty': 'a5bq6a', 'unit': 'a5bq6c', 'condition': 'a5bq6b',
                               'qty_sold': 'a5bq7a', 'value_sold': 'a5bq8',
                               'month': 'a5bq6f'}]},
         'intercrop': {'hhid': 'HHID', 'parcel': 'parcelID', 'plot': 'plotID',
@@ -1162,11 +1239,11 @@ CROP_COLMAPS = {
     },
     '2018-19': {
         'A': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid', 'crop': 'cropID',
-              'conditions': [{'qty': 's5aq06a_1', 'unit': None,
+              'conditions': [{'qty': 's5aq06a_1', 'unit': None, 'condition': 'a5aq6b',
                               'qty_sold': 's5aq07a_1', 'value_sold': 's5aq08_1',
                               'month': 's5aq06f_1'}]},
         'B': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid', 'crop': 'cropID',
-              'conditions': [{'qty': 's5bq06a_1', 'unit': None,
+              'conditions': [{'qty': 's5bq06a_1', 'unit': None, 'condition': 'a5bq6c',
                               'qty_sold': 's5bq07a_1', 'value_sold': 's5bq08_1',
                               'month': 's5bq06f_1'}]},
         'intercrop': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',
@@ -1175,15 +1252,15 @@ CROP_COLMAPS = {
     '2019-20': {
         'A': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid', 'crop': 'cropID',
               'conditions': [
-                  {'qty': 's5aq06a_1', 'unit': 's5aq06b_1',
+                  {'qty': 's5aq06a_1', 'unit': 's5aq06b_1', 'condition': 's5aq06c_1',
                    'qty_sold': 's5aq07a_1', 'value_sold': 's5aq08_1',
                    'month': 's5aq06f_1'},
-                  {'qty': 's5aq06a_2', 'unit': 's5aq06b_2',
+                  {'qty': 's5aq06a_2', 'unit': 's5aq06b_2', 'condition': 's5aq06c_2',
                    'qty_sold': 's5aq07a_2', 'value_sold': 's5aq08_2',
                    'month': 's5aq06f_2'},
               ]},
         'B': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid', 'crop': 'cropID',
-              'conditions': [{'qty': 's5bq06a_1', 'unit': 's5bq06b_1',
+              'conditions': [{'qty': 's5bq06a_1', 'unit': 's5bq06b_1', 'condition': 's5bq06c_1',
                               'qty_sold': 's5bq07a_1', 'value_sold': 's5bq08_1',
                               'month': 's5bq06f_1'}]},
         'intercrop': {'hhid': 'hhid', 'parcel': 'parcelID', 'plot': 'pltid',

--- a/lsms_library/data_info.yml
+++ b/lsms_library/data_info.yml
@@ -282,6 +282,68 @@ Columns:
   panel_ids:
     previous_i:
       type: str
+  crop_production:
+    # NOTE: `condition` is an INDEX level, not a column -- deliberately
+    # declared here anyway.  `_enforce_canonical_spellings` (country.py:3962)
+    # applies a spellings map to index levels as well as columns, so this is
+    # the working half of the mechanism.  The half that does NOT work for an
+    # index level is *enforcement*: nothing rejects a value outside the list
+    # (contrast food_acquired's `s`, enumerated in code as
+    # transformations.S_VALUES).  A follow-up should either add a
+    # CONDITION_VALUES constant alongside S_VALUES or, better, drive an
+    # index-level enumeration check from this file so `s` stops being
+    # special-cased.  Declaring the vocabulary here is not blocked on that.
+    condition:
+      type: str
+      note: |
+        Physical state of the crop at the moment the reported harvest
+        Quantity was measured.  A harvest module that asks "how much did
+        you harvest, in what unit, AND IN WHAT CONDITION" records one row
+        per condition for the same plot-crop-season, so this is a level of
+        the survey's own grain: 240 kg of dry coffee and 100 kg of fresh
+        coffee off one plot are two facts, not one 340 kg fact.  Quantities
+        in different conditions are NOT commensurable and must not be
+        summed across this level without a drying / shelling conversion.
+
+        The vocabulary crosses a DRYNESS family with a physical FORM:
+        `green` / `fresh` / `dry_at_harvest` / `dried`, each optionally
+        qualified by `_with_shell_and_stalk`, `_with_shell`, `_in_cob`,
+        `_in_pods` or `_grain`.  The unqualified family token means "state
+        not applicable" -- the survey asked, and the crop has no shell,
+        cob or pod to speak of.
+
+        Seeded from Uganda's UNPS scheme (GH #323 / #637), which is the
+        finest instrument in the library.  A country whose questionnaire
+        asks only a coarse dry/fresh distinction uses the bare family
+        tokens; a country asking something Uganda does not should extend
+        this list rather than force-fit a foreign category, per the
+        `Tenure` / `TenureSystem` precedent above.  `unknown_condition` is
+        the sentinel for a record whose condition code is missing or
+        outside the source's labelled scheme -- it is a real value, never
+        NA, because a null index key is silently dropped by the duplicate
+        collapse in a country's build script.
+      spellings:
+        green_with_shell_and_stalk: []
+        green_with_shell: []
+        green_in_cob: []
+        green_in_pods: []
+        fresh: []
+        fresh_with_shell_and_stalk: []
+        fresh_with_shell: []
+        fresh_in_cob: []
+        fresh_in_pods: []
+        dry_at_harvest_with_shell_and_stalk: []
+        dry_at_harvest_with_shell: []
+        dry_at_harvest_in_cob: []
+        dry_at_harvest_grain: []
+        dried: []
+        dried_with_shell_and_stalk: []
+        dried_with_shell: []
+        dried_in_cob: []
+        dried_in_pods: []
+        dried_grain: []
+        other_condition: []
+        unknown_condition: []
   food_acquired:
     # Acquisition source 's' is an INDEX level (see Index Info above),
     # not a column.  Canonical values: purchased, produced, inkind,

--- a/tests/test_uganda_crop_condition.py
+++ b/tests/test_uganda_crop_condition.py
@@ -17,13 +17,29 @@ These tests are written to FAIL on the pre-fix tree:
   one 340 kg row instead of 240 kg dry + 100 kg fresh.
 * ``test_harvest_conditions_table_exists``      — the mapping table did not exist.
 
+A second family of tests (added after the adversarial review of PR #649) guards
+the *other* failure mode — not "the level is missing" but "the level is there
+and silently wrong".  ``crop_production_for_wave`` used to fall through a quiet
+``in df5.columns`` guard, so a mis-typed ``CROP_COLMAPS`` condition column
+bucketed a whole wave-season into ``unknown_condition`` with every test green:
+
+* ``test_crop_colmap_columns_resolve_in_source``   — a NAMED column must exist.
+* ``test_sentinel_share_bounded_per_wave_season``  — per-cell sentinel ceiling.
+* ``test_condition_varies_within_every_wave_season`` — per-cell variety floor.
+
+The first catches a name that does not resolve; the other two catch a name that
+resolves to the wrong column.  Their thresholds are measured, not guessed —
+provenance is in the constants at the top of this module.
+
 Schema rules are READ from ``lsms_library/data_info.yml`` and from Uganda's
 ``_/data_scheme.yml`` / ``_/categorical_mapping.org``, never hardcoded here
 (CLAUDE.md, "Canonical Schema").
 """
 from __future__ import annotations
 
+import os
 import warnings
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -34,6 +50,62 @@ from lsms_library.paths import countries_root
 
 TABLE = "crop_production"
 LEVEL = "condition"
+SENTINEL = "unknown_condition"
+
+# --- ceilings for the wave-season invariants (see the tests that use them) ---
+#
+# Both numbers come from ONE cold rebuild (isolated LSMS_DATA_DIR with only
+# dvc-cache symlinked in, LSMS_COUNTRIES_ROOT pinned to the branch worktree,
+# Uganda cache physically removed), 2026-07-21, 133 683 rows.
+#
+# Observed `unknown_condition` share by (t, season), worst first:
+#     2009-10 A 25.72%   2009-10 B 20.46%   2010-11 A 7.10%   2013-14 B 4.35%
+#     2011-12 A  3.61%   2011-12 B  3.44%   2010-11 B 0.97%   2013-14 A 0.28%
+#     2015-16 A  0.22%   2018-19 A  0.13%   2019-20 A 0.12%   2015-16 B 0.03%
+#     2019-20 B  0.04%   2018-19 B  0.00%
+# The two leaders are 2009-10's seasons, which ship no value labels at all;
+# every labelled wave-season is under 4.4%.  The ceiling is set at 40% — well
+# clear of the worst honest cell, and far under the ~100% that a wave-season
+# collapses to when its condition column is mis-wired (the failure this
+# guards: the red-team mutation of CROP_COLMAPS['2018-19']['A'] took that
+# cell from 0.13% to 7 153 / 7 153 = 100%).
+#
+# This ceiling is NOT sufficient on its own, and the threshold is not tuned to
+# pretend otherwise.  Measured counter-example: pointing 2018-19 season A's
+# condition at `s5aq06f_1` (the harvest month — a plausible 6f/6b fat-finger)
+# leaves the sentinel share at 33.7%, UNDER this ceiling, while the cell
+# decodes only 2 real conditions.  That is what the variety floor below is
+# for; the two invariants are kept because neither alone suffices.
+MAX_SENTINEL_SHARE = 0.40
+# Observed distinct NON-sentinel conditions by (t, season): min 18 (2010-11 B),
+# max 20, every cell >= 18.  A mis-wired column yields 0-2.  Floor at 10.
+MIN_DISTINCT_CONDITIONS = 10
+
+
+def _aws_creds_available() -> bool:
+    """True iff DVC could perform an S3 pull right now.
+
+    Tests that read the RAW Stata sources need this; without credentials they
+    fail with ``NoCredentialsError`` regardless of whether the logic is right.
+    The CI ``unit-tests`` job sets ``LSMS_SKIP_AUTH=1`` and carries no secrets,
+    so they must silent-skip there and run in ``data-tests``.
+
+    (Mirrors the identical helper in ``tests/test_declared_spellings.py`` /
+    ``tests/test_canonical_shape_via_cache_miss.py``; that duplication is the
+    house pattern until a shared ``conftest.py`` lands.)
+    """
+    if os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"):
+        return True
+    creds_file = (
+        Path(__file__).parent.parent
+        / "lsms_library" / "countries" / ".dvc" / "s3_creds"
+    )
+    if creds_file.exists():
+        try:
+            return "aws_access_key_id" in creds_file.read_text()
+        except OSError:
+            return False
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -88,6 +160,16 @@ def harvest_conditions_table() -> pd.DataFrame:
 
 @pytest.fixture(scope="module")
 def crop_production() -> pd.DataFrame:
+    """The built table.
+
+    Skips only when the build could not have succeeded *for environmental
+    reasons* — no S3 credentials, hence no source data.  With credentials
+    present a build failure is a DEFECT and is re-raised, so that e.g. a
+    mis-wired `CROP_COLMAPS` entry (which now raises `CropColmapError`) turns
+    this module red instead of quietly reporting eight skips.  Turning a
+    config bug into a skip is the same silent-failure mode these tests exist
+    to close.
+    """
     try:
         import lsms_library as ll
 
@@ -95,8 +177,10 @@ def crop_production() -> pd.DataFrame:
             warnings.simplefilter("ignore")
             df = ll.Country("Uganda", preload_panel_ids=False,
                             verbose=False).crop_production()
-    except Exception as exc:  # pragma: no cover - environment-dependent
-        pytest.skip(f"Uganda crop_production unavailable: {exc!r}")
+    except Exception as exc:
+        if _aws_creds_available():
+            raise
+        pytest.skip(f"Uganda crop_production unavailable (no S3 creds): {exc!r}")
     if df is None or df.empty:
         pytest.skip("Uganda crop_production built empty")
     return df
@@ -137,9 +221,7 @@ def test_harvest_conditions_labels_are_canonical(harvest_conditions_table,
     )
 
 
-def test_every_wave_sources_a_condition_column():
-    """Each wave/season condition slot must name a condition column; a `None`
-    would silently sentinel the whole wave."""
+def _crop_colmaps():
     import sys
 
     sys.path.insert(0, str(countries_root() / "Uganda" / "_"))
@@ -147,9 +229,14 @@ def test_every_wave_sources_a_condition_column():
         from uganda import CROP_COLMAPS
     except ImportError as exc:  # pragma: no cover
         pytest.skip(f"cannot import uganda module: {exc!r}")
+    return CROP_COLMAPS
 
+
+def test_every_wave_sources_a_condition_column():
+    """Each wave/season condition slot must name a condition column; a `None`
+    would silently sentinel the whole wave."""
     missing = []
-    for wave, seasons in CROP_COLMAPS.items():
+    for wave, seasons in _crop_colmaps().items():
         for season in ("A", "B"):
             cm = seasons.get(season)
             if not cm:
@@ -158,6 +245,94 @@ def test_every_wave_sources_a_condition_column():
                 if not cond.get("condition"):
                     missing.append(f"{wave}/{season}[{n}]")
     assert not missing, f"condition column unwired for: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# the colmap must RESOLVE, not merely be non-empty  (GH #323 red-team F4)
+# ---------------------------------------------------------------------------
+#
+# `test_every_wave_sources_a_condition_column` above checks only that a name is
+# written down.  A name that does not exist in the source file used to fall
+# through a silent `in df5.columns` guard, so a typo'd condition column
+# sentinelled an entire wave-season to `unknown_condition` and every test
+# passed.  Proven by mutation: typo CROP_COLMAPS['2018-19']['A']'s condition
+# to `a5aq6b_TYPO`, clear the Uganda cache, and 2018-19 season A went from 20
+# distinct conditions to `unknown_condition` on 7 153 of 7 153 rows with 10/10
+# tests green.
+#
+# Two independent guards close it, because they catch different mistakes:
+#   * this test catches a name that does NOT resolve (typo / dropped column);
+#   * the wave-season invariants below catch a name that DOES resolve but is
+#     the wrong column — measured with `condition: 's5aq06f_1'` (the harvest
+#     month, a plausible 6f/6b fat-finger): the build succeeds, this test
+#     passes, and the variety floor is what fails.
+
+_MODULE_FILES = {"A": "agsec5a.dta", "B": "agsec5b.dta"}
+
+
+def _source_path(wave: str, basename: str) -> Path | None:
+    """Locate a wave's raw module by basename, case- and subdir-insensitively.
+
+    Derived from the shipped `.dvc` sidecars rather than hardcoded, so it
+    follows 2019-20's `Data/Agric/agsec5a.dta` without a special case.
+    """
+    root = Path(str(countries_root())) / "Uganda" / wave / "Data"
+    for side in root.rglob("*.dvc"):
+        if side.name[: -len(".dvc")].lower() == basename:
+            return side.with_suffix("")
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not _aws_creds_available(),
+    reason="reads the raw UNPS Stata modules (DVC -> S3); no credentials in the "
+           "`unit-tests` CI job (LSMS_SKIP_AUTH=1). Runs in `data-tests`.",
+)
+def test_crop_colmap_columns_resolve_in_source():
+    """Every column CROP_COLMAPS *names* must exist in the file it is read from.
+
+    `None` remains the declared, auditable way to say "this wave records no
+    such column" (2018-19 season A genuinely has no harvest unit).  A NAME is a
+    claim about the source file, and this test checks it.
+    """
+    from lsms_library.local_tools import get_dataframe
+
+    colmaps = _crop_colmaps()
+    bad, checked = [], 0
+    for wave, seasons in colmaps.items():
+        for season, basename in _MODULE_FILES.items():
+            cm = seasons.get(season)
+            if not cm:
+                continue
+            path = _source_path(wave, basename)
+            assert path is not None, f"no {basename} under Uganda/{wave}/Data"
+            try:
+                df = get_dataframe(str(path), convert_categoricals=False)
+            except Exception as exc:  # pragma: no cover - environment-dependent
+                pytest.skip(f"cannot read {path}: {exc!r}")
+            cols = set(df.columns)
+            for key in ("hhid", "parcel", "plot", "crop"):
+                name = cm.get(key)
+                if name is not None:
+                    checked += 1
+                    if name not in cols:
+                        bad.append(f"{wave}/{season} {key}={name!r}")
+            for n, cond in enumerate(cm["conditions"]):
+                for key in ("qty", "unit", "condition", "qty_sold",
+                            "value_sold", "month"):
+                    name = cond.get(key)
+                    if name is not None:
+                        checked += 1
+                        if name not in cols:
+                            bad.append(f"{wave}/{season}[{n}] {key}={name!r}")
+    assert checked > 100, f"only {checked} colmap entries checked; harness broke"
+    assert not bad, (
+        "CROP_COLMAPS names source columns that do not exist. Each one is "
+        "SILENT in the output — a bad `condition` sentinels a whole wave-"
+        "season to unknown_condition, a bad `qty` drops the slot entirely:\n  "
+        + "\n  ".join(bad)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -200,8 +375,14 @@ def test_fresh_and_dry_no_longer_collide(crop_production):
     f = crop_production.reset_index()
     sel = f[(f["t"] == "2011-12") & (f["i"] == "1033000506")
             & (f["plot"] == "1033000506-1-6") & (f["j"] == "Coffee")]
-    if sel.empty:  # pragma: no cover - data subset without this household
-        pytest.skip("2011-12 HH 1033000506 not present in this build")
+    # Deliberately NOT `pytest.skip` on empty: this is the PR's single most
+    # important regression test, and a skip-on-empty escape hatch would let an
+    # id remapping silently disarm it rather than fail it.
+    assert not sel.empty, (
+        "2011-12 HH 1033000506 plot -1-6 Coffee is missing from the build; the "
+        "GH #323 regression example can no longer be checked. If the household "
+        "id scheme changed, RE-DERIVE the example — do not delete the test."
+    )
 
     qty = sorted(float(x) for x in sel["Quantity"])
     assert qty == [100.0, 240.0], (
@@ -222,4 +403,57 @@ def test_condition_actually_separates_records(crop_production):
     assert n_split > 1000, (
         f"only {n_split} plot-crop-unit-season groups carry >1 condition; "
         f"expected ~3200 (2026-07-21 measurement)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# per-(wave, season) invariants  (GH #323 red-team F4)
+# ---------------------------------------------------------------------------
+#
+# The panel-wide checks above are all insensitive to ONE broken wave-season:
+# `test_condition_actually_separates_records`' > 1000 threshold survives losing
+# any single cell, and `test_condition_values_are_canonical` passes because
+# `unknown_condition` IS canonical.  These two are per-cell, so a single
+# mis-wired colmap entry cannot hide behind the other thirteen.
+
+def _by_wave_season(crop_production):
+    f = crop_production.reset_index()
+    assert {"t", "season"} <= set(f.columns), list(f.columns)
+    return f.groupby(["t", "season"])
+
+
+def test_sentinel_share_bounded_per_wave_season(crop_production):
+    """No wave-season may be mostly `unknown_condition`.
+
+    A condition column that resolves but is the WRONG column decodes to
+    nothing and buckets the whole cell into the sentinel.  Ceiling and its
+    provenance: see MAX_SENTINEL_SHARE at the top of this module.
+    """
+    share = _by_wave_season(crop_production)[LEVEL].apply(
+        lambda s: float((s == SENTINEL).mean()))
+    over = share[share > MAX_SENTINEL_SHARE]
+    assert over.empty, (
+        f"{LEVEL} is >{MAX_SENTINEL_SHARE:.0%} `{SENTINEL}` for:\n"
+        + "\n".join(f"  {t}/{s}: {v:.1%}" for (t, s), v in over.items())
+        + f"\nWorst honest cell measured 2026-07-21 was 2009-10/A at 25.7%. "
+          f"Check the `condition` entry in CROP_COLMAPS for these waves — it "
+          f"is the column that silently sentinels a whole cell when wrong."
+    )
+
+
+def test_condition_varies_within_every_wave_season(crop_production):
+    """Every wave-season must decode a real spread of conditions.
+
+    Floor and its provenance: see MIN_DISTINCT_CONDITIONS at the top of this
+    module (measured min was 18 distinct non-sentinel values per cell).
+    """
+    n = _by_wave_season(crop_production)[LEVEL].apply(
+        lambda s: int(s[s != SENTINEL].nunique()))
+    thin = n[n < MIN_DISTINCT_CONDITIONS]
+    assert thin.empty, (
+        f"fewer than {MIN_DISTINCT_CONDITIONS} distinct non-sentinel {LEVEL} "
+        f"values for:\n"
+        + "\n".join(f"  {t}/{s}: {v}" for (t, s), v in thin.items())
+        + "\nEvery wave-season carried >= 18 on 2026-07-21; a cell that "
+          "collapses to 0 or 1 means its condition column is mis-wired."
     )

--- a/tests/test_uganda_crop_condition.py
+++ b/tests/test_uganda_crop_condition.py
@@ -1,0 +1,225 @@
+"""Regression tests for the ``condition`` index level on Uganda ``crop_production``.
+
+GH #323 / #637.  The UNPS post-harvest module asks quantity, unit AND
+condition/state as one compound question, so the same plot-crop-season is
+reported once per condition.  ``crop_production`` was keyed
+``(t, i, plot, j, u, season)`` with no level for the condition, so those
+records collided and the de-duplication block at the end of
+``uganda.crop_production_for_wave`` SUMMED them — adding dry weight to
+fresh weight.
+
+These tests are written to FAIL on the pre-fix tree:
+
+* ``test_condition_is_an_index_level``          — the level did not exist.
+* ``test_declared_index_carries_condition``     — ``data_scheme.yml`` did not
+  declare it, and ``_normalize_dataframe_index`` drops undeclared levels.
+* ``test_fresh_and_dry_no_longer_collide``      — the 2011-12 coffee record was
+  one 340 kg row instead of 240 kg dry + 100 kg fresh.
+* ``test_harvest_conditions_table_exists``      — the mapping table did not exist.
+
+Schema rules are READ from ``lsms_library/data_info.yml`` and from Uganda's
+``_/data_scheme.yml`` / ``_/categorical_mapping.org``, never hardcoded here
+(CLAUDE.md, "Canonical Schema").
+"""
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+import pytest
+import yaml
+from importlib.resources import files
+
+from lsms_library.paths import countries_root
+
+TABLE = "crop_production"
+LEVEL = "condition"
+
+
+# ---------------------------------------------------------------------------
+# config fixtures (cheap — no data build)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def canonical_vocabulary() -> set[str]:
+    """Canonical `condition` values, from data_info.yml Columns.
+
+    `spellings` is an inverse dict; "the canonical values are simply
+    spellings.keys()" (data_info.yml, Columns preamble).
+    """
+    with open(files("lsms_library") / "data_info.yml", encoding="utf-8") as f:
+        info = yaml.safe_load(f)
+    col = info.get("Columns", {}).get(TABLE, {}).get(LEVEL)
+    assert isinstance(col, dict), (
+        f"data_info.yml declares no Columns.{TABLE}.{LEVEL} entry; the canonical "
+        f"{LEVEL} vocabulary has no home"
+    )
+    spellings = col.get("spellings") or {}
+    assert spellings, f"Columns.{TABLE}.{LEVEL} declares an empty spellings dict"
+    return set(spellings)
+
+
+class _SchemeLoader(yaml.SafeLoader):
+    """SafeLoader that handles the !make tag used in data_scheme.yml."""
+
+
+_SchemeLoader.add_constructor("!make", lambda loader, node: {"__make__": True})
+
+
+@pytest.fixture(scope="module")
+def uganda_scheme() -> dict:
+    path = countries_root() / "Uganda" / "_" / "data_scheme.yml"
+    with open(path, encoding="utf-8") as f:
+        return yaml.load(f, Loader=_SchemeLoader)["Data Scheme"][TABLE]
+
+
+@pytest.fixture(scope="module")
+def harvest_conditions_table() -> pd.DataFrame:
+    """The `harvest_conditions` Code -> Preferred Label table."""
+    from lsms_library.local_tools import df_from_orgfile
+
+    path = countries_root() / "Uganda" / "_" / "categorical_mapping.org"
+    return df_from_orgfile(str(path), name="harvest_conditions")
+
+
+# ---------------------------------------------------------------------------
+# built-table fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def crop_production() -> pd.DataFrame:
+    try:
+        import lsms_library as ll
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            df = ll.Country("Uganda", preload_panel_ids=False,
+                            verbose=False).crop_production()
+    except Exception as exc:  # pragma: no cover - environment-dependent
+        pytest.skip(f"Uganda crop_production unavailable: {exc!r}")
+    if df is None or df.empty:
+        pytest.skip("Uganda crop_production built empty")
+    return df
+
+
+# ---------------------------------------------------------------------------
+# config-level tests (run without any data)
+# ---------------------------------------------------------------------------
+
+def test_declared_index_carries_condition(uganda_scheme):
+    """`_normalize_dataframe_index` DROPS index levels the scheme does not
+    declare, so an undeclared `condition` would be a silent no-op that still
+    sums fresh onto dry."""
+    declared = uganda_scheme["index"]
+    assert LEVEL in [tok.strip() for tok in declared.strip("() ").split(",")], (
+        f"Uganda data_scheme.yml declares {TABLE} index {declared!r} without "
+        f"{LEVEL!r}; country.py::_normalize_dataframe_index would drop the level"
+    )
+
+
+def test_harvest_conditions_table_exists(harvest_conditions_table):
+    t = harvest_conditions_table
+    assert "Preferred Label" in t.columns, t.columns.tolist()
+    assert len(t) >= 20, f"harvest_conditions has only {len(t)} rows"
+    assert t["Preferred Label"].is_unique, "duplicate Preferred Labels"
+
+
+def test_harvest_conditions_labels_are_canonical(harvest_conditions_table,
+                                                 canonical_vocabulary):
+    """Every label Uganda emits must be a declared canonical value, so the
+    cross-country vocabulary in data_info.yml is not silently bypassed."""
+    labels = {str(v).strip() for v in harvest_conditions_table["Preferred Label"]
+              if pd.notna(v) and str(v).strip() not in ("", "---")}
+    unknown = labels - canonical_vocabulary
+    assert not unknown, (
+        f"harvest_conditions emits labels absent from data_info.yml "
+        f"Columns.{TABLE}.{LEVEL}.spellings: {sorted(unknown)}"
+    )
+
+
+def test_every_wave_sources_a_condition_column():
+    """Each wave/season condition slot must name a condition column; a `None`
+    would silently sentinel the whole wave."""
+    import sys
+
+    sys.path.insert(0, str(countries_root() / "Uganda" / "_"))
+    try:
+        from uganda import CROP_COLMAPS
+    except ImportError as exc:  # pragma: no cover
+        pytest.skip(f"cannot import uganda module: {exc!r}")
+
+    missing = []
+    for wave, seasons in CROP_COLMAPS.items():
+        for season in ("A", "B"):
+            cm = seasons.get(season)
+            if not cm:
+                continue
+            for n, cond in enumerate(cm["conditions"]):
+                if not cond.get("condition"):
+                    missing.append(f"{wave}/{season}[{n}]")
+    assert not missing, f"condition column unwired for: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# built-table tests
+# ---------------------------------------------------------------------------
+
+def test_condition_is_an_index_level(crop_production):
+    assert LEVEL in list(crop_production.index.names), (
+        f"crop_production index is {list(crop_production.index.names)}; harvest "
+        f"records differing only by condition collide and are summed (GH #323)"
+    )
+
+
+def test_condition_level_has_no_nulls(crop_production):
+    """A null index key is SILENTLY DROPPED by the duplicate collapse's
+    `groupby(level=...)` (pandas default dropna=True), so the level must carry
+    a sentinel string instead."""
+    values = crop_production.index.get_level_values(LEVEL)
+    assert int(pd.isna(values).sum()) == 0
+
+
+def test_condition_values_are_canonical(crop_production, canonical_vocabulary):
+    observed = set(crop_production.index.get_level_values(LEVEL).unique())
+    unknown = {v for v in observed if pd.notna(v)} - canonical_vocabulary
+    assert not unknown, (
+        f"crop_production emits {LEVEL} values not declared in data_info.yml: "
+        f"{sorted(unknown)}"
+    )
+
+
+def test_index_is_unique(crop_production):
+    assert crop_production.index.is_unique
+
+
+def test_fresh_and_dry_no_longer_collide(crop_production):
+    """The measured GH #323 example: one household's coffee off one plot,
+    reported twice in the same month and unit — 240 kg dry and 100 kg fresh.
+    Pre-fix these summed to a single 340 kg row, which is not a quantity of
+    anything."""
+    f = crop_production.reset_index()
+    sel = f[(f["t"] == "2011-12") & (f["i"] == "1033000506")
+            & (f["plot"] == "1033000506-1-6") & (f["j"] == "Coffee")]
+    if sel.empty:  # pragma: no cover - data subset without this household
+        pytest.skip("2011-12 HH 1033000506 not present in this build")
+
+    qty = sorted(float(x) for x in sel["Quantity"])
+    assert qty == [100.0, 240.0], (
+        f"expected the dry (240) and fresh (100) coffee records to stay "
+        f"separate, got quantities {qty}"
+    )
+    assert sel[LEVEL].nunique() == 2, sel[LEVEL].tolist()
+    assert {"dried_in_pods", "fresh_in_pods"} <= set(sel[LEVEL])
+
+
+def test_condition_actually_separates_records(crop_production):
+    """Sanity: the level does real work — thousands of plot-crop-unit-season
+    groups carry more than one condition.  A level that never varies would
+    pass every test above while fixing nothing."""
+    f = crop_production.reset_index()
+    keys = [k for k in ["t", "i", "plot", "j", "u", "season"] if k in f.columns]
+    n_split = int((f.groupby(keys, dropna=False)[LEVEL].nunique() > 1).sum())
+    assert n_split > 1000, (
+        f"only {n_split} plot-crop-unit-season groups carry >1 condition; "
+        f"expected ~3200 (2026-07-21 measurement)"
+    )


### PR DESCRIPTION
## The defect

The UNPS post-harvest module asks question 6 as one compound question — *how much did you harvest, in what unit, **and in what condition/state***. A household that takes some of a crop off a plot fresh and the rest after drying it answers **twice**.

`crop_production` was keyed `(t, i, plot, j, u, season)` with no level for the condition, so those answers landed on the same index tuple and the de-duplication block at the end of `uganda.crop_production_for_wave` **summed** them. Dry weight was added to fresh weight.

```
2011-12  HH 1033000506  plot -1-6  Coffee  Kilogram (KG)
   240 kg  "Dry after additional drying - in pods or shell/husks"  month 6
   100 kg  "Fresh/raw harvested - in pods or shell/husks"          month 6
   -> summed to a single 340 kg row
```

340 is not a quantity of anything. **3 654 index groups** were affected. The quietest instances were 2009-10 and 2010-11: those waves have no harvest-month column, so *every* one of their collisions looked like an exact duplicate of an identical record.

## The fix

Grain is now `(t, i, plot, j, u, condition, season)`.

**Both vintages use the same 20 integer codes.**

| vintage | shape | condition source |
|---|---|---|
| 2009-16 | LONG — one column group, multiple source rows per plot-crop | a value in `a5aq6b` / `a5bq6b` |
| 2018-20 | WIDE — parallel `_1`/`_2` slots | a value in each slot's own 6c column |

2019-20's `_1`/`_2` are **not** an ordinal "first/second harvest": the Stata variable labels read literally `6c. Condition/state of crop harvested (2018, full harvest, condition1)` / `(… condition2)`. So one `harvest_conditions` table in `categorical_mapping.org` serves every wave — **no harmonisation between vintages was needed or invented**, only cosmetic label drift (en-dash vs hyphen, mojibake in 2015-16 AGSEC5B, code 99 reading "Others" in 2011-12 and "Not Applicable" in 2018-20).

Labels encode the scheme's own 2-D cross: a dryness family (`green` / `fresh` / `dry_at_harvest` / `dried`) × a physical form (`_with_shell_and_stalk` / `_with_shell` / `_in_cob` / `_in_pods` / `_grain`).

The canonical cross-country vocabulary is declared in `lsms_library/data_info.yml` the way `plot_features.Tenure` is — `type` + prose `note` + `spellings` with empty variant lists, carrying the house "countries may extend this list rather than force-fit a local category" stance. **`_enforce_canonical_spellings` applies spelling maps to index levels, not just columns** (`country.py:3962`), which is what makes a `Columns:` declaration legitimate for an index level.

`condition` is sentinel-filled (`unknown_condition`) rather than left NA, because the collapse's `groupby(level=...)` defaults to `dropna=True` and **silently deletes** rows with a null index key.

## Verification of the `a5aq6b`/`a5aq6c` claim

Checked per wave against the Stata metadata, deciding by the **value-label vocabulary**, never the variable label. The old comment's claim that *"the WB .do's A5aq6b/A5aq6c unit/condition rename is inverted for these actual UNPS files"* is **true of exactly one file** — 2013-14 AGSEC5A. Every other wave labels its variables correctly. The wiring (`6c` = unit) was right in all cases; only the explanation was overstated. Corrected in place; the full per-wave table is in `Uganda/_/CONTENTS.org`.

2009-10 and 2010-11 carry **no value labels at all**; their mapping was confirmed from code distributions (6b's modes are 20/45/24 = the condition scheme's modes; 6c's are 22/1/10 = Plastic Basin / Kg / Sack 100 kg).

## Measured (cold, isolated `LSMS_DATA_DIR`)

| wave | dup groups before | after | rows before | rows after | Quantity (identical) |
|---|---:|---:|---:|---:|---:|
| 2009-10 | 670 | 181 | 24 997 | 25 485 | 310,664,565.8 |
| 2010-11 | 608 | 81 | 20 442 | 20 970 | 708,149.5 |
| 2011-12 | 653 | 55 | 19 552 | 20 152 | 1,128,560.3 |
| 2013-14 | 589 | 61 | 17 053 | 17 585 | 1,098,713.5 |
| 2015-16 | 764 | 63 | 18 874 | 19 576 | 1,050,367.4 |
| 2018-19 | 0 | 0 | 14 194 | 14 194 | 1,180,031.7 |
| 2019-20 | 370 | 18 | 15 369 | 15 721 | 1,175,600.8 |
| **total** | **3 654** | **459** | **130 481** | **133 683** | **317,005,989.0** |

Collisions fall **87.4%**. `Quantity`, `Quantity_sold` (18,134,251.4) and `Value_sold` (9,066,365,499.8) totals are **identical per wave before and after** — summing is conservative, so a correct fix moves rows apart without creating or destroying mass.

**Residual 459 groups** are now all *commensurable* (same crop, same unit, same condition), so summing them is arithmetically valid — precisely what was not true before. 50 groups' rows differ in `harvest_month`; ~320 differ only in `Quantity`; 49 are byte-identical source rows; 37 carry the `unknown_condition` sentinel and so may still hide a real difference.

## `Feature('crop_production')`

**Byte-identical before and after**: 250 692 rows, the same 8 kept countries, the same modal index `['country','i','t','v','plot','crop','u','currency']`, the same 6 excluded frames `[Ethiopia, EthiopiaRHS, Mali, Nigeria, Tanzania, Uganda]`.

Uganda was **already** modal-excluded — its shape `['i','t','v','plot','j','u','season']` diverges from the modal `['i','t','v','plot','crop','u']` — so a 7th level changes nothing. `crop_production` stays out of `index_info`, per the standing note there that the plot-level ag features need cross-country index NAME harmonisation (`plot` vs `plot_id`, `crop` vs `j`, across 14 countries) before registration. That is a separate PR.

## Tests

`tests/test_uganda_crop_condition.py`, 10 tests, schema rules **read** from `data_info.yml` / `data_scheme.yml` / `categorical_mapping.org`, never hardcoded.

**Negative control** — on the pre-fix tree (stashed working copy, Uganda cache physically cleared): **6 failed, 3 errors, 1 passed**, including

```
test_fresh_and_dry_no_longer_collide: expected the dry (240) and fresh (100)
coffee records to stay separate, got quantities [340.0]
test_condition_is_an_index_level: crop_production index is
['i','t','v','plot','j','u','season']
```

Post-fix, from a cleared cache: **10 passed**. Related suites (`test_schema_consistency`, `test_canonical_spellings`, `test_table_structure`, `test_uganda_tables`, `test_uganda_invariance`, `test_uganda_v_grain_invariants`, `test_quantity_kg`): **454 passed, 60 skipped**.

## Deliberately NOT in this PR

Four adjacent defects found while verifying — each **moves data**, so each needs its own before/after. All four are written up in `Uganda/_/CONTENTS.org` "Known Issues":

1. **2018-19 AGSEC5B's harvest unit exists but is unwired.** `a5bq6b` has the full 40-label `harvest_units` vocabulary and 7 041 non-null values, but the colmap sets `unit: None`, so every 2018-19 season-B row carries `u='Unknown'`. The long-standing note "2018-19's harvest side carries no unit label" is correct for 5A and **wrong for 5B**.
2. **2019-20 season B's condition2 slot is dropped entirely.** `s5bq06a_2`/`b_2`/`c_2`, labelled "(2019, condition2)", 1 306 non-null conditions, absent from the table. 2018-19's `_2` slot is labelled "second season of 2017" and may be a *season* slot — needs the questionnaire (#647).
3. **The dedup collapse silently deletes rows with a null index key** — 431 rows / 7 108 132 native units in 2009-10, all with a null `plot` id. Pre-existing; `condition` is sentinel-filled precisely so as not to add to it.
4. **2009-10 quantities carry an unstripped `99999` sentinel** — that wave's total is ~300× every other wave.

Also out of scope per the issue: the part-harvest columns `s5aq06a_11`/`_21` (#647), any `aggregation:` YAML key (D1: dead config), and any reducer (D1: a new index level or nothing).

## Follow-up the maintainer should weigh

`spellings:` **declares** the vocabulary and rewrites known variants, but nothing **rejects** a value outside it — the precedent for an enforced index-level enumeration is a code constant (`transformations.S_VALUES` for `s`), which is core and out of scope for a config-only PR. A follow-up should either add a `CONDITION_VALUES` constant alongside `S_VALUES`, or — better — drive an index-level enumeration check from `data_info.yml` so `s` stops being special-cased. Recorded in `.coder/ledger/323-uganda-crop-condition.md` §6.

No cells blessed: no human has read the per-condition numbers in real analysis.

Refs #637, #647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su5JKX3wKChyfMAdXrdCTr
