### PR TITLE
docs(#603): population-statement survey — all 111 waves, verbatim

### DIFF
--- a/slurm_logs/POPULATION_STATEMENTS_2026-07-21.org
+++ b/slurm_logs/POPULATION_STATEMENTS_2026-07-21.org
@@ -1,0 +1,4280 @@
+#+TITLE: The population record: what each LSMS_Library wave says it represents
+#+SUBTITLE: Evidence survey for GH #603 (design) / GH #601 (the population record)
+#+AUTHOR: assembled from a per-country documentation sweep, 2026-07-21
+#+DATE: 2026-07-21
+#+OPTIONS: toc:3 num:t ^:nil
+#+STARTUP: overview
+
+# ASCII EXCEPTION (deliberate, per the orgmode skill's "leave a comment" rule):
+# every block inside a #+begin_quote in this file is a VERBATIM transcription of
+# survey documentation.  Those blocks carry French, Spanish, Portuguese and
+# Arabic text, accented characters, typographic quotes, en/em dashes and sic
+# spellings.  They are NOT normalised to ASCII, because normalising them would
+# destroy the one property the whole exercise depends on.  All prose OUTSIDE the
+# quote blocks is ASCII, apart from short inline quotations of source spellings,
+# which are likewise preserved as printed.
+
+* 1. What this is, and how it was gathered
+
+** What this is
+
+This is the raw evidence base for GH #603 -- one document recording, for every
+one of the 111 wave directories the library currently ships across 38 country
+directories, *what the survey's own documentation says the sample represents*.
+
+It is not a proposal.  It deliberately stops short of one.  #601's own note is
+explicit that a proposal encoding a judgement about what the library will pool
+on a user's behalf is a *direction decision for Ethan*, so section 5 reports
+patterns and flags the awkward cases rather than resolving them.
+
+** The standing rule this obeys
+
+Three rules governed the sweep, and they are worth stating because they are what
+makes the document usable as evidence rather than as a summary:
+
+- Quotes are verbatim ::
+     Every population statement and every exclusion clause is reproduced
+     character-for-character from the source, including sic spellings
+     ("inclutyendo", "was been designed", "cover" for "covers",
+     "Bihar(Southern", "abovefor", "werestratified"), source typography
+     ("Education :", "Agriculture:holders"), and the source's own internal
+     contradictions.  Where
+     a PDF text layer forced a repair -- rejoining words split by justification,
+     collapsing runs of spaces, decoding a glyph-substituted numeral, or
+     reconstructing bidi Arabic -- the repair is declared in that wave's
+     extractor notes.  Nothing was silently corrected.
+
+- Gaps are recorded as gaps ::
+     Where no statement exists, the entry says NOT FOUND and records exactly what
+     was searched, so the claim is falsifiable.  Section 4 gives the full search
+     record for every gap.  A gap is never filled by adjacency, by a sibling
+     wave, or by the "obvious" inference.
+
+- Nothing is inferred from the data ::
+     No =.dta= file was opened for this exercise.  The universe of a survey is a
+     claim its documentation makes; it is not something to be reverse-engineered
+     from the microdata.  Several entries note explicitly where an inference was
+     available and was *declined* -- most importantly the EHCVM/EHCVM-2 panel
+     waves (Mali, Niger, Senegal 2021-22), where inheriting the 2018-19 universe
+     sentence would have been defensible and was not done.
+
+A fourth rule follows from the first three and is the one most likely to be
+misread: *a coverage claim is not a universe statement.*  "National coverage",
+"nationally representative", and "the survey covers all regions" describe where
+a sample was drawn or what it estimates.  They do not name the set of units the
+sample stands for.  The sweep kept them, but kept them labelled -- which is why
+the editorial tag =national-claimed= exists in section 2 and covers 28 waves.
+
+** How it was gathered
+
+For each wave, in order:
+
+1. The wave's own =Documentation/= directory in the repo, materialised through
+   =lsms_library.data_access.get_data_file()= (never the =dvc= CLI), including
+   =SOURCE.org=, =LICENSE.org=, DDI PDFs, Basic Information Documents, statistical
+   reports, field manuals and questionnaires.
+2. Where the local documentation had no statement, the World Bank Microdata
+   Library catalog record named by that wave's =SOURCE.org= -- the rendered
+   study-description page, the JSON metadata export, and the DDI XML export (the
+   XML matters: it distinguishes a *missing* =<universe>= element from a *present
+   but empty* one, and several waves are the latter).
+3. Where the WB catalog had nothing, the catalog's own related-materials
+   attachments (BIDs and technical reports not mirrored in this repo), and for
+   two Ghana panel waves the IHSN/ISSER mirror, which is not the World Bank.
+
+Both of the two mirrors of this repo were checked where a wave directory looked
+empty.  Scanned, image-only PDFs (Cote d'Ivoire, Kazakhstan, Peru 1985/1990/1991,
+Guyana, South Africa, parts of China) were rendered to page images and read
+visually where no OCR tool was available; those entries say so.
+
+** Field schema
+
+Each wave entry in section 3 carries:
+
+- Survey :: the survey's own title, as distinct from the repo's wave-directory label.
+- Source type :: =local-documentation= (the statement is in a file this repo
+     ships), =wb-catalog= (the statement exists only in catalog metadata or a
+     catalog-hosted document), or =not-found=.
+- Confidence :: the extractor's own confidence that the quoted text really is a
+     universe statement for that wave.  =medium= usually means "this is a
+     coverage or representativeness claim, not a universe declaration"; =low=
+     means "this is sample-design text and should not be laundered into a
+     universe".
+- Universe tag :: *editorial*.  See the legend in section 2.
+- Population statement, verbatim ::
+- Exclusions, verbatim :: called out separately on purpose.  The exclusions are
+     the point of the exercise: they are what makes two "nationally
+     representative" surveys represent different populations.
+- Extractor's notes :: editorial prose about the strength and provenance of the
+     evidence.  This is where "do not over-read this quote" lives, and it is
+     often the most decision-relevant text in the entry.
+
+* 2. Summary table
+
+** How to read the universe tag
+
+*THE TAG IS AN EDITORIAL READING.  IT IS NOT A QUOTE, AND NO DOCUMENT USES IT.*
+
+It is a one-phrase compression of what I judge the wave's documentation, taken
+as a whole, says the sample represents.  It exists so the 111 rows can be
+scanned; it is not evidence, and where it disagrees with the wave's own
+=UNIVERSE= field I say so in section 5.  The controlled set used here is:
+
+- national-all-households ::
+     The documentation names the population: all households (or all residents,
+     or all private dwellings) in the country.  Institutional-population
+     exclusions are compatible with this tag and are recorded separately.
+- national-claimed ::
+     Only a coverage or representativeness claim exists -- "National",
+     "nationally representative", "covers the entire country".  No document
+     names the population.  This is the honest tag for a large minority of
+     waves, including all eight Uganda waves and all four Cote d'Ivoire CILSS
+     waves.
+- region-excluded ::
+     National minus one or more named regions, districts or areas -- Tirana,
+     Kosovo and Metohija, Likoma, Kidal, Tigray, Arlit, rural Borno, FATA,
+     Ayacucho / Apurimac / Huancavelica, the occupied raions of Azerbaijan, nine
+     zones of Afar and Somali.
+- subnational-area ::
+     The universe is a named sub-national area from the outset: rural Hebei and
+     Liaoning; four statistical regions of Uttar Pradesh and Bihar; 15 Ethiopian
+     peasant associations; metropolitan Lima.
+- rural-and-small-town ::
+     Ethiopia ESS1 only.  Kept as its own tag because it is the one wave whose
+     declared universe is a rural/small-town restriction rather than a
+     geographic subtraction.
+- panel-inherited ::
+     The wave's universe is defined only by reference to an earlier wave's
+     sample -- a tracking universe, not a fresh draw.
+- mixed-national+panel ::
+     The library's config for this wave reads *two* source directories with
+     *two different declared universes* (Malawi 2016-17 and 2019-20: IHS4/IHS5
+     cross-section plus the IHPS long-term panel).
+- specialized ::
+     A purpose-built non-general population.  Liberia 2018-19 only: forest-
+     proximate enumeration areas within 2.5 km of a qualifying forest, urban
+     Montserrado excluded.
+- agricultural-households ::
+     Nigeria 2012-13 only, and only because the WB catalog's =Universe= field for
+     that wave literally reads "Agricultural farming household members." -- which
+     contradicts the wave's own BID.  See section 5.
+- not-stated ::
+     No population statement exists.  Seven waves.
+
+** The table
+
+#+CAPTION: Population-statement survey, all 111 waves.  The universe tag is
+#+CAPTION: editorial (see the tag legend); everything else is recorded fact.
+#+NAME: tbl:summary
+| country               | wave      | source_type         | confidence | universe tag (editorial) |
+|-----------------------+-----------+---------------------+------------+--------------------------|
+| Afghanistan           | 2016-17   | local-documentation | high       | national-all-households  |
+| Afghanistan           | 2020      | local-documentation | high       | national-all-households  |
+| Albania               | 1996      | local-documentation | high       | region-excluded          |
+| Albania               | 2002      | wb-catalog          | high       | national-all-households  |
+| Albania               | 2003      | local-documentation | medium     | panel-inherited          |
+| Albania               | 2004      | local-documentation | medium     | panel-inherited          |
+| Albania               | 2005      | local-documentation | high       | national-all-households  |
+| Albania               | 2008      | not-found           | high       | not-stated               |
+| Albania               | 2012      | local-documentation | low        | national-claimed         |
+| Armenia               | 1996      | wb-catalog          | high       | national-all-households  |
+| Azerbaijan            | 1995      | wb-catalog          | high       | region-excluded          |
+| Benin                 | 2018-19   | local-documentation | high       | national-all-households  |
+| Benin                 | 2018-2019 | local-documentation | medium     | national-all-households  |
+| Burkina_Faso          | 2014      | local-documentation | high       | national-all-households  |
+| Burkina_Faso          | 2018-19   | local-documentation | high       | national-all-households  |
+| Burkina_Faso          | 2021-22   | local-documentation | high       | panel-inherited          |
+| Cambodia              | 2019-20   | local-documentation | medium     | national-claimed         |
+| China                 | 1995-97   | local-documentation | high       | subnational-area         |
+| CotedIvoire           | 1985-86   | wb-catalog          | medium     | national-claimed         |
+| CotedIvoire           | 1986-87   | wb-catalog          | medium     | national-claimed         |
+| CotedIvoire           | 1987-88   | wb-catalog          | medium     | national-claimed         |
+| CotedIvoire           | 1988-89   | wb-catalog          | medium     | national-claimed         |
+| CotedIvoire           | 2018-19   | wb-catalog          | high       | national-all-households  |
+| Ethiopia              | 2011-12   | local-documentation | high       | rural-and-small-town     |
+| Ethiopia              | 2013-14   | local-documentation | high       | region-excluded          |
+| Ethiopia              | 2015-16   | local-documentation | high       | region-excluded          |
+| Ethiopia              | 2018-19   | wb-catalog          | high       | national-all-households  |
+| Ethiopia              | 2021-22   | wb-catalog          | high       | region-excluded          |
+| EthiopiaRHS           | 1989      | local-documentation | high       | subnational-area         |
+| EthiopiaRHS           | 1994a     | local-documentation | high       | subnational-area         |
+| EthiopiaRHS           | 1994b     | local-documentation | high       | subnational-area         |
+| EthiopiaRHS           | 1995      | local-documentation | high       | subnational-area         |
+| EthiopiaRHS           | 1997      | local-documentation | high       | subnational-area         |
+| EthiopiaRHS           | 1999      | local-documentation | high       | subnational-area         |
+| EthiopiaRHS           | 2004      | local-documentation | high       | subnational-area         |
+| EthiopiaRHS           | 2009      | local-documentation | medium     | subnational-area         |
+| GhanaLSS              | 1987-88   | local-documentation | high       | national-all-households  |
+| GhanaLSS              | 1988-89   | local-documentation | high       | national-claimed         |
+| GhanaLSS              | 1991-92   | local-documentation | high       | national-all-households  |
+| GhanaLSS              | 1998-99   | local-documentation | high       | national-claimed         |
+| GhanaLSS              | 2005-06   | local-documentation | high       | national-all-households  |
+| GhanaLSS              | 2012-13   | local-documentation | high       | national-all-households  |
+| GhanaLSS              | 2016-17   | local-documentation | medium     | national-claimed         |
+| GhanaSPS              | 2009-10   | local-documentation | high       | national-claimed         |
+| GhanaSPS              | 2013-14   | wb-catalog          | medium     | national-claimed         |
+| GhanaSPS              | 2017-18   | wb-catalog          | medium     | national-claimed         |
+| Guatemala             | 2000      | local-documentation | high       | national-all-households  |
+| Guinea-Bissau         | 2018-19   | local-documentation | high       | national-all-households  |
+| Guyana                | 1992      | wb-catalog          | high       | national-claimed         |
+| India                 | 1997-98   | local-documentation | high       | subnational-area         |
+| Iraq                  | 2006-07   | local-documentation | high       | national-all-households  |
+| Iraq                  | 2012      | not-found           | high       | not-stated               |
+| Kazakhstan            | 1996      | local-documentation | medium     | national-claimed         |
+| Kosovo                | 2000      | wb-catalog          | high       | national-all-households  |
+| Liberia               | 2018-19   | wb-catalog          | high       | specialized              |
+| Malawi                | 2004-05   | local-documentation | medium     | region-excluded          |
+| Malawi                | 2010-11   | local-documentation | high       | region-excluded          |
+| Malawi                | 2013-14   | wb-catalog          | high       | panel-inherited          |
+| Malawi                | 2016-17   | local-documentation | high       | mixed-national+panel     |
+| Malawi                | 2019-20   | local-documentation | high       | mixed-national+panel     |
+| Mali                  | 2014-15   | wb-catalog          | high       | region-excluded          |
+| Mali                  | 2017-18   | local-documentation | high       | region-excluded          |
+| Mali                  | 2018-19   | local-documentation | high       | region-excluded          |
+| Mali                  | 2021-22   | not-found           | high       | not-stated               |
+| Nepal                 | 1995-96   | wb-catalog          | high       | national-all-households  |
+| Nepal                 | 2003-04   | not-found           | high       | not-stated               |
+| Nepal                 | 2010-11   | local-documentation | high       | national-all-households  |
+| Niger                 | 2011-12   | local-documentation | high       | region-excluded          |
+| Niger                 | 2014-15   | local-documentation | high       | region-excluded          |
+| Niger                 | 2018-19   | local-documentation | high       | national-all-households  |
+| Niger                 | 2021-22   | wb-catalog          | low        | national-claimed         |
+| Nigeria               | 2010-11   | wb-catalog          | medium     | national-claimed         |
+| Nigeria               | 2012-13   | wb-catalog          | medium     | agricultural-households  |
+| Nigeria               | 2015-16   | wb-catalog          | high       | national-all-households  |
+| Nigeria               | 2018-19   | local-documentation | high       | region-excluded          |
+| Nigeria               | 2023-24   | wb-catalog          | high       | national-all-households  |
+| Pakistan              | 1991      | wb-catalog          | high       | region-excluded          |
+| Panama                | 1997      | wb-catalog          | high       | national-all-households  |
+| Panama                | 2003      | wb-catalog          | high       | national-all-households  |
+| Panama                | 2008      | wb-catalog          | high       | national-all-households  |
+| Peru                  | 1985      | wb-catalog          | high       | region-excluded          |
+| Peru                  | 1990      | wb-catalog          | high       | subnational-area         |
+| Peru                  | 1991      | wb-catalog          | medium     | national-claimed         |
+| Peru                  | 1994      | wb-catalog          | high       | national-all-households  |
+| Senegal               | 2018-19   | local-documentation | high       | national-all-households  |
+| Senegal               | 2021-22   | not-found           | high       | not-stated               |
+| Serbia                | 2007      | local-documentation | high       | region-excluded          |
+| Serbia and Montenegro | 2002      | local-documentation | high       | region-excluded          |
+| Serbia and Montenegro | 2003      | local-documentation | high       | region-excluded          |
+| South Africa          | 1993      | wb-catalog          | high       | national-all-households  |
+| Tajikistan            | 1999      | wb-catalog          | high       | national-claimed         |
+| Tajikistan            | 2003      | wb-catalog          | high       | national-claimed         |
+| Tajikistan            | 2007      | local-documentation | high       | national-claimed         |
+| Tajikistan            | 2009      | wb-catalog          | high       | panel-inherited          |
+| Tanzania              | 2008-09   | wb-catalog          | high       | national-all-households  |
+| Tanzania              | 2010-11   | wb-catalog          | high       | national-all-households  |
+| Tanzania              | 2012-13   | wb-catalog          | high       | national-all-households  |
+| Tanzania              | 2014-15   | wb-catalog          | high       | national-all-households  |
+| Tanzania              | 2019-20   | local-documentation | high       | national-all-households  |
+| Tanzania              | 2020-21   | not-found           | high       | not-stated               |
+| Timor-Leste           | 2001      | not-found           | high       | not-stated               |
+| Timor-Leste           | 2007-08   | local-documentation | high       | national-all-households  |
+| Togo                  | 2018      | wb-catalog          | high       | national-all-households  |
+| Uganda                | 2005-06   | local-documentation | medium     | national-claimed         |
+| Uganda                | 2009-10   | local-documentation | medium     | national-claimed         |
+| Uganda                | 2010-11   | local-documentation | medium     | national-claimed         |
+| Uganda                | 2011-12   | local-documentation | medium     | national-claimed         |
+| Uganda                | 2013-14   | local-documentation | medium     | national-claimed         |
+| Uganda                | 2015-16   | local-documentation | medium     | national-claimed         |
+| Uganda                | 2018-19   | wb-catalog          | medium     | national-claimed         |
+| Uganda                | 2019-20   | local-documentation | medium     | national-claimed         |
+
+*** Tag counts
+
+| universe tag             | waves |
+|--------------------------+-------|
+| national-all-households  |    37 |
+| national-claimed         |    28 |
+| region-excluded          |    18 |
+| subnational-area         |    11 |
+| not-stated               |     7 |
+| panel-inherited          |     5 |
+| mixed-national+panel     |     2 |
+| rural-and-small-town     |     1 |
+| specialized              |     1 |
+| agricultural-households  |     1 |
+| TOTAL                    |   111 |
+
+*** Source and confidence counts
+
+| source_type            | waves |
+|------------------------+-------|
+| local-documentation    |    63 |
+| wb-catalog             |    41 |
+| not-found              |     7 |
+
+| confidence             | waves |
+|------------------------+-------|
+| high                   |    84 |
+| medium                 |    25 |
+| low                    |     2 |
+
+* 3. The verbatim record, by country and wave
+
+This is the appendix.  A maintainer deciding on #603 should read sections 1, 2,
+4 and 5; this section is what those sections rest on, and is meant to be
+consulted per wave rather than read straight through.
+
+Every block inside a =#+begin_quote= below is a verbatim transcription of survey
+documentation, reproduced as recorded -- including sic spellings, source
+typography, original-language text, and the sources' own internal
+contradictions.  Translations, where present, are supplied by the extractor and
+are labelled as such; they are NEVER presented as source text.  The
+"Extractor's notes" block under each wave is editorial prose about the strength
+and provenance of the evidence, not survey text.
+
+Exclusions get their own block under every wave, including where the answer is
+NOT FOUND.  That is deliberate: the exclusions are what make two "nationally
+representative" surveys represent different populations, and burying them inside
+a general note is how they get lost.
+
+Paths are repo-relative where they pointed inside this checkout.
+
+** Afghanistan
+
+*** Afghanistan 2016-17
+
+- Survey :: Afghanistan Living Conditions Survey (ALCS) 2016-17 (formerly National Risk and Vulnerability Assessment, NRVA); Central Statistics Organization (CSO) of Afghanistan
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Afghanistan/2016-17/Documentation/Report/ALCS - 2016-17 Analysis report draft version.pdf
+- Locator :: 'Afghanistan Living Conditions Survey 2016-17 — Analysis report' (draft version), CSO. 421 PDF pages. Quotes: Ch.1 §1.1 printed p.1 = PDF p.45; Ch.2 §2.2.4 printed pp.13-14 = PDF pp.57-58; Ch.2 §2.3.1 printed p.15 = PDF p.59; Ch.3 §3.3.1 printed p.28 = PDF p.72; Annex IV §§IV.1-IV.6 + Table IV.1 printed pp.327-329 = PDF pp.371-373; Annex IX printed p.354 = PDF p.398.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+(a) Chapter 1, §1.1 'General survey backgrounds', printed p. 1 (PDF p. 45): "The survey is unique in the sense that – with inclusion of the nomadic Kuchi – it represents the entire population of Afghanistan, and that – since the 2007-08 survey – year-round data are collected in order to capture the seasonality of indicators like employment, food security and poverty. The survey was designed to produce representative estimates for the national and provincial levels, and for the Kuchi population."  ||  (b) Chapter 2, §2.2.4 'Sampling design', printed p. 13 (PDF p. 57): "The sampling design of the ALCS 2016-17 ensured results that are representative at national and provincial level, for the Kuchi population and for Shamsi calendar seasons. In total, 35 strata were identified, 34 for the provinces of Afghanistan and one for the nomadic Kuchi population."  ||  (c) Annex IV 'Sample design and implementation', §IV.2 'Sample frame', printed p. 327 (PDF p. 371): "The pre-census household listing that was conducted by CSO in 2003-05, updated in 2009, was used as the sampling frame. For seven provinces, the sampling frame consisted of the Socio-Demographic and Economic Survey (SDES) household listings: Bamyan (data collected in 2010), Ghor and Daykundi (both with data collected in 2012), Kapisa and Parwan (both with data collected in 2014), Kabul (data collected in 2013) and Samangan (data collected in 2015). Prior to the fieldwork, the selected enumeration areas (EAs) – urban and rural – were visited for a mapping update of the households, based on which the second sampling stage was implemented."  ||  (d) Annex IV, §IV.2, printed p. 327 (PDF p. 371): "The sampling frame that was used for the Kuchi population was the 2003-04 National Multi-sectoral Assessment of Kuchi (NMAK-2004). Although far from perfect given the rate of settlement of Kuchis in recent years and ongoing discussion about the definition of Kuchi, this is the best frame available for this part of Afghanistan's population."  ||  (e) Annex IX (data-quality assessment), printed p. 354 (PDF p. 398): "The ALCS is the only survey producing representative information for the entire population of Afghanistan, including the nomadic Kuchi (presently estimated at 5.0 percent of the total population)."
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a — source is in English.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+(a) Institutional/collective households — Chapter 3, §3.3.1 'Household structure', printed p. 28 (PDF p. 72): "Note that during the fieldwork only regular household were visited, as institutional and collective households were not in the sample." [sic: 'household' singular in the original]  ||  (b) Insecure districts excluded from the reserve sampling frame — §2.2.4, printed p. 14 (PDF p. 58): "In view of sustained levels of insecurity, from the fourth month of data collection onward, clusters in inaccessible areas were replaced by clusters drawn from a reserve sampling frame that excluded insecure districts."  And Annex IV, §IV.6, printed p. 328 (PDF p. 372): "A reserve sample of PSUs was drawn from the sampling frame, from which districts that were defined as insecure by the supervisors and PSOs were excluded, as well as EAs that were originally sampled. ... The districts excluded from the reserve sample list are listed in Table IV.1."  (Table IV.1 'Districts excluded from sample frame for the reserve sample', printed p. 329 / PDF p. 373, lists named districts in Kapisa, Wardak, Logar, Badghis, Nangarhar, Zabul, Baghlan, Ghazni, Helmand, Urozgan, Jawzjan, Kandahar, Kunarha, Laghman, Paktya and others.)  ||  (c) Realised non-coverage — §2.3.1 'Field operations', printed p. 15 (PDF p. 59): "Provinces that faced most security challenges were Kapisa, Nangarhar, Paktya, Paktika, Wardak, Sar-e-Pul, Urozgan, Baghlan, Kunarha, Kunduz and Helmand. As a last resort, insecure areas were replaced by more secure areas. The security situation in Paktika did not allow data collection after month six."  And: "Out of the 391 sampled districts and provincial centres of Afghanistan, in 342 (87 percent) information was collected. In total, information from 1,929 clusters was collected, against 2,042 clusters according to the sampling design (94 percent)."  And: "From the 60 Kuchi clusters, 55 were covered according to the sampling design, whereas for the five remaining the targeted Kuchi population could not be found in the field."  ||  (d) Kuchi seasonal restriction — Annex IV, §IV.4 'Stratification', printed p. 327-328 (PDF p. 371-372): "The Kuchi stratum was only collected in summer 2016 and winter 2016-17 (Shamsi calendar 1395) in view of the practical difficulty of locating migrating communities in spring and autumn."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The ALCS/NRVA is an Afghan CSO/NSIA survey, NOT a World Bank LSMS survey: the WB Microdata Library catalog has no ALCS, NRVA or IE&LFS entry for AFG (verified against the full 120-row AFG catalog listing). Afghanistan is also absent from lsms_library.provenance's local SOURCE.org coverage — neither Afghanistan wave has a Documentation/SOURCE.org, so there is no recorded #+CATALOG_ID: to fall back on. Local documentation is therefore the only source, and it is adequate.  ||  TRANSCRIPTION CAVEAT: the quotes above are from a pypdf text extraction of the PDF; that text layer inserts spurious intra-word spaces ('susta ined', 'e qual', 'diffic ulty', '201 5', 'Socio -Demographic', 'w as') and spaces before commas. I have joined those obvious extraction artifacts and nothing else; no wording, ordering or punctuation was otherwise altered. The raw unedited extraction is at /tmp/popdocs/alcs2016.txt for verification.  ||  SAMPLE DESIGN (context, not the universe statement): stratified two-stage cluster design; 35 strata (34 provinces + 1 Kuchi); target 21,000 households at a fixed cluster size of 10; EAs as PSUs selected PPS; a third stage selecting one village in multi-village rural EAs; 12 months of continuous fieldwork (Apr 2016 - Apr 2017, Shamsi 1395) so seasons are also analytical domains; realised 19,838 households / 155,680 persons. Weights up-scale to the official CSO provincial population estimate for January 2016.  ||  Household definition (§3.3, printed p.28): "The ALCS follows the UN definition of households. A household is defined as group of people, either related or unrelated, who live together as a single unit in the sense that they have common housekeeping arrangements, that is, they share or are supported by a common budget. They live together, pool their money, and eat at least one meal together each day."  ||  Note the report file is labelled 'draft version'; a final published ALCS 2016-17 report exists but is not in this repo. I did not substitute it.  ||  Fetching the PDF via get_data_file() materialised it at the (gitignored) in-tree Documentation/Report/ path; no tracked file was modified.
+#+end_quote
+
+*** Afghanistan 2020
+
+- Survey :: Income and Expenditure & Labor Force Survey (IE&LFS) 2020 (formerly Afghanistan Living Conditions Survey / NRVA); National Statistics and Information Authority (NSIA) of Afghanistan
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Afghanistan/2020/Documentation/!Income and Expenditure _ Labor Force Surveys-2020 .pdf
+- Locator :: 'Income and Expenditure & Labor Force Surveys 2020' final report, NSIA. 313 PDF pages. Quotes: Preface printed p.XXIII = PDF p.23; Ch.1 §1.1 printed p.1 = PDF p.25; Ch.1 §1.2.5 'Sampling Design' printed pp.5-6 = PDF pp.29-30; Ch.1 field operations printed p.7 = PDF p.31; survey-limitations list printed p.11 = PDF p.35; Ch.2 §2.3.1 printed p.20 = PDF p.44.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+(a) Chapter 1, §1.2.5 'Sampling Design', printed p. 5 (PDF p. 29): "The sampling design of the IE&LFS 2020 ensured results that are representative at the national and provincial levels for the Kuchi population and Shamsi calendar seasons. Thirty-five strata were identified, 34 for Afghanistan's provinces and one for the nomadic Kuchi population. Stratification by season was achieved by equal distribution of data collection over 12 months within the provinces. For the Kuchi population, the design only provided sampling in winter and summer when communities temporarily settle."  ||  (b) §1.2.5, printed p. 5 (PDF p. 29): "The sampling frame used for the IE&LFS 2020 is a high-resolution imagery-based frame created by National Statistics Information Authority (NSIA). The frame consisted of 30,060 Enumeration Areas (EA). NSIA has an electronic file consisting of 30,060 EAs that cover the entire country."  ||  (c) §1.2.5, printed p. 6 (PDF p. 30): "The Kuchi sample was designed based on the 2003-04 National Multi-Sectoral Assessment of Kuchi (NMAK-2004)."  ||  (d) Preface, printed p. XXIII (PDF p. 23): "The report consists of the most comprehensive data, and the main focus is on the national level. However, the frequently-disaggregated information is for residential populations (urban, rural, and Kuchi) and utmost provincial level."  ||  (e) §1.2.5, printed p. 6 (PDF p. 30): "Sample weights were calculated for up-scaling the surveyed households and persons to the total number of households and Afghanistan population. The calculation was based on the official NSIA population for the year 1398 (2019-20)."
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a — source is in English.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+(a) Institutional/collective households — Chapter 2, §2.3.1 'Household structure', printed p. 20 (PDF p. 44): "Note that only regular households were visited during the fieldwork, as institutional and collective households were not in the sample."  ||  (b) Districts not covered — Chapter 1, §'Field Operations', printed p. 7 (PDF p. 31): "The number of districts covered was 329 out of 399 districts in Afghanistan. The covered districts had at least one randomly selected cluster surveyed within that particular district's geographical boundaries. Fifty-eight districts were not covered due to security concerns, heavy snowfalls during the winter season, and other reasons. Twelve districts were not part of the survey as the randomly selected clusters did not fall in those districts. In 2100 planned clusters, 67 clusters were replaced with the reserve clusters."  ||  (c) Provinces under-covered — printed p. 7 (PDF p. 31): "There were provinces like Faryab, Badghis, Paktiya, Helmand, and Kapisa that could not achieve the desired coverage due to poor security conditions even after utilizing all the reserve clusters."  ||  (d) Overall realised coverage — 'Survey limitations' list item 8, printed p. 11 (PDF p. 35): "Initially, there were 2100 clusters planned to be surveyed throughout the country. Considering Afghanistan's tense security condition, the survey teams collectively managed to survey 1835 clusters in the country. The survey coverage was 87.4 percent. ... Precisely, Faryab and Badghis were the provinces with lower coverage, followed by Kapisa, Helmand, and Paktia provinces. The reason for low coverage in the provinces, as mentioned above, was the worst security situation."  ||  (e) Access limits on female respondents — 'Survey limitations' item 6-7, printed p. 11 (PDF p. 35): "the area under insurgents' control is challenging to be surveyed – they do not allow the fieldworkers to operate in their jurisdictions. Sometimes they only permit male fieldworkers while the female enumerators are not allowed to work." / "For example, in remote areas, the females might not be allowed to respond to the interview questions despite being female."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No explicit sentence of the form 'the target population is ...' appears in this report. The universe is stated only obliquely, via the sampling frame ('30,060 EAs that cover the entire country'), the 35 strata (34 provinces + nomadic Kuchi), the weighting target (total households and Afghanistan population, NSIA 1398 estimate), and the explicit exclusion of institutional and collective households. That is weaker than the ALCS 2016-17 wording ('it represents the entire population of Afghanistan') but is the strongest universe statement the document contains — I did not import the 2016-17 sentence into this wave.  ||  TRANSCRIPTION CAVEAT: as for 2016-17, the pypdf text layer inserts spurious spaces (e.g. '7 .8', 'diffic ulty', 'stratifi-cation' hyphen breaks). I joined only such obvious extraction artifacts; wording is otherwise unaltered. Raw extraction: /tmp/popdocs/ielfs2020.txt.  ||  Wave-label caveat worth recording: the wave directory is named '2020', but fieldwork ran 'early October 2019 (Meezan 1398)' to 'late September 2020 (Sunbula 1399)' (§'Field Operations', printed p. 6 / PDF p. 30).  ||  The second file in this Documentation/ directory, 'REACH_AFG_WoAA-2022-MSNA_Main-HH_Analysis_Sept2022.xlsx', is by its filename a REACH Whole-of-Afghanistan Assessment / MSNA 2022 analysis workbook — a different survey and a different year. I did not open it and it is not the source of any quote above; it should not be read as documenting the 2020 sample. Flagging rather than asserting: I have filename evidence only.  ||  SAMPLE DESIGN (context): two-stage cluster within province; extended sample of ~1.1x required EAs drawn PPS with implicit stratification by urban/rural and district, target sample drawn from it by systematic equal-probability sampling, unselected EAs forming the reserve sample; second stage 15 households by SRS (10 target + 5 reserve); design target 2,040 clusters / 20,400 households per year; Kuchi stratum 60 clusters (40 summer, 20 winter). Household definition (§2.3, printed p.20) follows the UN definition, same wording as ALCS 2016-17.
+#+end_quote
+
+** Albania
+
+*** Albania 1996
+
+- Survey :: Albania - Employment and Welfare Survey 1996 (EWS); WB Microdata catalog id 2311 / IDNO ALB_1996_EWS_v01_M
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Albania/1996/Documentation/ddi-documentation-english_microdata-2311.pdf
+- Locator :: PDF p.3, section "Sampling" > "Sampling Procedure" (first paragraph). Secondary: alb96bif.pdf ("Basic Documentation, Albania: Employment and Welfare Survey"), PDF p.4 (printed p.1) section 1 "Introduction" -- identical wording -- and PDF p.10 (printed p.7) section 3. alb96bif.pdf obtained from https://microdata.worldbank.org/index.php/catalog/2311/download/34511 ; local copy at /tmp/popdocs/bid/alb96bif.pdf
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+"The data collected cover approximately 1,500 households in rural and urban areas, excluding Tirana. Tirana was not included because it had been the focus of another household survey in 1994. The sample was designed to maximize the inclusion of poor areas to increase the number of program participants."  Corroborating statement in the survey's Basic Information Document (not held locally; downloaded from catalog 2311 as alb96bif.pdf), section 3 "Sample Design", PDF p.10 (printed p.7): "In other words, when the data are weighted the results are representative of rural and urban Albania with the exception of Tirana which was excluded from the study."  Catalog metadata field `study_desc.study_info.geog_coverage` (catalog 2311): "National (except Tirana)"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"excluding Tirana. Tirana was not included because it had been the focus of another household survey in 1994." (ddi-documentation-english_microdata-2311.pdf, Sampling > Sampling Procedure, PDF p.3)  "...representative of rural and urban Albania with the exception of Tirana which was excluded from the study." (alb96bif.pdf, PDF p.10 / printed p.7)  "National (except Tirana)" (catalog 2311, geog_coverage)
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+STRONGEST EXCLUSION FINDING FOR ALBANIA. This is the only Albania wave with a documented geographic exclusion, and it is stated twice independently (DDI sampling section + BID) and encoded in the catalog's geog_coverage field. CAVEAT: there is no formal 'Universe:' field anywhere -- catalog 2311's DDI has no `universe` key (verified by grepping the exported JSON). The quotes above are coverage/ representativeness statements, which is the strongest thing the documentation offers. Note also the purposive element: 'The sample was designed to maximize the inclusion of poor areas to increase the number of program participants' -- the sample is NOT a simple probability sample of the (non-Tirana) national population; weights are needed and the BID says weighted results are representative of rural and urban Albania ex-Tirana. This is a different survey from the LSMS series (Employment and Welfare Survey, Ministry of Labour and Social Affairs, fielded Aug-Nov 1996). Whitespace in quotes normalized (runs of whitespace/line-wrap collapsed to single spaces); wording otherwise character-for-character.
+#+end_quote
+
+*** Albania 2002
+
+- Survey :: Albania - Living Standards Measurement Survey 2002 (Wave 1 Panel); WB Microdata catalog id 86
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: /tmp/popdocs/bid/alb02bif.pdf  (LSMS 2002: Basic Information Document; NOT held in the repo)
+- Locator :: alb02bif.pdf, "Annex 5 - Sample implementation report" (memo from Ms. Blerina Zykaj), section 1 "Sampling frame", PDF p.63 (printed p.61). Obtained from https://microdata.worldbank.org/index.php/catalog/86/download/11834 . Local-repo secondary: lsms_library/countries/Albania/2002/Documentation/ddi-documentation-english_microdata-86.pdf, PDF p.3 and p.5.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+"The unit of analysis and the unit of observation is the household. The universe under study consists of all the households in the Republic of Albania. We have used the Housing Unit (defined as the space occupied by one household) as the sampling unit, instead of the household, because the HU is more permanent and easier to identify in the field."  The locally-held DDI has no universe sentence; its nearest statement (ddi-documentation-english_microdata-86.pdf, Sampling > Sampling Procedure > "Stratification", PDF p.3) is: "The survey is representative for Tirana, other urban and rural areas, as well as for Tirana and the three main agro-ecological/economic areas (Coastal, Central and Mountain)."  Catalog metadata field `geog_coverage` (catalog 86): "National coverage.\nDomains: Tirana, other urban, rural; Agro-ecological areas (coastal, central, mountain)"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+No geographic or population-group exclusion is stated anywhere in the 2002 documentation. The only exclusions documented are definitional (who counts as a household member), from ddi-documentation-english_microdata-86.pdf, Questionnaires > Overview, PDF p.5: "Household membership in this survey is defined as being away from the household for less than six months. Deceased individuals, lodgers, hired workers and servants are never considered household members. Guests who stay with the household for six months and over, infants of less than six months, new arrivals (such as newly weds) are considered household members. The household head was counted as a household member if he or she had been away less than 12 months, rather than the 6 month limit for anyone else absent."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The word 'universe' appears exactly once in the whole 2002 documentation set, in the sampling consultant's implementation memo reproduced as Annex 5 of the BID. It is NOT in the DDI's `universe` metadata field (that field does not exist for catalog 86) and NOT in the locally-held DDI PDF. Sample design detail (not the universe): 450 PSUs x 8 households = 3,600 target, final 3,599 after one household was dropped in Shkoder PSU 16; frame = April 2001 General Census of Population and Housing EAs, with zero-population EAs removed from the frame and EAs collapsed/split to 50-120 occupied housing units; 16 explicit strata (Coastal/Central/Mountain x major city/other urban/rural, plus Tirana); not self-weighted. The frame-construction step ('the EAs with zero population have been taken off the sampling frame') is a frame edit, not a stated population exclusion. Whitespace normalized; wording character-for-character.
+#+end_quote
+
+*** Albania 2003
+
+- Survey :: Albania - Living Standards Measurement Survey 2003 (Wave 2 Panel) / Albania Panel Survey (APS) Wave 2; WB Microdata catalog id 87
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: panel-inherited
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Albania/2003/Documentation/ddi-documentation-english_microdata-87.pdf
+- Locator :: PDF p.3, section "Sampling" > "Sampling Procedure" > "Panel design" (3rd paragraph); exclusions on PDF p.4. Identical wording appears in the Basic Information Document alb03bid.pdf ("Basic Documentation - Albanian panel survey description Waves 1 and 2 (2002/2003), December 2004"), PDF p.1, section 1 "Panel design" -- obtained from https://microdata.worldbank.org/index.php/catalog/87/download/11841 ; local copy at /tmp/popdocs/bid/alb03bid.pdf
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+"The sample selected from the LSMS for the panel was designed to provide a nationally representative sample of households and individuals within Albania (see Appendix B for full description of the sample design and selection procedure). This differs from the LSMS where the sample was designed to be representative of each strata which broadly represented the main regions in Albania so that regional level statistics could be generated (Mountain, Central, Coastal, Tirana)."  Catalog metadata field `geog_coverage` (catalog 87): "National"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+From ddi-documentation-english_microdata-87.pdf, Sampling > Sampling Procedure > "Panel design", PDF p.4 (bulleted list of panel design features): "- Sample members moving out of Albania are considered to be out of scope for that year of the survey (note that they remain potentially eligible for interview and it is possible they may return to a sample household at a future wave) - From Wave 2, only household members aged 15 years and over are eligible for interview. As children turn 15, they become eligible for interview (This differs from the LSMS where the individual questionnaire collected some data on children under 15 from the mother or main carer)."  Also (same section, on precision rather than coverage): "The panel data can be used for analysis broken down by strata to assess any differences between areas but should not be used to produce cross-sectional estimates at the regional level."  No geographic exclusion is stated.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+MEDIUM confidence because this is a representativeness claim about a derived panel sample, not a universe/target-population statement. No document in the 2003 set contains the word 'universe'. Structurally important for #603: the 2003 sample is not drawn from a population directly -- it is a subsample of the 2002 LSMS respondents ('The Albanian panel survey sample was selected from households interviewed on the 2002 LSMS conducted by INSTAT with support from the World Bank. The sample size for the panel took approximately half the LSMS households and has re-interviewed these households annually in each of 2003 and 2004.'). So its effective universe is the 2002 LSMS universe (all households in the Republic of Albania) propagated forward via the following rules, and the two documented scope restrictions above (emigrants out of scope; only 15+ interviewed) bite at the individual level. Sample size 2,155 households per the DDI sampling section. Whitespace normalized; wording character-for-character.
+#+end_quote
+
+*** Albania 2004
+
+- Survey :: Albania - Living Standards Measurement Survey 2004 (Wave 3 Panel) / Albania Panel Survey (APS) 2004; WB Microdata catalog id 88
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: panel-inherited
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Albania/2004/Documentation/ddi-documentation-english_microdata-88.pdf
+- Locator :: PDF p.3, section "Sampling" > "Sampling Procedure", opening paragraph under "Panel sample, with LSMS 2002 and 2004"; second quote from the same section under "APS 2003-2004 sample design". Identical wording in the Basic Information Document BasicInformationDocument_2004.pdf, section III "Sample Design", PDF p.7 (printed p.7) and PDF p.8 -- obtained from https://microdata.worldbank.org/index.php/catalog/88/download/11845 ; local copy at /tmp/popdocs/bid/BID2004.pdf
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+"The sample of the second and third waves of the panel (APS) has been selected from the LSMS 2002 in order to be representative of Albanian households and individuals at national level. The LSMS 2002 differs from the APS 2003 and 2004 in that the former is designed to be representative at regional level (Mountain, Central, Coastal and Tirana) as well as for urban and rural domains, while the latter are for last domains only (urban and rural)"  And, from the same section: "The panel component selected from the LSMS is designed to provide a nationally representative sample of households and individuals within Albania."  Catalog metadata field `geog_coverage` (catalog 88): "National coverage.\nDomains: Tirana, other urban,rura"  [sic -- truncated in the catalog record]
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+From ddi-documentation-english_microdata-88.pdf, Sampling > Sampling Procedure, PDF p.4: "From wave 2, only individuals aged 15 years and over are considered valid members, hence eligible for the interview. Individuals moved out of Albania are not accounted as valid for this survey year, though they are still eligible for future waves."  From the same PDF, Questionnaires > Overview, PDF p.5: "Household membership is defined as being an actual resident or away from the household for less than six months (the exceptions being: the household head even though he might be away from the household for up to 11 months). Deceased individuals, lodgers, hired workers and servants are never considered household members."  No geographic exclusion is stated.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+MEDIUM confidence, same reason as 2003: a representativeness claim about a derived panel subsample, not a universe statement. No document in the 2004 set contains the word 'universe'. Note the explicit DOMAIN narrowing relative to 2002 that #603 may want to record: the APS 2003/2004 are representative for urban and rural domains only, NOT at regional level, whereas the 2002 LSMS is representative at regional level too. 1,797 valid household observations, 7,476 individual observations. Panel-entry rule (bears on what the sample represents): 'The sample is designed to focus on individuals, who have been also traced when moving from the original household to a new one. This possibility represents the only way a household can enter the panel sample if it has not been already interviewed in the wave 1 (or in wave 2 for the APS 2004).' Whitespace normalized; wording character-for-character.
+#+end_quote
+
+*** Albania 2005
+
+- Survey :: Albania - Living Standards Measurement Survey 2005; WB Microdata catalog id 64
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Albania/2005/Documentation/ddi-documentation-english_microdata-64.pdf
+- Locator :: PDF p.3, section "Sampling" > "Sampling Procedure" > subsection "1. Sampling frame" (final paragraph, immediately before "2. Sample Size"). Identical wording in the Basic Information Document alb05bid.pdf, "Annex 5 Reports on the implementation of the sample / Annex 5.1 Sample implementation report", PDF p.48 (printed p.49) -- obtained from https://microdata.worldbank.org/index.php/catalog/64/download/11412 ; local copy at /tmp/popdocs/bid/alb05bid.pdf
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+"The unit of analysis and the unit of observation is the household. The universe under study consists of all the households in the Republic of Albania. We have used the Housing Unit (defined as the space occupied by one household) as the sampling unit, instead of the household, because the HU is more permanent and easier to identify in the field."  Catalog metadata field `geog_coverage` (catalog 64): "National coverage.\nDomains: Tirana, other urban, rural; Agro-ecological areas (coastal, central, mountain)"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+No geographic, regional, or population-group exclusion is stated anywhere in the 2005 documentation. The only frame edits documented are (same page, ddi-documentation-english_microdata-64.pdf PDF p.2-3): "In order to obtain EAs with the minimum of 50 and the maximum of 120 occupied housing units, the EAs with zero population have been taken off the sampling frame." and "During of the listing update process, HUs identified as invalid were taken off the frame."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+HIGH confidence that the documentation makes this claim FOR THE 2005 WAVE -- the sentence is what the 2005 DDI's Sampling Procedure section says, and it is what the WB catalog serves as catalog 64's sampling_procedure. IMPORTANT PROVENANCE CAVEAT, recorded because it is easy to over-read this quote: the paragraph is verbatim-identical to the 2002 text (alb02bif.pdf Annex 5, PDF p.63), and in alb05bid.pdf it sits inside 'Annex 5.1 Sample implementation report', a memo whose surrounding sentences describe the 2002 fieldwork ('Given that the 2002 LSMS has been conducted less than a year after the April 2001 census...'). So this universe sentence is INHERITED 2002 text that INSTAT/WB carried forward into the 2005 documentation, not a freshly-written 2005 universe declaration. It was verified by diffing the two annexes. The 2005 BID's own sample-design chapter (PDF pp.6-9) states that a completely new sample was drawn for 2005 (hypothesis (ii)) rather than reusing the 2002 PSUs. Whitespace normalized; wording character-for-character.
+#+end_quote
+
+*** Albania 2008
+
+- Survey :: Albania - Living Standards Measurement Survey 2008; WB Microdata catalog id 1933
+- Source type :: not-found
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: not-stated
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Albania/2008/Documentation/ddi-documentation-english_microdata-1933 (1).pdf
+- Locator :: PDF p.2, heading "Sampling", body "No content available". Catalog fields from https://microdata.worldbank.org/index.php/metadata/export/1933/json , keys study_desc.study_info.geog_coverage and .analysis_unit.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND. No universe / target-population / coverage-exclusion statement exists in any documentation available for this wave.  The locally-held DDI PDF's sampling section reads, in full: "Sampling  No content available"  The only population-scope claim anywhere is the catalog metadata field `geog_coverage` (catalog 1933): "National" and the units-of-analysis field `analysis_unit`: "- individuals,\n- households,\n- communities" Neither is a universe statement.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND. No exclusion of any kind is stated for the 2008 wave.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+This is a genuine, fully-sourced GAP, not an unsearched cell. The 2008 wave is the worst-documented Albania wave by a wide margin: the WB catalog record itself carries no sampling_procedure, and no BID was ever published for it. Do NOT infer 2008's universe from 2005 or 2012 by adjacency: the abstract says only 'In 2008, 3,600 households participated in the survey' -- the same 3,600 target as 2002/2005, and different from 2012's 6,671 -- but that is a sample-size coincidence, not evidence about the universe. If #603 needs 2008, the acquisition route is INSTAT Albania directly (instat.gov.al), not the WB catalog.
+#+end_quote
+
+*** Albania 2012
+
+- Survey :: Albania - Living Standards Measurement Survey 2012; WB Microdata catalog id 1970 / IDNO ALB_2012_LSMS_v01_M
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: low
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Albania/2012/Documentation/ddi-documentation-english_microdata-1970.pdf
+- Locator :: Quote (a) and (d): PDF p.4, section "Sampling" > "Sampling Procedure". Quotes (b) and (c): PDF p.2, section "Overview" > "Coverage" / "UNITS OF ANALYSIS". Identical text is served by the catalog at https://microdata.worldbank.org/index.php/metadata/export/1970/json , keys study_desc.method.data_collection.sampling_procedure and study_desc.study_info.geog_coverage / .analysis_unit.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+No sentence declaring a universe/target population exists. The nearest coverage claims, both verbatim, are:  (a) ddi-documentation-english_microdata-1970.pdf, Sampling > Sampling Procedure, PDF p.4: "In the first round, 834 Primary Selection Units (PSUs) have been chosen randomly to represent the whole territory of the country."  (b) same PDF, Overview > Coverage, PDF p.2: "GEOGRAPHIC COVERAGE National"  (c) same PDF, Overview > "UNITS OF ANALYSIS", PDF p.2: "- Households  - Individuals"  (d) same section as (a), on the analytic domains: "However, the geographic domains of analysis have been expanded to include the 12 individual prefectures of Albania, by urban and rural strata, compared to four geographic regions (Central, Coastal, Mountain and Tirana) by urban and rural strata defined previously as domains for the survey."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND. No geographic, regional, or population-group exclusion is stated for the 2012 wave.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+LOW confidence deliberately: quote (a) is a SAMPLE DESIGN statement about PSU selection, not a universe declaration, and (b) is a catalog coverage tag. I am recording them because they are what the documentation actually claims; they should not be laundered into a universe statement. Note the extraction artifact I corrected: pdfminer renders the PDF's 'fi' ligature, so the raw extraction of (a) reads 'In the ﬁrst round'. The spelling given above ('first') is the form the WB catalog JSON serves for the same sentence, and is the correct reading. Design detail (not universe): 834 PSUs x 8 households = 6,671 completed; frame = Population and Housing Census of October 2011; 4 substitute households per PSU; sample size raised from 3,600 to 6,671 to support 24 strata (12 prefectures x urban/rural). Whitespace normalized; wording otherwise character-for-character.
+#+end_quote
+
+** Armenia
+
+*** Armenia 1996
+
+- Survey :: Armenian Household Budget Survey 1996 (AHBS 96 / HBS 1996)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: ar96binf.pdf ("Basic Information Document — Republic Of Armenia, Household Budget Survey -- 1996 (AHBS 1996)", Development Research Group, Poverty and Human Resources Division, The World Bank, December 1998). NOT present in the local repo; downloaded from the World Bank Microdata catalog entry 2324 (https://microdata.worldbank.org/index.php/catalog/2324/download/34650).
+- Locator :: Section 3. Sample, §3.1 Coverage, p. 9 (first paragraph); the exclusion is footnote 3 on the same page, attached to the word "households." in that paragraph.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The AHBS 96 covered the whole territory of the ROA which had an estimated population at the time of the survey of 3.75 million people and 875,000 households.3 According to the SDS records, about 61% of the households were classified as ‘Urban Dwellers’. Approximately 253,000 households  (i.e. 28.9% of the total in the republic and 47.7% of the urban households) were registered in the capital, Yerevan.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+3 This excludes the enclave of Nagorni Karabakh within Azerbaijan, which is Armenian in population but not part of the Armenian Republic, and the Azerbaijanian territories of Nakhichevan and Artsvashen.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+There is exactly one wave directory for Armenia (1996); `_` and `var` excluded. The wave has NO local microdata (CLAUDE.md lists Armenia under "Countries Without Microdata": "No data files downloaded"), and no local BID/report — hence the catalog fallback.  The WB catalog DDI for study 2324 has NO <universe> element. Its <sumDscr> records only <geogCover>National</geogCover>, <nation abbr="ARM">Armenia</nation>, and <anlyUnit>- Households\n- Individuals</anlyUnit>. The nearest catalog-level universe-like claim is in the abstract: "The Armenian Household Budget Survey (HBS) 1996 was designed to be a nationally representative survey capable of measuring the standard of living in the Republic of Armenia (ROA) ... The survey was conducted in November - December 1996, on the whole territory of the republic by the State Department of Statistics (SDS) of ROA with technical and financial assistance from the World Bank." The identical sentences open §1 Introduction of ar96binf.pdf, p. 3, with "(AHBS 96)" in place of "(HBS) 1996".  Unit of analysis, verbatim, ar96binf.pdf §1 Introduction, p. 3: "The unit of study in the survey was the household, defined as a group of co-resident individuals with a common living budget."  SAMPLE DESIGN (not the universe; recorded for context). ar96binf.pdf §3.5 Sample design, p. 11 (identical text is the catalog's <sampProc>): "The State Department of Statistics specified 3 domains of interest for this study. These are Yerevan (the capital of ROA), Other Urban areas and Rural areas." and "A self-weighting sample was derived by selecting Primary Sampling Units (PSUs) with probability proportional to their size (where size is defined as the number of households) and then taking a constant number of households from each selected. The sample, therefore, was designed to be self-weighted and representative at the administrative regions (Marzes) level, for urban and rural areas, and within urban areas by the size of cities,  and in rural areas by elevation. The number of households to be selected in each PSU was 20, so 250 PSUs were required to make up 5000 households."  SAMPLING FRAME (§3.2 Sampling Frames, pp. 9-10), which bears on coverage: "Accurate sampling frames for AHBS 96 were available at all levels down to the individual as lists are frequently updated in the Marzes, Zheks and Villages of the ROA5." and "Current lists of households and dwellings were available covering the whole Republic of Armenia. Only in case ( iv ) above  - i.e. urban public housing at the Zhek level - was it possible to select apartments which could contain more than one household. This was most likely to occur in Yerevan."  NO statement about institutional / collective / homeless / nomadic population was found anywhere in ar96binf.pdf or in the catalog metadata — the only stated exclusion is the territorial one in footnote 3. Do not read the silence as an assertion that such populations were in scope.  Quotes were extracted with pdfminer.six from the PDF; pdfminer inserts a blank line at each PDF line break, which I removed to reconstitute the running paragraph. Double spaces inside the quotes ("households  (i.e.", "cities,  and") are present in the extracted text and are preserved verbatim. Curly apostrophes in ‘Urban Dwellers’ are as in the source.  Working copies of the extracted text: /tmp/claude-43292/-global-scratch-fsa-fc-jevons-ligon-mirrors-LSMS-Library/25acb4c7-829d-4815-b875-abb430c22b9c/scratchpad/arm/ (ar96binf.txt, projcomp.txt, ddi.xml, stdydscr.xml). Note: running data_access.get_data_file() materialized the four gitignored PDFs into lsms_library/countries/Armenia/1996/Documentation/; no tracked file was modified.
+#+end_quote
+
+** Azerbaijan
+
+*** Azerbaijan 1995
+
+- Survey :: Azerbaijan Survey of Living Conditions (ASLC) / Survey of Living Conditions 1995 (AZE_1995_SLC_v01_M, catalog id 408)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: World Bank Microdata Library catalog metadata for AZE_1995_SLC_v01_M (catalog id 408), retrieved via https://microdata.worldbank.org/index.php/api/catalog/AZE_1995_SLC_v01_M ; local copy saved at /tmp/claude-43292/-global-scratch-fsa-fc-jevons-ligon-mirrors-LSMS-Library/25acb4c7-829d-4815-b875-abb430c22b9c/scratchpad/aze/meta408.json . Supporting local file: lsms_library/countries/Azerbaijan/1995/Documentation/queshhe.pdf
+- Locator :: DDI fields dataset.metadata.study_desc.method.data_collection.sampling_procedure (sections "Design", "Outside of Baku", "Internally Displaced Population", "Sampling as Implemented"); dataset.metadata.study_desc.study_info.geog_coverage; dataset.metadata.study_desc.study_info.analysis_unit. Rendered on the catalog page https://microdata.worldbank.org/index.php/catalog/408/study-description under "Sampling > Sampling Procedure". Local supporting quote: queshhe.pdf, p.1 (interviewer introduction, above the "POPULATION POINT" header).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+Three separate populations were covered: households in Baku, households outside of Baku and households of Displaced Persons. Within each of those populations, the sample was chosen in such a manner that each household had an equal probability of being selected. ... The Azerbaijan Survey of Living Conditions sample design included 408 households in the eleven raions that make up the city of Baku, 1200 households in the population outside of Baku, and 408 households among the registered Internally Displaced Persons residing throughout the country. This results in an oversampling of the Internally Displaced Persons population and an undersampling of the urban population of Baku. In order to use all data to provide nationally representative estimates, weighting factors must be applied to the data to account for the difference between the population and sample distributions.  [study_info/geog_coverage] "National" [study_info/analysis_unit] "- Households\n- Individuals\n- Community"  [Outside of Baku] The country is divided into towns, villages of the town type, and villages. Every household is located in one of those three types of population points. A list prepared by the National Statistical Committee contains just over 4,250 of these population points.  [from the household questionnaire preamble, local file queshhe.pdf p.1] "I represent the SORGU Social Studies Center.  We are conducting a survey on the conditions of people’s lives in all regions of Azerbaijan for the World Bank."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+To choose the sample outside of Baku, Baku was excluded from this list as were all the population points located in raions of the country currently occupied (Agdam, Xankendi, Xodjali, Xodjvendi, Susha, Kubatli, Zangelan, Kelbadjar, Lachin, Fizuli and Djebrali). The remainder of the country included 3453 population points.  [IDP frame is the REGISTERED IDP population] "408 households among the registered Internally Displaced Persons residing throughout the country" ... "In each raion, the administrative offices for the Ministry of Refugees was consulted to locate the internally displaced persons. Each office should have a list of internally displaced persons by households."  [Sampling as Implemented — field-work non-coverage] "During field work, one population point, Xandar, was not accessible due to security concerns and its proximity to the occupied region. A second population point, Sofukent, was not accessible because of the weather. In both cases, it was not practicable to replace the population points with two other population points randomly selected from the national list. Instead, field teams were instructed to visit the nearest population point of approximately the same size to the chosen population point."  [Baku frame coverage caveats] "There is one passport for each dwelling in that raion regardless of the number of separate household/family units occupied the dwelling. The passport lists are, in principle, continuously updated with information from the housing maintenance offices. However, dwellings that are used for business, unoccupied, abandoned or rented to foreigners may remain listed. Furthermore, it is not clear how new privately built housing units would be listed."  No statement about institutional population, nomadic households, or an age/citizenship restriction appears anywhere in the catalog metadata or the local documentation.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+There is only ONE wave directory under lsms_library/countries/Azerbaijan/ (1995/); `_` and `var` excluded.  The DDI record has NO dedicated `universe` field — the universe statement lives inside `sampling_procedure`, which is why the quote above mixes universe and design language. I have kept the design detail attached because the universe here IS a three-way stratified union (Baku / outside-Baku / registered IDPs) and cannot be quoted intelligibly without it.  POINT WORTH FLAGGING FOR #603: `geog_coverage` is asserted as "National", but the frame explicitly excises the eleven occupied raions (Agdam, Xankendi, Xodjali, Xodjvendi, Susha, Kubatli, Zangelan, Kelbadjar, Lachin, Fizuli, Djebrali) — 4,250 population points reduced to 3,453. "National" and the actual universe therefore disagree in the source itself; both are recorded above verbatim rather than reconciled.  The three sub-samples are self-weighted within themselves but not jointly: "The three samples of households: outside Baku (PPID 100-199), Baku (PPID 1-34), and IDPs (PPID 201-234) are self-weighted for those three groups of households. ... However, the number of households selected from each group do not correspond to the percent of the three groups in the national population. To use all sample households to represent all households in Azerbaijan, weighting factors should be used. This weight is included as variable W in the PP data" (DDI field .method.data_collection.weight). This is directly relevant to the CONTENTS.org data-quality note that `sample.weight` has only 3 distinct values — the documentation says the weight is a three-group post-stratification factor, which is consistent with 3 distinct values. I did NOT open any .dta to check this; the reconciliation is between two documents.  Field-work dates: 1995-11 to 1995-12 (Baku Nov 20–Dec 13; outside Baku and IDPs Nov 23–Dec 20). Authoring entity: "Social Studies Center, Institute of Sociology and Political Science (SORGU) and the World Bank".  No statement was found, in any source, excluding institutional/collective households, nomadic households, or non-citizens. That is a recorded gap, not a claim that no such exclusion existed.
+#+end_quote
+
+** Benin
+
+*** Benin 2018-19
+
+- Survey :: Enquête Harmonisée sur le Conditions de Vie des Ménages 2018-2019 (EHCVM) / Harmonized Survey on Households Living Standards 2018-2019 — Survey ID BEN_2018_EHCVM_v02_M
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Benin/2018-19/Documentation/ddi-documentation-english_microdata-4291.pdf
+- Locator :: p. 3, section "Coverage" > "UNIVERSE" (and "GEOGRAPHIC COVERAGE" immediately above it). The Littoral exclusion sentence is p. 4, section "Sampling" > "SAMPLING PROCEDURE", first paragraph.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+UNIVERSE The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.  GEOGRAPHIC COVERAGE National coverage
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.  [Sampling frame, p. 4:] "This frame contains 10032 enumeration areas, is nationally representative, and covers all regions with urban and rural areas surveyed in all regions apart from Littoral, a purely urban region."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The DDI PDF was materialized via lsms_library.data_access.get_data_file('Benin/2018-19/Documentation/ddi-documentation-english_microdata-4291.pdf') and independently re-downloaded from https://microdata.worldbank.org/catalog/4291/pdf-documentation; the downloaded file's md5 is 89b38f943a8a7c5e6b14016c196beb6c, which matches the md5 recorded in the repo's DVC sidecar ddi-documentation-english_microdata-4291.pdf.dvc byte-for-byte, so the text quoted here is the repo's own local documentation. Provenance chain verified: SOURCE.org's DOI 10.48529/rn3k-z374 302-redirects to https://microdata.worldbank.org/index.php/catalog/study/BEN_2018_EHCVM_v02_M, i.e. catalog entry 4291, whose Survey ID number is BEN_2018_EHCVM_v02_M. The catalog web page carries the identical universe sentence, so local and catalog sources agree exactly.  DESIGN DETAIL (not the universe statement; verbatim from the same DDI, p. 3-4): SERIES INFORMATION — "The Benin EHCVM 2018/19 is the first edition of a nationally representative household survey conducted within the West Africa Economic Monetary Union (WAEMU) Household Survey harmonization Project (P153702) ... The survey covers all regions and includes approximately 8,000 households." ABSTRACT — "The EHCVM is a nationally representative survey of 8,000 households, which are also representative of the geopolitical zones (at both the urban and rural level)." SAMPLING PROCEDURE — "The Benin EHCVM 2018/19 used the 2013 Census of Population and Housing (RGPH) as the sampling frame. This frame contains 10032 enumeration areas, is nationally representative, and covers all regions with urban and rural areas surveyed in all regions apart from Littoral, a purely urban region. ... The survey design also defined the domains as country, urban and rural areas, and each of the 12 regions. Taking this into account, 23 explicit sample strata were selected." ... "At the first stage, 670 enumeration areas (EAs) were selected with Probability Proportional to Size (PPS) using the 2013 RGPH and the number of households as a measure of size. In the second stage, 12 households were selected in each enumeration area randomly." ... "The total estimated survey sample size was 8040 households - 3960 from urban areas and 4080 from rural areas. ... the final sample size comprises 8012 households, including 3940 households from urban areas and 4072 households from rural areas. In wave one, the survey teams interviewed 3997 households (1940 in urban areas and 2057 in rural areas. In wave two, the teams interviewed 4015 households (2000 in urban areas and 2015 in rural areas)." UNIT OF ANALYSIS — "- Household / - Individual / - Community".  Note on "vague": the two EHCVM vagues (Oct-Dec 2018, Apr-Jul 2019) are two visits to disjoint halves of the SAME sample, not two independent samples; the repo models them as a single wave directory 2018-19.  No French-language universe statement was located: the shipped DDI is the English edition (filename ddi-documentation-english_microdata-4291.pdf) and the catalog page served is English. The survey title itself is French.
+#+end_quote
+
+*** Benin 2018-2019
+
+- Survey :: Enquête Harmonisée sur le Conditions de Vie des Ménages 2018-2019 (EHCVM) — same survey extract as 2018-19 (Survey ID BEN_2018_EHCVM_v02_M)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Benin/2018-19/Documentation/ddi-documentation-english_microdata-4291.pdf
+- Locator :: p. 3, section "Coverage" > "UNIVERSE". NOTE: this file lives under the SIBLING directory 2018-19/, not under 2018-2019/ — the 2018-2019/ directory contains no Documentation/ subdirectory at all.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+UNIVERSE The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.  GEOGRAPHIC COVERAGE National coverage
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.  [Sampling frame, p. 4:] "This frame contains 10032 enumeration areas, is nationally representative, and covers all regions with urban and rural areas surveyed in all regions apart from Littoral, a purely urban region."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The quote is carried over from the 2018-19 wave directory's DDI, NOT read from anything under 2018-2019/. This is a stated inference, and here is exactly the evidence for it, so a reader can falsify it: (1) all 52 .dvc sidecars in Benin/2018-2019/Data/ are byte-identical to those in Benin/2018-19/Data/ (verified with md5sum over the sidecar files; `diff` of the two md5 lists is empty), so both directories point at exactly the same DVC blobs — the same survey extract, file for file; (2) every data filename carries the ben2018 suffix (s01_me_ben2018.dta, ehcvm_menage_ben2018.dta, …), i.e. the EHCVM 2018 Benin extract; (3) Benin/_/CONTENTS.org states verbatim: "A second directory =Benin/2018-2019/= contains a =Data/= sub-directory only — appears to be a duplicate-wave staging area.  The configured wave is =2018-19=; the =2018-2019= folder is not referenced by any extractor and may be safely ignored or removed by a future cleanup pass."  Confidence is 'medium' rather than 'high' solely because no document under 2018-2019/ asserts anything; the universe statement is inherited on the strength of blob identity. If GH #603 wants a strictly per-directory answer, the honest answer for 2018-2019/ alone is NOT FOUND (no documentation present).  Operational note: this directory is already staged for deletion in the working tree (git status shows the 2018-2019/Data/*.dvc sidecars as D), so it is likely to disappear and need no population record of its own.
+#+end_quote
+
+** Burkina_Faso
+
+*** Burkina_Faso 2014
+
+- Survey :: Enquête Multisectorielle Continue 2014 (EMC 2014) — WB catalog id 2538, BFA_2014_EMC_v01_M
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: fr
+- Source file :: lsms_library/countries/Burkina_Faso/2014/Documentation/Report.pdf
+- Locator :: INSD, « Rapport — Enquête multisectorielle continue (EMC) 2014 : Profil de pauvreté et d'inégalités », Novembre 2015; section 1.2.1 « Champ de l'EMC », p. 20 (PDF page 20). Materialized from DVC sidecar Report.pdf.dvc via data_access.get_data_file('Burkina_Faso/2014/Documentation/Report.pdf'); text extracted with pdfminer (pdf2txt.py).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+Pour des besoins de conformité au principe de comptabilité nationale, le champ social est constitué de l'ensemble des ménages, toutes catégories confondues, nationaux ou non, résidant sur le territoire national. [...] Le champ géographique de l'EMC est le territoire national burkinabè. Le niveau spatial de représentativité des données collectées concerne les milieux de résidence (urbain et rural) et les 13 régions administratives du pays.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+TRANSLATION (not source text): "To comply with the principle of national accounting, the social scope consists of the totality of households, of all categories, nationals or non-nationals, residing on the national territory. [...] The geographic scope of the EMC is the Burkinabè national territory. The spatial level of representativeness of the data collected concerns the areas of residence (urban and rural) and the 13 administrative regions of the country."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Sont exclus de ce champ, les ménages collectifs (camps militaires, casernes, hôpitaux, etc.), les ménages des membres du corps diplomatique, les sans domiciles fixes. [TRANSLATION, not source text: "Excluded from this scope are collective households (military camps, barracks, hospitals, etc.), households of members of the diplomatic corps, and the homeless."]
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Whitespace in the quoted French was normalized (the PDF is justified text and pdfminer emits multiple spaces between words); wording, punctuation and accents are unaltered, and '[...]' marks the elision of one intervening paragraph break. The two quoted paragraphs are consecutive in the source, separated only by a blank line.  INDEPENDENT CORROBORATION — WB catalog DDI (source_type would be wb-catalog), field study_desc.study_info.universe of https://microdata.worldbank.org/metadata/export/2538/json, also shown as 'Universe' on https://microdata.worldbank.org/index.php/catalog/2538/study-description, VERBATIM: "The universe includes all households currently living in Burkina Faso. Individuals living in group households (such as academic institutions, hospitals or military installations) are not included." Same JSON, study_info.geog_coverage: "The survey is nationally representative." and study_info.analysis_unit: "The unit of measure is the household and the individuals within the household."  SAMPLE DESIGN (context only, not the universe). Report.pdf §1.2.2 « Plan de sondage », p. 20, VERBATIM: "Le plan de sondage adopté est celui d'un sondage aréolaire stratifié à deux degrés. La stratification est faite avant le tirage des unités primaires et basée sur l'urbanisation des agglomérations." Sampling frame, same page, VERBATIM: "La base de sondage des unités primaires ou zones de dénombrement de l'EMC est constituée de la liste des 13 821 ZD définies lors de la cartographie du RGPH réalisée en 2006. Un certain nombre de ces ZD a fait l'objet d'une opération de mise à jour en 2008 pour disposer d'un fichier actualisé sur lequel l'opération de tirage des unités primaires a été faite." Method, VERBATIM: "Au premier degré, 900 ZD ont été tirées avec des probabilités proportionnelles à la taille en population ; Au second degré, un échantillon de 12 ménages a été tiré à probabilité égale et de façon systématique dans chacune des ZD sélectionnée au premier degré. Ces ménages sont tirés à partir de la liste des ménages recensés lors de l'opération de dénombrement réalisée dans les 900 ZD échantillon. Ce qui a donné un échantillon de 10 800 ménages." (The catalog DDI sampling_procedure instead says 905 EAs / ~10860 households — an ex ante figure; the report's 900 ZD / 10 800 is the realized design. Recorded as a discrepancy, not adjudicated.)  No region is excluded and no rural-only restriction: coverage is the whole national territory, both milieux de résidence, all 13 regions.
+#+end_quote
+
+*** Burkina_Faso 2018-19
+
+- Survey :: Enquête Harmonisée sur les Conditions de Vie des Ménages 2018-2019 (EHCVM 2018/19) — WB catalog id 4290, BFA_2018_EHCVM_v03_M
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: fr
+- Source file :: lsms_library/countries/Burkina_Faso/2018-19/Documentation/ehcvm_2018_rapport_general.pdf
+- Locator :: PRIMARY (French): INSD, « Enquête harmonisée sur les conditions de vie des ménages de 2018 (EHCVM-2018) » rapport général; section 1.3 « Champ de l'EHCVM », printed page 16 (PDF page 22). SECONDARY (English, same wave, also local): lsms_library/countries/Burkina_Faso/2018-19/Documentation/Documentation.pdf — 'Microdata Library / Burkina Faso - Enquête Harmonisée sur le Conditions de Vie des Ménages 2018-2019', report generated 2022-09-01, page 3, section 'Coverage' > 'UNIVERSE'. Both materialized via data_access.get_data_file(); text extracted with pdfminer.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+Pour des besoins de conformité au principe de comptabilité nationale, le champ social est constitué de l'ensemble des ménages, toutes catégories confondues, nationaux ou africains, résidant sur le territoire national. [...] Le champ géographique de l'EHCVM est le territoire national burkinabè. Le niveau de représentativité des données collectées concerne les milieux de résidence (urbaine et rurale) et les 13 régions administratives du pays.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+TRANSLATION (not source text): "To comply with the principle of national accounting, the social scope consists of the totality of households, of all categories, national or African, residing on the national territory. [...] The geographic scope of the EHCVM is the Burkinabè national territory. The level of representativeness of the data collected concerns the areas of residence (urban and rural) and the 13 administrative regions of the country." Note the source's own English-language universe statement (see source_locator's second file) reads: "The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Sont exclus de ce champ, les ménages collectifs (camps militaires, casernes, hôpitaux, etc.), les ménages ayant un statut diplomatique et les sans domiciles fixes. [TRANSLATION, not source text: "Excluded from this scope are collective households (military camps, barracks, hospitals, etc.), households having diplomatic status, and the homeless."] --- English exclusion clause, VERBATIM from the local Microdata Library DDI report (Documentation.pdf, p. 3, heading 'UNIVERSE'): "The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Whitespace normalized from the justified-text PDF extraction; wording/punctuation/accents unaltered. '[...]' marks the elision of one intervening paragraph break; the two quoted paragraphs are consecutive in the source.  NOTABLE WORDING CHANGE vs. 2014: the 2014 EMC report says 'nationaux ou non', the 2018 EHCVM report says 'nationaux ou africains'. Quoted as printed in each; not reconciled here.  The English 'UNIVERSE' text is identical in the local Documentation.pdf (p. 3) and in the WB catalog DDI export (https://microdata.worldbank.org/metadata/export/4290/json, study_desc.study_info.universe): "The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories." So local and catalog agree.  REPRESENTATIVITY (context, from the local BID basicinformationdocument_bfa.pdf, section 'Sample', PDF page 10), VERBATIM: "The Burkina Faso EHCVM 2018/19 sample covers all regions with urban and rural areas surveyed in all regions and is representative for the strata of Ouagadougou, other urban areas and rural areas." NOTE the tension: the BID names Ouagadougou / other-urban / rural strata, while the French report §1.3 claims representativity for the 13 administrative regions and the two milieux. Recorded, not adjudicated.  SAMPLE DESIGN (context only). Rapport général §1.3.1 « Plan de sondage », p. 16, sampling frame VERBATIM: "La base de sondage des unités primaires ou zones de dénombrement (ZD) de l'enquête harmonisée sur les conditions de vie des ménages est constituée de la liste des zones de dénombrement définies lors de la cartographie préalable du RGPH-2006. L'INSD a mis à jour certaines ZD en 2008 et 2013. Le tirage des unités primaires a été fait sur la base de ce fichier actualisé." Method VERBATIM: "La technique de sondage utilisée dans le cadre de cette enquête est un sondage stratifié à deux degrés : Au premier degré, 585 zones de dénombrement sont tirées avec des probabilités proportionnelles à la taille de la population issue du fichier des ZD du RGPH-2006 mise à jour ; Au second degré, un échantillon de 12 ménages est tiré à probabilité égale et de façon systématique dans chacune des zones de dénombrement." Catalog/BID sampling_procedure VERBATIM: "The total survey sample size is 7010 households - 3149 from urban areas and 3861 from rural areas."  No region is excluded and there is no rural-only restriction.
+#+end_quote
+
+*** Burkina_Faso 2021-22
+
+- Survey :: Enquête Harmonisée sur les Conditions de Vie des Ménages, Panel Survey 2021-2022 (EHCVM-P / EHCVM-2 2021/22 Panel) — WB catalog id 6224, BFA_2021_EHCVM-P_v04_M
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: panel-inherited
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Burkina_Faso/2021-22/Documentation/ddi-documentation-english_microdata-6224.pdf
+- Locator :: 'Microdata Library — Burkina Faso - Enquête Harmonisée sur le Conditions de Vie des Ménages, Panel Survey 2021-2022' (WB NADA DDI report), page 3, section 'Coverage' > heading 'UNIVERSE'. Secondary local source for the panel-frame restrictions: lsms_library/countries/Burkina_Faso/2021-22/Documentation/bid_bfa_ehcvm2.pdf, section 'Sample', page 4. Both materialized via data_access.get_data_file(); text extracted with pdfminer.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a — source is in English.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories. --- Additional panel-frame restrictions, VERBATIM from the local Basic Information Document (bid_bfa_ehcvm2.pdf, section 'Sample', page 4): "The panel sample of the EHCVM-2 2021/22 corresponds to half of the households interviewed in EHCVM-1 2018/19 Households were tracked within the EA. In other words, EHCVM-1 households that have left their EA of origin were not surveyed." and "Household members in 2018 who have since left the household were not followed up physically." and "Additionally, if the number of available households in a given Enumeration Area (EA) fell below 6, no additional households were included in the survey."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The local DDI report's UNIVERSE text is byte-identical to the WB catalog DDI export field study_desc.study_info.universe at https://microdata.worldbank.org/metadata/export/6224/json, and to the 2018-19 wave's universe statement. Local and catalog agree.  IMPORTANT for #603: this wave is a PANEL sub-sample, not a fresh national draw. The stated universe ('all de jure households excluding prisons, hospitals, military barracks, and school dormitories') is inherited from EHCVM-1 2018/19; what the 2021-22 sample actually represents is constrained by the panel-frame restrictions quoted in exclusions_verbatim (no tracking outside the EA of origin; no replacement when fewer than 6 households remained in an EA).  SAMPLE DESIGN (context only, VERBATIM from bid_bfa_ehcvm2.pdf, 'Sample', p. 4): "The sampling strategy used is a two-stage sampling with stratification in the first stage. The first stage sampling frame consists of enumeration areas (EAs) or clusters. A study area is a portion of the population for which meaningful results are sought, i.e., separate estimates with sufficient precision. Each region is considered a study area, as is the entire urban environment and the entire rural environment. The different strata result from the combination of the 13 regions with the two areas of residence (urban, rural)." and "A total of 585 EAs were selected (half (293) for the first wave and half (292) for the second wave). Within each EA, 6 households out of the 12 surveyed in 2018 were surveyed." and "The sampling plan stipulated the selection of 3,510 households, with 1,758 to be surveyed during the initial wave and 1,972 during the subsequent wave. The final actual size of the panel sample is 3,227 households, of which 1647 were interviewed in the first wave and 1,580 in the second wave." (Note the BID's own arithmetic 1,758 + 1,972 = 3,730 ≠ 3,510 as printed; quoted as printed.)  ADDITIONAL LOCAL FRENCH SCOPE STATEMENT (partial — covers who is in/out of scope, not the full universe), from lsms_library/countries/Burkina_Faso/2021-22/Documentation/manuelagent_ehcvm2_version_v2.pdf — 'ENQUETE HARMONISEE SUR LES CONDITIONS DE VIE DES MENAGES (EHCVM 2021/2022), MANUEL DE L'AGENT ENQUETEUR', Août 2021 (UEMOA / INSD / Banque Mondiale), printed page 4 (PDF page 7), VERBATIM: "Attention : le personnel diplomatique ne fait pas partie du champ de l'enquête. En effet la résidence d'un diplomate est considérée comme extraterritorial, c'est-à-dire que juridiquement hors du pays concerné. Cependant les autres personnes travaillant dans ces organisations font partie du champ de l'enquête, tout comme les étrangers n'ayant pas de statut de personnel diplomatique." Same page, residency rule defining a household member, VERBATIM: "Membre du ménage. Un membre du ménage est une personne résidant habituellement dans le ménage. Un individu réside habituellement dans le ménage dans deux situations : (i) il vit dans ce ménage depuis au moins 6 mois ; (ii) Il est arrivé dans le ménage depuis moins de 6 mois, mais avec l'intention d'y rester au moins 6 mois." CAVEAT: this manual is the WAEMU-common EHCVM-2 instrument (its worked examples name Dosso and Niamey, i.e. Niger), so these paragraphs are regional boilerplate shipped in the Burkina Faso wave's Documentation/, not Burkina-specific text.  No region is excluded and there is no rural-only restriction in any statement found.
+#+end_quote
+
+** Cambodia
+
+*** Cambodia 2019-20
+
+- Survey :: Cambodia Living Standards Measurement Study - Plus (LSMS+) 2019-2020 (KHM_2019_LSMS-PLUS_v02_M; the repo's SOURCE.org cites v01)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Cambodia/2019-20/Documentation/ddi-documentation-english_microdata-4045.pdf (local, DVC-tracked); Basic Information Document, WB catalog 4045 download id 50889 (NOT present locally); Field Operational Manual, download id 50888 (NOT present locally); DDI XML export https://microdata.worldbank.org/index.php/metadata/export/4045/ddi
+- Locator :: DDI PDF p. 2 (ABSTRACT) and p. 3 (Coverage > GEOGRAPHIC COVERAGE; Sampling > SAMPLING PROCEDURE). BID pp. 4 (1.0 Introduction; 2.0 The Survey Instruments), 5 (3.1 Survey Sample), 7 (3.2 Survey Weights > SAMPLING METHODOLOGY, items 1 and 2 and Table 1). DDI XML: stdyDscr/stdyInfo/sumDscr/{geogCover,universe}, method/dataColl/{sampProc,sampleFrame/universe}.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+NO LABELLED UNIVERSE / TARGET-POPULATION STATEMENT EXISTS. The DDI's <universe> element is literally empty (`<universe/>`, in both stdyDscr/stdyInfo/sumDscr and method/dataColl/sampleFrame), and no document carries a "Universe"/"Target population" heading. The nearest documented coverage statements, quoted verbatim:  (A) DDI, ABSTRACT (local `ddi-documentation-english_microdata-4045.pdf`, p. 2): "The survey attempted to conduct private interviews with all the adult household members (aged 18 and older) in each sampled household as part of a nationally-representative survey sample."  (B) DDI, Coverage > GEOGRAPHIC COVERAGE (same PDF, p. 3), the field's entire content: "National"  (C) Basic Information Document, 1.0 Introduction, p. 4: "The Cambodia LSMS Plus Survey was conducted in 25 percent of the enumeration areas (EAs) that was visited by the 2019/20 round of the Cambodia Socioeconomic Survey (CSES) which is implemented by the National Institute of Statistics (NIS)."  (D) Basic Information Document, 1.0 Introduction, p. 4 (next paragraph): "Specifically, in the CSES EAs that were visited during the period of October-December 2019, the NIS selected additional households that were NOT be part of the planned CSES sample and that constituted the LSMS Plus Survey sample, to whom the World Bank-required survey questionnaire modules was administered, based on the World Bank-required fieldwork protocols. The LSMS Plus Survey data was collected in parallel with the CSES data in these EAs."  (E) Basic Information Document, 2.0 The Survey Instruments, p. 4: "The Individual Questionnaire was administered to all adult individuals (18 years and above) in the household"  (F) Basic Information Document, 3.2 Survey Weights > SAMPLING METHODOLOGY > "1. The primary Sampling Units (PSUs)", p. 7: "The Primary Sampling Units (PSUs) of this survey were the subsamples of the selected PSUs of the Cambodia Socio-Economic Survey (CSES) 2019/20. The PSU in this case can either be a village (if the village is small) or an Enumeration Area (EA) from the mapping operation of 2019 General Population Census of Cambodia (if the village is large, probably exceed 120 households).These covered all the CSES' s sample villages in three months (those selected for interviews during the October - December period of fieldwork) out of its twelve-month sample."
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a — source documentation is in English.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND. No exclusion statement of any kind (institutional population, collective/group quarters, nomadic households, homeless, security-inaccessible regions, urban- or rural-only design) appears in any document. A case-insensitive search for `exclud|not covered|institution|nomad|homeless|collective|private household|universe|target population` over the BID, the field manual, the DDI PDF and the questionnaire returned only unrelated hits (ISCO occupation labels such as "Engineering professionals (excluding electrotechnology)", a consumption-module instruction "…telephone service (exclude telephone accessories)", and credit-source codes).  The only documented *restrictions of scope*, quoted verbatim (these are frame/eligibility restrictions, NOT stated exclusions from a universe):  (i) BID, 1.0 Introduction, p. 4: "The Cambodia LSMS Plus Survey was conducted in 25 percent of the enumeration areas (EAs) that was visited by the 2019/20 round of the Cambodia Socioeconomic Survey (CSES)"  (ii) BID, SAMPLING METHODOLOGY, p. 7: "These covered all the CSES' s sample villages in three months (those selected for interviews during the October - December period of fieldwork) out of its twelve-month sample."  (iii) BID, 3.1 Survey Sample, p. 5: "The survey took approximately 3 months running from October-December 2019 with a few final interviews in early January 2020. The NIS sampled 6 additional households in the 252 enumeration areas that were visited during the period of October-December 2019 by the 2019/20 round of the Cambodia Socioeconomic Survey (CSES). The LSMS+ Survey sample includes a total of 1,512 households."  (iv) BID, 2.0 The Survey Instruments, p. 4 (eligibility for the individual questionnaire only): "The Individual Questionnaire was administered to all adult individuals (18 years and above) in the household"
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+PARAPHRASE/EXTRACTION CAVEAT: the BID and DDI PDFs are justified text, so pdfminer emits runs of multiple spaces inside words/phrases (e.g. 'The  Cambodia  LSMS  Plus  Survey'). I collapsed those runs to single spaces in the quotes above; no words were added, removed, reordered or corrected. Apparent grammatical errors in the BID ('that was visited', 'that were NOT be part of', 'probably exceed 120 households', "CSES' s") are IN THE SOURCE and are reproduced. The DDI PDF renders fi/ff ligatures as U+FB01 etc.; quote (A) is taken from the DDI XML export, whose text is byte-identical to the PDF apart from those ligatures.  WHY confidence is 'medium', not 'high': there is a real, recorded gap. The DDI <universe> element is empty and no document states a target population in universe language. Everything above is a *coverage/frame* statement, not a universe statement. In particular, 'National' (geogCover) and 'nationally-representative survey sample' (abstract) are the strongest claims available, and the abstract's phrase describes the sample, not the universe it represents. Nothing in the documentation says 'all private households in Cambodia' or equivalent.  DESIGN NOTE FOR #603 (frame, not universe): the LSMS+ sample is NOT an independent national sample. Its frame is the CSES 2019/20 PSU sample restricted to the Oct–Dec 2019 fieldwork quarter (252 EAs, 25% of CSES EAs), with 6 households per PSU drawn by CSRS from the CSES enumerator's household listing, and those households were deliberately DISJOINT from the CSES sample ('additional households that were NOT be part of the planned CSES sample'). n = 1,512 households. Any universe declaration therefore inherits the CSES 2019-2020 frame, which is documented elsewhere ('For more details on the CSES sample village selection, please see the CSES 2019-2020 report, NIS.' — BID p. 7, footnote 2). That CSES report was NOT consulted here and is not in this repo.  OBSERVATION ABOUT BID TABLE 1 — EXPLICITLY NOT AN EXCLUSION CLAIM: BID Table 1 ('Number of sample villages and households in each province', p. 7) lists provinces numbered 1–22, 24, 25. Province 23 (Kep, in the standard Cambodian province numbering) does not appear as a row. The listed village counts sum to 252 and the household counts to 1512, both matching the printed TOTAL row, so this is not a PDF-extraction dropout. The BID offers NO explanation, and I am NOT asserting that Kep was excluded by design — the documentation is simply silent. Recording the observation so a later reader can check it against the CSES 2019-2020 sample design rather than re-deriving it.  VERSION MISMATCH: SOURCE.org cites 'Ref. KHM_2019_LSMS-PLUS_v01_M'; the current catalog entry and the local DDI PDF are v02. The v02 version note reads: 'Update to HH_SEC_1. The Urban/Rural variable was previously omitted from the datafile.' This does not affect any statement quoted above (none of them changed between versions as far as can be checked), but the repo's pinned version is one behind.  No data files were opened; nothing under lsms_library/countries/ was modified. get_data_file() wrote the three Documentation PDFs into their (gitignored) local paths as part of normal DVC-cache materialization.
+#+end_quote
+
+** China
+
+*** China 1995-97
+
+- Survey :: China Living Standards Survey (CLSS), 1995-1997
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: subnational-area
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/China/1995-97/Documentation/chnbinfo.pdf
+- Locator :: "China Living Standards Survey 1995-1997, Basic Information Document" (February 2003), Section 3 "Sample", p.10 (first paragraph). Supporting quotes: Section 1 "Overview", p.1; Section 2.1 Sections 1A/1C/2/3, pp.2-3; Section 2.2 Section 10, p.10. Corroborated by WB Microdata catalog study id 409 / idno CHN_1995_LSS_v01_M (https://microdata.worldbank.org/index.php/catalog/409), fields study_desc/study_info/geog_coverage and study_desc/method/data_collection/sampling_procedure, retrieved 2026-07-21 via the catalog API.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The CLSS sample is not a rigorous random sample drawn from a well-defined population. Instead it is only a rough approximation of the rural population in Hebei and Liaoning provinces in Northeastern China. [BID §3 "Sample", p.10]  Corroborating statements:  (a) BID §1 "Overview", p.1: "China Living Standards Survey (CLSS) consists of one household survey and one community (village) survey, conducted in Hebei and Liaoning Provinces (northern and northeast China) in July 1995 and July 1997 respectively. Five villages from each three sample counties of each province were selected (six were selected in Liaoyang County of Liaoning Province because of administrative area change). About 880 farm households were selected from total thirty-one sample villages for the household survey. The same thirty-one villages formed the samples of community survey."  (b) WB Microdata catalog CHN_1995_LSS_v01_M, field study_desc/study_info/geog_coverage: "The China Living Standards Survey (CLSS) was conducted only in Hebei and Liaoning Provinces (northern and northeast China)."  (c) WB Microdata catalog CHN_1995_LSS_v01_M, field study_desc/method/data_collection/sampling_procedure: "The CLSS sample is not a rigorous random sample drawn from a well-defined population. Instead it is only a rough approximation of the rural population in Hebei and Liaoning provinces in Northeastern China." (word-for-word identical to the BID §3 text)
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a — the source documentation is written in English.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Geographic/domain restriction (BID §3, p.10): "...three counties in Hebei and three counties in Liaoning were selected as “primary sampling units” because data had been collected from those six counties by the Japanese occupation government in the 1930’s. Within each of these six counties (xian) five villages (cun) were selected, for an overall total of 30 villages (in fact, an administrative change in one village led to 31 villages being selected)." and "These other villages were not drawn randomly but were selected so as to “represent” variation within the county."  Household-membership rule (BID §2.1, Section 1A, p.2): "Household members were defined to include “all the people who normally live and eat their meals together in this dwelling.” Those who were absent more than nine of the last twelve months were excluded, except for the head of household."  Non-resident children (BID §2.1, Section 1C, p.2): "Section 1C collects information for children of household members who are not living in home. Children who have died are not included."  Module-level universes (not household-frame exclusions, recorded for completeness): - Schooling (BID §2.1, Section 2, p.2): "...in essence the data on schooling can be said to apply all persons 6 age and above." - Employment (BID §2.1, Section 3, p.3): "All individuals age thirteen and above were asked to respond to the employment activity questions in Section 3." - Community questionnaire (BID §2.2, Section 10, p.10): "Section 10 on Forestry was not administered in the 1997 survey."  No statement of an institutional-population, nomadic-population, or security-related regional exclusion appears anywhere in the BID or in the catalog metadata. NOT FOUND for those categories.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Only one wave exists for China in this repo: 1995-97.  Key point for GH #603: this survey has NO well-defined target population, and the documentation says so explicitly and self-consciously. The BID's universe statement is a *negative* one — the sample is a purposive/convenience approximation of 'the rural population in Hebei and Liaoning provinces in Northeastern China', not a probability sample of it. County and village selection were purposive (chosen to match 1930s Japanese-occupation survey sites); only within-village household selection was probabilistic (systematic random sampling from a village household list with a random start). Consequently no sampling weights exist in the data files, and the repo's China `sample` table carries village-level PSU identity (v) but no weight/strata/Rural columns (see lsms_library/countries/China/_/CONTENTS.org).  The WB catalog record for this study has NO `universe` field at all (study_info keys present are: abstract, coll_dates, nation, geog_coverage, data_kind, notes). The universe language lives in `sampling_procedure`, and is byte-for-byte the BID §3 text — so catalog and local documentation are the same statement, not two independent attestations.  Sample-design detail (NOT the universe, recorded here per instructions): 2 provinces (Hebei, Liaoning); 6 counties (3 per province) as 'primary sampling units'; 5 villages per county, 31 in total (one county got 6 due to an administrative area change); 50 households in each of the 6 'main villages' (the 1930s survey sites) and 20 in each other village; intended sample size 780 households, 130 per county. BID §3, p.11: "In fact, the number of households in the sample is 785, as opposed to 780. Most of this difference is due to a village in which 24 households were interviewed, as opposed to the goal of 20 households". The Overview says "About 880 farm households were selected" — the BID is internally inconsistent between 880 (Overview) and 780 intended / 785 actual (§3); both figures are quoted verbatim above rather than reconciled.  Unit of observation: 'farm households' (BID Overview). The BID nowhere states that non-farm rural households were eligible, nor does it state they were excluded — do not infer either.  Caveat on the one unread source: CHI01.pdf (the household questionnaire, 1.2 MB) is an image-only scan and could not be text-searched. A questionnaire cover page could in principle carry additional coverage language; this was not verified. Everything reported above comes from chnbinfo.pdf and the catalog.
+#+end_quote
+
+** CotedIvoire
+
+*** CotedIvoire 1985-86
+
+- Survey :: Enquête Permanente Auprès des Ménages 1985-1986, Wave 1 Panel (Côte d'Ivoire Living Standards Survey, CILSS) — Reference ID CIV_1985_EPAM_v01_M
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: https://microdata.worldbank.org/index.php/catalog/83/study-description (World Bank Microdata Library, catalog id 83 = the id recorded in lsms_library/countries/CotedIvoire/1985-86/Documentation/SOURCE.org). Corroborating technical document: "Cote d'Ivoire Living Standards Survey (CLSS) 1985-88: Basic information for users of the data" (The World Bank / Institut National de la Statistique, 1996-08-06), catalog 83 download id 15551, https://microdata.worldbank.org/catalog/83/download/15551
+- Locator :: Catalog study description, sections "Coverage > Geographic Coverage" and "Sampling > Sampling Procedure" (first paragraph); membership rule under "Survey instrument > Questionnaires", SECTION 1 Part A. The identical sampling sentence appears in the Basic Information Document at section "III.  Sample Design and Selection", PDF page 27 (printed page 22).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+[Coverage > Geographic Coverage] "National coverage." / "Domains: Urban/rural; Regions (East Forest, West Forest,  East Savannah, West Savannah)"  ||  [Sampling > Sampling Procedure, opening sentence] "The principal objective of the sample selection process for the CILSS Household Survey was to obtain a nationally representative cross-section of African households, some of which could be interviewed in successive years as panel households."  ||  [Identification > Unit of Analysis] "Households" / "Individuals" / "Community"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+No exclusion is stated at the universe level (there is no "Universe" field on this catalog entry, and no statement excluding any region, institutional population, or nomadic population). The only exclusion language found is the household-MEMBERSHIP rule, in [Survey instrument > Questionnaires > SECTION 1: HOUSEHOLD ROSTER, Part A: Household Roster]: "To qualify as a household member, a person must have resided in the household for 3 months or more during the previous 12 months. ... The household head, newborn babies and new spouses are considered household members even if they do not satisfy the months of residence criterion. CILSS always excludes servants and boarders from household membership because they are considered to be separate households."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+IMPORTANT: catalog entry 83 has NO "Universe" field — the quoted text above is the nearest universe-defining language, from the Coverage and Sampling Procedure sections, and is labelled as such. It is NOT a formal universe statement, hence confidence=medium. The verbatim phrase "a nationally representative cross-section of African households" is quoted exactly as written (the word "African" is in the source, in both the catalog and the 1996 Basic Information Document, p. 22); no inference is offered here as to whether it implies non-African residents were out of scope. Sample design detail (not the universe): two-stage design, 100 PSUs selected PPS, 16 households per PSU, 1600 households/year, rotating panel (half replaced each year). Regional/urban-rural classification, from "Sampling > Sampling Procedure > Classification of Clusters by Geographic Location": "Thus, the urban-rural classification is as follows: Urban - Abidjan and Other Cities; Rural - East Forest, West Forest and Savanna." All four CILSS waves (catalog 83, 84, 85, 82) carry byte-identical Sampling Procedure and questionnaire text, because they share the single 1985-88 Basic Information Document.
+#+end_quote
+
+*** CotedIvoire 1986-87
+
+- Survey :: Enquête Permanente Auprès des Ménages 1986-1987 (Wave 2 Panel) (Côte d'Ivoire Living Standards Survey, CILSS) — Reference ID CIV_1986_EPAM_v01_M
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: https://microdata.worldbank.org/index.php/catalog/84/study-description (World Bank Microdata Library, catalog id 84 = the id recorded in lsms_library/countries/CotedIvoire/1986-87/Documentation/SOURCE.org). Corroborating: "Cote d'Ivoire Living Standards Survey (CLSS) 1985-88: Basic information for users of the data", https://microdata.worldbank.org/catalog/83/download/15551
+- Locator :: Catalog study description, "Coverage > Geographic Coverage" (line 116-118 of the extracted page text) and "Sampling > Sampling Procedure" first paragraph (line 132); membership rule at line 169. BID section "III.  Sample Design and Selection", PDF p. 27 (printed p. 22).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+[Coverage > Geographic Coverage] "National coverage." / "Domains: Urban/rural; Regions (East Forest, West Forest, East Savannah, West Savannah)"  ||  [Sampling > Sampling Procedure, opening sentence] "The principal objective of the sample selection process for the CILSS Household Survey was to obtain a nationally representative cross-section of African households, some of which could be interviewed in successive years as panel households."  ||  [Identification > Unit of Analysis] "Households" / "Individuals" / "Community"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+No exclusion is stated at the universe level (no "Universe" field; no statement excluding any region, institutional population, or nomadic population). Household-MEMBERSHIP rule, [Survey instrument > Questionnaires > SECTION 1: HOUSEHOLD ROSTER, Part A]: "To qualify as a household member, a person must have resided in the household for 3 months or more during the previous 12 months. ... CILSS always excludes servants and boarders from household membership because they are considered to be separate households."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Catalog entry 84 has NO "Universe" field. Text of the Sampling Procedure and questionnaire sections is identical to catalog 83/85/82 (verified by grep) — the four CILSS waves share one 1985-88 Basic Information Document. Sample design (not universe): two-stage, 100 PSUs, 16 HH per PSU, 1600 HH/year, rotating panel; from 1987 onward a second sampling frame ("Block 2", based on the RSH census of inhabited sites prepared for the 1988 Population Census) replaced the "Block 1" frame (1975 Census updated to 1983; 1979-80 electoral census for Abidjan and Bouaké).
+#+end_quote
+
+*** CotedIvoire 1987-88
+
+- Survey :: Enquête Permanente Auprès des Ménages 1987-1988 (Wave 3 Panel) (Côte d'Ivoire Living Standards Survey, CILSS) — Reference ID CIV_1987_EPAM_v01_M
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: https://microdata.worldbank.org/index.php/catalog/85/study-description (World Bank Microdata Library, catalog id 85 = the id recorded in lsms_library/countries/CotedIvoire/1987-88/Documentation/SOURCE.org). Corroborating: "Cote d'Ivoire Living Standards Survey (CLSS) 1985-88: Basic information for users of the data", https://microdata.worldbank.org/catalog/83/download/15551
+- Locator :: Catalog study description, "Coverage > Geographic Coverage" (lines 124-126 of extracted page text) and "Sampling > Sampling Procedure" first paragraph (line 140); membership rule at line 177. BID section "III.  Sample Design and Selection", PDF p. 27 (printed p. 22).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+[Coverage > Geographic Coverage] "National coverage." / "Domains: Urban/rural; Regions (East Forest, West Forest, East Savannah, West Savannah)"  ||  [Sampling > Sampling Procedure, opening sentence] "The principal objective of the sample selection process for the CILSS Household Survey was to obtain a nationally representative cross-section of African households, some of which could be interviewed in successive years as panel households."  ||  [Identification > Unit of Analysis] "Households" / "Individuals" / "Community"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+No exclusion is stated at the universe level (no "Universe" field; no statement excluding any region, institutional population, or nomadic population). Household-MEMBERSHIP rule, [Survey instrument > Questionnaires > SECTION 1: HOUSEHOLD ROSTER, Part A]: "To qualify as a household member, a person must have resided in the household for 3 months or more during the previous 12 months. ... CILSS always excludes servants and boarders from household membership because they are considered to be separate households."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Catalog entry 85 has NO "Universe" field. Sampling Procedure text identical to the other three CILSS waves. 1987 is the year the sampling frame changed mid-stream: half the 1987 clusters are "Block 1" (panel households retained from 1986) and half are "Block 2" (new frame). Verbatim: "It is important to note that there was a change in the sampling procedures (the sampling frame, PSU selection process and listing procedures), used to select half of the clusters/households interviewed in 1987 (the other half were panel households retained from 1986), and all of the clusters/households interviewed in 1988." This is sample-design, not universe, detail.
+#+end_quote
+
+*** CotedIvoire 1988-89
+
+- Survey :: Enquête Permanente Auprès des Ménages 1988-1989 (Wave 4 Panel) (Côte d'Ivoire Living Standards Survey, CILSS) — Reference ID CIV_1988_EPAM_v01_M
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: https://microdata.worldbank.org/index.php/catalog/82/study-description (World Bank Microdata Library, catalog id 82 = the id recorded in lsms_library/countries/CotedIvoire/1988-89/Documentation/SOURCE.org). Corroborating: "Cote d'Ivoire Living Standards Survey (CLSS) 1985-88: Basic information for users of the data", https://microdata.worldbank.org/catalog/83/download/15551
+- Locator :: Catalog study description, "Coverage > Geographic Coverage" (lines 116-118 of extracted page text; note this entry reads "National coverage" with no trailing period, unlike waves 83/84/85) and "Sampling > Sampling Procedure" first paragraph (line 132); membership rule at line 169. BID section "III.  Sample Design and Selection", PDF p. 27 (printed p. 22).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+[Coverage > Geographic Coverage] "National coverage" / "Domains: Urban/rural; Regions (East Forest, West Forest, East Savannah, West Savannah)"  ||  [Sampling > Sampling Procedure, opening sentence] "The principal objective of the sample selection process for the CILSS Household Survey was to obtain a nationally representative cross-section of African households, some of which could be interviewed in successive years as panel households."  ||  [Identification > Unit of Analysis] "Households" / "Individuals" / "Community"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+No exclusion is stated at the universe level (no "Universe" field; no statement excluding any region, institutional population, or nomadic population). Household-MEMBERSHIP rule, [Survey instrument > Questionnaires > SECTION 1: HOUSEHOLD ROSTER, Part A]: "To qualify as a household member, a person must have resided in the household for 3 months or more during the previous 12 months. ... CILSS always excludes servants and boarders from household membership because they are considered to be separate households."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Catalog entry 82 has NO "Universe" field. Sampling Procedure text identical to the other three CILSS waves. All 1988 clusters/households come from the "Block 2" frame: "The sampling frame for Block 2 data was established from a list of places from the results of the Census of inhabited sites (RSH) performed in preparation for the 1988 Population Census." (sample-design detail, not universe).
+#+end_quote
+
+*** CotedIvoire 2018-19
+
+- Survey :: Enquête Harmonisée sur le Conditions de Vie des Ménages 2018-2019 (EHCVM 2018/19) — Reference ID CIV_2018_EHCVM_v02_M
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: https://microdata.worldbank.org/index.php/catalog/4292/study-description (World Bank Microdata Library, catalog id 4292 = the id recorded in lsms_library/countries/CotedIvoire/2018-19/Documentation/SOURCE.org)
+- Locator :: Catalog study description, section "Coverage" > field "Universe" (immediately after "Geographic Coverage: National coverage"); sampling sentence from section "Sampling > Sampling Procedure".
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+[Coverage > Universe] "The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories."  ||  [Coverage > Geographic Coverage] "National coverage"  ||  [Sampling > Sampling Procedure, opening sentence] "The Cote d'Ivoire EHCVM 2018/19 sample covers all regions with urban and rural areas surveyed in all regions."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories." (the exclusion clause verbatim: "excluding prisons, hospitals, military barracks, and school dormitories"). No geographic or regional exclusion is stated; the Sampling Procedure states the opposite: "The Cote d'Ivoire EHCVM 2018/19 sample covers all regions with urban and rural areas surveyed in all regions."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+This is the one CotedIvoire wave with an explicit, formally labelled "Universe" field — quoted verbatim above and verified character-for-character against the raw catalog HTML, not a summariser. Sample design (not universe): 2-stage, 1084 EAs at stage 1, 12 households per EA at stage 2, total 12992 households (5275 urban, 7717 rural), split into two vagues (wave 1: 6490 HH; wave 2: 6502 HH). The BID's Sample section reproduces the same design text. Note the catalog metadata is in English even though the survey instruments are in French; no French-language universe statement was found in any accessible document.
+#+end_quote
+
+** Ethiopia
+
+*** Ethiopia 2011-12
+
+- Survey :: Ethiopia Rural Socioeconomic Survey 2011-2012 (ERSS / ESS1); WB catalog id 2053, idno ETH_2011_ERSS_v02_M
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: rural-and-small-town
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Ethiopia/2011-12/Documentation/ddi-documentation-english_microdata-2053.pdf
+- Locator :: Primary quote: ddi-documentation-english_microdata-2053.pdf, PDF p. 3, section "Sampling" > "Sampling Procedure" (this DDI export contains no field labelled "Universe"). Bracketed frame/exclusion quotes: lsms_library/countries/Ethiopia/2015-16/Documentation/basic_information_document_wave__3_dec19.pdf, section "3. Sample Design" > "3.1 Wave 1 coverage, Rural and small towns (ESS1)", printed pp. 13-14 (PDF pp. 13-14), incl. footnotes 8, 9, 13. Catalog coverage quote: https://microdata.worldbank.org/api/catalog/2053?id_format=id , field study_desc.study_info.geog_coverage.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The ERSS sample is designed to be representative of rural and small town areas of Ethiopia. The ERSS rural sample is a sub-sample of the AgSS while the small town sample comes from the universe of small town EAs. The ERSS sample size provides estimates at the national level for rural and small town households. At the regional level, it provides estimates for four regions including Amhara, Oromiya, SNNP, and Tigray.  [Second, more explicit frame statement, from a LATER wave's Basic Information Document describing wave 1 -- cited separately in source_locator:] "In wave 1, the ESS1 sample was designed to be representative of rural and small town areas in Ethiopia.8 The ESS sample is drawn from a population frame that includes all areas of Ethiopia except for three zones of Afar and six zones of Somalie region.9 The frame for rural areas is the 2011/2012 Agricultural Sample Survey (AgSS), so the ESS rural sample is a complete subset of the AgSS sample. The small town and urban area samples come from the universe of small town and urban EAs, excluding the same three zones of Afar and six zones of Somalie. The wave 1 sample design provides representative estimates for all rural-area households and for the combination of rural-area and small-town households (excepting the 9 zones excluded from the frame)."  [WB catalog field GEOGRAPHIC COVERAGE, catalog id 2053:] "Rural and small towns"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The sample is not representative for each of the small regions including Afar, Benshangul Gumuz, Dire Dawa, Gambella, Harari, and Somalie regions. However, estimates can be produced for a combination of all smaller regions as one "other region" category.  [Frame exclusion, from the ESS3 Basic Information Document, footnote 9 on printed p. 13:] "Zones excluded from the sampling frame include Zones 2, 4, and 5 in the Afar Region and Zones 3, 4, 5, 6, 7, and 8 in the Somali Region."  [Same document, footnote 13, printed p. 14:] "There is an exception to this statement. The ESS and the AgSS surveys both exclude 9 zones from the population frame -- zones 2, 4, and 5 in the Afar Region and zones 3, 4, 5, 6, 7, and 8 in the Somali Region."  [Small-town definition, same document, footnote 8, printed p. 13:] "The CSA defines small towns based on population estimates from the 2007 Population Census; a town with the population of less than 10,000 is a small town."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The local DDI export for this wave is a partial print (16 pp.) containing only the Sampling section plus a file/variable listing -- it has no Overview/Coverage/Universe block, and the WB catalog record for id 2053 likewise has NO study_info.universe field (it has only geog_coverage = 'Rural and small towns'). So the strongest universe statement for ESS1 is the ESS3 BID passage quoted in brackets, which is a later document describing wave 1 retrospectively -- flagged as such rather than silently merged. Design detail (not universe): two-stage probability sample; 290 rural EAs drawn from the AgSS EA sample, 43 small-town EAs; 12 households per rural EA of which 10 are AgSS (farming/livestock) households and 2 non-agricultural; 3,996 households planned. Series statement (catalog): 'The ERSS rural sample is a sub-sample of the AgSS.'
+#+end_quote
+
+*** Ethiopia 2013-14
+
+- Survey :: Ethiopia Socioeconomic Survey 2013-2014 (ESS2); WB catalog id 2247, idno ETH_2013_ESS_v03_M
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Ethiopia/2013-14/Documentation/ddi-documentation-english_microdata-2247.pdf
+- Locator :: Primary quote: ddi-documentation-english_microdata-2247.pdf, PDF p. 5, section "Coverage" > "GEOGRAPHIC COVERAGE" (this DDI export has NO "UNIVERSE" heading -- verified by grep over the full 803-page text extraction). Bracketed frame quotes: lsms_library/countries/Ethiopia/2015-16/Documentation/basic_information_document_wave__3_dec19.pdf, section "3.2 Wave 2 and 3 coverage, Rural and all urban areas (ESS2 and ESS3)", printed p. 14 (PDF p. 14), incl. footnotes 12, 13. Catalog quotes: https://microdata.worldbank.org/api/catalog/2247?id_format=id .
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The Ethiopia Socioeconomic Survey 2013/2014 (ESS2) covered all regional states including the capital, Addis Ababa. The majority of the sample comprises rural areas as it was carried over from ESS1. The ESS2 was implemented in 433 enumeration areas (EAs) out of which 290 were rural, 43 were small town EAs from ESS1, and 100 were new EAs from major urban areas.  [Frame statement for the ESS2 urban expansion, from a LATER wave's Basic Information Document -- cited separately in source_locator:] "The population frame for the urban expansion consists of all households in towns with population greater than 10,000 people. This population cut off of 10,000 people is the same threshold that is used to define small towns.12 In addition to the existing sample of rural and small towns, this expansion means now that all households in Ethiopia have some positive probability of selection into the expanded ESS2 sample.13"  [WB catalog field, catalog id 2247, series_statement.series_info:] "ESS2 also serves as a nationally representative sample because the sample of rural and small town households was expanded to include all urban areas as well."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+[WB catalog id 2247, study_desc.method.data_collection.sampling_procedure:] "The sample is not representative for each of the small regions including Afar, Benshangul Gumuz, Dire Dawa, Gambella, Harari, and Somalie regions. However, estimates can be produced for a combination of all smaller regions as one “other region” category."  [Frame exclusion, ESS3 Basic Information Document, footnote 13, printed p. 14:] "There is an exception to this statement. The ESS and the AgSS surveys both exclude 9 zones from the population frame -- zones 2, 4, and 5 in the Afar Region and zones 3, 4, 5, 6, 7, and 8 in the Somali Region."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Neither the local DDI nor the WB catalog record for ESS2 carries a field labelled 'Universe' -- the geographic-coverage statement quoted above is the closest thing the wave's own documentation provides. Catalog UNITS OF ANALYSIS: 'Households, individuals and communities.' Design detail (not universe): 433 EAs (290 rural + 43 small town + 100 large town); 12 households per rural/small-town EA, 15 per large-town EA; 'A total of 3,776 panel households and 1,486 new households (total 5,262 households) were interviewed with a response rate of 96.2 percent.'
+#+end_quote
+
+*** Ethiopia 2015-16
+
+- Survey :: Ethiopia Socioeconomic Survey 2015-2016 (ESS3); WB catalog id 2783, idno ETH_2015_ESS_v03_M
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Ethiopia/2015-16/Documentation/ddi-documentation-english_microdata-2783.pdf
+- Locator :: Primary quote ("ESS uses a nationally representative sample..."): ddi-documentation-english_microdata-2783.pdf, PDF p. 3, section "Coverage" > "UNIVERSE"; the GEOGRAPHIC COVERAGE quote is on the same page. Frame/exclusion quotes: lsms_library/countries/Ethiopia/2015-16/Documentation/basic_information_document_wave__3_dec19.pdf, section "3. Sample Design" ss. 3.1-3.2, printed pp. 13-14 (PDF pp. 13-14), footnotes 9 and 13. Weighting/representativity quote: lsms_library/countries/Ethiopia/2015-16/Documentation/9331_ethiopia_survey_report_web_final.pdf, introductory section on how results are weighted (text-extraction lines 946-955).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+ESS uses a nationally representative sample of over 5,000 households living in rural and urban areas. The urban areas include both small and large towns.  [Same document, immediately above, GEOGRAPHIC COVERAGE:] "National Coverage. ESS2 and ESS3 covered all regional states including the capital, Addis Ababa. The majority of the sample comprises rural areas as it was carried over from ESS1. The ESS2 and ESS3 were implemented in 433 enumeration areas (EAs) out of which 290 were rural, 43 were small town EAs from ESS1, and 100 were EAs from major urban areas."  [Basic Information Document, printed p. 13, on the frame the ESS sample is drawn from:] "The ESS sample is drawn from a population frame that includes all areas of Ethiopia except for three zones of Afar and six zones of Somalie region.9"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+[Basic Information Document, footnote 9, printed p. 13:] "Zones excluded from the sampling frame include Zones 2, 4, and 5 in the Afar Region and Zones 3, 4, 5, 6, 7, and 8 in the Somali Region."  [Basic Information Document, footnote 13, printed p. 14:] "There is an exception to this statement. The ESS and the AgSS surveys both exclude 9 zones from the population frame -- zones 2, 4, and 5 in the Afar Region and zones 3, 4, 5, 6, 7, and 8 in the Somali Region."  [Basic Information Document, printed p. 13:] "The sample size is insufficient to support region-specific estimates for each of the small regions including Afar, Benshangul Gumuz, Dire Dawa, Gambella, Harari, and Somalie regions. However, estimates can be produced for a combination of all smaller regions as one “other region” category."  [Survey report, 9331_ethiopia_survey_report_web_final.pdf:] "The results presented have been weighted to be nationally representative for rural areas, small towns, and large towns. For regional estimates, results are presented for five regions and the remaining six regions (Afar, Benshangul-Gumuz, Dire Dawa, Gambella, Harari and Somali regions) are grouped into an “other region” category."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+This is the only Ethiopia wave whose LOCAL documentation carries an explicit heading 'UNIVERSE'; its text is identical to the WB catalog study_info.universe field for id 2783, so local and catalog agree. The BID is the richest source in the whole Ethiopia tree for frame/exclusion detail and covers ESS1, ESS2 and ESS3. Design detail (not universe): 'ESS3 covered all those EAs covered by ESS2'; two-stage probability sample, regions as strata, 5 analysis domains in ESS1 (Amhara, Oromiya, SNNP, Tigray, 'all other regions') plus Addis Ababa from ESS2 on.
+#+end_quote
+
+*** Ethiopia 2018-19
+
+- Survey :: Ethiopia Socioeconomic Survey 2018-2019 (ESS4, Panel II baseline); WB catalog id 3823, idno ETH_2018_ESS_v04_M
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: https://microdata.worldbank.org/api/catalog/3823?id_format=id (WB Microdata catalog; local wave folder has no document carrying a universe statement)
+- Locator :: WB Microdata Library catalog entry 3823 (https://microdata.worldbank.org/index.php/catalog/3823), JSON field dataset.metadata.study_desc.study_info.universe; secondary quotes from study_info.geog_coverage, series_statement.series_info and method.analysis_info.response_rate in the same record.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.  [Same record, study_info.geog_coverage:] "National Regional Urban and Rural"  [Same record, series_statement.series_info:] "The 2018/19 ESS (ESS4) is a new panel. It is not a follow-up of the previous ESS waves. It is a baseline survey for the next ESS waves. It covers all nine regional states and two administrative cities, Addis Ababa and Dire Dawa. ESS4 is conducted in 565 EAs and of which 316 are rural and 219 are urban. The difference between ESS4 and previous ESS waves is that its coverage; ESS4 is representative at regional level in addition to rural and urban level."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.  [Same record, method.analysis_info.response_rate -- an implementation shortfall, not a design exclusion:] "ESS4 planned to interview 7,527 households from 565 enumeration areas (EAs) (Rural 316 EAs and Urban 249 EAs). A total of 6770 households from 535 EAs were interviewed for both the agriculture and household modules. The household module was not implemented in 30 EAs due to security reasons (See the Basic Information Document for additional information on survey implementation)."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Local documentation genuinely has no universe statement for this wave; the quote above is from the catalog and is labelled as such. The ESS4 BID (referenced by the catalog and by the local DDI's Documentation listing) would be the authoritative local source and is NOT in the repo -- worth acquiring for #603. Design detail (not universe): sampling frame is 'the updated 2018 pre-census cartographic database of enumeration areas by CSA'; two-stage stratified probability sample; rural EAs are a subsample of the 2018 AgSS EA sample; 10 agricultural + 2 non-agricultural households per rural EA, 15 households per urban EA; 7,527 households sampled.
+#+end_quote
+
+*** Ethiopia 2021-22
+
+- Survey :: Ethiopia Socio-Economic Panel Survey 2021-2022, Wave 5 (ESPS-5); WB catalog id 6161, idno ETH_2021_ESPS-W5_v02_M
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: https://microdata.worldbank.org/api/catalog/6161?id_format=id (WB Microdata catalog; the local wave folder contains no documentation beyond SOURCE/LICENSE)
+- Locator :: WB Microdata Library catalog entry 6161 (https://microdata.worldbank.org/index.php/catalog/6161), JSON field dataset.metadata.study_desc.study_info.universe; secondary quotes from study_info.geog_coverage, series_statement.series_info, method.data_collection.sampling_procedure, method.data_collection.weight and method.analysis_info.response_rate in the same record.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.  [Same record, study_info.geog_coverage:] "National Regional Urban and Rural"  [Same record, series_statement.series_info:] "ESPS-5 covers all regions of the country except Tigray. Therefore, the survey is nationally representative and provides national and regional estimates for rural and urban areas except for Tigray."  [Same record, method.data_collection.weight:] "Accordingly, ESPS-5 cross-sectional weights were calculated to represent the 2021/22 Ethiopia population (excluding Tigray) at regional and rural/urban levels."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.  [Same record, series_statement.series_info:] "ESPS-5 covers all regions of the country except Tigray."  [Same record, method.data_collection.sampling_procedure:] "The ESPS-5 kept all the ESPS-4 samples except for those in the Tigray region and a few other places."  [Same record, method.analysis_info.response_rate:] "ESPS-5 planned to interview 7,527 households from 565 enumeration areas (EAs) (Rural 316 EAs and Urban 249 EAs). However, due to the security situation in northern Ethiopia and to a lesser extent in the western part of the country, only a total of 4999 households from 438 EAs were interviewed for both the agriculture and household modules. The security situation in northern parts of Ethiopia meant that, in Tigray, ESPS-5 did not cover any of the EAs and households previously sampled. In Afar, while 275 households in 44 EAs had been covered by both the ESPS-4 agriculture and household modules, in ESPS-5 only 252 households in 22 EAs were covered by both modules. During the fifth wave, security was also a problem in both the Amhara and Oromia regions, so there was a comparable reduction in the number of households and EAs covered there."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No local documentation exists for this wave at all -- the catalog is the only source. The Tigray exclusion is the single most consequential fact here for #603: it is described in the catalog both as a coverage statement ('covers all regions of the country except Tigray') and as a weighting statement ('cross-sectional weights were calculated to represent the 2021/22 Ethiopia population (excluding Tigray)'), i.e. Tigray is outside the represented population, not merely non-response. The reductions in Afar, Amhara and Oromia are described as fieldwork shortfalls due to security, not as frame exclusions. The ESPS-5 Basic Information Document (referenced repeatedly by the catalog, 'Section 3 of the Basic Information Document provided under the Related Materials tab') is NOT in the repo and should be acquired.
+#+end_quote
+
+** EthiopiaRHS
+
+*** EthiopiaRHS 1989
+
+- Survey :: Ethiopian Rural Household Survey (ERHS), 1989 round (pre-expansion IFPRI survey)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: subnational-area
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/EthiopiaRHS/1989/Documentation/Overview and Acknowledgements and Data Description.pdf
+- Locator :: "The Ethiopian Rural Household Surveys 1989-2009: Introduction" (Dercon & Hoddinott, July 20, 2011), Section 3 "Overview of the surveys", printed p. 6, first paragraph. Companion statements: Section 1 "Introduction", printed p. 2; Table 1 discussion + footnote, printed p. 8.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+In 1989, IFPRI conducted a survey in seven Peasant Associations located in the regions Amhara, Oromiya and the Southern Ethiopian People’s Association (now called SNNPR), see Webb, von Braun and Yohannes (1992). Civil conflict prevented survey work from being undertaken in Tigray. Under extremely difficult field conditions, household data were collected in order to study the response of households to food crises. The study collected consumption, asset and income data on about 450 households. Households were randomly selected within each Peasant Association, while the Peasant Associations selected were mainly areas that had suffered from the 1984-1985 famine and other droughts that followed between 1987 and 1989. At least four of the areas are considered particularly vulnerable, while two (Debre Berhan and Adele Keke) may be less vulnerable but still suffered from the famine (See also Dercon and Krishnan 1995).
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"Civil conflict prevented survey work from being undertaken in Tigray." (Section 3, p. 6; the same sentence appears in Section 1, p. 2) ||| "For the 1989 sample, however, the sampling proportions deviate from the population shares due to the absence of Northern Highland villages that were inaccessible because of war activity." (Section 3, p. 8) ||| Footnote to Table 1 (p. 8): "percentage of rural sedentary population;  pastoralist   population is about 10 percent of total rural pop."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+EthiopiaRHS is NOT a World Bank survey (flagged discoverable=False in _COUNTRY_CATALOG), so there is no WB catalog fallback; local documentation is the only source. SOURCE.org records IFPRI Dataverse doi:10.7910/DVN/T8G8IV, not a WB catalog id. One single document — 'Overview and Acknowledgements and Data Description.pdf' — is byte-identical (md5 bd61f8994668f4fb143daae09ad6d34b) in all eight wave Documentation directories, and it is the only document in the repo that states a universe. It covers all rounds 1989-2009. SAMPLE DESIGN detail (not the universe): 'The data collection was a complicated process, using different questionnaires - which contained common parts - for the different Peasant Associations' (Section 4, p. 12). The 1989 sample is not part of the 1994 self-weighting frame; Table 1 (p. 8) gives 1989 sampling shares by farming system against 1994 population shares.
+#+end_quote
+
+*** EthiopiaRHS 1994a
+
+- Survey :: Ethiopian Rural Household Survey (ERHS), Round 1 (1994a)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: subnational-area
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/EthiopiaRHS/1994a/Documentation/Overview and Acknowledgements and Data Description.pdf
+- Locator :: "The Ethiopian Rural Household Surveys 1989-2009: Introduction" (Dercon & Hoddinott, July 20, 2011), Section 3 "Overview of the surveys", printed p. 8, paragraph beginning "To be clear..." (immediately preceding Table 1). Supporting: Section 1, printed p. 2; Section 3, printed pp. 6-7.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+To be clear, these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994. With only 15 communities, but relatively large samples within each village, the interpretation of the results in terms of rural Ethiopia as a whole has to be done with care.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"In 1994, CSAE and Economics/AAU started a panel survey incorporating six of the seven villages earlier surveyed in 1989 by IFPRI. (The remaining village in a semi-pastoralist area in Southern Ethiopia could not be revisited again because of violent conflict in the area)." (Section 3, pp. 6-7) ||| "these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994." (Section 3, p. 8) ||| Footnote to Table 1 (p. 8): "percentage of rural sedentary population;  pastoralist   population is about 10 percent of total rural pop." ||| "it should be remembered that we have sampled only 15 of the thousands of villages in rural Ethiopia." (Section 3, p. 7)
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The universe statement is a single ERHS-wide statement anchored to 1994 (the expansion round) — it is stated once, in the shared overview document, and applies to the 1994-onwards panel. Additional verbatim frame/design detail from the same document, Section 1 (p. 2) and Section 3 (pp. 6-7): "In 1994, the survey was expanded to cover 15 villages across the country.1 ... In addition, nine new villages were selected giving a sample of 1477 households. The nine additional communities were selected to account for the diversity in the farming systems in the country, including the grain-plough areas of the Northern and Central highlands, the enset-growing areas and the sorghum-hoe areas."; footnote 1: "In Ethiopia, the smallest unit of aggregation is the Peasant Association, an administrative unit of one or a small number of villages. In this documentation, we use “Peasant Association” and “village” interchangeably." SAMPLE DESIGN (p. 7): "A list of all households was constructed with the help of the local Peasant Association (PA) officials. ... In virtually all villages, therefore, there were good lists of the households in the village which could be used as a sampling frame."; "Within each village, random sampling was used, stratified by female headed and non-female headed households, including (as explained above) an attempt to re-randomize the 1989 study villages, via extra sampling from new entrants, splits and newly formed households."; "Sampling size in each village was governed by an attempt to obtain a self-weighting sample, when considered in terms of farming system: each person (approximately) represents the same number of persons from the main farming systems." Tracing rule (p. 6): "the tracing rule was based on the definition of a panel household, a household that had still members of the 1989 household living in the village." Village count caveat (Section 2 vii, p. 6): "Even though a tab of the variable q1c lists 18 Peasant Associations/villages, there really is only data for 15 villages. The largest village, Debre Berhan, is divided into four parts each with its own identifier (17, 18, 19 and 20)."
+#+end_quote
+
+*** EthiopiaRHS 1994b
+
+- Survey :: Ethiopian Rural Household Survey (ERHS), Round 2 (1994b)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: subnational-area
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/EthiopiaRHS/1994b/Documentation/Overview and Acknowledgements and Data Description.pdf
+- Locator :: "The Ethiopian Rural Household Surveys 1989-2009: Introduction" (Dercon & Hoddinott, July 20, 2011), Section 3, printed p. 8, paragraph beginning "To be clear...".
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+To be clear, these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994. With only 15 communities, but relatively large samples within each village, the interpretation of the results in terms of rural Ethiopia as a whole has to be done with care.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994." (Section 3, p. 8) ||| Footnote to Table 1 (p. 8): "percentage of rural sedentary population;  pastoralist   population is about 10 percent of total rural pop." ||| "(The remaining village in a semi-pastoralist area in Southern Ethiopia could not be revisited again because of violent conflict in the area)." (Section 3, p. 6 — exclusion carried from the 1994 re-start of the panel)
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No round-2-specific universe statement exists. The documentation states one universe for the 1994-onwards panel and treats Round 2 as a re-visit of the same households: "An additional round was conducted in late 1994, with further rounds in 1995, 1997, 1999, 2004 and 2009." (Section 1, p. 2). The verbatim quote above is the ERHS-wide statement and is what the documentation CLAIMS for this wave by inheritance, not a round-2 statement.
+#+end_quote
+
+*** EthiopiaRHS 1995
+
+- Survey :: Ethiopian Rural Household Survey (ERHS), Round 3 (1995)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: subnational-area
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/EthiopiaRHS/1995/Documentation/Overview and Acknowledgements and Data Description.pdf
+- Locator :: "The Ethiopian Rural Household Surveys 1989-2009: Introduction" (Dercon & Hoddinott, July 20, 2011), Section 3, printed p. 8, paragraph beginning "To be clear...".
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+To be clear, these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994. With only 15 communities, but relatively large samples within each village, the interpretation of the results in terms of rural Ethiopia as a whole has to be done with care.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994." (Section 3, p. 8) ||| Footnote to Table 1 (p. 8): "percentage of rural sedentary population;  pastoralist   population is about 10 percent of total rural pop."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No round-3-specific universe statement. Inherits the single ERHS-wide statement (15 villages, non-pastoralist farming systems as of 1994). Attrition, not universe, is what the document says changes across rounds: "Just under 8 per cent of the sample was lost between 1994 and 1999, and a further 5.2 percent were lost from 1999 and 2004." (Section 2 ix, p. 6).
+#+end_quote
+
+*** EthiopiaRHS 1997
+
+- Survey :: Ethiopian Rural Household Survey (ERHS), Round 4 (1997)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: subnational-area
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/EthiopiaRHS/1997/Documentation/Overview and Acknowledgements and Data Description.pdf
+- Locator :: "The Ethiopian Rural Household Surveys 1989-2009: Introduction" (Dercon & Hoddinott, July 20, 2011), Section 3, printed p. 8, paragraph beginning "To be clear...".
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+To be clear, these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994. With only 15 communities, but relatively large samples within each village, the interpretation of the results in terms of rural Ethiopia as a whole has to be done with care.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994." (Section 3, p. 8) ||| Footnote to Table 1 (p. 8): "percentage of rural sedentary population;  pastoralist   population is about 10 percent of total rural pop."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No round-4-specific universe statement. The 1997 community questionnaire notes give a coverage statement for the COMMUNITY (not household) sample, from Table of Contents.pdf: "3 files in Stata format with data on the 15 communities surveyed in Round 4 (1997) of the survey".
+#+end_quote
+
+*** EthiopiaRHS 1999
+
+- Survey :: Ethiopian Rural Household Survey (ERHS), Round 5 (1999)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: subnational-area
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/EthiopiaRHS/1999/Documentation/Overview and Acknowledgements and Data Description.pdf
+- Locator :: "The Ethiopian Rural Household Surveys 1989-2009: Introduction" (Dercon & Hoddinott, July 20, 2011), Section 3, printed p. 8, paragraph beginning "To be clear...". Wave-specific coverage change: Section 2 viii "The number of villages (2)", printed p. 6.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+To be clear, these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994. With only 15 communities, but relatively large samples within each village, the interpretation of the results in terms of rural Ethiopia as a whole has to be done with care.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994." (Section 3, p. 8) ||| Footnote to Table 1 (p. 8): "percentage of rural sedentary population;  pastoralist   population is about 10 percent of total rural pop."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+1999 is the one round whose COVERAGE differs from the shared statement, and the document says so verbatim (Section 2 viii, p. 6): "In 1999, three additional villages - Oda Dawata, Bako Tibe and Somodo were surveyed. The principal focus of the 1999 survey round was agricultural productivity interest and it was felt that adding villages in higher productivity villages would be informative. There was not sufficient funding to re-survey these villages in 2004." The document does NOT state a revised universe for the enlarged 1999 sample — it gives the rationale only. So for 1999 the recorded universe is the ERHS-wide statement PLUS this documented extension to three extra villages.
+#+end_quote
+
+*** EthiopiaRHS 2004
+
+- Survey :: Ethiopian Rural Household Survey (ERHS), Round 6 (2004)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: subnational-area
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/EthiopiaRHS/2004/Documentation/Overview and Acknowledgements and Data Description.pdf
+- Locator :: "The Ethiopian Rural Household Surveys 1989-2009: Introduction" (Dercon & Hoddinott, July 20, 2011), Section 3, printed p. 8, paragraph beginning "To be clear..."; exclusion at Section 2 viii, printed p. 6.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+To be clear, these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994. With only 15 communities, but relatively large samples within each village, the interpretation of the results in terms of rural Ethiopia as a whole has to be done with care.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"There was not sufficient funding to re-survey these villages in 2004." (Section 2 viii, p. 6 — referring to the three villages Oda Dawata, Bako Tibe and Somodo added in 1999) ||| "these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994." (Section 3, p. 8) ||| Footnote to Table 1 (p. 8): "percentage of rural sedentary population;  pastoralist   population is about 10 percent of total rural pop."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No round-6-specific household universe statement. The 2004 community questionnaire does define the community unit verbatim: "For this questionnaire, the community is defined as the peasant association (PA), but we want to know information about locally well-defined neighborhoods as well." (ERHS_Community Questionnaire 2004.pdf, 'Instructions to enumerators', p. 1). Table of Contents.pdf records "3 files in Stata format with data on the 15 communities surveyed in Round 6 (2004) of the survey".
+#+end_quote
+
+*** EthiopiaRHS 2009
+
+- Survey :: Ethiopian Rural Household Survey (ERHS), Round 7 (2009)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: subnational-area
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/EthiopiaRHS/2009/Documentation/Overview and Acknowledgements and Data Description.pdf
+- Locator :: "The Ethiopian Rural Household Surveys 1989-2009: Introduction" (Dercon & Hoddinott, July 20, 2011): first sentence + rounds list, Section 1 "Introduction", printed p. 2; representativeness statement, Section 3, printed p. 8. The two fragments are joined by "..." above and are NOT contiguous in the source.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The Ethiopia Rural Household Survey (ERHS) is a unique longitudinal household data set covering households in a number of villages in rural Ethiopia. ... In 1994, the survey was expanded to cover 15 villages across the country. An additional round was conducted in late 1994, with further rounds in 1995, 1997, 1999, 2004 and 2009. ... To be clear, these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"these data are not nationally representative. However, they can be considered broadly representative of households in non-pastoralist farming systems as of 1994." (Section 3, p. 8) ||| Footnote to Table 1 (p. 8): "percentage of rural sedentary population;  pastoralist   population is about 10 percent of total rural pop." ||| No 2009-specific exclusion statement was found. The only 2009-specific sentence in the document is Section 2 v "Other survey rounds", p. 5: "Data have also been collected in 2009. This data will be made available in the future."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+CONFIDENCE MEDIUM, and the reason matters. The shared overview document is dated July 20, 2011 and its title covers 1989-2009, and Section 1 (p. 2) explicitly lists 2009 among the rounds — so the ERHS-wide universe statement is documented as covering Round 7. BUT the document also says, at Section 2 v "Other survey rounds" (p. 5): "Data have also been collected in 2009. This data will be made available in the future." — i.e. the body of the document was written before the 2009 release, and there is NO 2009-specific description of coverage, village count, or exclusions anywhere in the local documentation. Whether the 15-village frame was fully re-surveyed in 2009 is NOT stated in any document in this repo. Table of Contents.pdf does record "19 files in Excel format with data on the 15 communities surveyed in Round 7 (2009) of the survey" for the community module, which is the closest thing to a 2009 coverage statement. Note also this quote is assembled from two non-contiguous passages, marked with "...".
+#+end_quote
+
+** GhanaLSS
+
+*** GhanaLSS 1987-88
+
+- Survey :: Ghana Living Standards Survey 1: 1987-1988 (GLSS 1)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/GhanaLSS/1987-88/Documentation/GLSS 1987-88 Report.pdf
+- Locator :: Section 'Scope & Coverage' -> 'Universe' field, PDF page 10 (printed page '- 2 -'); the file is in fact the GSS NADA DDI study-documentation PDF for GLSS 1, titled 'Ghana Living Standards Survey 1: 1987-1988 - Overview', not a substantive report.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+Universe The survey covered all household members of all age and sex category who reside in Ghana.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND - no exclusion statement appears in the Universe field or in the Sampling Procedure section. The nearest design-level statement is: "A final concern was that all three of the country's ecological zones (coastal, forest and savannah), and each of urban, semi-urban and rural areas (population greater than 5000, 1500 to 5000, and less than 1500, respectively) form the same proportion in the sample as they do in the national population." (same file, Sampling Procedure) - this is sample design, not an exclusion.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The local PDF's text layer uses a CID-encoded subset font with no ToUnicode map, so naive pdftotext/pdfminer extraction yields '(cid:NN)' garbage; I reconstructed the glyph map from cribs ('Ghana Statistical Service Office of the President', 'Ghana Living Standards Survey 1: 1987-1988') and decoded the page. The decoded sentence is character-for-character identical to the Universe field currently shown on the live GSS NADA catalog page for id 7, which is an independent corroboration. GHA_1987_GLSS_Basicinfo_EN.pdf (the LSMS Basic Information Document, which covers BOTH the 1987-88 and 1988-89 rounds) contains NO universe/target-population statement; its Section 1 Overview says only 'This nationwide survey gathered individual and household level data using a multi-purpose household questionnaire.' and its Section 3.1 Sample Design describes the stratified PPS selection from the 1984 Census's ~13,000 EAs. The WB catalog entry (2313) for this round carries no Universe field at all.
+#+end_quote
+
+*** GhanaLSS 1988-89
+
+- Survey :: Ghana Living Standards Survey 2:1988-1989, Second round (GLSS 2)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/GhanaLSS/1988-89/Documentation/ddi-documentation-english-4.pdf
+- Locator :: 'Coverage' block -> UNIVERSE field, PDF page 6 (document ID DDI-GHA-GSS-GLSS2-2008-v2.0)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+UNIVERSE The survey covered all household members in the nationally representative sample. Different sections of the instruments have individual universes.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND - no exclusion statement in the DDI Universe field, the Sampling Procedure section, or the Basic Information Document.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The GSS NADA catalog page for id 4 shows the identical sentence, so the local DDI PDF and the live catalog agree. GHA_1988_GLSS_Basicinfo_EN.pdf is the same joint 1987-88/1988-89 LSMS Basic Information Document as in the 1987-88 wave and has no universe statement. GHA_1988_GLSS_Samplingrecoomendations_EN.pdf (Chris Scott, World Bank consultant, October 1989) is a forward-looking design memo for the *next* (GLSS3) round and contains no universe statement for 1988-89. The DDI phrase 'Different sections of the instruments have individual universes' is a pointer, not a specification - the per-section universes are not enumerated for this round (they ARE enumerated for GLSS3).
+#+end_quote
+
+*** GhanaLSS 1991-92
+
+- Survey :: Ghana Living Standards Survey 3 -1991, Third round (GLSS 3)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/GhanaLSS/1991-92/Documentation/ddi-documentation-english-12.pdf
+- Locator :: Universe: 'Coverage' block -> UNIVERSE field, PDF pages 5-6. Exclusion: a DIFFERENT file - lsms_library/countries/GhanaLSS/1991-92/Documentation/pdf/G3report.pdf, Appendix 1 'SAMPLE DESIGN FOR ROUND 3 OF THE GLSS', printed page 112.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+UNIVERSE The survey is nationally representative. It has the following sub-universes:  Household roster: all usual household members  Education : usual household members 5 years and older  Health: all usual household members  Employment and time use: usual household members 7 years and older  Migration: usual household members 15 years and older  Housing: heads of households  Agriculture:holders
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The figure of 28 rural workloads with no workload, shown in Table 2, includes one EA which had to be excluded from the final sampling frame because the local chiefs refused to allow the listing exercise to be done.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The verbatim sub-universe list is the most granular universe statement of any GLSS round in this repo. Note the source's own typography is preserved: 'Education :' (space before colon) and 'Agriculture:holders' (no space after colon). SOURCE.org points at WB catalog 2315, but that WB page carries no Universe field; the statement above comes from the LOCAL GSS DDI PDF (and matches GSS NADA catalog id 12 verbatim). The GLSS3 main report (pdf/G3report.pdf) has no 'universe' heading; its Appendix 1 describes the master sample of 800 EAs drawn from the 12,969 EAs of the 1984 Population Census and states that under the GLSS1/GLSS2 design 'each household in Ghana had an equal probability of being selected' (printed p. 109). Whitespace inside quotes has been normalised from PDF line-wrapping; wording is unaltered.
+#+end_quote
+
+*** GhanaLSS 1998-99
+
+- Survey :: Ghana Living Standard Survey 4 - 1998, With labour force model (GLSS 4)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/GhanaLSS/1998-99/Documentation/ddi-documentation-english-14.pdf
+- Locator :: 'Coverage' block -> UNIVERSE field, PDF page 6
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+UNIVERSE The survey is nationally representative household survey that covers region , zones and urban/rural residence.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND - no exclusion statement in the DDI Universe field or in Appendix 1 of the main report. Appendix 1 does record a frame quality caveat rather than an exclusion: "For the purposes of this survey the list of the 1984 population census Enumeration Areas (EAs) with population and household information was used as the sampling frame. ... This frame, though quite old, was considered inadequate, it being the best available at the time."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Verbatim typography preserved: 'covers region , zones' (space before the comma) is as printed in the source. The main report (GHA_1998_GLSS_Report_EN.pdf, identical content to glss4_report.pdf) opens its Appendix 1 'SAMPLE DESIGN FOR ROUND 4 OF THE GLSS' with: 'A nationally representative sample of households was selected in order to achieve the survey objectives.' (printed page 114). Section 1.1 of the report reports estimates for 'the total number of persons in private households in Ghana', implying a private-household universe, but the documentation never states that as a universe definition - I am not treating an implication as a claim.
+#+end_quote
+
+*** GhanaLSS 2005-06
+
+- Survey :: Ghana Living Standard Survey 5: 2005, With Non-Farm Household Enterprise Module (GLSS 5)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/GhanaLSS/2005-06/Documentation/ddi-documentation-english-5.pdf
+- Locator :: UNIVERSE field: 'Coverage' block, PDF page 4. Sampling-frame universe + institutional-population exclusion: 'Sampling' -> 'Sampling Procedure' -> 'Sampling Frame and Units', PDF page 5. (Document ID DDI-GHA-GSS-GLSS-2005-v2.0, version 2.0 November 2008.)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+UNIVERSE The survey covered all de jure household members (usual residents) who have not been away from their usual residents for more than 6 months. This excludes heads of households.  [and, in the Sampling section of the same document:]  As in all probability sample surveys, it is important that each sampling unit in the surveyed population have a known, non-zero probability of selection. To achieve this, there has to be an appropriate list, or sampling frame of the primary sampling units (PSUs).The universe defined for the GLSS 5 survey is the population living within private households in Ghana.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The institutional population (such as schools, hospitals etc), which represents a very small percentage in the 2000 Population and Housing Census (PHC), is excluded from the frame for the GLSS 5 survey.  [and, from the UNIVERSE field itself:] This excludes heads of households.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+This wave carries TWO distinct universe statements that are not the same thing, and both are recorded above. (1) The DDI 'UNIVERSE' field describes the RESPONDENT universe (de jure members absent <=6 months) and contains the odd clause 'This excludes heads of households' - quoted verbatim; the intended meaning is unclear (heads certainly are enumerated in the data) and I am NOT interpreting it. (2) The 'Sampling Frame and Units' text gives the TARGET population proper: 'the population living within private households in Ghana', with the institutional population excluded from the frame. For GH #603 the second is the population record; the first is a module-eligibility rule. Note the missing space after '(PSUs).' in the original - preserved verbatim. Whitespace otherwise normalised from PDF line-wrapping.
+#+end_quote
+
+*** GhanaLSS 2012-13
+
+- Survey :: Ghana Living Standards Survey 6 (With a Labour Force Module) 2012-2013 (GLSS 6)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/GhanaLSS/2012-13/Documentation/REPORTS/GLSS6_Main Report.pdf
+- Locator :: APPENDIX 1: METHODOLOGY OF THE SURVEY, section 6.2 'Sampling Frame and Units', printed page 204 (PDF page 225)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+6.2 Sampling Frame and Units  The GLSS6 is a household probability sample survey designed to cater for a variety of analyses at the various domains of interest. As in all probability sample surveys, it is important that each sampling unit in the target population has a known, non-zero probability of being included in the sample. To achieve this, an appropriate list, or sampling frame of the PSUs is required. The list of standardized census EAs - together with their respective population and household sizes - obtained from the 2010 Population and Housing Census (PHC) conducted by the Ghana Statistical Service was used as the sampling frame for the GLSS6.  However, the unit of measurement was the population living within individual households.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The institutional population (those who were in schools, hospitals, etc.), which represents a very small percentage of the 2010 Population and Housing Census (PHC), was excluded from the frame.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The GSS NADA catalog id 72 does carry a UNIVERSE field, but it is uselessly terse: 'The survey covered all household members'. The local main report is far more informative and is what I have quoted. The report's Table 2.1 note also states, verbatim, 'Excludes institutional population.' (printed page 5), corroborating the frame exclusion in the survey estimates themselves. Whitespace normalised from PDF line-wrapping (the report is justified, producing multiple spaces between words); wording is unaltered.
+#+end_quote
+
+*** GhanaLSS 2016-17
+
+- Survey :: Ghana Living Standard Survey (GLSS 7) 2016/17
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/GhanaLSS/2016-17/Documentation/GLSS7 Final Manual.docx
+- Locator :: Chapter 1 INTRODUCTION: the quoted paragraph closes section '1.2 METHODOLOGY OF THE SURVEY' (immediately after Table 1, 'Regional Distribution of EAs and Households', and immediately before '1.3 SURVEY PERIOD'); the 'nationally representative' sentence is the first sentence of section 'Background'. The .docx has no page numbering in its XML, hence the section locator.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+Basic information on all persons living in private households would be solicited.  In addition, all persons 15 years and older would be eligible for the labour force survey.  For the child labour module, the survey would solicit information from persons between the ages of 5-14 years.  [preceded, in section Background, by:] The Ghana Living Standards Survey (GLSS) is a nationally representative household survey which provides reliable, disaggregated and internationally comparable welfare and living conditions statistics in Ghana. ... The GLSS-7 is also a nation-wide household survey conducted in 2016/17.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND - no exclusion statement anywhere in the local GLSS7 documentation or in the GSS NADA catalog entry. (The 'private households' phrasing implies the usual institutional-population exclusion, as stated explicitly for GLSS5 and GLSS6, but GLSS7's own documentation does not say so and I am not asserting it.)
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Confidence is 'medium', not 'high', for a specific reason: unlike every other GLSS round in this repo, GLSS7 has NO DDI 'Universe' field - neither the shipped ddi-documentation-english-97.pdf nor the live GSS NADA catalog page has one, and the catalog's Sampling section is literally 'No content available'. The quote above is therefore from the interviewers' manual (a fieldwork instrument), stated in the future/conditional tense ('would be solicited') because it was written before fieldwork. It is a genuine coverage statement in an official GSS document, but it is a weaker instrument than a DDI universe field. The GLSS7 Main Report published by GSS is NOT in this repository's Documentation directory and was not consulted. If GH #603 needs a hardened GLSS7 population record, acquiring the GLSS7 Main Report (its Appendix on methodology is the analogue of the GLSS6 section 6.2 quoted above) is the concrete next step.
+#+end_quote
+
+** GhanaSPS
+
+*** GhanaSPS 2009-10
+
+- Survey :: Ghana Socioeconomic Panel Survey 2009-2010 (Wave 1) / "Socioeconomic Panel Survey: 2009-2010", WB study id 2534, IDNO GHA_2009_GSPS_v01_M
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/GhanaSPS/2009-10/Documentation/Basic_Information_Dec_2015.pdf ; lsms_library/countries/GhanaSPS/2009-10/Documentation/Baseline_Descriptive_Report.pdf ; (corroborating, non-local) https://microdata.worldbank.org/index.php/catalog/2534/study-description
+- Locator :: Basic_Information_Dec_2015.pdf: section "3. Sampling and Survey Design", printed p. 8 (PDF page 9). Baseline_Descriptive_Report.pdf: section "2.1. Household composition", printed p. 5 (PDF page 15); the same sampling paragraph also appears at section "1.3. Sample Design and Organization of the Survey", printed p. 2 (PDF page 12). WB catalog 2534: study-description page, "Coverage" block, "Universe" field.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+[LOCAL DOC 1 - Basic_Information_Dec_2015.pdf, section "3. Sampling and Survey Design", printed p. 8:] "The survey provides regionally representative data for the 10 regions of Ghana. In all, 5010 households from 334 Enumeration Areas (EAs) were sampled. Fifteen households were selected from each of the EAs. The distribution of the enumeration areas across the regions in Ghana is presented in Table 1. The number of EAs for each region was proportionately allocated based on estimated 2009 population share for each region. EAs for Upper East and Upper West regions, which have relatively smaller population sizes, were over sampled to allow for a reasonable number of households to be interviewed in these regions."  ||  [LOCAL DOC 2 - Baseline_Descriptive_Report.pdf, section "2.1. Household composition", printed p. 5:] "The data from the baseline Ghana Socio-Economic Panel Survey consists of a nationally representative sample of 5009 households in 334 enumeration areas (EAs) containing 18,889 household members. The survey defines household as a person or a group of persons, who live together in the same dwelling, share the same house-keeping arrangements and are catered for as one unit."  ||  [WORLD BANK CATALOG - microdata.worldbank.org/index.php/catalog/2534, study-description, explicit "Universe" field:] "Nationally representative, regionally representative for all 10 regions."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND - no statement of excluded regions, localities, or population groups appears in any of the local wave-1 documentation or in the WB catalog entry. The nearest related population-definition rule (household-membership eligibility, NOT a geographic/population exclusion) is, verbatim from Basic_Information_Dec_2015.pdf, section 2 preamble, printed p. 3: "The survey defined a household as a person or a group of persons, who live together in the same dwelling, share the same house-keeping arrangements and are catered for as one unit under one recognized head. A person qualifies as a member of a household if he/she in the last 6 months regularly participated in this living arrangement with the household."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+SOURCE.org for this wave contains only two bare URLs (https://microdata.worldbank.org/index.php/catalog/2534/get-microdata and https://egc.yale.edu/data/egc-isser-northwestern-ghana-panel-survey); it carries NO #+CATALOG_ID/#+CATALOG_IDNO/#+PROVENANCE_* keywords. The WB catalog id 2534 is nevertheless stated in the local LICENSE.org and matches _wb_catalog_search('GHA', collection='lsms') -> id 2534, idno GHA_2009_GSPS_v01_M, title 'Socioeconomic Panel Survey: 2009-2010'. Sample-design detail (NOT the universe): two-stage stratified design, stratified by region, 334 EA clusters drawn from an updated master sampling frame built on the 2000 Ghana Population and Housing Census, then simple random selection of 15 listed households per cluster; Upper East and Upper West deliberately over-sampled; design is not self-weighting so household sample weights are supplied. Note the 5010-vs-5009 household discrepancy between the Basic Information Document / WB catalog (5010 sampled) and the Baseline Descriptive Report (5009 interviewed) - quoted as found, not reconciled. Local documentation PDFs were fetched via data_access.get_data_file(); no dvc CLI was used. No file under lsms_library/countries/ was modified.
+#+end_quote
+
+*** GhanaSPS 2013-14
+
+- Survey :: Ghana Socioeconomic Panel Survey, Wave 2 (2013-2014). Instrument cover page: "GHANA SOCIO-ECONOMIC PANEL SURVEY / HOUSEHOLD INSTRUMENT / Wave 2(2013-2014)". Catalogued elsewhere as "Socioeconomic Panel Survey 2013-2014, Wave 2", IDNO GHA_2013_GSPS_v01_M.
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: NOT the World Bank catalog: https://catalog.ihsn.org/catalog/10354/study-description (IHSN NADA mirror of the ISSER data portal entry). Local files searched and found to contain no universe statement: lsms_library/countries/GhanaSPS/2013-14/Documentation/ISSER_Yale_Part A_WAVE II.docx, ISSER_Yale_Community Survey_WAVE II.docx, ISSER_Yale_Part B_WAVE II.docx (sidecar only), Data Map.xlsx, Food Consumption Unit Codes.xlsx, Variable Lists/, Variable Labels/.
+- Locator :: IHSN catalog 10354, study-description page: "Coverage" block -> "Geographic Coverage" field; and "Identification" block -> "Abstract" field.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND in local documentation, and this wave is NOT in the World Bank Microdata catalog. || [NOT a "Universe" field, and NOT the World Bank catalog. Source: IHSN NADA catalog entry 10354 (study id GHA_2013_GSPS_v01_M), "Coverage" block, "Geographic Coverage" field:] "The survey provides regionally representative data for the 10 regions of Ghana." || [Same IHSN entry, "Abstract" field, sample-size sentences - a description of the achieved sample, not a universe statement:] "The data from the second wave of the Ghana Socioeconomic Panel Survey covered a sample of 4,774 households containing 16,356 household members. The second wave was unique in the sense that it tracked movement of households as well as individual within a household. Thus, increasing the number of households in the Panel Study due to the nature of the design; tracking wholly moved and split households. A total of 5484 households were selected for the survey comprising of 5009 households from the baseline survey and 475 households from split of households created of which 4774 households were successfully interviewed."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND. No exclusion statement of any kind (region, locality, institutional population, nomadic households, security-related drops) appears in the local wave-2 documentation or in the IHSN catalog entry. The IHSN entry for this wave has no "Universe" field and no "Sampling" section at all - its only metadata sections are Identification, Scope, Coverage, Producers and sponsors, Survey instrument, Data collection, Data Access, Disclaimer, Metadata production.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+IMPORTANT ATTRIBUTION: source_type is recorded as 'wb-catalog' only because the enum has no value for 'other survey catalog'. The quote is from the IHSN NADA catalog (catalog.ihsn.org/catalog/10354), which mirrors the ISSER (University of Ghana) data portal entry. It is NOT from the World Bank Microdata Library - GSPS Wave 2 is not in the WB catalog at all. Neither the local documentation nor that catalog entry contains an explicit universe/target-population statement; the strongest available statement is a coverage claim ('regionally representative data for the 10 regions of Ghana'). GSPS is a panel: Wave 2's frame is the Wave 1 sample plus split-off households, so its universe is inherited from Wave 1 rather than restated - but note that no document says this in so many words, so it is NOT asserted here. The nearest EGC-level statement, from 'Ghana Panel Creation User Guide.pdf' p. 1 and the EGC project page, is: "we have implemented a large-scale, nation-wide panel survey in Ghana that will extend for at least 15 years. The first three survey waves have been completed - conducted in 2009/2010, 2013/2014, and 2017/2018." The Wave 2 community instrument is titled "RURAL COMMUNITY INSTRUMENT", which constrains the community-level module only, not the household sample. Repo note: GhanaSPS/_/CONTENTS.org records that '2013-14' has no region or urban/rural variables and that all of 2013-14 is currently assigned region 'Ghana' - that is a data-availability fact, not a universe statement.
+#+end_quote
+
+*** GhanaSPS 2017-18
+
+- Survey :: Ghana Socioeconomic Panel Survey, Wave 3. Instrument cover page: "GHANA SOCIO-ECONOMIC PANEL SURVEY / HOUSEHOLD INSTRUMENT / WAVE 3 (2018-2019)". Catalogued elsewhere as "Socioeconomic Panel Survey 2018-2019, Wave 3", IDNO GHA_2018_GSPS_v01_M.
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: NOT the World Bank catalog: https://catalog.ihsn.org/catalog/10355/study-description (IHSN NADA mirror of the ISSER data portal entry). Local file searched and found to contain no universe statement: lsms_library/countries/GhanaSPS/2017-18/Documentation/Questionnaire/HH_Questionnaire_23_10.docx.
+- Locator :: IHSN catalog 10355, study-description page: "Coverage" block -> "Geographic Coverage" field.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND in local documentation, and this wave is NOT in the World Bank Microdata catalog. || [NOT a "Universe" field, and NOT the World Bank catalog. Source: IHSN NADA catalog entry 10355 (study id GHA_2018_GSPS_v01_M), "Coverage" block, "Geographic Coverage" field:] "The survey is nationally representative."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND. No exclusion statement of any kind appears in the local wave-3 documentation (a single household questionnaire) or in the IHSN catalog entry, which has no "Universe" field and no "Sampling" section - its only metadata sections are Identification, Scope, Coverage, Producers and sponsors, Survey instrument, Data collection, Data Access, Disclaimer, Metadata production. (Within-module respondent-eligibility rules do exist in the instrument, e.g. "Can you confirm that [Name] is female, 18-40 years old, speaks either English, Asante, Akuapem, Fanti, Ewe, Dagbani, Kokomba/Likpakpa, Wali/Dagari, Frafra/Gruni or Dangme and is therefore eligible to be interviewed?" - these govern who answers a particular module, NOT which households are in the sample.)
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+IMPORTANT ATTRIBUTION: source_type is recorded as 'wb-catalog' only because the enum has no value for 'other survey catalog'. The quote is from the IHSN NADA catalog (catalog.ihsn.org/catalog/10355), mirroring the ISSER data portal entry; it is NOT the World Bank Microdata Library - GSPS Wave 3 is not in the WB catalog. WAVE-LABEL DISCREPANCY worth recording: this repo directory is named '2017-18', but the local questionnaire's own cover page reads "WAVE 3 (2018-2019)" and the IHSN/ISSER catalog entry is titled "Socioeconomic Panel Survey 2018-2019, Wave 3" with Dates of Data Collection start 2018 / end 2019, while the Yale EGC project page and the Panel Creation User Guide both describe the third wave as "conducted in ... 2017/2018". The identification of the local '2017-18' directory with GSPS Wave 3 is corroborated by the local instrument's own cover page, not inferred from the microdata. Note also the coverage wording changed between waves: Wave 1 and Wave 2 catalog entries say 'regionally representative data for the 10 regions of Ghana', Wave 3 says only 'The survey is nationally representative' - quoted as found, not reconciled. Separately, the EGC user guide records a supplementary 2019 collection ("In 2019, the Ghana Panel Survey was also administered to a sample of participants in Ghana's rural north who had been classified as 'extremely poor' through community-level focus groups") - that is a distinct sample and is NOT the wave in this directory.
+#+end_quote
+
+** Guatemala
+
+*** Guatemala 2000
+
+- Survey :: Encuesta Nacional sobre Condiciones de Vida 2000 (ENCOVI 2000)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: Spanish
+- Source file :: lsms_library/countries/Guatemala/2000/Documentation/ddi-documentation-english_microdata-586.pdf
+- Locator :: PDF page 3 (the page whose footer reads "3"), section "Sampling" → sub-heading "Sampling Procedure", block "DISEÑO DE LA MUESTRA", numbered items 1, 4 and 5. Corroborated character-for-character against the same DDI rendered on the World Bank Microdata catalog, https://microdata.worldbank.org/index.php/catalog/586/study-description — fields study_desc.study_info.universe ("Universe") and study_desc.study_info.geog_coverage ("Geographic Coverage"), plus the "Sampling procedure" field.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+DDI "Universe" field: "Viviendas particulares y hogares existentes en el país, según la Encuesta Nacional de Ingresos y Gastos - ENIGFAM 98."  Sampling Procedure, "DISEÑO DE LA MUESTRA", item 1: "1. Universo de estudio: Viviendas particulares y hogares existentes en el país, según ENIGFAM 98."  Sampling Procedure, item 5 (also the DDI "Geographic Coverage" field): "5. Cobertura: ENCOVI’2000 se diseña para cubrir las áreas urbanas, áreas rurales y áreas indígenas del país."  Sampling Procedure, item 4 (secondary sampling unit): "4. Unidades Secundarias de Muestreo: Las Unidades Secundarias de Muestreo están constituidas por las viviendas particulares ocupadas y ausentes."
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+Universe: "Private dwellings and households existing in the country, according to the National Income and Expenditure Survey - ENIGFAM 98." / Item 1, Study universe: "Private dwellings and households existing in the country, according to ENIGFAM 98." / Item 5, Coverage: "ENCOVI'2000 is designed to cover the urban areas, rural areas and indigenous areas of the country." / Item 4: "The Secondary Sampling Units are made up of occupied and absent private dwellings." (Translation supplied by the agent; NOT present in the source.)
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND — no explicit exclusion / non-coverage statement appears anywhere in the local documentation or in the WB catalog record. There is no sentence excluding institutional/collective population, nomadic households, or any region. The only exclusion-adjacent language is the restriction of the frame to *private* dwellings, quoted verbatim above: "Universo de estudio: Viviendas particulares y hogares existentes en el país" and "Las Unidades Secundarias de Muestreo están constituidas por las viviendas particulares ocupadas y ausentes." Whether "viviendas particulares" is intended to exclude collective/institutional dwellings is NOT stated in the documentation and is not asserted here.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+ONE WAVE ONLY. Guatemala has a single wave directory, 2000; there is no other wave to report.  ACCENT CAVEAT (important for the verbatim rule). pdfminer's extraction of the local DDI PDF silently DROPS all Spanish diacritics in the body font — it yields "DISEO DE LA MUESTRA", "en el pas, segn ENIGFAM 98", "se disea para cubrir las reas ... indgenas". Those are extraction artifacts of the font encoding, NOT the source text (the cover-page font renders "Instituto Nacional de Estadística" correctly). I therefore reconstructed the accents from the World Bank catalog's HTML rendering of the SAME DDI record (study 586), fetched raw and JSON-unescaped, which agrees word-for-word with the PDF extraction on every unaccented character. The quotes above carry the catalog's accented spelling. pdftotext was not available on this machine.  ONE WORDING DIFFERENCE between the two renderings of the universe, recorded rather than smoothed: the DDI's dedicated "Universe" field spells the acronym out — "según la Encuesta Nacional de Ingresos y Gastos - ENIGFAM 98" — whereas Sampling-Procedure item 1 (the version in the local PDF) has the short form "según ENIGFAM 98". Both are quoted above; neither is a paraphrase of the other by me.  Apostrophe: "ENCOVI’2000" uses U+2019 RIGHT SINGLE QUOTATION MARK in the source, not an ASCII apostrophe.  SAMPLE DESIGN (context only, NOT the universe statement) — verbatim from the same Sampling Procedure block: "ENCOVI’2000 se aplica a una muestra que en su diseño es: -Bietápica -Estratificada -De conglomerados y aleatoria en su primera etapa. -De segmentos compactos y sistemática en su segunda etapa. -Sin reemplazo."; "2. Marco Muestral: El marco muestral esta configurado por 11170 Unidades Primarias de Muestreo, que lo constituyen los sectores cartográficos del Censo de Población y Habitación 1994, de los cuales 3544 son urbanos y 7626 son rurales."; "3. Unidades Primarias de Muestreo: la unidades primarias de muestreo están constituidas por los sectores censales, tanto urbanos como rurales."; "6. Tamaño de la Muestra : Para la encuesta de condiciones de vida se seleccionó una muestra sin reemplazo de 8, 940 viviendas. Se espera que con una tasa de rechazo no mayor al 10% se obtenga una muestra total de 8,046 viviendas efectivas."; "7. Dominios de Estudio: Los dominios de inferencia del Estudio de condiciones de Vida son los siguientes: a) Total Nacional: Urbano y rural b) Región Metropolitana: Urbana y Rural c) Región Norte: Urbana y Rural d) Región Nor-Oriente: Urbana y Rural e) Región Sur-Oriente: Urbana y Rural f) Región Central: Urbana y Rural g) Región Sur-Occidente; Urbana y Rural h) Región Nor-Occidente: Urbana y Rural i) Región Petén: Urbana y Rural." (the a)–i) list is run together in the source; line breaks inserted only between the lettered items). Response rate field, verbatim: "90% dado que se esperaba que 8046 hogares contestaran pero la base de datos reporta 7276 hogares".  NOTE ON A REPO CLAIM I DID NOT VERIFY AND DID NOT USE: CLAUDE.md's "Countries Without Microdata" table lists Guatemala with reason "No PSU/cluster variable in data". That is a statement about the DATA, not about the documented universe, and it is unrelated to — and not contradicted by — the universe statement above. The documentation is explicit that PSUs exist in the DESIGN (item 3: "sectores censales"); whether a PSU identifier survives into the distributed .dta files is a different question, deliberately not investigated here (this task forbids inferring from data).  SOURCE.org GAP (repo-hygiene observation, no file modified): Guatemala/2000/Documentation/SOURCE.org contains only the bare DOI link and carries NONE of the provenance org keywords (#+CATALOG_ID, #+CATALOG_IDNO, #+PROVENANCE_SOURCE, #+PROVENANCE_VALIDATION) that CLAUDE.md describes as present on all 123 shipped SOURCE.org files. The catalog id 586 used for the fallback was recovered from the DDI PDF's filename, not from SOURCE.org.
+#+end_quote
+
+** Guinea-Bissau
+
+*** Guinea-Bissau 2018-19
+
+- Survey :: Inquérito Harmonizado sobre as Condiçöes de vide dos Agreagados Familiares 2018-2019 (EHCVM 2018/19) — translated title: "Harmonized Survey on Households Living Standards 2018-2019"; Survey ID number GNB_2018_EHCVM_v02_M; WB Microdata catalog id 4293
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Guinea-Bissau/2018-19/Documentation/ddi-documentation-english_microdata-4293.pdf
+- Locator :: p. 3, section "Coverage" > "UNIVERSE" (and "GEOGRAPHIC COVERAGE"); exclusion/design sentence at p. 4, section "Sampling" > "SAMPLING PROCEDURE". Corroborated by the World Bank Basic Information Document (catalog 4293, download id 52550), section "Sample", p. 10.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+UNIVERSE The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.  [preceded on the same page by:] GEOGRAPHIC COVERAGE National coverage
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a — the quoted documentation is already in English. (The survey's own title is Portuguese: "Inquérito Harmonizado sobre as Condiçöes de vide dos Agreagados Familiares 2018-2019".)
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+From UNIVERSE (p. 3): "The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories."  From SAMPLING PROCEDURE (p. 4) — a geographic-coverage restriction, not a universe statement: "The Guinea-Bissau EHCVM 2018/19 sample covers all regions with urban and rural areas surveyed in all regions apart from the autonomous sector of Bissau (SAB) where all respondents are from urban areas."  The same sentence appears verbatim (bar the hyphen in the country name) in the Basic Information Document, "Sample", p. 10: "The Guinea Bissau EHCVM 2018/19 sample covers all regions with urban and rural areas surveyed in all regions apart from the autonomous sector of Bissau (SAB) where all respondents are from urban areas."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Only one wave directory exists for Guinea-Bissau, so this is the complete answer for the country.  The universe statement is short and thin: it says only 'all de jure households' plus an institutional-population exclusion. It does not state a geographic or age restriction beyond 'National coverage'.  Two further verbatim statements bear on what the sample represents, but are series/abstract framing rather than the universe field, so they are recorded here rather than in `population_verbatim`:  SERIES INFORMATION (DDI p. 1): "The Guinea-Bissau EHCVM 2018/19 is the first edition of a nationally representative household survey conducted within the West Africa Economic Monetary Union (WAEMU) Household Survey harmonization Project (P153702) a joint program by the World Bank and the WAEMU Commision that aims at producing household survey data in member countries (Benin, Burkina Faso, Chad, Cote d'Ivoire, Guinea Bissau, Mali, Niger, Senegal and Togo). The survey covers all regions and includes approximately 5,000 households."  ABSTRACT (DDI p. 1): "... The EHCVM is a nationally representative survey of 5,000 households, which are also representative of the geopolitical zones (at both the urban and rural level)."  Sample design detail (DDI p. 4 / BID p. 10, verbatim): "Upon deciding on the sample size and repartition, the survey design team implemented a 2-stage sampling methodology. At the first stage, 450 enumeration areas (EAs) were selected from the sample frame. In the second stage, 12 households were selected in each enumeration area randomly." and "The total survey sample size is 5351 households - 1990 from urban areas and 3361 from rural areas. ... In wave one, the survey teams interviewed 2664 households (1015 in urban areas and 1649 in rural areas. In wave two, the teams interviewed 2687 households (975 in urban areas and 1712 in rural areas)."  Caution on the word 'wave': the repo's single wave directory `2018-19` contains BOTH of the survey's own internal waves/vagues (Sept-Dec 2018 and Apr-Jun 2019), each covering half the sample, chosen 'to account for seasonality of consumption' (DDI p. 1). These are seasonal visits within one cross-section, not two panel rounds.  The DDI text was extracted with pdfminer; ligatures render as 'fi'/'ffi' glyphs in the PDF and are reproduced here as ordinary characters ('first', 'Affiliation'). The quoted UNIVERSE sentence contains no ligature-affected words. The em-dash in the BID's '5351 households – 1990' is an en dash in the BID and a hyphen in the DDI; quoted as it appears in each source.  The fetch of the DDI PDF materialized a gitignored file into `2018-19/Documentation/`; no tracked file under `lsms_library/countries/` was modified (`git status --short lsms_library/countries/Guinea-Bissau/` is clean).
+#+end_quote
+
+** Guyana
+
+*** Guyana 1992
+
+- Survey :: Guyana Living Standards Measurements Survey (GLSMS) 1992-1993 / Living Standards Measurements Survey 1992 (WB catalog title); administered as a supplement to the Guyana Bureau of Statistics Household Income and Expenditure Survey (HIES) 1992
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: gy92info.pdf ("Guyana Living Standards Measurements Survey (GLSMS) 1992-1993: Basic Information Documentation", Country Operations Division II, Department III, Latin America and the Caribbean Region, The World Bank, July 15, 1996) — downloaded from the World Bank Microdata catalog, https://microdata.worldbank.org/catalog/2319/download/34615 . NOT present in the local repo. Local repo files consulted: lsms_library/countries/Guyana/1992/Documentation/{SOURCE.org, LICENSE.org, ddi-documentation-english_microdata-2319.pdf, GUY01.pdf, GUY02.pdf, GUY03.pdf, GUY09.pdf}.
+- Locator :: gy92info.pdf, Section III "Sample": ¶28-¶29 and ¶32 on printed p.7 (PDF p.11); ¶33-¶35 on printed p.8 (PDF p.12); ¶36-¶40 incl. "Sample Design of the LSMS" ¶38 on printed p.9 (PDF p.13); ¶41-¶43 on printed p.10 (PDF p.14). ¶30 is on printed p.7 (PDF p.11). ¶50 on printed p.12 (PDF p.16). Catalog "Geographic Coverage: National" from https://microdata.worldbank.org/index.php/catalog/2319/study-description , Coverage section.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+¶28: "The objectives of the HIES and the LSMS called for a national sample representative of rural and urban populations at all income levels. Based on the experiences of Labor Force Survey and the Survey of Living Conditions in Jamaica, it was decided to draw a one-percent sample of households. The design called for a two-stage stratified sample. For the first stage sample, Enumeration Districts (geographical areas designated during the 1991 population census) were selected from 16 geographical regions. In the second, households, the units of inquiry, were selected from a listing of all households in the selected Enumeration Districts."  ¶29: "The First Stage Sample. Guyana is divided into 10 Administrative Regions (Annex F contains a map displaying their borders). For the 1991 population census, each Administrative Region was divided into Enumeration Districts (EDs) of about 100 households each. There were 2,610 EDs in the country, of which 616 were selected to the sample for the HIES."  ¶30: "The urban sampling frame contained the EDs comprised of the Georgetown metropolitan area (central and suburban areas), which accounts for 21 percent of the total population, and the EDs comprised of the other urban areas which include New Amsterdam, Linden, Anna Regina, and Corriverton, accounting for 11.2 percent of the population. The Rural sampling frame was defined as the EDs in all ten Administrative Regions not defined as urban."  ¶38 (the LSMS sample specifically): "Sample Design of the LSMS. The LSMS was implemented in conjunction with the HIES and drew data from the third round of the four-round HIES 7,000 household sample. Because each round represented a national sample, it was possible to administer the LSMS in one round only, covering 1,795 households in 154 EDs."  WB catalog metadata, Coverage section: "Geographic Coverage: National"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+¶32: "Table 1 presents the allocation of selected EDs. Note that the number of EDs selected in each stratum is a multiple of 8. This was to ensure that each of the strata would be represented by at least two EDs in each of the four calendar rounds. This sub-round restriction was not applied to interior regions 1, 7, 8, and 9 which are not accessible during certain periods of the year. In these regions, the total sample allocated was programmed to be surveyed during the part of the year when they were accessible."  ¶42: "Of the entire sample, only two EDS had to be substituted due to inaccessibility, and three became casualties. Karisparu (ED no. 364) could not be surveyed because the air strip was closed, making the ED inaccessible. A second ED in Region 4 was found to have only institutional population (the Georgetown Jail) and was not included. The third ED not included was in Region 10 due to unsatisfactory completion of the survey by the Enumerator and his subsequent resignation. There was a substantial time lag, making revisits impossible."  ¶37 (substitution rule, i.e. non-response is replaced rather than excluded): "From each of the rearranged sample frames, twelve (12) households were selected circular systematically with a random start and with substitution. If a sample household could not be surveyed due to the temporary absence from the ED, refusal to give information or for other reasons, it was substituted by the household with the next sample serial number of the same column of the listing schedule so that the substitute household had the same economic characteristics as the original one. ..."  ¶50 / Data Collection Notes (limits on the anthropometric follow-up only): "No follow-up visits subsequent to the administration of the anthropometric module were attempted in interior regions due to prohibitive logistics and transportation costs."  No statement was found anywhere declaring a categorical exclusion of institutional population, nomadic households, or any Administrative Region from the frame. The Georgetown Jail exclusion (¶42) is recorded as a single-ED field outcome, not as a frame rule.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+TEXT-FIDELITY CAVEAT (read before treating the quotes as character-exact): gy92info.pdf is a 1996 print-to-PDF whose text layer inserts spurious spaces inside words, especially at justified line ends (raw pdfminer output contains e.g. 'Househ old', 'implement ed', 'ED s comprised', '1,79 5', 'was no t applied', 'Corrivert on', 'suburban ar eas', 'institutional populati on', 'and hi s subsequent'). In the quotes above I have (a) rejoined those split words, (b) collapsed runs of whitespace to single spaces, and (c) removed the marginal paragraph numbers that pdfminer interleaves into the middle of sentences. NO word was changed, added, dropped, translated or reordered. One deliberate non-repair: '¶42' reads 'only two EDS' and '¶39' reads 'each of the EDS' in the source text layer — I left the odd capitalisation 'EDS' as extracted rather than normalise it to 'EDs'. The raw extractions are reproducible with: pdfminer extract_text(gy92info.pdf, page_numbers=[10..13], laparams=LAParams(word_margin=0.2, char_margin=3.0, line_margin=0.5, boxes_flow=0.5)).  SUBSTANTIVE NOTES: (i) No document I could read contains a field or sentence literally labelled 'universe' or 'target population'. ¶28 ('a national sample representative of rural and urban populations at all income levels') is the closest thing to an explicit universe claim, and ¶29-¶30 define the frame operationally as the 2,610 1991-census Enumeration Districts covering all ten Administrative Regions, urban EDs being Georgetown metro + New Amsterdam, Linden, Anna Regina and Corriverton and rural EDs being everything else. So on the documentation's own claim this is a NATIONAL, urban+rural, private-household universe — not an ISA-style rural-only or region-restricted one. (ii) DESIGN detail, not universe, but load-bearing for #603: the LSMS is not an independent sample — it is the third of four HIES subrounds (¶38), the BID asserting that 'each round represented a national sample'. The HIES full-year sample is 7,392 households in 616 EDs; the LSMS wave in this repo is the ~1,795 households in 154 EDs of that third round. (iii) Household counts in the documentation are mutually inconsistent and I did not reconcile them: ¶28 '7,392 households ... drawn', ¶38 'HIES 7,000 household sample' and 'covering 1,795 households', ¶41 'total 7,254 households surveyed in HIES', ¶7 / catalog 'approximately 1,800 households'. (iv) Per the task instruction I did NOT open any .dta to check the realised composition of the sample; everything above is the documentation's claim only. (v) SOURCE.org for this wave carries no provenance keywords, so the catalog id 2319 was recovered from the local filename 'ddi-documentation-english_microdata-2319.pdf' and confirmed by matching the catalog page's title, sampling text and related-materials filenames (GUY01-GUY09, gy92info.pdf) against the local Documentation/ directory listing. Catalog survey id number is GUY_1992_LSMS_v01_M.
+#+end_quote
+
+** India
+
+*** India 1997-98
+
+- Survey :: India - Uttar Pradesh and Bihar Survey of Living Conditions 1997-1998 (catalog title); questionnaire cover reads "SURVEY OF LIVING CONDITIONS / UTTAR PRADESH AND BIHAR". Catalog IDNO: IND_1997_SLCUPB_v01_M; WB Microdata catalog entry 276; DOI https://doi.org/10.48529/q6sh-b869
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: subnational-area
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/India/1997-98/Documentation/ddi-documentation-english_microdata-276.pdf
+- Locator :: ddi-documentation-english_microdata-276.pdf, printed page 3 (PDF page index 2), section "Sampling" > "Sampling Procedure", sub-heading "Sampling Universe:". Byte-identical text also appears in the World Bank catalog record at dataset.metadata.study_desc.method.data_collection.sampling_procedure (https://microdata.worldbank.org/index.php/api/catalog/IND_1997_SLCUPB_v01_M).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+Sampling Universe:   The universe for the study comprised 4 statistical regions: 2 in Uttar Pradesh (Eastern and Southern), and 2 in Bihar (Northern and Central). Altogether, there were 55 districts in the area covered by the study: 24 districts in the 2 statistical regions in Uttar Pradesh, and 31 districts in the 2 statistical regions covered in Bihar.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND — neither the local DDI documentation nor the World Bank catalog record contains any explicit exclusion / omission / "not covered" statement (no "sampling deviation", no "response rate", no institutional-population or nomadic-household exclusion clause). The only statement that bounds the universe by exclusion-of-the-remainder is the immediately preceding "Sampling Information" paragraph, quoted verbatim here for context (this is context, NOT an exclusion statement): "Uttar Pradesh and Bihar, the two states selected for the study, are divided into 8 statistical regions: 5 in Uttar Pradesh (Himalayan, Western, Central, Eastern, and Southern) and 3 in Bihar(Southern, Northern, and Central)." [sic — "Bihar(Southern" is unspaced in the source]
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+One wave only. The universe statement is REGION-level, not household-level: the record never says "all private households in ..." — it names the 4 statistical regions (55 districts) that constitute the study area, and no unit-level inclusion/exclusion rule is stated anywhere.  Corroborating verbatim quotes from the World Bank catalog record (source_type would be wb-catalog for these; recorded as notes, NOT as the population field): - geog_coverage: "The survey covered south and eastern Uttar Pradesh and north and central Bihar." - abstract (opening): "A two-part study of rural poverty was carried out in 1997-98 in south and eastern Uttar Pradesh and north and central Bihar. This study utilized both qualitative methods - rapid rural appraisal (RRA) & participatory rural appraisal (PRA) methodologies, and semi-structured interviews - as well as quantitative methods drawing on data collected from household and community surveys modelled after the World Bank's Living Standards Measurement Study (LSMS) surveys." - abstract (continued): "The data being distributed are from the quantitative component of the study, field work for which was carried out between December 1997 and March 1998. Data were collected through household and village-level questionnaires in 120 villages drawn from a sample of 25 districts in UP and Bihar states; a total of 2,250 households were interviewed during the course of the survey (more details on distribution of the sample are provided in the sampling section of this note). Of the sample of 120 villages where the household and village surveys were conducted, 30 had been visited in the earlier qualitative component of the study, while the remaining 90 were drawn at random from the sample districts." - analysis_unit: "- Households\n- Individuals\n- Community" - data_kind: "Sample survey data [ssd]"  IMPORTANT CAVEAT on rural-only: the phrase "a two-part study of rural poverty" and the fact that all PSUs are described as "villages" are strongly suggestive of a rural-only universe, but NO document in either source states a rural-only universe as such. Do not record "rural households" as the population on the strength of these; it is an inference, not a claim. What the documentation actually claims is the 4-region / 55-district study area quoted above.  SAMPLE DESIGN (not the universe; recorded here for completeness, verbatim from the same DDI page 3): "The sampling strategy followed for the quantitative study basically involved dividing the sample population into four main strata:\n1) districts that were covered in the qualitative study in Bihar (i.e. 4 districts)\n2) districts that were covered in the qualitative study in Uttar Pradesh (i.e. 3 districts)\n3) remaining districts in the 2 selected regions of Bihar (i.e. 27 districts)\n4) remaining districts in the 2 selected regions of Uttar Pradesh (i.e. 21 districts)" and "All 12 villages in Stratum 1 that were covered in the qualitative study were included in the sample. Similarly, all 18 villages in Stratum 2 that were covered in the qualitative study were included in the sample. In each of these 30 villages, 30 households each were picked at random for the survey.\n\nIn stratums 3 and 4, 45 villages each were selected for the survey. A two-step procedure was used to select villages in these two strata: first, 9 districts were selected in each stratum using PPS. In each of the 9 districts, 5 villages were then selected at the second stage, again using PPS. In each of these 90 villages altogether, 15 households each were selected for the survey." Also verbatim from the DDI, first phase: "In the first phase of the project, qualitative field work was carried out in 30 villages: 3 villages each from 4 districts in Bihar (Mungher, Jehanabad, Saharsa, and Vaishali), and 6 villages each from 3 districts in Uttar Pradesh (Banda, Allahabad, and Gorakhpur)."  Data collection dates per DDI: start 1997-12, end 1998-03; mode "Face-to-face [f2f]". DDI report generated 2014-04-17. The DDI's "Data Processing" and "Data Appraisal" sections both read "No content available", which is why no sampling-deviation or response-rate text exists.  Provenance housekeeping (observed, not changed — read-only task): India/1997-98/Documentation/SOURCE.org contains only the bare DOI link and none of the #+CATALOG_ID/#+CATALOG_IDNO/#+PROVENANCE_SOURCE keywords described in CLAUDE.md. The catalog IDNO is IND_1997_SLCUPB_v01_M (numeric catalog id 276). No files were modified; the three PDFs materialized into Documentation/ are gitignored DVC-tracked artifacts (git status clean).
+#+end_quote
+
+** Iraq
+
+*** Iraq 2006-07
+
+- Survey :: Iraq Household Socio-Economic Survey 2006-2007 (IHSES / IHSES-I). WB catalog: "Iraq - Household Socio-Economic Survey 2006-2007", Reference ID IRQ_2006_IHSES_v02_M, catalog id 69, DOI https://doi.org/10.48529/ebk1-rr24.
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Iraq/2006-07/Documentation/Vol.1_Objectives_methodology.pdf
+- Locator :: VOLUME I ("Objectives, Methodology, and Highlights"), chapter "4. Sample", subsection "B. Sample frame", second paragraph. PDF page 17 of 23 (the file is a two-up spread; this sheet carries printed pages 16–17, and the passage is on printed page 16).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The population covered by IHSES included all households residing in Iraq from November 1, 2006, to October 30, 2007, meaning that every household residing within Iraq’s geographical boundaries during that period potentially could be selected for the sample.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a — source is in English.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NONE STATED. The universe sentence itself is explicitly inclusive ("every household ... potentially could be selected"); the documentation states no exclusion of institutional, collective, nomadic or homeless population, and no excluded region. The only nearby "excluded" wording is about the SAMPLE FRAME, not the universe, and is quoted here verbatim so it is not mistaken for a universe exclusion — same subsection, immediately preceding paragraph: "The 1997 population census frame was applied to the 15 governorates that participated in the census (the three governorates in Kurdistan Region of Iraq were excluded). For Sulaimaniya, the population frame prepared for the compulsory education project was adopted. For Erbil and Duhouk, the enumeration frame implemented in the 2004 Iraq Living Conditions Survey was updated and used." (i.e. the three Kurdistan governorates were excluded from the 1997 CENSUS, so alternative frames were used for them; they are IN the survey — all 18 governorates are sampled.)
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+WHITESPACE: the PDF is justified, so pdfminer emits the sentence with runs of multiple spaces ("meaning  that  every  household  residing  within  Iraq’s  geographical  boundaries  during  that  period  potentially  could  be"). I have normalised those to single spaces in population_verbatim; no words, punctuation or characters were changed. The apostrophe in "Iraq’s" is the typographic U+2019 as in the source.  SUPPORTING (not the universe statement, kept separate on purpose): - WB catalog id 69, Coverage > Geographic Coverage, VERBATIM: "National coverage" / "Domains: Urban/rural/metropolitan; governorates". - The DDI XML study-level universe element is EMPTY: <universe/> inside <sumDscr>. So the WB catalog itself records no universe for this study; the statement above comes from the Iraqi statistical office's own report volume, which is the stronger source anyway. - SAMPLE DESIGN (context, not universe), WB catalog id 69, Sampling > Sampling Procedure, VERBATIM: "The total effective sample size of the IHSES 2007 is 17,822 households. The survey was nominally designed to visit 18,144 households - 324 in each of 56 major strata. The strata are the rural, urban and metropolitan sections of each of Iraq's 18 governorates, with the exception of Baghdad, which has three metropolitan strata." - FIELD DEVIATION (context, not a universe exclusion), same catalog page, Sampling > Deviations from the Sample Design, VERBATIM: "The design did not consider the replacement of any of the randomly selected units (PSUs or households.) However, certain emergency procedures were defined to deal with security situations: If a survey team was unable to visit a trio of PSUs in the originally allocated wave, that trio was to be swapped with the trio from a randomly selected future wave that was secure at the time." and "This explains why the survey datasets only contain data from 2,876 of the 3,024 originally selected PSUs, whereas 55 of the PSUs contain more that the six households nominally dictated by the design." - Vol.1, chapter 4 subsection "A. Design", VERBATIM: "The survey was designed to visit 18,144 households—324 households in each of 56 strata, defined as the rural, urban, and metropolitan portions of each of Iraq's 18 governorates. Baghdad, with five strata, was the exception."  SIDE EFFECT OF THIS TASK: fetching the documentation materialised previously DVC-only PDFs into lsms_library/countries/Iraq/{2006-07,2012}/Documentation/. Those paths are covered by the Documentation/.gitignore in each wave; no tracked file was modified.
+#+end_quote
+
+*** Iraq 2012
+
+- Survey :: Iraq Household Socio-Economic Survey 2012, Second Round (IHSES-II). WB catalog: "Iraq - Household Socio-Economic Survey 2012, Second Round", Reference ID IRQ_2012_IHSES_v02_M, catalog id 2334, DOI https://doi.org/10.48529/xh5a-y392.
+- Source type :: not-found
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: not-stated
+- Language of the quoted source :: n/a (no universe statement exists); the closest related statements are in Arabic, the catalog metadata in English
+- Source file :: NOT FOUND — searched: lsms_library/countries/Iraq/2012/Documentation/{ddi-documentation-english_microdata-2334.pdf, IHSES_II_2012_Arabic_Reviewed.pdf, Iraq_Poverty_Methodology_Note_Final.pdf, Part_1_Socio_Economic_Data.pdf, Part_3_Income_and_Other_13_24.pdf, SOURCE.org}, plus catalog-only documents Sampling_and_fieldwork_2012.pdf, Iraq_2012_IHSES_Users_Note.pdf, IHSES_2012_Manual_English.pdf, plus the catalog study description and DDI XML.
+- Locator :: n/a — statement absent. Closest passages located at: IHSES_II_2012_Arabic_Reviewed.pdf PDF page 29 (chapter "4. عينة المسح", subsections "أ. تصميم العينة" and "ب. إطار العينة:"); WB catalog 2334 Coverage > Geographic Coverage.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND. No document — local or catalog — states a target population / universe for IHSES-II 2012. The closest documented statements are a SAMPLE-SIZE statement and a SAMPLE-FRAME statement in the official Arabic report; both are quoted verbatim in `notes` and neither is a universe declaration.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND — no exclusion from a universe is stated anywhere (no statement about institutional/collective/nomadic/homeless population, and no excluded governorate or region). The only coverage shortfall recorded is a FIELDWORK deviation, not a design exclusion: IHSES_II_2012_Arabic_Reviewed.pdf, section "ز. إجراءات استثنائية:" (PDF page 31 of the file), VERBATIM as extracted: "اما العناقيد المؤجلة التي لم يكن بالإمكان شمولها بسبب عدم تحسن الوضع الأمني فيها فقد بلغت (5) عناقيد فقط في كركوك." (approx.: "As for the postponed clusters that could not be covered because the security situation there did not improve, they amounted to only (5) clusters in Kirkuk.")
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+THE CATALOG RECORDS NO UNIVERSE. In the machine-readable DDI for study 2334, <stdyDscr>/<stdyInfo>/<sumDscr> contains VERBATIM: <geogCover>National coverage</geogCover>, <anlyUnit>Households and individuals</anlyUnit>, <universe/> — i.e. the universe element is present but empty. (Study 69 / 2006-07 is the same: <universe/>.) So neither Iraq study has a WB-recorded universe; for 2006-07 the statement comes from the Iraqi report, and for 2012 the equivalent report simply does not make one.  CLOSEST AVAILABLE STATEMENTS (Arabic; these are SAMPLE-SIZE and SAMPLE-FRAME statements, NOT universe statements — do not promote them to a universe declaration):  (a) IHSES_II_2012_Arabic_Reviewed.pdf, PDF page 29, chapter "4. عينة المسح", subsection "أ. تصميم العينة": "بلغ حجم العينة المختارة (25488) أسرة من جميع محافظات العراق، (216) أسرة من كل من أقضية العراق البالغة (118)." Approx. translation (separate from the quote): "The selected sample size amounted to (25,488) households from all governorates of Iraq, (216) households from each of Iraq's (118) districts."  (b) Same file, PDF page 29, subsection "ب. إطار العينة:": "اعتمدت نتائج الحصر والترقيم المنجزة في إطار التعداد العام للسكان والمساكن للفترة 2009-2010 في جميع محافظات العراق بما فيها إقليم كردستان كإطار لتحديد الأسر، وقد تم اختيار العينة وسحبها في مرحلتين:" Approx. translation (separate from the quote): "The results of the listing and numbering carried out within the framework of the general population and housing census for the period 2009-2010 in all governorates of Iraq including the Kurdistan Region were adopted as a frame for identifying households, and the sample was selected and drawn in two stages:"  TWO EXTRACTION CAVEATS THAT AFFECT HOW LITERALLY THESE ARABIC QUOTES MAY BE TRUSTED (recorded so a later reader can re-verify rather than trust me): 1. Bidi: pdfminer returns this PDF's Arabic in VISUAL order. The quotes above come from a per-character reconstruction (group LTChar by y, sort by x, then reverse Arabic runs only). Letter sequences reproduce correctly, but Arabic ligature/hamza normalisation is not guaranteed (the raw stream renders "الأسر" via a lam-alef presentation form). 2. NUMERALS ARE GLYPH-SUBSTITUTED IN THIS PDF and I have decoded them. The raw extracted digits are "45288", "406", "008", "4834", "4101-4119"; cross-checking against known facts (25,488 nominal households = 118 qadhas x 24 EAs x 9 HH; 216 HH per qadha; 2,832 EAs; response rate 98.6%) yields the consistent glyph map 0->1, 1->0, 2->4, 4->2 (others identity), giving 25488 / 216 / 118 / 2832 / 2010-2009 (a range displayed RTL, i.e. 2009-2010). I substituted the DECODED digits into quotes (a) and (b) above. THIS IS NOT STRICTLY VERBATIM for the numerals — anyone re-deriving these numbers must repeat the decode, and the Arabic letters, not the digits, are the verbatim part.  WHY 'not-found' RATHER THAN QUOTING (b) AS THE POPULATION: (b) says what the SAMPLING FRAME was built from ('all governorates of Iraq including the Kurdistan Region'), which constrains coverage but does not declare the set of units the sample represents, says nothing about which residents of those governorates are in or out, and is silent on institutional/collective/nomadic population. Recording it as the universe would be an inference, and #601/#603 needs the claim, not my reconstruction of it.  Survey design (context): stratified by all 118 qadhas (districts), two-stage, 24 EAs per qadha by PPS with implicit urban/rural stratification, 9 households per EA by SEPS; frame from the 2010 census enumeration. Final realised sample 24,944 households / 176,042 individuals (Iraq_2012_IHSES_Users_Note.pdf, VERBATIM: "The final sample size is 24,944 households and 176,042 individuals."). Three modules (anthropometrics s7, time use s21, food consumption by recall s24) were administered to SUBSAMPLES of 3 of the 9 households per cluster — relevant to #603 because those tables represent a different sample than the rest of the survey; Sampling_and_fieldwork_2012.pdf, section "Subsamples", VERBATIM: "Most questionnaire modules will be administered to all households. However, in order to reduce some of the fieldwork effort, three of the modules will be administered in subsamples, each composed of three of the nine households visited in each Gadha."
+#+end_quote
+
+** Kazakhstan
+
+*** Kazakhstan 1996
+
+- Survey :: Living Standards Measurement Survey in Kazakstan 1996 (LSMSK) / Kazakhstan - Living Standards Measurement Survey 1996
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Kazakhstan/1996/Documentation/finrep1.pdf
+- Locator :: finrep1.pdf ("Living Standards Measurement Survey 1996: Final Report (Part 1)", GOSKOMSTAT and SIGMA Institute Berlin, Dec. 1996): PREFACE p. II (PDF page 3); sec. 1.1 and sec. 2 p. IV (PDF page 5); sec. 2 p. V (PDF page 6); p. VIII (PDF page 9); sec. 3.1 p. XV (PDF page 16); sec. 5.2 p. XVII (PDF page 18). Also ddi-documentation-english_microdata-2292.pdf, "Sampling / Sampling Procedure" (p. 3): "Sample size is 1,996 households" — no universe field. Catalog quote from https://microdata.worldbank.org/index.php/catalog/2292 (Geographic Coverage: "National").
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+[finrep1.pdf, PREFACE, p. II] "The survey "Living Standards Measurement Survey" (LSMS) carried out by "Sigma-Institute" of Berlin under the World Bank Technical Assistance Project named "Social Protection" was a multipurpose probability sample which covered 2000 households of the Republic of Kazakstan."  [finrep1.pdf, sec. 1.1 "Verification of the status of living standards", p. IV] "The aim of this survey was to select objective, representative and as far as possible, total information, which would enable users to draw up a picture of the actual status of living standards of the population of the Republic of Kazakstan."  [finrep1.pdf, sec. 2 "Sampling", p. IV] "A Sample designed for LSMS had to assist to:  - reflect the realistic picture of social and territorial distribution of the population in the Republic   of Kazakstan (representativeness); and - compare the outcome of LSMS in Kazakstan with the results of LSMS in other countries, which   were performed based on possible sample principals (comparability)."  [finrep1.pdf, sec. 2, p. V — the sampling frame] "To create a basis to design a probability sample GOSCOMSTAT and its oblast branches in May 1996 have delivered the most actual numerical material concerning population (01.01.1996). It contains the following information:  - a list of all 2534 agricultural regions without exception with the measurement of their quantity (number of households and number of inhabitants). This data has been received from rural administrations where total registration is carried out; - a list of all 263 villages, small and middle-size cities without exception with the measurement of their quantity (number of households and number of inhabitants). This data has been received from village councils and from householding administration bodies for the cities where the total registration is carried out.  - a list of all 24 large cities without exception with measurement of their quantity (number of households and number of inhabitants). This data has been received from householding administration bodies (e.g. Technical Inventory Bureau, Householding Administrations, Cooperatives, Street Committees, Branch Agencies and Dormitories)."  [finrep1.pdf, sec. 2, p. VIII] "We have thus accepted as a basis to define samples:  - number of households and inhabitants in rural areas; - number of households and inhabitants in villages, small/middle-size cities; - extrapolated number of households and inhabitants in large cities."  [finrep1.pdf, sec. 3.1 "Context of the survey", p. XV] "Households (h/h) are subjects of the survey (interviewing)."  [WB Microdata catalog entry 2292, study description] Geographic Coverage: "National"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND — no statement excluding any population group (institutional population, nomadic households, a region, etc.) appears anywhere in the sampling/coverage sections of finrep1.pdf (pp. I-XVII) or in the DDI documentation. The frame lists are described as covering the units "without exception". The nearest things to a coverage limitation, quoted verbatim so they are not mistaken for an exclusion statement:  [finrep1.pdf, p. V] "b) Quality of the data which had been received from some cities was not fully acceptable (Almaty, Akmola, Ecibastuz, Zhambyl, Kostanai and Arcalyk). It was noted that underregistration was up to 25% in those cities. It was impossible therefore to find out the precise number of households, and as a result extrapolation was performed."  [finrep1.pdf, p. VI] "Whilst an inaccuracy up to 5 per cent /migration, underegistration/ is assumed. See Table 1."  [finrep1.pdf, p. X, on selection within large-city PSUs] "Cities of Almaty, Akmola, Karaganda, Temirtau, Ust-Kamenogorsk, Pavlodar, Ekibastuz, Shymkent, Zhambyl, Aktobe, Uralsk, Kokshetau, Rudnyi, Kostanai, Semipalatinsk, Petropavlovsk, Taldykorgan, Atyrau, Aktau, Kzyl-Orda, Zheskazgan, Balhash, Arkalyk and Turkestan were involved in sample since more 23666 households (sampling fraction) live in each of this cities." (i.e. all 24 large cities were self-representing; this is a design statement, not an exclusion.)  [finrep1.pdf, sec. 5.2, p. XVII — an instrument-level respondent restriction, not a sample-universe exclusion] "Questions from the Individual Questionnaire were discussed with all grown up members of a family (over 16 years old). An individual who was the most familiar with specific aspect of child life answered on their behalf (usually mother)."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Only one wave directory exists for Kazakhstan (1996). No document uses the words 'universe' or 'target population'; the quotes above are the strongest coverage/universe statements the documentation actually makes, which is why confidence is 'medium' rather than 'high' — the population is stated as the population/households of the Republic of Kazakstan, assembled from three exhaustive frame strata (rural agricultural regions; villages and small/middle-size cities; large cities), but no formally-labelled universe definition exists. Sample DESIGN (not the universe, recorded here for context): stratified two-stage probability sample; 200 PSUs and 2000 households targeted, allocated 45.23% large cities (90 PSU, 900 HH), 18.75% villages+small/middle cities (38 PSU, 380 HH), 36.02% rural (72 PSU, 720 HH), ~10 interviews per PSU; frame totals given as 4,708,277 households / ~16,432,399 inhabitants 'Total within the Republic of Kazakhstan' (Table 2, p. VIII). Realized sample: DDI says 1,996 households; the Preface says the sample 'covered 2000 households'. Fieldwork June-August 1996 (DDI); finrep1 sec. 5.1 says 'Collection of data was carried out in July 1996'. All 24 large cities were included with certainty. NOTE ON METHOD: the local PDFs have no text layer; page images were extracted from the PDF with pdfminer's ImageWriter and read visually. Quotes were transcribed from those page images, so OCR-style transcription error is possible in principle; the spellings 'Kazakstan' (Preface/sec.1/sec.2) vs 'Kazakhstan' (Table 2 header), 'Ecibastuz'/'Arcalyk' (p. V) vs 'Ekibastuz'/'Arkalyk' (Table 1, p. X), and 'underegistration' (p. VI) are as printed in the source, not typos introduced here. No files under lsms_library/countries/ were modified; get_data_file() materialized the (git-ignored, DVC-tracked) PDFs into the wave's Documentation/ directory as a side effect of reading them.
+#+end_quote
+
+** Kosovo
+
+*** Kosovo 2000
+
+- Survey :: Kosovo Living Standards Measurement Study Survey 2000 (Kosovo LSMS 2000); WB catalog idno KSV_2000_LSMS_v01_M, catalog id 77, DOI 10.48529/215m-9g90
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: en
+- Source file :: Kosovo Living Standards Measurement Survey 2000: Basic Information (Basic Information Document), Poverty and Human Resources Development Research Group, The World Bank, October 2001 — downloaded from https://microdata.worldbank.org/index.php/catalog/77/download/11570 . NOT present in the repo: lsms_library/countries/Kosovo/2000/Documentation/ holds only comeng.pdf, hheng.pdf, hhalb.pdf (questionnaires), LICENSE.org and SOURCE.org.
+- Locator :: Appendix F, "RECOMMENDATIONS AND IMPLEMENTATION OF THE SAMPLE DESIGN FOR THE KOSOVO LSMS SURVEY, 2000", opening paragraph — printed page 43 (PDF page 46). The exclusions quoted second are from the same Appendix F, PDF page 54 (dwelling-unit listing / valid-unit determination); the community-questionnaire quote is from the main text ("Community Survey" subsection), also reproduced verbatim in the WB catalog field method/data_collection/coll_situation.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The  unit  of  analysis  and  the  unit  of  observation  is  the  household.    The  universe  under  study consists of all the households in Kosovo, except those inhabited by members of the international community.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+... The  universe  under  study consists of all the households in Kosovo, except those inhabited by members of the international community. | [Frame/eligibility, same document, Appendix F, printed p. 51 (PDF p. 54), section on listing dwelling units:] "Afterwards, in the office, a determination of the \"valid\" dwelling units will be carried out, that is, those units that are occupied permanently (the first and fourth categories mentioned above) and these are the only ones that will be used during the selection process." [the six listed occupancy statuses being: "Occupied permanently. / Under construction (occupied) / Under construction (not occupied). / Vacant. / Seasonally occupied / Demolished or being demolished."] | [On the community questionnaire, same document, main text:] "The data from community questionnaire are not a representative sample of communities in Kosovo.  These data are intended to provide information on the context in which the households are located for the analyses of the household data."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Single wave for this country. Design detail (NOT the universe statement, recorded here for context, verbatim from the WB catalog DDI / the same BID): geog_coverage = "Kosovo.\nDomains: Urban/rural; Area of Responsibility (American, British, French, German, Italian); Serbian minority"; sampling_procedure = "The sample was preset at 2,880 households in order to allow analyses in the following breakdowns: (a) Kosovo as a whole; (b) by area of responsibility, (c) by urban/rural locations. In addition, the survey data can be used to derive separate estimates for the Serbian minority." and "The final sample size was 1,200 rural and urban Albanian households and 240 rural and urban Serb households, for a total sample size of 2,880 households." Note the design explicitly covers BOTH urban and rural, and treats the Serbian minority as a separate explicit stratum with its own frame ("Enumeration of the Serbs as a separate frame required counting households in all Serbian villages and urban zones."), which is why the Data/ directory carries parallel R_*/U_*/Serb_* community files. The rural frame derives from the IMG/UNHCR Housing Damage Assessment Survey, which per the BID "covered 95 percent of the Albanian rural areas" — a frame-coverage limitation, not a stated universe exclusion, so it is reported here rather than in exclusions_verbatim. The only universe-level exclusion the documentation states is households "inhabited by members of the international community". A separately-stated Serb-area coverage incident ("Some zones in North Mirovica were deemed too dangerous to be listed systematically ... the team was pulled out of the field and alternative EAs had to be selected") is fieldwork, not a declared universe exclusion. The recorded SOURCE.org lacks the provenance org keywords documented in CLAUDE.md; the DOI was resolved manually and _get_catalog_idno('https://doi.org/10.48529/215m-9g90') returned None.
+#+end_quote
+
+** Liberia
+
+*** Liberia 2018-19
+
+- Survey :: Liberia - National Household Forest Survey 2018-2019 (NHFS), Liberia Institute of Statistics and Geo-Information Services (LISGIS)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: specialized
+- Language of the quoted source :: English
+- Source file :: https://microdata.worldbank.org/index.php/catalog/3787/study-description ; and liberia__nhfs_basicinformationdocument_v1.pdf (Basic Information Document, World Bank, 2020-08), downloaded from https://microdata.worldbank.org/catalog/3787/download/50661
+- Locator :: Catalog study description: Coverage > Geographic Coverage and Coverage > Universe; Methodology > Sampling Procedure. BID: s2.2 SAMPLING DESIGN / s2.3 DEFINITION OF FOREST (p. 9); s2.6 POST-FIELDWORK ADJUSTMENT (p. 11); map note p. 13.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+Universe "All EAs within 2.5 kilometers of forests except for the EAs from the urban part of the Montserrado county."  Geographic Coverage "The NHFS is focused on forest proximate households. Therefore, the sample is limited to enumeration areas which fall within 2.5km of the nearest forest, as defined using Metria and Geoville (2019) land cover data. The final sample includes enumeration areas from all 15 of Liberia's counties, but excludes urban areas of Montserrado."  Basic Information Document, s2.3 DEFINITION OF FOREST (p. 9) "Given the focus of the NHFS on the population living in close proximity to forests4, a first step was to clearly define forest for the purposes of the survey. Building on the national definition of forest used in Liberia, and modifying it in order to minimize the impact of small urban forests and facilitate survey operations, the NHFS employed the following definition:  Forest = area with at least 30 percent tree canopy cover, with trees higher than 5 meters and at least 50 hectares in size5  The forest cover was determined using high-resolution forest cover data produced in 2019 based on satellite information on forest cover in Liberia for 2015.6 All EAs within 2.5 kilometers of forests identified with this definition were deemed eligible for inclusion in the NHFS.7 EAs from the Montserrado county (part of Greater Monrovia) were excluded from the sample universe due to the high rate of urbanization. However, rural parts of Montserrado county were included in the sample universe."  Basic Information Document, s2.6 POST-FIELDWORK ADJUSTMENT (p. 11) "The resulting sample, therefore, is weighted to reflect all EAs in Liberia (with the exception of urban Montserrado) that fall within 2.5 km of the nearest forest, which was the upper bound of the distances for the selected EAs."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"... except for the EAs from the urban part of the Montserrado county." (Universe field, catalog study description)  "EAs from the Montserrado county (part of Greater Monrovia) were excluded from the sample universe due to the high rate of urbanization. However, rural parts of Montserrado county were included in the sample universe." (Basic Information Document, s2.3, p. 9)  "The final sample includes enumeration areas from all 15 of Liberia's counties, but excludes urban areas of Montserrado." (Geographic Coverage, catalog study description)  "... the sample is limited to enumeration areas which fall within 2.5km of the nearest forest ..." (Geographic Coverage, catalog study description)  "Finally, the map provided in illustrates the degree of forest cover in each of the three clusters. The NHFS sample is weighted to reflect the population in all areas of the map except for the areas in white, which represent areas more than 2.5km from an EA center." (Basic Information Document, p. 13)
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Only one wave directory exists for Liberia. This is NOT a standard LSMS/HIES dwelling survey: it is the National Household Forest Survey, a forest-livelihoods instrument, though the catalog classifies Study type as 'Living Standards Measurement Study [hh/lsms]'. Analysis unit: 'Household; Community'. Kind of data: 'Sample survey data [ssd]'.  CRITICAL for #603: the universe is NOT national. It is deliberately restricted to forest-proximate enumeration areas (within 2.5 km of a qualifying forest) and excludes urban Montserrado (Greater Monrovia). The Policy Note abstract in the local DDI (p. 10) frames the covered population's size: 'In 2019, 47.5 percent of the Liberian households (HHs) lived in proximity to and were significantly dependent on the country's forests.' The forest qualifying rule is itself part of the universe definition: 'Forest = area with at least 30 percent tree canopy cover, with trees higher than 5 meters and at least 50 hectares in size' plus footnote 5 'In addition, any forest patch with a perimeter to area ratio more than 0.02 was excluded.'  SAMPLE DESIGN (not the universe, recorded for context): two-stage. Stage 1: 250 EAs by PPS, originally stratified by distance to forest -- S1 (<2km), S2 (2-7km), S3 (7-15km) -- allocated 90/90/70, MOS = households listed in the 2008 PHC. Stage 2: random selection of 12 households per EA from a fresh listing. Design n=3,000; 14 households missing/unusable => final 2,986 households, and 245 usable community questionnaires (of 250).  IMPORTANT WEIGHTING CAVEAT that changes the represented universe: 'Upon post-data collection analysis, it was discovered that the initial variable that was used to stratify EAs by distance to forest was incorrectly computed... This error rendered the stratification incorrect. Therefore, the stratification by distance to forest has been abandoned and the sample weighted to reflect only geographic clusters, not distance to forest.' Consequently the weights represent 'all EAs in Liberia (with the exception of urban Montserrado) that fall within 2.5 km of the nearest forest'. Weighting section: 'Sample weights are constructed to reflect the population in EAs within 2.5 kms of the forests, for three geographic clusters. The weights are also adjusted to reflect population estimates as of 2016.'  SOURCE PROVENANCE GAP worth flagging separately: Liberia/2018-19/Documentation/SOURCE.org has none of the #+CATALOG_ID / #+CATALOG_IDNO / #+PROVENANCE_SOURCE / #+PROVENANCE_VALIDATION keywords the repo convention calls for -- only the bare DOI link. The catalog id was recovered by resolving the DOI. Not modified (read-only task).  SOURCE_TYPE JUDGEMENT: marked wb-catalog rather than local-documentation because the local DDI PDF's study-description pages are blank and the BID is not among the repo's DVC-tracked Documentation files; every quote above came from the live WB catalog (study-description page) or from the BID PDF downloaded from that catalog. The local DDI PDF does list the BID as a Technical document, so the BID is the survey's own documentation, just not mirrored in-repo. Data collection dates 2018-09 to 2019-01. No .dta file was opened for this task.
+#+end_quote
+
+** Malawi
+
+*** Malawi 2004-05
+
+- Survey :: Second Integrated Household Survey 2004-2005 (IHS2); WB catalog id 2307 (MWI_2004_IHS-II_v01_M)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Malawi/2004-05/Documentation/ddi-documentation-english_microdata-2307.pdf
+- Locator :: PDF p. 3, section 'Sampling' -> 'Sampling Procedure'. Identical text appears in the World Bank catalog DDI for study 2307 (element <sampProc>), https://microdata.worldbank.org/index.php/metadata/export/2307/ddi
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The sample for IHS-2 was drawn using a two-stage stratified sampling procedure from a sample frame using the 1998 Population Census Enumeration Areas (EAs). The population covered by the IHS-2 was all individuals living in selected households.  The sample frame includes all three regions of Malawi: north, centre and south.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Each of the twenty-seven districts was considered as a separate sub-stratum of the main rural stratum (for IHS-2, Likoma District was excluded because of difficulty in travel to the island, so only twenty-six administrative districts were considered). Thus the total number of strata in the survey was thirty: twenty-six districts and four urban centers.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+IMPORTANT CAVEAT ON STRENGTH OF EVIDENCE: unlike the later Malawi waves, the IHS2 documentation in this repository contains NO field or heading explicitly labelled 'Universe' or 'Target universe'. The World Bank DDI for catalog 2307 has no <universe> element at all (verified by parsing the DDI XML). The sentence quoted above ('The population covered by the IHS-2 was all individuals living in selected households.') is the closest thing to a universe statement and is embedded in the Sampling Procedure narrative; it is arguably circular (it describes coverage of the drawn sample rather than the target universe). The one hard, design-level exclusion that IS documented is Likoma District. No local Basic Information Document for IHS2 is present in the repo (only the DDI report PDF and the two questionnaires). Sample-design detail (not the universe): two-stage stratified; 564 EAs x 20 households = 11,280 households; 30 strata = 26 rural districts + 4 urban centres (Lilongwe, Blantyre, Mzuzu, Zomba Municipality); frame = 1998 Population Census EAs. Library config for this wave reads the flat 2004-05/Data/ directory (single cross-sectional sample; no panel component — 'The IHPS sample does NOT have any links to the IHS2 sample', ihps_2016_bid_updated_final.pdf p. 4 footnote 1).
+#+end_quote
+
+*** Malawi 2010-11
+
+- Survey :: Third Integrated Household Survey 2010-2011 (IHS3); WB catalog id 1003 (MWI_2010_IHS-III_v01_M)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Malawi/2010-11/Documentation/IHS3_Report.pdf
+- Locator :: IHS3_Report.pdf, Chapter 1, section '1.2 Sample design and coverage', PDF page 19 (printed page 2). Corroborating exclusions: lsms_library/countries/Malawi/2010-11/Documentation/ddi-documentation-english_microdata-1003.pdf, PDF p. 3 ('Sampling' -> 'Sampling Procedure'). The bulleted ineligibility list is from the World Bank catalog DDI XML for study 1003 (<universe>), https://microdata.worldbank.org/index.php/metadata/export/1003/ddi — it is NOT in either local PDF.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The sampling frame for the IHS-3 is based on the listing information and cartography from the 2008 Malawi Population and Housing Census.  The target universe for the IHS-3 includes individual households and persons living in those households within all the districts of Malawi except for Likoma. Also excluded from this survey is the population living in institutions, such as hospitals, prisons and military barracks.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+[IHS3_Report.pdf, s. 1.2, PDF p. 19] "...within all the districts of Malawi except for Likoma. Also excluded from this survey is the population living in institutions, such as hospitals, prisons and military barracks."  [ddi-documentation-english_microdata-1003.pdf, PDF p. 3, 'Sampling Procedure'] "It was decided to exclude the island district of Likoma from the IHS3 sampling frame, since it only represents about 0.1% of the population of Malawi, and the corresponding cost of enumeration would be relatively high. The sampling frame further excludes the population living in institutions, such as hospitals, prisons and military barracks. Hence, the IHS3 strata are composed of 31 districts in Malawi."  [World Bank catalog DDI for study 1003, <universe> element] "Members of the following households are not eligible for inclusion in the survey:  • All people who live outside the selected EAs, whether in urban or rural areas.  • All residents of dwellings other than private dwellings, such as prisons, hospitals and army barracks.  • Members of the Malawian armed forces who reside within a military base. (If such individuals reside in private dwellings off the base, however, they should be included among the households eligible for random selection for the survey.)  • Non-Malawian diplomats, diplomatic staff, and members of their households. (However, note that non-Malawian residents who are not diplomats or diplomatic staff and are resident in private dwellings are eligible for inclusion in the survey. The survey is not restricted to Malawian citizens alone.)  • Non-Malawian tourists and others on vacation in Malawi."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Two documented, mutually consistent exclusion sets: (a) design-level frame exclusions — Likoma island district (~0.1% of the national population; excluded on cost/logistics grounds, leaving 31 of 32 districts) and the institutional population (hospitals, prisons, military barracks); (b) household-level ineligibility rules (the DDI bullet list) — people outside the selected EAs, non-private dwellings, on-base armed forces, non-Malawian diplomats and their households, non-Malawian tourists/vacationers. Note the DDI explicitly says the survey is NOT restricted to Malawian citizens. Geographic coverage: 'National'. Sample-design detail (not the universe): stratified two-stage; PSU = 2008 PHC census EA (avg. ~235 households); 768 EAs, 16 households each = 12,288 households; strata = 27 rural districts (sub-strata) + 4 urban areas (Lilongwe City, Blantyre City, Mzuzu City, Zomba Municipality); data representative at national, urban/rural, regional and district level (hhwght). PDF text extraction inserted spurious intra-word spaces; the quote above was cross-checked against a second extractor (pdfminer) and is character-for-character as printed. The wave directory also contains Data/Panel/ (the 204-EA IHPS 2010 baseline sub-sample), but the library's 2010-11 config reads only Data/Full_Sample/ (13 references, 0 to Data/Panel/), i.e. the IHS3 cross-section.
+#+end_quote
+
+*** Malawi 2013-14
+
+- Survey :: Integrated Household Panel Survey 2010-2013 (Short-Term Panel, 204 EAs) — IHPS 2013; WB catalog id 2248 (MWI_2010-2013_IHPS_v..._M)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: panel-inherited
+- Language of the quoted source :: English
+- Source file :: World Bank Microdata catalog, study 2248 — DDI XML <universe> element (https://microdata.worldbank.org/index.php/metadata/export/2248/ddi). Local corroboration (near-identical wording): lsms_library/countries/Malawi/2016-17/Documentation/ihps_2016_bid_updated_final.pdf p. 5, and lsms_library/countries/Malawi/2019-20/Documentation/the_integrated_household_panel_survey_2010_2019_report.pdf p. 20.
+- Locator :: DDI XML for catalog 2248, <stdyDscr>/<stdyInfo>/<sumDscr>/<universe>. Local: ihps_2016_bid_updated_final.pdf, section '1.20 INTEGRATED HOUSEHOLD PANEL SURVEY (IHPS)', PDF p. 5; the_integrated_household_panel_survey_2010_2019_report.pdf, section '1.1 Integrated Household Panel Survey', PDF p. 20 (printed p. 2).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The IHPS attempted to track all baseline households (from the IHS3) as well as individuals that moved away from the baseline dwellings between 2010 and 2013 as long as they were neither servants nor guests at the time of the IHS3; were projected to be at least 12 years of age and were known to be residing in mainland Malawi but excluding those in Likoma Island and in institutions, including prisons, police compounds, and army barracks.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"...as long as they were neither servants nor guests at the time of the IHS3; were projected to be at least 12 years of age and were known to be residing in mainland Malawi but excluding those in Likoma Island and in institutions, including prisons, police compounds, and army barracks."  [ihps_2016_bid_updated_final.pdf, p. 5, footnote 2] "The exclusion of the Likoma Island is rooted in the traditional exclusion of the district for IHS purposes, largely due to logistical considerations."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The universe here is a TRACKING universe, not a fresh-draw universe: the IHPS 2013 target population is defined relative to the IHS3 (2010) baseline sub-sample. Baseline representativeness, verbatim from the local DDI report PDF (p. 3): 'At baseline, the IHPS sample was selected to be representative at the national, regional, urban/rural levels and for each of the following 6 strata: (i) Northern Region - Rural, (ii) Northern Region - Urban, (iii) Central Region - Rural, (iv) Central Region - Urban, (v) Southern Region - Rural, and (vi) Southern Region - Urban.' Sample-design detail (not the universe): 204 of the 768 IHS3 EAs, 3,246 baseline households; split-off individuals were tracked and 'Once a split-off individual was located, the new household that he/she formed/joined since 2010 was also brought into the IHPS sample'; the final 2013 sample was 4,000 households traceable to 3,104 baseline households. The individual-level tracking eligibility cut (>= 12 years of age, not a servant or guest at baseline) is a genuine part of the declared universe and is easy to miss. Weights: 'panel weight', with design variables ea_id and stratum.
+#+end_quote
+
+*** Malawi 2016-17
+
+- Survey :: Fourth Integrated Household Survey 2016-2017 (IHS4), WB catalog id 2936 (MWI_2016_IHS-IV_v..._M) — PLUS Integrated Household Panel Survey 2010-2013-2016 (Long-Term Panel, 102 EAs) i.e. IHPS 2016, WB catalog id 2939
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: mixed-national+panel
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Malawi/2016-17/Documentation/ddi-documentation-english_microdata-2936.pdf ; lsms_library/countries/Malawi/2016-17/Documentation/Panel/ddi-documentation-english_microdata-2939.pdf ; lsms_library/countries/Malawi/2016-17/Documentation/ihps_2016_bid_updated_final.pdf
+- Locator :: [A] ddi-documentation-english_microdata-2936.pdf, PDF p. 12, heading 'Universe' (under 'Geographic Coverage: National'). [B] Panel/ddi-documentation-english_microdata-2939.pdf, PDF p. 5, heading 'Coverage' -> 'UNIVERSE'. [B, design] ihps_2016_bid_updated_final.pdf, section '1.20 INTEGRATED HOUSEHOLD PANEL SURVEY (IHPS)', PDF p. 5. IHS4 <sampProc> quote is from the WB catalog DDI XML for study 2936 (https://microdata.worldbank.org/index.php/metadata/export/2936/ddi).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+[A] IHS4 cross-section — 'Universe' field, ddi-documentation-english_microdata-2936.pdf p. 12: "Members of the following households are not eligible for inclusion in the survey: • All people who live outside the selected EAs, whether in urban or rural areas. • All residents of dwellings other than private dwellings, such as prisons, hospitals and army barracks. • Members of the Malawian armed forces who reside within a military base. (If such individuals reside in private dwellings off the base, however, they should be included among the households eligible for random selection for the survey.) • Non-Malawian diplomats, diplomatic staff, and members of their households. (However, note that non-Malawian residents who are not diplomats or diplomatic staff and are resident in private dwellings are eligible for inclusion in the survey. The survey is not restricted to Malawian citizens alone.) • Non-Malawian tourists and others on vacation in Malawi."  [B] IHPS 2016 panel — 'UNIVERSE' field, Panel/ddi-documentation-english_microdata-2939.pdf p. 5: "The IHPS 2016 attempted to track all IHPS 2013 households stemming from 102 of the original 204 baseline panel enumeration areas as well as individuals that moved away from the 2013 dwellings between 2013 and 2016 as long as they were neither servants nor guests at the time of the IHPS 2013; were projected to be at least 12 years of age and were known to be residing in mainland Malawi but excluding those in Likoma Island and in institutions, including prisons, police compounds, and army barracks."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+[A] IHS4 frame exclusions — WB catalog DDI 2936, <sampProc>: "This is the first round of the survey to include the island district of Likoma in the sampling frame. The sampling frame further excludes the population living in institutions, such as hospitals, prisons and military barracks. Hence, the IHS4 strata are composed of 32 districts in Malawi." Plus the five household-ineligibility bullets quoted in population_verbatim [A].  [B] IHPS 2016 exclusions — "...as long as they were neither servants nor guests at the time of the IHPS 2013; were projected to be at least 12 years of age and were known to be residing in mainland Malawi but excluding those in Likoma Island and in institutions, including prisons, police compounds, and army barracks." Plus, from ihps_2016_bid_updated_final.pdf p. 5: "Given the increasing numbers of households to be tracked, as well as budget/resource constraints, starting in 2016, the IHPS target household sample was adjusted as the households that have been associated with 102 out of 204 baseline EAs. Although the IHPS 2016 cannot be tabulated by region, the stratification of the IHPS 2010 sample by region, urban and rural strata was still maintained... Thus, starting in 2016, the IHPS domains of analysis will be limited to the national, urban and rural areas."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+THIS WAVE MIXES TWO UNIVERSES. The library's 2016-17 config reads BOTH ../Data/Cross_Sectional/ (IHS4, 16 references) and ../Data/Panel/ (IHPS 2016, 17 references) — e.g. food_acquired.py, people_last7days.py, livestock.py, anthropometry.py, crop_production.py, plot_features.py, plot_inputs.py all read both. So rows in this wave come from two different declared target populations: (A) the IHS4 national cross-section, and (B) the IHPS 2016 long-term panel, whose universe is defined by tracking rules relative to the IHPS 2013 / IHS3 2010 baseline and which is representative only at national and urban/rural level (NOT by region or district) from 2016 onward. Note also SOURCE.org for this wave lists catalog 2936 AND 2248 (2248 is the IHPS 2013 entry; the IHPS 2016 entry is actually 2939, which is what the Panel/ subdirectory's DDI is). IHS4 is the FIRST round to include Likoma in the frame (IHS1-IHS3 excluded it), so the 32-district frame here is a real break from 2004-05 and 2010-11. Sample-design detail (not the universe): IHS4 cross-section = 12,480 households, representative at national, district, urban and rural levels; IHPS 2016 = all households and split-off individuals stemming from 102 of the 204 original baseline EAs.
+#+end_quote
+
+*** Malawi 2019-20
+
+- Survey :: Fifth Integrated Household Survey 2019-2020 (IHS5), WB catalog id 3818 (MWI_2019_IHS-V_v06_M) — PLUS Integrated Household Panel Survey 2010-2013-2016-2019 (Long-Term Panel, 102 EAs) i.e. IHPS 2019, WB catalog id 3819
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: mixed-national+panel
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Malawi/2019-20/Documentation/fifth_integrated_household_survey_ihs5_2019_2020_basic_information_document.pdf ; lsms_library/countries/Malawi/2019-20/Documentation/the_integrated_household_panel_survey_2010_2019_report.pdf ; World Bank catalog DDI XML for study 3819
+- Locator :: [A] fifth_integrated_household_survey_ihs5_2019_2020_basic_information_document.pdf, section '2.0 SURVEY DESIGN' -> '2.1 Sampling Frame and Sampling Units for the Malawi IHS5', PDF page 7 (printed page 7); COVID weight-adjustment text at PDF pp. 41-42. [B] https://microdata.worldbank.org/index.php/metadata/export/3819/ddi, <stdyDscr>/<stdyInfo>/<sumDscr>/<universe>; local corroboration in the_integrated_household_panel_survey_2010_2019_report.pdf, section '1.1 Integrated Household Panel Survey', PDF pp. 20-21 (printed pp. 2-3).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+[A] IHS5 cross-section — Basic Information Document, s. 2.1, p. 7: "The sampling frame for the IHS5 is based on the cartography and data from the 2018 Malawi Census of Population.  This will provide a very updated frame for the first sampling stage compared to the IHS-4, which was based on the 2008 Census.  The target universe for the IHS5 includes the individual households and persons living in these households within all the districts of Malawi, including the small island district of Likoma, which had also been included in IHS-4, but not in the previous surveys.  The sampling frame excludes the population living in institutions, such as school dormitories, hospitals, prisons and military barracks."  [B] IHPS 2019 panel — WB catalog DDI 3819, <universe>: "The IHPS 2016 and 2019 attempted to track all IHPS 2013 households stemming from 102 of the original 204 baseline panel enumeration areas as well as individuals that moved away from the 2013 dwellings between 2013 and 2016 as long as they were neither servants nor guests at the time of the IHPS 2013; were projected to be at least 12 years of age and were known to be residing in mainland Malawi but excluding those in Likoma Island and in institutions, including prisons, police compounds, and army barracks."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+[A] IHS5 — "The sampling frame excludes the population living in institutions, such as school dormitories, hospitals, prisons and military barracks." (BID s. 2.1, p. 7). Likoma is INCLUDED but is not an analysis domain: "Because of the small size of Likoma, for stratification purposes it was combined with the district of Nkhata Bay.  Although it will be represented in the national-level survey results, Likoma will not be considered a domain of analysis for the IHS5." (BID s. 2.1, p. 7).  [A, realised-coverage shortfall, NOT a design exclusion] BID p. 41-42: "Due to the COVID-19 pandemic, the data collection for IHS5 was suspended around 10 April 2020 before the end of the fourth quarter.  For this reason, it was necessary to adjust the basic design weights described above to account for sample EAs that were not enumerated because the data collection was suspended." and "...in the case of the 51 sample EAs in the fourth quarter that were not enumerated, the weights were calculated as 0 since there were no households interviewed.  These missing EAs were represented by the weight adjustment for the enumerated EAs in the stratum and quarter...". WB catalog DDI 3818, <respRate>: "12, 288 households from 768 Enumeration Areas were selected. Due to COVID-19, 51 Enumeration Areas were unable to be visited at the end of the 12-month fieldwork period. Due to this, the final response rate was 93 percent."  [B] IHPS 2019 — "...as long as they were neither servants nor guests at the time of the IHPS 2013; were projected to be at least 12 years of age and were known to be residing in mainland Malawi but excluding those in Likoma Island and in institutions, including prisons, police compounds, and army barracks." Note (the_integrated_household_panel_survey_2010_2019_report.pdf, p. 20, footnote 2): "Likoma is included in the list of the districts."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+THIS WAVE ALSO MIXES TWO UNIVERSES: the library's 2019-20 config reads BOTH ../Data/Cross_Sectional/ (IHS5, 21 references) and ../Data/Panel/ (IHPS 2019, 18 references). Note that the WB catalog record for IHS5 (3818) has an EMPTY <universe> element — the universe statement comes from the local Basic Information Document, not the catalog. The IHPS 2019 catalog id (3819) is NOT recorded in this wave's SOURCE.org (which lists only 3818); it was identified by probing catalog ids adjacent to 3818 and confirmed by the catalog page title 'Malawi - Integrated Household Panel Survey 2010-2013-2016-2019 (Long-Term Panel, 102 EAs)'. The IHPS 2019 <universe> text as published by the World Bank is verbatim as quoted but is internally odd: it says '2016 and 2019 attempted to track all IHPS 2013 households ... that moved away from the 2013 dwellings between 2013 and 2016' — i.e. the 2016 wording was extended in place rather than rewritten for 2019. The local 2019 panel report describes the 2019 operation as: 'The IHPS4 (2019), attempted to track households and individuals that moved away from the dwellings they were living during IHPS 2016.' (p. 20). Panel analysis domains: 'The areas of analysis were limited to the national, urban and rural areas since the number of EAs was halved during IHPS3 (2016).' (p. 20). Sample-design detail (not the universe): IHS5 stratified two-stage, PSU = 2018 census EA (avg. ~215 households), 768 EAs / 12,288 households, 32 districts as estimation domains with Likoma combined with Nkhata Bay for stratification; nationally representative subsample enumerated each quarter to capture seasonality. PDF text extraction inserted spurious intra-word spaces; every quote above was cross-checked against a second extractor (pdfminer) and is character-for-character as printed.
+#+end_quote
+
+** Mali
+
+*** Mali 2014-15
+
+- Survey :: Enquête Agricole de Conjoncture Intégrée 2014 (EAC-I 2014) — Integrated Agricultural Survey 2014
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: Basic Information Document (English), Mali — Enquête Agricole de Conjoncture Intégrée 2014. NOT present in lsms_library/countries/Mali/2014-15/Documentation/; obtained from the World Bank Microdata catalog entry 2583, resource 47801 (https://microdata.worldbank.org/catalog/2583/download/47801). Local working copy: /tmp/popdocs/bid2014.pdf, text /tmp/popdocs/bid2014.txt
+- Locator :: Section 4 "Sample", printed page 5 (PDF page 8) — first and second paragraphs.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+"The EAC-I 2014 has been designed to have national coverage, including both urban and rural areas in all the regions of the country except Kidal. The domains were defined as the entire country, district of Bamako, other urban areas, and rural areas; and in the rural areas: agricultural zones, agro-pastoral zones and pastoral zones. Taking this into account, 51 explicit sample strata were selected."  "The target population was drawn from households in all regions of Mali except Kidal which was not accessible for security reasons. Kidal also has very low population density."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"...national coverage, including both urban and rural areas in all the regions of the country except Kidal." / "The target population was drawn from households in all regions of Mali except Kidal which was not accessible for security reasons. Kidal also has very low population density."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The wave's own local Documentation.pdf has NO 'Universe' field. Its Sampling Procedure section does, however, define the observation units, and this is worth recording for #603 because the unit of observation differs by stratum. VERBATIM (French, local Documentation.pdf, Sampling Procedure, printed p.5; identical text on the catalog page): “L'EAC-I est une enquête par sondage. Elle se distingue d'un recensement en ce sens que tous les ménages/exploitations ne sont pas enquêtés. Elle s'effectue auprès d'un nombre restreint d'unités d'observations (exploitations agricoles en milieu rural, ménage en milieu urbain) sélectionnées parmi l'ensemble plus vaste de toutes les unités du domaine d'intérêt en question. Ce nombre restreint d'unités d'observations constitue l'échantillon. Il est déterminé de telle sorte qu'il soit un format réduit de la population étudiée.” (translation: "The EAC-I is a sample survey. It differs from a census in that not all households/holdings are surveyed. It is carried out on a restricted number of observation units (agricultural holdings in rural areas, households in urban areas) selected from the much larger set of all units in the domain of interest..."). SAMPLE DESIGN (not universe): two-stage; 1,070 EAs selected PPS from the 2009 Census of Population; 3 households per rural EA and 9 per urban EA; total planned sample 4,218. FIDELITY NOTE: the English BID quote has had the PDF's justified multi-space runs collapsed to single spaces and its hard line-breaks removed; no words were added, removed or reordered. Byte-exact extraction is at /tmp/popdocs/bid2014.txt lines 503-516.
+#+end_quote
+
+*** Mali 2017-18
+
+- Survey :: Enquête Agricole de Conjoncture Intégrée aux Conditions de Vie des Ménages 2017 (EAC-I 2017)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: French
+- Source file :: lsms_library/countries/Mali/2017-18/Documentation/Documentation.pdf
+- Locator :: Section "Sampling" > "Sampling Procedure", printed page 4 — first bullet. (Text extraction: /tmp/popdocs/doc2017.txt lines 182-184.)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+“• L'échantillon est représentatif au niveau national et couvre toutes les régions et zones (urbaines et rurales) à l'exception de Kidal.”
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+"The sample is representative at the national level and covers all regions and zones (urban and rural) with the exception of Kidal."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+“à l'exception de Kidal” — and, from the Basic Information Document footnote 4: "At the time of the sample selection, the new regions (Menaka and Taoudénit) were not officially announced. Thus, the sample does not take into consideration these new divisions."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No labelled UNIVERSE exists for this wave in either the local documentation or the DDI. The quote above is the closest coverage statement and comes from the Sampling Procedure. The English Basic Information Document (WB catalog 3409, resource 47785, "Basic Information Document - Enquête Agricole de Conjoncture Intégrée aux Conditions de Vie des Ménages (EAC-I 2017)"), Section 4 "Sample", printed p.7 (PDF p.10), states VERBATIM: "The EAC-I 2017 replicates the same sampling design as the first edition, visiting the same EAs. The sample is nationally representative and cover all regions and areas (urban and rural) except Kidal4. The domains were defined as the entire country, district of Bamako, other urban areas, and rural areas; and in the rural areas: agricultural zones, agro-pastoral zones and pastoral zones. Taking this into account, 51 explicit sample strata were selected." — with footnote 4 VERBATIM: "At the time of the sample selection, the new regions (Menaka and Taoudénit) were not officially announced. Thus, the sample does not take into consideration these new divisions." ("cover" for "covers" is as printed.) The same BID adds: "Because of security reasons in the country not all the enumeration areas were visited: 8711 households were interviewed in the first visit; whereas 8658 household were reached during the second visit. The final sample was refined on the base of quality data assessment. The final sample size comprises 8390 households." SAMPLE DESIGN (not universe): revisits the 2014 EAs; 1,070 EAs PPS from the 2009 Census; 9 households per urban EA and 9 per rural EA, of which rural households #3, 6, 9 get the 'Lourd' questionnaire and #1, 2, 4, 5, 7, 8 the 'Léger'; planned n = 9,630. FIDELITY NOTE: whitespace normalized (justified spacing / line-breaks) in the BID quotes; no words changed.
+#+end_quote
+
+*** Mali 2018-19
+
+- Survey :: Enquête Harmonisée sur les Conditions de Vie des Ménages 2018-2019 (EHCVM 2018/19)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Mali/2018-19/Documentation/Documentation.pdf
+- Locator :: Section "Coverage" > heading "UNIVERSE", printed page 3 (PDF page 3). (Text extraction: /tmp/popdocs/doc2018.txt lines 189-191; sampling-procedure quote at lines 238-256.)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+"The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"...excluding prisons, hospitals, military barracks, and school dormitories." — and, from the SAMPLING PROCEDURE section of the same document (printed p.4): "The survey collected data in rural and urban areas in all regions in each of the two waves, except Kidal, Bamako, Toaudénit, and Menaka. More specifically, during the first wave, the survey did not collect data in rural Kidal. Moreover, due to Bamako's purely urban nature, no rural area data are available for this district. Likewise, concerning Taoudenit and Menaka, the survey did not collect data for those regions during the first wave. In addition, there is no urban data for Taoudenit in wave 2."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+This is the ONLY Mali wave with an explicit, labelled UNIVERSE statement. It appears identically in three independent renderings of the same NADA metadata record: (a) the local Documentation.pdf p.3 under the heading 'UNIVERSE'; (b) the WB catalog 4295 study-description page under 'Universe'; (c) the DDI XML <sumDscr><universe> element. The regional exclusions in exclusions_verbatim come from the SAMPLING PROCEDURE section — note these are statements about where data were COLLECTED, not a formal universe restriction, and the document is internally inconsistent in spelling the region ('Toaudénit' in the exclusion list, 'Taoudenit' two sentences later); quoted as printed. SAMPLE DESIGN (not universe): sampling frame = 6th edition of the 2017/18 EMOP, itself derived from the 2009 RGPH, 1,153 EAs; 2-stage stratified without replacement; 500 EAs PPS + 51 additional EAs in wave 2 to cover Menaka and Taoudenit; 12 households per EA; planned n = 6,603 (2,752 urban / 3,851 rural). FIDELITY NOTE: pdfminer renders the 'fi' ligature in this PDF as a single glyph, so raw extraction shows 'speciﬁcally'/'ﬁrst'; the quotes above use ordinary letters, matching the byte-exact catalog rendering at /tmp/popdocs/cat4295.txt line 154. Whitespace normalized; no words changed.
+#+end_quote
+
+*** Mali 2021-22
+
+- Survey :: Enquête Harmonisée sur les Conditions de Vie des Ménages 2021-2022 (EHCVM 2021/22)
+- Source type :: not-found
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: not-stated
+- Language of the quoted source :: (not recorded)
+- Source file :: Searched (both local, neither states a universe): lsms_library/countries/Mali/2021-22/Documentation/mli_ehcvm2_information_de_base_eng.pdf ; lsms_library/countries/Mali/2021-22/Documentation/ddi-documentation-english_microdata-6275.pdf
+- Locator :: English BID: Section 4 "Sampling" / 4.1 "Household and Community Sampling" (PDF pp.10-11) — read in full. DDI documentation PDF: read in full (15,827 characters). French BID (catalog 6275 resource 100367): Section 4 "Échantillonnage" / 4.1 "Volet ménage et communautaire" — read in full.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND — no universe / target-population statement exists in any Mali 2021-22 documentation examined. Positive evidence of absence: the DDI XML for catalog 6275 contains NO <universe> element at all inside <sumDscr> (2018-19's catalog 4295 does contain one), the catalog study-description page has a Coverage section with only "Geographic Coverage / National coverage" and no Universe field, and neither the English nor the French Basic Information Document contains a universe, 'population cible' or 'champ de l'enquête' statement. The nearest verbatim material is Sampling-Procedure text, given in exclusions_verbatim and notes; it is NOT a universe declaration and must not be quoted as one.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+(Sampling Procedure, WB catalog 6275 — describing the inherited 2018/19 design, NOT a universe statement): "The Mali EHCVM 2018/19 utilized the sixth edition of the 2017/18 modular and permanent household survey (EMOP) as the sampling frame. This frame comes from the 2009 Census of Population and Housing (RGPH) and contains 1153 enumeration areas, is nationally representative, and covers all ten regions and the Bamako district. The survey collected data in rural and urban areas in all regions in each of the two waves, except Kidal, Bamako, Toaudénit, and Menaka. More specifically, during the first wave, the survey did not collect data in rural Kidal. Moreover, due to Bamako's purely urban nature, no rural area data are available for this district. Likewise, concerning Taoudenit and Menaka, the survey did not collect data for those regions during the first wave. In addition, there is no urban data for Taoudenit in wave 2." — and, from the local English BID, Section 4.1, note beneath Table 2: "Note: For the regions of Kidal and Timbuktu, an additional sample was added to include rural Kidal and Taoudeni in the survey. The relative error in Table 1 concerns the initial sample." (French original: “Nb : Pour la région de Kidal et Tombouctou, un échantillon supplémentaire a été ajouté pour intégrer Kidal rural et Taoudéni à l'enquête. L'erreur relative dans le tableau 1 concerne l'échantillon initiale.”)
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+2021-22 is a panel revisit of the 2018/19 clusters, so its documentation describes the 2018/19 design rather than declaring its own universe. Local English BID, Section 4.1, VERBATIM: "The sampling frame for the 2018/2019 survey is based on the 2009 general population and housing census (RGPH). In 2021/2022, an enumeration was conducted in the same clusters." / "The survey is a panel cluster survey, and the sampling plan is based on that of the 2018/2019 survey. Therefore, it is appropriate to describe the 2018/2019 plan." / "In 2021/2022, the strategy is to revisit the same clusters. This involves either surveying the 12 households from 2018/2019 if they are found (after the enumeration phase), or surveying the found households and completing the sample to 12 in clusters where fewer households are found during the enumeration phase (either because there were fewer than 12 households in the final 2018/2019 database or because some households were not found)." French BID equivalent, 4.1 "Base de sondage", VERBATIM: “La base de sondage de l'enquête de 2018/2019 est le recensement général de la population et de l'habitat (RGPH) de 2009. En 2021/2022, il a été procédé à un dénombrement dans les mêmes grappes.” SAMPLE DESIGN (not universe): planned n = 6,708 (3,528 urban / 3,180 rural); achieved 2,732 urban and 3,411 rural. CAUTION FOR #603: it would be defensible to INHERIT the 2018-19 universe ("all de jure households excluding prisons, hospitals, military barracks, and school dormitories") for 2021-22, given the explicit panel linkage stated above. That is an INFERENCE, not a documented claim for this wave, and is recorded here only as such.
+#+end_quote
+
+** Nepal
+
+*** Nepal 1995-96
+
+- Survey :: Nepal Living Standards Survey 1995-1996, First Round (NLSS I)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: https://microdata.worldbank.org/index.php/catalog/2301/study-description
+- Locator :: WB Microdata Library catalog id 2301, Study Description > Scope > 'Universe' field (also returned verbatim by https://microdata.worldbank.org/index.php/api/catalog/2301?id_format=id at dataset.metadata.study_desc.study_info.universe). Exclusions quote is from the LOCAL report: 'Nepal Living Standards Survey 1995-96 Report Vol 1.pdf', Section 1.2 Survey Methodology / Sample Design, footnote 1, p. 2.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The survey covered all modified de jure household members (usual residents).
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The two districts not selected in the sample due to their low population were Rasuwa and Mustang.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The universe statement exists ONLY in the World Bank catalog metadata, not in any local document I could find -- flagged accordingly (source_type: wb-catalog). Verified character-for-character against both the JSON API and the rendered study-description HTML ('Universe\r\n---------------------------\r\n\r\nThe survey covered all modified de jure household members (usual residents).'). SAMPLE DESIGN, not universe (context only): catalog geog_coverage field reads 'National coverage The 4 strata of the survey:\n- Mountains\n- Hills (Urban)\n- Hills (Rural)\n- Terai'; the report says 'The sample frame considered all the 75 districts in the country, and indeed 73 of them were represented in the sample.' with the footnote quoted in exclusions_verbatim. Note that the Rasuwa/Mustang exclusion is a FRAME/selection outcome, not a declared universe exclusion. NB: the repo has no Nepal microdata (.dta) at all -- NSO-hosted, not WB (see Nepal/_/CONTENTS.org); this task used documentation only, as instructed.
+#+end_quote
+
+*** Nepal 2003-04
+
+- Survey :: Nepal Living Standards Survey 2003-2004, Second Round (NLSS II)
+- Source type :: not-found
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: not-stated
+- Language of the quoted source :: (not recorded)
+- Source file :: lsms_library/countries/Nepal/2003-04/Documentation/NLSSIIReportVol1.pdf
+- Locator :: NO universe statement found in any source. The exclusions quote is from NLSSIIReportVol1.pdf, CHAPTER I: METHODOLOGY, unnumbered chapter preamble, p. 1 (immediately above Table 1.0 'Summary statistics').
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+It should be noted that 96 out of 4008 households (8 out of 334 PSUs), mostly from the Far Western development region, were not enumerated as a result of ongoing conflict in those areas.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+This is a genuine, checked gap: NLSS II is the one Nepal wave for which the World Bank catalog carries no Universe field and the local CBS statistical report has no universe/target-population sentence. WARNING on the exclusions field: the quote is an IMPLEMENTATION outcome (PSUs unreachable during the Maoist conflict), NOT a declared design exclusion from the universe -- do not read it as 'the Far Western region is out of scope'. §1.7 Survey Limitations confirms these PSUs were dropped rather than replaced: 'As already noted above, the survey was unable to reach/interview all the sampled PSUs and their households. With the consultation of the design experts it was decided not to replace the affected PSUs for enumeration and ultimately they were dropped.' The DDI PDF states the same differently ('Deviations from Sample Design ... altogether 13 rural enumeration areas (PSUS) could not be interviewed comprising 8 from cross-section and 5 from the panel samples ... Response Rate: Five PSUs out of 434 PSUs for the survey could not be carried due to unavoidable reasons. Thus the response rate is 98.5%.'). SAMPLE DESIGN, not universe (context only): catalog geog_coverage = 'National\nDomains: Urban/rural; ecological zones (Mountains, Kathmandu Valley (urban), Hills (urban), Hills (rural), Tarai (urban), Tarai (rural)).'; report says 'nationally representative random cross-section sample of 4008 households from six explicit strata of the country' plus a panel sample of 1232 households drawn from NLSS I households. If a universe is needed for #603, the defensible move is to inherit NLSS-III's wording only with an explicit note that it was NOT stated for NLSS II -- or, better, leave it unrecorded.
+#+end_quote
+
+*** Nepal 2010-11
+
+- Survey :: Nepal Living Standards Survey 2010-2011, Third Round (NLSS III)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Nepal/2010-11/Documentation/Statistical_Report_Vol1.pdf
+- Locator :: Statistical_Report_Vol1.pdf (Nepal Living Standards Survey 2010/11, Statistical Report Volume One, CBS), Chapter 1, Section 1.5 'Coverage', p. 5. The identical text is also the 'Universe' field of WB Microdata Library catalog id 1000 (https://microdata.worldbank.org/index.php/catalog/1000/study-description).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The survey in principle covers the whole country, including both rural and urban areas. ... All households in the country were considered eligible for selection in the survey. The survey, however, excluded the households of diplomatic missions. The institutional households (like people living in schools hostels, prisons, army camps and hospitals) were also excluded from the survey. The household members were determined on the basis of the usual place of their residence. Foreign nationals whose usual place of residence is within the country were included in the survey.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The survey, however, excluded the households of diplomatic missions. The institutional households (like people living in schools hostels, prisons, army camps and hospitals) were also excluded from the survey.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The ellipsis in population_verbatim elides an intervening geographic-description passage (75 districts -> 3 ecological belts -> 5 development regions -> 15 eco-development regions, Box 1.1); the two quoted blocks are the first and last paragraphs of §1.5 Coverage, verbatim. '(like people living in schools hostels, prisons, army camps and hospitals)' is quoted sic -- the report has no apostrophe in 'schools hostels'. Related, from §1.4 Statistical Unit (p. 5), for the household definition: 'NLSS-III is basically a household survey and the enumeration unit of the survey is the household. The definition of a household for the survey is primarily adopted from the guidelines laid down by the United Nations in its "Principles and Recommendations for Population and Housing Censuses, Rev 2" (UN, 2008).' SAMPLE DESIGN, not universe (context only): catalog geog_coverage = 'National Urban-Rural areas Ecological Zones Development Regions'; NLSS-III drew two independent samples, a cross-section (500 of the 800 NLFS-II PSUs, 14 explicit strata, 12 households per PSU) and a panel from NLSS-I/II households. No conflict-related non-enumeration is reported for this wave.
+#+end_quote
+
+** Niger
+
+*** Niger 2011-12
+
+- Survey :: Enquête Nationale sur les Conditions de Vie des Ménages et l'Agriculture (ECVM/A) 2011 — "Niger - National Survey on Household Living Conditions and Agriculture 2011" (WB catalog 2050)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Niger/2011-12/Documentation/ddi-documentation-english_microdata-2050.pdf (identical text also in lsms_library/countries/Niger/2011-12/Documentation/ECVMA_Information_de_Base_V9_eng.pdf)
+- Locator :: ddi-documentation-english_microdata-2050.pdf, section 'Sampling' > 'Sampling Procedure', PDF p. 3. Same passage in ECVMA_Information_de_Base_V9_eng.pdf, section '3. SAMPLING', printed pp. 3-4 (PDF pp. 6-7).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The ECVM/A 2011 has been designed to have national coverage, including both urban and rural areas in all the regions of the country. The domains are defined as the entire country, the city of Niamey; and other urban areas, rural areas, and in the rural areas, agricultural zones, agro-pastoral zones and pastoral zones. Taking this into account, 26 explicit sampling strata were selected: Niamey, and urban, agriculture, agro-pastoral and pastoral zones of the seven regions other than Niamey.  The target population is drawn from households in all 8 regions of the country with the exception of certain strata found in Arlit (Agadez Region) because of difficulties in going there, the very low population density, and collective housing. The portion of the population excluded from the sample represents less than 0.4% of the total population of Niger. Of a total of 36,000 people not included in the sample design, about 29,000 live in Arlit and 7,000 in collective housing.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a — the shipped documentation is already in English (the Basic Information Document filename is explicitly '_eng'; a French original was not shipped in this wave's Documentation/ directory).
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+with the exception of certain strata found in Arlit (Agadez Region) because of difficulties in going there, the very low population density, and collective housing. The portion of the population excluded from the sample represents less than 0.4% of the total population of Niger. Of a total of 36,000 people not included in the sample design, about 29,000 live in Arlit and 7,000 in collective housing.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+There is NO DDI 'Universe' field for this wave — neither in the shipped DDI PDF nor in the catalog DDI/XML export for id 2050 ('universe' does not occur in the XML at all). The universe statement is therefore the 'target population' sentence inside the Sampling Procedure, quoted above. Both shipped documents (the DDI abstract and the Basic Information Document) carry the same wording, present tense in the 2011 documents. SAMPLE DESIGN (not the universe, recorded here for context): two-stage; stage 1 ZDs (Zones de Dénombrement) selected PPS from the 2001 RGPH with number of households as measure of size; stage 2 12 (urban) or 18 (rural) households with equal probability; total estimated sample 4,074 households; 26 explicit strata. Documentation/Source lists https://microdata.worldbank.org/index.php/catalog/2050/. Note the exclusion of 'collective housing' is stated as an exclusion from the sampling frame, alongside the geographic exclusion of certain Arlit (Agadez) strata.
+#+end_quote
+
+*** Niger 2014-15
+
+- Survey :: ECVM/A 2014 — "Niger - National Survey on Household Living Conditions and Agriculture 2014, Wave 2 Panel Data" (WB catalog 2676; DDI_NER_2014_ECVMA-II_v03_M_WB)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Niger/2014-15/Documentation/ddi-documentation-english_microdata-2676.pdf
+- Locator :: Section 'Sampling' > 'Sampling Procedure' > subsection '2011 Survey', PDF p. 6 (the panel/tracking rule is on the same page, subsection '2014 Survey'). The GEOGRAPHIC COVERAGE sentence is under 'Coverage' > 'GEOGRAPHIC COVERAGE', PDF p. 4.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The ECVM/A 2011 was been designed to have national coverage, including both urban and rural areas in all the regions of the country. The domains are defined as the entire country, the city of Niamey; and other urban areas, rural areas, and in the rural areas, agricultural zones, agro-pastoral zones and pastoral zones. Taking this into account, 26 explicit sampling strata were selected: Niamey, and urban, agriculture, agro-pastoral and pastoral zones of the seven regions other than Niamey.  The target population was drawn from households in all 8 regions of the country with the exception of certain strata found in Arlit (Agadez Region) because of difficulties in going there, the very low population density, and collective housing. The portion of the population excluded from the sample represents less than 0.4% of the total population of Niger. Of a total of 36,000 people not included in the sample design, about 29,000 live in Arlit and 7,000 in collective housing.  [GEOGRAPHIC COVERAGE, p. 4:] The ECVM/A 2014 is a panel survey with the ECVM/A 2011. The ECVM/A 2011 was designed to have national coverage, including both urban and rural areas in all the regions of the country. The domains are defined as the entire country, the city of Niamey; and other urban areas, rural areas, and in the rural areas, agricultural zones, agro-pastoral zones and pastoral zones.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a — source documentation is in English.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+with the exception of certain strata found in Arlit (Agadez Region) because of difficulties in going there, the very low population density, and collective housing. The portion of the population excluded from the sample represents less than 0.4% of the total population of Niger. Of a total of 36,000 people not included in the sample design, about 29,000 live in Arlit and 7,000 in collective housing.  [Panel-specific attrition rule, same section, '2014 Survey':] In the ECVM/A 2014, all households that had been interviewed in 2011 were tracked. Households that did not move were interviewed in their existing location. Households that had moved to other locations in Niger were followed and interviewed in their new locations if they could be found in the new location. Households that moved outside of Niger were not followed.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The 2014 wave is a panel follow-up of the 2011 ECVM/A and its documentation states the universe by REFERENCE to the 2011 design — there is no separately stated 2014 universe. Note the ungrammatical 'was been designed' is verbatim in the source. Ligature glyphs in the PDF (ﬁ/ﬃ) have been normalised to 'fi'/'ffi' in the quote above; that is a font-encoding artifact of extraction, the document reads 'defined' / 'difficulties'. SAMPLE DESIGN context: 2011 sample = 4,074 households; households identified by GRAPPE + MENAGE + EXTENSION; EXTENSION 0 = non-mover, 1 = whole household moved, 2 = split-off individual in a new household. The 2014 DDI's own 'Coverage > GEOGRAPHIC COVERAGE' field says only that it is a panel of the 2011 survey and restates the 2011 coverage; there is no 'UNIVERSE' field.
+#+end_quote
+
+*** Niger 2018-19
+
+- Survey :: Enquête Harmonisée sur le Conditions de Vie des Ménages (EHCVM) 2018-2019 (WB catalog 4296; DOI 10.48529/ggam-ax39)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Niger/2018-19/Documentation/ddi-documentation-english_microdata-4296.pdf
+- Locator :: Section 'Coverage', field 'UNIVERSE' (immediately below 'GEOGRAPHIC COVERAGE: National coverage'), PDF p. 3.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+UNIVERSE The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.  [GEOGRAPHIC COVERAGE, same page:] National coverage
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a — source documentation is in English.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+excluding prisons, hospitals, military barracks, and school dormitories
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+This is the only Niger wave with an explicit DDI 'UNIVERSE' field, and it is corroborated verbatim by the catalog DDI/XML (<universe><![CDATA[The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.]]></universe>). SAMPLE DESIGN context (from the same PDF, 'Sampling' > 'SAMPLING PROCEDURE'): two-stage, 504 EAs at stage 1, 12 households per EA at stage 2; total 6,024 households (1,577 urban, 4,447 rural); each EA split into two halves interviewed in wave 1 (2,983 HH) and wave 2 (3,041 HH). No Basic Information Document is shipped locally for this wave; the DDI PDF is the local source.
+#+end_quote
+
+*** Niger 2021-22
+
+- Survey :: Enquête Harmonisée sur le Conditions de Vie des Ménages (EHCVM) 2021-2022 (WB catalog 6276; NER_2021_EHCVM-2_v01_M)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: low
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Niger/2021-22/Documentation/SOURCE.org (contains only the URL https://microdata.worldbank.org/index.php/catalog/6276); quoted text from https://microdata.worldbank.org/index.php/catalog/6276/study-description
+- Locator :: WB Microdata catalog 6276, study-description page: sections 'Coverage > Geographic Coverage', 'Identification > Series Information', and 'Abstract'. Also checked: catalog 6276 'Documentation' tab -> 'Basic Information Document' (download id 100374, EN, section '4. Sampling', pp. 9-10) and 'Basic Information Document - French version' (download id 100375, section 'Base de sondage' / 'Stratégie d'échantillonnage').
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND — no universe/target-population statement exists for this wave. The strongest coverage claims available, quoted verbatim from the WB catalog study description (there is no local documentation beyond SOURCE.org):  [Coverage > Geographic Coverage:] National coverage  [Series Information:] The Niger EHCVM 2021/22 is the second edition of a nationally representative household survey conducted within the West Africa Economic Monetary Union (WAEMU) Household Survey harmonization Project (P153702) a joint program by the World Bank and the WAEMU Commision that aims at producing household survey data in member countries (Benin, Burkina Faso, Chad, Cote d'Ivoire, Guinea Bissau, Mali, Niger, Senegal and Togo). The survey covers all regions and includes approximately 6,000 households.  [Abstract:] The EHCVM is a nationally representative survey of 6,000 households, which are also representative of the geopolitical zones (at both the urban and rural level).
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a — the quoted catalog text is in English. The French-language Basic Information Document ('Document d'Information de Base', catalog 6276 download id 100375) was also checked and likewise contains no universe statement; its closest text is 'Base de sondage — La base de sondage de l'enquête de 2018/19 était le recensement général de la population et de l'habitat (RGPH) de [PRECISER L'ANNÉE]. En 2021/22, il a été procédé à un dénombrement dans les mêmes grappes.' (note the unfilled placeholder, verbatim in the source).
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND — no exclusion statement (no institutional-population exclusion, no dropped region, no security-related exclusion) appears in the catalog metadata, the DDI/XML, or either language version of the Basic Information Document.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+IMPORTANT — the quoted text is a geographic-coverage / representativeness claim, NOT a universe declaration; it should not be recorded as one. Unlike 2018-19 (catalog 4296), the 2021-22 catalog entry has no DDI 'Universe' field. The 2021-22 BID is visibly an incomplete template: it contains unfilled placeholders in the sampling chapter, verbatim 'For a sample size of [xxxxx households], the precision was [...] at the national level and varied from [...] to [...] for the regions.' and 'the general population and housing census (RGPH) of [SPECIFY THE YEAR]'. SAMPLE DESIGN context (BID '4. Sampling' and catalog 'Sampling Procedure'): a cluster PANEL of the 2018/19 survey — the same clusters are revisited, the 2018/19 12 households per cluster re-interviewed where found and topped back up to 12 where fewer are found; stratum = region x milieu (urban/rural); stage 1 PPS by number of households, stage 2 12 households with equal probability; final sample 6,622 households (2,511 urban, 4,111 rural), wave 1 = 3,303 HH (Nov 17 2021 - Feb 13 2022), wave 2 = 3,319 HH (Jun 3 - Aug 31 2022). Because 2021-22 is a panel on the 2018/19 frame, the 2018-19 universe statement ('all de jure households excluding prisons, hospitals, military barracks, and school dormitories') is the natural candidate to inherit — but NO document says so, and that inference is explicitly NOT made here.
+#+end_quote
+
+** Nigeria
+
+*** Nigeria 2010-11
+
+- Survey :: Nigeria - General Household Survey, Panel 2010-2011, Wave 1 (GHS-Panel W1; NGA_2010_GHSP-W1_v03_M)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: English
+- Source file :: Nigeria2010_11_GHS-Panel_BINFO_Jan_2019.pdf (Wave 1 Basic Information Document, downloaded from WB catalog 1002 -> https://microdata.worldbank.org/index.php/catalog/1002/download/48233; NOT present in lsms_library/countries/Nigeria/2010-11/Documentation/)
+- Locator :: Section 1.3 'Coverage and Scope', printed p. 3 (PDF page 7)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The revised GHS with the panel component, while having an intensive focus on agriculture, is a national survey. The survey covered all the 36 states and the Federal Capital Territory (FCT), Abuja. Both urban and rural enumeration areas (EAs) were canvassed.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND — no exclusion statement in the Wave 1 Basic Information Document or on the WB catalog page for catalog id 1002 (that page has no 'Universe' field at all). The nearest exclusion statement for the same NISH/2006-census frame appears in the WAVE 3 BID's annexed weighting report (Megill), p. 55: "The institutional population living in prisons, hospitals, military barracks, school dormitories, etc. are excluded from the universe defined for the household surveys." — quoted here for context only; it is NOT from a Wave 1 document.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Wave directory = GHS-Panel Wave 1 (data files carry the _w1 / wave1 suffix). No document for this wave states a 'universe' in those words; the quote above is the closest inclusion statement. Two further verbatim statements from the WB catalog 1002 study-description page: Geographic Coverage — "National, the survey covered all the 36 states and Federal Capital Territory (FCT)."; Sampling Procedure > Sample Framework — "The sample frame includes all thirty-six (36) states of the federation and Federal Capital Territory (FCT), Abuja. Both urban and rural areas were covered and in all, 500 clusters/EAs were canvassed and 5,000 households were interviewed. These samples were proportionally selected in the states such that different states have different samples." Sample-design detail (BID §3.0, p. 11): "The sample is designed to be representative at the national level as well as at the zonal level. The sample size of the GHS-Panel (unlike the full GHS) is not adequate for state-level estimates." Whitespace in PDF quotes normalized (pdfminer inserts multiple spaces); wording is unaltered.
+#+end_quote
+
+*** Nigeria 2012-13
+
+- Survey :: Nigeria - General Household Survey, Panel 2012-2013, Wave 2 (GHS-Panel W2; NGA_2012_GHSP-W2_v02_M)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: agricultural-households
+- Language of the quoted source :: English
+- Source file :: World Bank Microdata Library catalog entry 1952 (https://microdata.worldbank.org/index.php/catalog/1952/study-description)
+- Locator :: Study description > Coverage > 'Universe' field (adjacent fields: Geographic coverage = "National Zone State Sector"; Analysis unit = "Agricultural Households.")
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+Agricultural farming household members.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND — neither the catalog entry (id 1952) nor the Wave 2 Basic Information Document states any exclusion from the universe.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Wave directory = GHS-Panel Wave 2 (data files carry _w2 / wave2). CAUTION: the catalog's Universe field for this wave ("Agricultural farming household members.") is narrower than every other GHS-Panel wave's universe field and appears inconsistent with the wave's own documentation, which describes a re-interview of ALL Wave 1 households. Verbatim from the Wave 2 BID, §3.0 'Wave 2 Sample and Weights', p. 23: "The GHS-Panel sample is designed to be representative at the national level as well as at the zonal level. The sample size of the GHS-Panel is not adequate for state-level estimates. The complete sampling information for the GHS-Panel Wave is described in the Basic Information Document for GHS-Panel 2010/2011." and "The objective of the GHS-Panel Wave 2 was to re-interview all of the Wave 1 households." I record both verbatim rather than adjudicate between them. The Wave 2 BID contains no 'universe' statement of its own (grep for 'universe'/'institutional' returns nothing).
+#+end_quote
+
+*** Nigeria 2015-16
+
+- Survey :: Nigeria - General Household Survey, Panel 2015-2016, Wave 3 (GHS-Panel W3; NGA_2015_GHSP-W3_v02_M)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: World Bank Microdata Library catalog entry 2734 (https://microdata.worldbank.org/index.php/catalog/2734/study-description); corroborating exclusion sentence from GHS-Panel_BINFO_2015_16_Jan_2019.pdf (catalog 2734 -> download/46028)
+- Locator :: Study description > Coverage > 'Universe' field (Geographic Coverage = "National coverage"; Geographic Unit = "North-Central Zone North-East Zone North-West Zone South-East Zone South-South Zone South-West Zone")
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories. [WB catalog 2734, Universe field]  ||  "The institutional population living in prisons, hospitals, military barracks, school dormitories, etc. are excluded from the universe defined for the household surveys." [GHS-Panel_BINFO_2015_16_Jan_2019.pdf, annexed weighting report ('Final Sample Design and Estimation Procedures for 2010 Nigeria General Household Panel Survey', Megill), §2 'Summary of Sample Design for the 2010 GHS and Panel Survey', PDF p. 55]
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Wave directory = GHS-Panel Wave 3 (data files carry _w3 / wave3). The universe quote is from the live catalog page, not from the local DDI PDF, because the local PDF has no Universe section. Sample-design context, verbatim from the catalog Sampling Procedure (identical to local DDI PDF p. 2): "A multi-stage stratified sample design was used for the GHS and the Panel Survey. The GHS-Panel sample is fully integrated with the 2010 GHS Sample. ... Out of these 22,000 households, 5,000 households from 500 EAs were selected for the panel component and 4,916 households completed their interviews in the first wave. Given the panel nature of the survey, some households had moved from their location and were not able to be located by the time of the Wave 3 visit, resulting in a slightly smaller sample of 4,581 households for Wave 3." The Wave 3 BID annex also notes a conflict-area supplement: "The sample EAs in the Panel Survey that are located in areas classified as conflict areas were identified, and a supplemental sample of 5 households was selected in each of these EAs, after a new listing was conducted." (BID p. 54).
+#+end_quote
+
+*** Nigeria 2018-19
+
+- Survey :: Nigeria - General Household Survey, Panel 2018-2019, Wave 4 (GHS-Panel W4; NGA_2018_GHSP-W4_v03_M)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Nigeria/2018-19/Documentation/ddi-documentation-english_microdata-3557.pdf
+- Locator :: Coverage section, 'UNIVERSE' (PDF p. 4, under 'GEOGRAPHIC COVERAGE: National'); exclusions in 'Sampling > Deviations from Sample Design' (PDF pp. 5-6)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories. [UNIVERSE field, p. 4]  ||  'Deviations from Sample Design' (p. 6): "While the combined sample generally maintains both national and Zonal representativeness of the original GHS-Panel sample, the security situation in the North East of Nigeria prevented full coverage of the Zone. Due to security concerns, rural areas of Borno state were fully excluded from the refresh sample and some inaccessible urban areas were also excluded. Security concerns also prevented interviewers from visiting some communities in other parts of the country where conflict events were occurring. Refresh EAs that could not be accessed were replaced with another randomly selected EA in the Zone so as not to compromise the sample size. As a result, the combined sample is representative of areas of Nigeria that were accessible during 2018/19. The sample will not reflect conditions in areas that were undergoing conflict during that period. This compromise was necessary to ensure the safety of interviewers."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Wave directory = GHS-Panel Wave 4 (all 191 Data/*.dvc entries carry the w4 suffix, e.g. secta_plantingw4.dta, sect10a_harvestw4.dta). PROVENANCE DISCREPANCY worth flagging for #603: this wave's Documentation/SOURCE.org records https://microdata.worldbank.org/index.php/catalog/3827, which is 'Nigeria - Living Standards Survey 2018-2019' (NGA_2018_LSS_v01_M) — a DIFFERENT survey — while the local documentation PDF and the data files are GHS-Panel Wave 4 = catalog 3557 (NGA_2018_GHSP-W4_v03_M). CLAUDE.md already warns about this exact 3557/3827 collision. (Both catalog entries happen to carry the same Universe sentence, so the population quote is unaffected; the catalog id is not.) Note the Borno rural exclusion is a design-level exclusion, not just non-response.
+#+end_quote
+
+*** Nigeria 2023-24
+
+- Survey :: Nigeria - General Household Survey, Panel 2023-2024, Wave 5 (GHS-Panel W5; NGA_2023_GHSP-W5_v01_M)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: World Bank Microdata Library catalog entry 6410 (https://microdata.worldbank.org/index.php/catalog/6410/study-description) for the universe sentence; lsms_library/countries/Nigeria/2023-24/Documentation/ghs_panel_wave_5_basic_information_document_v1.pdf for the exclusions and representativeness statements
+- Locator :: Catalog: Study description > Coverage > 'Universe' (Geographic Coverage = "National"). BID: section 'Wave 5 Sample and Weights', PDF pp. 32-33; weighting subsection PDF p. 35
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories. [WB catalog 6410, Universe field]  ||  Local BID, 'Wave 5 Sample and Weights', pp. 32-33: "Although 518 EAs were identified for the post-planting visit, conflict events prevented interviewers from visiting eight EAs in the North West zone of the country. Therefore, the final number of EAs visited both post-planting and post-harvest comprised 157 long panel EAs and 354 refresh EAs."  ||  The catalog's 'Deviations from the Sample Design' adds the states: "Although 518 EAs were identified for the post-planting visit, conflict events prevented interviewers from visiting eight EAs in the North West zone of the country. The EAs were located in the states of Zamfara, Katsina, Kebbi and Sokoto."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Wave directory = GHS-Panel Wave 5 (Data/ holds 'Post Planting Wave 5' and 'Post Harvest Wave 5' subdirectories). The universe sentence is identical to Waves 3 and 4. Local BID representativeness statements, verbatim: "This 'long panel' sample of 1,590 households was designed to be nationally representative to enable continued longitudinal analysis for the sample going back to 2010." and "The combined sample of refresh and long panel EAs in Wave 5 that were eligible for inclusion consisted of 518 EAs based on the EAs selected in Wave 4. The combined sample generally maintains both the national and zonal representativeness of the original GHS-Panel sample." (BID p. 32); and on the cross-sectional weight: "Cross-sectional weights to be applied to the combined sample: used for analysis that seeks to provide representative estimates of the current population of Nigerian households at the time of wave 5 (2023/24)." (BID p. 35). Footnote on the community data (BID p. 6, footnote 1): "The Community Questionnaire does not collect information from communities in the sociological sense. The data cannot be used to represent communities in Nigeria. The data collected at the community level represent information that is common to the households selected for inclusion in the selected sample enumeration areas (EAs)."
+#+end_quote
+
+** Pakistan
+
+*** Pakistan 1991
+
+- Survey :: Pakistan Integrated Household Survey (PIHS) 1991 / "Integrated Household Survey 1991" (WB catalog idno PAK_1991_IHS_v01_M)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: World Bank Microdata Library catalog entry PAK_1991_IHS_v01_M (https://microdata.worldbank.org/index.php/catalog/study/PAK_1991_IHS_v01_M ; DOI https://doi.org/10.48529/azv8-cf20 , the URL recorded in lsms_library/countries/Pakistan/1991/Documentation/SOURCE.org)
+- Locator :: Sampling > Sampling Procedure; JSON path metadata.study_desc.method.data_collection.sampling_procedure, opening paragraph and the 'SAMPLE FRAME:' paragraph (retrieved 2026-07-21 from https://microdata.worldbank.org/index.php/api/catalog/PAK_1991_IHS_v01_M)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The sample for the PIHS was drawn using a multi-stage stratified sampling procedure from the Master Sample Frame developed by FBS based on the 1981 Population Census.  SAMPLE FRAME:  This sample frame covers all four provinces (Punjab, Sindh, NWFP, and Balochistan) and both urban and rural areas. Excluded, however, are the Federally Administered Tribal Areas, military restricted areas, the districts of Kohistan, Chitral and Malakand and protected areas of NWFP. According to the FBS, the population of the excluded areas amounts to about 4 percent of the total population of Pakistan. Also excluded are households which depend entirely on charity for their living.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Excluded, however, are the Federally Administered Tribal Areas, military restricted areas, the districts of Kohistan, Chitral and Malakand and protected areas of NWFP. According to the FBS, the population of the excluded areas amounts to about 4 percent of the total population of Pakistan. Also excluded are households which depend entirely on charity for their living.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+NO wave directory other than 1991 exists for Pakistan.  The WB NADA record has NO dedicated 'universe' field (study_desc.study_info contains only abstract, coll_dates, nation, geog_coverage='National', analysis_unit='- Households\n- Individuals\n- Communities', data_kind, notes). The universe/frame statement quoted above therefore comes from the 'Sampling Procedure' field, which is where the frame and its exclusions are stated.  LOCAL DOCUMENTATION: the local report pak08a.pdf contains no explicit universe/target-population sentence. Its closest statement is section I.C 'Sample Design', report page 3 (= page 13 of 55 in the PDF), which reads (transcribed by eye from the page image — the PDF is a scan with no text layer, so treat this transcription as high-fidelity but not machine-extracted):    "PIHS survey teams were scheduled to visit 4800 households residing in 300 urban and rural communities between January and December, 1991.  Each team visited approximately 20 communities (denoted Primary Sampling Units, or PSUs) and interviewed 16 households (denoted Secondary Sampling Units, or SSUs) in each.  The sample is drawn from the master sample frame maintained by FBS.    The sample is divided equally between Pakistan's urban and rural areas, with provincial shares roughly approximating population shares."  That local passage names the frame (FBS master sample frame) but states NO exclusions; the exclusions are recorded only in the catalog metadata. Table A.1 on the same page reports the realised sample: 4,794 households / 36,071 individuals / 300 PSUs, broken out for Punjab, Sindh, N.W.F.P. and Balochistan, urban and rural.  SAMPLE-DESIGN DETAIL (not the universe, recorded for context), from the same catalog field: the frame has three domains — '(a) Self-representing cities: All cities with a population of 500,000 or more are classified as self-representing cities. These include Karachi, Lahore, Gujranwala, Faisalabad, Rawalpindi, Multan, Hyderabad and Peshawar. In addition to these cities, Islamabad and Quetta are also included in this group as a result of being the national and provincial capitals respectively.'; '(b) Other urban areas: All settlements with a population of 5,000 or more at the time of the 1981 Population Census are included in this group (excluding the self-representing cities mentioned above).'; '(c) Rural areas: Villages and communities with population less than 5,000 (at the time of the Census) are classified as rural areas.'  REPRESENTATIVITY (catalog, metadata.study_desc.method.analysis_info.sampling_error_estimates): 'The PIHS sample was designed to yield representative statistics at the national and urban/rural) levels. Care however should be taken when interpreting results for smaller analytic domains as the sample was not designed to be representative at a more disaggregated level.' (the stray ')' is in the source).  Environment note: no poppler/pdftotext/tesseract on this host; scanned pages were converted with pdfminer's ImageWriter + PIL and read as images. No dvc CLI was invoked; PDFs were materialised with lsms_library.data_access.get_data_file(). No file under lsms_library/countries/ was modified.
+#+end_quote
+
+** Panama
+
+*** Panama 1997
+
+- Survey :: Encuesta de Niveles de Vida 1997 (ENV-97) / Living Standards Survey 1997
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: Spanish
+- Source file :: pn97bif.pdf (WB Microdata catalog id 598 = PAN_1997_ENV_v01_M, resource download id 15751, 'Documento de Informacion Basica' / basic information document); corroborated verbatim by the catalog study-description page https://microdata.worldbank.org/index.php/catalog/598/study-description
+- Locator :: pn97bif.pdf, section 6 'DISEÑO DE LA MUESTRA', sub-section 'A. Universo de Estudio', printed page 8 (PDF page 12). Catalog duplicate: Coverage > Universe field on the catalog study-description page.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+A. Universo de Estudio  Lo constituyen el conjunto de viviendas particulares existentes en el país según el Censo de 1990 (Cuadro No. 1), existen 525,236 viviendas particulares ocupadas, de las cuales 295,156 (56.2%) integran el área urbana y 230,080 (43.8%) pertenecen al área rural, de estas últimas 198,016 viviendas se ubican en el área rural no indígena, 25,141 en el área rural indígena y 6,923 en el área rural de difícil acceso.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+A. Study universe. It is constituted by the set of private dwellings existing in the country according to the 1990 Census (Table No. 1); there are 525,236 occupied private dwellings, of which 295,156 (56.2%) make up the urban area and 230,080 (43.8%) belong to the rural area; of the latter, 198,016 dwellings are located in the non-indigenous rural area, 25,141 in the indigenous rural area and 6,923 in the hard-to-reach rural area. [translation mine, not from the source]
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NO EXPLICIT EXCLUSION STATEMENT FOUND. The ENV-97 documentation states the opposite — an explicit inclusion claim (pn97bif.pdf, section 1 'INTRODUCCION', printed p. 1 / PDF p. 5): "La encuesta tiene cobertura nacional, regional, urbana y rural e incluye, por primera vez, las poblaciones indígenas, el área rural dispersa y alejada y las poblaciones de difícil acceso." The catalog's Geographic Coverage field reads in full: "Se cubre la totalidad del territorio nacional". The only implicit restriction is the universe unit itself — "viviendas particulares" (private dwellings), which by Panamanian census convention excludes collective/institutional dwellings; the documentation does not spell this out and I am not asserting it as a documented exclusion.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The catalog's own Universe field carries the identical sentence but with a mojibake artifact: acute accents appear as a following U+00B4 ('pai´s', 'a´rea', 'indi´gena'). I quote the clean text from pn97bif.pdf instead; the two are word-for-word identical otherwise. Whitespace in my quote is normalised (the PDF is justified and text extraction yields doubled spaces); no words, punctuation or figures were altered. SAMPLE DESIGN (not the universe, for context only): frame built from 1990 Census cartography, 14,203 PSUs (10,850 urban, 3,353 rural = 2,508 non-indigenous, 396 indigenous, 449 hard-to-reach); designed sample 5,591 dwellings, effective 5,000, achieved 4,945 households. pn97bif.pdf also defines each area stratum verbatim, incl. "Difícil Acceso. Se incluyen aquí las comunidades rurales más alejadas y dispersas del país a las que se llega principalmente a pie, a caballo o en canoa, muchas veces sólo en determinadas épocas del año (verano)." Note the universe is benchmarked to the 1990 Census even though the survey ran in 1997.
+#+end_quote
+
+*** Panama 2003
+
+- Survey :: Encuesta de Niveles de Vida 2003 (ENV-03) / Living Standards Survey 2003
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: Spanish
+- Source file :: pan03bif.pdf ('Informe Techico de la Encuesta de Niveles de Vida 2003', WB Microdata catalog id 2346 = PAN_2003_ENV_v01_M, resource download id 34948). NOT held locally: lsms_library/countries/Panama/2003/Documentation/ does not contain this file.
+- Locator :: pan03bif.pdf, section 'B. LA MUESTRA' > '1. LA MUESTRA' > 'a. Universo', printed page 11 (PDF page 14).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+a. Universo  El Universo de estudio de esta muestra fueron las viviendas particulares de los Censos Nacionales de Población y Vivienda del año 2000. En el año de referencia había un total de 790,813 viviendas particulares, de las cuales 681,803 estaban ocupadas al momento de los censos. De éstas, 653,211 estaban ubicadas en áreas no indígenas y 28,592 en áreas indígenas.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+a. Universe. The study universe of this sample was the private dwellings of the National Population and Housing Censuses of the year 2000. In the reference year there was a total of 790,813 private dwellings, of which 681,803 were occupied at the time of the censuses. Of these, 653,211 were located in non-indigenous areas and 28,592 in indigenous areas. [translation mine, not from the source]
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Domain-level exclusion (pan03bif.pdf, section 'B. LA MUESTRA', sub-section '2. DISEÑO DE LA MUESTRA', printed p. 13 / PDF p. 16): "Es necesario destacar que el dominio provincia excluye de éstas, las áreas habitadas mayoritariamente por pueblos indígenas. Por consiguiente, las estimaciones de este dominio se refieren a características de la población residente en áreas no indígenas de las provincias. Por otra parte, el dominio área indígena está conformado por los territorios de las Comarcas Indígenas de Kuna Yala, Ngöbe Buglé y Emberá más áreas específicas habitadas mayoritariamente por población indígena, ubicadas en cinco provincias del país. Este mismo criterio se aplicó en la ENV de 1997." || Module-level exclusion, prices questionnaire only (pan03bif.pdf, printed p. 11 / PDF p. 14): "j. Precios en establecimientos. Cotización de precios de un conjunto de artículos de consumo cotidiano: alimentos, bebidas y tabaco (48 artículos), y bienes de aseo personal y del hogar (20 artículos) en áreas urbanas (a excepción de la Ciudad de Panamá y el Distrito de San Miguelito) rurales e indígenas de todo el país." || Module-level restriction, community questionnaire (same page): "i. Actividad Agropecuaria (sólo para las áreas rurales e indígenas)." || NO statement excluding any geographic region from the household sample itself was found.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+IMPORTANT for #603: the WB catalog record for ENV-2003 carries NO Universe field — the universe statement exists only inside the catalog-hosted technical report pan03bif.pdf, which is not mirrored in this repo. The local 2003/Documentation/ tree is questionnaires + the poverty-map report only. Small discrepancy to be aware of: the 2003 technical report gives 790,813 total private dwellings from Census 2000, while the 2008 sample-design document (muestra.pdf) gives 790,858 for the same census; both are quoted verbatim here, unreconciled. Whitespace normalised in the quotes (justified-PDF double spaces); wording, punctuation and figures unaltered. SAMPLE DESIGN (context only): random probabilistic design, ~8,000 dwellings, designed by Dr. Edmundo Berumen (who also designed the ENV-97 sample); frame = 69,709 census segments (38,857 urban, 30,852 rural incl. 4,808 indigenous); 15 inference domains listed on printed pp. 12-13; fieldwork 2003-08 to 2003-11.
+#+end_quote
+
+*** Panama 2008
+
+- Survey :: Encuesta de Niveles de Vida 2008 (ENV-08) / Living Standards Survey 2008
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: Spanish
+- Source file :: muestra.pdf ('DISEÑO MUESTRAL DE LA ENCUESTA DE NIVELES DE VIDA, JULIO 2008', Contraloría General de la República / Dirección de Estadística y Censo — WB Microdata catalog id 70 = PAN_2008_ENV_v01_M, resource download id 11488); reproduced verbatim as the Universe field of https://microdata.worldbank.org/index.php/catalog/70/study-description. NOT held locally: lsms_library/countries/Panama/2008/Documentation/ contains only hogar_V2.pdf, comunidad.pdf, precios.pdf.
+- Locator :: muestra.pdf, section '1. UNIVERSO DE ESTUDIO', printed pages 1-2 (PDF pages 1-2). Catalog duplicate: Coverage > Universe field on the catalog study-description page for id 70.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+1. UNIVERSO DE ESTUDIO  La encuesta de niveles de vida, consideró como universo de estudio a la población total residente en las viviendas particulares ocupadas del país, según el Censo de Población y Vivienda del 2000.  El universo, de acuerdo al objetivo de la investigación, se dividió en un sub-universo no indígena y en otro indígena; este último constituido por las comarcas del país y por las áreas rurales indígenas fuera de las áreas comarcales, y que mantienen sus patrones socio culturales.  El total de viviendas particulares en el país, según el Censo, ascendió a 790,858 unidades habitacionales particulares, de las cuales 496,971 se localizan en el área urbana (62.8%) y 293,887 pertenecen al área rural (37.2%). Las viviendas ocupadas representan el 86.2% de las viviendas particulares totales. El universo no indígena, por su parte, constituye un 95.8% y el indígena un 4.2% de las viviendas particulares totales del país.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+1. Study universe. The living standards survey took as its study universe the total population resident in the country's occupied private dwellings, according to the 2000 Population and Housing Census. The universe, in accordance with the objective of the research, was divided into a non-indigenous sub-universe and an indigenous one; the latter constituted by the country's comarcas and by the indigenous rural areas outside the comarca areas, which maintain their socio-cultural patterns. The total of private dwellings in the country, according to the Census, came to 790,858 private housing units, of which 496,971 are located in the urban area (62.8%) and 293,887 belong to the rural area (37.2%). Occupied dwellings represent 86.2% of total private dwellings. The non-indigenous universe, for its part, constitutes 95.8% and the indigenous 4.2% of the country's total private dwellings. [translation mine, not from the source]
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NO GEOGRAPHIC EXCLUSION FROM THE HOUSEHOLD SAMPLE WAS FOUND. Geographic Coverage field (catalog study-description page, catalog id 70), verbatim in full: "National coverage.\nDomains: Urban/rural; Panama City; Rest of Panama District; San Miguelito; West Panama; East Panama; Colon; Cocle; Herrera; Los Santos; Veraguas; Bocas del Toro; Chiriqui; Darien; Indigenous Area". || Module-level exclusion, prices questionnaire only (catalog Scope > Notes; identical wording to the ENV-03 report): "Precios en establecimientos. Cotización de precios de un conjunto de artículos de consumo cotidiano: alimentos, bebidas y tabaco (48 artículos), y bienes de aseo personal y del hogar (20 artículos) en áreas urbanas (a excepción de la Ciudad de Panamá y el Distrito de San Miguelito) rurales e indígenas de todo el país." || Module-level restriction, community questionnaire (catalog Scope > Notes): "Actividad Agropecuaria (sólo para las áreas rurales e indígenas)." || The universe unit is "viviendas particulares ocupadas" (occupied private dwellings), which by census convention excludes collective/institutional dwellings; the documentation does not spell this out and I do not assert it as a documented exclusion.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Note the unit shift versus 1997 and 2003: ENV-08 defines the universe as the resident POPULATION in occupied private dwellings (1997 and 2003 define it as the DWELLINGS themselves). Benchmark census is the 2000 Population and Housing Census. The explicit non-indigenous / indigenous sub-universe split — indigenous = the comarcas plus indigenous rural areas outside them — is the single most #603-relevant feature of this wave, and it is a design partition, not an exclusion: 550 of the 8,000 designed dwellings (55 of 800 PSUs) fall in the indigenous sample. Whitespace normalised in the quotes; wording, punctuation and figures unaltered. Small unreconciled discrepancy: 790,858 total private dwellings here vs 790,813 in the 2003 technical report, both citing Census 2000. SAMPLE DESIGN (context only): frame = 69,707 census segments (38,847 urban 55.7%, 30,860 rural 44.3%; 93.1% non-indigenous); two-stage stratified, PSUs = groupings of >=20 private dwellings selected PPS, SSUs = private dwellings; designed n = 8,000 dwellings (4,165 urban / 3,835 rural; 7,450 non-indigenous / 550 indigenous) in 800 PSUs; achieved 7,274 dwellings visited, 6,977 occupied-complete, 7,045 households, 26,162 persons; 1.4% refusal.
+#+end_quote
+
+** Peru
+
+*** Peru 1985
+
+- Survey :: Encuesta Nacional de Hogares sobre Medición de Niveles de Vida 1985 (ENNIV 1985-86) / Peru Living Standards Measurement Survey 1985-1986
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: es
+- Source file :: https://microdata.worldbank.org/index.php/catalog/597/study-description (WB Microdata Library, PER_1985_ENNIV_v01_M; DOI 10.48529/dsz6-gh05 — matches lsms_library/countries/Peru/1985/Documentation/SOURCE.org)
+- Locator :: Study Description page, section "Coverage" > "Universe" (and "Geographic Coverage" immediately above it). Saved HTML/text: /tmp/popdocs/cat/597.html, /tmp/popdocs/cat/597.txt lines 128-134.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+la población está definida como el conjunto de todas la viviendas particulares y sus ocupantes residentes o no de las áreas urbana y rural del país, con la excepción de tres departamentos.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+the population is defined as the set of all private dwellings and their occupants, resident or not, of the urban and rural areas of the country, with the exception of three departments.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Geographic Coverage: "Cobertura nacional con la exepción de tres departamentos que se encontraban en emergencia, a saber: / Ayacucho / Apurímac / Huancavelica" [sic, "exepción" as printed]. The Universe statement repeats: "... con la excepción de tres departamentos."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The three PDFs are all image-only scans; the machine-extractable text layer is empty (67/41/72 pages respectively). Local corroboration of the sample (NOT a universe statement) from PER14.pdf p.2, section 'Metodología de la Encuesta', VERBATIM: "La metodología utilizada en la encuesta, consistió en entrevistar una muestra aleatoria de 5,120 viviendas, proporcional a la distribución de la población, en las áreas urbanas como en las áreas rurales y en las regiones naturales del Perú, por un período de 12 meses." and the household definition VERBATIM: "Un \"hogar\" fue definido como un grupo de individuos que han dormido usualmente en la misma vivienda y han compartido las comidas, por lo menos durante 3 de los 12 meses anteriores a la entrevista." Note PER14 does NOT mention the Ayacucho/Apurímac/Huancavelica exclusion — that exclusion is documented only in the WB catalog record. Catalog sample-design detail (not the universe): "El tamaño de la muestra seleccionada a nivel nacional fue de 5,024 viviendas. La muestra del área urbana total fue de 2,688 viviendas (incluyendo Lima Metropolitana) y del área rural total de 2,336 viviendas." and inference levels "Total Naci onal, Nacional Urbano, Nacional Rural, Lima Metropolitana y Regiones Naturales (costa, sierra y selva)" [sic, spacing as in source].
+#+end_quote
+
+*** Peru 1990
+
+- Survey :: Encuesta Nacional de Hogares sobre Medición de Niveles de Vida 1990 (ENNIV 1990)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: subnational-area
+- Language of the quoted source :: es
+- Source file :: https://microdata.worldbank.org/index.php/catalog/596/study-description (WB Microdata Library, PER_1990_ENNIV_v01_M; DOI 10.48529/w7v4-sz09 — matches lsms_library/countries/Peru/1990/Documentation/SOURCE.org)
+- Locator :: Study Description page, section "Coverage" > "Universe" (and "Geographic Coverage" immediately above). Saved: /tmp/popdocs/cat/596.html, /tmp/popdocs/cat/596.txt lines 137-141.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+Todas las viviendas particulares y sus ocupantes, de todos los distritos de Lima metropolitana (inclutyendo Callao)
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+All private dwellings and their occupants, in all the districts of metropolitan Lima (including Callao)
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Geographic Coverage: "La encuesta sólamente cubre el área metropolitana de Lima, la capital del Perú" — i.e. the whole of Peru outside Metropolitan Lima is outside the universe. [sic: "sólamente", "inclutyendo" as printed in the source.]
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+STRONG LOCAL CORROBORATION of the Lima-only scope: the cover sheet of the local questionnaire pe90hhq.pdf reads, VERBATIM: "ENCUESTA DE HOGARES / SOBRE MEDICION DE NIVELES DE VIDA / JUNIO 1990 / IDENTIFICACION DE LA VIVIENDA SELECCIONADA / LIMA METROPOLITANA" (p.1). That is a scope label on the instrument, not a universe statement, so the universe quote itself is taken from the catalog. Catalog Series Information (context, not universe): "La segunda verisón, 1990, constituye un panel de datos para el Área Metropolitana de Lima, capital del Perú." [sic]. Sample design (not universe): "La muestra es probabilística y bietápica, y no es autoponderada." ... total "1540 viviendas seleccionadas (154 conglomerados)".
+#+end_quote
+
+*** Peru 1991
+
+- Survey :: Encuesta Nacional de Hogares sobre Medición de Niveles de Vida 1991 (ENNIV 1991)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: es
+- Source file :: https://microdata.worldbank.org/index.php/catalog/618/study-description (WB Microdata Library, PER_1991_ENNIV_v01_M; DOI 10.48529/n513-d685 — matches lsms_library/countries/Peru/1991/Documentation/SOURCE.org)
+- Locator :: Study Description page, "Coverage" > "Universe" (line 179 of /tmp/popdocs/cat/618.txt) and "Coverage" > "Geographic Coverage" (lines 164-177). Saved: /tmp/popdocs/cat/618.html, /tmp/popdocs/cat/618.txt.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+Población nacional
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+National population
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+No explicit exclusion statement. The catalog's "Geographic Coverage" field instead enumerates the covered domains, VERBATIM: "La Población de la ENNIV 1991, es el conjunto de viviendas particulares y sus ocupantes de las siguientes zonas geográficas: / Norte / Costa Urbana / Sierra Urbana / Sierra Rural / Centro / Sierra Urbana / Sierra Rural / Sur / Costa Urbana / Sierra Urbana / Sierra Rural / Lima Metropolitana". Field-level non-coverage is recorded under Sampling, VERBATIM: "Esto último sucedió en los distritos de Puquina (Moquegua) y July (Puno)." ... "Por otro lado en el departamento de Cajamarca, en los distritos de Asunción, Llapa y San Pablo, no se pudo visitar los caseríos, según ellos por carecer de la documentación apropiada para respaldar esta labor, además la policía no se hacía responsable de la seguridad de las encuestadoras." ... "En la Sierra Centro Rural fue necesario reemplazar 2 segmentos ya que a causa del terrorismo no había la mínima seguridad para trabajar."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Confidence is 'medium' because the catalog's Universe field is a two-word statement ("Población nacional") that sits in tension with the enumerated Geographic Coverage, which lists nine domains covering only Costa Urbana, Sierra Urbana, Sierra Rural (in Norte/Centro/Sur) plus Lima Metropolitana — Selva and Costa Rural do not appear in the list. I am NOT asserting that Selva/Costa Rural were excluded; I record only that the coverage list as printed does not name them, and that the Universe field says 'Población nacional'. Anyone relying on this cell should resolve the discrepancy against the INE/Cuánto technical document, which is not present in this repo. Sample design (not universe): "El tamaño de la muestra fue de 2,252 viviendas distribuídas en 9 dominios."; the Lima sample was "la misma encuestada en la ENNIV 85-86, más un 15% de viviendas seleccionadas de la ampliación muestral trabajada para ENNIV 90". Unit of Analysis (catalog): "Es el hogar integrado por una o más personas, sean o no parientes, que residan habitualmente en una misma vivienda y que atiendan en común sus necesidades vitales."
+#+end_quote
+
+*** Peru 1994
+
+- Survey :: Encuesta Nacional de Hogares sobre Medición de Niveles de Vida 1994 (ENNIV 1994)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: es
+- Source file :: https://microdata.worldbank.org/index.php/catalog/617/study-description (WB Microdata Library, PER_1994_ENNIV_v01_M; DOI 10.48529/ntxg-ed63 — matches lsms_library/countries/Peru/1994/Documentation/SOURCE.org)
+- Locator :: Study Description page, "Coverage" > "Universe" (line 157 of /tmp/popdocs/cat/617.txt) and "Geographic Coverage" (line 155). Saved: /tmp/popdocs/cat/617.html, /tmp/popdocs/cat/617.txt.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+El universo a cubrir es la totalidad de hof¡gares en el territorio nacional
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+The universe to be covered is the totality of households in the national territory. ["hof¡gares" is a typo for "hogares" in the source; quoted here exactly as printed.]
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+No exclusion statement found. Geographic Coverage, VERBATIM: "El ámbito geográfico de la investigación abarcó a todo el territorio nacional: Costa, Sierra y Selva".
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The local 1994 documentation is rich but states scope only through sample counts, never a universe. Closest local statements, VERBATIM, from m-encues.pdf (MANUAL DEL ENCUESTADOR, section I. INTRODUCCION): "El Instituto Cuánto, con el apoyo financiero del Banco Mundial y el Banco Interamericano de Desarrollo, ejecutará a nivel Nacional la Encuesta de Hogares sobre Medición de Niveles de Vida (ENNIV-94)." and "La ENNIV 1994 será efectuada en 3,544 viviendas en todo el País. La muestra incluye: 820 viviendas en Lima Metropolitana, 1380 viviendas en el área urbana y 1344 viviendas en el área rural." From programa.pdf, section '3. CARACTERISTICAS BASICAS DE LA ENCUESTA': "La operación de campo de la encuesta se ejecutará simultáneamente en las 3 regiones naturales." Sampling-unit definitions (local, m-encues.pdf §6.1-6.3): "Son las viviendas particulares que se obtienen del marco muestral. Dichas viviendas serán las unidades de empadronamiento."; "Vivienda Particular: Es todo local formado por un cuarto o conjunto de cuartos, estructuralmente separada e independiente y destinada al alojamiento de uno o más hogares."; "Hogar: Es la persona o conjunto de personas, sean o no parientes, que residen habitualmente en una misma vivienda particular, ocupándola total o parcialmente y que atienden en común sus alimentos." (programa.pdf §4.4 adds the residence rule: "...que residen habitualmente más de 7 meses en los últimos 12 meses en una misma vivienda particular..."). Note the ENNIV-94 sample is partly a panel: "La muestra ha considerado las viviendas seleccionadas de la ENNIV-1991 y siguiendo la misma metodología, se han seleccionado las unidades muestrales en las áreas no estudiadas en 1991" (catalog Sampling Procedure; identical sentence appears in the local m-encues.pdf).
+#+end_quote
+
+** Senegal
+
+*** Senegal 2018-19
+
+- Survey :: Enquête Harmonisée sur le Conditions de Vie des Ménages 2018-2019 (EHCVM 2018/19) — Harmonized Survey on Households Living Standards 2018-2019
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Senegal/2018-19/Documentation/ddi-documentation-english_microdata-4297.pdf
+- Locator :: PDF page 3, section "Coverage" > "UNIVERSE" (immediately after "GEOGRAPHIC COVERAGE: National coverage"). Identical text confirmed in the WB DDI XML export for study 4297: <universe><![CDATA[The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.]]></universe>
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+SOURCE.org contains only [[https://doi.org/10.48529/hhhx-j012]] (no #+CATALOG_ID: keywords yet); catalog id resolved as 4297 / idno SEN_2018_EHCVM_v02_M via _wb_catalog_search('SEN').  SAMPLE DESIGN (not the universe; quoted verbatim from the same DDI PDF, section "Sampling" > "SAMPLING PROCEDURE", PDF page 4): "The Senegal EHCVM 2018/19 sample covers all regions with urban and rural areas surveyed in all regions." / "Upon deciding on the sample size and repartition, the survey design team implemented a 2-stage sampling methodology. At the first stage, 598 enumeration areas (EAs) were selected from the sample frame. In the second stage, 12 households were selected in each enumeration area randomly." / "The total survey sample size is 7156 households - 3941 from urban areas and 3215 from rural areas."  RELATED (representativeness, from ABSTRACT, PDF page 2): "The EHCVM is a nationally representative survey of 7,100 households, which are also representative of the geopolitical zones (at both the urban and rural level)." GEOGRAPHIC COVERAGE (PDF page 3): "National coverage".  Note there is NO urban exclusion and no dropped region: urban and rural are both sampled in all 14 regions.
+#+end_quote
+
+*** Senegal 2021-22
+
+- Survey :: Enquête Harmonisée sur le Conditions de Vie des Ménages, 2021-2022 (EHCVM-2) — alternate title "SEN EHCVM-2 2021-2022"
+- Source type :: not-found
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: not-stated
+- Language of the quoted source :: (not recorded)
+- Source file :: (none -- no statement to locate)
+- Locator :: (none -- no statement to locate)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No universe/target-population statement exists for this wave in any local or catalog source. Recording the gap rather than inferring one.  The CLOSEST statements found, quoted verbatim and clearly NOT universe statements:  (a) WB catalog 6278, study_info > geog_coverage: "National coverage"  (b) WB catalog 6278, series_statement > series_info: "The Senegal EHCVM 2021/22 is the second edition of a nationally representative household survey conducted within the West Africa Economic Monetary Union (WAEMU) Household Survey harmonization Project (P153702) a joint program by the World Bank and the WAEMU Commision that aims at producing household survey data in member countries (Benin, Burkina Faso, Chad, Cote d'Ivoire, Guinea Bissau, Mali, Niger, Senegal and Togo). The survey covers all regions and includes approximately 7,100 households."  (c) WB catalog 6278, study_info > abstract: "The EHCVM is a nationally representative survey of 7,100 households, which are also representative of the geopolitical zones (at both the urban and rural level)."  (d) SAMPLE DESIGN — WB catalog 6278, method > data_collection > sampling_procedure: "The sampling base for the 2018/2019 survey was the General Census of Population and Housing, Agriculture, and Livestock (RGPHAE) of 2013. In 2021/2022, a enumeration was conducted in the same clusters. The Senegal EHCVM 2018/19 sample covers all regions with urban and rural areas surveyed in all regions." ... "The total survey sample size is 7,120 households - 3,922 from urban areas and 3,198 from rural areas."  (e) SAMPLE DESIGN — Basic Information Document (French), catalog/6278/download/100389, section "4. Échantillonnage / 4.1. Volet ménage et communautaire": "La base de sondage de l'enquête de 2018/2019 est le Recensement général de la Population et de l'Habitat, de l'Agriculture et de l'Elevage (RGPHAE) de 2013. En 2021/2022, il a été procédé à un dénombrement dans les mêmes grappes." / "L'édition 2 est une enquête de panel par grappes et le plan d'échantillonnage s'appuie sur celui de l'enquête de 2018/2019." / "L'échantillon de l'enquête de 2018/2019 a été tiré selon un plan de sondage stratifié à deux degrés. La strate est la combinaison région/milieu de résidence."  The English BID says the same: "The second edition is a cluster panel survey, and the sampling plan builds upon that of the 2018/2019 survey." — i.e. 2021-22 re-samples the SAME clusters as 2018-19, so the 2018-19 universe statement is the natural candidate to inherit. That inheritance is an INFERENCE, not a documented claim, and must not be recorded as this wave's universe without a human decision.
+#+end_quote
+
+** Serbia
+
+*** Serbia 2007
+
+- Survey :: Serbia - Living Standards Measurement Survey 2007 (LSMS 2007), Statistical Office of the Republic of Serbia / World Bank
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Serbia/2007/Documentation/ddi-documentation-english_microdata-2291.pdf
+- Locator :: p. 3, section "Sampling" > "Sampling Procedure" (paragraphs 1-2)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The population for LSMS consists of Republic of Serbia residents, excluding Kosovo and Metohija . The sampling frame for the LSMS was based on the Enumeration District (ED) delineated for the 2002 Serbia Census, excluding those with less than 20 households. It is estimated that the households in the excluded EDs only represent about 1 percent of the population of Serbia.  The sampling frame also excludes the population living in group quarters, institutions and temporary housing units, as well as the homeless population: these groups also represent less than 1 percent of the population, so the sampling frame should cover at least 98 percent of the Serbian population.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"excluding Kosovo and Metohija"; "excluding those [Enumeration Districts] with less than 20 households"; "The sampling frame also excludes the population living in group quarters, institutions and temporary housing units, as well as the homeless population: these groups also represent less than 1 percent of the population, so the sampling frame should cover at least 98 percent of the Serbian population."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Only one wave exists for Serbia in this repo (Country('Serbia').waves == ['2007']).  The SAME universe statement appears verbatim in a second, independent local document: the English study report studijaE.pdf ('Living Standards Measurement Study - Serbia 2002-2007'), p. 166, section 12.3. Sampling > 12.3.1. Sample description, which reads: "The population for LSMS consists of Republic of Serbia residents, excluding Kosovo and Metohija.  The sampling frame for the LSMS was based on the Enumeration Districts (ED) delineated for the 2002 Serbia Census, excluding those with less than 20 households.  It is estimated that the households in the excluded EDs only represent about 1 percent of the population of Serbia.  The sampling frame also excludes the population living in group quarters, institutions and temporary housing units, as well as the homeless population; these groups also represent less than 1 percent of the population, so the sampling frame should cover at least 98 percent of the Serbian population." (Two trivial differences from the DDI text, reproduced above as they appear in each source: the DDI writes "Enumeration District (ED)" singular and uses a colon before "these groups", where the report writes "Enumeration Districts (ED)" and a semicolon.)  The WB catalog page for study 2291 has no field explicitly labelled 'Universe'; its Sampling Procedure text matches the DDI verbatim.  SAMPLE DESIGN (not the universe; recorded for context, verbatim from the DDI p. 3): "Stratification was done in the same way as for the previous LSMSs. Enumeration District werestratified according to: - Region in 6 strata (Vojvodina, Belgrade, West Serbia, Sumadija and Pomoravlj e, East Serbia and South East Serbia). - Type of settlement (urban and other)." and "The sample size for LSMS 2007 was 71 40 households from 510 selected EDs. Within each ED 14 occupied dwellings were selected. From each selected occupied dwellings one household was selected (using a Kish Grid). The sample size was determined according with the aim of achieving 5,000 household interviews with an expected non-response rate of around 30%. The final response rate was 78%, producing a sample size of 5,557 households." (The odd spacings 'werestratified', 'Pomoravlj e', '71 40' are artefacts of the source PDF's own text layer and are quoted as extracted; the study report renders these as 'were stratified', 'Pomoravlje', '7140'.)  Note for #603: this is a NATIONAL survey covering both urban and 'other' (non-urban) settlements - type of settlement is a stratification dimension, not an exclusion. The substantive geographic exclusion is Kosovo and Metohija.
+#+end_quote
+
+** Serbia and Montenegro
+
+*** Serbia and Montenegro 2002
+
+- Survey :: Living Standards Measurement Survey 2002 (General Population, Wave 1 Panel) and Family Income Support Survey 2002
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Serbia and Montenegro/2002/Documentation/LSMS_Project_2002_2003_text.pdf
+- Locator :: Chapter "METHODOLOGY", section 1.3 "Basic Methodological Assumptions", subsection "Sample frame", printed p. 26 (= PDF page 26). Objectives quote: section 1.1 "Objectives", printed p. 24. Geographic-coverage quote: World Bank Microdata catalog id 80, IDNO SCG_2002_LSMS_v01_M, study_desc.study_info.geog_coverage.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+Sample frame: Sample frame for both surveys of general population in 2002 and 2003 consisted of all permanent residents of Serbia, without the population of Kosovo and Metohija, according to definition of permanently resident population contained in UN Recommendations for Population Censuses, which were applied in 2002 Census of Population in the Republic of Serbia. Therefore, permanent residents were all persons living in the territory Serbia longer than one year, with the exception of diplomatic and consular staff.  The sample frame for the survey of Family Income Support recipients included all current recipients of this program on the territory of Serbia based on the official list of recipients given by Ministry of Social Affairs.  [Section 1.1 Objectives, p. 24:] "LSMS represents multi-topical study of household living standard and is based on international experience in designing and conducting this type of research. The basic survey was carried out in 2002 on a representative sample of households in Serbia (without Kosovo and Metohija)."  [Catalog, Geographic coverage:] "The surveys were conducted on the whole territory of Serbia (without Kosovo and Metohija)."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"without the population of Kosovo and Metohija" ... "with the exception of diplomatic and consular staff" (LSMS_Project_2002_2003_text.pdf, p. 26, "Sample frame"). Also, from the objectives, p. 24: "a representative sample of households in Serbia (without Kosovo and Metohija)". Catalog geographic coverage: "The surveys were conducted on the whole territory of Serbia (without Kosovo and Metohija)."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+SAMPLE-DESIGN detail (not the universe): two-stage stratified sample; PSU = enumeration districts selected PPS to number of households; SSU = households; six territorial strata (Vojvodina, Belgrade, Western Serbia, Central Serbia (Sumadija and Pomoravlje), Eastern Serbia, South-east Serbia), each further stratified urban/rural. Planned 6,500 households; 7,491 contacted, 6,386 interviewed in 621 census rounds, 19,725 persons; response rate 85.2%. Family Income Support (MOP) sample: 500 planned, 456 achieved, drawn randomly from the Ministry of Social Affairs recipient list.  IMPORTANT SCOPE POINT: the country label is 'Serbia and Montenegro' but every universe statement in the documentation covers SERBIA ONLY (and excludes Kosovo and Metohija). Montenegro is nowhere claimed as covered. Neither the local documentation nor the catalog contains an explicit statement that Montenegro was excluded; the exclusion is what the affirmative statements ('the whole territory of Serbia', 'all permanent residents of Serbia') imply. I record that as an observation, not as a quotation.  The 2002 wave directory contains TWO distinct samples: the general-population LSMS ('2002 N ....dta' files) and the Family Income Support / MOP survey ('mop_*.dta' files). They have different universes; both are quoted above.  The World Bank DDI record has NO 'universe' field (grep for 'universe' in the exported JSON returns 0 hits). The sample-frame paragraph reproduced above appears verbatim (modulo whitespace) in the catalog's method.data_collection.sampling_procedure, corroborating the local PDF.  TRANSCRIPTION NOTE: the PDF is typeset with justified text, so pdfminer extraction contains hyphenated line breaks and multiple internal spaces (e.g. 'permanently  resident  population', 'Popu-\nlation'). I have rejoined hyphenated words and collapsed runs of spaces to single spaces. No word, punctuation mark, or spelling has been altered. The catalog's identical passage confirms the rejoining.  LANGUAGE NOTE: the shipped report is the English edition (LSMS Project 2002-2003: Life in Serbia through the Survey Data, SMMRI / Strategic Marketing, Belgrade, 2007; translated by Lidija Babovic). It is itself a translation of a Serbian original, which is not in this repository. The quotes above are verbatim from the English edition as shipped.
+#+end_quote
+
+*** Serbia and Montenegro 2003
+
+- Survey :: Living Standards Measurement Survey 2003 (General Population, Wave 2 Panel) and Roma Settlement Survey 2003
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: region-excluded
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Serbia and Montenegro/2003/Documentation/LSMS_Project_2002_2003_text.pdf
+- Locator :: Chapter "METHODOLOGY", section 1.3 "Basic Methodological Assumptions", subsection "Sample frame", printed p. 26 (= PDF page 26). Roma-exclusion quote: section 1.1 "Objectives", printed p. 25. Panel/objectives quote: printed p. 24. Geographic-coverage quote: World Bank Microdata catalog id 81, IDNO SCG_2003_LSMS_v01_M, study_desc.study_info.geog_coverage.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+Sample frame: Sample frame for both surveys of general population in 2002 and 2003 consisted of all permanent residents of Serbia, without the population of Kosovo and Metohija, according to definition of permanently resident population contained in UN Recommendations for Population Censuses, which were applied in 2002 Census of Population in the Republic of Serbia. Therefore, permanent residents were all persons living in the territory Serbia longer than one year, with the exception of diplomatic and consular staff.  The definition of the Roma population from Roma settlements was faced with obstacles since precise data on the total number of Roma population in Serbia are not available. According to the last population Census from 2002 there were 108,000 Roma citizens, but the data from the Census are thought to significantly underestimate the total number of the Roma population. However, since no other more precise data were available, this number was taken as the basis for estimate on Roma population from Roma settlements. According to the 2002 Census, settlements with at least 7% of the total population who declared itself as belonging to Roma nationality were selected. A total of 83% or 90,000 self-declared Roma lived in the settlements that were defined in this way and this number was taken as the sample frame for Roma from Roma settlements.  [On the 2003 general-population sample being a panel, section 1.1 Objectives, p. 24:] "The survey was repeated in 2003 on a panel sample32." [footnote 32, p. 24: "The households which participated in 2002 survey were interviewed"]  [Catalog, Geographic coverage:] "The surveys were conducted on the whole territory of Serbia (without Kosovo and Metohija)."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"without the population of Kosovo and Metohija" ... "with the exception of diplomatic and consular staff" (LSMS_Project_2002_2003_text.pdf, p. 26, "Sample frame"). For the Roma settlement sample, p. 25: "However, it is necessary to stress that the LSMS of the Roma population comprised potentially most imperilled Roma, while the Roma integrated in the main population were not included in this study." Catalog geographic coverage: "The surveys were conducted on the whole territory of Serbia (without Kosovo and Metohija)."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The 2003 Documentation/ directory ships the SAME methodology report as 2002 (LSMS_Project_2002_2003_text.pdf, identical DVC md5 4aa224781967e012b8f6a76c7ad4cbc6 in both wave dirs). That report covers both years explicitly ('both surveys of general population in 2002 and 2003'), so the universe statement is a joint one, not a 2002-only statement reused.  SAMPLE-DESIGN detail (not the universe): the 2003 general-population sample is a PANEL subsample of 2002 -- 'first-stage units (census block units) were selected from the basic sample obtained in 2002 by including only even numbered census block units ... In each selected enumeration district the same households interviewed in the previous round were included and interviewed.' Planned 3,000 households; 3,119 selected, 2,548 realized (81.7%), 8,027 persons. Roma settlement sample: two-stage stratified, PSU = settlements where Roma were over 7% of population, SSU = Roma households, three territorial strata (Vojvodina, Beograd, Central Serbia); 500 planned, 525 achieved. Non-response correction by gender, age and number of household members.  IMPORTANT SCOPE POINT: as for 2002, the country label is 'Serbia and Montenegro' but every universe statement covers SERBIA ONLY (excluding Kosovo and Metohija). Montenegro is nowhere claimed as covered, and there is no verbatim statement excluding it -- that is an inference from the affirmative statements, recorded here as an observation, not as a quotation.  The 2003 wave directory contains TWO distinct samples: the general-population panel LSMS ('2003 N ....dta' files) and the Roma settlement survey ('roma_*.dta' files). They have different universes; both are quoted above. The Roma sample's universe is explicitly NOT all Roma in Serbia -- see the exclusions field.  The World Bank DDI record has NO 'universe' field (grep for 'universe' in the exported JSON returns 0 hits). The sample-frame paragraph reproduced above appears verbatim (modulo whitespace) in the catalog's method.data_collection.sampling_procedure, corroborating the local PDF.  TRANSCRIPTION NOTE: same as 2002 -- hyphenated line breaks rejoined and runs of spaces collapsed; no words, punctuation or spellings altered. Note the British spelling 'imperilled' is as printed.  LANGUAGE NOTE: English edition (SMMRI / Strategic Marketing, Belgrade, 2007), itself a translation from Serbian; the Serbian original is not in this repository.
+#+end_quote
+
+** South Africa
+
+*** South Africa 1993
+
+- Survey :: Project for Statistics on Living Standards and Development (PSLSD) 1993 / catalogued by the World Bank LSMS collection as "Integrated Household Survey 1993" (ZAF_1993_IHS_v01_M, catalog id 297); the identical study is also catalogued in the WB `datafirst` collection as ZAF_1993_PSLSD_v01_M (catalog id 902). Conducted by the Southern Africa Labour and Development Research Unit (SALDRU), University of Cape Town.
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: World Bank Microdata Library DDI XML export for study 902 (https://microdata.worldbank.org/index.php/metadata/export/902/ddi, idno ZAF_1993_PSLSD_v01_M) for the <universe> element; and for study 297 (https://microdata.worldbank.org/index.php/metadata/export/297/ddi, idno ZAF_1993_IHS_v01_M -- the record identified by the DOI in lsms_library/countries/South Africa/1993/Documentation/SOURCE.org) for <sampProc>/<geogCover>/<abstract>/<weight>/<dataAppr>.
+- Locator :: codeBook/stdyDscr/stdyInfo/sumDscr/universe (study 902); codeBook/stdyDscr/method/dataColl/sampProc, .../sumDscr/geogCover, .../sumDscr/geogUnit, .../sumDscr/anlyUnit, .../stdyInfo/abstract, codeBook/stdyDscr/method/anlyInfo/... <weight>, and <dataAppr> (studies 297 and 902). Catalog landing pages: https://microdata.worldbank.org/index.php/catalog/297 and .../catalog/902.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+DDI <universe> (catalog 902, ZAF_1993_PSLSD_v01_M): "All Household members.  Individuals in hospitals, old age homes, hotels and hostels of educational institutions were not included in the sample. Migrant labour hostels were included. In addition to those that turned up in the selected ESDs, a sample of three hostels was chosen from a national list provided by the Human Sciences Research Council and within each of these hostels a representative sample was drawn on a similar basis as described above for the households in ESDs."  DDI <geogCover> (both catalog 297 and 902): "National coverage"  DDI <geogUnit> (catalog 902): "Enumeration Area"  DDI <anlyUnit> (both records): "- Households - Individuals - Community"  DDI <abstract> (both records), first two sentences: "The Project for Statistics on Living standards and Development was a coutrywide World Bank Living Standards Measurement Survey. It covered approximately 9000 households, drawn from a representative sample of South African households."  (NOTE: the WB `lsms` record we hold, catalog 297, has NO <universe> element at all. Its <sampProc> ends with the same exclusion sentences, quoted under exclusions_verbatim.)
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+DDI <universe> (catalog 902) and closing paragraph of DDI <sampProc> (catalog 297), verbatim: "Individuals in hospitals, old age homes, hotels and hostels of educational institutions were not included in the sample. Migrant labour hostels were included. In addition to those that turned up in the selected ESDs, a sample of three hostels was chosen from a national list provided by the Human Sciences Research Council and within each of these hostels a representative sample was drawn on a similar basis as described above for the households in ESDs."  (Character-level variant: in the catalog-297 <sampProc> copy the same sentence reads "...on a similar basis as described abovefor the households in ESDs." -- 'abovefor' run together. The catalog-902 <universe> copy has the space. Otherwise identical.)  Separately, a post-collection deletion is recorded in DDI <dataAppr> (both records): "The data collected in clusters 217 and 218 should be viewed as highly unreliable and therefore removed from the data set. The data currently available on the web site has been revised to remove the data from these clusters. Researchers who have downloaded the data in the past should revise their data sets. For information on the data in those clusters, contact SALDRU http://www.saldru.uct.ac.za/."  And a fieldwork-failure exclusion recorded in DDI <weight> (catalog 297): "A number of factors intervened, however, which made it essential to use weights after all. Amongst these was violence, which prevented survey teams from conducting interviews in two clusters on the East Rand; failure to continue interviewing in a cluster until the required take had been interviewed; and systematic under-representation of whites in the sample."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+ONE WAVE ONLY. Country('South Africa').waves == ['1993']; the only directories under lsms_library/countries/South Africa/ are _, var and 1993.  SOURCE PROVENANCE CAVEAT (important for how much weight to put on the quote): the <universe> element quoted above comes from WB `datafirst` catalog 902, NOT from catalog 297 -- the record that this wave's SOURCE.org DOI actually points at. They are the same underlying survey; lsms_library/data_access.py (line ~127) and .claude/skills/add-wave/SKILL.md both state this explicitly ('`datafirst` 902 (`ZAF_1993_PSLSD`) is the same 1993 South African survey' as `lsms` 297). The claim is further corroborated character-for-character: the exclusion paragraph in 902's <universe> is verbatim identical to the closing paragraph of 297's <sampProc>. I have NOT inferred anything from the microdata itself.  SAMPLE DESIGN (context only, not the universe -- DDI <sampProc>, catalog 297): 'Sample size is 9,000 households ... The sample design adopted for the study was a two-stage self-weightingdesign in which the first stage units were Census Enumerator Subdistricts (ESDs, or their equivalent) and the second stage were households. ... For most of the country, census ESDs were used. Where some ESDs comprised relatively large populations as for instance in some black townships such as Soweto, aerial photographs were used to divide the areas into blocks of approximately equal population size. In other instances, particularly in some of the former homelands, the area units were not ESDs but villages or village groups. ... The sampling interval for the selection of the ESDs was obtained by dividing the 1991 census population of 38,120,853 by the 300 clusters to be selected. ... In three or four instances, the ESD chosen was judged inaccessible and replaced with a similar one.' Stratification: 'listing the area stage units (ESDs) by statistical region and then within the statistical region by urban or rural. Within these sub-statistical regions, the ESDs were then listed in order of percentage African.' Note this is a 1993 apartheid-era frame: the sampling frame is the 1991 census including the former homelands (Transkei, Bophuthatswana, Venda, Ciskei, Qwa-Qwa, Lebowa, Gazankulu, KwaNdebele, KwaZulu, KaNgwane), which the <collSitu> element confirms were covered by named fieldwork organisations. Fieldwork dates (DDI coll_dates): 1993-08 to 1993-12.  WHAT IS *NOT* IN THE DOCUMENTATION: neither record contains any statement of the form 'all private households in ...'. The strongest inclusion statements available are the three-word <universe> line 'All Household members.', <geogCover> 'National coverage', and the abstract's 'drawn from a representative sample of South African households'. If GH #603 needs a crisper universe sentence for South Africa 1993, it does not exist in either the local documentation or the WB catalog metadata; the SALDRU PSLSD 1993 final report (SALDRU, 'South Africans Rich and Poor: Baseline Household Statistics', 1994) is a plausible further source but is not held in this repo and was not consulted.
+#+end_quote
+
+** Tajikistan
+
+*** Tajikistan 1999
+
+- Survey :: Tajik Living Standards Survey (TLSS) 1999 / Living Standards Survey 1999 (TJK_1999_LSMS_v01_M, WB catalog id 279)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: "BASIC INFORMATION / LIVING STANDARDS SURVEY IN THE REPUBLIC OF TAJIKISTAN (TLSS) / JUNE 2000" - Technical document attached to WB Microdata catalog entry 279; downloaded from https://microdata.worldbank.org/catalog/279/download/11687 (local working copy: /tmp/popdocs_tjk_docs/tjk1999_summary.pdf). NOT present in the repo's lsms_library/countries/Tajikistan/1999/Documentation/.
+- Locator :: Section "Field work" -> "Sampling", document page 3 (PDF page 5). Exclusion quote is footnote 1 on the same document page (PDF page 5).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The TLSS sample was designed to represent the population of the country as a whole as well as the strata. The sample was stratified by oblast and by urban and rural areas.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a - source is in English
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+In addition to the main sample, the TLSS also included a secondary sample of 15 extra PSU (containing 400 households) in Dangara and Varzob. Data in the oversampled areas were collected for the sole purpose of providing baseline data for the World Bank Health Project in these areas. The sampling for these additional units was carried out separately after the main sampling procedure in order to allow for their exclusion in nationally representative analysis.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+There is no field literally labelled 'Universe' anywhere for this study: the NADA catalog API metadata has no 'universe' key and the rendered catalog page contains the string 'Universe' zero times. The quote above is the strongest universe statement available and is reproduced verbatim and identically in the catalog's Sampling Procedure field. Corroborating verbatim quotes: (a) WB catalog 279, study_info.geog_coverage: "National coverage.\nThe TLSS sample was designed to represent the population of the country as a whole as well as the strata. The sample was stratified by oblast and by urban and rural areas."; (b) same BID, Introduction (document p. 2): "The TLSS was carried out between May-June of 1999. A total of 2,000 households containing 14,142 individuals were interviewed. Households were randomly selected over 125 population points, which were stratified across urban and rural areas within oblasts, to ensure a nationally representative sample."; (c) catalog technical document 'Methodology of living standard survey sampling in the Republic of Tajikistan' (https://microdata.worldbank.org/catalog/279/download/11689), p. 1: "Sampling for the living standard survey is in general to provide representativeness of the population therefore it was based on the number of population of the republic, urban and rural population i.e. specific gravity of the urban and rural population, and also administrative territorial division i.e. in oblast levels (see Appendix)."; (d) same BID, section 'Weights': "Since the sample is nationally representative there are no weighting variables." Sample design detail (not the universe): two-stage sample, 125 PSU selected PPS within strata, 16 households per PSU, 4 reserve households per PSU, 2,000 households total; oblasts at the time were Leninabad, Khatlon, RRS, GBAO plus separately administered Dushanbe. No statement was found anywhere excluding institutional population, nomads, refugees, military/collective quarters, or any region for security or accessibility reasons; grep for 'institution|collective|barrack|military|homeless|nomad|refugee|dormitor|prison|not covered|were excluded|does not cover|inaccessib|security reason' over the BID and the sampling-methodology document returned only unrelated hits (education/community-module content).
+#+end_quote
+
+*** Tajikistan 2003
+
+- Survey :: Tajikistan Living Standards Survey (TLSS) 2003 / Living Standards Survey 2003 (TJK_2003_LSMS_v01_M, WB catalog id 278)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: "Tajikistan Living Standards Survey, 2003 / Notes for Users of the Data" - Technical document attached to WB Microdata catalog entry 278; downloaded from https://microdata.worldbank.org/catalog/278/download/11666 (local working copy: /tmp/popdocs_tjk_docs/tjk2003_instructions.pdf). NOT present in the repo's lsms_library/countries/Tajikistan/2003/Documentation/.
+- Locator :: Page 1 (unnumbered first page), opening paragraph; the second sentence of the quote is the standalone sentence four paragraphs further down the same page.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The Tajikistan Living Standards Survey (TLSS) for 2003 was based on a stratified random probability sample, with the sample stratified according to oblast and urban/rural settlements and with the share of each strata in the overall sample being in proportion to its share in the total number of households as recorded in the 2000 Census. ... The 2003 data are representative at the regional level (4 regions) and urban/rural.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a - source is in English
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND - no exclusion statement of any kind (institutional population, nomads, refugees, regions dropped for security or accessibility) appears in the 2003 documentation examined.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No field labelled 'Universe' exists for this study (0 hits on the catalog page; no 'universe' key in the API metadata). The quoted text is reproduced verbatim and identically in the catalog's study_info.geog_coverage ("National coverage. The 2003 data are representative at the regional level (4 regions) and urban/rural.") and method.data_collection.sampling_procedure fields, so the catalog metadata and the Notes-for-Users document agree word for word. The elision '...' in the population quote spans intervening sample-design text (comparison to TLSS 1999, oversampling by 40 percent in Dushanbe, 300 percent in rural GBAO and 600 percent in urban GBAO, sample size 4,156 households vs 2,000 in 1999) plus a paragraph describing the four oblasts. Notes for Users also states verbatim: "This is not a panel survey with the Tajikistan Living Standards Survey done in 1999." and "The weight variable is wgt_nat." The document footnotes its sampling paragraph to "Republic of Tajikistan: Poverty Assessment Update", Report No. 30853, World Bank, January 2005.
+#+end_quote
+
+*** Tajikistan 2007
+
+- Survey :: Tajikistan Living Standards Survey (TLSS07) 2007 / Living Standards Survey 2007 (TJK_2007_TLSS_v01_M, WB catalog id 72)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Tajikistan/2007/Documentation/ddi-documentation-english_microdata-72.pdf (fetched via data_access.get_data_file('Tajikistan/2007/Documentation/ddi-documentation-english_microdata-72.pdf'))
+- Locator :: PDF page 3, section "Sampling" -> "Sampling Procedure". Identical text appears in the Basic Information Document, TLSS 2007 (July 2008), section "Sample Design", document page 6, and again in its Appendix B "Sample Design for the Tajikistan Living Standard Survey 2007", document page 23.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The TLSS sample was designed to allow reliable estimation of poverty and most variables for a variety of other living standard indicators at the various domains of interest based on a representative probability sample on the level of: - Tajikistan as a whole - Total urban and total rural areas - The five main administrative regions (oblasts) of the country: Dushanbe, Rayons of Republican Subordination (RRS), Sogd, Khatlon, and Gorno-Badakhshan Autonomous Oblast (GBAO)
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a - source is in English
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND - no statement excluding any population group or area from the survey universe. The only 'exclusion' language found concerns fieldwork/data quality, not the universe: "During the monitoring process, it was discovered that data from 216 households in the Sughd Oblast had to be excluded.4 Information from these households was re-collected during the Second Round of data collection (see Appendix F)." (footnote 4: "There were 1,008 households in the total sample in the Sughd Oblast.")
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Bullet markers in the source are typographic bullets; rendered as '-' here. The line breaks in the original PDF are layout artifacts - wording is character-for-character as printed. The local DDI PDF omits any Scope/Coverage section (it begins at 'Sampling'), and neither the catalog page nor the API metadata carries a 'Universe' field, so the sample-design statement above is the universe statement of record. Corroborating verbatim: WB catalog 72 study_info.geog_coverage: "National"; BID p. 12 (Comparison to Earlier Data Collections): "The TLSS99, TLSS03 and TLSS07 data cannot be used as panel data. The same households were not visited in all surveys. In addition, the sample designs used in the three years were different although all three surveys are representative at the national, urban/rural and oblast levels."; BID p. 12: "Because the sample is not self weighted, the weight variable, HHWEIGHT, must be used in analyses of the data to have estimates that are valid at the national, urban/rural and oblast levels." Design detail (not the universe): frame is the 2000 census enumeration sectors as digitised for UNICEF's MICS05; 270 clusters x 18 households = 4,860; final cluster allocation Dushanbe 50 urban / 0 rural, RRP 9/45, Sogd 18/38, Khatlon 12/59, GBAO 6/33. There is a deliberate oversample, documented verbatim as a bullet "An oversample in 7 rayons in Khatlon3" with footnote 3: "The oversample is for a crop survey that will be done at a future date." - unlike the 1999 Dangara/Varzob oversample, no instruction is given to exclude it from nationally representative analysis; the weight variable HHWEIGHT is the stated remedy. No institutional/nomad/refugee/security-based exclusion statement found.
+#+end_quote
+
+*** Tajikistan 2009
+
+- Survey :: Tajikistan Living Standards Survey 2009 (TLSS09) / Tajikistan Panel Survey 2009 / Living Standards Survey 2009 (TJK_2009_TLSS_v01_M, WB catalog id 73)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: panel-inherited
+- Language of the quoted source :: en
+- Source file :: "Tajikistan Living Standards Survey 2009 / Notes for Users / May 2010" - Technical document attached to WB Microdata catalog entry 73; downloaded from https://microdata.worldbank.org/catalog/73/download/11539 (local working copy: /tmp/popdocs_tjk_docs/tjk2009_notes_for_users_REAL.pdf). NOT present in the repo's lsms_library/countries/Tajikistan/2009/Documentation/.
+- Locator :: Page 1, first and second paragraphs (the '...' elides only the paragraph break between them).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The Tajikistan 2009 Living Standards Survey (TLSS09) is a panel survey of 1,500 households interviewed during the Tajikistan 2007 Living Standards Survey (TLSS07). The households were revisited in November 2009 which is the same time period in which they were visited originally in 2007. ... The sample is representative at the national, regional level (4 regions and Dushanbe), and urban/rural. See http://go.worldbank.org/6TUMCB3K30 for a copy of the Basic Information Document for the TLSS07 which describes in detail how the sample was designed for the TLSS07. The same methodology was used to select the households for the TLSS09.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a - source is in English
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND - no exclusion statement of any kind appears in the 2009 documentation examined. Note that the universe is itself restricted by construction (a 1,500-household subset of the TLSS07 sample), but the documentation gives no statement of which TLSS07 households were dropped or why.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The first sentence of the population quote is also present VERBATIM in local documentation: lsms_library/countries/Tajikistan/2009/Documentation/ddi-documentation-english_microdata-73.pdf, PDF page 5, section 'Data Collection' -> 'DATA COLLECTION NOTES'. The second half of the quote (the representativeness claim) exists only in the catalog. Corroborating verbatim: WB catalog 73 study_info.geog_coverage: "National coverage; the sample is representative at the national, regional level (4 regions and Dushanbe), and urban/rural"; catalog method.data_collection.sampling_procedure, in full: "Sample size is 1,500 households". The local questionnaire cover page (TJ_Pan_09_V11.pdf, page 1) is headed "TAJIKISTAN PANEL SURVEY, 2009 / MAIN QUESTIONNAIRE" and carries pre-printed identification fields "FROM TLSS07" and "TLSS PSU", consistent with (but not itself a statement of) the panel universe. No 'Universe' field exists on the catalog page or in the API metadata for this study.
+#+end_quote
+
+** Tanzania
+
+*** Tanzania 2008-09
+
+- Survey :: Tanzania National Panel Survey (NPS) 2008-2015, Uniform Panel Dataset (TZA_2008-2014_NPS-UPD_v01_M)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: WB Microdata catalog DDI export for catalog id 3814 (TZA_2008-2014_NPS-UPD_v01_M); local mirror saved at /tmp/popdocs/ddi_3814.xml. Provenance recorded in lsms_library/countries/Tanzania/2008-15/Documentation/SOURCE.org
+- Locator :: DDI 1.2.2 element codeBook/stdyDscr/stdyInfo/sumDscr/universe (retrieved 2026-07-21 from https://microdata.worldbank.org/index.php/metadata/export/3814/ddi)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The universe includes all households and individuals in Tanzania with the exception of those residing in military barracks or other institutions.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+… with the exception of those residing in military barracks or other institutions.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Geographic coverage, same record, element sumDscr/geogCover, VERBATIM: "Designed for analysis of key indicators at four primary domains of inference, namely: Dar es Salaam, other urban, rural, Zanzibar.". Library wave label maps to directory 2008-15/ (multi-round folder; see .claude/skills/multi-round-waves.md and Tanzania/_/tanzania.py wave_folder_map). The 2008-15 directory holds the Uniform Panel Dataset covering NPS rounds 1-4, so this single universe statement is the documented universe for all four of 2008-09, 2010-11, 2012-13 and 2014-15. LOCAL documentation adds: "The Tanzania National Panel Survey (NPS) is a series of nationally representative multi-topic household surveys that collect information on topics including agricultural production, non-farm income generating activities, consumption expenditures, and a wealth of other socio-economic characteristics." (NPS_UPD_Basic_Information_Document.pdf, p. 4, section "Background") — this is the strongest statement in the LOCAL 2008-15 documentation; it is a representativeness claim, NOT a universe statement, so it is recorded here rather than in population_verbatim. Round-specific corroboration — the separate WB catalog entry for NPS Wave 1 (id 76, TZA_2008_NPS-R1_v03_M) has an EMPTY <universe/> element; its sumDscr/geogCover reads VERBATIM: "The survey covered all regions and all districts of Tanzania, both mainland and Zanzibar." and its sumDscr/sampProc opens VERBATIM: "In order to monitor progress toward the MKUKUTA goals, it was vital that the NPS have a nationally-representative sample design. As such, in 2008/09 the NPS interviewed 3,280 households spanning all regions and all districts of Tanzania, both mainland and Zanzibar." (that second one is sample design, not universe).
+#+end_quote
+
+*** Tanzania 2010-11
+
+- Survey :: Tanzania National Panel Survey (NPS) 2008-2015, Uniform Panel Dataset (TZA_2008-2014_NPS-UPD_v01_M)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: WB Microdata catalog DDI export for catalog id 3814 (TZA_2008-2014_NPS-UPD_v01_M); local mirror saved at /tmp/popdocs/ddi_3814.xml. Provenance recorded in lsms_library/countries/Tanzania/2008-15/Documentation/SOURCE.org
+- Locator :: DDI 1.2.2 element codeBook/stdyDscr/stdyInfo/sumDscr/universe (retrieved 2026-07-21 from https://microdata.worldbank.org/index.php/metadata/export/3814/ddi)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The universe includes all households and individuals in Tanzania with the exception of those residing in military barracks or other institutions.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+… with the exception of those residing in military barracks or other institutions.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Geographic coverage, same record, element sumDscr/geogCover, VERBATIM: "Designed for analysis of key indicators at four primary domains of inference, namely: Dar es Salaam, other urban, rural, Zanzibar.". Library wave label maps to directory 2008-15/ (multi-round folder; see .claude/skills/multi-round-waves.md and Tanzania/_/tanzania.py wave_folder_map). The 2008-15 directory holds the Uniform Panel Dataset covering NPS rounds 1-4, so this single universe statement is the documented universe for all four of 2008-09, 2010-11, 2012-13 and 2014-15. LOCAL documentation adds: "The Tanzania National Panel Survey (NPS) is a series of nationally representative multi-topic household surveys that collect information on topics including agricultural production, non-farm income generating activities, consumption expenditures, and a wealth of other socio-economic characteristics." (NPS_UPD_Basic_Information_Document.pdf, p. 4, section "Background") — this is the strongest statement in the LOCAL 2008-15 documentation; it is a representativeness claim, NOT a universe statement, so it is recorded here rather than in population_verbatim. Round-specific corroboration — the separate WB catalog entry for NPS Wave 2 (id 1050, TZA_2010_NPS-R2_v03_M) has an EMPTY <universe/> element; its sumDscr/geogCover reads VERBATIM: "National Coverage: Dar es Salaam, other urban areas in Mainland, rural areas in Mainland, and Zanzibar" and its anlyUnit reads VERBATIM: "A living standards survey with community-level questionnaire with the following units of analysis: individuals, household, and communities."
+#+end_quote
+
+*** Tanzania 2012-13
+
+- Survey :: Tanzania National Panel Survey (NPS) 2008-2015, Uniform Panel Dataset (TZA_2008-2014_NPS-UPD_v01_M)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: WB Microdata catalog DDI export for catalog id 3814 (TZA_2008-2014_NPS-UPD_v01_M); local mirror saved at /tmp/popdocs/ddi_3814.xml. Provenance recorded in lsms_library/countries/Tanzania/2008-15/Documentation/SOURCE.org
+- Locator :: DDI 1.2.2 element codeBook/stdyDscr/stdyInfo/sumDscr/universe (retrieved 2026-07-21 from https://microdata.worldbank.org/index.php/metadata/export/3814/ddi)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The universe includes all households and individuals in Tanzania with the exception of those residing in military barracks or other institutions.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+… with the exception of those residing in military barracks or other institutions.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Geographic coverage, same record, element sumDscr/geogCover, VERBATIM: "Designed for analysis of key indicators at four primary domains of inference, namely: Dar es Salaam, other urban, rural, Zanzibar.". Library wave label maps to directory 2008-15/ (multi-round folder; see .claude/skills/multi-round-waves.md and Tanzania/_/tanzania.py wave_folder_map). The 2008-15 directory holds the Uniform Panel Dataset covering NPS rounds 1-4, so this single universe statement is the documented universe for all four of 2008-09, 2010-11, 2012-13 and 2014-15. LOCAL documentation adds: "The Tanzania National Panel Survey (NPS) is a series of nationally representative multi-topic household surveys that collect information on topics including agricultural production, non-farm income generating activities, consumption expenditures, and a wealth of other socio-economic characteristics." (NPS_UPD_Basic_Information_Document.pdf, p. 4, section "Background") — this is the strongest statement in the LOCAL 2008-15 documentation; it is a representativeness claim, NOT a universe statement, so it is recorded here rather than in population_verbatim. Round-specific corroboration — the separate WB catalog entry for NPS Wave 3 (id 2252, TZA_2012_NPS-R3_v01_M) DOES carry its own universe, VERBATIM: "The survey covers all individuals included in the households in the sample.\n\nThe eligibility requirement for the NPS is defined as any household member aged 15 years and above, excluding live-in servants. Households with at least one eligible member where completely interviewed, including any subsequent non-eligible members present in the household. Any household or eligible members that had either moved or split away from a primary household were tracked and interviewed in their new location." Its geogCover reads VERBATIM: "Representative at the national, urban/rural and major ago-ecological zones levels." (sic, "ago-ecological").
+#+end_quote
+
+*** Tanzania 2014-15
+
+- Survey :: Tanzania National Panel Survey (NPS) 2008-2015, Uniform Panel Dataset (TZA_2008-2014_NPS-UPD_v01_M)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: WB Microdata catalog DDI export for catalog id 3814 (TZA_2008-2014_NPS-UPD_v01_M); local mirror saved at /tmp/popdocs/ddi_3814.xml. Provenance recorded in lsms_library/countries/Tanzania/2008-15/Documentation/SOURCE.org
+- Locator :: DDI 1.2.2 element codeBook/stdyDscr/stdyInfo/sumDscr/universe (retrieved 2026-07-21 from https://microdata.worldbank.org/index.php/metadata/export/3814/ddi)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The universe includes all households and individuals in Tanzania with the exception of those residing in military barracks or other institutions.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+… with the exception of those residing in military barracks or other institutions.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Geographic coverage, same record, element sumDscr/geogCover, VERBATIM: "Designed for analysis of key indicators at four primary domains of inference, namely: Dar es Salaam, other urban, rural, Zanzibar.". Library wave label maps to directory 2008-15/ (multi-round folder; see .claude/skills/multi-round-waves.md and Tanzania/_/tanzania.py wave_folder_map). The 2008-15 directory holds the Uniform Panel Dataset covering NPS rounds 1-4, so this single universe statement is the documented universe for all four of 2008-09, 2010-11, 2012-13 and 2014-15. LOCAL documentation adds: "The Tanzania National Panel Survey (NPS) is a series of nationally representative multi-topic household surveys that collect information on topics including agricultural production, non-farm income generating activities, consumption expenditures, and a wealth of other socio-economic characteristics." (NPS_UPD_Basic_Information_Document.pdf, p. 4, section "Background") — this is the strongest statement in the LOCAL 2008-15 documentation; it is a representativeness claim, NOT a universe statement, so it is recorded here rather than in population_verbatim. Round-specific corroboration — the separate WB catalog entry for NPS Wave 4 (id 2862, TZA_2014_NPS-R4_v03_M) carries the SAME universe text VERBATIM: "The universe includes all households and individuals in Tanzania with the exception of those residing in military barracks or other institutions." and the same four-domain geogCover.
+#+end_quote
+
+*** Tanzania 2019-20
+
+- Survey :: Tanzania National Panel Survey 2019-2020 — Extended Panel with Sex Disaggregated Data (NPS-SDD 2019/20; TZA_2019_NPS-SDD_v06_M)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Tanzania/2019-20/Documentation/TZA_2019_NPS-SDD_v06_M.xml
+- Locator :: DDI 1.2.2 element codeBook/stdyDscr/stdyInfo/sumDscr/universe, line 74 of the XML. Identical text is in the WB catalog DDI export for catalog id 3885 (https://microdata.worldbank.org/index.php/metadata/export/3885/ddi), so local and catalog agree exactly.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The universe includes all households and individuals in Tanzania with the exception of those residing in military barracks or other institutions.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+… with the exception of those residing in military barracks or other institutions.  Additional eligibility restriction, from the same DDI, element sumDscr/../method/dataColl/sampProc (and identically in the local BID, p. 7, section "Sample Design"), VERBATIM: "The eligibility requirement for inclusion in the NPS is defined as any household member aged 15 years and above, excluding live-in servants. Households with at least one eligible member were completely interviewed, including any non-eligible members present in the household. Any household or eligible members that had either moved or split away from a primary household were tracked and interviewed in their new location."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Library wave label 2019-20 maps to directory 2019-20/. Geographic coverage, same DDI, element sumDscr/geogCover, VERBATIM: "Designed for analysis of key indicators at the national level." — note this differs from the four-domain geogCover of the other NPS rounds, because NPS-SDD 2019/20 followed only the 'Extended Panel' cohort. Unit of analysis, element sumDscr/anlyUnit, VERBATIM: "Households; Individuals;". SAMPLE-DESIGN detail (NOT the universe), local BID p. 7, VERBATIM: "The sample design for the NPS-SDD 2019/20 targeted the sub-sample of households from the initial NPS cohort originating in 2008/09 and subsequently surveyed in all four consecutive rounds, considered the “Extended Panel”. This consisted of 989 households from the NPS 2014/15 sample to be tracked and interviewed in the NPS-SDD 2019/20." So the DECLARED universe is national, while the realised sample is a longitudinal sub-cohort — exactly the distinction GH #603 wants recorded; do not conflate them.
+#+end_quote
+
+*** Tanzania 2020-21
+
+- Survey :: Tanzania National Panel Survey 2020-21, Wave 5 (TZA_2020_NPS-R5_v02_M)
+- Source type :: not-found
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: not-stated
+- Language of the quoted source :: English
+- Source file :: lsms_library/countries/Tanzania/2020-21/Documentation/ddi-documentation-english_microdata-5639.pdf (and the WB catalog DDI export for id 5639, mirrored at /tmp/popdocs/ddi_5639.xml)
+- Locator :: Local PDF pp. 2-4 ("Scope" > NOTES; "Coverage" > GEOGRAPHIC COVERAGE; "Sampling" > SAMPLING PROCEDURE / WEIGHTING) — the PDF has NO Universe line at all. Catalog DDI element codeBook/stdyDscr/stdyInfo/sumDscr/universe is present and empty (retrieved 2026-07-21).
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND. No universe / target-population statement exists in any 2020-21 document I checked. The authoritative DDI field is present but EMPTY: the WB catalog DDI export for catalog id 5639 contains, VERBATIM, "<universe><![CDATA[]]></universe>". The nearest documented statements are recorded in exclusions_verbatim and notes and are NOT universe statements.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+No universe-level exclusion statement found. The only documented restriction on which units qualify is an ELIGIBILITY rule stated under SAMPLING PROCEDURE, VERBATIM: "The eligibility requirement for inclusion of a household in this round of the NPS and all others is defined as any household having at least one member aged 15 years and above, excluding live-in servants. Households with at least one eligible member were completely interviewed, including any non-eligible members present in the household." (ddi-documentation-english_microdata-5639.pdf, p. 3, section "Sampling" > "SAMPLING PROCEDURE"; identical text in codeBook/stdyDscr/method/dataColl/sampProc of the catalog DDI export for id 5639.)
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+Library wave label 2020-21 maps to directory 2020-21/. Recorded gap, not an absence claim about the survey itself. VERBATIM statements that are the closest available but are NOT universe statements: (a) sumDscr/geogCover, catalog DDI id 5639 and local PDF p. 3 "Coverage" > GEOGRAPHIC COVERAGE: "Designed for analysis of key indicators at four primary domains of inference, namely:\nDar es Salaam,\nOther Urban,\nRural,\nZanzibar,"; (b) sumDscr/anlyUnit: "Households; Individuals"; (c) nps_wave_5_report.pdf, report p. 1 (PDF p. 21), section 1.1 Introduction: "The National Panel Survey (NPS) is a nationally representative household survey that collects information on the living standards of the population, including their consumption expenditure, non-farm income generating activities, agricultural production, and other socio-economic characteristics."; (d) executive_summary_tanzania_printfile_02b.pdf, p. 1: "The Tanzania National Panel Survey (NPS) is a nationally representative longitudinal survey that collects information on the living standards of the population, including consumption expenditure, farm and non-farm income-generating activities, and other socio-economic characteristics."  DO NOT infer the 2014-15 universe text onto this wave: NPS 2020/21 follows the NPS 2014/15 'Refresh Panel' cohort plus a 545-household urban 'Booster Sample' (Mbeya, Arusha, Mwanza, Tanga, Dodoma), so its realised sample is not the same set of units. That is sample design, quoted in exclusions_verbatim/sampProc, and it does not license writing a universe sentence the documentation never wrote.
+#+end_quote
+
+** Timor-Leste
+
+*** Timor-Leste 2001
+
+- Survey :: Timor-Leste Living Standards Survey 2001 (TLSS); WB catalog title "Timor-Leste - Living Standards Survey 2001", Reference ID TLS_2001_TLSS_v01_M, DOI 10.48529/3gq7-sk98
+- Source type :: not-found
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: not-stated
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Timor-Leste/2001/Documentation/ddi-documentation-english_microdata-75.pdf; lsms_library/countries/Timor-Leste/2001/Documentation/ETPA-Vol2-Final-web.pdf; lsms_library/countries/Timor-Leste/2001/Documentation/timorlestehhqeng_V2.pdf; WB catalog https://microdata.worldbank.org/index.php/catalog/75/study-description and API https://microdata.worldbank.org/index.php/api/catalog/TLS_2001_TLSS_v01_M
+- Locator :: (a),(b) WB catalog study 75, sections "Coverage > Geographic Coverage" and "Abstract" (DDI JSON keys dataset.metadata.study_desc.study_info.geog_coverage / .abstract). (c) ETPA-Vol2-Final-web.pdf Ch.1 "Survey Design and Welfare Measurement", ¶1.2, printed p.1 (PDF p.15); same text in ddi-documentation-english_microdata-75.pdf p.2, "Sampling > Sampling Procedure > SAMPLE SIZE AND ANALYTIC DOMAINS". (d) ddi-...-75.pdf p.2-3, "SAMPLING STRATEGY". Listing quote: same PDF pp.3-4, "HOUSEHOLD LISTING". Questionnaire quote: timorlestehhqeng_V2.pdf, Section 1A interviewer instructions for Q23.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND (no explicit universe / target-population statement). Nearest documented coverage statements, quoted verbatim:  (a) WB catalog, Coverage > Geographic Coverage (DDI field study_info.geog_coverage): "National coverage. Domains: Urban/rural; Agro-ecological zones (Highlands, Lowlands, Western Region, Eastern Region, Central Region)"  (b) WB catalog Abstract: "A second element was the Timor-Leste Living Standards Measurement Survey (TLSS). This is a household survey with a nationally representative sample of 1,800 families from 100 sucos."  (c) Local: ETPA-Vol2-Final-web.pdf, Ch. 1 ¶1.2 (and verbatim identical in ddi-documentation-english_microdata-75.pdf, "Sampling Procedure / SAMPLE SIZE AND ANALYTIC DOMAINS"): "A survey relies on identifying a subgroup of a population that is representative both for the underlying population and for specific analytical domains of interest. The main objective of the TLSS is to derive a poverty profile for the country and salient population groups. The fundamental analytic domains identified are the Major Urban Centers (Dili and Baucau), the Other Urban Centers and the Rural Areas. ... The survey has a sample size of 1,800 households, or about one percent of the total number of households in Timor-Leste."  (d) Local: ddi-documentation-english_microdata-75.pdf, "Sampling Procedure / SAMPLING STRATEGY": "This implies that the sample is approximately selfweighted within the stratum: all households in the stratum had the same chance of being visited by the survey."
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND. No statement of excluded populations (institutional households, nomads, dropped regions, etc.) appears in the local 2001 documentation or in the WB catalog metadata. The only related definitional restriction found is the household-listing frame definition, ddi-documentation-english_microdata-75.pdf, "Sampling Procedure / HOUSEHOLD LISTING": "The improvements introduced to the PLD consisted in clarifying the concept of a household \"currently living in the aldeia\", both by intensive training and supervision of the enumerators and by making its meaning explicit in the form's wording (it means that the household members are regularly eating and sleeping in the aldeia at the time of the operation)." A separate membership rule (not a universe exclusion) appears in the questionnaire, timorlestehhqeng_V2.pdf, Section 1 Part A, instructions to QUESTION 23: "DECEASED INDIVIDUALS ARE NEVER CLASSIFIED AS HOUSEHOLD MEMBERS. / LODGERS ARE NOT CLASSIFIED AS HOUSEHOLD MEMBERS."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+SOURCE.org for this wave carries only the DOI URL (https://doi.org/10.48529/3gq7-sk98) — no #+CATALOG_ID/#+CATALOG_IDNO keywords; the catalog entry was matched via that DOI (Reference ID TLS_2001_TLSS_v01_M = catalog id 75, which also matches the local filename 'ddi-documentation-english_microdata-75.pdf'). The local DDI PDF is a partial export: it contains Sampling / Questionnaires / Data Collection / Data Processing / variable lists, but NOT the Study Description 'Coverage' block, so 'National coverage.' is available only from the catalog. SAMPLE DESIGN (not the universe, recorded here as context): 1,800 households; stratified into Major Urban Centers (450 hh: 378 Dili, 72 Baucau), Other Urban Centers (252 hh), Rural Areas (1,098 hh); 3-stage PPS/PPS/EP outside Urban Dili, 2-stage in Urban Dili; 300 aldeias x 6 households; fieldwork Aug-Nov/early Dec 2001; 303 household replacements from a reserve list. Quotes above have line-break hyphenation rejoined and hard line breaks normalized to spaces; no other alteration. No .dta file was opened for this task.
+#+end_quote
+
+*** Timor-Leste 2007-08
+
+- Survey :: Timor-Leste Survey of Living Standards 2007 (TLSLS 2) and Extension 2008 (TLSLS2-X); WB catalog title "Timor-Leste - Survey of Living Standards 2007 and Extension 2008", Reference ID TLS_2007_TLSLS_v01_M, DOI 10.48529/x7qj-ne03
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Timor-Leste/2007-08/Documentation/TLSLS07_Final_Statistical_Abstract.pdf (primary); lsms_library/countries/Timor-Leste/2007-08/Documentation/ddi-documentation-english_microdata-78.pdf; lsms_library/countries/Timor-Leste/2007-08/Documentation/TLSS_annexes.pdf; WB catalog https://microdata.worldbank.org/index.php/catalog/78/study-description
+- Locator :: Primary quote and the institutional-household exclusion: TLSLS07_Final_Statistical_Abstract.pdf (Direcção Nacional de Estatística, Ministério de Finanças, July 2008), Section "1. Demographics — Concepts and definitions", printed p. 15 (PDF p. 27), final three paragraphs of the section. Supporting (b): ddi-documentation-english_microdata-78.pdf p.2, "Sampling > Sampling Procedure > SAMPLE DESIGN FOR THE 2007-2008 SURVEY" and, for the representativeness sentence, same section p.3; also TLSS_annexes.pdf "Annex 1: The 2007 Timor-Leste Survey of Living Standards". Supporting (c),(d): WB catalog study 78, "Coverage > Geographic Coverage" and "Scope > Unit of Analysis" (DDI JSON study_info.geog_coverage / .analysis_unit). Fieldwork exclusion quote: ddi-...-78.pdf, "Data Collection > DATA COLLECTION NOTES > 2007-2008 SURVEY FIELDWORK".
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+"The TLSLS captures the population living in private households. A household is a group of persons (or a single person) who usually live together and have a common arrangement for food, such as using a common kitchen or a common food budget.  The persons may be related to each other or may be non-relatives, including servants or other employees, staying with the employer. Students and employees residing in and having a common food arrangement with the household are considered members of the household if they have been in the household for the last year and absent for no more than one month.   If absent for longer than nine months, only infants less than three months old, newly weds or a bride who has joined her husband's family are considered household members."  Supporting statements: (b) Local ddi-documentation-english_microdata-78.pdf, "Sampling Procedure / SAMPLE DESIGN FOR THE 2007-2008 SURVEY" (identical text on the WB catalog page): "The TLSLS sample was designed to have two components: (i) a cross-sectional component of 4,500 households selected with the intention of representing the current population of Timor-Leste, and (ii) a panel component of 900 households, where half of the 2001 TLSS sample of 1800 households are randomly selected and re-interviewed, with the purpose to evaluating changes in the living conditions for the same set of households between the two surveys." ... "The sample can be considered representative at national level as well as at the level of the ten domains represented by the rural and urban areas of the five regions." (c) WB catalog, Coverage > Geographic Coverage: "National coverage. Domains: Urban/rural; Regional" (d) WB catalog, Unit of Analysis: "- Household - Individual"
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+"However, this does not include boarders/lodgers or boarding houses operated by the household.  Boarding houses with more than five persons are considered to be institutional households.  Institutional households are not covered by the survey.  They are defined as a group of five or more unrelated persons living together, for example, those living in boarding houses, military barracks, prisons, or student dormitories."  Data-release exclusions (not universe exclusions, but they restrict what the shipped extract represents), ddi-documentation-english_microdata-78.pdf, "SAMPLE DESIGN FOR THE 2007-2008 SURVEY": "However, this panel component is not being released at this time, so it will be neither covered in the rest of the documentation nor included in the data files." And, same PDF, "Data Collection Notes / 2007-2008 SURVEY FIELDWORK": "In order to maintain a sample for a continuous period of a year, the final TLSLS sample thus excludes the 351 households interviewed in 2006 and instead includes the 358 revisited or replaced households."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+SOURCE.org carries only the DOI (https://doi.org/10.48529/x7qj-ne03); catalog id 78 / TLS_2007_TLSLS_v01_M matched via that DOI and the local filename 'ddi-documentation-english_microdata-78.pdf'. The wave folder covers TWO instruments: the 2007-08 cross-section (TLSLS 2) and the 2008 extension (TLSLS2-X), a sub-sample of 133 PSUs (19 randomly chosen fieldwork 'weeks' x 7 PSUs, 12 of the original 15 households per PSU, nominal n=1596), plus 25 re-interview PSUs in Manatuto (6) and Oecussi (19). Universe of the extension = the TLSLS2 households it re-visits; no separate universe statement exists for it. SAMPLE DESIGN context (not the universe): 10 explicit strata = urban/rural within 5 regions (R1 Baucau/Lautem/Viqueque; R2 Ainaro/Manufahi/Manatuto; R3 Aileu/Dili/Ermera; R4 Bobonaro/Cova Lima/Liquiçá; R5 Oecussi); frame = 1,163 Census EAs from the 2004 Census, PPS at stage 1 then 15 households by systematic EP from a fresh listing; realized cross-section 4,477 households in 269 distinct EAs; weights post-stratified to mid-2007 demographic projections totalling 1,047,632 persons. Quotes have line-break hyphenation rejoined and hard line breaks normalized to spaces (double spaces after sentences preserved as in the source); no other alteration. No .dta file was opened for this task.
+#+end_quote
+
+** Togo
+
+*** Togo 2018
+
+- Survey :: Enquête Harmonisée sur les Conditions de Vie des Ménages (EHCVM) 2018-2019 / Harmonized Survey on Households Living Standards, Togo 2018-2019 (TGO_2018_EHCVM_v02_M)
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: high
+- Universe tag (EDITORIAL, not a quote) :: national-all-households
+- Language of the quoted source :: English
+- Source file :: https://microdata.worldbank.org/index.php/catalog/4298/study-description (World Bank Microdata Library catalog entry 4298, ref. TGO_2018_EHCVM_v02_M); corroborating: Basic Information Document, INSEED, June 2021, PDF downloaded from https://microdata.worldbank.org/catalog/4298/download/52590
+- Locator :: Catalog study-description page, section "Coverage" > field "Universe" (the exclusion clause is inside that same Universe field). Corroborating sample-coverage sentence: catalog section "Sampling" > "Sampling Procedure", first sentence; identical text in the Basic Information Document, page 10, section "Sample", first sentence.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.
+#+end_quote
+
+Translation (supplied by the extractor; NOT source text):
+
+#+begin_quote
+n/a — the source text is in English. (The catalog metadata page for this WAEMU/INSEED survey is published in English; the local questionnaires are in French.)
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+excluding prisons, hospitals, military barracks, and school dormitories  [Geographic Coverage, same page:] "National coverage"  [Sampling Procedure, same catalog page, and Basic Information Document p.10 §"Sample":] "The Togo EHCVM 2018/19 sample covers all regions with urban and rural areas surveyed in all regions except Lome Commune where all respondents are from rural areas."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+One wave only. The wave directory is labelled '2018' but the survey is the two-wave EHCVM 2018/19: wave 1 fielded Sept-Dec 2018, wave 2 April-June 2019 (BID p.4, §"Survey Characteristics": "The surveys took place in two waves with each wave covering half of the sample. The first wave was fielded between September 2018 and December 2018, while the second wave occurred between April 2019 and June 2019. The two-wave approach was chosen to account for seasonality of consumption.").  NO universe/target-population statement exists in any LOCAL repo document for this wave; the quote above is from the World Bank catalog (and is corroborated verbatim, for the sample-coverage sentence, by the INSEED Basic Information Document). The local Documentation/ folder holds only questionnaires.  WARNING about the sample-coverage sentence, quoted verbatim above and NOT corrected here: the documentation says "...surveyed in all regions except Lome Commune where all respondents are from rural areas." That is what both the catalog page and BID p.10 literally say. It is internally implausible (Lomé Commune is the wholly urban capital district) and reads like an urban/rural transposition error in the source document, but it is reproduced exactly as written; do not silently 'fix' it when recording the population.  Sample design detail (NOT the universe; BID p.10 §"Sample" / catalog "Sampling Procedure"): two-stage design, 540 EAs selected at stage 1, 12 households per EA at stage 2; total 6,171 households — 2,270 urban, 3,901 rural; each EA split into two halves, one per wave; wave 1 = 2,931 households (1,034 urban, 1,897 rural), wave 2 = 3,240 households (1,236 urban, 2,004 rural).  Programme context (BID p.3): the EHCVM 2018/19 is described as "the first edition of a nationally representative household survey conducted within the Programme d'Harmonisation et de Modernisation des enquetes sur les Conditions de Vie des Menages (PHMECV program)", a joint World Bank / WAEMU Commission programme covering Benin, Burkina Faso, Cote d'Ivoire, Guinee Bissau, Mali, Niger, Senegal and Togo — so a near-identical universe statement should be expected for the sibling EHCVM countries.  Note also: lsms_library/countries/Togo/2018/Data/ additionally contains non-EHCVM extracts (Togo_survey2018_*_forEthan.dta / .csv) with no documentation of their own; no universe statement is available for those files, and nothing was inferred from any .dta.
+#+end_quote
+
+** Uganda
+
+*** Uganda 2005-06
+
+- Survey :: Uganda National Household Survey 2005/06 (UNHS 2005/06) — the baseline from which the UNPS panel was drawn; the wave's SOURCE.org points at WB catalog 1001 (Uganda National Panel Survey 2005-2009)
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Uganda/2005-06/Documentation/UNHS.2005-06.Interviewer.Manual.FINAL.pdf
+- Locator :: Chapter One, section 'SURVEY DESIGN' (PDF page 4; printed page 2). Note: pdfminer inserts the running header 'Manual of Instructions for UNHS 2005/05' between the objectives and the SURVEY DESIGN heading; the '...' elision in population_verbatim replaces the sentence 'EA maps prepared by the GIS Section will guide the interviewers in tracing the EA boundaries.'
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The UNHS 2005/06 will use the 2002 Population and Housing Census list of Enumeration Areas (EAs) as its sampling frame. ... A sample of about 750 Enumeration Areas (EAs) has been selected. The selected areas will be visited by UBOS field workers who will list all households living in the EAs. 10 households will be selected randomly from each EA. The UNHS sample covers the entire country and was selected in such a way that it will generate estimates for the whole of Uganda, for urban and rural Uganda, and each of the four (statistical) regions: Central, Eastern, Northern and Western, and for a few selected districts.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND — no exclusion statement located. The only boundary-of-coverage statement in the manual is an INCLUSION, not an exclusion: "However, in some districts of Northern Uganda where large populations have been displaced by the LRA war and are living in Internally Displaced People (IDP) Camps, a three-stage sampling design will be adopted, with the selection of the IDP as the first stage unit, the respective 'blocks' within the camp as the second stage selection and the households within the blocks as the third stage units of selection."
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No document for this wave carries an explicit DDI 'Universe' field. The quoted statement is the survey-design coverage claim from the UNHS 2005/06 interviewer manual and is the strongest universe-like statement available locally. The wave's SOURCE.org cites WB catalog 1001 (UNPS 2005-2009), whose Overview records 'Geographic Coverage: National' and whose Series Information says 'The 2005-2009/10 Uganda National Panel Survey (UNPS) is the first multi-topic panel household survey conducted in Uganda. The UNPS is carried out annually, over a twelve-month period on a nationally representative sample of households.' Design detail (not universe): stratified two-stage design (EA then household), ~750 EAs, 10 households per EA; three-stage in IDP-camp districts of Northern Uganda. PDF text was extracted with pdfminer; runs of whitespace introduced by the PDF's justification have been collapsed to single spaces in the quotes — no words were changed, added, or reordered.
+#+end_quote
+
+*** Uganda 2009-10
+
+- Survey :: Uganda National Panel Survey 2005-2009/10 (UNPS Wave 1) — WB catalog 1001
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Uganda/2009-10/Documentation/ddi-documentation-english_microdata-1001.pdf
+- Locator :: 'National Panel Survey 2005-2009 - Overview': Series (PDF page ~14) and 'Geographic Coverage' (PDF page 16, printed page '- 6 -'); exclusion sentence in 'Sampling > Sampling Procedure' (PDF page 17, printed pages '- 6 -'/'- 7 -'). The '...' in population_verbatim elides the intervening Abstract / Survey Objectives / Scope material between the Series statement and the Geographic Coverage field.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The 2005-2009/10 Uganda National Panel Survey (UNPS) is the first multi-topic panel household survey conducted in Uganda. The UNPS is carried out annually, over a twelve-month period on a nationally representative sample of households. ... Geographic Coverage National
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Since IDP camps are now mostly unoccupied, the extra EAs in IDP camps are not a part of the UNPS subsample.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+There is no explicit DDI 'Universe' element in this document; 'Geographic Coverage: National' plus the 'nationally representative sample of households' phrasing is the whole of the universe claim. Design detail (not universe): 3,123 households in 322 EAs drawn from the 783 EAs of UNHS 2005/06; all 34 Kampala EAs plus 72 EAs (58 rural, 14 urban) in each of Central-excl.-Kampala, Eastern, Western and Northern; strata of representativeness are Kampala City, Other Urban Areas, Central Rural, Eastern Rural, Western Rural, Northern Rural. Whitespace normalized from pdfminer extraction; no wording altered.
+#+end_quote
+
+*** Uganda 2010-11
+
+- Survey :: Uganda National Panel Survey 2010-2011 (UNPS Wave II) — WB catalog 2166
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Uganda/2010-11/Documentation/UNPS_2010-11_Basic-Info-2014.pdf
+- Locator :: Section 1.2 'Survey Design' (PDF page 3; printed page 2)
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The UNPS is carried out annually, over a twelve-month period on a nationally representative sample of households, for the purpose of accommodating the seasonality associated with the composition of and expenditures on consumption.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+NOT FOUND — neither the 2010-11 Basic Information Document nor the local DDI (nor the catalog 2166 study description) contains any exclusion statement for this wave. Searched for: excluded, exclusion, IDP, nomadic, institutional, universe, target population. 'IDP' returns 0 hits in all three 2010-11 sources.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+The local DDI (ddi-documentation-english_microdata-2166.pdf, PDF page 11) independently records 'Geographic Coverage: National coverage'. Design detail (not universe), from the same DDI's Sampling Procedure: 'The 2010/11 UNPS survey maintained the 2009/10 UNPS sample design where all the households that were sampled for Wave I (2009/10) were tracked and re-interviewed in Wave II (2010/11). Out of the 7,400 households interviewed during the UNHS 2005/06, 3,200 households were selected for the UNPS and the same sample was maintained in both 2009/10 and 2010/11 Panel surveys.' (Note this says 3,200 where every other UNPS document says 3,123.) The BID adds: 'In 2010/11, the final UNPS sample stood at 2,716 households.' Whitespace normalized from pdfminer extraction; no wording altered.
+#+end_quote
+
+*** Uganda 2011-12
+
+- Survey :: Uganda National Panel Survey 2011-2012, Wave III (UNPS) — WB catalog 2059
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Uganda/2011-12/Documentation/unps_2011_12_bid_rev2014july.pdf
+- Locator :: Section 1.2 'Survey Design' (PDF page 6; printed page 4) — both the population sentence and the IDP exclusion sentence are in this section
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The UNPS is carried out annually, over a twelve-month period (a “wave”) on a nationally representative sample of households, for the purpose of accommodating the seasonality associated with the composition of and expenditures on consumption.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Since IDP (internally displaced people) camps are now mostly unoccupied, the extra EAs in IDP camps are not a part of the UNPS subsample.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No explicit 'Universe' field anywhere for this wave. Design detail (not universe), from the local DDI (ddi-documentation-english_microdata-2059.pdf, PDF page 3, 'Sampling > Sampling Procedure'): 'The 2011/12 UNPS survey maintained the 2010/11 UNPS sample design whereby all households that were sampled for Wave II (2010/11) were tracked and re-interviewed in Wave III (2011/12). Out of the 7,400 households interviewed during the UNHS 2005/06, 3,123 households were selected for the panel surveys.' Strata of representativeness: Kampala City, Other Urban Areas, Central Rural, Eastern Rural, Western Rural, Northern Rural. Whitespace normalized from pdfminer extraction; no wording altered. Note the BID uses a typographic left/right double quote around “wave”.
+#+end_quote
+
+*** Uganda 2013-14
+
+- Survey :: Uganda National Panel Survey 2013-2014 (UNPS Wave 4) — WB catalog 2663
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Uganda/2013-14/Documentation/Basic Information Document.pdf
+- Locator :: Section 1.2 'Survey Design' (PDF page 6; printed page 6) — both sentences are in this section
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The UNPS is carried out annually, over a twelve-month period on a nationally representative sample of households, for the purpose of accommodating the seasonality associated with the composition of and expenditures on consumption.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Since IDP camps are now mostly unoccupied, the extra EAs in IDP camps are not a part of the UNPS subsample.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No explicit 'Universe' field. Design detail (not universe): 3,123 households in 322 EAs selected from the 783 EAs of UNHS 2005/06; strata of representativeness Kampala City, Other Urban Areas, Central Rural, Eastern Rural, Western Rural, Northern Rural. This is the wave at which the one-third sample refresh began. Whitespace normalized from pdfminer extraction; no wording altered.
+#+end_quote
+
+*** Uganda 2015-16
+
+- Survey :: Uganda - National Panel Survey 2015-2016 (UNPS Wave 5) — WB catalog 3460
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Uganda/2015-16/Documentation/ddi-documentation-english_microdata-3460.pdf
+- Locator :: 'Coverage > GEOGRAPHIC COVERAGE' (PDF page 3) and 'Sampling > Sampling Procedure' (PDF page 4). The '...' in population_verbatim elides the intervening Producers/Sponsors and Metadata Production blocks that separate the two fields.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+GEOGRAPHIC COVERAGE National Coverage. ... The UNPS is carried out over a twelve-month period (a “wave”) on a nationally representative sample of households, for the purpose of accommodating the seasonality associated with the composition of and expenditures on consumption.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Since most IDP (Internally Displaced People) camps in the Northern region are currently unoccupied, the EAs that constituted IDP camps were not part of the UNPS sample.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No explicit 'Universe' field. Design detail (not universe): 3,123 households over 322 EAs from the UNHS 2005/06 frame; strata of representativeness Kampala City, Other Urban Areas, Central Rural, Eastern Rural, Western Rural, Northern Rural. SAMPLE REFRESH: 'Starting with the UNPS 2013/14 (Wave 4) fieldwork, one third of the initial UNPS sample was refreshed ... This same sample was used for the UNPS 2015/16 (Wave 5)' and 'The total sample will never be too different from a representative cross-section of the country, yet two-thirds of it will be a panel with a background of a year or two.' The PDF renders 'ti' and 'ff' as ligatures (e.g. 'stratiﬁcation'); these have been transcribed as ordinary ASCII letters in the quotes above. Whitespace normalized from pdfminer extraction; no wording altered.
+#+end_quote
+
+*** Uganda 2018-19
+
+- Survey :: Uganda National Panel Survey 2018-2019 (UNPS 2018) — WB catalog 3795, ref UGA_2018_UNPS_v02_M
+- Source type :: wb-catalog
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: https://microdata.worldbank.org/index.php/catalog/3795/study-description (World Bank Microdata Library catalog entry; NOT a local file)
+- Locator :: 'Series Information' (first sentence pair); 'Coverage > Geographic Coverage'; 'Sampling > Sampling Procedure' (exclusion sentence and the third quoted sentence). Fetched 2026-07-21. The '...' marks elide the intervening Abstract / Kind of Data / Unit of Analysis / Version / Scope blocks and the Producers-and-sponsors block.
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The 2018/19 Uganda National Panel Survey (UNPS) is the seventh multi-topic panel household survey conducted in Uganda and follows surveys carried out in 2009/10, 2010/11, 2011/12, 2013/14 and 2015/16. The UNPS is carried out over a twelve-month period on a nationally representative sample of households. ... Coverage Geographic Coverage National ... The UNPS is carried out over a twelve-month period (a “wave”) on a nationally representative sample of households, for the purpose of accommodating the seasonality associated with the composition of and expenditures on consumption.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Since most IDP (Internally Displaced People) camps in the Northern region are currently unoccupied, the EAs that constituted IDP camps were not part of the UNPS sample.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+This is the only Uganda wave for which the population statement comes from the catalog rather than a local document. No explicit 'Universe' field on the catalog page. Design detail (not universe): 3,123 households over 322 EAs from the UNHS 2005/06 frame; strata of representativeness Kampala City, Other Urban Areas, Central Rural, Eastern Rural, Western Rural, Northern Rural; the one-third-per-wave sample refresh begun in 2013/14 continues, with new households drawn from UBOS's 2013 updated sample frames prepared for the 2014 Uganda Population and Housing Census. Whitespace normalized from the HTML-to-text conversion; no wording altered.
+#+end_quote
+
+*** Uganda 2019-20
+
+- Survey :: Uganda National Panel Survey 2019-2020 (UNPS Wave VIII) — WB catalog 3902
+- Source type :: local-documentation
+- Confidence (as recorded by the extractor) :: medium
+- Universe tag (EDITORIAL, not a quote) :: national-claimed
+- Language of the quoted source :: en
+- Source file :: lsms_library/countries/Uganda/2019-20/Documentation/unps2019_20_bid.pdf
+- Locator :: Section 1.2 'Survey Design' (PDF page 7) — both sentences are in this section
+
+Population statement, verbatim as recorded:
+
+#+begin_quote
+The UNPS is carried out over a twelve-month period (a “wave”) on a nationally representative sample of households, for the purpose of accommodating the seasonality associated with the composition of and expenditures on consumption.
+#+end_quote
+
+Exclusions, verbatim as recorded:
+
+#+begin_quote
+Since most IDP (Internally Displaced People) camps in the Northern region are currently unoccupied, the EAs that constituted IDP camps were not part of the UNPS sample.
+#+end_quote
+
+Extractor's notes (editorial prose about the evidence, not survey text):
+
+#+begin_quote
+No explicit 'Universe' field. Design detail (not universe): 3,123 households over 322 EAs from the UNHS 2005/06 frame; 'This allocation allows for reliable estimates at the national, rural-urban and regional levels i.e. at level of strata representativeness which includes: (i) Kampala City, (ii) Other Urban Areas, (iii) Central Rural, (iv) Eastern Rural, (v) Western Rural, and (vi) Northern Rural.' The BID additionally documents a tracking rule that narrows who is followed (a panel-attrition rule, NOT a universe exclusion): 'In those households, the only individuals marked for tracking are the previous wave's household head, spouse, and children over age 15. Other household members were not tracked beyond their known location from the previous wave ... If they were last interviewed in Wave 0 or Wave 1, they were excluded from the survey at this time.' (PDF text around the tracking section.) Whitespace normalized from pdfminer extraction; no wording altered.
+#+end_quote
+
+* 4. The gaps
+
+Seven of the 111 waves have *no population statement of any kind* -- not in the
+local documentation, not in the World Bank catalog metadata, not in any
+catalog-hosted technical document that could be located.  Three more record NOT
+FOUND for a universe while offering a weaker fallback coverage claim; they are
+listed separately below as partial gaps.
+
+This section is not softened, and it should not be.  Every entry below is a
+*checked* gap: it records what was searched, so that a later reader can falsify
+the claim by finding the document that was missed.  That is the difference
+between "no statement exists" and "nobody looked" -- and per CLAUDE.md's own
+warning about the Albania shocks episode, an unevidenced negative is
+unfalsifiable and therefore permanent whether or not it is true.
+
+Two of the seven are gaps of a stronger kind than mere absence: the DDI
+=<universe>= element is *present and empty*.
+
+- Tanzania 2020-21 :: catalog 5639 contains, verbatim,
+     =<universe><![CDATA[]]></universe>=.
+- Iraq 2012 :: catalog 2334's study-level =<universe/>= is empty, as is
+     2006-07's (catalog 69) -- for 2006-07 the Iraqi statistical office's own
+     report supplied a statement; for 2012 the equivalent report simply never
+     makes one.
+
+Mali 2021-22 is the mirror image: catalog 6275 has *no* =<universe>= element at
+all inside =<sumDscr>=, where the 2018-19 record (catalog 4295) does.  That
+absence is itself evidence, and it is recorded as such.
+
+Three of the seven are 2020-21 / 2021-22 panel revisits (Mali, Senegal,
+Tanzania); the other four are waves whose documentation simply never made the
+claim (Albania 2008, Iraq 2012, Nepal 2003-04, Timor-Leste 2001).  In each of
+the three panel cases the inheritance from the prior wave would have been
+defensible -- Senegal's own BID says "The second edition is a cluster panel
+survey, and the sampling plan builds upon that of the 2018/2019 survey" -- and
+in each case it was declined, and the entry says so.
+
+** The seven not-found waves
+
+*** Albania 2008 -- Albania - Living Standards Measurement Survey 2008
+
+- Confidence that this is a real gap :: high
+
+What the extractor recorded in place of a statement:
+
+#+begin_quote
+NOT FOUND. No universe / target-population / coverage-exclusion statement exists in any documentation available for this wave.
+
+The locally-held DDI PDF's sampling section reads, in full:
+"Sampling
+
+No content available"
+
+The only population-scope claim anywhere is the catalog metadata field `geog_coverage` (catalog 1933):
+"National"
+and the units-of-analysis field `analysis_unit`:
+"- individuals,\n- households,\n- communities"
+Neither is a universe statement.
+#+end_quote
+
+What was searched:
+
+#+begin_quote
+(1) lsms_library/countries/Albania/2008/Documentation/ -- SOURCE.org (catalog 1933); ddi-documentation-english_microdata-1933 (1).pdf fetched via data_access.get_data_file and fully text-extracted (only 2,800 chars; 'Sampling', 'Questionnaires', 'Data Processing' and 'Data Appraisal' all read 'No content available'); the three .xls files are questionnaires/community instrument. LICENSE.org checked. (2) WB catalog 1933: /metadata/export/1933/json -- full DDI metadata, grepped for 'universe' (ABSENT); study_desc.method contains ONLY {'data_collection': {'coll_mode': 'Face-to-face [f2f]'}} -- there is no sampling_procedure field at all. (3) Catalog 1933 related-materials page enumerated (8 items): the only prose document is 'Living Standard Measurement Survey 2008.pdf' (= 'Albania Trends in Poverty: 2002-2005-2008'), which was downloaded and text-searched for 'universe|target population|excluding|excluded|represent|sample|cover|nation' -- it is a results report with no sampling or universe section. The remaining items are questionnaires (.xls), a price range spreadsheet, a prefecture code list, and the generic 'Guide to LSMS' handbook. (4) No Basic Information Document exists for 2008 in the catalog (unlike 1996/2002/2003/2004/2005, all of which have one).
+#+end_quote
+
+*** Iraq 2012 -- Iraq Household Socio-Economic Survey 2012, Second Round (IHSES-II)
+
+- Confidence that this is a real gap :: high
+
+What the extractor recorded in place of a statement:
+
+#+begin_quote
+NOT FOUND. No document — local or catalog — states a target population / universe for IHSES-II 2012. The closest documented statements are a SAMPLE-SIZE statement and a SAMPLE-FRAME statement in the official Arabic report; both are quoted verbatim in `notes` and neither is a universe declaration.
+#+end_quote
+
+What was searched:
+
+#+begin_quote
+(1) lsms_library/countries/Iraq/2012/Documentation/ — full listing; SOURCE.org (only the DOI line [[https://doi.org/10.48529/xh5a-y392]], no provenance keywords). (2) ddi-documentation-english_microdata-2334.pdf (WB DDI documentation PDF) — extracted and READ IN FULL (332 lines, 10 pp.): it contains only Sampling / Weighting / Questionnaires / Data Collection / Related Materials; there is no Scope-Coverage-Universe section at all. (3) IHSES_II_2012_Arabic_Reviewed.pdf (the official IHSES-II report, Arabic only) — fetched via data_access.get_data_file() (md5 0b62e19a519afc731ec395c94689157e, identical to the WB catalog copy), 47 pp., re-extracted with a per-page char-position + bidi reconstruction (pdfminer's naive extraction returns Arabic in visual order and is unusable); searched the reconstructed text for المجتمع, المستهدف, يشمل المسح, شمل المسح, يغطي, التغطية, الأسر المقيمة, جميع الأسر, كافة الأسر, الشمول, استثن, النطاق, إطار, عينة — and read the whole of chapter 4 (عينة المسح) plus chapter 3 (questionnaire/pre-test/pilot). (4) Sampling_and_fieldwork_2012.pdf ("IHSES-II Sampling design and fieldwork organization", Beirut July 2011 / upd. Nov 2011) — downloaded from the catalog (id 34769) and READ IN FULL (216 lines): sections Introduction, Sample size and strata, Sampling stages, Selection probabilities and sampling weights, Fieldwork organization, Quality assurance, Human and material resources, Subsamples. No universe statement. (5) Iraq_2012_IHSES_Users_Note.pdf (catalog id 34770) — READ IN FULL (235 lines). No universe statement. (6) IHSES_2012_Manual_English.pdf (enumerator manual, catalog id 34768) — extracted (279 kB text) and grepped for universe / target population / survey covers / covers all / all households in / exclud / nomad / institution / collective; introduction read. No universe statement. (7) Iraq_Poverty_Methodology_Note_Final.pdf — extracted and grepped for the same terms. No universe statement. (8) WB Microdata catalog HTML https://microdata.worldbank.org/index.php/catalog/2334/study-description — rendered to text (246 lines) and READ IN FULL: the Scope section has only 'Notes' (topic list); Coverage has only 'Geographic Coverage: National coverage'. There is no Universe field. (9) DDI XML https://microdata.worldbank.org/index.php/metadata/export/2334/ddi — the study-level universe element is literally empty.
+#+end_quote
+
+*** Mali 2021-22 -- Enquête Harmonisée sur les Conditions de Vie des Ménages 2021-2022 (EHCVM 2021/22)
+
+- Confidence that this is a real gap :: high
+
+What the extractor recorded in place of a statement:
+
+#+begin_quote
+NOT FOUND — no universe / target-population statement exists in any Mali 2021-22 documentation examined. Positive evidence of absence: the DDI XML for catalog 6275 contains NO <universe> element at all inside <sumDscr> (2018-19's catalog 4295 does contain one), the catalog study-description page has a Coverage section with only "Geographic Coverage / National coverage" and no Universe field, and neither the English nor the French Basic Information Document contains a universe, 'population cible' or 'champ de l'enquête' statement. The nearest verbatim material is Sampling-Procedure text, given in exclusions_verbatim and notes; it is NOT a universe declaration and must not be quoted as one.
+#+end_quote
+
+What was searched:
+
+#+begin_quote
+LOCAL: lsms_library/countries/Mali/2021-22/Documentation/SOURCE.org (bare catalog URL); mli_ehcvm2_information_de_base_eng.pdf and ddi-documentation-english_microdata-6275.pdf both extracted with pdfminer (/tmp/popdocs/doc2021bid.txt, /tmp/popdocs/doc2021ddi.txt) and grepped for univers|popul|champ|couvre|couverture|exclu|cible|de jure|target population|barracks|prison|Kidal — no universe statement. mli_ehcvm2_qnr_men_excel_vague1.pdf / vague2.pdf not extracted (questionnaires). CATALOG: catalog/6275/study-description HTML — Coverage section has ONLY 'Geographic Coverage / National coverage', no Universe field; DDI XML export metadata/export/6275/ddi — <sumDscr> contains collDate, nation, geogCover, anlyUnit, dataKind and NO <universe> element; catalog/6275/related-materials; French-language Basic Information Document (resource 100367) downloaded to /tmp/popdocs/bid2021fr.pdf, extracted and grepped for population cible|univers|champ|Kidal|exclu|couvre|couverture — no universe statement.
+#+end_quote
+
+*** Nepal 2003-04 -- Nepal Living Standards Survey 2003-2004, Second Round (NLSS II)
+
+- Confidence that this is a real gap :: high
+
+What the extractor recorded in place of a statement:
+
+#+begin_quote
+NOT FOUND
+#+end_quote
+
+What was searched:
+
+#+begin_quote
+lsms_library/countries/Nepal/2003-04/Documentation/Source.org (bare URL https://microdata.worldbank.org/index.php/catalog/74 only); ddi-documentation-english_microdata-74.pdf (fetched + pdfminer-extracted; contains only Sampling / Questionnaires / Data Collection -- no Universe/Coverage/Scope section); NLSSIIReportVol1.pdf (fetched + extracted in full; CHAPTER I METHODOLOGY read end-to-end -- 1.1 Background, 1.2 Objectives, 1.3 Survey Methodology, 1.3.1 Sample design, 1.3.2 Sample frame, 1.3.3 Stratification, 1.5 Survey Difficulties, 1.7 Survey Limitations, 1.8 Contents, pp. 1-17; there is NO 'Coverage' or 'Statistical Unit' section of the kind NLSS-III has); NLSSIIReportVol2.pdf (extracted; grep for 'universe|diplomatic|institutional household|eligible for selection|usual place of residence|de jure|coverage' -> zero hits); NepalPovertyTrendsforPovertyAssessment.pdf (extracted; same grep -> zero hits); nlss2_hh_questionnaire.pdf (extracted); WB catalog id 74 -- BOTH the JSON API (dataset.metadata.study_desc.study_info has keys abstract, coll_dates, nation, geog_coverage, analysis_unit, data_kind, notes -- the 'universe' key is ABSENT, unlike ids 2301 and 1000) and the rendered /catalog/74/study-description HTML (grep for 'Universe' -> zero hits). Not opened: nlss2_rural.pdf, nlss2_urban.pdf (community questionnaires).
+#+end_quote
+
+*** Senegal 2021-22 -- Enquête Harmonisée sur le Conditions de Vie des Ménages, 2021-2022 (EHCVM-2) — alternate title "SEN EHCVM-2 2021-2022"
+
+- Confidence that this is a real gap :: high
+
+What the extractor recorded in place of a statement:
+
+#+begin_quote
+NOT FOUND
+#+end_quote
+
+What was searched:
+
+#+begin_quote
+(1) Local: lsms_library/countries/Senegal/2021-22/ has NO Documentation/ directory at all (only _/ and Data/) and no SOURCE.org — verified with find over the whole wave dir, and in the second mirror at /global/home/users/ligon/mirrors/LSMS_Library. (2) WB Microdata catalog entry 6278 / idno SEN_2021_EHCVM-2_v01_M (resolved via _wb_catalog_search('SEN')): fetched the full JSON metadata (api/catalog/6278?id_format=id) — study_info keys are exactly ['abstract','coll_dates','nation','geog_coverage','analysis_unit','data_kind','notes']; there is NO 'universe' key. (3) Fetched the full DDI XML export (/index.php/metadata/export/6278/ddi, 1.99 MB): grep -c -i 'universe' returns 0 — no <universe> element exists (the same grep on the 4297 export DOES return the 2018-19 universe text, so the method is sound). (4) WebFetch of https://microdata.worldbank.org/index.php/catalog/6278/study-description — no Universe section; headings under Coverage are Geographic Coverage, Producers and sponsors, Sampling. (5) Downloaded and text-extracted all four related-materials documents from the catalog: Basic Information Document English (download/100388), Basic Information Document French (download/100389), Household questionnaire Wave 1 (download/100386), Household questionnaire Wave 2 (download/100387). Grepped the BID (en + fr) for universe / target population / population cible / de jure / ménages ordinaires / caserne / prison / hôpital / internat / dormitory / barrack / nomad — zero hits describing a target population; the only hits were 'hospitalization' / 'hospitalisation' in the health-module description.
+#+end_quote
+
+*** Tanzania 2020-21 -- Tanzania National Panel Survey 2020-21, Wave 5 (TZA_2020_NPS-R5_v02_M)
+
+- Confidence that this is a real gap :: high
+
+What the extractor recorded in place of a statement:
+
+#+begin_quote
+NOT FOUND. No universe / target-population statement exists in any 2020-21 document I checked. The authoritative DDI field is present but EMPTY: the WB catalog DDI export for catalog id 5639 contains, VERBATIM, "<universe><![CDATA[]]></universe>". The nearest documented statements are recorded in exclusions_verbatim and notes and are NOT universe statements.
+#+end_quote
+
+What was searched:
+
+#+begin_quote
+lsms_library/countries/Tanzania/2020-21/Documentation/ (full listing): ddi-documentation-english_microdata-5639.pdf (12 pp, text-extracted; grepped universe/coverage/scope/population/represent — 'universe' string ABSENT), nps_wave_5_report.pdf (125 pp, text-extracted; grepped universe/target population/covers all/eligib/exclud/institution/barrack/nationally representative — 'universe'/'target population' strings ABSENT), executive_summary_tanzania_printfile_02b.pdf (8 pp, same greps, ABSENT), the four questionnaire PDFs (nps_household/agriculture/livestock/community_qx_y5*.pdf, not read for universe), SOURCE.org, LICENSE.org. Fallback: WB catalog id 5639 DDI XML export — <universe> element present but EMPTY.
+#+end_quote
+
+*** Timor-Leste 2001 -- Timor-Leste Living Standards Survey 2001 (TLSS)
+
+- Confidence that this is a real gap :: high
+
+What the extractor recorded in place of a statement:
+
+#+begin_quote
+NOT FOUND (no explicit universe / target-population statement). Nearest documented coverage statements, quoted verbatim:
+
+(a) WB catalog, Coverage > Geographic Coverage (DDI field study_info.geog_coverage): "National coverage.
+Domains: Urban/rural; Agro-ecological zones (Highlands, Lowlands, Western Region, Eastern Region, Central Region)"
+
+(b) WB catalog Abstract: "A second element was the Timor-Leste Living Standards Measurement Survey (TLSS). This is a household survey with a nationally representative sample of 1,800 families from 100 sucos."
+
+(c) Local: ETPA-Vol2-Final-web.pdf, Ch. 1 ¶1.2 (and verbatim identical in ddi-documentation-english_microdata-75.pdf, "Sampling Procedure / SAMPLE SIZE AND ANALYTIC DOMAINS"): "A survey relies on identifying a subgroup of a population that is representative both for the underlying population and for specific analytical domains of interest. The main objective of the TLSS is to derive a poverty profile for the country and salient population groups. The fundamental analytic domains identified are the Major Urban Centers (Dili and Baucau), the Other Urban Centers and the Rural Areas. ... The survey has a sample size of 1,800 households, or about one percent of the total number of households in Timor-Leste."
+
+(d) Local: ddi-documentation-english_microdata-75.pdf, "Sampling Procedure / SAMPLING STRATEGY": "This implies that the sample is approximately selfweighted within the stratum: all households in the stratum had the same chance of being visited by the survey."
+#+end_quote
+
+What was searched:
+
+#+begin_quote
+Local 2001/Documentation/: ddi-documentation-english_microdata-75.pdf (full text, 296k chars, extracted with pdfminer; grepped universe|target population|coverage|geographic coverage|scope|represent|nationally representative|national coverage|Domains:), ETPA-Vol2-Final-web.pdf (Poverty Assessment Vol. II Technical Report, full text 509k chars; grepped universe|institutional|private household|not covered by the survey|target population|household is defined|definition of a household|usually live together|common kitchen|common food|excluded from the survey), timorlestehhqeng_V2.pdf (household questionnaire, full text; grepped universe|household member|eligible|definition|resident|usual), SOURCE.org, LICENSE.org, Timor-Leste/_/CONTENTS.org. Remote: WB Microdata catalog study 75 (study-description HTML + related-materials HTML + DDI JSON via /api/catalog/TLS_2001_TLSS_v01_M) — study_info keys are exactly [abstract, coll_dates, nation, geog_coverage, data_kind, notes]; there is NO `universe` key and no "Universe" heading anywhere on the catalog page.
+#+end_quote
+
+** Three partial gaps (recorded NOT FOUND, but not counted in the seven)
+
+These three waves record NOT FOUND for a universe statement in their
+=population_verbatim= field, but carry a =source_type= other than =not-found=
+because a weaker fallback coverage claim was located.  The headline count of
+"7 not found" is the =source_type= count; on the stricter reading -- "does any
+document name the population this sample represents?" -- the answer is *no* for
+ten waves, not seven.  Both counts are correct; they answer different questions,
+and the difference is itself a finding for #603.
+
+Note also that for the two GhanaSPS waves the fallback is *not the World Bank
+catalog*: it is the IHSN NADA mirror of the ISSER (University of Ghana) data
+portal.  GSPS waves 2 and 3 are not in the WB catalog at all.  The recorded
+=source_type= reads =wb-catalog= only because the extraction schema had no value
+for "some other survey catalog" -- a schema limitation worth fixing if #603
+formalises these fields.
+
+*** GhanaSPS 2013-14 -- Ghana Socioeconomic Panel Survey, Wave 2 (2013-2014)
+
+- Recorded source_type :: wb-catalog (so it is NOT in the headline "7 not found")
+
+What was searched:
+
+#+begin_quote
+Local: full text of ISSER_Yale_Part A_WAVE II.docx (4464 paragraphs, extracted from word/document.xml) and ISSER_Yale_Community Survey_WAVE II.docx (1466 paragraphs) - grepped for universe / target population / eligib / nationally / representative / 'all households in' / 'sample of' with zero hits; directory listing of Documentation/ (only questionnaires, a Data Map, a food-unit-code sheet, and per-file Variable Lists/Labels spreadsheets - no BID, no DDI, no report). There is NO Documentation/SOURCE.org for this wave, hence no recorded catalog id. Catalog: _wb_catalog_search('GHA', collection='lsms') returns only 2534 (GSPS wave 1) plus the four GLSS studies - no GSPS wave 2; full GHA catalog search likewise. Non-WB catalogs: catalog.ihsn.org/catalog/10354 (fetched, converted to text); dataportal-isser.ug.edu.gh/index.php/catalog/3 (404 / TLS cert mismatch - unreachable); datafirst.uct.ac.za/dataportal/index.php/catalog/884 (404). Official distribution: Harvard Dataverse doi:10.7910/DVN/E5QP0F full file listing (333 files) - the only Wave 2 documentation shipped is 'Wave 2 - Part A.docx' and 'Wave 2 -Part B.docx' under Documentation/Questionnaires; ALL technical documents in that dataset (Basic_information_Document.pdf, Baseline_Descriptive_Report.pdf, Codebook.pdf, DDI_Documentation.pdf, Interviewers_Manual) are Wave 1 only. Also read 'Ghana Panel Creation User Guide.pdf' (Dataverse file 6693676) and the EGC project page https://egc.yale.edu/isser-northwestern-yale-long-term-ghana-socioeconomic-panel-survey-gsps.
+#+end_quote
+
+*** GhanaSPS 2017-18 -- Ghana Socioeconomic Panel Survey, Wave 3
+
+- Recorded source_type :: wb-catalog (so it is NOT in the headline "7 not found")
+
+What was searched:
+
+#+begin_quote
+Local: full text of HH_Questionnaire_23_10.docx (9671 paragraphs, extracted from word/document.xml) - grepped for universe / target population / eligib / nationally / representative / 'all households in' / 'sample of' / excluded; only module-level respondent-eligibility hits, no universe statement. The wave's Documentation/ directory contains that one file and nothing else (no BID, no DDI, no report, no variable lists). There is NO Documentation/SOURCE.org for this wave, hence no recorded catalog id. Catalog: _wb_catalog_search('GHA', collection='lsms') and full GHA catalog search - no GSPS wave 3 in the World Bank catalog. Non-WB catalogs: catalog.ihsn.org/catalog/10355 (fetched, converted to text); dataportal-isser.ug.edu.gh/index.php/catalog/4 (404 / TLS cert mismatch - unreachable); datafirst.uct.ac.za/dataportal/index.php/catalog/885 (unreachable). Official distribution: Harvard Dataverse doi:10.7910/DVN/E5QP0F full file listing - the only Wave 3 documentation shipped is 'Wave 3.docx' under Documentation/Questionnaires; all technical documents in that dataset are Wave 1 only. Also read 'Ghana Panel Creation User Guide.pdf' (Dataverse file 6693676) and the EGC project page.
+#+end_quote
+
+*** Niger 2021-22 -- Enquête Harmonisée sur le Conditions de Vie des Ménages (EHCVM) 2021-2022 (WB catalog 6276; NER_2021_EHCVM-2_v01_M)
+
+- Recorded source_type :: wb-catalog (so it is NOT in the headline "7 not found")
+
+What was searched:
+
+#+begin_quote
+lsms_library/countries/Niger/2021-22/Documentation/ — contains ONLY SOURCE.org, no PDFs, no DVC-tracked documentation at all. Fell back to WB catalog 6276: downloaded and text-extracted the study-description HTML, the full DDI/XML metadata export (grepped for '<universe>' — the string 'universe' does not occur anywhere in the 1.8 MB XML), the related-materials listing (4 items: 2 household questionnaires, BID English, BID French), and both Basic Information Documents (grepped for 'universe|univers|population cible|target population|base de sondage|champ|couvre|excluant|exclu|represent|coverage|frame').
+#+end_quote
+
+* 5. What the evidence suggests for #603
+
+This section reports what the 111 entries actually show.  It stops short of a
+proposal.  Where the evidence points two ways, both ways are recorded and
+neither is chosen: #601's own note is that a proposal encoding a judgement about
+what the library will pool on a user's behalf is a direction decision for Ethan,
+and several of the disagreements below cannot be settled without making exactly
+that judgement.
+
+** 5.1 Headline counts
+
+| finding                                                             | waves |
+|---------------------------------------------------------------------+-------|
+| total waves swept (38 country directories)                          |   111 |
+| a documented statement of some kind (=source_type != not-found=)     |   104 |
+| no statement of any kind (=source_type = not-found=)                 |     7 |
+| plus: records NOT FOUND for a universe, fallback coverage claim only |     3 |
+| ...so, waves where NO document names the population                  |    10 |
+| statement lives in a file this repo ships                           |    63 |
+| statement lives ONLY in catalog metadata or a catalog-hosted PDF     |    41 |
+| extractor confidence high / medium / low                            | 84/25/2 |
+
+The 41 is the first structural finding.  *Roughly two fifths of the library's
+population record does not exist inside the library.*  It lives on
+=microdata.worldbank.org= (and, for two Ghana panel waves, on =catalog.ihsn.org=),
+in fields the World Bank can revise or blank at any time -- and several already
+have been blanked, since three waves have a =<universe>= element that is present
+and empty.  Whatever shape #603 lands on, a population record built by *linking*
+to the catalog would be recording a moving target.  The only durable option
+observed here is transcription with a locator, which is what this sweep did.
+
+** 5.2 How many are explicitly national
+
+| editorial tag           | waves |
+|-------------------------+-------|
+| national-all-households |    37 |
+| national-claimed        |    28 |
+| region-excluded         |    18 |
+| subnational-area        |    11 |
+| not-stated              |     7 |
+| panel-inherited         |     5 |
+| mixed-national+panel    |     2 |
+| rural-and-small-town    |     1 |
+| specialized             |     1 |
+| agricultural-households |     1 |
+
+65 waves assert national scope in some form -- but only 37 of those actually
+*name the population*; the other 28 offer nothing stronger than "National",
+"national coverage", or "a nationally representative sample of households".  All
+eight Uganda waves are in the second group, as are all four Cote d'Ivoire CILSS
+waves, all four Tajikistan waves, and the three Ghana panel waves.
+
+By a separate count, run over all 111 entries: a field or heading *literally
+labelled* "Universe" / "UNIVERSE" / "Universo de estudio" / "Sampling Universe",
+whose content is the quoted statement, exists for *47 of 111 waves*.  For the
+other 64 the strongest available text is coverage prose, sampling-procedure
+prose, or a report's methodology chapter.  This is an editorial count against a
+stated criterion, not a machine count; the per-wave evidence is in section 3.
+
+** 5.3 How many exclude urban, or a region, by design
+
+*Named-region subtraction, at design level: 19 waves.*  The 18 tagged
+=region-excluded= plus Ethiopia 2011-12, whose rural/small-town restriction is a
+different shape of the same thing.  What is excluded, and why, varies
+enormously, and the *reason* matters as much as the fact:
+
+- Administrative / definitional :: Albania 1996 excludes Tirana because Tirana
+     had been surveyed separately in 1994.  Serbia 2007 and Serbia and
+     Montenegro 2002/2003 exclude Kosovo and Metohija.  Armenia 1996's footnote
+     excludes Nagorni Karabakh, Nakhichevan and Artsvashen as not part of the
+     Republic.
+- Cost / logistics :: Malawi excludes Likoma island in IHS2 and IHS3 ("it only
+     represents about 0.1% of the population of Malawi, and the corresponding
+     cost of enumeration would be relatively high"), then *includes* it from IHS4
+     -- a real break in the universe between 2010-11 and 2016-17 that a naive
+     panel would silently absorb.  Nepal 1995-96 did not select Rasuwa and
+     Mustang for low population.  Niger excludes certain Arlit strata for
+     difficulty of access, low density and collective housing (<0.4% of the
+     population, quantified).
+- Security / conflict :: Mali excludes Kidal.  Ethiopia ESPS-5 excludes Tigray.
+     Nigeria 2018-19 fully excludes rural Borno from the refresh sample.
+     Pakistan 1991 excludes FATA, military restricted areas, and Kohistan /
+     Chitral / Malakand (~4% of the population).  Peru 1985 excludes Ayacucho,
+     Apurimac and Huancavelica "que se encontraban en emergencia".  Azerbaijan
+     1995 excises eleven occupied raions from the frame.
+- Frame construction :: Ethiopia excludes nine zones of Afar and Somali from the
+     ESS/AgSS frame across ESS1-ESS3.  Serbia 2007 excludes enumeration
+     districts with fewer than 20 households.
+
+*Urban excluded entirely, by declaration: exactly one wave.*  Ethiopia 2011-12
+(ESS1): "designed to be representative of rural and small town areas of
+Ethiopia".  Three more surveys are rural in fact but never say so as a universe,
+and the sweep declined to write it for them: China 1995-97 ("a rough
+approximation of the rural population in Hebei and Liaoning"), India 1997-98
+(all PSUs are villages, the abstract calls it "a two-part study of rural
+poverty", but the universe is stated as four statistical regions), and the eight
+EthiopiaRHS rounds (15 peasant associations).  If #603 wants a =rural= flag it
+will be writing that flag itself for three of those four.
+
+*Rural excluded entirely: zero declared waves* -- but note Togo 2018, whose
+documentation says the sample covers all regions "except Lome Commune where all
+respondents are from rural areas".  Lome Commune is the wholly urban capital
+district.  This reads like an urban/rural transposition in the source; it is
+quoted uncorrected in section 3 and should not be silently repaired.
+
+** 5.4 How many are specialized
+
+Only *one whole wave* is a purpose-built non-general population: Liberia 2018-19,
+the National Household Forest Survey, whose universe is "All EAs within 2.5
+kilometers of forests except for the EAs from the urban part of the Montserrado
+county", with the forest itself defined by a canopy-cover rule.  The WB catalog
+nevertheless classifies its study type as "Living Standards Measurement Study
+[hh/lsms]", so a type-based filter would not catch it.
+
+But specialization mostly does *not* appear at wave granularity.  It appears
+*inside* waves, and this is the second structural finding:
+
+- Serbia and Montenegro 2002 :: one wave directory, two samples with two
+     universes -- the general-population LSMS, and the Family Income Support
+     (MOP) survey drawn from the Ministry of Social Affairs recipient list.
+- Serbia and Montenegro 2003 :: again two -- the general-population panel, and a
+     Roma settlement survey whose universe is explicitly *not* all Roma in
+     Serbia: "the LSMS of the Roma population comprised potentially most
+     imperilled Roma, while the Roma integrated in the main population were not
+     included in this study."
+- Azerbaijan 1995 :: three sub-populations (Baku, outside Baku, registered
+     IDPs), self-weighted within each and *not* jointly.
+- Tajikistan 1999 :: a 400-household oversample in Dangara and Varzob for a
+     World Bank Health Project, drawn separately "in order to allow for their
+     exclusion in nationally representative analysis".
+- Iraq 2012 :: anthropometrics, time use and food-consumption-by-recall were
+     administered to a subsample of three of the nine households per cluster --
+     so those three tables represent a different sample than the rest of the wave.
+- Malawi 2016-17 and 2019-20 :: the library's config reads both
+     =Data/Cross_Sectional/= (IHS4/IHS5 national cross-section) and =Data/Panel/=
+     (IHPS long-term panel, representative only at national and urban/rural level
+     from 2016) into a single wave.
+- GhanaLSS 1991-92 :: the DDI enumerates *per-module sub-universes* explicitly
+     (roster: all usual members; education: 5+; employment and time use: 7+;
+     migration: 15+; housing: heads; agriculture: holders).  GLSS2's DDI says
+     "Different sections of the instruments have individual universes" and then
+     does not list them.
+- Tanzania NPS :: household eligibility is "any household member aged 15 years
+     and above, excluding live-in servants".
+- Malawi IHPS :: individual tracking eligibility is "neither servants nor guests
+     at the time of the IHS3; ... projected to be at least 12 years of age".
+
+A wave-level population record would flatten all of these.  Whether that is
+acceptable is a design decision, not an evidentiary one -- but the evidence is
+that it happens in at least nine waves across seven countries.
+
+** 5.5 The universe / represented-sample split
+
+The documents themselves keep two things apart that a single "population" field
+would merge, and in several waves they come apart sharply:
+
+- Ethiopia 2021-22 :: universe = "all de jure households excluding prisons,
+     hospitals, military barracks, and school dormitories"; series info = "covers
+     all regions of the country except Tigray"; weighting = "cross-sectional
+     weights were calculated to represent the 2021/22 Ethiopia population
+     (excluding Tigray)".  Tigray is outside the *represented* population, not
+     merely non-response, and it takes the weighting sentence to establish that.
+- Nigeria 2018-19 :: "the combined sample is representative of areas of Nigeria
+     that were accessible during 2018/19.  The sample will not reflect conditions
+     in areas that were undergoing conflict during that period."
+- Liberia 2018-19 :: a stratification variable was computed incorrectly, so
+     "the stratification by distance to forest has been abandoned and the sample
+     weighted to reflect only geographic clusters" -- the represented population
+     changed *after* fieldwork.
+- Tanzania 2019-20 :: declared universe is national ("all households and
+     individuals in Tanzania"), realised sample is the 989-household Extended
+     Panel cohort, and this round's =geogCover= drops to "Designed for analysis of
+     key indicators at the national level" where the other NPS rounds name four
+     domains.
+- Malawi IHS5 2019-20 :: COVID suspended fieldwork; 51 EAs got weight zero and
+     were represented by reweighting the enumerated EAs in their stratum.
+
+On this evidence a population record with a single field would be lossy.  What
+the documents consistently supply is three separable things: the declared
+universe, the declared exclusions, and what the weights are stated to represent.
+Whether #603 wants all three is the maintainer's call.
+
+** 5.6 Is the vocabulary consistent enough to build a controlled vocabulary from?
+
+*Partly -- and much more so on the exclusion axis than the inclusion axis.*
+
+Against consistency:
+
+- The single most repeated sentence in the whole corpus is template text, not a
+  survey claim.  "The survey covered all de jure households excluding prisons,
+  hospitals, military barracks, and school dormitories." appears verbatim in
+  *15 waves* -- and not only in the eight WAEMU/EHCVM countries where you would
+  expect it (Benin x2, Burkina Faso 2018-19 and 2021-22, Cote d'Ivoire, Guinea-
+  Bissau, Mali, Niger, Senegal, Togo) but also in Ethiopia 2018-19 and 2021-22
+  and Nigeria 2015-16, 2018-19 and 2023-24.  It is World Bank NADA boilerplate.
+  Its presence tells you which metadata template was used; it does *not*
+  independently attest that a particular statistical office made that claim about
+  that survey.  Building a vocabulary on it would be building on the template.
+- The *unit* of the universe is not stable, even within one country's own series.
+  Households: most.  Individuals/persons: GhanaLSS 1987-88 ("all household
+  members of all age and sex category who reside in Ghana"), South Africa 1993
+  ("All Household members."), Malawi IHS3 ("individual households and persons").
+  Dwellings: Guatemala 2000 and Panama 1997 and 2003 ("viviendas particulares").
+  And Panama shifts unit *between its own waves*: 2008's universe is "la
+  población total residente en las viviendas particulares ocupadas del país",
+  where 1997 and 2003 name the dwellings themselves.  Mali EAC-I is different
+  again: "exploitations agricoles en milieu rural, ménage en milieu urbain" --
+  the observation unit differs by stratum inside one survey.
+- The phrasing of the same idea varies without limit: "The universe under study
+  consists of all the households in the Republic of Albania"; "le champ social
+  est constitué de l'ensemble des ménages, toutes catégories confondues,
+  nationaux ou non, résidant sur le territoire national"; "Universo de estudio:
+  Viviendas particulares y hogares existentes en el país"; "The population
+  covered by IHSES included all households residing in Iraq from November 1,
+  2006, to October 30, 2007"; "The universe includes all households and
+  individuals in Tanzania with the exception of those residing in military
+  barracks or other institutions"; "the population living within private
+  households in Ghana"; "The survey covered all modified de jure household
+  members (usual residents)".
+- "de jure" is used in two different senses -- the NADA boilerplate's, and
+  Nepal's "modified de jure household members (usual residents)".
+- Some documentation is circular.  GhanaLSS 1988-89's UNIVERSE field reads "The
+  survey covered all household members in the nationally representative sample."
+  Malawi IHS2's nearest statement is "The population covered by the IHS-2 was all
+  individuals living in selected households."  Both describe the sample, not the
+  universe.
+- And at least three waves' documentation *denies* a well-defined universe
+  outright.  China 1995-97: "The CLSS sample is not a rigorous random sample
+  drawn from a well-defined population."  EthiopiaRHS: "To be clear, these data
+  are not nationally representative."  Albania 1996: "The sample was designed to
+  maximize the inclusion of poor areas to increase the number of program
+  participants."  The library currently has no way to express "this survey says
+  it does not represent anything in particular", and these are exactly the cells
+  most dangerous to pool.
+
+For consistency, on the exclusion axis:
+
+The *categories* of exclusion recur across languages and decades with far more
+regularity than the inclusion phrasing does, and a controlled vocabulary looks
+buildable over roughly these:
+
+1. institutional / collective quarters (prisons, hospitals, barracks, school
+   dormitories, hostels, old-age homes) -- exclusion language of this kind is
+   present in *55 of 111 waves*, in English, French ("les ménages collectifs
+   (camps militaires, casernes, hôpitaux, etc.)") and Portuguese-titled surveys
+   alike;
+2. diplomatic / consular households (Burkina Faso, Serbia and Montenegro, Nepal,
+   Malawi);
+3. homeless / no fixed abode ("les sans domiciles fixes" -- Burkina Faso; Serbia
+   2007);
+4. non-private dwellings ("viviendas particulares", "private households");
+5. a named geographic unit (19 waves; see 5.3);
+6. an age or residence eligibility rule (15+ in Tanzania NPS and Albania APS,
+   12+ in Malawi IHPS, 18+ in Cambodia LSMS+, months-of-residence rules
+   everywhere);
+7. a status rule (servants, lodgers, boarders, guests -- Cote d'Ivoire "CILSS
+   always excludes servants and boarders from household membership because they
+   are considered to be separate households"; Timor-Leste's five-person boarding
+   house rule).
+
+Note that categories 6 and 7 are *household-membership* rules, not universe
+exclusions, and the documents themselves usually keep them apart.  Merging them
+into one "exclusions" field would be a substantive modelling choice.
+
+** 5.7 Disagreements and awkward cases, flagged and NOT resolved
+
+These are the cases where the evidence does not settle the question.  Each is
+recorded verbatim in section 3.  None is adjudicated here.
+
+1. *Nigeria 2012-13 (GHS-Panel W2).*  The WB catalog's =Universe= field says
+   "Agricultural farming household members."  The wave's own Basic Information
+   Document says "The objective of the GHS-Panel Wave 2 was to re-interview all
+   of the Wave 1 households."  Every other GHS-Panel wave has the standard
+   national universe sentence.  Two sources, one wave, incompatible universes.
+2. *Azerbaijan 1995.*  =geog_coverage= asserts "National" while the frame
+   explicitly excises eleven occupied raions, reducing 4,250 population points to
+   3,453.  The source disagrees with itself.
+3. *Peru 1991.*  =Universe= reads "Población nacional" (two words) while the
+   enumerated Geographic Coverage lists nine domains that do not include Selva or
+   Costa Rural.  The sweep did not assert an exclusion; it recorded the tension.
+4. *Mali 2018-19.*  The wave has a proper =UNIVERSE= field asserting a national
+   universe, while its Sampling Procedure says data were not collected in Kidal,
+   Bamako (rural), Taoudenit and Menaka.  *My editorial tag says =region-excluded=
+   and the wave's own Universe field says otherwise* -- this is the clearest case
+   where the tag is a judgement, and a maintainer may reasonably reverse it.
+5. *Albania 2005.*  The quoted universe sentence is verbatim-identical to
+   Albania 2002's, and in the 2005 BID it sits inside an annex whose surrounding
+   sentences describe the *2002* fieldwork -- while the 2005 BID's own design
+   chapter says a completely new sample was drawn.  Inherited text presented as a
+   current claim.  Any population record that treats "the document says X for
+   wave W" as sufficient will import this.
+6. *GhanaLSS 2005-06.*  Two universes in one document.  The DDI =UNIVERSE= field
+   describes respondent eligibility and ends "This excludes heads of households"
+   -- which is uninterpretable, since heads are plainly enumerated.  The Sampling
+   Frame text gives the real target population, "the population living within
+   private households in Ghana".  The sweep recorded both and interpreted
+   neither.
+7. *Burkina Faso 2018-19.*  The French rapport général claims representativity
+   for the 13 administrative regions and both milieux; the English BID says the
+   sample "is representative for the strata of Ouagadougou, other urban areas and
+   rural areas".  Different claims about the same sample.
+8. *Burkina Faso wording drift.*  2014 says the social scope is households
+   "nationaux ou non"; 2018 says "nationaux ou africains".  Quoted as printed,
+   not reconciled.  If that change is real it narrows the universe.
+9. *Togo 2018.*  "surveyed in all regions except Lome Commune where all
+   respondents are from rural areas" -- see 5.3.  Do not silently fix it.
+10. *Tanzania 2019-20.*  Declared national universe, realised Extended-Panel
+    cohort, and a =geogCover= that quietly drops from four inference domains to
+    "national level".  The single most instructive case in the corpus for why
+    "declared" and "represented" need separating.
+11. *Malawi 2016-17 and 2019-20.*  One library wave, two declared universes,
+    because the config reads both the cross-section and the panel directories.
+    Also note IHS4 is the first round to *include* Likoma -- the universe changes
+    across the panel.
+12. *Serbia and Montenegro.*  The country directory is named for a state union;
+    every universe statement covers Serbia only, minus Kosovo and Metohija.  No
+    document says Montenegro was excluded -- the exclusion is an inference from
+    the affirmative statements, and the sweep recorded it as an observation
+    rather than a quotation.
+13. *Benin.*  Two wave directories (=2018-19= and =2018-2019=) whose DVC sidecars
+    are byte-identical.  Only the first has documentation.  The second's entry is
+    an explicit, evidenced inheritance -- and the honest per-directory answer for
+    it alone is NOT FOUND.  It is already staged for deletion in the working tree.
+14. *Nigeria 2018-19 provenance.*  =SOURCE.org= records catalog 3827 (Nigeria
+    Living Standards Survey) while the data and documentation are GHS-Panel Wave
+    4 = catalog 3557.  Both entries happen to carry the same universe sentence,
+    so the population statement is unaffected -- but the recorded catalog id is
+    wrong, and CLAUDE.md already warns about this exact collision.
+15. *GhanaSPS waves 2 and 3.*  Not in the World Bank catalog at all; the only
+    catalog record is the IHSN mirror of ISSER's portal, which has no =Universe=
+    field and no Sampling section.  Wave 3's repo label (=2017-18=) disagrees with
+    its own instrument cover page ("WAVE 3 (2018-2019)") and with the IHSN entry.
+16. *Ethiopia ESS1.*  Its strongest frame statement comes from the *ESS3* Basic
+    Information Document describing wave 1 retrospectively.  A later document
+    speaking for an earlier wave is weaker evidence than it looks, and the entry
+    flags it rather than merging it.
+17. *Uganda, all eight waves.*  No =Universe= field exists anywhere -- not in any
+    BID, not in any DDI, not on any catalog page.  The population record for
+    Uganda would rest entirely on one repeated sentence about a "nationally
+    representative sample of households" plus an IDP-camp exclusion whose wording
+    drifts between waves ("are not a part of" / "were not a part of" / "were not
+    part of the UNPS sample").  Uganda is the library's most-used country.
+
+** 5.8 Acquisition queue (documents that would close or harden a cell)
+
+Recorded because several gaps are *acquirable*, not permanent:
+
+- Albania 2008 :: no BID was ever published; the route is INSTAT Albania
+     directly (=instat.gov.al=), not the World Bank catalog.
+- Ethiopia 2018-19 (ESS4) and 2021-22 (ESPS-5) :: the Basic Information Documents
+     are referenced by the catalog and are not in this repo.  ESPS-5's wave
+     directory contains no documentation at all.
+- GhanaLSS 2016-17 :: the GLSS7 Main Report (its methodology appendix is the
+     analogue of GLSS6's section 6.2) is not in the repo; the shipped DDI's
+     Sampling section reads "No content available".
+- Cambodia 2019-20 :: the universe, if any, is inherited from the CSES 2019-2020
+     sample design, whose report is not in this repo.
+- South Africa 1993 :: the SALDRU final report ("South Africans Rich and Poor",
+     1994) is the plausible source of a crisper statement.
+- Guyana 1992, Cote d'Ivoire 1985-89, Kazakhstan 1996, Peru 1985/1990/1991 ::
+     several questionnaires and manuals are image-only scans that no OCR tool on
+     this host could read.  A cover page or manual introduction could in
+     principle carry coverage language that this sweep therefore does not cover.
+- All 41 catalog-only waves :: transcription into the repo is the durability fix,
+     per 5.1.
+
+** 5.9 What this document deliberately does not do
+
+- It does not propose a schema, a YAML key, a =data_info.yml= field, or a
+  =population= table.
+- It does not decide whether =Feature()= should refuse to pool waves with
+  different universes, warn, or ignore the difference.
+- It does not resolve any of the seventeen disagreements in 5.7.
+- It does not fill any of the ten waves with no named population.
+
+Those are the direction decisions.  The evidence for them is in sections 2, 3
+and 4.


### PR DESCRIPTION
Assembles the per-country population-statement sweep into one reviewable evidence document:
`slurm_logs/POPULATION_STATEMENTS_2026-07-21.org`.

It records, for every wave the library ships, **what that survey's own documentation says its sample represents** — verbatim, with exclusions called out separately, and with the gaps left as gaps.

### Headline counts

| finding | waves |
|---|---|
| total waves swept (38 country directories) | **111** |
| a documented statement of some kind (`source_type != not-found`) | **104** |
| no statement of any kind (`source_type = not-found`) | **7** |
| plus: records NOT FOUND for a universe, fallback coverage claim only | 3 |
| …so, waves where **no document names the population** | **10** |
| statement lives in a file this repo ships | 63 |
| statement lives **only** in catalog metadata or a catalog-hosted PDF | **41** |
| extractor confidence high / medium / low | 84 / 25 / 2 |

### The standing rule it obeys

- **Quotes are verbatim** — sic spellings (`"was been designed"`, `"Bihar(Southern"`, `"abovefor"`), source typography (`"Education :"`, `"Agriculture:holders"`) and the sources' own internal contradictions are preserved. Every PDF-extraction repair (rejoined split words, collapsed justification spaces, a decoded glyph-substituted numeral, reconstructed bidi Arabic) is declared in that wave's notes.
- **Gaps are recorded as gaps** — every NOT FOUND carries the full search record, so the claim is falsifiable rather than permanent-by-default.
- **Nothing is inferred from the data** — no `.dta` was opened. Where inheriting a sibling wave's universe would have been defensible (Mali / Niger / Senegal 2021-22 EHCVM-2 panels), it was **declined**, and the entry says so.

### Structure

1. What this is, how it was gathered, and the rule above.
2. Summary table — country, wave, `source_type`, `confidence`, and a **short universe tag marked throughout as an editorial reading, not a quote**.
3. The verbatim record per wave — population statement, translation clearly separated where present, **exclusions in their own block for every wave**, source file + locator, and the extractor's evidence notes.
4. The gaps, unsoftened, with what was searched for each.
5. What the evidence suggests — patterns observed, **disagreements flagged and not resolved**.

### What the evidence shows

- **41 of 111 waves' population record does not exist inside the library.** It lives on `microdata.worldbank.org` (and, for two Ghana panel waves, `catalog.ihsn.org`), and three waves already have a `<universe>` element that is *present and empty*. A record built by linking would track a moving target.
- A field **literally labelled "Universe"** exists for only **47 of 111** waves. For the other 64 the strongest text is coverage prose, sampling-procedure prose, or a report methodology chapter. 65 waves assert national scope in some form — but only 37 actually *name* the population.
- **The single most repeated sentence in the corpus is boilerplate.** *"The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories."* appears verbatim in **15 waves** — and not only in the WAEMU/EHCVM countries but also Ethiopia 2018-19 / 2021-22 and Nigeria 2015-16 / 2018-19 / 2023-24. It attests a WB NADA metadata template, not a statistical office's claim about that survey.
- **19 waves subtract a named region by design** (Tirana, Kosovo and Metohija, Likoma, Kidal, Tigray, Arlit, rural Borno, FATA, Ayacucho/Apurimac/Huancavelica, eleven occupied raions, nine zones of Afar and Somali…). Reasons split into administrative, cost/logistics, security, and frame-construction — and the reason matters. Malawi *excludes* Likoma through IHS3 and *includes* it from IHS4: a real universe break mid-panel.
- **Exactly one wave declares an urban exclusion** (Ethiopia ESS1, "rural and small town areas"). Three more are rural in fact but never say so (China 1995-97, India 1997-98, EthiopiaRHS) — the sweep declined to write it for them.
- **Specialization mostly appears *inside* waves, not as whole waves.** Only Liberia 2018-19 (forest-proximate EAs) is a specialized wave. But Serbia and Montenegro 2002/2003 each carry two samples with two universes (MOP recipients; Roma settlements), Azerbaijan 1995 has three sub-populations, Iraq 2012 administers three modules to a one-third subsample, Malawi 2016-17/2019-20 read a national cross-section *and* a panel into one library wave, and GLSS3 enumerates per-module sub-universes explicitly.
- **"Declared universe" and "what the weights represent" come apart** in real documents — Ethiopia ESPS-5 (weights represent the population *excluding Tigray*), Nigeria 2018-19 ("representative of areas of Nigeria that were accessible during 2018/19"), Liberia (stratification error changed the represented population after fieldwork), Tanzania 2019-20 (national universe, Extended-Panel cohort).
- **Vocabulary consistency: partly — the exclusion axis far more than the inclusion axis.** The *unit* of the universe is unstable even within one country's series (Panama shifts from dwellings to resident population between waves); several universes are circular; and three surveys' documentation *denies* a well-defined universe outright (China: "not a rigorous random sample drawn from a well-defined population"; EthiopiaRHS: "these data are not nationally representative"). The library currently has no way to express that.

### Deliberately not done

No schema, no YAML key, no decision about whether `Feature()` should refuse to pool waves with different universes. §5.7 lists **17 unresolved disagreements**, including one where my own editorial tag contradicts the wave's own `UNIVERSE` field (Mali 2018-19) — flagged, not adjudicated. Per #601's note, a proposal that encodes a judgement about what the library will pool on a user's behalf is a direction decision for Ethan.

Refs #603, #601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su5JKX3wKChyfMAdXrdCTr
