### PR TITLE
fix(#645): to_parquet stops deleting real data via string-matched nulls

### DIFF
--- a/.coder/ledger/645-to-parquet-null-coercion.md
+++ b/.coder/ledger/645-to-parquet-null-coercion.md
@@ -1,0 +1,168 @@
+# Prior-Art Ledger — GH #645: `to_parquet` destroys values that spell like nulls
+
+**Search tier used:** ripgrep + git (floor), plus a **live cross-country cold
+sweep**: 28 data-bearing countries × `individual_education`, each in its own
+process with its own empty `LSMS_DATA_DIR` (only `dvc-cache` symlinked to the
+shared L1), plus targeted before/after cold builds of `Nigeria/food_acquired`
+and `Guyana`/`South Africa` `housing`.  gitnexus not used.
+**Inherits:** `.coder/ledger/STANDING.md` §2/§3/§4 — cited, not restated.
+**Base commit:** rebased onto `4c236d11`.  The branch started at `45aee170`; the
+`origin/development` ref moved **twice** mid-task (`eadafe75` India #611, then
+`4c236d11` through #644) — see §6, and note that #644 changes Ethiopia's
+baseline numbers, so every Ethiopia figure here was **re-measured** on
+`4c236d11`.
+
+---
+
+## §1 Task, restated
+
+`local_tools.to_parquet` serializes every `dtype == object` column as
+`astype(str).astype('string[pyarrow]').replace({'nan': None, 'None': None,
+'<NA>': None})`.  It stringifies **first** and then tries to recover the nulls
+by matching the resulting characters — but after `astype(str)` a genuine
+missing and a legitimate value spelling `'None'` are the same characters, so
+the recovery is wrong in principle, not merely in practice.
+
+`None` was the canonical library label for *"no education"*
+(`categorical_mapping/harmonize_education.org`), so the write path nulled every
+never-schooled person, and `Country._finalize_result`'s `dropna(how='all')`
+(`country.py`) then **deleted the row** — `individual_education` has exactly one
+column.  Fix the write path, rename the hostile label, force one cache rebuild.
+
+## §2 Existing machinery (reused, did NOT rebuild)
+
+| symbol | path | what it does | tested? | decision |
+|---|---|---|---|---|
+| `to_parquet` | `local_tools.py` (STANDING §2) | the only sanctioned writer | yes | **extend in place** — 3-line change inside the existing coercion loop; no new writer, no new call site, no signature change |
+| `LSMS_CACHE_SCHEMA` | `local_tools.py` | the manual library-version lever folded into `Wave._input_hash` / `Country._table_cache_hash` | cache tests | **reuse** — `4 -> 5`.  This is exactly the lever's documented purpose (a library-wide change to the *pre-write* extraction logic whose per-table input hashes are unchanged); no new invalidation mechanism |
+| `_enforce_canonical_spellings` | `country.py` (STANDING §2) | variant → canonical at API time, on columns AND index levels | `test_schema_consistency.py` | **reuse** — the `None -> No education` back-compat mapping is a `spellings` entry, not migration code.  Historical caches resolve forward with no rebuild |
+| `spellings` block in `data_info.yml` | STANDING §3 | the sanctioned place to declare accepted values | `test_declared_spellings.py` | **reuse** — followed the `plot_features.Tenure` / `TenureSystem` pattern (full vocabulary, empty variant lists) |
+| `harmonize_education` org tables | `categorical_mapping/` + 25 country `categorical_mapping.org` | raw label → canonical level | via country builds | **edit data, not code** — the rename is 38 table rows; no mapping code changed |
+| `tests/conftest.py` `requires_s3` | added on `development` in #648 | skips data-dependent tests in the data-free CI job | — | **reuse** — the three cold integration cases carry it |
+
+**Did NOT reinvent:**
+- *A migration script for existing caches.*  `LSMS_CACHE_SCHEMA` already forces
+  exactly one rebuild everywhere; a bespoke rewriter would be a second,
+  untested invalidation path.
+- *A null-sentinel scrubber on the read path.*  `transformations.py`
+  `_na_strings`, `country.py` `_NA_SENTINELS` and `conversion.py` already do
+  targeted, deliberate mop-ups on `Relationship` / `sex` / `age` / dates.  Those
+  are *correct* (they operate on columns whose vocabulary genuinely excludes
+  these strings) and are left alone — see §4.3.  Adding a general one would
+  re-create this bug one layer up.
+- *A reducer or an `aggregation:` key.*  GH #323 D1 forbids it; nothing here
+  needed one (`test_gh323_explicit_reducers.py` and
+  `test_gh323_grain_contract.py` both green, 280 assertions).
+
+## §3 Definitions & conventions in force (cited)
+
+- **Canonical schema** = `lsms_library/data_info.yml` (STANDING §3).  The
+  education vocabulary is now declared there, so
+  `diagnostics._check_declared_vocabularies` enforces it.
+- **Canonical education ladder** = `categorical_mapping/canonical_education_labels.org`
+  — 14 ordered levels + the non-ordinal `Unknown` sentinel.  Level 0 renamed
+  `None` → **`No education`**.
+- **Cache tiers / staleness** = `CLAUDE.md` §"Cache Behavior (v0.7.0+)" and the
+  `LSMS_CACHE_SCHEMA` comment block in `local_tools.py`.
+- **`sane` is not `blessed`** = `CLAUDE.md` §"Coverage Matrix".  Directly
+  load-bearing here: `Guatemala,individual_education,2000,sane,declared,20678`
+  certified a table missing 30% of its rows.
+- **GH #323 D1 — no aggregation in core** = `SkunkWorks/grain_aggregation_policy.org` §3a.
+
+## §4 Invariants & assumptions (the landmines)
+
+1. **The pyarrow guard is still load-bearing.**  Measured in this venv
+   (pandas 3.0.2 / pyarrow 23.0.1, `future.infer_string=True`): a genuinely
+   mixed object column still raises `ArrowTypeError` — `str`+`int`, `str`+`float`,
+   `str`+`Timestamp`, `str`+`list`/`tuple`/`dict`, `bool`+`str`, `str`+`Decimal`
+   all fail.  The block may NOT be deleted.  Pinned by
+   `test_mixed_type_object_column_is_still_stringified`.
+2. **But it fires arbitrarily.**  Under pandas 3.0 a *pure string* column is
+   inferred as `str`, not `object`, so it skips the block entirely.  Only
+   whatever still lands as `object` (Stata reads: 16 of 32 columns in Ethiopia
+   2011-12 `sect2_hh_w1.dta`) is affected.  That is why exactly 3 of 25
+   at-risk countries were hit — the other 22 were correct *by accident of dtype
+   inference*, not by design.  **Narrowing the block to "genuinely mixed"
+   columns was considered and rejected** — see §5.
+3. **`LSMS_NO_CACHE=1` MASKS this bug.**  It skips the L2-wave write where the
+   rebinding coercion happens, so it returns the *right* answer and hides the
+   defect.  Every measurement here used a genuinely fresh `LSMS_DATA_DIR`; the
+   integration tests do the same, in a subprocess, and say so.
+4. **The two `to_parquet` call sites disagree.**  `country.py` `Wave.grab_data`
+   **rebinds** the return value; the country-level writer **discards** it.  That
+   is the whole mechanism of the cold≠warm signature, and why Guatemala (whose
+   loss is entirely at the wave level) is cold == warm == wrong and therefore
+   invisible to any A/B comparison.  Left as-is — with a value-preserving write
+   the difference is unobservable, and `cold == warm` is now a *tested*
+   invariant rather than an accident (`test_cold_and_warm_builds_agree`).
+5. **Declaring a `spellings` vocabulary is an assertion that FAILS a country.**
+   `diagnostics._check_declared_vocabularies` returns `Check(..., "fail")` for
+   any value outside `spellings.keys()`.  Declaring only `No education` would
+   have turned every other education level into a violation in 24 countries.
+   Verified empirically instead of assumed — §5.
+6. **`groupby(dropna=True)` deletes NaN index keys** (GH #323 §3b, open).
+   Relevant because the pre-fix code was nulling an *index level* in Nigeria
+   `food_acquired` (`u`).  Measured: no rows were actually lost there — but the
+   combination is a live hazard, and one fewer NaN key is a strict improvement.
+
+## §5 Reuse decision & the two judgement calls
+
+| quantity | decision | reason |
+|---|---|---|
+| null-preserving write | **extend `to_parquet`** | capture `isna()` before the cast, `.mask(na)` after.  Smallest change that makes the recovery well-posed |
+| cache invalidation | **reuse `LSMS_CACHE_SCHEMA`** | documented lever, exact fit |
+| back-compat for the old label | **reuse `spellings`** | applies at API time to columns *and* index levels; no rebuild needed |
+| keep vs. narrow the object-dtype block | **KEEP** | narrowing changes stored dtypes for homogeneous non-str object columns (an object column of ints would be stored `int64` instead of the strings `'1'`,`'2'`), i.e. it would silently change returned data across the corpus — the exact class of failure this issue is about.  The premise ("pyarrow can't take mixed object") is **still true**; what has changed is only that fewer columns reach it.  Recorded, not acted on |
+| declaring the full education vocabulary | **DO IT, on evidence** | swept 28 data-bearing countries cold at the API level, then audited **107 freshly cold-built parquets** (wave + country level) with the real `_check_declared_spellings`: **zero** off-vocabulary values after the one leak below.  Cross-checked statically against all 20 `harmonize_education` tables (`test_harmonize_education_targets_stay_inside_the_declared_vocabulary`) |
+| Ethiopia 2013-14 `76.0` | **fix at the wave `df_edit` hook**, not in the org table | the leak (1 row of 12,583, a bare float that never got a Stata value label) CANNOT be fixed in `categorical_mapping.org`: the table's `Original Label` column is mixed text, so `df_from_orgfile` reads every key as a **string** and a float source value can never match one — verified empirically after an org-row attempt failed (contrast Guyana, whose all-numeric table parses keys as floats).  The hook reuses the shape of Uganda's tested `_/_education_helpers.py` and reads the vocabulary from `data_info.yml` (via the already-tested `diagnostics._DECLARED_VOCABULARIES`) rather than re-listing it.  `Unknown` is the vocabulary's own definition for "unmappable", so this is not a guess.  Zero effect on the API output (Ethiopia 59,092 before and after) |
+
+## §6 Notes for the human
+
+- `origin/development` advanced twice **during** this task (`45aee170` →
+  `eadafe75` India #611 → `4c236d11` through #644).  A
+  `git checkout origin/development -- <path>` for the negative-control revert
+  therefore pulled in unrelated India work; caught and reverted by pinning the
+  base SHA.  Worth knowing: in a shared-object-store worktree, `origin/*` refs
+  are not stable within a session — **pin the SHA for any A/B measurement.**
+- **#644 interacts with this fix on Ethiopia, benignly but visibly.**  It
+  re-keys 2013-14 `individual_education` onto the wave-native ids, which stops
+  5,247 people collapsing onto one blank tuple.  A side effect is that the
+  stray unlabelled `76.0` code **now survives to the API frame**, where before
+  it was collapsed away — so the `df_edit` hook added here is doing real work
+  on the current base, not just tidying a wave parquet.  All Ethiopia numbers
+  in this ledger, the tests and the PR are measured on `4c236d11`.
+- **`Nigeria/*/_/food_acquired.py` writes `fillna('None')` into the `u` index
+  level** (4 waves, 1,151 rows) — the same hostile-sentinel pattern, one table
+  over.  Pre-fix those became NaN index keys; post-fix they are the literal
+  `'None'`.  Not renamed here (out of scope, and `u` feeds the unit-conversion
+  tables), but it should be renamed to something like `Not recorded`.
+
+---
+
+### Phase 3 — verification (anchored on this ledger)
+
+- `to_parquet` (`local_tools.py`) — **OK (§2, §4.1, §5)**: extended in place, no
+  new writer; the pyarrow guard retained and pinned by a test that asserts raw
+  `df.to_parquet` still raises on a mixed column.
+- `LSMS_CACHE_SCHEMA = 5` — **OK (§2, §5)**: the documented lever, with a
+  comment stating the reason (content change, unchanged input hashes).
+- `Columns.individual_education.Educational Attainment.spellings` — **OK (§3,
+  §4.5)**: full vocabulary, `Tenure`-pattern, verified against a 28-country cold
+  sweep before being declared.  Not a REINVENTION of `_check_value_constraints`
+  (which reads the *country's* `data_scheme.yml` and only acts on list
+  declarations) — it is data for the existing canonical checker.
+- 38 `harmonize_education` rows + `canonical_education_labels.org` — **OK
+  (§3)**: data edits onto the vocabulary of record; no mapping code touched.
+- `tests/test_gh645_to_parquet_null_coercion.py` — **OK (§2)**: uses
+  `requires_s3` from `tests/conftest.py` (#648) rather than a private
+  creds helper; cold isolation per §4.3 rather than `LSMS_NO_CACHE`.
+- `Ethiopia/2013-14/_/mapping.py::individual_education` — **OK (§2, §5)**: a
+  wave `df_edit` hook, the mechanism Uganda already uses for exactly this
+  ("unlabelled float junk code"); reads the vocabulary from the schema of record
+  instead of hardcoding a second copy of it.
+- `country.py` `dropna(how='all')` log line — **OK (§1)**: reports, changes
+  nothing.  Anchored on the fact that this step is where the value corruption
+  became a deletion; deliberately INFO, and the escalation policy is left to the
+  maintainer rather than invented here.
+- **No CONTRADICTION found** with GH #323 D1: no `aggregation:` key, no reducer;
+  `test_gh323_explicit_reducers.py` + `test_gh323_grain_contract.py` green.

--- a/lsms_library/categorical_mapping/canonical_education_labels.org
+++ b/lsms_library/categorical_mapping/canonical_education_labels.org
@@ -17,7 +17,7 @@ alongside the label for quantitative analysis.
 
 | Order | Preferred Label             | Covers                                                                 |
 |-------+-----------------------------+------------------------------------------------------------------------|
-|     0 | None                        | Never attended; no formal schooling; "not educated"                    |
+|     0 | No education                | Never attended; no formal schooling; "not educated"                    |
 |     1 | Informal                    | Adult literacy; quranic / religious / integrated; non-graded informal  |
 |     2 | Pre-primary                 | Nursery; kindergarten; pre-school                                      |
 |     3 | Primary incomplete          | Some primary grades; primary cycle not finished                        |
@@ -54,6 +54,19 @@ alongside the label for quantitative analysis.
   ladder (P/M/S/A/T/PS/U, K=Koranic) was decoded from the GLSS questionnaires.  No
   numeric residue remains across the LSMS-ISA education tables.
 - *Never-schooled handling.* The universal `dropna(how='all')` drops rows whose
-  only column (`Educational Attainment`) is NaN, so never-schooled members are
-  currently dropped rather than represented as `None`.  Whether to surface them
-  as a `None` row is an open #171 design question.
+  only column (`Educational Attainment`) is NaN, so members for whom the survey
+  recorded *nothing at all* are dropped.  Members the survey positively records
+  as never-schooled are kept, as `No education`.  Whether to surface the
+  *silent* never-schooled as a row too is an open #171 design question.
+- *Level 0 was spelled `None` until GH #645, and that spelling destroyed data.*
+  `to_parquet` used to stringify object columns and then recover nulls by
+  matching the strings `'nan'` / `'None'` / `'<NA>'` — so the label was
+  indistinguishable from a missing value and was nulled on every parquet write,
+  after which `_finalize_result`'s `dropna(how='all')` deleted the row outright
+  (8,849 rows — 30% — of Guatemala's `individual_education`).  The write path is
+  fixed, but the label is renamed as well: a canonical value that collides with
+  the null literal under `str()`, YAML, CSV and parquet round-trips is a trap
+  that will keep re-arming itself.  `None` remains an accepted *variant*
+  spelling (`data_info.yml` → `Columns.individual_education.Educational
+  Attainment.spellings`), so historical data and any not-yet-updated country
+  still resolve to `No education` at API time.

--- a/lsms_library/categorical_mapping/harmonize_education.org
+++ b/lsms_library/categorical_mapping/harmonize_education.org
@@ -10,11 +10,11 @@
 #+name: harmonize_education
 | Original Label               | Preferred Label              |
 |------------------------------+------------------------------|
-| None                         | None                         |
-| NONE                         | None                         |
-| No education                 | None                         |
-| Not educated                 | None                         |
-| Never attended               | None                         |
+| None                         | No education                 |
+| NONE                         | No education                 |
+| No education                 | No education                 |
+| Not educated                 | No education                 |
+| Never attended               | No education                 |
 | Informal                     | Informal                     |
 | Adult education              | Informal                     |
 | Quranic                      | Informal                     |

--- a/lsms_library/countries/Benin/_/categorical_mapping.org
+++ b/lsms_library/countries/Benin/_/categorical_mapping.org
@@ -465,7 +465,7 @@
 #+name: harmonize_education
 | Original Label  | Preferred Label              |
 |-----------------+------------------------------|
-| Aucun           | None                         |
+| Aucun           | No education                 |
 | Maternelle      | Pre-primary                  |
 | Postsecondaire  | Tertiary certificate/diploma |
 | Primaire        | Primary complete             |

--- a/lsms_library/countries/Burkina_Faso/_/categorical_mapping.org
+++ b/lsms_library/countries/Burkina_Faso/_/categorical_mapping.org
@@ -574,7 +574,7 @@
 #+name: harmonize_education
 | Original Label                | Preferred Label              |
 |-------------------------------+------------------------------|
-| Aucun                         | None                         |
+| Aucun                         | No education                 |
 | Maternelle                    | Pre-primary                  |
 | Postprimaire  technique       | Vocational/Technical         |
 | Postprimaire général          | Lower secondary              |

--- a/lsms_library/countries/Cambodia/_/categorical_mapping.org
+++ b/lsms_library/countries/Cambodia/_/categorical_mapping.org
@@ -10,7 +10,7 @@ BacII / Baccalaureate II higher-education-entrance certificate).
 #+name: harmonize_education
 | Original Label                                          | Preferred Label              |
 |---------------------------------------------------------+------------------------------|
-| No class completed                                      | None                         |
+| No class completed                                      | No education                 |
 | Pre-school/Kindergarten                                 | Pre-primary                  |
 | Class one completed                                     | Primary incomplete           |
 | Class two completed                                     | Primary incomplete           |

--- a/lsms_library/countries/China/_/china.py
+++ b/lsms_library/countries/China/_/china.py
@@ -56,7 +56,7 @@ def _years_to_education_level(y):
     if y == 99 or y < 0:
         return pd.NA                       # missing sentinel
     if y == 0:
-        return 'None'
+        return 'No education'
     if y <= 5:
         return 'Primary incomplete'
     if y == 6:

--- a/lsms_library/countries/CotedIvoire/_/categorical_mapping.org
+++ b/lsms_library/countries/CotedIvoire/_/categorical_mapping.org
@@ -428,7 +428,7 @@
 #+name: harmonize_education
 | Original Label  | Preferred Label              |
 |-----------------+------------------------------|
-| Aucun           | None                         |
+| Aucun           | No education                 |
 | Maternelle      | Pre-primary                  |
 | Postsecondaire  | Tertiary certificate/diploma |
 | Primaire        | Primary complete             |
@@ -437,8 +437,8 @@
 | Second. tech. 1 | Vocational/Technical         |
 | Second. tech. 2 | Vocational/Technical         |
 | Superieur       | Bachelor                     |
-| NUL             | None                         |
-| B               | None                         |
+| NUL             | No education                 |
+| B               | No education                 |
 | JE              | Pre-primary                  |
 | CP1             | Primary incomplete           |
 | CP2             | Primary incomplete           |

--- a/lsms_library/countries/Ethiopia/2013-14/_/mapping.py
+++ b/lsms_library/countries/Ethiopia/2013-14/_/mapping.py
@@ -87,6 +87,40 @@ def Age(value):
     return [age_yrs, age_mos, greg_d, greg_m, greg_y, corrected]
 
 
+def individual_education(df):
+    """``df_edit`` hook: fold unlabelled junk codes onto ``Unknown``.  GH #645.
+
+    ``hh_s2q05`` is a fully value-labelled column with exactly **one** row (of
+    12,583) carrying a bare float that never got a Stata value label: ``76.0``.
+    It cannot be handled in ``_/categorical_mapping.org`` -- that table's
+    ``Original Label`` column is mixed text, so ``df_from_orgfile`` reads every
+    key as a *string* and a float source value can never match one (contrast
+    Guyana, whose all-numeric table parses its keys as floats).
+
+    ``Unknown`` is not a guess: ``canonical_education_labels.org`` defines it as
+    the sentinel for "Don't Know / refused / **unmappable**", which is exactly
+    what an unlabelled code is.  Mapping it onto an ordinal level would be the
+    guess.  Same shape as Uganda's ``_/_education_helpers.py``.
+
+    The vocabulary is read from the canonical ``data_info.yml`` rather than
+    re-listed here, so it cannot drift from the schema of record.
+    """
+    col = "Educational Attainment"
+    if col not in df.columns:
+        return df
+    from lsms_library.diagnostics import _DECLARED_VOCABULARIES
+    vocab = (_DECLARED_VOCABULARIES
+             .get("individual_education", {}).get(col, (frozenset(), {}))[0])
+    if not vocab:
+        return df
+    s = df[col]
+    leftover = s.notna() & ~s.astype("string").isin(vocab)
+    if leftover.any():
+        df = df.copy()
+        df.loc[leftover, col] = "Unknown"
+    return df
+
+
 def household_roster(df):
     """Reduce list-valued ``Age`` to a scalar via DOB-aware fallback chain.
 

--- a/lsms_library/countries/Ethiopia/_/categorical_mapping.org
+++ b/lsms_library/countries/Ethiopia/_/categorical_mapping.org
@@ -854,6 +854,12 @@ appear in some waves) fall outside the WB 1-18 industry range and map to
 # onto the canonical ordinal levels (grades 1-8 primary, 9-10 lower / 11-12 upper
 # secondary; NC 10+N = TVET -> Vocational/Technical; college->diploma, university/1st
 # degree->Bachelor, above-1st/graduate->Postgraduate).
+# NB one wave-2 row (of 12,583) carries a bare, unlabelled float code (76.0) in
+# this otherwise fully-labelled column.  It CANNOT be handled here: this table's
+# Original Label column is mixed text, so df_from_orgfile reads every key as a
+# string and a float source value can never match one (contrast Guyana, whose
+# all-numeric table parses its keys as floats).  It is folded onto `Unknown` by
+# the `individual_education` df_edit hook in `2013-14/_/mapping.py`.  GH #645.
 #+name: harmonize_education
 | Original Label                                       | Preferred Label              |
 |------------------------------------------------------+------------------------------|
@@ -914,7 +920,7 @@ appear in some waves) fall outside the WB 1-18 industry range and map to
 | 94. ADULT EDUCATION                                  | Informal                     |
 | 95. ALTERNATIVE EDUCATION                            | Informal                     |
 | 96. NON-REGULAR                                      | Informal                     |
-| 98. ILLITRATE                                        | None                         |
+| 98. ILLITRATE                                        | No education                 |
 | 99. DON'T KNOW                                       | Unknown                      |
 | 9th Grade Complete                                   | Lower secondary              |
 | Above 1st Degree / Level 4                           | Postgraduate                 |
@@ -937,12 +943,12 @@ appear in some waves) fall outside the WB 1-18 industry range and map to
 | NC Certificate (10+3) Level 3 One Year Complete      | Vocational/Technical         |
 | NC Certificate (10+3) Level 3 Two Years Complete     | Vocational/Technical         |
 | NC Diploma (10+3) Level 3                            | Vocational/Technical         |
-| Not educated                                         | None                         |
-| Not educated - Can not read and write                | None                         |
+| Not educated                                         | No education                 |
+| Not educated - Can not read and write                | No education                 |
 | Teacher Training Certificate                         | Tertiary certificate/diploma |
 | adult education                                      | Informal                     |
 | alternative education                                | Informal                     |
 | basic education                                      | Informal                     |
-| illitrate                                            | None                         |
+| illitrate                                            | No education                 |
 | informal education                                   | Informal                     |
 | non-regular- literate from religious schl            | Informal                     |

--- a/lsms_library/countries/GhanaLSS/1998-99/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1998-99/_/data_info.yml
@@ -66,7 +66,7 @@ individual_education:
             # the harmonize_education table on one myvar, so map to canonical here
             # (same targets the table gives the other GhanaLSS waves' text labels).
             - mapping:
-                1: None
+                1: No education
                 2: Pre-primary
                 3: Primary complete
                 4: Lower secondary complete

--- a/lsms_library/countries/GhanaLSS/_/categorical_mapping.org
+++ b/lsms_library/countries/GhanaLSS/_/categorical_mapping.org
@@ -152,8 +152,8 @@ the full file.  Code -> native label; canonicalized to Preferred Label through
 | M4                      | Lower secondary complete     |
 | m4                      | Lower secondary complete     |
 | Middle                  | Lower secondary complete     |
-| none                    | None                         |
-| None                    | None                         |
+| none                    | No education                 |
+| None                    | No education                 |
 | nursing                 | Tertiary certificate/diploma |
 | Nursing                 | Tertiary certificate/diploma |
 | Other                   | Unknown                      |
@@ -220,7 +220,7 @@ the full file.  Code -> native label; canonicalized to Preferred Label through
 | A1                      | Upper secondary complete     |
 | A2                      | Upper secondary complete     |
 | JSS2                    | Lower secondary              |
-| B                       | None                         |
+| B                       | No education                 |
 | T1                      | Tertiary certificate/diploma |
 | T2                      | Tertiary certificate/diploma |
 | T3                      | Tertiary certificate/diploma |

--- a/lsms_library/countries/Guatemala/_/categorical_mapping.org
+++ b/lsms_library/countries/Guatemala/_/categorical_mapping.org
@@ -40,7 +40,7 @@ refined outputs such as "Primary incomplete" pass through unchanged).
 #+name: harmonize_education
 | Original Label     | Preferred Label  |
 |--------------------+------------------|
-| ninguno            | None             |
+| ninguno            | No education     |
 | educacion adultos  | Informal         |
 | preparatoria       | Pre-primary      |
 | primaria           | Primary complete |

--- a/lsms_library/countries/Guinea-Bissau/_/categorical_mapping.org
+++ b/lsms_library/countries/Guinea-Bissau/_/categorical_mapping.org
@@ -343,7 +343,7 @@
 | Ensino Secundário           | Lower secondary              |
 | Ensino Superior             | Bachelor                     |
 | Ensino Técnico/Profissional | Vocational/Technical         |
-| Nenhum                      | None                         |
+| Nenhum                      | No education                 |
 | Pre-escolar                 | Pre-primary                  |
 
 # harmonize_assets (GH #168): per-country delta on top of the global

--- a/lsms_library/countries/Guyana/_/categorical_mapping.org
+++ b/lsms_library/countries/Guyana/_/categorical_mapping.org
@@ -55,7 +55,7 @@ Level rationale:
 | 12.0           | Upper secondary          |
 | 13.0           | Upper secondary complete |
 | 14.0           | Unknown                  |
-| 15.0           | None                     |
+| 15.0           | No education             |
 | 17.0           | Unknown                  |
 
 * Housing (Roof) -- canonical harmonization (GH #170)

--- a/lsms_library/countries/India/_/categorical_mapping.org
+++ b/lsms_library/countries/India/_/categorical_mapping.org
@@ -22,7 +22,7 @@
 #+name: harmonize_education
 | Original Label | Preferred Label              |
 |----------------+------------------------------|
-| Illitera       | None                         |
+| Illitera       | No education                 |
 | Literate       | Informal                     |
 | < Primar       | Primary incomplete           |
 | Primary        | Primary complete             |

--- a/lsms_library/countries/Iraq/_/categorical_mapping.org
+++ b/lsms_library/countries/Iraq/_/categorical_mapping.org
@@ -13,10 +13,10 @@
 #+name: harmonize_education
 | Original Label                    | Preferred Label              |
 |-----------------------------------+------------------------------|
-| No diploma, do not read and write | None                         |
-| No diploma, read only             | None                         |
-| No diploma, read and write        | None                         |
-| No certificate                    | None                         |
+| No diploma, do not read and write | No education                 |
+| No diploma, read only             | No education                 |
+| No diploma, read and write        | No education                 |
+| No certificate                    | No education                 |
 | Elementary                        | Primary complete             |
 | Intermediate                      | Lower secondary complete     |
 | Intermediate (mid school)         | Lower secondary complete     |

--- a/lsms_library/countries/Malawi/_/categorical_mapping.org
+++ b/lsms_library/countries/Malawi/_/categorical_mapping.org
@@ -887,7 +887,7 @@
 | MSCE/GCSE              | Lower secondary complete     |
 | NON-UNIV DIPLOMA       | Tertiary certificate/diploma |
 | NON-UNIVERSITY DIPLOMA | Tertiary certificate/diploma |
-| NONE                   | None                         |
+| NONE                   | No education                 |
 | Non-Univ Diploma       | Tertiary certificate/diploma |
 | POST-GRAD DEGREE       | Postgraduate                 |
 | POST-GRADUATE DEGREE   | Postgraduate                 |
@@ -899,5 +899,5 @@
 | Univer Diploma         | Tertiary certificate/diploma |
 | jce                    | Lower secondary              |
 | msce                   | Lower secondary complete     |
-| none                   | None                         |
+| none                   | No education                 |
 | pslc                   | Primary complete             |

--- a/lsms_library/countries/Mali/_/categorical_mapping.org
+++ b/lsms_library/countries/Mali/_/categorical_mapping.org
@@ -657,7 +657,7 @@
 #+name: harmonize_education
 | Original Label                        | Preferred Label              |
 |---------------------------------------+------------------------------|
-| Aucun                                 | None                         |
+| Aucun                                 | No education                 |
 | Maternelle                            | Pre-primary                  |
 | Fondamental 1                         | Primary complete             |
 | Fondamental 2                         | Lower secondary              |

--- a/lsms_library/countries/Niger/_/categorical_mapping.org
+++ b/lsms_library/countries/Niger/_/categorical_mapping.org
@@ -1131,7 +1131,7 @@
 #+name: harmonize_education
 | Original Label                                      | Preferred Label              |
 |-----------------------------------------------------+------------------------------|
-| Aucun                                               | None                         |
+| Aucun                                               | No education                 |
 | Maternelle                                          | Pre-primary                  |
 | Préscolaire                                         | Pre-primary                  |
 | Preschool                                           | Pre-primary                  |

--- a/lsms_library/countries/Nigeria/_/categorical_mapping.org
+++ b/lsms_library/countries/Nigeria/_/categorical_mapping.org
@@ -889,9 +889,9 @@ Level collapse (mirrors Uganda's grade collapse):
 #+name: harmonize_education
 | Original Label                                                     | Preferred Label              |
 |--------------------------------------------------------------------+------------------------------|
-| none                                                               | None                         |
-| NONE                                                               | None                         |
-| 0. NONE                                                            | None                         |
+| none                                                               | No education                 |
+| NONE                                                               | No education                 |
+| 0. NONE                                                            | No education                 |
 | n1                                                                 | Pre-primary                  |
 | n2                                                                 | Pre-primary                  |
 | N1                                                                 | Pre-primary                  |

--- a/lsms_library/countries/Senegal/_/categorical_mapping.org
+++ b/lsms_library/countries/Senegal/_/categorical_mapping.org
@@ -642,7 +642,7 @@
 #+name: harmonize_education
 | Original Label  | Preferred Label              |
 |-----------------+------------------------------|
-| Aucun           | None                         |
+| Aucun           | No education                 |
 | Maternelle      | Pre-primary                  |
 | Postsecondaire  | Tertiary certificate/diploma |
 | Primaire        | Primary complete             |

--- a/lsms_library/countries/Serbia/_/categorical_mapping.org
+++ b/lsms_library/countries/Serbia/_/categorical_mapping.org
@@ -19,8 +19,8 @@ zero-padded raw codes ("00".."11").  One non-numeric cell forces the whole
 | Original Label | Preferred Label              |
 |----------------+------------------------------|
 | Unknown        | Unknown                      |
-| 00             | None                         |
-| 01             | None                         |
+| 00             | No education                 |
+| 01             | No education                 |
 | 02             | Primary incomplete           |
 | 03             | Primary complete             |
 | 04             | Vocational/Technical         |

--- a/lsms_library/countries/South Africa/1993/_/data_info.yml
+++ b/lsms_library/countries/South Africa/1993/_/data_info.yml
@@ -100,7 +100,7 @@ individual_education:
                 -4: ~          # sentinel for missing — null out
                 -3: ~          # sentinel for missing — null out
                 -1: ~          # sentinel for missing — null out
-                0: "None"
+                0: "No education"
                 1: "Primary incomplete"          # Sub A (Grade 1)
                 2: "Primary incomplete"          # Sub B (Grade 2)
                 3: "Primary incomplete"          # Standard 1 (Grade 3)

--- a/lsms_library/countries/Tajikistan/1999/_/data_info.yml
+++ b/lsms_library/countries/Tajikistan/1999/_/data_info.yml
@@ -97,7 +97,7 @@ individual_education:
                 6.0: Doctorate                   # candidate of science (kandidat nauk)
                 7.0: Doctorate                   # doctor of science (doktor nauk)
                 8.0: Unknown                     # other
-                9.0: None
+                9.0: No education
 
 housing:
     # SSEC2 Part 2A (structure) + Part 2B (tenure/toilet).  Value labels are

--- a/lsms_library/countries/Tajikistan/_/categorical_mapping.org
+++ b/lsms_library/countries/Tajikistan/_/categorical_mapping.org
@@ -28,7 +28,7 @@ Notes on the non-obvious levels:
 #+name: harmonize_education
 | Original Label                      | Preferred Label          |
 |-------------------------------------+--------------------------|
-| none                                | None                     |
+| none                                | No education             |
 | primary                             | Primary complete         |
 | primary (grades 1-4)                | Primary complete         |
 | basic                               | Lower secondary complete |

--- a/lsms_library/countries/Togo/_/categorical_mapping.org
+++ b/lsms_library/countries/Togo/_/categorical_mapping.org
@@ -417,7 +417,7 @@
 #+name: harmonize_education
 | Original Label  | Preferred Label              |
 |-----------------+------------------------------|
-| Aucun           | None                         |
+| Aucun           | No education                 |
 | Maternelle      | Pre-primary                  |
 | Postsecondaire  | Tertiary certificate/diploma |
 | Primaire        | Primary complete             |

--- a/lsms_library/countries/Uganda/_/_education_helpers.py
+++ b/lsms_library/countries/Uganda/_/_education_helpers.py
@@ -17,7 +17,7 @@ import pandas as pd
 
 # Canonical ordinal vocabulary (categorical_mapping/canonical_education_labels.org).
 CANONICAL_EDUCATION_LABELS = frozenset({
-    "None", "Informal", "Pre-primary",
+    "No education", "Informal", "Pre-primary",
     "Primary incomplete", "Primary complete",
     "Lower secondary", "Lower secondary complete",
     "Upper secondary", "Upper secondary complete",

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -2240,7 +2240,25 @@ class Country:
             # scripts that need the stricter "drop unless any DATA column is
             # non-null" form should use ``subset=`` themselves; this step is
             # the universal safety-net.
+            #
+            # GH #645: say how many rows it took.  This step is where a *value*
+            # corruption upstream turns into a silent *deletion* -- a nulled
+            # `Educational Attainment` is a deleted person, because the table
+            # has exactly one column.  30% of Guatemala's individual_education
+            # vanished here and nothing said a word (the cell was still graded
+            # `sane`).  INFO, not a warning: legitimately-hollow rows are
+            # common and this must not cry wolf on every table.  Whether it
+            # should escalate above some rate is a judgement for the
+            # maintainer, deliberately not made here.
+            n_before = len(df)
             df = df.dropna(how='all')
+            if len(df) < n_before and n_before:
+                n_dropped = n_before - len(df)
+                logger.info(
+                    "%s/%s: dropna(how='all') removed %d of %d rows (%.1f%%) "
+                    "-- every dropped row had NO non-index data at all",
+                    self.name, method_name or "?", n_dropped, n_before,
+                    100.0 * n_dropped / n_before)
 
             # Attach the ISO 4217 currency label (last, so it rides through the
             # caller's _relabel_j / _add_market_index without being dropped).

--- a/lsms_library/data_info.yml
+++ b/lsms_library/data_info.yml
@@ -279,6 +279,35 @@ Columns:
   individual_education:
     Educational Attainment:
       type: str
+      note: |
+        Canonical ordinal vocabulary, low -> high, defined in
+        categorical_mapping/canonical_education_labels.org.  Country grade
+        detail collapses onto these levels; `Unknown` is the non-ordinal
+        sentinel for don't-know / refused / unmappable.
+      spellings:
+        # GH #645: level 0 was spelled `None` until the to_parquet null-coercion
+        # fix.  That spelling was indistinguishable from a missing value after
+        # `astype(str)` -- and from YAML/CSV nulls -- so it was silently nulled
+        # on every parquet write and the row then deleted by
+        # `_finalize_result`'s `dropna(how='all')`.  Renamed to `No education`
+        # throughout `harmonize_education`; `None` stays here as an accepted
+        # VARIANT so parquets written before the rename, and any country whose
+        # mapping table has not been updated, still resolve at API time.
+        No education: ['None', 'NONE', 'none']
+        Informal: []
+        Pre-primary: []
+        Primary incomplete: []
+        Primary complete: []
+        Lower secondary: []
+        Lower secondary complete: []
+        Upper secondary: []
+        Upper secondary complete: []
+        Vocational/Technical: []
+        Tertiary certificate/diploma: []
+        Bachelor: []
+        Postgraduate: []
+        Doctorate: []
+        Unknown: []
   panel_ids:
     previous_i:
       type: str

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -1372,7 +1372,16 @@ def change_encoding(s: str, from_encoding: str, to_encoding: str = 'utf-8', erro
 # carries an audit stamped before GPS was audited, so it under-reports.  Not a
 # cosmetic bump: without it, a warm cache serves values this version would never
 # compute.
-LSMS_CACHE_SCHEMA = 4
+#
+# Bumped 4 -> 5 (GH #645): ``to_parquet`` no longer destroys the literal strings
+# 'None' / 'nan' / '<NA>'.  The loss happened IN THE ACT OF WRITING, so every
+# L2-wave and L2-country parquet on every existing machine already has the nulls
+# baked in -- and the per-table input hashes are unchanged, so without this bump
+# nothing rebuilds and the fix is invisible on exactly the machines where the
+# corruption is already present.  This CHANGES RETURNED DATA (Guatemala
+# individual_education 20,678 -> 29,527 rows), which is precisely why the
+# rebuild must be forced rather than offered.
+LSMS_CACHE_SCHEMA = 5
 
 # Schema-metadata key under which the content hash is embedded.  Embedding
 # (rather than a ``{parquet}.hash`` sidecar) means the hash rotates
@@ -1648,13 +1657,29 @@ def to_parquet(df: pd.DataFrame, fn: str | Path, index: bool = True, absolute_pa
             if str in [type(x) for x in cats]: # At least some categories are strings...
                 df[col] = df[col].cat.rename_categories(lambda x: str(x))
 
-    # Pyarrow can't deal with mixes of types in columns of type object. Just
-    # convert them all to str.
+    # Pyarrow can't deal with mixes of types in columns of type object -- a
+    # genuinely mixed object column still raises ArrowTypeError under
+    # pandas 3.0 / pyarrow 23 ("Expected bytes, got a 'float' object"), so
+    # this guard is still load-bearing.  Just convert them all to str.
+    #
+    # GH #645: capture the null mask BEFORE ``astype(str)``.  The previous
+    # implementation stringified first and then tried to recover the nulls
+    # with ``.replace({'nan': None, 'None': None, '<NA>': None})`` -- but
+    # once a genuine missing has become the three characters ``nan`` it is
+    # indistinguishable from a legitimate value that spells ``nan``, and the
+    # recovery therefore deleted real data.  ``None`` was the canonical
+    # library label for "no education" (see harmonize_education.org), so
+    # every such person was nulled on write and then removed outright by
+    # ``_finalize_result``'s ``dropna(how='all')`` -- 8,849 rows (30%) of
+    # Guatemala's individual_education, 5,328 of Tajikistan's, 242 of
+    # Ethiopia's.  Masking after the cast is information-preserving: only
+    # cells that were *actually* missing become null.
     idxnames = df.index.names
     all = df.reset_index()
     for column in all:
         if all[column].dtype=='O':
-            all[column] = all[column].astype(str).astype('string[pyarrow]').replace({'nan': None, 'None': None, '<NA>': None})
+            na = all[column].isna()
+            all[column] = all[column].astype(str).astype('string[pyarrow]').mask(na)
     if index:
         resolved_idxnames = []
         for i, name in enumerate(idxnames):

--- a/tests/test_gh645_to_parquet_null_coercion.py
+++ b/tests/test_gh645_to_parquet_null_coercion.py
@@ -1,0 +1,369 @@
+"""GH #645 -- ``to_parquet`` must not destroy values that spell like nulls.
+
+``to_parquet`` used to serialize object columns as::
+
+    col.astype(str).astype('string[pyarrow]').replace(
+        {'nan': None, 'None': None, '<NA>': None})
+
+i.e. it stringified **first** and then tried to recover the nulls by matching
+the resulting characters.  After ``astype(str)`` a genuine missing value and a
+legitimate value that happens to spell ``'None'`` are the same three-to-four
+characters, so the recovery cannot be right -- and it was not.  ``None`` was
+the canonical library label for "no education", so every person the survey
+recorded as never-schooled was nulled **in the act of writing the cache**, and
+``Country._finalize_result``'s ``dropna(how='all')`` then deleted the row
+outright (``individual_education`` has exactly one column).
+
+Two independent things are pinned here.
+
+1. **The write path** (unit, data-free): the null/not-null distinction must be
+   captured *before* the cast and restored after, so a literal ``'None'`` /
+   ``'nan'`` / ``'<NA>'`` survives a round-trip and only genuinely-missing
+   cells come back null.  The pyarrow guard the block exists for -- genuinely
+   mixed-type object columns -- must still work.
+
+2. **The vocabulary** (unit, data-free): level 0 of the canonical education
+   ladder is no longer spelled ``None``.  A canonical value that collides with
+   the null literal under ``str()``, YAML, CSV and parquet round-trips is a
+   trap that re-arms itself; the write-path fix alone would leave it loaded.
+   ``None`` survives as an accepted *variant* so historical caches and any
+   not-yet-updated country still resolve.
+
+3. **The recovered rows** (integration, needs S3 + a cold cache): the three
+   countries measured on the issue.  These MUST run against a genuinely fresh
+   ``LSMS_DATA_DIR`` -- ``LSMS_NO_CACHE=1`` alone actually *masks* this bug,
+   because it skips the wave-level parquet write where the destruction
+   happened.  Each case therefore runs in its own subprocess with its own
+   empty data root.
+
+Negative control (2026-07-21, this worktree, cold isolated data dirs, measured
+against the merge-base for each arm):
+
+===============  ==================  ============  =============
+country          before (cold/warm)  after         rows recovered
+===============  ==================  ============  =============
+Guatemala        20,678 / 20,678     29,527        8,849  (30%)
+Tajikistan       59,297 / 54,462     59,790        493 / 5,328
+Ethiopia         63,139 / 62,939     63,181        42 / 242
+===============  ==================  ============  =============
+
+Ethiopia's pair is exactly the 63,139 vs 62,939 reported on the issue.  (An
+earlier arm of this work measured 59,059 / 58,859 / 59,092 for Ethiopia; those
+predate PR #644, which re-keyed 2013-14 `individual_education` onto the
+wave-native ids and recovered 5,247 people independently of this bug.)
+
+Guatemala is the reason this went unnoticed for so long: cold == warm == wrong,
+so no A/B comparison could see it, and the coverage matrix graded it ``sane``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import yaml
+
+try:                                  # `tests` is a package, so the bare name
+    from tests.conftest import requires_s3   # `conftest` resolves to the ROOT
+except ImportError:                   # conftest.py, which has no requires_s3.
+    from conftest import requires_s3
+
+import lsms_library.local_tools as lt
+from lsms_library.local_tools import get_dataframe, to_parquet
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COL = "Educational Attainment"
+
+
+# ---------------------------------------------------------------------------
+# 1. The write path
+# ---------------------------------------------------------------------------
+
+def _edu_frame() -> pd.DataFrame:
+    """One-column frame in ``individual_education`` shape.
+
+    Deliberately ``dtype=object``: that is the only dtype the coercion block
+    fires on, and under pandas 3.0 a *pure* string column is inferred as ``str``
+    and skips it entirely -- which is why the bug was so patchy across
+    countries (Guatemala/Tajikistan/Ethiopia had object columns; 22 others did
+    not, and were fine only by accident of dtype inference).
+    """
+    idx = pd.MultiIndex.from_tuples(
+        [("2000", f"h{k}", f"p{k}") for k in range(6)], names=["t", "i", "pid"])
+    return pd.DataFrame({COL: pd.Series(
+        ["Primary complete", "None", "Upper secondary", np.nan, "nan", "<NA>"],
+        dtype=object, index=idx)})
+
+
+def _roundtrip(df: pd.DataFrame) -> pd.DataFrame:
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "t.parquet")
+        to_parquet(df.copy(), p, absolute_path=True)
+        return get_dataframe(p)
+
+
+def test_literal_none_survives_the_parquet_roundtrip():
+    """The minimal repro from the issue: 5 rows in, 5 rows out."""
+    df = _edu_frame()
+    assert len(df.dropna(how="all")) == 5
+    back = _roundtrip(df)
+    assert len(back.dropna(how="all")) == 5, (
+        "rows were deleted by the write path; values that spell like nulls are "
+        f"being coerced to NULL: {list(back[COL])}")
+    assert back[COL].iloc[1] == "None"
+
+
+@pytest.mark.parametrize("literal", ["None", "nan", "<NA>"])
+def test_null_spelling_literals_are_not_coerced(literal):
+    idx = pd.Index(["a", "b"], name="i")
+    df = pd.DataFrame({"c": pd.Series([literal, "other"], dtype=object, index=idx)})
+    back = _roundtrip(df)
+    assert back["c"].iloc[0] == literal
+    assert back["c"].notna().all()
+
+
+def test_genuine_missing_values_still_become_null():
+    """The block's legitimate job: real NaN / None / NaT round-trip as NULL."""
+    idx = pd.Index(list("abcd"), name="i")
+    df = pd.DataFrame({"c": pd.Series(
+        [np.nan, None, pd.NaT, "kept"], dtype=object, index=idx)})
+    back = _roundtrip(df)
+    assert list(back["c"].isna()) == [True, True, True, False]
+
+
+def test_mixed_type_object_column_is_still_stringified():
+    """The reason the coercion block exists at all.
+
+    Under pandas 3.0 / pyarrow 23 a genuinely mixed object column still raises
+    ``ArrowTypeError`` ("Expected bytes, got a 'int' object"), so the guard is
+    load-bearing and must not be narrowed away.  Pinned so a future "this is
+    obsolete under pandas 3" cleanup has to confront the evidence.
+    """
+    idx = pd.Index(list("abc"), name="i")
+    mixed = pd.DataFrame({"c": pd.Series(["a", 3, None], dtype=object, index=idx)})
+    with pytest.raises(Exception):
+        pd.DataFrame({"c": mixed["c"]}).to_parquet(
+            tempfile.mktemp(suffix=".parquet"), engine="pyarrow", index=False)
+    back = _roundtrip(mixed)
+    assert list(back["c"][:2]) == ["a", "3"]
+    assert back["c"].isna().iloc[2]
+
+
+def test_cache_schema_was_bumped_for_this_fix():
+    """The fix changes cached parquet CONTENT, not any per-table input hash.
+
+    Without the schema bump every warm machine keeps serving the nulls and the
+    fix is invisible on exactly the machines where the corruption already
+    exists.  See ``LSMS_CACHE_SCHEMA`` in ``local_tools.py``.
+    """
+    assert lt.LSMS_CACHE_SCHEMA >= 5
+
+
+# ---------------------------------------------------------------------------
+# 2. The vocabulary
+# ---------------------------------------------------------------------------
+
+def _harmonize_education_tables():
+    """Yield ``(path, header, rows)`` for every ``harmonize_education`` table."""
+    paths = sorted((REPO_ROOT / "lsms_library" / "countries").glob(
+        "*/_/categorical_mapping.org"))
+    paths.append(REPO_ROOT / "lsms_library" / "categorical_mapping"
+                 / "harmonize_education.org")
+    for path in paths:
+        if not path.exists():
+            continue
+        in_tbl, header, rows = False, None, []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            m = re.match(r"\s*#\+name:\s*(\S+)", line)
+            if m:
+                if in_tbl and header:
+                    yield path, header, rows
+                in_tbl, header, rows = m.group(1) == "harmonize_education", None, []
+                continue
+            if in_tbl and line.strip().startswith("|"):
+                if set(line.strip()) <= set("|-+ "):
+                    continue
+                cells = [c.strip() for c in line.strip().strip("|").split("|")]
+                if header is None:
+                    header = cells
+                else:
+                    rows.append(cells)
+            elif line.strip() and not line.strip().startswith("|"):
+                if in_tbl and header:
+                    yield path, header, rows
+                in_tbl, header, rows = False, None, []
+        if in_tbl and header:
+            yield path, header, rows
+
+
+def test_no_harmonize_education_table_still_emits_the_label_None():
+    """``None`` must not be a *target* of any education mapping.
+
+    It may remain on the left (a raw survey label spelled ``None``); what must
+    go is the canonical value.
+    """
+    offenders = []
+    for path, header, rows in _harmonize_education_tables():
+        if "Preferred Label" not in header:
+            continue
+        col = header.index("Preferred Label")
+        for cells in rows:
+            if col < len(cells) and cells[col] == "None":
+                offenders.append(f"{path.relative_to(REPO_ROOT)}: {cells}")
+    assert not offenders, (
+        "'None' is still a canonical education label. It is indistinguishable "
+        "from a null under str()/YAML/CSV/parquet round-trips -- use "
+        "'No education' (GH #645):\n  " + "\n  ".join(offenders))
+
+
+def test_harmonize_education_targets_stay_inside_the_declared_vocabulary():
+    """Every mapping target must be a canonical value in ``data_info.yml``.
+
+    This is what makes the rename safe to declare: the ``spellings`` block for
+    ``Educational Attainment`` is an assertion, and
+    ``diagnostics._check_declared_vocabularies`` FAILS a country whose values
+    fall outside it.
+    """
+    vocab, variants = _declared_education_vocabulary()
+    offenders = []
+    for path, header, rows in _harmonize_education_tables():
+        if "Preferred Label" not in header:
+            continue
+        col = header.index("Preferred Label")
+        for cells in rows:
+            if col >= len(cells):
+                continue
+            v = variants.get(cells[col], cells[col])
+            if v and v not in vocab:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}: {cells[col]!r}")
+    assert not offenders, (
+        "education mapping targets outside the declared vocabulary "
+        f"{sorted(vocab)}:\n  " + "\n  ".join(sorted(set(offenders))))
+
+
+def _declared_education_vocabulary():
+    info = yaml.safe_load(
+        (REPO_ROOT / "lsms_library" / "data_info.yml").read_text(encoding="utf-8"))
+    spellings = info["Columns"]["individual_education"][COL]["spellings"]
+    variants = {v: canonical
+                for canonical, vs in spellings.items() for v in (vs or [])}
+    return frozenset(spellings), variants
+
+
+def test_None_is_a_declared_variant_of_No_education():
+    """Historical parquets and un-updated countries must still resolve.
+
+    ``_enforce_canonical_spellings`` runs at API time on columns AND index
+    levels, so a cache written before the rename maps forward without a
+    rebuild.
+    """
+    vocab, variants = _declared_education_vocabulary()
+    assert "No education" in vocab
+    assert "None" not in vocab, "the null-colliding spelling is canonical again"
+    assert variants.get("None") == "No education"
+
+
+def test_declared_education_vocabulary_matches_the_canonical_org_file():
+    """``canonical_education_labels.org`` is the documentation of record."""
+    text = (REPO_ROOT / "lsms_library" / "categorical_mapping"
+            / "canonical_education_labels.org").read_text(encoding="utf-8")
+    vocab, _ = _declared_education_vocabulary()
+    documented = set()
+    for line in text.splitlines():
+        if not line.strip().startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        documented.update(cells)
+    missing = {v for v in vocab if v not in documented}
+    assert not missing, (
+        f"declared but undocumented education levels: {sorted(missing)}")
+
+
+# ---------------------------------------------------------------------------
+# 3. The recovered rows (cold cache, real data)
+# ---------------------------------------------------------------------------
+
+# (country, expected rows, rows recovered vs. the pre-fix warm cache)
+RECOVERED = [
+    ("Guatemala", 29527, 8849),
+    ("Tajikistan", 59790, 5328),
+    ("Ethiopia", 63181, 242),
+]
+
+_COLD_PROBE = """
+import json, warnings
+warnings.filterwarnings("ignore")
+import lsms_library as ll
+c = %r
+cold = len(ll.Country(c).individual_education())
+warm = len(ll.Country(c).individual_education())
+df = ll.Country(c).individual_education()
+print("PROBE" + json.dumps({
+    "cold": cold, "warm": warm,
+    "no_education": int((df["Educational Attainment"] == "No education").sum()),
+}))
+"""
+
+
+def _cold_probe(country: str) -> dict:
+    """Build *country* in a subprocess with a genuinely empty data root.
+
+    ``LSMS_NO_CACHE=1`` is deliberately NOT used: it skips the wave-level
+    parquet write, which is where the destruction happened, so it *hides* the
+    bug this test exists to catch.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        blobs = Path.home() / ".local" / "share" / "lsms_library" / "dvc-cache"
+        if blobs.exists():                       # reuse L1 blobs, never L2
+            os.symlink(blobs, Path(d) / "dvc-cache")
+        env = dict(os.environ)
+        env.pop("LSMS_NO_CACHE", None)
+        env["LSMS_DATA_DIR"] = d
+        env["PYTHONPATH"] = os.pathsep.join(
+            [str(REPO_ROOT), env.get("PYTHONPATH", "")]).rstrip(os.pathsep)
+        r = subprocess.run([sys.executable, "-c", _COLD_PROBE % country],
+                           capture_output=True, text=True, env=env, cwd=str(REPO_ROOT))
+    for line in r.stdout.splitlines():
+        if line.startswith("PROBE"):
+            return json.loads(line[len("PROBE"):])
+    pytest.fail(f"cold probe for {country} produced no result:\n"
+                f"stdout:\n{r.stdout[-3000:]}\nstderr:\n{r.stderr[-3000:]}")
+
+
+@requires_s3
+@pytest.mark.parametrize("country,expected,recovered", RECOVERED)
+def test_individual_education_row_count_is_restored(country, expected, recovered):
+    got = _cold_probe(country)
+    assert got["cold"] == expected, (
+        f"{country}.individual_education(): expected {expected} rows, got "
+        f"{got['cold']}. Before GH #645 this returned {expected - recovered} on a "
+        "warm cache -- every missing row a person the survey recorded as having "
+        "no education.")
+    assert got["no_education"] >= 1, (
+        f"{country} has no 'No education' rows at all, which is what the bug "
+        "looked like")
+
+
+@requires_s3
+@pytest.mark.parametrize("country,expected,recovered", RECOVERED)
+def test_cold_and_warm_builds_agree(country, expected, recovered):
+    """The invariant the destruction broke.
+
+    ``to_parquet`` REBINDS its return value at the wave level
+    (``country.py`` ``Wave.grab_data``) but the country level DISCARDS it, so a
+    write-path coercion made the building call and every later call disagree.
+    With a value-preserving write they must be identical.
+    """
+    got = _cold_probe(country)
+    assert got["cold"] == got["warm"], (
+        f"{country}.individual_education() is call-order / cache-state "
+        f"dependent: cold {got['cold']} vs warm {got['warm']}")

--- a/tests/test_gh645_to_parquet_null_coercion.py
+++ b/tests/test_gh645_to_parquet_null_coercion.py
@@ -58,6 +58,7 @@ so no A/B comparison could see it, and the coverage matrix graded it ``sane``.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import re
@@ -71,10 +72,17 @@ import pandas as pd
 import pytest
 import yaml
 
-try:                                  # `tests` is a package, so the bare name
-    from tests.conftest import requires_s3   # `conftest` resolves to the ROOT
-except ImportError:                   # conftest.py, which has no requires_s3.
-    from conftest import requires_s3
+# `requires_s3` lives in tests/conftest.py (#648) but CANNOT be imported by
+# name: the repo root is ahead of tests/ on sys.path, so a bare
+# `import conftest` picks up the ROOT conftest.py (which has no requires_s3),
+# while `import tests.conftest` fails as `tests.tests` under the CI rootdir.
+# Both were observed failing on this PR's first CI run.  Load it by PATH, which
+# is import-mode agnostic and keeps #648's single source of truth.
+_conftest_spec = importlib.util.spec_from_file_location(
+    "_lsms_tests_conftest", Path(__file__).resolve().parent / "conftest.py")
+_conftest = importlib.util.module_from_spec(_conftest_spec)
+_conftest_spec.loader.exec_module(_conftest)
+requires_s3 = _conftest.requires_s3
 
 import lsms_library.local_tools as lt
 from lsms_library.local_tools import get_dataframe, to_parquet

--- a/tests/test_gh645_to_parquet_null_coercion.py
+++ b/tests/test_gh645_to_parquet_null_coercion.py
@@ -148,11 +148,14 @@ def test_mixed_type_object_column_is_still_stringified():
     load-bearing and must not be narrowed away.  Pinned so a future "this is
     obsolete under pandas 3" cleanup has to confront the evidence.
     """
+    import pyarrow.lib as _pa
+
     idx = pd.Index(list("abc"), name="i")
     mixed = pd.DataFrame({"c": pd.Series(["a", 3, None], dtype=object, index=idx)})
-    with pytest.raises(Exception):
-        pd.DataFrame({"c": mixed["c"]}).to_parquet(
-            tempfile.mktemp(suffix=".parquet"), engine="pyarrow", index=False)
+    with tempfile.TemporaryDirectory() as d:
+        with pytest.raises((_pa.ArrowTypeError, _pa.ArrowInvalid)):
+            pd.DataFrame({"c": mixed["c"].reset_index(drop=True)}).to_parquet(
+                os.path.join(d, "raw.parquet"), engine="pyarrow", index=False)
     back = _roundtrip(mixed)
     assert list(back["c"][:2]) == ["a", "3"]
     assert back["c"].isna().iloc[2]


### PR DESCRIPTION
Closes #645.

`local_tools.to_parquet` stringified every `dtype == object` column and then
tried to recover the nulls by **string matching**:

```python
col.astype(str).astype('string[pyarrow]').replace({'nan': None, 'None': None, '<NA>': None})
```

After `astype(str)` a genuine missing and a legitimate value spelling `'None'`
are the same characters, so the recovery cannot be right — and `None` was the
**canonical library label for "no education"**
(`categorical_mapping/harmonize_education.org`). Every such person was nulled
*in the act of writing the cache*, and `_finalize_result`'s `dropna(how='all')`
then deleted the row outright: `individual_education` has exactly one column,
so a nulled value is a **deleted person**.

## Recovered counts (cold, isolated `LSMS_DATA_DIR`, measured both directions)

| country | before (cold / warm) | after | recovered |
|---|---:|---:|---:|
| **Guatemala** | 20,678 / 20,678 | **29,527** | **+8,849 (30%)** |
| **Tajikistan** | 59,297 / 54,462 | **59,790** | +493 / **+5,328** |
| **Ethiopia** | 63,139 / 62,939 | **63,181** | +42 / +242 |

Every recovered row is a person the survey recorded as having **no education**.
Ethiopia's pair is exactly the `63,139 vs 62,939` in the issue title — that
call-order symptom is gone.

Guatemala is why this survived so long: cold == warm == wrong, so no A/B
comparison could see it, and `.coder/coverage/latest.csv` certified it
`Guatemala,individual_education,2000,sane,declared,20678`. After the fix all
three are cold == warm, which is now a **tested invariant**.

## What changed

1. **The write path** (`local_tools.py`). Capture the null mask *before* the
   cast, restore it after — `na = col.isna()` … `.mask(na)`. Only cells that
   were actually missing become null.
2. **`LSMS_CACHE_SCHEMA` 4 → 5.** The loss happened *in the act of writing*, so
   every existing L2-wave and L2-country parquet already has the nulls baked in,
   and the per-table input hashes are unchanged. Without the bump nothing
   rebuilds and the fix is invisible on exactly the machines where the
   corruption is present. **This forces one full rebuild.**
3. **The canonical label `None` → `No education`** (38 rows across 20
   `harmonize_education` tables, `canonical_education_labels.org`, 3 wave
   `data_info.yml` inline mappings, `China/_/china.py`,
   `Uganda/_/_education_helpers.py`). A canonical value that collides with the
   null literal under `str()`, YAML, CSV *and* parquet round-trips is a trap
   that keeps re-arming itself; the write-path fix alone leaves it loaded.
   `None` / `NONE` / `none` stay as accepted **variants** in the new
   `data_info.yml` `spellings` block, so historical caches and any
   not-yet-updated country still resolve at API time — no rebuild needed for
   the rename itself.
4. **`dropna(how='all')` now says how many rows it took** (`country.py`,
   `logger.info`). This is where a *value* corruption upstream becomes a silent
   *deletion*; 30% of a table vanished here without a word. INFO, not a warning
   — legitimately hollow rows are common and it must not cry wolf. Whether it
   should escalate above some rate is left to you.

## The pandas-3.0 assessment (issue asked; answer: KEEP the block)

The comment's premise — *"Pyarrow can't deal with mixes of types in columns of
type object"* — is **still true** under pandas 3.0.2 / pyarrow 23.0.1.
Measured: `str+int`, `str+float`, `str+Timestamp`, `str+list/tuple/dict`,
`bool+str`, `str+Decimal` all still raise `ArrowTypeError`. Pinned by
`test_mixed_type_object_column_is_still_stringified`.

What *has* changed is that far fewer columns reach it: with
`future.infer_string=True` a pure string column is inferred as `str`, not
`object`, so it skips the guard entirely. That is why exactly **3 of 25**
at-risk countries were hit — the other 22 were correct *by accident of dtype
inference*, not by design.

**Narrowing the block to genuinely-mixed columns was considered and rejected.**
It would change the stored dtype of homogeneous non-`str` object columns (an
object column of ints would round-trip as `int64` instead of the strings
`'1'`,`'2'`), i.e. it would silently change returned data across the corpus —
the exact class of failure this issue is about. Recorded in the ledger, not
acted on.

## Blast radius — everything that changed behaviour

Swept **28 data-bearing countries** cold (one process, one empty
`LSMS_DATA_DIR` each, only `dvc-cache` symlinked), plus before/after cold
builds of the other tables that could manufacture these literals.

- **`individual_education`, 28 countries** — only the 3 above change. All 28
  are cold == warm, and every value falls inside the canonical vocabulary.
- **`Nigeria.food_acquired`** — the only other site deliberately manufacturing
  the literal: `df['u'].fillna('None')` in 4 waves' `food_acquired.py`.
  1,005,656 rows before and after (no rows gained or lost) and `Quantity_kg`
  identical; what changes is that 1,151 rows now carry the intended sentinel
  `u='None'` instead of a **NaN index key**. Strictly better (a NaN key is the
  GH #323 §3b delete-on-collapse hazard) but it *is* visible to anyone reading
  that level. **Recommend renaming that sentinel too** (e.g. `Not recorded`) —
  deliberately not bundled here, since `u` feeds the unit-conversion tables.
- **`Guyana.housing` / `South Africa.housing`** — carry `Toilet == 'None'`
  (52 / 1,102 rows). Measured **identical before and after**: those columns
  arrive as `str`, not `object`, so the block never fired. No change.
- **Read-path NA mop-ups left alone** — `transformations.py` `_na_strings`,
  `country.py` `_NA_SENTINELS`, `conversion.py`. All operate on `Relationship`
  / `sex` / `age` / dates, whose vocabularies genuinely exclude these strings.
  They are deliberate and correct; generalising one would recreate this bug a
  layer up.

## One pre-existing defect surfaced (not caused by this PR)

Declaring the `Educational Attainment` vocabulary makes
`diagnostics._check_declared_spellings` enforce it. Auditing **107 freshly
cold-built parquets** (28 countries, wave- and country-level) turned up exactly
one off-vocabulary value in the whole corpus:
Ethiopia 2013-14 `hh_s2q05` has **one row of 12,583** carrying a bare `76.0`
that never received a Stata value label. It cannot be handled in
`categorical_mapping.org` — that table's `Original Label` column is mixed text,
so every key is read as a *string* and a float source value can never match
(contrast Guyana, whose all-numeric table parses its keys as floats). Folded to
`Unknown` by a `df_edit` hook in `2013-14/_/mapping.py`, reusing the shape of
Uganda's existing `_/_education_helpers.py` and reading the vocabulary from
`data_info.yml` rather than re-listing it. `Unknown` is not a guess:
`canonical_education_labels.org` defines it as the sentinel for "unmappable".

On the pre-#644 base this was cosmetic (the row was collapsed away before
reaching the API); **on the current base it is not** — #644's re-key means
`'76.0'` now survives into the user-facing frame, so the hook is what keeps
Ethiopia's `Educational Attainment` inside its own declared vocabulary.
Row count is unaffected either way (63,181); `Unknown` goes 33 → 34.

## Tests

`tests/test_gh645_to_parquet_null_coercion.py` — 17 tests, in three groups: the
write path (data-free), the vocabulary (data-free), and the three recovered row
counts (cold, `requires_s3` from `tests/conftest.py` so the data-free CI job
skips rather than errors). The integration cases run in a subprocess with a
genuinely empty data root — **`LSMS_NO_CACHE=1` MASKS this bug** (it skips the
L2-wave write where the destruction happened), so it is exactly the wrong lever.

**Negative control:** against unmodified `origin/development`, **14 of 17
fail**. The 3 that pass are the two deliberate "behaviour must NOT change"
guards, plus `cold == warm` for Guatemala — which passed because Guatemala was
equal *and wrong*, the whole reason nobody noticed.

Merged guards re-run and green: `test_gh323_explicit_reducers.py`,
`test_gh323_grain_contract.py`, `test_schema_consistency.py`,
`test_canonical_spellings.py`, `test_cache_hash_invalidation.py` (280 passed).
No `aggregation:` key, no reducer — GH #323 D1 respected.

Ledger: `.coder/ledger/645-to-parquet-null-coercion.md`.

## For the reviewer

- **Row counts change**, so anything published off `Guatemala`,
  `Tajikistan` or `Ethiopia` `individual_education` needs re-checking; Guatemala
  grows 43%.
- **`.coder/coverage/latest.csv` is now wrong** for those cells and needs a
  `make matrix` refresh (not done here — it is a generated snapshot).
- No cell is blessed in this PR: I read these numbers as row counts and label
  censuses, not as substantive education distributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su5JKX3wKChyfMAdXrdCTr
