### PR TITLE
docs(#601): record the sampling universe, exclusions and sub-samples in 38 country CONTENTS.org

### DIFF
--- a/lsms_library/countries/Afghanistan/_/CONTENTS.org
+++ b/lsms_library/countries/Afghanistan/_/CONTENTS.org
@@ -1,0 +1,520 @@
+#+title: Contents
+
+* Sampling universe, exclusions and sub-samples
+
+# ASCII EXCEPTION (deliberate, per the orgmode skill's "leave a comment" rule):
+# every block inside a #+begin_quote below is a VERBATIM transcription of survey
+# documentation.  The sources use en dashes and typographic apostrophes and
+# contain sic spellings; these are NOT normalised to ASCII, because normalising
+# them would destroy the one property that makes a quote usable as evidence.
+# All prose outside the quote blocks is ASCII.
+
+Evidence gathered 2026-07-21 for GH #601 / #603.  What follows records what the
+survey documentation *claims* the sample represents.  Nothing here is inferred
+from the =.dta= files; none were opened for this record.
+
+Both Afghanistan waves are documented from files *inside this repository*, not
+from World Bank catalog metadata:
+
+- The ALCS / NRVA / IE&LFS series is a survey of the Afghan statistical office
+  (CSO, later NSIA), *not* a World Bank LSMS survey.  A query of the WB Microdata
+  Library catalog for =country=AFG= returned 120 entries and *none* of them is an
+  ALCS, NRVA or IE&LFS entry.  There is therefore no WB catalog fallback and no
+  WB NADA template universe sentence for either wave -- the boilerplate that
+  supplies the "universe" field for 15 other waves in the corpus does not apply
+  here.  What is quoted below is a statistical office's own claim about its own
+  survey.
+- Neither wave has a =Documentation/SOURCE.org=, so there is no recorded
+  =#+CATALOG_ID:= to fall back on either.  Local documentation is the only
+  source, and it is adequate: both waves are =high= confidence.
+
+| Wave    | Source of statement | Confidence | Shape of the declared universe                         |
+|---------+---------------------+------------+--------------------------------------------------------|
+| 2016-17 | local documentation | high       | explicit: entire population of Afghanistan incl. Kuchi |
+| 2020    | local documentation | high       | oblique: frame + strata + weighting target only        |
+
+** 2016-17 -- Afghanistan Living Conditions Survey (ALCS) 2016-17, CSO
+
+Source: =lsms_library/countries/Afghanistan/2016-17/Documentation/Report/ALCS - 2016-17 Analysis report draft version.pdf=
+(421 PDF pages, DVC-tracked).  Citations give the printed page first and the PDF
+page second.
+
+*** The declared universe
+
+Chapter 1, section 1.1 "General survey backgrounds", printed p. 1 (PDF p. 45):
+
+#+begin_quote
+The survey is unique in the sense that – with inclusion of the nomadic Kuchi –
+it represents the entire population of Afghanistan, and that – since the 2007-08
+survey – year-round data are collected in order to capture the seasonality of
+indicators like employment, food security and poverty. The survey was designed
+to produce representative estimates for the national and provincial levels, and
+for the Kuchi population.
+#+end_quote
+
+Corroborated in the data-quality self-assessment, Annex IX, printed p. 354 (PDF
+p. 398), as a bullet under "Completeness":
+
+#+begin_quote
+The ALCS is the only survey producing representative information for the entire
+population of Afghanistan, including the nomadic Kuchi (presently estimated at
+5.0 percent of the total population).
+#+end_quote
+
+The frame from which that universe is operationalised -- Annex IV "Sample design
+and implementation", section IV.2 "Sample frame", printed p. 327 (PDF p. 371):
+
+#+begin_quote
+The pre-census household listing that was conducted by CSO in 2003-05, updated
+in 2009, was used as the sampling frame. For seven provinces, the sampling frame
+consisted of the Socio-Demographic and Economic Survey (SDES) household
+listings: Bamyan (data collected in 2010), Ghor and Daykundi (both with data
+collected in 2012), Kapisa and Parwan (both with data collected in 2014), Kabul
+(data collected in 2013) and Samangan (data collected in 2015). Prior to the
+fieldwork, the selected enumeration areas (EAs) – urban and rural – were visited
+for a mapping update of the households, based on which the second sampling stage
+was implemented.
+#+end_quote
+
+The household unit is the UN definition -- section 3.3, printed p. 28 (PDF
+p. 72):
+
+#+begin_quote
+The ALCS follows the UN definition of households. A household is defined as
+group of people, either related or unrelated, who live together as a single unit
+in the sense that they have common housekeeping arrangements, that is, they
+share or are supported by a common budget. They live together, pool their money,
+and eat at least one meal together each day.
+#+end_quote
+
+[sic: "as group of people", no article, as printed.]
+
+*** Exclusions
+
+**** Institutional and collective households -- excluded by design
+
+Chapter 3, section 3.3.1 "Household structure", printed p. 28 (PDF p. 72):
+
+#+begin_quote
+Note that during the fieldwork only regular household were visited, as
+institutional and collective households were not in the sample.
+#+end_quote
+
+[sic: "household" singular in the original.]  This is the one categorical
+population exclusion, and it qualifies the "entire population of Afghanistan"
+claim above: the declared universe is the *regular-household* population.
+
+**** Insecure districts excluded from the reserve frame -- exclusion by design, mid-fieldwork
+
+Chapter 2, section 2.2.4 "Sampling design", printed p. 14 (PDF p. 58):
+
+#+begin_quote
+In view of sustained levels of insecurity, from the fourth month of data
+collection onward, clusters in inaccessible areas were replaced by clusters
+drawn from a reserve sampling frame that excluded insecure districts.
+#+end_quote
+
+Annex IV, section IV.6, printed p. 328 (PDF p. 372):
+
+#+begin_quote
+A reserve sample of PSUs was drawn from the sampling frame, from which districts
+that were defined as insecure by the supervisors and PSOs were excluded, as well
+as EAs that were originally sampled. EAs that were originally selected in these
+districts and not yet covered were replaced by EAs from this reserve list.
+Isolated emerging security issues in other districts could also urge the use of
+replacement from this reserve list. The districts excluded from the reserve
+sample list are listed in Table IV.1.
+#+end_quote
+
+Table IV.1, "Districts excluded from sample frame for the reserve sample"
+(printed p. 329 / PDF p. 373), names the excluded districts; they fall in
+Kapisa, Wardak, Logar, Badghis, Nangarhar, Zabul, Baghlan, Ghazni, Helmand,
+Urozgan, Jawzjan, Kandahar, Kunarha, Laghman, Paktya and other provinces.
+
+Note the mechanism, because it is stronger than plain non-response: insecure
+clusters were *replaced* by secure ones, so security-correlated non-coverage is
+not merely missing from the sample -- it is partly reweighted onto the secure
+part of the country.
+
+**** Realised non-coverage
+
+Chapter 2, section 2.3.1 "Field operations", printed p. 15 (PDF p. 59):
+
+#+begin_quote
+Provinces that faced most security challenges were Kapisa, Nangarhar, Paktya,
+Paktika, Wardak, Sar-e-Pul, Urozgan, Baghlan, Kunarha, Kunduz and Helmand. As a
+last resort, insecure areas were replaced by more secure areas. The security
+situation in Paktika did not allow data collection after month six.
+#+end_quote
+
+#+begin_quote
+Out of the 391 sampled districts and provincial centres of Afghanistan, in 342
+(87 percent) information was collected. In total, information from 1,929
+clusters was collected, against 2,042 clusters according to the sampling design
+(94 percent).
+#+end_quote
+
+#+begin_quote
+From the 60 Kuchi clusters, 55 were covered according to the sampling design,
+whereas for the five remaining the targeted Kuchi population could not be found
+in the field.
+#+end_quote
+
+*** Oversamples and sub-populations
+
+**** The nomadic Kuchi: a separate stratum, from a separate frame, in two seasons only
+
+This is the sub-population that matters most for anyone pooling this country.
+The Kuchi are not drawn from the same frame as everybody else.  Annex IV, section
+IV.2, printed p. 327 (PDF p. 371):
+
+#+begin_quote
+The sampling frame that was used for the Kuchi population was the 2003-04
+National Multi-sectoral Assessment of Kuchi (NMAK-2004). Although far from
+perfect given the rate of settlement of Kuchis in recent years and ongoing
+discussion about the definition of Kuchi, this is the best frame available for
+this part of Afghanistan’s population.
+#+end_quote
+
+That frank statement of frame weakness applies to the Kuchi stratum *only*; it is
+not transferable to the other 34 strata.
+
+The Kuchi stratum is also restricted in time.  Annex IV, section IV.4
+"Stratification", printed pp. 327-328 (PDF pp. 371-372):
+
+#+begin_quote
+The Kuchi stratum was only collected in summer 2016 and winter 2016-17 (Shamsi
+calendar 1395) in view of the practical difficulty of locating migrating
+communities in spring and autumn.
+#+end_quote
+
+Consequence for a user: the seasonal domains and the Kuchi domain are *not*
+crossed.  Any spring or autumn subset of this wave contains no Kuchi at all.
+Design size of the stratum: "The 60 clusters (600 households) for this stratum
+were divided between the summer and winter periods within the survey period,
+with 40 and 20 clusters, respectively" (Chapter 2, printed p. 14 / PDF p. 58),
+against 2,040 clusters overall.
+
+**** Disproportionate allocation across provinces -- a deliberate small-province oversample
+
+Annex IV, section IV.4 "Stratification", printed p. 327 (PDF p. 371):
+
+#+begin_quote
+The sample was stratified into 35 analytical domains: one for each of the 34
+provinces of Afghanistan and one for the Kuchi population. For an optimal sample
+allocation across the provinces, a balance was obtained between proportional
+allocation and equal-size allocation with a Kish power allocation of I = 0.25.
+This assured sufficient weight for provinces with small populations, while
+improving the comparability of results across the provinces.
+#+end_quote
+
+Small provinces are therefore over-sampled relative to their population share, by
+design.  *Unweighted national statistics from this wave are not national
+statistics.*
+
+**** Season as an analytical domain
+
+Chapter 2, section 2.2.4, printed p. 13 (PDF p. 57):
+
+#+begin_quote
+The sampling design of the ALCS 2016-17 ensured results that are representative
+at national and provincial level, for the Kuchi population and for Shamsi
+calendar seasons. In total, 35 strata were identified, 34 for the provinces of
+Afghanistan and one for the nomadic Kuchi population.
+#+end_quote
+
+Fieldwork ran continuously from April 2016 to April 2017 (Shamsi 1395), so the
+four seasons are additional analytical domains.  A partial-year subset of this
+wave is not a representative subset.
+
+**** Urban / rural: an analytical domain, but not a stratum
+
+Annex IV, section IV.1 "Introduction", printed p. 327 (PDF p. 371):
+
+#+begin_quote
+The design developed for the 2016-17 survey round was a stratified, two-stage
+cluster approach. The sample distribution is sufficiently close to the national
+urban-rural distribution that separate analysis for these populations is
+justified.
+#+end_quote
+
+Note the form of the claim: urban/rural representativeness is asserted *ex post*
+from the realised distribution, not guaranteed by the design.
+
+*** Universe vs. what the weights represent
+
+Chapter 2, section 2.2.4, printed p. 14 (PDF p. 58):
+
+#+begin_quote
+Sample weights were calculated for up-scaling the surveyed households and
+persons to the total number of households and population in Afghanistan. The
+calculation was based on the official CSO population estimate by province for
+January 2016 and average provincial household sizes derived from the survey.
+#+end_quote
+
+The weights are benchmarked to a CSO *projection*, province by province, for a
+single reference month -- not to a census.  The weight variables are named in
+Annex IV, section IV.8.3, printed p. 334 (PDF p. 378): "hh_weight" and
+"ind_weight".
+
+For the Kuchi stratum the weighting is more than a projection; it is a declared
+policy position.  Annex IV, section IV.8.2 "Kuchi population", printed p. 334
+(PDF p. 378):
+
+#+begin_quote
+In the absence of up-to-date information about the actual number of Kuchis and
+the political sensitivity of addressing this issue, the present position taken by
+CSO is that the Kuchi population is stable at a number close to 1.5 million
+people.
+#+end_quote
+
+#+begin_quote
+Apart from the sampling frame, the restriction to two seasons and the absence of
+the need to accommodate population growth, the procedures for the calculation of
+the sampling weights for the Kuchi stratum are the same as those for the resident
+population.
+#+end_quote
+
+And the report's own coverage-error assessment undercuts the Kuchi frame
+directly -- Annex IX, section IX.4.1, under "Coverage errors", printed p. 362
+(PDF p. 406):
+
+#+begin_quote
+The sampling frames used for ALCS 2013-14 included the 2003-05 pre-census
+household listing, updated in 2009, and the 2003-04 National Multi-sectoral
+Assessment of Kuchi (NMAK-2004). Whereas the former was reasonably up-to-date
+for the survey in 2013-14, the latter was outdated and it is likely that in the
+intervening period considerable changes occurred with respect to the number and
+geographic distribution of Kuchi households. Besides the observed, but
+un-quantified rate of settlement of Kuchi households and natural population
+growth, changing migration patterns will have caused a population distribution in
+2016-17 that is different to the one represented in the NMAK list.
+#+end_quote
+
+[sic: this passage in the 2016-17 report speaks of "ALCS 2013-14" and "the
+survey in 2013-14" -- evidently carried over from the previous round's report --
+while its conclusion is stated for 2016-17.  Quoted as printed; the reader should
+not silently repair it.]
+
+So for the Kuchi sub-population the document asserts a universe ("the entire
+population of Afghanistan, including the nomadic Kuchi") while simultaneously
+recording that the frame is stale, the population total is a fixed political
+assumption rather than a measurement, and two of four seasons are unobserved.
+Those are three different facts and this file keeps them separate.
+
+** 2020 -- Income and Expenditure & Labor Force Survey (IE&LFS) 2020, NSIA
+
+Source: =lsms_library/countries/Afghanistan/2020/Documentation/!Income and Expenditure _ Labor Force Surveys-2020 .pdf=
+(313 PDF pages, DVC-tracked).
+
+*** The declared universe -- stated only obliquely
+
+*No sentence of the form "the target population is ..." appears in this report.*
+That is worth stating plainly rather than papering over.  The 2016-17 wording
+("it represents the entire population of Afghanistan") has *no counterpart* in the
+2020 report and has deliberately not been carried over here.  What the 2020
+document supplies instead is a frame, a stratification, and a weighting target.
+
+Chapter 1, section 1.2.5 "Sampling Design", printed p. 5 (PDF p. 29):
+
+#+begin_quote
+The sampling design of the IE&LFS 2020 ensured results that are representative
+at the national and provincial levels for the Kuchi population and Shamsi
+calendar seasons. Thirty-five strata were identified, 34 for Afghanistan’s
+provinces and one for the nomadic Kuchi population. Stratification by season was
+achieved by equal distribution of data collection over 12 months within the
+provinces. For the Kuchi population, the design only provided sampling in winter
+and summer when communities temporarily settle.
+#+end_quote
+
+Section 1.2.5, printed p. 5 (PDF p. 29) -- the closest thing to a coverage claim:
+
+#+begin_quote
+The sampling frame used for the IE&LFS 2020 is a high-resolution imagery-based
+frame created by National Statistics Information Authority (NSIA). The frame
+consisted of 30,060 Enumeration Areas (EA). NSIA has an electronic file
+consisting of 30,060 EAs that cover the entire country.
+#+end_quote
+
+*The frame changed between the two waves*: 2016-17 used a pre-census household
+listing (2003-05, updated 2009, with SDES listings in seven provinces); 2020 used
+a satellite-imagery-derived EA frame.  A 2016-17 / 2020 comparison is not a
+comparison against a fixed frame.
+
+Preface, printed p. XXIII (PDF p. 23) -- what the report claims to report on:
+
+#+begin_quote
+The report consists of the most comprehensive data, and the main focus is on the
+national level. However, the frequently-disaggregated information is for
+residential populations (urban, rural, and Kuchi) and utmost provincial level.
+#+end_quote
+
+[sic throughout, including "utmost provincial level".]
+
+*** Exclusions
+
+**** Institutional and collective households -- excluded by design
+
+Chapter 2, section 2.3.1 "Household structure", printed p. 20 (PDF p. 44):
+
+#+begin_quote
+Note that only regular households were visited during the fieldwork, as
+institutional and collective households were not in the sample.
+#+end_quote
+
+The same exclusion as 2016-17, restated grammatically.
+
+**** Districts not covered
+
+Chapter 1, section 1.3 "Data Collection", printed p. 7 (PDF p. 31).  (The report
+numbers this subsection "3.3.1 Field Operations" even though it sits inside
+Chapter 1 -- an error in the source's own numbering, recorded here so the
+citation can be located.)
+
+#+begin_quote
+The number of districts covered was 329 out of 399 districts in Afghanistan. The
+covered districts had at least one randomly selected cluster surveyed within that
+particular district’s geographical boundaries. Fifty-eight districts were not
+covered due to security concerns, heavy snowfalls during the winter season, and
+other reasons. Twelve districts were not part of the survey as the randomly
+selected clusters did not fall in those districts. In 2100 planned clusters, 67
+clusters were replaced with the reserve clusters.
+#+end_quote
+
+**** Provinces under-covered
+
+Same section, printed p. 7 (PDF p. 31):
+
+#+begin_quote
+There were provinces like Faryab, Badghis, Paktiya, Helmand, and Kapisa that
+could not achieve the desired coverage due to poor security conditions even after
+utilizing all the reserve clusters.
+#+end_quote
+
+And section 3.5.2 "Data Limitations", numbered item 8, printed p. 11 (PDF p. 35):
+
+#+begin_quote
+Initially, there were 2100 clusters planned to be surveyed throughout the
+country. Considering Afghanistan’s tense security condition, the survey teams
+collectively managed to survey 1835 clusters in the country. The survey coverage
+was 87.4 percent. [...] Precisely, Faryab and Badghis were the provinces with
+lower coverage, followed by Kapisa, Helmand, and Paktia provinces. The reason for
+low coverage in the provinces, as mentioned above, was the worst security
+situation.
+#+end_quote
+
+("[...]" elides two intervening sentences about reserve clusters.  The source
+spells the province "Paktiya" in the first passage and "Paktia" in the second;
+both are as printed.)
+
+**** Access limits on female respondents -- a within-household coverage gap
+
+Section 3.5.2 "Data Limitations", items 6 and 7, printed p. 11 (PDF p. 35):
+
+#+begin_quote
+For instance, the area under insurgents’ control is challenging to be surveyed –
+they do not allow the fieldworkers to operate in their jurisdictions. Sometimes
+they only permit male fieldworkers while the female enumerators are not allowed
+to work.
+#+end_quote
+
+#+begin_quote
+Similarly, there are cultural limitations that do not pave the way for smoothly
+conducting the national surveys. For example, in remote areas, the females might
+not be allowed to respond to the interview questions despite being female.
+#+end_quote
+
+This is a *non-geographic* coverage gap that the report itself flags: in part of
+the sample, women were not interviewed.  The 2020 microdata in this repo is split
+by respondent sex (=household_male.dta= / =household_female.dta= /
+=roster_male.dta= / =labour_male.dta=).  We do NOT assert a link between those two
+facts -- establishing one would require reading the questionnaire and the data,
+neither of which was done for this record.  It is flagged so that anyone pooling
+the male and female files knows the documentation records a sex-differential
+coverage problem.
+
+*** Oversamples and sub-populations
+
+The same Kuchi structure as 2016-17: a separate stratum, from the same 2003-04
+frame, restricted to two seasons.  Section 1.2.5, printed p. 6 (PDF p. 30):
+
+#+begin_quote
+The Kuchi sample was designed based on the 2003-04 National Multi-Sectoral
+Assessment of Kuchi (NMAK-2004). For this stratum, a community selection was
+implemented with PPS, and a second stage selection of households was similar to
+that of the Non-Kuchi population, as discussed earlier. The 60 clusters (600
+households) for this stratum were divided between the summer and winter seasons
+within the survey period, with 40 and 20 clusters, respectively.
+#+end_quote
+
+So the Kuchi stratum is 60 of 2,040 design clusters, and the "no Kuchi in spring
+or autumn" caveat carries over from 2016-17.  Note that the 2020 report repeats
+the NMAK-2004 frame without repeating the 2016-17 report's own warning that that
+frame was outdated; the warning is not restated, which is not the same as its
+having been resolved.
+
+Urban/rural enters this design only as *implicit* stratification within the PPS
+draw -- section 1.2.5, printed p. 6 (PDF p. 30): "with implicit stratification by
+urban/rural and by the district".  It is not an explicit stratum.
+
+*** Universe vs. what the weights represent
+
+Section 1.2.5, printed p. 6 (PDF p. 30):
+
+#+begin_quote
+Sample weights were calculated for up-scaling the surveyed households and
+persons to the total number of households and Afghanistan population. The
+calculation was based on the official NSIA population for the year 1398
+(2019-20).
+#+end_quote
+
+As in 2016-17, the weights are benchmarked to the statistical office's own
+population figure rather than to a census.  Given that no explicit universe
+sentence exists in this report, *the weighting target is effectively the
+strongest available statement of what the 2020 sample stands for*, and it should
+be cited as such rather than as a universe declaration.
+
+** Caveats on this record
+
+- Transcription :: Quotes for both waves are transcribed from a =pypdf= text
+     extraction of the source PDF.  That text layer inserts spurious intra-word
+     spaces ("susta ined", "e qual", "diffic ulty", "201 5", "Socio -Demographic",
+     "7 .8"), spaces before punctuation, and hyphen breaks at line ends
+     ("stratifi-cation", "enu-merators").  Those obvious extraction artifacts
+     were rejoined and *nothing else was altered* -- no wording, ordering or
+     punctuation.  Sic spellings in the sources are preserved and marked.  Every
+     quote above was re-checked against the extracted text on 2026-07-21.
+
+- The 2016-17 report in this repo is a draft :: The file is titled "ALCS -
+     2016-17 Analysis report draft version".  A final published ALCS 2016-17
+     report exists but is not in this repository, and was *not* substituted.  If
+     a quote above is ever checked against the final report and differs, the final
+     report wins and this section should be corrected.
+
+- 2020 wave label vs. fieldwork dates :: The wave directory is named =2020=, but
+     fieldwork ran from "early October 2019 (Meezan 1398)" to "late September 2020
+     (Sunbula 1399)" (printed p. 6 / PDF p. 30).  The wave label is not the
+     reference period.
+
+- The other file in =2020/Documentation/= is a different survey ::
+     =REACH_AFG_WoAA-2022-MSNA_Main-HH_Analysis_Sept2022.xlsx= is, by its
+     filename, a REACH Whole-of-Afghanistan Assessment / MSNA 2022 analysis
+     workbook -- a different instrument in a different year.  It was not opened and
+     is not the source of any quote here.  It should not be read as documenting the
+     IE&LFS 2020 sample.  (Filename evidence only; this is a flag, not a claim
+     about its contents.)
+
+- What was searched, so the gaps are falsifiable :: For both waves: the wave's
+     own =Documentation/= tree (materialised via
+     =lsms_library.data_access.get_data_file()=, never the =dvc= CLI); a full text
+     extraction of the report PDF; grep for "target population", "universe",
+     "sampling frame", "sample frame", "covers", "coverage", "represent", "entire
+     population", "institutional", "nomad", "Kuchi", "excluded"; and full reading
+     of the survey-methodology chapter, the household-structure section, the
+     field-operations and limitations sections, and (for 2016-17) Annex IV in
+     full.  The 2020 report has no separate sample-design annex -- section 1.2.5
+     is the fullest statement it contains.  Additionally the WB Microdata catalog
+     was queried for =country=AFG= (120 entries) and filtered for "living
+     condition" / "risk and vulnerab" / "nrva" / "alcs" / "labor force" / "labour
+     force" / "income and expenditure": *zero* matches.  There is no WB catalog
+     record for either wave, and neither wave has a =Documentation/SOURCE.org=.

--- a/lsms_library/countries/Albania/_/CONTENTS.org
+++ b/lsms_library/countries/Albania/_/CONTENTS.org
@@ -1,5 +1,572 @@
 #+TITLE: Albania — country notes & known data issues
 
+* Sampling universe, exclusions and sub-samples
+  :PROPERTIES:
+  :Recorded: 2026-07-21
+  :Context: GH #601 (the population record); evidence only -- GH #603 decides
+            how the library REPRESENTS any of this.  Nothing here proposes a
+            schema, a YAML key, or a code change.
+  :END:
+
+What each Albania wave's own documentation says its sample represents, quoted
+verbatim.  Three rules govern every entry below:
+
+- Verbatim or nothing :: every quoted sentence is reproduced
+     character-for-character from the cited file, with runs of whitespace and
+     PDF line-wrap collapsed to single spaces.  Where a repair was needed it is
+     declared inline.  No paraphrase is offered as a quote.
+- Gaps are recorded as gaps :: a wave with no statement gets an explicit "not
+     found" entry naming what was searched, so the claim is falsifiable.  No
+     wave's universe is filled in from a sibling wave, from the country, or from
+     the "obvious" inference.
+- Nothing is inferred from the data :: no =.dta= was opened for this.  A survey's
+     universe is a claim its documentation makes; it is not something to be
+     reverse-engineered from the microdata.  Keeping "what the survey claims"
+     apart from "what the data look like" is the whole point.
+
+All page references below were re-verified against the PDFs in this repo on
+2026-07-21 (pdfminer text extraction, page-by-page).  Two locators in the
+upstream sweep record were off by one page and are corrected here; see the 2003
+and 2008 entries.
+
+** Summary
+
+| wave | strongest statement available            | universe stated? | geographic exclusion | sub-sample / oversample                | where it lives     |
+|------+------------------------------------------+------------------+----------------------+----------------------------------------+--------------------|
+| 1996 | coverage + representativeness (2 sources) | no ("Universe" field absent) | *yes -- Tirana dropped* | *yes -- PPS to social-assistance recipients* | repo DDI + BID (catalog) |
+| 2002 | "The universe under study consists of all the households in the Republic of Albania." | yes | none stated | none                                    | *BID only -- NOT in this repo* |
+| 2003 | panel representativeness claim            | no               | none stated          | *yes -- ~half of the 2002 LSMS households* | repo DDI (+ BID)   |
+| 2004 | panel representativeness claim            | no               | none stated          | *yes -- same 2002-derived panel*        | repo DDI (+ BID)   |
+| 2005 | same "universe under study" sentence as 2002 | yes (but see caveat) | none stated      | none -- a completely new sample         | repo DDI (+ BID)   |
+| 2008 | *none*                                    | no               | not stated           | not stated                              | *nowhere*          |
+| 2012 | PSU-selection sentence + catalog coverage tag | no           | none stated          | none stated                             | repo DDI           |
+
+Read the "universe stated?" column strictly.  For 1996, 2003, 2004 and 2012 the
+documentation makes *coverage* or *representativeness* claims, which are not the
+same thing as a declared target population; they are recorded as what they are.
+The word "universe" appears in exactly one of the seven repo-held DDI PDFs
+(2005), and in no Albania WB catalog record's DDI =universe= field -- that field
+does not exist for any of catalogs 2311, 86, 87, 88, 64, 1933 or 1970.
+
+*Boilerplate check*: none of the Albania statements is the World Bank NADA
+template sentence ("The survey covered all de jure households excluding prisons,
+hospitals, military barracks, and school dormitories") that recurs verbatim in 15
+waves elsewhere in the library.  Every Albania statement below is survey-specific
+text.
+
+** 1996 -- Employment and Welfare Survey (directory present; NOT a declared wave)
+
+Note first what =_/data_scheme.yml= already says, and do not contradict it:
+
+: # 1996 excluded: Employment and Welfare Survey (EWS), not LSMS.
+
+The evidence below *corroborates and strengthens* that exclusion rather than
+challenging it.  1996 is a different survey (Ministry of Labour and Social
+Affairs, fielded August-November 1996), with a different geographic coverage and
+a purposive design.
+
+*** Declared coverage (no formal universe statement exists)
+
+#+begin_quote
+"The data collected cover approximately 1,500 households in rural and urban
+areas, excluding Tirana.  Tirana was not included because it had been the focus
+of another household survey in 1994.  The sample was designed to maximize the
+inclusion of poor areas to increase the number of program participants."
+#+end_quote
+
+- Source :: =1996/Documentation/ddi-documentation-english_microdata-2311.pdf=,
+     PDF p.3, "Sampling" > "Sampling Procedure", first paragraph.  Identical
+     wording opens section 1 of the Basic Information Document =alb96bif.pdf=
+     ("Basic Documentation, Albania: Employment and Welfare Survey"), PDF p.4 /
+     printed p.1.
+- Catalog field :: =study_desc.study_info.geog_coverage= (catalog 2311) reads
+     "National (except Tirana)".
+
+*** Exclusion: Tirana, by design
+
+This is the strongest exclusion finding in Albania, and it is stated three times
+independently.
+
+#+begin_quote
+"The sampling frame includes all rural and the urban areas of Albania except
+Tirana (see Introduction)."
+#+end_quote
+
+- Source :: =alb96bif.pdf=, section 3.1 "General description and sample size",
+     printed p.2.
+
+#+begin_quote
+"In other words, when the data are weighted the results are representative of
+rural and urban Albania with the exception of Tirana which was excluded from the
+study."
+#+end_quote
+
+- Source :: =alb96bif.pdf=, section 3, PDF p.10 / printed p.7.
+
+*** Oversample: social-assistance (Ndihma Ekonomike) recipients
+
+The 1996 sample is *not* a simple probability sample of the non-Tirana national
+population.  It is a program-evaluation sample with a deliberate oversample:
+
+#+begin_quote
+"In the first stage, formal administrative units were selected with probability
+proportional to the number of individuals receiving economic assistance (NE).
+The administrative units are communes in rural areas and bashki in urban areas.
+The areas with more participants were over-sampled to have a larger pool of NE
+recipients.  The behavior of recipients can be compared to non-participants in
+the program because they were drawn randomly.  In the second stage, households
+were selected with equal probability as described below."
+#+end_quote
+
+- Source :: =alb96bif.pdf=, section 3.1, printed p.3.
+- Repair declared :: the PDF hyphenates "over-" / "sampled" across a line break.
+     It is transcribed as "over-sampled"; whether the printed hyphen is lexical
+     or typographic cannot be settled from the text layer.
+- Design detail (context, not universe) :: rural -- 50 of 314 communes selected
+     PPS to estimated recipients, then a target of 29 households per commune by
+     systematic random sampling from civil registry lists; urban -- 8 of 48
+     bashkies PPS to NE recipients, then 60 households per bashki from a fresh
+     physical listing.
+
+*** Where the statements live
+
+The DDI PDF is held in this repo.  The Basic Information Document =alb96bif.pdf=
+is *not* -- it was fetched from
+https://microdata.worldbank.org/index.php/catalog/2311/download/34511 for this
+sweep.  The two exclusion quotes and the whole oversample paragraph come from
+that non-repo document; only the first coverage quote is held locally.
+
+** 2002 -- LSMS (Wave 1 Panel)
+
+*** Declared universe
+
+#+begin_quote
+"The unit of analysis and the unit of observation is the household.  The universe
+under study consists of all the households in the Republic of Albania.  We have
+used the Housing Unit (defined as the space occupied by one household) as the
+sampling unit, instead of the household, because the HU is more permanent and
+easier to identify in the field."
+#+end_quote
+
+- Source :: =alb02bif.pdf= (LSMS 2002 Basic Information Document), "Annex 5 --
+     Sample implementation report" (memo from Ms. Blerina Zykaj), section 1
+     "Sampling frame", PDF p.63 / printed p.61.
+
+*** WHERE THIS LIVES -- flag
+
+*The universe sentence is not in this repository.*  It exists only in
+=alb02bif.pdf=, obtained from
+https://microdata.worldbank.org/index.php/catalog/86/download/11834 .  It is not
+in the repo-held DDI PDF, and it is not in the WB catalog's DDI =universe= field
+(catalog 86 has no such field).  Albania 2002's universe statement is therefore a
+*moving target held by a third party*, not something the library holds.
+
+The nearest thing the repo does hold is a representativeness claim:
+
+#+begin_quote
+"The survey is representative for Tirana, other urban and rural areas, as well as
+for Tirana and the three main agro-ecological/economic areas (Coastal, Central
+and Mountain)."
+#+end_quote
+
+- Source :: =2002/Documentation/ddi-documentation-english_microdata-86.pdf=,
+     PDF p.3, "Sampling" > "Sampling Procedure" > "Stratification".
+- Catalog field :: =geog_coverage= (catalog 86) reads "National coverage.
+     Domains: Tirana, other urban, rural; Agro-ecological areas (coastal,
+     central, mountain)".
+
+*** Exclusions
+
+No geographic or population-group exclusion is stated anywhere in the 2002
+documentation.  The only exclusions documented are definitional -- who counts as
+a household member:
+
+#+begin_quote
+"Household membership in this survey is defined as being away from the household
+for less than six months.  Deceased individuals, lodgers, hired workers and
+servants are never considered household members.  Guests who stay with the
+household for six months and over, infants of less than six months, new arrivals
+(such as newly weds) are considered household members.  The household head was
+counted as a household member if he or she had been away less than 12 months,
+rather than the 6 month limit for anyone else absent."
+#+end_quote
+
+- Source :: =2002/Documentation/ddi-documentation-english_microdata-86.pdf=,
+     PDF p.5, "Questionnaires" > "Overview".
+
+Two frame edits are documented and are *not* population exclusions: enumeration
+areas with zero population were removed from the frame, and housing units found
+invalid during the listing update were removed.  They are recorded here so that a
+later reader does not mistake them for a coverage carve-out.
+
+*** Sub-samples
+
+None within 2002.  But note the forward direction: 2002 is the *parent* of the
+2003 and 2004 panel waves (below), which are drawn from it rather than from the
+population.
+
+** 2003 -- LSMS (Wave 2 Panel) / Albania Panel Survey
+
+*** No universe statement; the strongest claim is about representativeness
+
+#+begin_quote
+"The sample selected from the LSMS for the panel was designed to provide a
+nationally representative sample of households and individuals within Albania
+(see Appendix B for full description of the sample design and selection
+procedure).  This differs from the LSMS where the sample was designed to be
+representative of each strata which broadly represented the main regions in
+Albania so that regional level statistics could be generated (Mountain, Central,
+Coastal, Tirana)."
+#+end_quote
+
+- Source :: =2003/Documentation/ddi-documentation-english_microdata-87.pdf=,
+     PDF p.3, "Sampling" > "Sampling Procedure" > "Panel design".  Identical
+     wording in the BID =alb03bid.pdf= (not held in this repo), PDF p.1.
+- No document in the 2003 set contains the word "universe".  Catalog 87's
+     =geog_coverage= reads "National"; catalog 87 has no abstract.
+
+*** THIS WAVE IS A SUB-SAMPLE OF 2002 -- read before pooling
+
+#+begin_quote
+"The Albanian panel survey sample was selected from households interviewed on the
+2002 LSMS conducted by INSTAT with support from the World Bank.  The sample size
+for the panel took approximately half the LSMS households and has re-interviewed
+these households annually in each of 2003 and 2004."
+#+end_quote
+
+- Source :: same PDF, PDF p.3, "Panel design".
+
+So 2003 is not drawn from a population at all.  Its effective universe is 2002's,
+propagated forward through the panel-following rules -- which is a different kind
+of object from a fresh national draw, and the documentation says nothing about
+how well the propagation held.  Sample size 2,155 households (DDI sampling
+section).
+
+*** Scope restrictions (individual level)
+
+#+begin_quote
+"- Sample members moving out of Albania are considered to be out of scope for
+that year of the survey (note that they remain potentially eligible for interview
+and it is possible they may return to a sample household at a future wave)
+- From Wave 2, only household members aged 15 years and over are eligible for
+interview.  As children turn 15, they become eligible for interview (This differs
+from the LSMS where the individual questionnaire collected some data on children
+under 15 from the mother or main carer)."
+#+end_quote
+
+- Source :: same PDF, PDF p.4, "Panel design" bulleted list.
+
+No geographic exclusion is stated for 2003.
+
+*** Universe vs. what the weights support
+
+The documentation is explicit that the panel's representativeness is *narrower
+than 2002's*, on the analytic-domain axis:
+
+#+begin_quote
+"The panel data can be used for analysis broken down by strata to assess any
+differences between areas but should not be used to produce cross-sectional
+estimates at the regional level."
+#+end_quote
+
+- Source :: same PDF, *PDF p.3* (the upstream sweep record cited p.4 for this
+     sentence; re-verified 2026-07-21, it is on p.3 alongside the panel-design
+     narrative).
+
+** 2004 -- LSMS (Wave 3 Panel) / Albania Panel Survey
+
+*** No universe statement; representativeness claim, with an explicit domain narrowing
+
+#+begin_quote
+"The sample of the second and third waves of the panel (APS) has been selected
+from the LSMS 2002 in order to be representative of Albanian households and
+individuals at national level.  The LSMS 2002 differs from the APS 2003 and 2004
+in that the former is designed to be representative at regional level (Mountain,
+Central, Coastal and Tirana) as well as for urban and rural domains, while the
+latter are for last domains only (urban and rural)"
+#+end_quote
+
+#+begin_quote
+"The panel component selected from the LSMS is designed to provide a nationally
+representative sample of households and individuals within Albania."
+#+end_quote
+
+- Source :: =2004/Documentation/ddi-documentation-english_microdata-88.pdf=,
+     PDF p.3, "Sampling" > "Sampling Procedure" (opening paragraph under "Panel
+     sample, with LSMS 2002 and 2004"; second quote from the same section under
+     "APS 2003-2004 sample design").  Identical wording in the BID
+     =BasicInformationDocument_2004.pdf= (not held in this repo), section III
+     "Sample Design".
+- No document in the 2004 set contains the word "universe".  Catalog 88's
+     =geog_coverage= reads "National coverage. Domains: Tirana, other
+     urban,rura" -- truncated in the catalog record, quoted as served.
+- Sample size :: 1,797 valid household observations, 7,476 individual
+     observations.
+
+The domain narrowing in the first quote is the sharpest universe-vs-weights point
+in the Albania series: *2002 and 2005 support regional (Coastal / Central /
+Mountain / Tirana) estimates; 2003 and 2004 support only urban/rural.*  Anyone
+computing a regional series across Albania waves needs to know this before
+averaging.
+
+*** Scope restrictions
+
+#+begin_quote
+"From wave 2, only individuals aged 15 years and over are considered valid
+members, hence eligible for the interview.  Individuals moved out of Albania are
+not accounted as valid for this survey year, though they are still eligible for
+future waves."
+#+end_quote
+
+- Source :: same PDF, PDF p.4, "Sampling" > "Sampling Procedure".
+
+#+begin_quote
+"Household membership is defined as being an actual resident or away from the
+household for less than six months (the exceptions being: the household head even
+though he might be away from the household for up to 11 months).  Deceased
+individuals, lodgers, hired workers and servants are never considered household
+members."
+#+end_quote
+
+- Source :: same PDF, PDF p.5, "Questionnaires" > "Overview".
+
+No geographic exclusion is stated for 2004.
+
+*** How a household can enter the panel
+
+#+begin_quote
+"The sample is designed to focus on individuals, who have been also traced when
+moving from the original household to a new one.  This possibility represents the
+only way a household can enter the panel sample if it has not been already
+interviewed in the wave 1 (or in wave 2 for the APS 2004)."
+#+end_quote
+
+- Source :: same PDF, "Sampling" > "Sampling Procedure".
+
+** 2005 -- LSMS
+
+*** Declared universe
+
+#+begin_quote
+"The unit of analysis and the unit of observation is the household.  The universe
+under study consists of all the households in the Republic of Albania.  We have
+used the Housing Unit (defined as the space occupied by one household) as the
+sampling unit, instead of the household, because the HU is more permanent and
+easier to identify in the field."
+#+end_quote
+
+- Source :: =2005/Documentation/ddi-documentation-english_microdata-64.pdf=,
+     PDF p.3, "Sampling" > "Sampling Procedure" > subsection "1. Sampling frame",
+     final paragraph immediately before "2. Sample Size".  This is the *only*
+     repo-held Albania DDI in which the word "universe" appears at all.
+- Catalog field :: =geog_coverage= (catalog 64) reads "National coverage.
+     Domains: Tirana, other urban, rural; Agro-ecological areas (coastal,
+     central, mountain)".
+
+*** PROVENANCE CAVEAT -- this sentence is inherited 2002 text
+
+Easy to over-read, so record it plainly.  The paragraph is *verbatim identical*
+to the 2002 text (=alb02bif.pdf= Annex 5), and in the 2005 BID =alb05bid.pdf= it
+sits inside "Annex 5.1 Sample implementation report" -- a memo whose surrounding
+sentences describe the *2002* fieldwork ("In the LSMS the sample size is 450 EA
+and in each EA 8 households were selected.  So the total sample size of the LSMS
+is 3600 households.").  Verified 2026-07-21 by diffing the two annexes.
+
+It is nonetheless what the 2005 DDI's own Sampling Procedure section says, and
+what the WB catalog serves as catalog 64's =sampling_procedure=.  So: the claim
+is genuinely made *for* the 2005 wave, but it is carried-forward text, not a
+freshly written 2005 universe declaration.  Both facts, not one.
+
+*** Not a panel wave
+
+The 2005 sample is a fresh draw, not a continuation of the 2002 PSUs:
+
+#+begin_quote
+"These problems related to the two different working hypotheses concerning the
+new sample were deeply discussed with the LSMS staff during the visit to Albania's
+National Statistical Institute (INSTAT) the last January (24-27 January 2005).
+Finally, it was decided to carry out a new survey (hypothesis (ii))."
+#+end_quote
+
+- Source :: =alb05bid.pdf= (not held in this repo; fetched from
+     https://microdata.worldbank.org/index.php/catalog/64/download/11412 ),
+     section 2 "The hypotheses for the 2005 LSMS sample", printed p.8.
+     Hypothesis (ii) is "Select a new sample of PSUs and SSUs using a design
+     analogous to the one used in 2002"; hypothesis (i), rejected, would have
+     reused the 450 PSUs of 2002 and joined the panel households to the new
+     sample.
+
+So there is *no* 2005 panel sub-sample and no pooled cross-section-plus-panel
+structure inside this wave.  (The 2005 questionnaire's cover page does carry
+"Additional household information for panel tracking" -- that is tracking
+information collected for *future* waves, not a panel component of 2005.)
+
+*** Exclusions
+
+No geographic, regional, or population-group exclusion is stated anywhere in the
+2005 documentation.  The only documented frame edits are:
+
+#+begin_quote
+"In order to obtain EAs with the minimum of 50 and the maximum of 120 occupied
+housing units, the EAs with zero population have been taken off the sampling
+frame."
+#+end_quote
+
+#+begin_quote
+"During of the listing update process, HUs identified as invalid were taken off
+the frame."
+#+end_quote
+
+- Source :: same PDF, PDF pp.2-3.  Frame edits, not stated population
+     exclusions; recorded so they are not later mistaken for one.
+
+** 2008 -- NO STATEMENT FOUND
+
+*This is a documented gap, not an unsearched cell.*  Nothing about the 2008
+universe, coverage, or exclusions is recorded anywhere that could be found.
+
+The repo-held DDI PDF's sampling section reads, in full:
+
+#+begin_quote
+"Sampling
+
+No content available"
+#+end_quote
+
+- Source :: =2008/Documentation/ddi-documentation-english_microdata-1933 (1).pdf=,
+     *PDF p.3* (the upstream sweep record cited p.2; re-verified 2026-07-21 --
+     the heading and its "No content available" body are on p.3).  The
+     "Questionnaires", "Data Processing" and "Data Appraisal" sections read "No
+     content available" as well; the whole PDF extracts to about 2,800
+     characters.
+
+The only population-scope claims that exist at all are catalog metadata tags --
+=geog_coverage= = "National" and =analysis_unit= = "- individuals, - households, -
+communities" (catalog 1933).  Neither is a universe statement.
+
+*** What was searched
+
+1. =2008/Documentation/= in this repo -- =SOURCE.org= (catalog 1933), the DDI PDF
+   (fully text-extracted), =LICENSE.org=; the three =.xls= files are the
+   household and community questionnaires.
+2. WB catalog 1933 =/metadata/export/1933/json= -- full DDI metadata, grepped for
+   "universe" (ABSENT).  =study_desc.method= contains *only*
+   ={'data_collection': {'coll_mode': 'Face-to-face [f2f]'}}= -- there is no
+   =sampling_procedure= field at all.
+3. Catalog 1933 related materials, all 8 items enumerated.  The only prose
+   document is "Living Standard Measurement Survey 2008.pdf" (= "Albania Trends
+   in Poverty: 2002-2005-2008"), downloaded and text-searched for
+   "universe|target population|excluding|excluded|represent|sample|cover|nation"
+   -- it is a results report with no sampling or universe section.  The rest are
+   questionnaires, a price-range spreadsheet, a prefecture code list, and the
+   generic "Guide to LSMS" handbook.
+4. No Basic Information Document exists for 2008 in the catalog, unlike 1996,
+   2002, 2003, 2004 and 2005, all of which have one.
+
+*** Do not fill this gap by adjacency
+
+The 2008 abstract says only "In 2008, 3,600 households participated in the
+survey" -- the same 3,600 target as 2002 and 2005, and different from 2012's
+6,671.  That is a sample-size coincidence and is *not* evidence about the 2008
+universe.  Do not inherit 2005's or 2012's statement for it.  If a statement is
+needed, the acquisition route is INSTAT Albania directly (instat.gov.al), not the
+WB catalog.
+
+** 2012 -- NO UNIVERSE STATEMENT FOUND (design and coverage text only)
+
+No sentence declaring a universe or target population exists for 2012.  What the
+documentation does say is sample-design text and a catalog coverage tag, recorded
+here as exactly that and *not* laundered into a universe claim.
+
+#+begin_quote
+"In the first round, 834 Primary Selection Units (PSUs) have been chosen randomly
+to represent the whole territory of the country."
+#+end_quote
+
+- Source :: =2012/Documentation/ddi-documentation-english_microdata-1970.pdf=,
+     PDF p.4, "Sampling" > "Sampling Procedure".  This is a statement about PSU
+     selection, not a declared population.
+- Extraction repair declared :: pdfminer renders the PDF's "fi" ligature, so the
+     raw text layer reads "In the first round" with a ligature glyph.  The
+     spelling above is the form the WB catalog JSON serves for the same sentence.
+
+#+begin_quote
+"GEOGRAPHIC COVERAGE
+
+National"
+#+end_quote
+
+#+begin_quote
+"UNITS OF ANALYSIS
+
+- Households
+
+- Individuals"
+#+end_quote
+
+- Source :: same PDF, PDF p.2, "Overview" > "Coverage" / "UNITS OF ANALYSIS".
+     This is the only Albania DDI that ships the study-level Overview /
+     Identification / Scope / Coverage block -- and even it has no Universe
+     field.
+
+*** Domain expansion (bears on what the weights support)
+
+#+begin_quote
+"However, the geographic domains of analysis have been expanded to include the 12
+individual prefectures of Albania, by urban and rural strata, compared to four
+geographic regions (Central, Coastal, Mountain and Tirana) by urban and rural
+strata defined previously as domains for the survey."
+#+end_quote
+
+- Source :: same PDF, PDF p.4, "Sampling" > "Sampling Procedure".
+- Consequence stated in the same paragraph :: "This required a considerable
+     increase in the sample size from 3,600 to 6,671 households".
+
+So 2012 supports *finer* analytic domains (24 strata = 12 prefectures x
+urban/rural) than any earlier wave.  Design detail, for context only: frame =
+Population and Housing Census of October 2011; 834 PSUs x 8 households, plus 4
+substitute households per PSU, to 6,671 completed.
+
+*** Exclusions
+
+None found.  No geographic, regional, or population-group exclusion is stated for
+2012.
+
+*** What was searched
+
+=2012/Documentation/= in this repo (=SOURCE.org=, the DDI PDF fully
+text-extracted, =LICENSE.org=; the =.xls=/=.xlsx= files are questionnaires and
+the food diary); WB catalog 1970 =/metadata/export/1970/json= grepped for
+"universe" (ABSENT); all 5 related-materials items, including
+"living_standard_measurement_survey__2012__preliminary_results_.pdf" (= "Albania
+Trends in Poverty: 2002-2005-2008-2012"), which is a results report with no
+sampling or universe section.  No Basic Information Document exists for 2012.
+
+** What this means before pooling Albania waves
+
+Stated as consequences of the evidence above, not as a design proposal:
+
+- 1996 is a different survey with a different geography and a purposive,
+  recipient-weighted design.  =_/data_scheme.yml= already leaves it out of
+  =Waves:=; the Tirana exclusion and the NE-recipient oversample are two further,
+  independent reasons that decision is right.
+- 2003 and 2004 are not independent national draws.  They are roughly half of the
+  2002 LSMS households, re-interviewed, with emigrants out of scope and only
+  people aged 15+ eligible for individual interview from Wave 2 on.  Treating
+  them as four independent cross-sections is not what the documentation supports.
+- The analytic domain changes three times across the series: regional
+  (2002, 2005) -> urban/rural only (2003, 2004) -> prefecture x urban/rural
+  (2012).  A regional time series across all six declared waves is not supported
+  by the 2003/2004 documentation, which says so in as many words.
+- 2008 carries no statement of any kind.  Any claim about what Albania 2008
+  represents is currently unsourced.
+- Albania 2002's universe sentence is not in this repository and not in the WB
+  catalog's structured metadata.  It exists in one PDF on the World Bank's
+  download endpoint.  If that matters for reproducibility, the fix is to acquire
+  =alb02bif.pdf= (and =alb03bid.pdf=, =BasicInformationDocument_2004.pdf=,
+  =alb05bid.pdf=, =alb96bif.pdf=) into the corresponding =Documentation/=
+  directories -- an acquisition question, not a schema question.
+
 * Known issues
 
 ** household_roster 2002 & 2005 collapsed to the within-cluster id (RESOLVED)

--- a/lsms_library/countries/Armenia/_/CONTENTS.org
+++ b/lsms_library/countries/Armenia/_/CONTENTS.org
@@ -1,0 +1,293 @@
+#+title: Contents
+
+* Sampling universe, exclusions and sub-samples
+
+# ASCII EXCEPTION (deliberate, per the orgmode skill's "leave a comment" rule):
+# every #+begin_quote block below is a VERBATIM transcription of survey
+# documentation.  Curly apostrophes ('Urban Dwellers'), curly double quotes
+# ("organized"), and the source's own double spaces ("households  (i.e.",
+# "cities,  and", "of  selection") are reproduced as printed.  Do not normalise
+# them: the point of these blocks is that a later reader can diff them against
+# the PDF.  All prose outside the quote blocks is ASCII apart from the section
+# sign in citations (§3.1 etc.), which matches the assembled
+# slurm_logs/POPULATION_STATEMENTS_2026-07-21.org.
+
+Armenia ships exactly one wave, =1996= (the Armenian Household Budget Survey,
+AHBS 96 / HBS 1996), and ships no microdata -- =_/data_scheme.yml= carries
+=data_available: false=.  Everything below is documentation evidence.  No =.dta=
+file was opened, and none could have been: the universe of a survey is a claim
+its documentation makes, not something to reverse-engineer from data.
+
+Evidence gathered 2026-07-21 for GH #601; the cross-country assembly is
+=slurm_logs/POPULATION_STATEMENTS_2026-07-21.org= on branch
+=docs/601-population-statements=, where this wave is tagged
+=national-all-households=, confidence *high*.
+
+** Where the statement lives -- NOT in this repo
+
+| wave | statement source                          | in this checkout? | confidence |
+|------+-------------------------------------------+-------------------+------------|
+| 1996 | =ar96binf.pdf= (WB Basic Information Doc) | *no*              | high       |
+
+The statement quoted below comes from *"Basic Information Document -- Republic
+Of Armenia, Household Budget Survey -- 1996 (AHBS 1996)"*, Development Research
+Group, Poverty and Human Resources Division, The World Bank, December 1998,
+filename =ar96binf.pdf=.  That file is *not present in this repository*.  It was
+downloaded from World Bank Microdata catalog entry 2324
+(https://microdata.worldbank.org/index.php/catalog/2324/download/34650).
+
+=1996/Documentation/= holds only =SOURCE.org= (the catalog URL plus provenance
+keywords), a =.gitignore=, and four DVC-tracked PDFs: =arm01.pdf= (Household
+Questionnaire), =arm03.pdf= (Diary Questionnaire), =arm04.pdf= (Diary of Current
+Expenditures), and =ddi-documentation-english_microdata-2324.pdf=.  That last
+file is a 12.7 kB related-materials *listing* -- it names =ar96binf.pdf= as the
+Basic Information Document but contains no universe statement of its own.
+
+Consequence, stated plainly: *for Armenia the library holds no copy of the
+document that defines its sample's universe.*  The record is a moving target on
+a World Bank server rather than something this repository can vouch for.  If the
+catalog entry is revised or withdrawn, the citations below become unverifiable.
+
+*This is not NADA boilerplate.*  The single most-repeated "universe" sentence in
+the cross-country corpus is World Bank NADA template text (15 waves).  Armenia
+is not one of them -- for the opposite reason: the DDI XML export for study 2324
+has *no* =<universe>= element at all.  Its =<sumDscr>= records only
+=<geogCover>National</geogCover>=, =<nation abbr="ARM">Armenia</nation>=, and
+=<anlyUnit>- Households\n- Individuals</anlyUnit>=.  The statement below is the
+Bank's own authored BID prose, which is stronger evidence than a template field,
+but it is prose in a document the repo does not hold.
+
+** 1996 -- the declared universe
+
+=ar96binf.pdf=, Section 3 "Sample", §3.1 "Coverage", p. 9, first paragraph
+(language: English; no translation needed):
+
+#+begin_quote
+The AHBS 96 covered the whole territory of the ROA which had an estimated population at the time of the survey of 3.75 million people and 875,000 households.3 According to the SDS records, about 61% of the households were classified as ‘Urban Dwellers’. Approximately 253,000 households  (i.e. 28.9% of the total in the republic and 47.7% of the urban households) were registered in the capital, Yerevan.
+#+end_quote
+
+The superscript =3= is the footnote reference reproduced under "Exclusions"
+below.  =ROA= = Republic of Armenia; =SDS= = State Department of Statistics.
+
+Unit of analysis, =ar96binf.pdf= §1 "Introduction", p. 3:
+
+#+begin_quote
+The unit of study in the survey was the household, defined as a group of co-resident individuals with a common living budget.
+#+end_quote
+
+A *representativity claim*, which is a different kind of claim and is kept
+labelled as such -- =ar96binf.pdf= §1 "Introduction", p. 3 (the same sentences,
+with =(HBS) 1996= substituted for =(AHBS 96)=, open the catalog abstract for
+study 2324, so this is also the catalog-level statement):
+
+#+begin_quote
+The Armenian Household Budget Survey (AHBS 96) was designed to be a nationally representative survey capable of measuring the standard of living in the Republic of Armenia (ROA) through the collection of data on the family, demographic, socio-economic and financial status of households. The survey was conducted in November - December 1996, on the whole territory of the republic by the State Department of Statistics (SDS) of ROA with technical and financial assistance from the World Bank.
+#+end_quote
+
+"Nationally representative" and "on the whole territory of the republic"
+describe where the sample was drawn and what it estimates.  The §3.1 sentence is
+the closer thing to a named universe: all households of the Republic of Armenia,
+approximately 875,000, containing approximately 3.75 million people.
+
+** 1996 -- exclusions
+
+*** Territorial (stated)
+
+The only exclusion the documentation states is territorial, and it is stated in
+a footnote -- =ar96binf.pdf=, footnote 3 on p. 9, attached to the word
+"households." in the §3.1 paragraph quoted above:
+
+#+begin_quote
+3 This excludes the enclave of Nagorni Karabakh within Azerbaijan, which is Armenian in population but not part of the Armenian Republic, and the Azerbaijanian territories of Nakhichevan and Artsvashen.
+#+end_quote
+
+Spelling "Nagorni Karabakh" is the source's.  Three territories are named:
+Nagorno-Karabakh, Nakhichevan, and Artsvashen.  Read carefully, the footnote is
+less a carve-out from the frame than a clarification of what "the whole
+territory of the ROA" and the 875,000-household figure do *not* count -- these
+are territories outside the Republic's jurisdiction, not regions dropped for
+cost or security.
+
+*** Population-group exclusions: NO STATEMENT FOUND
+
+No statement about institutional, collective, homeless, nomadic, refugee or
+displaced populations was found anywhere in =ar96binf.pdf=, in =projcomp.pdf=,
+or in the catalog metadata for study 2324.
+
+*Silence is not inclusion.*  This entry is recorded as a gap, not as a finding
+that such populations were in scope.  What was searched, and how, is in the
+"Search record" subsection at the end.
+
+*** Frame coverage (bears on the above)
+
+=ar96binf.pdf= §3.2 "Sampling Frames", pp. 9-10.  The frames are household and
+dwelling lists, which is the mechanism by which any non-household population
+would fall out of scope, whether or not the document says so:
+
+#+begin_quote
+Accurate sampling frames for AHBS 96 were available at all levels down to the individual as lists are frequently updated in the Marzes, Zheks and Villages of the ROA5.
+#+end_quote
+
+#+begin_quote
+Current lists of households and dwellings were available covering the whole Republic of Armenia. Only in case ( iv ) above  - i.e. urban public housing at the Zhek level - was it possible to select apartments which could contain more than one household. This was most likely to occur in Yerevan.
+#+end_quote
+
+"Case (iv)" is one of five enumerated frames: "At the Zhek level for urban
+public housing in large towns, a list of rent-payers with addresses including
+that of privatized apartments."  A =Zhek= is a Housing Management Office, an
+administrative division of roughly 15,000-20,000 population.
+
+** 1996 -- domains, strata and sub-samples
+
+*** The diary sub-sample (the within-wave split that matters for pooling)
+
+AHBS 96 measured household expenditure by *two different instruments inside the
+same wave*.  =ar96binf.pdf= §3.7 "Sub-sampling for the diary participants",
+p. 13:
+
+#+begin_quote
+As mentioned earlier, AHBS 96 collected household expenditure in two ways: the recall method and the diary method. About 25% of the selected sample households had to participate in diary method to record their daily income and expenditure activities while the remaining 75% were interviewed using the traditional recall method. In selecting the 25% sub-sample households that had to be part of the diary method, a 1-in-4 systematic sample from among the selected households in each sampling area was adopted.
+#+end_quote
+
+Realised counts, =ar96binf.pdf= §3.8 "Sample implemented", p. 15:
+
+#+begin_quote
+Out of the 4,920 households who answered questionnaires, 1,260 were systematically selected using the procedure discussed above to fill in the ‘household income and expenditure diary’.
+#+end_quote
+
+This is a *probability sub-sample of the same universe* (1-in-4 systematic
+within each sampling area), not a separate population -- so it does not split
+the universe.  But it splits the *measurement*: a quarter of households have
+30-day diary expenditure and three quarters have 30-day recall expenditure, and
+the two are not the same instrument.  Anyone pooling Armenian expenditure with
+other countries, or averaging within this wave, needs to know that before
+averaging anything.  The repo's questionnaire PDFs match this split: =arm01.pdf=
+is the household (recall) questionnaire, =arm03.pdf= / =arm04.pdf= are the diary
+instruments.
+
+*** Domains of interest
+
+=ar96binf.pdf= §3.5 "Sample design", p. 11 (this text is also the catalog's
+=<sampProc>=):
+
+#+begin_quote
+The State Department of Statistics specified 3 domains of interest for this study. These are Yerevan (the capital of ROA), Other Urban areas and Rural areas.
+#+end_quote
+
+No oversample follows from these domains.  The document says so explicitly and
+gives the reason -- same section, immediately after:
+
+#+begin_quote
+Recent estimates of earthquake zones assigned almost equal populations to these domain zones of interest, and as a result there was no need for special targeting and no particular reason was implied for departing from a proportionate (or self-weighting) design.
+#+end_quote
+
+So: *no oversample, no booster, no targeted sub-population sample in this wave.*
+That is an affirmative statement in the source, not an inference from silence.
+
+*** Stratification, and one unexplained number
+
+=ar96binf.pdf= §3.3 "Stratification", p. 10:
+
+#+begin_quote
+In AHBS 96, thirty four (34) of the 37 rayons of the rural sector in ROA were stratified into 3 strata based on the rayons’  altitude as follows:
+#+end_quote
+
+(followed by a table: Low =<= 1300m / Medium 1300-1700m / High =>= 1700m, with
+10 / 13 / 11 rayons.)
+
+The document *does not say* what became of the remaining 3 rural rayons -- not
+whether they were separately handled, differently stratified, or omitted.  §3.8's
+implementation table reports selected households in all 11 Marzes, so there is
+no evidence of a dropped region; but the 34-of-37 discrepancy is unexplained in
+the source and is recorded here as unexplained rather than resolved.
+
+*** Realised sample
+
+=ar96binf.pdf= §3.8 "Sample implemented", p. 14:
+
+#+begin_quote
+Out of the 5,040 initially selected for the AHBS 96 survey, a total of 4,920 households were actually interviewed (i.e. 120 or 2.4% of the total sample either refused to answer or were not found).
+#+end_quote
+
+The same paragraph gives 20,088 individuals in those 4,920 households; the
+implementation table gives 1,980 rural-village households across 10 Marzes and
+3,060 city households (of which Yerevan 1,445).
+
+** 1996 -- universe vs. what the weights represent
+
+The design is self-weighting, so the two do not come apart here -- there are no
+design weights to reconcile against the universe.  =ar96binf.pdf= §3.5, p. 11:
+
+#+begin_quote
+A self-weighting sample was derived by selecting Primary Sampling Units (PSUs) with probability proportional to their size (where size is defined as the number of households) and then taking a constant number of households from each selected. The sample, therefore, was designed to be self-weighted and representative at the administrative regions (Marzes) level, for urban and rural areas, and within urban areas by the size of cities,  and in rural areas by elevation. The number of households to be selected in each PSU was 20, so 250 PSUs were required to make up 5000 households.
+#+end_quote
+
+Two cautions on that sentence, both worth carrying:
+
+1. The document asserts *both* that there were exactly 3 domains of interest
+   (§3.5, quoted above) *and* that the sample is "representative at the
+   administrative regions (Marzes) level".  Those are different and much
+   stronger claims -- 11 Marzes, several with only 60-200 sampled rural
+   households -- and the BID does not reconcile them.  Reported here as the
+   document's own unreconciled pair, quoted rather than adjudicated.
+2. "Self-weighted" is a claim about the *design*.  Nonresponse (120 households,
+   2.4%) and the case-(iv) multiple-households-per-apartment situation both
+   perturb it, and the BID describes no post-survey weight adjustment.
+
+Because =data_available: false=, Armenia currently has no =sample= table and
+hence no =weight= / =panel_weight= column in the library at all.  If microdata
+is ever added, a constant weight is the design-consistent default -- but check
+the delivered files for a weight variable before assuming it.
+
+** NOT an AHBS 96 exclusion -- the predecessor budget survey
+
+One passage in the corpus reads like an exclusion list and is not one.  It
+appears in =projcomp.pdf= ("Armenia Living Standards Survey 1996, Project
+Completion Report", Julia Magluchiants, Ministry of Statistics, State Register
+and Analysis, Republic of Armenia), Part III "Survey Assessment", §2 "Lessons
+Learnt", p. 18.  Its subject, stated in the preceding sentences, is the *old
+permanent family-budget-survey network* that AHBS 96 replaced:
+
+#+begin_quote
+For many years the statisticians were carrying out a survey on family budget for the purpose of studying the living conditions of the population.
+
+The survey was organized due to the methods of selection. The selection of the families was carried out in two stages, at first the enterprises were mentioned, then the workers were selected, families where the survey on budget was carried out. Approximately one thousand families were involved in the survey on budget. The method of  selection and the permanent net of the families have their problems.
+
+Firstly, during the selection, the following entities were not included in the main group: some ministries (Ministry of National Security, Ministry of Internal Affairs Ministry of Defense), private and co-operative enterprises, as well as families, which members are unemployed.
+
+Secondly, constant budget network could not be representational  as required, as being systematically observed by families, owing to keeping the regular track of incomes and expenditures,  they were gradually becoming more “organized”  and thus lost their representational character.
+#+end_quote
+
+Do not attribute those exclusions to AHBS 96.  They are a retrospective critique
+of the enterprise-based Soviet-era design, offered as the motivation for the
+1996 redesign; =ar96binf.pdf= §3 records no such exclusions for AHBS 96 itself.
+The passage is transcribed here precisely so that a future reader who finds it
+does not have to re-adjudicate it.  =projcomp.pdf= is likewise *not* in this
+repository (WB catalog 2324, download/34652).
+
+** Search record (what was looked at, so the gaps above are falsifiable)
+
+- Local :: =lsms_library/countries/Armenia/1996/Documentation/= -- =SOURCE.org=
+  (catalog URL + =#+CATALOG_ID: 2324=, =#+CATALOG_IDNO: ARM_1996_HBS_v01_M=),
+  =.gitignore=, and the four DVC-tracked PDFs listed above, materialised through
+  =lsms_library.data_access.get_data_file()= (never the =dvc= CLI).  No Basic
+  Information Document, statistical report or technical document is stored
+  locally.
+- Catalog fallback :: WB Microdata catalog study 2324 -- the rendered
+  study-description page, the full DDI XML export
+  (https://microdata.worldbank.org/index.php/metadata/export/2324/ddi), the
+  related-materials page, and then the two technical documents =ar96binf.pdf=
+  (download/34650) and =projcomp.pdf= (download/34652).
+- Grep terms over all extracted text ::
+  =universe=, =target population=, =population of interest=, =coverage=,
+  =frame=, =exclud=, =omit=, =institution=, =nomad=, =homeless=, =refuge=,
+  =whole territory=, =all households=.
+- DDI :: no =<universe>= element present (checked in the XML export, which
+  distinguishes a *missing* element from a *present but empty* one).
+- Extraction :: quotes pulled with =pdfminer.six=.  pdfminer inserts a blank
+  line at each PDF line break; those were removed to reconstitute running
+  paragraphs.  No other repair was applied -- in particular the source's double
+  spaces and curly quotes are preserved.  Quotes re-verified against the
+  extracted text on 2026-07-21 before being written here.
+- Not done :: no =.dta= was opened (there are none locally, and it would be the
+  wrong evidence in any case).

--- a/lsms_library/countries/Azerbaijan/_/CONTENTS.org
+++ b/lsms_library/countries/Azerbaijan/_/CONTENTS.org
@@ -26,6 +26,300 @@ HHOPEN.dta).  =cluster_features.Region= is therefore declared
 Cluster identifier =v= = =ppid= (primary-place ID, 92 distinct
 values).  Household identifier =i= = =(ppid, hid)=.
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered 2026-07-21 for GH #601.  Azerbaijan has exactly one wave
+(=1995=), and its declared universe is *high*-confidence but *catalog-only*:
+see "Where the statement lives" below.  This section records what the
+documentation *claims*; nothing here was inferred from the =.dta= files.
+
+This section extends =* Sampling Design= above (geographic coverage, PSU
+identification) and bears directly on =* Data Quality Notes > sample.weight has
+only 3 distinct values=, which it *contradicts* -- see "Universe vs. what the
+weights represent".  It also discharges the standing request in that note
+("The original questionnaires ... are DVC-tracked but not yet read into this
+note"): both questionnaires have now been read, and *neither contains a
+sampling plan or a universe statement*.  The only substantive line in them is
+the interviewer preamble quoted below.
+
+** 1995 -- the declared universe (verbatim)
+
+The World Bank DDI record for =AZE_1995_SLC_v01_M= (catalog id 408) has *no*
+=universe= element.  The universe statement lives inside
+=study_desc.method.data_collection.sampling_procedure=, section "Design", and
+is inseparable from the design, because the universe *is* a three-way union:
+
+#+begin_quote
+The methodology that was chosen reflects the purpose of the survey. To balance
+a desire for a large, representative sample with the expense of a detailed
+survey instrument, a sample size of 2,016 households was selected. Three
+separate populations were covered: households in Baku, households outside of
+Baku and households of Displaced Persons. Within each of those populations, the
+sample was chosen in such a manner that each household had an equal probability
+of being selected.
+#+end_quote
+
+-- WB Microdata catalog 408, DDI
+=study_desc.method.data_collection.sampling_procedure=, section "Design"
+(rendered at https://microdata.worldbank.org/index.php/catalog/408/study-description
+under "Sampling > Sampling Procedure").
+
+The only other universe-like fields in the DDI:
+
+| DDI field                    | verbatim value                            |
+|------------------------------+-------------------------------------------|
+| =study_info.geog_coverage=   | =National=                                |
+| =study_info.analysis_unit=   | =- Households / - Individuals / - Community= (three lines) |
+| =study_info.universe=        | *absent* (no such element in the record)   |
+
+The frame outside Baku, same source, section "Outside of Baku":
+
+#+begin_quote
+The country is divided into towns, villages of the town type, and villages.
+Every household is located in one of those three types of population points. A
+list prepared by the National Statistical Committee contains just over 4,250 of
+these population points.
+#+end_quote
+
+The single *local* coverage claim, from the household questionnaire preamble
+(=1995/Documentation/queshhe.pdf=, p. 1, above the =POPULATION POINT= header):
+
+#+begin_quote
+I represent the SORGU Social Studies Center.  We are conducting a survey on the
+conditions of people's lives in all regions of Azerbaijan for the World Bank.
+#+end_quote
+
+(The source uses a curly apostrophe in "people's"; otherwise verbatim,
+including the double space after "Center.")
+
+Two lines later the same preamble says "For that purpose 2000 addresses have
+been chosen at random as in a lottery."  That figure matches the February 1995
+Baku address list described in the catalog's "Baku" section, *not* the 2,016
+households of the three-frame design.  Recorded as printed; not reconciled.
+
+** "National" and the frame do not agree, in the source itself
+
+=geog_coverage= asserts =National=, but the sampling frame explicitly excises
+eleven occupied raions, taking the population-point list from "just over 4,250"
+to 3,453.  Both statements are in the same DDI record.  They are recorded here
+verbatim rather than reconciled; a reader who takes =National= at face value
+will be wrong about roughly 800 population points.
+
+** Exclusions
+
+*** Geographic: eleven occupied raions, by design
+
+#+begin_quote
+To choose the sample outside of Baku, Baku was excluded from this list as were
+all the population points located in raions of the country currently occupied
+(Agdam, Xankendi, Xodjali, Xodjvendi, Susha, Kubatli, Zangelan, Kelbadjar,
+Lachin, Fizuli and Djebrali). The remainder of the country included 3453
+population points.
+#+end_quote
+
+-- catalog 408, =sampling_procedure=, section "Outside of Baku".  (Baku's own
+exclusion from *this* list is not a coverage exclusion: Baku is the separate
+first frame.  The eleven raions are excluded outright.)
+
+*** Field-work non-coverage: two population points not visited
+
+#+begin_quote
+During field work, one population point, Xandar, was not accessible due to
+security concerns and its proximity to the occupied region. A second population
+point, Sofukent, was not accessible because of the weather. In both cases, it
+was not practicable to replace the population points with two other population
+points randomly selected from the national list. Instead, field teams were
+instructed to visit the nearest population point of approximately the same size
+to the chosen population point.
+#+end_quote
+
+-- catalog 408, =sampling_procedure=, section "Sampling as Implemented".  This
+is *substitution*, not random replacement: two sampled points are represented
+by their nearest neighbours of similar size.
+
+*** Frame-quality caveats that bear on coverage
+
+Baku (passport-office lists), same source, section "Baku":
+
+#+begin_quote
+There is one passport for each dwelling in that raion regardless of the number
+of separate household/family units occupied the dwelling. The passport lists
+are, in principle, continuously updated with information from the housing
+maintenance offices. However, dwellings that are used for business, unoccupied,
+abandoned or rented to foreigners may remain listed. Furthermore, it is not
+clear how new privately built housing units would be listed.
+#+end_quote
+
+Major urban areas outside Baku, section "Sampling as Implemented":
+
+#+begin_quote
+In the course of the field work, it was discovered that population lists are not
+maintained in major urban areas. In Kuba, Xachmas, Devichi, Qaxi, Sheki, Ali
+Bairamli, Gojai and Agdash, supervisors had to improvise. In some cases passport
+registration lists were used, as was done in Baku. In other cases electric users
+lists, gas office books and butter/meat coupon distribution lists were used in
+order to capture a sample that was as representative as possible.
+#+end_quote
+
+*** Population exclusions: no statement found
+
+*No* statement excluding institutional or collective households, nomadic
+households, the homeless, or non-citizens appears anywhere in the catalog
+metadata or in any local document (list of what was searched below).  That is a
+*recorded gap*, not an assertion that such populations were in scope.
+
+** Oversamples and sub-populations -- the thing to know before pooling
+
+Specialization here lives *inside* the single wave.  The 1995 SLC is three
+separately-drawn samples reported as one dataset, each self-weighted within
+itself and none of them proportional to its share of the population:
+
+#+begin_quote
+The Azerbaijan Survey of Living Conditions sample design included 408
+households in the eleven raions that make up the city of Baku, 1200 households
+in the population outside of Baku, and 408 households among the registered
+Internally Displaced Persons residing throughout the country. This results in
+an oversampling of the Internally Displaced Persons population and an
+undersampling of the urban population of Baku. In order to use all data to
+provide nationally representative estimates, weighting factors must be applied
+to the data to account for the difference between the population and sample
+distributions.
+#+end_quote
+
+-- catalog 408, =sampling_procedure=, section "Design".
+
+The three groups are identified by =ppid= ranges (which is the library's =v=;
+see =* Sampling Design > PSU identification=), per DDI
+=study_desc.method.data_collection.weight=:
+
+| sub-population | designed n | =ppid= range (verbatim from the DDI weight field) |
+|----------------+------------+---------------------------------------------------|
+| outside Baku   |       1200 | =PPID 100-199=                                    |
+| Baku           |        408 | =PPID 1-34=                                       |
+| IDPs           |        408 | =PPID 201-234=                                    |
+
+The designed total, 2,016, is the same household count already recorded in
+=* Data Quality Notes= for this wave.
+
+The IDP frame is the *registered* IDP population, located through the Ministry
+of Refugees, with a further stage of sampling inside each raion:
+
+#+begin_quote
+In each raion, the administrative offices for the Ministry of Refugees was
+consulted to locate the internally displaced persons. Each office should have a
+list of internally displaced persons by households. An additional level of
+sampling took place to choose three places and four interviews will be
+conducted in each place. These places were buildings, towns, or tent camps
+depending on how the households were listed.
+#+end_quote
+
+-- catalog 408, =sampling_procedure=, section "Internally Displaced
+Population".  Unregistered displaced persons are outside this frame by
+construction.
+
+*Consequence for consumers*: an unweighted mean over Azerbaijan 1995 is a mean
+over a sample that over-represents registered IDPs and under-represents Baku.
+Do not pool it with other countries as though it were a self-weighting national
+sample.
+
+** Universe vs. what the weights represent -- CONTRADICTS an existing note
+
+The documentation is explicit that the weight is a *three-group*
+post-stratification factor, not a household-level design weight:
+
+#+begin_quote
+The three samples of households: outside Baku (PPID 100-199), Baku (PPID 1-34),
+and IDPs (PPID 201-234) are self-weighted for those three groups of households.
+(PPID is the variable name for population point identification code.) However,
+the number of households selected from each group do not correspond to the
+percent of the three groups in the national population.
+
+To use all sample households to represent all households in Azerbaijan,
+weighting factors should be used. This weight is included as variable W in the
+PP data
+file.
+#+end_quote
+
+-- catalog 408, DDI =study_desc.method.data_collection.weight= (line break
+before "file." is as in the source).
+
+This *contradicts* the existing note in =* Data Quality Notes= below, which
+reads:
+
+#+begin_quote
+The =weight= column on the =sample= table has just 3 unique values
+(min 0.694, max 1.258) across all 2,016 households.  [...]  This is far too
+uniform to be a true survey weight; it is more likely a normalising / fallback
+weight.  Consumers expecting genuine sampling weights for inference
+should treat Azerbaijan as effectively unweighted.
+#+end_quote
+
+Three distinct weight values is *exactly* what the documented design predicts:
+one factor per sub-population, because each sub-population is self-weighted
+internally.  The weight is not a fallback; per the DDI it is the intended
+variable =W=, and it is the *only* thing that makes the pooled sample
+nationally representative.  Advising consumers to treat Azerbaijan as
+"effectively unweighted" therefore inverts the documentation's instruction
+("weighting factors must be applied to the data").
+
+Both readings are quoted above; neither has been deleted.  Resolving this needs
+a check that =sample.weight= is in fact =W= from the PP file and that its three
+values map to the three =ppid= ranges -- a data check, deliberately *not*
+performed for this evidence pass.  Until then, treat the existing
+"effectively unweighted" advice as *disputed by the survey documentation*.
+
+** Where the statement lives -- catalog only
+
+The universe, exclusions, sub-samples and weight description exist *only* in
+World Bank NADA catalog metadata for study 408.  *No file in this repository
+contains them.*  The repo holds a pointer, not the text:
+=1995/Documentation/SOURCE.org= records =#+CATALOG_ID: 408= /
+=#+CATALOG_IDNO: AZE_1995_SLC_v01_M= and the DOI
+(https://doi.org/10.48529/z7ee-4p39), and =_/CONTENTS.org= cites the DOI.
+
+This makes Azerbaijan one of the waves whose population record is a *moving
+target*: if the World Bank edits or re-versions the study description, the
+statements quoted above change under us, and nothing in the repository would
+show it.  The quotes here are as retrieved 2026-07-21 from
+https://microdata.worldbank.org/index.php/api/catalog/AZE_1995_SLC_v01_M .
+
+*Not boilerplate.*  The most-repeated universe sentence in the cross-country
+corpus is WB NADA template text (15 waves).  It does *not* appear here -- this
+DDI has no =universe= element at all, and the text quoted above is
+survey-specific prose naming Azerbaijani raions, the National Statistical
+Committee and the Ministry of Refugees.  What is quoted is a claim about *this*
+survey, not a template.
+
+** What was searched, and what was not found
+
+Local (=lsms_library/countries/Azerbaijan/1995/Documentation/=), all read in
+full or grepped for =sampl|universe|populat|coverage|represent|strat|design|weight=:
+
+| file            | what it is                                   | universe statement? |
+|-----------------+----------------------------------------------+---------------------|
+| =SOURCE.org=    | catalog pointer + DOI                        | no (pointer only)   |
+| =LICENSE.org=   | WB Public Use Files terms                    | no                  |
+| =abstracte.pdf= | "SUMMARY OF RESULTS", English                | no -- results only  |
+| =abstractr.pdf= | Russian translation of the same              | no                  |
+| =ppabse.pdf=    | Abstract of the Population Point Qs, English | no (community counts only) |
+| =ppabsr.pdf=    | Russian counterpart                          | no                  |
+| =queshhe.pdf=   | household questionnaire, English             | preamble line only (quoted above) |
+| =quespope.pdf=  | population point questionnaire, English      | no                  |
+
+No Basic Information Document, sampling report, or Poverty Assessment is
+present in the repo for this wave.  Catalog: study 408 resolved via the DOI and
+the catalog search API; the full DDI JSON was retrieved and grepped for
+=exclud|Karabakh|occupied|not covered|omitted|institution|univ|coverage|analysis_unit=.
+
+Not found anywhere, and therefore *not* claimed either way: any exclusion of
+institutional / collective / nomadic / homeless households or of non-citizens;
+any age or citizenship restriction; any =universe= element in the DDI.
+
+Related, from =* Sampling Design= above: the microdata carries no region /
+oblast / rayon variable, so the eleven-raion exclusion *cannot be verified or
+re-imposed from the delivered data* -- it is knowable only from this
+documentation.
+
 * Files configured
 
 ** sample

--- a/lsms_library/countries/Benin/_/CONTENTS.org
+++ b/lsms_library/countries/Benin/_/CONTENTS.org
@@ -30,6 +30,306 @@ Standard EHCVM convention: =grappe= is the cluster identifier
 identifier is =(grappe, menage)= without a vague level.  See
 CLAUDE.md "EHCVM countries" for the cross-country pattern.
 
+* Sampling universe, exclusions and sub-samples
+
+What the Benin survey *claims* to represent, quoted from its own
+documentation.  This is deliberately separate from what the data look
+like: nothing below is inferred from the =.dta= files, and the one
+place where a data observation appears it is labelled as such and is
+about wave structure, not about the universe.
+
+Companion to the =Sampling Design= section in this file, which covers
+the =(grappe, menage)= identifier convention.  This section covers the
+declared population; that one covers the index.  Benin has exactly one
+configured wave, =2018-19=, so there is one universe statement.
+
+** 2018-19 -- the declared universe
+
+VERBATIM, from the local DDI report shipped in this repo at
+=lsms_library/countries/Benin/2018-19/Documentation/ddi-documentation-english_microdata-4291.pdf=,
+PDF page 3, section =Coverage=:
+
+#+begin_quote
+GEOGRAPHIC COVERAGE
+
+National coverage
+
+UNIVERSE
+
+The survey covered all de jure households excluding prisons,
+hospitals, military barracks, and school dormitories.
+#+end_quote
+
+Language: English.  The source document is the English edition of the
+DDI (=ddi-documentation-english_...=); the survey's own title is
+French (=Enquete Harmonisee sur le Conditions de Vie des Menages
+2018-2019=, printed with "le" not "les" -- see
+=Documentation/SOURCE.org=, =#+CATALOG_TITLE:=).  *No French-language
+universe statement was located* -- see "Gaps" below.
+
+*** Where the statement lives: locally, and it is verifiable
+
+Unlike the ~41 of 111 waves in the corpus whose only universe
+statement is WB catalog metadata, Benin's statement is *in this
+repository*.  The DDI PDF is a tracked DVC object
+(=ddi-documentation-english_microdata-4291.pdf.dvc=), and the copy
+downloaded independently from
+https://microdata.worldbank.org/catalog/4291/pdf-documentation has md5
+=89b38f943a8a7c5e6b14016c196beb6c=, matching the sidecar.  The WB
+catalog entry 4291 carries the identical sentence, so local and
+catalog agree exactly; the record is not a moving target.
+
+Provenance chain: =SOURCE.org='s DOI =10.48529/rn3k-z374= redirects to
+catalog study =BEN_2018_EHCVM_v02_M= = catalog entry 4291.
+
+*** WARNING: the universe sentence is WB NADA boilerplate
+
+"The survey covered all de jure households excluding prisons,
+hospitals, military barracks, and school dormitories." is *template
+text*.  It appears verbatim in 15 waves across the library -- the
+eight WAEMU/EHCVM countries where a shared instrument would explain it
+(Benin, Burkina Faso 2018-19 and 2021-22, Cote d'Ivoire, Guinea-
+Bissau, Mali, Niger, Senegal, Togo) *and also* Ethiopia 2018-19 and
+2021-22 and Nigeria 2015-16, 2018-19 and 2023-24, which share no
+instrument with EHCVM at all.
+
+So its presence attests *which metadata template the DDI was produced
+from*.  It does not independently attest that INSAE made this specific
+claim about this specific survey.  Treat it as weak evidence of
+Benin's intent and strong evidence of DECDG's template.  (Corpus-wide
+finding; see the cross-country population-statements review, GH #601.)
+
+Note also that "de jure" is used in two distinct senses across the
+corpus -- the NADA boilerplate's, and Nepal's "modified de jure
+household members (usual residents)".  The boilerplate does not define
+its own term.  Benin's own residency rule lives in the questionnaire,
+not in the universe statement: see the =Household Presence /
+MonthsSpent= section of this file for =s01q12= / =s01q13=, the two binary
+6-month filters that actually determine membership.
+
+** Exclusions
+
+*** Population exclusions (institutional): stated
+
+Prisons, hospitals, military barracks, and school dormitories -- i.e.
+the institutional/collective population.  This is the entire content
+of the exclusion clause; it is the boilerplate wording (above).
+
+Not mentioned either way, and therefore *not established for Benin*:
+the homeless, diplomatic households, and nomadic populations.  Sibling
+EHCVM documentation is explicit about two of these where Benin is
+silent -- Burkina Faso's French =Rapport general= excludes "les
+menages ayant un statut diplomatique et les sans domiciles fixes", and
+the WAEMU-common EHCVM-2 enumerator manual excludes diplomatic
+personnel.  *Do not carry those over to Benin.*  No Benin document
+found says it, and an unevidenced "excluded here too" is exactly the
+kind of claim this repo has a standing rule against.
+
+*** Geographic exclusions: NONE -- and the Littoral clause is not one
+
+The frame description contains a region name, which is easy to misread
+as a dropped region.  It is not.  VERBATIM, same PDF, page 4, section
+=Sampling= > =SAMPLING PROCEDURE=, first paragraph:
+
+#+begin_quote
+The Benin EHCVM 2018/19 used the 2013 Census of Population and Housing
+(RGPH) as the sampling frame. This frame contains 10032 enumeration
+areas, is nationally representative, and covers all regions with urban
+and rural areas surveyed in all regions apart from Littoral, a purely
+urban region.
+#+end_quote
+
+Read carefully, this says every region is surveyed, and every region
+is surveyed in *both* milieux except Littoral, which has *no rural
+milieu to survey*.  Littoral is in the sample; it simply has no rural
+stratum.
+
+The document's own stratum count corroborates that reading and
+excludes the alternative.  Same paragraph, VERBATIM:
+
+#+begin_quote
+The survey design also defined the domains as country, urban and rural
+areas, and each of the 12 regions. Taking this into account, 23
+explicit sample strata were selected.
+#+end_quote
+
+12 regions x 2 milieux = 24, minus the non-existent Littoral-rural
+cell = *23*.  Had Littoral been dropped, the count would be 22.
+
+Sibling EHCVM waves carry the same construction with a different name
+in the slot -- Guinea-Bissau's is "apart from the autonomous sector of
+Bissau (SAB) where all respondents are from urban areas", which spells
+out the intended meaning; Cote d'Ivoire's has no carve-out at all
+("all regions with urban and rural areas surveyed in all regions").
+Benin's phrasing is the terse variant of Guinea-Bissau's.
+
+*** Security carve-outs: none stated
+
+No "for security reasons" exclusion appears anywhere in the Benin DDI.
+This is a real difference from several LSMS-ISA neighbours in the
+library (Nigeria 2018-19 excluded rural Borno; Ethiopia ESPS-5
+excluded Tigray entirely).  Benin's DDI has no =Deviations from Sample
+Design= and no =Response Rate= section in which such a carve-out could
+have been recorded, so the correct statement is *"none stated"*, not
+"none occurred".
+
+*** No urban-only or rural-only restriction
+
+Both milieux are in scope nationally, and the design is explicit about
+their sizes.  VERBATIM, same page:
+
+#+begin_quote
+The total estimated survey sample size was 8040 households - 3960 from
+urban areas and 4080 from rural areas. [...] the final sample size
+comprises 8012 households, including 3940 households from urban areas
+and 4072 households from rural areas.
+#+end_quote
+
+** Oversamples and sub-populations
+
+*** No oversample of any named sub-population is documented
+
+There is no MOP/Roma-style booster sample, no ethnic or programme
+sub-sample, no module administered to a fraction of households, and no
+refresh-vs-extended panel split.  Benin 2018-19 is a single
+cross-sectional national draw.  The documentation is silent on the
+subject, which here is weak but consistent evidence of absence: the
+=SAMPLING PROCEDURE= section is otherwise detailed (frame, allocation
+rule, strata count, both stages, planned vs achieved n), so a booster
+would have had an obvious place to be described.
+
+*** The two =vague= are NOT two sub-samples
+
+This is the one thing about Benin's structure most likely to be
+misread by someone pooling the country, so state it plainly.  The two
+=vague= are two seasonal visits to *disjoint halves of one sample*,
+not two independent samples and not a panel.  VERBATIM (page 2,
+=ABSTRACT=):
+
+#+begin_quote
+The surveys took place in two waves with each wave covering half of
+the sample. The first wave was fielded between October 2018 and
+December 2018, while the second wave occurred between April 2019 and
+July 2019. The two-wave approach was chosen to account for seasonality
+of consumption.
+#+end_quote
+
+Achieved sizes, VERBATIM (page 4): "In wave one, the survey teams
+interviewed 3997 households (1940 in urban areas and 2057 in rural
+areas. In wave two, the teams interviewed 4015 households (2000 in
+urban areas and 2015 in rural areas)." (Unbalanced parenthesis in the
+original; quoted as printed.)
+
+Consequences for an analyst: the library models both =vague= as the
+single wave directory =2018-19=, which is correct -- they are one
+sample.  But =vague= is *confounded with season*, so a =vague=-level
+contrast is a season contrast, and consumption aggregates in
+particular should not be compared across =vague= as if they were two
+draws from the same moment.
+
+*** Allocation across regions is disproportionate by design
+
+Not an oversample of a sub-population, but it is the reason weights are
+not close to uniform.  VERBATIM (page 4):
+
+#+begin_quote
+In Benin, the survey design decided on the sample size using the
+poverty rate - obtained from the 2011 Integrated Modular Survey on
+living conditions of households - as a variable of interest. Then the
+survey design split the decided sample size among regions considering
+the number of households in the region and the necessity to minimize
+the relative error.
+#+end_quote
+
+Design context (VERBATIM, same page): two-stage; "At the first stage,
+670 enumeration areas (EAs) were selected with Probability
+Proportional to Size (PPS) using the 2013 RGPH and the number of
+households as a measure of size. In the second stage, 12 households
+were selected in each enumeration area randomly."
+
+Representativity claim, VERBATIM (page 2, =ABSTRACT=): "The EHCVM is a
+nationally representative survey of 8,000 households, which are also
+representative of the geopolitical zones (at both the urban and rural
+level)."
+
+** Universe vs. what the weights represent: NOT DOCUMENTED
+
+The Benin DDI has *no weighting section at all*.  There is no
+=WEIGHT=, no =Weighting= subsection under =Sampling=, and no
+=Response Rate= field; =Sampling= runs straight from =SAMPLING
+PROCEDURE= into =Data Collection=.  The data ship a weights file
+(=ehcvm_ponderations_ben2018=, named in the DDI's =VERSION NOTES=),
+but *no document in this repository states what population those
+weights inflate to*, nor whether they are adjusted for the 8040 -> 8012
+shortfall.
+
+So for Benin the universe and the weight base cannot be checked against
+each other.  Record that as a gap, not as agreement.
+
+** Gaps: what was searched and not found
+
+| looked for | where | result |
+|------------+-------+--------|
+| universe statement | =2018-19/Documentation/ddi-...-4291.pdf= | FOUND, p. 3 |
+| French universe statement | same PDF (English edition); WB catalog 4291 page (English) | not found |
+| Basic Information Document | =2018-19/Documentation/= | none shipped -- Benin has no BID, unlike Burkina Faso / Guinea-Bissau |
+| weighting / weight-base statement | same PDF, front matter pp. 1-6 | none -- no such section exists |
+| response rate, deviations from design | same PDF, front matter pp. 1-6 | none -- no such section exists |
+| universe statement in repo prose | =Benin/_/CONTENTS.org=, =2018-19/Documentation/SOURCE.org=, =LICENSE.org= | none (SOURCE.org is provenance keywords only; LICENSE.org is generic WB public-use-file terms) |
+
+The four questionnaire instruments shipped alongside
+(=ben_ehcvm1_qnr_household_excel_vague{1,2}.xls=,
+=ben_ehcvm1_qnr_community_excel_vague{1,2}.xls=) were *not* mined for
+a universe statement, since the DDI supplies one.  They remain the
+place to look if the institutional-exclusion wording ever needs to be
+corroborated independently of the NADA template.
+
+Historical note: the duplicate =Benin/2018-2019/= directory carried no
+documentation of its own and was removed on [2026-07-12] (see
+the =Overview= section of this file).  It needs no population record; it was the same
+extract, file for file.
+
+** FLAG: the DDI's account of the vague split does not match the shipped data
+
+Recorded, not adjudicated -- and flagged because the repo's
+=Sampling Design= convention above depends on which account is right.
+
+The DDI says each *enumeration area* was split in half across the two
+vague.  VERBATIM (page 4):
+
+#+begin_quote
+After that, the survey design randomly divided each enumeration area
+into two equal groups. The survey team interrogated the first group in
+wave 1 and the other in wave 2.
+#+end_quote
+
+The repo's =Sampling Design= section (and CLAUDE.md's cross-country
+EHCVM note) say the opposite about the unit that is split:
+
+#+begin_quote
+Standard EHCVM convention: =grappe= is the cluster identifier (=v=);
+each grappe is visited in exactly one =vague=, so household identifier
+is =(grappe, menage)= without a vague level.
+#+end_quote
+
+Under the DDI's sentence, every grappe would appear in *both* vague and
+=(grappe, menage)= would not identify a household.  The shipped
+=s00_me_ben2018.dta= is consistent with the repo, not with the DDI: 670
+grappes, *0* of them appearing in more than one vague, 335 grappes in
+vague 1 and 335 in vague 2, with 3997 / 4015 households -- household
+counts that match the DDI's own per-wave figures exactly.  (This is a
+wave-structure observation about the distributed file, offered only to
+adjudicate a documentation conflict.  It is *not* an inference about
+the universe, and no universe claim in this section rests on it.)
+
+Reading that reconciles them: the *list of EAs* was halved, not each
+EA's household list.  Sibling Burkina Faso's BID describes exactly
+that -- "A total of 585 EAs were selected (half (293) for the first
+wave and half (292) for the second wave)".  The Benin DDI sentence
+appears to be either loose wording or a plan not executed as written.
+The repo's index convention stands; the DDI sentence should not be
+quoted as authority for how vague and grappe relate.
+
 * Files configured
 
 (Per =data_scheme.yml=: sample, cluster_features, household_roster,

--- a/lsms_library/countries/Burkina_Faso/_/CONTENTS.org
+++ b/lsms_library/countries/Burkina_Faso/_/CONTENTS.org
@@ -3,6 +3,445 @@
 Brief table of contents and todo list.
 
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered for GH #601 (population / universe statements).  This section
+records *what the survey documentation claims* about the population each wave
+represents.  It is deliberately separate from the =sample= notes elsewhere in
+this file (the "DONE sample" subsection), which describe the *data* -- realized
+household and cluster counts, weight variables, strata columns.  Nothing here
+was inferred from the =.dta= files; every claim below is quoted from a document,
+with a citation.
+
+No schema is proposed here.  How the library should *represent* this is being
+decided in GH #603.
+
+Transcription conventions.  French quotations are reproduced with their original
+accents and punctuation -- fidelity beats the ASCII house preference here, since
+a de-accented quote is no longer verbatim.  The source PDFs are justified text,
+so pdfminer emits runs of multiple spaces between words; that whitespace has
+been collapsed to single spaces, and the typographic apostrophe (U+2019) is
+rendered as ASCII ='=.  Words the PDF hyphenates across a line break (e.g.
+"sous-\nechantillons", "EHCVM-\n1") are rejoined to their printed form.  Wording,
+accents and punctuation are otherwise unaltered.  =[...]= marks the elision of a paragraph break between two
+consecutive paragraphs.  Quotes were re-checked against the PDFs when this
+section was written.
+
+** Summary across waves
+
+| Wave    | Survey  | Universe statement held in-repo?      | Geographic exclusion | Population exclusion (as stated)           | Wave-internal structure                    |
+|---------+---------+---------------------------------------+----------------------+--------------------------------------------+--------------------------------------------|
+| 2014    | EMC     | yes -- INSD report (French)           | none stated          | collective HH, diplomatic corps, homeless  | 4 quarterly passages, same households      |
+| 2018-19 | EHCVM-1 | yes -- INSD report (fr) + NADA DDI (en) | none stated        | collective HH, diplomatic status, homeless | ZD sample split at random into 2 vagues    |
+| 2021-22 | EHCVM-2 | yes, but NADA boilerplate only (en)   | none stated          | prisons, hospitals, barracks, dormitories  | *panel sub-sample of EHCVM-1*              |
+
+Headline findings:
+
+- *No Burkina Faso wave excludes a region, and none is rural-only.*  All three
+  declare the whole national territory, urban and rural, all 13 regions.
+- *No oversample or booster is declared in any wave.*  The specialization in this
+  country is sub-sampling, not oversampling.
+- The thing a pooling analyst must know is the *2021-22 panel frame*: a strict
+  half-sub-sample of the 2018-19 households, with no tracking outside the EA of
+  origin and no top-up when an EA fell below 6 available households.
+
+** 2014 -- Enquête Multisectorielle Continue (EMC 2014)
+
+Source: =2014/Documentation/Report.pdf= (in-repo, DVC-tracked) -- INSD,
+« Rapport -- Enquête multisectorielle continue (EMC) 2014 : Profil de pauvreté
+et d'inégalités », Novembre 2015, section 1.2.1 « Champ de l'EMC », p. 20.
+WB catalog id 2538.
+
+*** Declared universe (verbatim, French)
+
+#+begin_quote
+Pour des besoins de conformité au principe de comptabilité nationale, le champ
+social est constitué de l'ensemble des ménages, toutes catégories confondues,
+nationaux ou non, résidant sur le territoire national. [...] Le champ
+géographique de l'EMC est le territoire national burkinabè. Le niveau spatial de
+représentativité des données collectées concerne les milieux de résidence
+(urbain et rural) et les 13 régions administratives du pays.
+#+end_quote
+
+TRANSLATION (not source text): "To comply with the principle of national
+accounting, the social scope consists of the totality of households, of all
+categories, nationals or non-nationals, residing on the national territory.
+[...] The geographic scope of the EMC is the Burkinabè national territory.  The
+spatial level of representativeness of the data collected concerns the areas of
+residence (urban and rural) and the 13 administrative regions of the country."
+
+*** Exclusions (verbatim, same page, immediately following)
+
+#+begin_quote
+Sont exclus de ce champ, les ménages collectifs (camps militaires, casernes,
+hôpitaux, etc.), les ménages des membres du corps diplomatique, les sans
+domiciles fixes.
+#+end_quote
+
+TRANSLATION (not source text): "Excluded from this scope are collective
+households (military camps, barracks, hospitals, etc.), households of members of
+the diplomatic corps, and the homeless."
+
+*** Independent corroboration in WB catalog metadata
+
+WB catalog 2538, DDI field =study_desc.study_info.universe=
+(https://microdata.worldbank.org/metadata/export/2538/json ; also shown as
+"Universe" on the study-description page), VERBATIM:
+
+#+begin_quote
+The universe includes all households currently living in Burkina Faso.
+Individuals living in group households (such as academic institutions, hospitals
+or military installations) are not included.
+#+end_quote
+
+Worth noting: this is *not* the WB NADA "de jure households" boilerplate that the
+two EHCVM waves carry.  2014 has a survey-specific catalog universe, and it
+agrees in substance with the INSD report.  Same record:
+=study_info.geog_coverage= = "The survey is nationally representative.";
+=study_info.analysis_unit= = "The unit of measure is the household and the
+individuals within the household."
+
+*** Sample design (context, not the universe)
+
+Report.pdf section 1.2.2 « Plan de sondage », p. 20, VERBATIM: « Le plan de
+sondage adopté est celui d'un sondage aréolaire stratifié à deux degrés. La
+stratification est faite avant le tirage des unités primaires et basée sur
+l'urbanisation des agglomérations. »  Frame, same page: « La base de sondage des
+unités primaires ou zones de dénombrement de l'EMC est constituée de la liste
+des 13 821 ZD définies lors de la cartographie du RGPH réalisée en 2006. »
+Method: 900 ZD drawn with probability proportional to size at the first stage,
+12 households per ZD systematically at the second -- « Ce qui a donné un
+échantillon de 10 800 ménages. »
+
+- The catalog DDI's =sampling_procedure= instead gives 905 EAs / ~10 860
+  households.  Recorded as a design-figure discrepancy; *not adjudicated*.
+- The realized counts recorded in the =sample= section of this file (10,224
+  households, 900 clusters) are data-side counts, a different kind of fact from
+  these design figures.  No claim is made here about which is "right".
+
+*** Sub-samples / oversamples
+
+None declared.  The EMC's four quarterly passages are *repeat visits to the same
+households* -- Report.pdf p. 20, VERBATIM: « Le dispositif de l'EMC a prévu la
+reconduite de l'ensemble des ménages enquêtés au premier passage aux trois
+passages suivants (deuxième, troisième et quatrième). »  They are not distinct
+sub-samples.  This matters when reading the =food_acquired= notes elsewhere in
+this file (only passage 1 records quantities): that is a module-coverage fact,
+not a sampling fact.
+
+** 2018-19 -- EHCVM-1 (Enquête Harmonisée sur les Conditions de Vie des Ménages)
+
+Sources, both in-repo.  PRIMARY (French):
+=2018-19/Documentation/ehcvm_2018_rapport_general.pdf= -- INSD, section 1.3
+« Champ de l'EHCVM », printed p. 16 (PDF p. 22).  SECONDARY (English):
+=2018-19/Documentation/Documentation.pdf= -- WB NADA DDI report generated
+2022-09-01, p. 3, "Coverage" > "UNIVERSE".  WB catalog id 4290.
+
+*** Declared universe (verbatim, French)
+
+#+begin_quote
+Pour des besoins de conformité au principe de comptabilité nationale, le champ
+social est constitué de l'ensemble des ménages, toutes catégories confondues,
+nationaux ou africains, résidant sur le territoire national. [...] Le champ
+géographique de l'EHCVM est le territoire national burkinabè. Le niveau de
+représentativité des données collectées concerne les milieux de résidence
+(urbaine et rurale) et les 13 régions administratives du pays.
+#+end_quote
+
+TRANSLATION (not source text): "To comply with the principle of national
+accounting, the social scope consists of the totality of households, of all
+categories, national or African, residing on the national territory. [...] The
+geographic scope of the EHCVM is the Burkinabè national territory.  The level of
+representativeness of the data collected concerns the areas of residence (urban
+and rural) and the 13 administrative regions of the country."
+
+*WORDING CHANGE vs. 2014.*  The 2014 EMC report says « nationaux ou non »
+(nationals or non-nationals); the 2018 EHCVM report says « nationaux ou
+africains » (nationals or Africans).  Each is quoted as printed.  Whether this is
+a real narrowing of the universe or loose drafting is *not* resolved here -- but
+an analyst pooling 2014 with 2018-19 should know the two documents differ on who
+counts as in scope.
+
+*** Exclusions (verbatim, same paragraph)
+
+#+begin_quote
+Sont exclus de ce champ, les ménages collectifs (camps militaires, casernes,
+hôpitaux, etc.), les ménages ayant un statut diplomatique et les sans domiciles
+fixes.
+#+end_quote
+
+TRANSLATION (not source text): "Excluded from this scope are collective
+households (military camps, barracks, hospitals, etc.), households having
+diplomatic status, and the homeless."
+
+*** The English "UNIVERSE" field is WB NADA boilerplate -- read it accordingly
+
+=Documentation.pdf=, p. 3, heading "UNIVERSE", VERBATIM:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military
+barracks, and school dormitories.
+#+end_quote
+
+The same string appears byte-identically in the WB catalog DDI export
+(=study_desc.study_info.universe=, catalog 4290), so local and catalog agree.
+But *this exact sentence is the single most repeated statement in the whole
+cross-country corpus, appearing verbatim in 15 waves* -- across the WAEMU/EHCVM
+countries and also Ethiopia and Nigeria.  It is World Bank NADA template text.
+Its presence attests which metadata template was used; it does *not*
+independently attest that INSD made that claim about this survey.
+
+For this wave the French INSD report is the load-bearing statement.  The two are
+not word-for-word equivalent: the French additionally excludes
+diplomatic-status households and the homeless, which the boilerplate does not
+mention; the boilerplate names prisons and school dormitories, which the French
+does not.
+
+*** Sub-sample structure: two vagues, each a nationally representative half
+
+This is the wave-internal specialization a pooling analyst needs.  Rapport
+général, p. 16, VERBATIM:
+
+#+begin_quote
+Le dispositif de l'enquête harmonisée a prévu une répartition aléatoire de
+l'échantillon des ZD en deux sous-échantillons représentatifs au niveau
+national, en milieu urbain, en milieu rural et dans chacune des 13 régions
+administratives.
+#+end_quote
+
+And p. 17, « Méthode de sondage », VERBATIM: « L'enquête devant se dérouler par
+vague, l'échantillon des ZD est réparti de façon aléatoire en deux sous
+échantillons. Chaque sous-échantillon devrait être déployé pour une vague de
+collecte. »
+
+So each *cluster* (=grappe= / ZD) belongs to exactly one vague -- consistent with
+the library-wide EHCVM convention =v: grappe= (not =[vague, grappe]=).  Vague 1
+ran September--November 2018, vague 2 April--June 2019 (rapport, section 1.3).
+
+*DOCUMENTED TENSION, not adjudicated.*  The English Basic Information Document
+=basicinformationdocument_bfa.pdf=, "Sample", p. 10, describes the split
+differently, VERBATIM: "After that, the survey design randomly divided each
+enumeration area into two equal groups.  The survey team interrogated the first
+group in wave 1 and the other in wave 2."  That reads as a *within-EA household*
+split -- both vagues visiting every EA -- whereas the French report splits the
+*ZD sample* between vagues.  Both quotations are recorded; the repo's existing
+EHCVM handling follows the French reading, and the 2021-22 BID's "half (293) for
+the first wave and half (292) for the second" (quoted below) corroborates it.
+This note does not settle the point.
+
+*** Universe vs. what the sample is stated to represent
+
+The two documents also come apart on representativity:
+
+- French rapport, section 1.3: representativity « concerne les milieux de
+  résidence (urbaine et rurale) et les 13 régions administratives du pays »
+  -- 13 regions x 2 milieux.
+- English BID, "Sample", p. 10, VERBATIM: "The Burkina Faso EHCVM 2018/19 sample
+  covers all regions with urban and rural areas surveyed in all regions and is
+  representative for the strata of Ouagadougou, other urban areas and rural
+  areas." -- three strata, not 26.
+
+Recorded, *not* adjudicated.  Note also that the =sample= section of this file
+records "No explicit strata variable" for this wave, so a user cannot recover
+either stratification from the shipped =sample()= table without reconstructing
+it.
+
+*** Sample-size figures (context only; the documents disagree)
+
+| Source                                   | Figure                                                                                              |
+|------------------------------------------+-----------------------------------------------------------------------------------------------------|
+| Rapport général, p. 17                   | 585 ZD drawn PPS, 12 HH per ZD; target size « estimée à 7020 ménages »                              |
+| BID p. 10 / catalog =sampling_procedure= | "The total survey sample size is 7010 households - 3149 from urban areas and 3861 from rural areas." |
+| BID p. 10, by vague                      | wave 1: 3507 HH (1577 urban / 1930 rural); wave 2: 3503 HH (1572 urban / 1931 rural)                 |
+
+The precision target behind the design, rapport p. 17, VERBATIM: « Le coefficient
+de variation ne devrait pas excéder 2% au niveau national, 5% en milieu urbain et
+en zone rural et 10% dans chacune des treize régions administratives du pays. »
+
+*** Oversamples
+
+None declared.  No urban booster, no refresh cohort, no special sub-population.
+
+** 2021-22 -- EHCVM-2 Panel Survey (EHCVM-P)
+
+Sources, both in-repo:
+=2021-22/Documentation/ddi-documentation-english_microdata-6224.pdf= (WB NADA
+DDI report), p. 3, "Coverage" > "UNIVERSE"; and
+=2021-22/Documentation/bid_bfa_ehcvm2.pdf= (Basic Information Document),
+"Sample", p. 4.  WB catalog id 6224.
+
+*** Declared universe (verbatim, English) -- and it is the boilerplate
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military
+barracks, and school dormitories.
+#+end_quote
+
+Byte-identical to the 2018-19 wave's English universe field and to the catalog
+DDI export for 6224.  *This is the NADA boilerplate described above*, so it
+attests a template rather than an INSD claim about this particular survey.
+
+Unlike 2014 and 2018-19, *no French INSD rapport général is shipped in this
+wave's =Documentation/=*, so the repo holds no Burkina-specific « champ de
+l'enquête / champ social » paragraph for 2021-22.  The universe statement the
+repo holds for this wave is therefore template text only -- plus the panel-frame
+restrictions below, which are survey-specific and far more informative about
+what this sample can represent.
+
+*** THE THING TO KNOW: this wave is a panel sub-sample, not a fresh national draw
+
+=bid_bfa_ehcvm2.pdf=, "Sample", p. 4, VERBATIM (three separate passages from that
+page):
+
+#+begin_quote
+The panel sample of the EHCVM-2 2021/22 corresponds to half of the households
+interviewed in EHCVM-1 2018/19 Households were tracked within the EA. In other
+words, EHCVM-1 households that have left their EA of origin were not surveyed.
+#+end_quote
+
+(The missing sentence break after "EHCVM-1 2018/19" is in the source; quoted as
+printed.)
+
+#+begin_quote
+Household members in 2018 who have since left the household were not followed up
+physically. The survey collected some information on these individuals in one of
+the modules of the EHCVM-2 2021/22 questionnaire.
+#+end_quote
+
+#+begin_quote
+Sampling only 6 households out of the 12 surveyed in 2018/19 allowed for the
+possibility of replacements in cases where a previously sampled household was
+unavailable for the new round of surveys Additionally, if the number of available
+households in a given Enumeration Area (EA) fell below 6, no additional
+households were included in the survey.
+#+end_quote
+
+Consequences a user pooling this wave must weigh:
+
+1. The *declared* universe is inherited template text describing a national
+   household population.  What the 2021-22 sample can represent is bounded by a
+   frame that is half of the 2018-19 households, restricted to households still
+   in their EA of origin.
+2. *Attrition by migration is structural, not accidental.*  Households that left
+   their EA were by design not surveyed, and individuals who left the household
+   were not followed physically.
+3. There is *no replacement floor*: EAs that fell below 6 available households
+   were not topped up, so realized cluster sizes vary in a way correlated with
+   local mobility.
+4. The distinct panel weight (=hhweight_panel=, see the =sample= section of this
+   file) exists because of exactly this; =hhweight2021= and =hhweight_panel= are
+   not interchangeable.
+
+*** Sample design (context, verbatim from the same page)
+
+#+begin_quote
+The sampling strategy used is a two-stage sampling with stratification in the
+first stage. The first stage sampling frame consists of enumeration areas (EAs)
+or clusters. A study area is a portion of the population for which meaningful
+results are sought, i.e., separate estimates with sufficient precision. Each
+region is considered a study area, as is the entire urban environment and the
+entire rural environment. The different strata result from the combination of the
+13 regions with the two areas of residence (urban, rural).
+#+end_quote
+
+VERBATIM, same page: "A total of 585 EAs were selected (half (293) for the first
+wave and half (292) for the second wave).  Within each EA, 6 households out of
+the 12 surveyed in 2018 were surveyed."
+
+Planned vs. realized, VERBATIM: "The sampling plan stipulated the selection of
+3,510 households, with 1,758 to be surveyed during the initial wave and 1,972
+during the subsequent wave.  The final actual size of the panel sample is 3,227
+households, of which 1647 were interviewed in the first wave and 1,580 in the
+second wave."
+
+- The BID's own arithmetic does not close: 1,758 + 1,972 = 3,730, not 3,510.
+  Quoted as printed, not corrected.
+- The =sample= section of this file records 3,218 households across 550 clusters
+  in the data -- a data-side count, neither confirming nor refuting these design
+  figures, and not used here to adjudicate anything.
+
+*** Additional French scope statement -- but it is WAEMU-common boilerplate
+
+=2021-22/Documentation/manuelagent_ehcvm2_version_v2.pdf= -- « ENQUETE HARMONISEE
+SUR LES CONDITIONS DE VIE DES MENAGES (EHCVM 2021/2022), MANUEL DE L'AGENT
+ENQUETEUR », Août 2021 (UEMOA / INSD / Banque Mondiale), printed p. 4 (PDF p. 7),
+VERBATIM:
+
+#+begin_quote
+Attention : le personnel diplomatique ne fait pas partie du champ de l'enquête.
+En effet la résidence d'un diplomate est considérée comme extraterritorial,
+c'est-à-dire que juridiquement hors du pays concerné. Cependant les autres
+personnes travaillant dans ces organisations font partie du champ de l'enquête,
+tout comme les étrangers n'ayant pas de statut de personnel diplomatique.
+#+end_quote
+
+Same page, the residency rule defining a household member, VERBATIM: « Membre du
+ménage. Un membre du ménage est une personne résidant habituellement dans le
+ménage. Un individu réside habituellement dans le ménage dans deux situations :
+(i) il vit dans ce ménage depuis au moins 6 mois ; (ii) Il est arrivé dans le
+ménage depuis moins de 6 mois, mais avec l'intention d'y rester au moins 6
+mois. »  This is the operational counterpart of the =s01q12= / =s01q13= binary
+eligibility filters documented in the "Household Presence / MonthsSpent" section
+of this file.
+
+*CAVEAT*: this manual is the WAEMU-common EHCVM-2 instrument -- its worked
+examples name Dosso and Niamey, i.e. Niger.  These paragraphs are regional
+boilerplate shipped inside the Burkina Faso wave's =Documentation/=, not
+Burkina-specific text.  Treat them as instrument-level scope rules, not as an
+INSD claim about this survey.
+
+*** Oversamples
+
+None declared.  The specialization in this wave is *sub-sampling* (the panel
+frame above), not oversampling.
+
+** Where the statements live
+
+| Wave    | Universe statement held in-repo?                                                 | Also in WB catalog metadata?                                     |
+|---------+----------------------------------------------------------------------------------+------------------------------------------------------------------|
+| 2014    | yes -- =2014/Documentation/Report.pdf= p. 20 (French, INSD)                      | yes, in *different wording*, survey-specific; the two agree       |
+| 2018-19 | yes -- French rapport p. 16 AND English =Documentation.pdf= p. 3                 | yes, byte-identical to the local English DDI                     |
+| 2021-22 | yes, but NADA boilerplate only -- =ddi-documentation-english_microdata-6224.pdf= p. 3 | yes, byte-identical                                          |
+
+No Burkina Faso wave is in the "catalog-only" position (a statement that exists
+only in WB catalog metadata, with nothing in the repo).  All three have a local
+file, so the record is something the library holds rather than a moving target.
+The weak case is 2021-22, where the local file carries template text rather than
+an INSD-authored scope paragraph.
+
+Note that none of the three =Documentation/SOURCE.org= files carry
+=#+CATALOG_ID:= / =#+PROVENANCE_*:= keywords; each records only the catalog URL
+(2538 / 4290 / 6224).
+
+** Gaps and what was searched
+
+Recorded so a later reader knows what was and was not looked at.  No =.dta= file
+was opened for any of this: the universe is a documentation claim, and reading it
+off the data would conflate the claim with the realization.
+
+- All files under each of =2014/=, =2018-19/= and =2021-22/= were listed; every
+  =Documentation/SOURCE.org= was read.
+- Text was extracted (pdfminer) from =2014/Documentation/Report.pdf=;
+  =2018-19/Documentation/{basicinformationdocument_bfa,ehcvm_2018_rapport_general,Documentation}.pdf=;
+  =2021-22/Documentation/{bid_bfa_ehcvm2,ddi-documentation-english_microdata-6224,manuelagent_ehcvm2_version_v2}.pdf=.
+  Each was searched for: /univers/, /population/, /cible/, /couvert/, /exclu/,
+  "de jure", /base de sondage/, /champ/, /champ social/, /ménages collectifs/,
+  /sont exclus/, "Sample".
+- The WB catalog DDI JSON exports for 2538, 4290 and 6224 were pulled and their
+  study-description pages fetched.
+- *Not opened*: the 2014 questionnaire (=Questionnaire_EMC_2014_Passage_1.pdf=,
+  DVC sidecar only), the EHCVM nomenclature PDFs, and the EHCVM questionnaires
+  (=bfa_ehcvm1_qnr_household_excel_vague{1,2}.xls=, =bfa_ehcvm2_vague{1,2}.pdf=,
+  =questionnaire_ehcvm_com_bfa.pdf=).  For 2014 and 2018-19 the universe was
+  already found in multiple independent documents.  For 2021-22 the
+  questionnaires were *not* searched for a scope paragraph, so if a
+  Burkina-specific French EHCVM-2 scope statement exists it may be in those
+  files.  That is a live gap, not a negative finding.
+- *Explicit gap*: no French INSD rapport général for EHCVM-2 2021/22 is present
+  in this repo.  The absence of a Burkina-specific French « champ de l'enquête »
+  paragraph for that wave is a gap in what the repo holds; it is *not* a claim
+  that INSD never wrote one.
+
 * Files in Burkina_Faso/_/
 ** TODO food_items.org
 ** TODO nutrition

--- a/lsms_library/countries/Cambodia/_/CONTENTS.org
+++ b/lsms_library/countries/Cambodia/_/CONTENTS.org
@@ -19,6 +19,297 @@ legacy Makefile/script path exclusively---there is no =data_scheme.yml=
 and no =data_info.yml= at the country level, so Cambodia is not yet
 accessible via the =Country()= API.
 
+* Sampling universe, exclusions and sub-samples
+
+What the survey documentation *claims* about the population it represents, as
+distinct from what the data look like.  Nothing in this section was inferred
+from the =.dta= files; every statement is quoted from documentation, with a
+citation.  Cambodia has a single wave (2019-20), so this section has a single
+wave entry.
+
+Headline: *this wave has no universe statement at all.*  What it has instead is
+a frame statement, and the frame is a quarter-year sub-sample of another
+survey.  Both facts matter before anyone pools Cambodia with other countries.
+
+** 2019-20: no universe / target-population statement exists
+
+The DDI's =universe= element is *empty* -- =<universe/>= -- in both places it
+occurs in the catalog XML export
+(=stdyDscr/stdyInfo/sumDscr/universe= and =method/dataColl/sampleFrame/universe=,
+[[https://microdata.worldbank.org/index.php/metadata/export/4045/ddi]]).  No
+document in this repo or in the catalog carries a "Universe" or "Target
+population" heading.  This is a recorded gap, not an omission of this write-up.
+
+The nearest documented coverage statements, verbatim, are these two.  Neither is
+a universe declaration; both describe the *sample*, and are recorded here only
+because they are the strongest coverage language that exists.
+
+- DDI report, ABSTRACT, printed p. 2 --
+  =lsms_library/countries/Cambodia/2019-20/Documentation/ddi-documentation-english_microdata-4045.pdf=
+  (in-repo, DVC-tracked):
+
+  #+begin_quote
+  The survey attempted to conduct private interviews with all the adult
+  household members (aged 18 and older) in each sampled household as part of a
+  nationally-representative survey sample.
+  #+end_quote
+
+- DDI report, Coverage > GEOGRAPHIC COVERAGE, printed p. 3 (same file).  The
+  field's *entire* content is one word:
+
+  #+begin_quote
+  National
+  #+end_quote
+
+Read carefully, "as part of a nationally-representative survey sample" is a
+claim about the sample, not a definition of the universe it stands for.
+Nothing in any consulted document says "all private households in Cambodia" or
+any equivalent.  So: geographic coverage is asserted national; the population
+covered is *never stated*.
+
+** 2019-20: exclusions -- none stated anywhere (documented gap)
+
+*No exclusion statement of any kind appears in any consulted document* -- no
+institutional or collective-quarters exclusion, no nomadic or homeless
+exclusion, no diplomatic carve-out, no named region dropped, no security
+carve-out, no urban-only or rural-only restriction.
+
+This is a genuine negative with the search behind it recorded (see the
+"What was searched" subsection below), not an assumption.  Case-insensitive searches for
+=universe=, =target population=, =exclud=, =institution=, =nomad=, =homeless=,
+=collective= and =private household= over the full text of the in-repo DDI
+report, the Basic Information Document, the Field Operational Manual and the
+public questionnaire return *zero* relevant hits.  The only =exclud= matches in
+the DDI are ISCO occupation labels ("Engineering professionals (excluding
+electrotechnology)", "Street vendors (excluding food)") and one consumption-
+module instruction ("telephone service (exclude telephone accessories)"); the
+BID returns no hits at all for any of these terms.
+
+Note what this does *not* mean.  It does not mean the survey covered
+institutional populations; it means nobody wrote down what it covered.  The
+absence of an exclusion sentence here is an absence of documentation, and the
+real exclusions (if any) live in the CSES 2019-2020 sample design, which is not
+in this repo.
+
+** 2019-20: the frame -- a three-month sub-sample of the CSES, disjoint from it
+
+This is the substantive finding, and it is the thing a reader pooling Cambodia
+needs to know.  *The LSMS+ sample is not an independent national draw.*  It is
+drawn inside the CSES 2019/20 PSU sample, restricted to one fieldwork quarter,
+and its households were deliberately chosen *not* to be CSES households.
+
+Verbatim, Basic Information Document, "1.0 Introduction", printed p. 4:
+
+#+begin_quote
+The Cambodia LSMS Plus Survey was conducted in 25 percent of the enumeration
+areas (EAs) that was visited by the 2019/20 round of the Cambodia Socioeconomic
+Survey (CSES) which is implemented by the National Institute of Statistics
+(NIS).
+#+end_quote
+
+Same page, next sentence:
+
+#+begin_quote
+Specifically, in the CSES EAs that were visited during the period of
+October-December 2019, the NIS selected additional households that were NOT be
+part of the planned CSES sample and that constituted the LSMS Plus Survey
+sample, to whom the World Bank-required survey questionnaire modules was
+administered, based on the World Bank-required fieldwork protocols.  The LSMS
+Plus Survey data was collected in parallel with the CSES data in these EAs.
+#+end_quote
+
+BID, "3.1 Survey Sample", printed p. 5:
+
+#+begin_quote
+The survey took approximately 3 months running from October-December 2019 with
+a few final interviews in early January 2020.  The NIS sampled 6 additional
+households in the 252 enumeration areas that were visited during the period of
+October-December 2019 by the 2019/20 round of the Cambodia Socioeconomic Survey
+(CSES).  The LSMS+ Survey sample includes a total of 1,512 households.
+#+end_quote
+
+And the PSU definition, DDI report, Sampling > SAMPLING PROCEDURE, printed
+p. 3 (in-repo file):
+
+#+begin_quote
+The Primary Sampling Units (PSUs) of this survey were the subsamples of the
+selected PSUs of the Cambodia Socio-Economic Survey (CSES) 2019/20.  The PSU in
+this case can either be a village (if the village is small) or an Enumeration
+Area (EA) from the mapping operation of 2019 General Population Census of
+Cambodia (if the village is large, exceeding 120 households).  The Cambodia
+LSMS+ sample covered all the CSES' s sample villages in three months (those
+selected for interviews during the October - December period of fieldwork) out
+of its twelve-month sample.
+#+end_quote
+
+The BID gives the same passage in slightly different words (BID, "3.2 Survey
+Weights" > SAMPLING METHODOLOGY, item 1, printed p. 7): "...if the village is
+large, probably exceed 120 households).These covered all the CSES' s sample
+villages in three months...".  Where the two differ, the in-repo DDI text is the
+one quoted above.
+
+Second stage, BID p. 8 / DDI p. 3: 6 households per PSU, selected in the field
+by Circular Systematic Random Sampling (CSRS) from the household listing that
+the *CSES* enumerator had made for that PSU.
+
+Summary of the design as documented:
+
+| Element              | As documented                                                |
+|----------------------+--------------------------------------------------------------|
+| Stated universe      | none -- DDI =<universe/>= is empty                           |
+| Geographic coverage  | "National" (DDI, one word, no elaboration)                   |
+| Frame                | the CSES 2019/20 PSU sample, restricted to Oct-Dec 2019       |
+| PSU                  | village, or census EA where the village exceeds ~120 HH       |
+| PSUs selected        | 252 EAs = 25% of the CSES EAs                                |
+| SSU selection        | 6 HH per PSU, CSRS from the CSES enumerator's listing         |
+| Disjointness         | explicit -- households "NOT be part of the planned CSES sample" |
+| Sample size          | 1,512 households                                             |
+| Fieldwork            | 2019-10-08 to 2020-01-03 (DDI, Data Collection)              |
+
+*Consequence for #601/#603, stated as a fact about the documents and not as a
+design proposal*: any universe Cambodia 2019-20 has is *inherited from the CSES
+2019-2020 sample design*, and that report is not in this repo.  The BID says so
+itself, in a footnote on p. 7: "For more details on the CSES sample village
+selection, please see the CSES 2019-2020 report, NIS."  This wave therefore
+belongs in the acquisition queue: the document that would close the cell exists
+and is named, it is simply not held here.
+
+Note also that the sample covers one quarter of a twelve-month CSES fieldwork
+cycle.  Whether the resulting estimates carry the seasonality of Oct-Dec is not
+addressed by any document consulted.
+
+** Sub-samples, oversamples and eligibility rules
+
+- *No oversample and no booster sample is documented.*  There is no
+  sub-population module, no ethnic or programme sub-sample, no urban booster, no
+  panel/refresh split.  The allocation is a flat 6 households in each of 252
+  PSUs (BID Table 1, pp. 7-8), which is the opposite of an oversample design.
+- *The whole wave is itself a sub-sample* -- of the CSES, as set out above.  In
+  the taxonomy that the cross-country sweep uses, Cambodia is the case where the
+  specialization is the *wave*, not something inside it.
+- *One eligibility rule, at the individual level.*  BID, "2.0 The Survey
+  Instruments", printed p. 4, verbatim: "The Individual Questionnaire was
+  administered to all adult individuals (18 years and above) in the household"
+  (the sentence ends without a period in the source).  The DDI abstract says the
+  same ("all the adult household members (aged 18 and older)").  This is a
+  *module eligibility* rule, not a universe exclusion: the household
+  questionnaire has no age restriction, and individual-level tables built from
+  this wave are 18+ by design.  The cross-country document files this alongside
+  Tanzania NPS / Albania APS 15+ and Malawi IHPS 12+ as an age rule, explicitly
+  kept apart from universe exclusions.
+
+** Where the statements live
+
+| Document                                 | In this repo?                    |
+|------------------------------------------+----------------------------------|
+| DDI report PDF (catalog 4045)            | *yes* -- =2019-20/Documentation/=, DVC-tracked |
+| Public questionnaire (English)           | *yes* -- =2019-20/Documentation/=, DVC-tracked |
+| Basic Information Document (dl id 50889) | *no* -- WB catalog only          |
+| Field Operational Manual (dl id 50888)   | *no* -- WB catalog only          |
+| CSES 2019-2020 report (NIS)              | *no* -- not in the WB catalog either |
+
+The two DDI statements quoted above are held locally and are durable.  *Every
+frame statement -- the 25%-of-CSES sentence, the disjointness sentence, the
+1,512 households, Table 1 -- exists only in the Basic Information Document,
+which this repo does not hold.*  It is a live catalog download, i.e. a moving
+target: it can be revised or withdrawn without the repo noticing.  Transcribing
+it (or DVC-tracking the PDF) is the durability fix.
+
+Version note: =2019-20/Documentation/SOURCE.org= is provenance-stamped
+(=#+CATALOG_IDNO: KHM_2019_LSMS-PLUS_v02_M=, recorded 2026-07-12) and matches
+the local DDI PDF, which is v02.  The =v01= reference that survives in the
+preserved legacy citation block at the bottom of that file is historical.  The
+v02 version note reads "Update to HH_SEC_1.  The Urban/Rural variable was
+previously omitted from the datafile" -- it does not touch any statement quoted
+here.
+
+** Not boilerplate -- and that cuts both ways
+
+The single most-repeated sentence in the cross-country corpus is World Bank NADA
+template text: "The survey covered all de jure households excluding prisons,
+hospitals, military barracks, and school dormitories.", appearing verbatim in 15
+waves.  *Cambodia 2019-20 does not contain it*, in any form.
+
+Which is worth stating precisely.  Cambodia is not a wave whose universe is a
+template; it is a wave with *no* universe field filled in at all.  The
+comparison is therefore: 15 waves attest a template rather than a statistical
+office's claim, and Cambodia attests nothing.  Do not repair the gap by
+importing the boilerplate -- it is not this survey's claim, and no document
+supports applying it here.
+
+** Universe vs. what the weights represent
+
+The documents come apart on this, and neither side should be read as settling
+the other.
+
+- The DDI asserts geographic coverage "National" and calls the sample
+  "nationally-representative" (abstract, p. 2).
+- The weights are =finalhhweight= in =hh_sec_1.dta= (DDI, WEIGHTING, p. 3:
+  "Details can be found in the Basic Information Document and the weights can be
+  found in the household-level data file HH_SEC_1.  The variable name is
+  finalhhweight.").  Their construction is documented only in the BID (3.2
+  Survey Weights) -- i.e. only outside this repo.
+- What the weights inflate to is *not stated*.  With no universe declared, there
+  is no documented answer to "weighted totals estimate the total number of
+  what?"  A reader who needs that answer has to go to the CSES 2019-2020 report.
+
+So the documentation *asserts national representativeness while declining to
+define the population represented*.  That is the shape of the gap; recording it
+is not the same as doubting the claim.
+
+** Open observation, explicitly NOT an exclusion claim
+
+BID Table 1, "Number of sample villages and households in each province"
+(pp. 7-8), lists provinces numbered 1-22, 24 and 25 -- *24 rows*.  Province
+number 23 (Kep, in the standard Cambodian province numbering) has no row.  This
+is not a PDF-extraction dropout: the listed village counts sum to 252 and the
+household counts to 1,512, both matching the printed TOTAL row.
+
+The BID offers no explanation, and *no claim is made here that Kep was excluded
+by design*.  The documentation is simply silent.  The observation is recorded so
+that a later reader checks it against the CSES 2019-2020 sample design rather
+than re-deriving it -- and, per the repo's standing rule, so that no unevidenced
+"province X was excluded" claim gets written anywhere on the strength of a
+missing table row.
+
+** What was searched
+
+Recorded so the negatives above are falsifiable.
+
+1. Wave directories under =lsms_library/countries/Cambodia/= -- only =2019-20=
+   (plus =_= and =var=).
+2. =2019-20/Documentation/SOURCE.org= and =LICENSE.org= -- citation, URL and
+   provenance keywords only; no coverage language.
+3. =_/CONTENTS.org= (this file, prior to this section) -- build status and data
+   issues only; no universe or sampling statement, so nothing here contradicts
+   anything already recorded.
+4. All three in-repo Documentation PDFs, materialized via
+   =lsms_library.data_access.get_data_file()= and extracted with =pdfminer.six=:
+   =ddi-documentation-english_microdata-4045.pdf= (~917k chars),
+   =ddi-documentation-english_microdata-4045 (1).pdf= (~4.7k chars -- a
+   documentation-listing stub, no body), and
+   =cambodia_lsms_plus_questionnaire_english_public.pdf= (~97k chars).
+5. Full-text search of all of the above for =universe=, =target population=,
+   =exclud=, =coverage=, =represent=, =institution=, =nomad=, =homeless=,
+   =collective=, =private household=, =eligib=.
+6. The DDI XML export for catalog 4045, whole =<stdyDscr>= block read --
+   =<universe/>= empty in both occurrences.
+7. WB catalog pages =/catalog/4045/study-description= and =/related-materials=.
+   (The =/api/catalog/4045= endpoint returns =IDNO-NOT-FOUND=; the metadata
+   export endpoint works.)
+8. The Basic Information Document (download id 50889) and the Field Operational
+   Manual (download id 50888), downloaded and read in full.  Neither contains a
+   universe statement.
+
+Transcription note: the BID and DDI PDFs are justified text, so the extractor
+emits runs of multiple spaces inside phrases; those runs were collapsed to single
+spaces in the quotations above.  No words were added, removed, reordered or
+corrected.  The apparent grammatical errors -- "that was visited", "that were
+NOT be part of", "probably exceed 120 households", "CSES' s" (a stray space
+after a curly apostrophe in the source), and the missing period after "in the
+household" -- are *in the source* and are reproduced as printed.  The DDI PDF
+renders =fi=/=ff= as ligature codepoints; these are written as plain ASCII here.
+
 * Known issues
 - Makefile :: FIXED (2026-06-08).  The generic =%.parquet= rule
   previously referenced =malawi.py= (copy-paste error from Malawi); it

--- a/lsms_library/countries/China/_/CONTENTS.org
+++ b/lsms_library/countries/China/_/CONTENTS.org
@@ -47,6 +47,247 @@ Counties 1--3 map to Province 7 (Hebei); counties 4--6 to Province 8
 - https://microdata.worldbank.org/index.php/catalog/study/CHN_1995_LSS_v01_M
 - BID: =Documentation/chnbinfo.pdf= (Section 3 "Sample")
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered 2026-07-21 for GH #601.  China has exactly one wave in
+this repo (=1995-97=), and its universe statement lives in a file the
+repo holds: =1995-97/Documentation/chnbinfo.pdf= (the Basic Information
+Document, dated February 2003).  Every quote below was re-checked
+character-for-character against that PDF's extracted text, and the two
+catalog quotes against a live pull of
+https://microdata.worldbank.org/index.php/api/catalog/CHN_1995_LSS_v01_M
+on 2026-07-21.  Curly quotes and apostrophes inside the quote blocks are
+reproduced as they appear in the source.
+
+This section *extends* "Sampling Design" above; it does not replace it.
+That section already quotes the first sentence of the BID's §3 and
+correctly records that no weights exist.  The mechanics of PSU coding
+(=hid= digits, =v = hid // 100=) stay there and are not repeated here.
+
+** 1995-97: the declared universe is an explicit DENIAL of a universe
+
+The BID's statement of population is negative -- it says, in the survey's
+own words, that there is no well-defined population the sample is drawn
+from:
+
+#+begin_quote
+The CLSS sample is not a rigorous random sample drawn from a well-defined
+population.  Instead it is only a rough approximation of the rural
+population in Hebei and Liaoning provinces in Northeastern China.
+#+end_quote
+
+Citation: /China Living Standards Survey (CLSS), 1995-1997, Basic
+Information Document/, §3 "Sample", p.10, first sentence of the section.
+File: =lsms_library/countries/China/1995-97/Documentation/chnbinfo.pdf=.
+Language: English; no translation required.  (The instruments themselves
+were fielded in Chinese -- BID §5 "Using the Data", p.12: "Since the questionnaires used to
+collect the data were in Chinese, it is also advisable to check the
+Chinese versions of the questionnaires" -- but the *documentation* quoted
+here is English.)
+
+The Overview gives the geographic and unit-of-observation framing:
+
+#+begin_quote
+China Living Standards Survey (CLSS) consists of one household survey and
+one community (village) survey, conducted in Hebei and Liaoning Provinces
+(northern and northeast China) in July 1995 and July 1997 respectively.
+Five villages from each three sample counties of each province were
+selected (six were selected in Liaoyang County of Liaoning Province
+because of administrative area change).  About 880 farm households were
+selected from total thirty-one sample villages for the household survey.
+The same thirty-one villages formed the samples of community survey.
+#+end_quote
+
+Citation: BID §1 "Overview", p.1.
+
+*** Universe vs. what the weights represent
+
+There is nothing to reconcile, because there is nothing to weight with:
+the documentation denies a well-defined universe, the county and village
+stages were purposive, and *no sampling weights exist in the data files*
+(already noted under "Sampling Design").  The =sample= table therefore
+carries =v= but no =weight= / =panel_weight= / =strata= / =Rural=.  The
+practical consequence for a pooling user: nothing in this country can be
+inflated to any population, not even to rural Hebei + Liaoning, and the
+BID says so itself.
+
+*** Where the statement lives, and why the catalog is not a second witness
+
+The statement is held locally, in a DVC-tracked file in this repo -- this
+is *not* one of the waves whose universe exists only as WB catalog
+metadata.
+
+The catalog does carry the same language, but it is not independent
+corroboration:
+
+- =study_desc/method/data_collection/sampling_procedure= is byte-for-byte
+  the BID §3 text (verified 2026-07-21).
+- =study_desc/study_info/geog_coverage= reads: "The China Living
+  Standards Survey (CLSS) was conducted only in Hebei and Liaoning
+  Provinces (northern and northeast China)."
+- The record has *no* =universe= field at all.  The =study_info= keys
+  present are exactly: =abstract=, =coll_dates=, =nation=,
+  =geog_coverage=, =data_kind=, =notes=.
+
+So: catalog and local documentation are one statement, not two.
+
+*Boilerplate check*: not applicable.  This is survey-specific prose
+written about CLSS, not the WB NADA template sentence that recurs
+verbatim across ~15 waves in the corpus.  Nothing here attests a template.
+
+** Exclusions
+
+*** Geographic / domain restriction (by design, purposive)
+
+#+begin_quote
+Because of this, three counties in Hebei and three counties in Liaoning
+were selected as “primary sampling units” because data had been collected
+from those six counties by the Japanese occupation government in the
+1930’s.  Within each of these six counties (xian) five villages (cun)
+were selected, for an overall total of 30 villages (in fact, an
+administrative change in one village led to 31 villages being selected).
+#+end_quote
+
+#+begin_quote
+These other villages were not drawn randomly but were selected so as to
+“represent” variation within the county.
+#+end_quote
+
+Citation: BID §3, p.10 (both).  The domain is thus *rural* Hebei and
+Liaoning only -- 2 of China's 31 province-level units -- and within those,
+six purposively chosen counties picked to match 1930s Japanese-occupation
+survey sites.  Urban areas are outside the described domain; the BID never
+frames this as an "exclusion", it simply never claims them.
+
+*** Household-membership rule
+
+#+begin_quote
+Household members were defined to include “all the people who normally
+live and eat their meals together in this dwelling.”  Those who were
+absent more than nine of the last twelve months were excluded, except for
+the head of household.
+#+end_quote
+
+Citation: BID §2.1, Section 1A, p.2.  (This is the roster-eligibility
+rule; the wave's =household_roster= carries =MonthsAway= from =s01a212=.)
+
+*** Non-resident children
+
+#+begin_quote
+Section 1C collects information for children of household members who are
+not living in home.  Children who have died are not included.
+#+end_quote
+
+Citation: BID §2.1, Section 1C, p.2.
+
+*** Module-level universes (not household-frame exclusions)
+
+Recorded so a user does not read a module's denominator as the sample's:
+
+| module               | stated universe                                                                 | citation           |
+|----------------------+---------------------------------------------------------------------------------+--------------------|
+| Schooling (§2)       | "in essence the data on schooling can be said to apply all persons 6 age and above." | BID §2.1, p.2      |
+| Employment (§3)      | "All individuals age thirteen and above were asked to respond to the employment activity questions in Section 3." | BID §2.1, p.3      |
+| Community §10 Forestry | "Section 10 on Forestry was not administered in the 1997 survey."               | BID §2.2, p.10     |
+
+*** Exclusion categories with NO statement found
+
+No institutional / collective-quarters exclusion, no nomadic or homeless
+exclusion, and no "for security reasons" carve-out is stated anywhere in
+=chnbinfo.pdf= or in the catalog record.  Recorded as NOT FOUND, not as
+"none applied".  What was searched: the full extracted text of
+=chnbinfo.pdf= (62,706 chars) for /universe/, /population/, /random
+sample/, /Sample/; the full text of =chnville.pdf= (44,646 chars, the 1997
+Village Survey Form -- a blank instrument, no target-population
+statement); and the complete DDI metadata for CHN_1995_LSS_v01_M.  See
+"Sources that could not be searched" below for the one gap.
+
+** Oversamples and sub-samples
+
+There is one, and it is unweightable.  Six of the thirty-one villages --
+the "main villages", i.e. the actual 1930s survey sites -- were sampled at
+2.5x the per-village household count of the other twenty-five:
+
+#+begin_quote
+In each county a “main village” was selected that was in fact a village
+that had been surveyed in the 1930s.  Because of the interest in these
+villages 50 households were selected from each of these six villages (one
+for each of the six counties).  In addition, four other villages were
+selected in each county. [...] Within each of these villages 20
+households were selected for interviews.  Thus the intended sample size
+was 780 households, 130 from each county.
+#+end_quote
+
+Citation: BID §3, p.10.
+
+Read plainly: ~38% of the intended household sample (6 x 50 = 300 of 780)
+comes from six historically-selected villages.  Because there are no
+weights, *a naive pooled mean over China 1995-97 over-represents the
+1930s-survey villages* relative to any notion of rural Hebei/Liaoning, and
+nothing in the shipped data lets a user undo it.  Anyone averaging across
+countries needs to know this before pooling.
+
+The only probabilistic stage is within-village:
+
+#+begin_quote
+Unlike county and village selection, the selection of households within
+each village was done according to standard sample selection procedures.
+In each village, a list of all households in the village was obtained from
+village leaders.
+#+end_quote
+
+Citation: BID §3, p.11.  (Systematic selection with a random start, from a
+village-leader-supplied household list.)
+
+No other sub-population design is documented: no urban booster, no
+refresh/extended sub-panel, no module subsample, no minority oversample.
+
+** Two instruments, two years, one library wave
+
+The wave label =1995-97= folds together two fieldwork rounds two years
+apart -- relevant to anyone treating =t= as a single point in time:
+
+- Household survey: "Data collection began in July 1995 and ended in
+  August 1995." (BID §4, p.11)
+- Community/village survey: "Although village level data were also
+  collected in the summer of 1995, analysis of those data revealed many
+  problems and all 31 villages were revisited in July and August of 1997
+  to collect village level data." (BID §4, p.11)
+
+So =cluster_features= for =t='1995-97'= describes village conditions
+measured in 1997 (with recall for 1995 and 1988: "Enumerators asked for
+information about two years – 1995 and 1988." -- BID §2.2, p.7), while
+=household_roster= and the household modules are 1995.
+
+** Unreconciled household counts
+
+Three different numbers are in play; none of them is being "corrected"
+here, because the source itself is inconsistent:
+
+| figure | source                                                        |
+|--------+---------------------------------------------------------------|
+|   ~880 | BID §1 Overview, p.1: "About 880 farm households were selected" |
+|    780 | BID §3, p.10: "the intended sample size was 780 households"     |
+|    785 | BID §3, p.11: "In fact, the number of households in the sample is 785, as opposed to 780." |
+
+The "Sampling Design" section above reports "~880 farm households (787 in
+final data)".  The 787 is a data-side count and is not in conflict with
+anything quoted here; the 880-vs-780/785 gap is *the BID contradicting
+itself*, and is left as such.
+
+Unit of observation is stated as "farm households" (BID Overview).  The
+BID nowhere says non-farm rural households were eligible, and nowhere says
+they were excluded.  Do not infer either.
+
+** Sources that could not be searched
+
+=1995-97/Documentation/CHI01.pdf= (the household questionnaire, 1.2 MB) is
+an image-only scan: text extraction yields 52 characters, all page-break
+marks.  No OCR was run.  A questionnaire cover page can in principle carry
+additional coverage or eligibility language; that possibility is
+*unverified*, not excluded.  Everything above comes from =chnbinfo.pdf=
+and the WB catalog record.
+
 * Features configured
 ** sample
 ** cluster_features

--- a/lsms_library/countries/CotedIvoire/_/CONTENTS.org
+++ b/lsms_library/countries/CotedIvoire/_/CONTENTS.org
@@ -129,6 +129,420 @@ Wave-level =_/food_expenditures.py= scripts exist for 1985-86, 1986-87 using the
 files as CSV format via =dvc.api.open=. They are legacy scripts and use the retired
 =lsms.tools= package — do not extend them.
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered 2026-07-21 for GH #601.  Everything below is quoted
+verbatim from the cited source; the section headers, the tables and any
+sentence not inside a quote are editorial.  Nothing here is inferred from
+the microdata -- what a survey *claims* to represent and what its =.dta=
+files happen to contain are kept strictly apart.
+
+** Where the statements live (read this first)
+
+*No universe or coverage statement exists in any file this repository
+ships for any Côte d'Ivoire wave.*  All five waves' statements are
+*World Bank catalog metadata only*.  That makes the record a moving
+target: the text can change under us without any change in this repo.
+
+| Wave    | Catalog | Universe field? | Statement lives in                    | Confidence |
+|---------+---------+-----------------+---------------------------------------+------------|
+| 1985-86 |      83 | *no*            | catalog metadata only                 | medium     |
+| 1986-87 |      84 | *no*            | catalog metadata only                 | medium     |
+| 1987-88 |      85 | *no*            | catalog metadata only                 | medium     |
+| 1988-89 |      82 | *no*            | catalog metadata only                 | medium     |
+| 2018-19 |    4292 | yes             | catalog metadata only (and see 3.2)   | high       |
+
+What is in the repo instead, per wave =Documentation/=:
+
+- 1985-89 :: questionnaire scans only (=cot15A_V2.pdf=, =cot15B.pdf=,
+  =cot17.pdf=, =cot24A_V2.pdf=, =cot24B.pdf=, =cot08.pdf=, =cot23_V2.pdf=,
+  =cot23B.pdf=, =cot25A_V2.pdf=, =cot25B.pdf=, =cot30A_V2.pdf=,
+  =cot30B.pdf=) plus =SOURCE.org= and =LICENSE.org=.  *All twelve PDFs are
+  image-only scans with no text layer*, and no OCR tool was available on
+  the extraction host, so they could not be searched textually.  They are
+  questionnaires, not reports; a universe statement would not normally
+  live in them.  No Basic Information Document is DVC-tracked here.
+- 2018-19 :: questionnaires and code nomenclatures only
+  (=CIV-EHCVM1-QNR-*=, =CIV-EHCVM1-NOMENCLATURE-*=).
+  =CIV-EHCVM1-QNR-MEN-CAPI-VAGUE1.pdf= was text-extracted and searched for
+  « population cible », « univers », « champ de l' », « couverture »: the
+  only COUVERTURE hits are the questionnaire's own cover block.  No report
+  and no BID is DVC-tracked here.
+
+The corroborating documents cited below are catalog-hosted, not local:
+
+- CILSS :: "Cote d'Ivoire Living Standards Survey (CLSS) 1985-88: Basic
+  information for users of the data" (World Bank / Institut National de la
+  Statistique, 1996-08-06), https://microdata.worldbank.org/catalog/83/download/15551
+- EHCVM :: Basic Information Document (INS, June 2021),
+  https://microdata.worldbank.org/catalog/4292/download/52543 -- its
+  "Sample" section (p. 10) gives sizes and the two-stage design and
+  contains *no* universe or target-population statement.
+
+Both are in the acquisition queue: adding them to =Documentation/= would
+move four of the five rows above from "catalog metadata only" to
+something the library actually holds.
+
+** 1. CILSS / EPAM waves 1985-86, 1986-87, 1987-88, 1988-89
+
+*** 1.1 What is declared
+
+The four catalog entries (83, 84, 85, 82) carry *byte-identical*
+=sampling_procedure= text -- re-verified 2026-07-21 by fetching all four
+=/api/catalog/{id}?id_format=id= records and comparing the strings.  They
+share the single 1985-88 Basic Information Document.  Treat the four
+waves as carrying one statement, not four.
+
+*None of the four has a =Universe= field.*  =study_info.universe= is
+=null= in all four API records.  What follows is the nearest
+universe-defining language the documentation offers, and it is a
+*coverage and representativeness claim, not a declaration of the
+population*.
+
+Coverage, verbatim, =study_info.geog_coverage=, catalog 83 (identical in
+84 and 85; catalog 82 differs only in dropping the full stop after
+"coverage"):
+
+#+begin_quote
+National coverage.
+Domains: Urban/rural; Regions (East Forest, West Forest,  East Savannah, West Savannah)
+#+end_quote
+
+Nearest thing to a universe, verbatim, opening sentence of
+=method.data_collection.sampling_procedure=, all four entries:
+
+#+begin_quote
+The principal objective of the sample selection process for the CILSS Household Survey was to obtain a nationally representative cross-section of African households, some of which could be interviewed in successive years as panel households.
+#+end_quote
+
+Unit of analysis, verbatim, =study_info.analysis_unit=, all four entries:
+
+#+begin_quote
+- Households
+- Individuals
+- Community
+#+end_quote
+
+Three things a reader must not skip:
+
+1. The word "African" is *in the source*, in both the catalog and the
+   1996 Basic Information Document (printed p. 22, section "III.  Sample
+   Design and Selection").  It is quoted here exactly as written.  *No
+   claim is made here as to whether it implies non-African residents of
+   Côte d'Ivoire were out of scope* -- the documentation does not say, and
+   guessing would be exactly the kind of unevidenced claim this file
+   exists to prevent.
+2. "Nationally representative cross-section" describes the *sample*, not
+   the population.  No document found names the population.
+3. The =Domains= field names *four* regions with the savannah split
+   East/West, but the same entry's own Sampling Procedure section
+   classifies clusters into *five*: "Regional classification was
+   constructed so that clusters in Abidjan would be classified as
+   Abidjan; clusters in other major cities in East Forest, West Forest and
+   Savana would be classified as \"Other Cities \"; and only rural clusters
+   would be included in the East Forest, West Forest and Savanna.  Thus,
+   the urban-rural classification is as follows: Urban - Abidjan and Other
+   Cities; Rural - East Forest, West Forest and Savanna."  The two
+   statements are in the same catalog record and disagree.  The five-way
+   classification is the one this repo's config follows (see
+   [[*Sampling Design][1985-89 Waves (CILSS EPAM) > Sampling Design]]).  Recorded, not adjudicated.
+
+*** 1.2 Exclusions
+
+*No exclusion is stated at the universe level* for any of the four waves.
+No region, no institutional population (prisons, barracks, hospitals,
+dormitories), no nomadic or homeless population, and no security carve-out
+is named anywhere in the four catalog records.  Searched: =universe=,
+=nomad=, =institution=, =foreign= over the full study-description text of
+all four entries.
+
+The only exclusion language found anywhere is a household-*membership*
+rule -- a different thing from a universe exclusion, and quoted here so
+the difference is visible.  Verbatim, catalog study description,
+"Survey instrument > Questionnaires", SECTION 1: HOUSEHOLD ROSTER,
+Part A (identical in all four entries):
+
+#+begin_quote
+This section lists all people w ho normally live and eat their meals together in the dwelling as well as those who spent the previous night in the household, but cannot otherwise be considered household members. To qualify as a household member, a person must have resided in the household for 3 months or more during the previous 12 months. Since the number of months the person was resident in the household is recorded, users of the data can choose a more restrictive definition if they wish. For example, one study used six months of residence, rather than three months, as the criterion for household membership. The household head, newborn babies and new spouses are considered household members even if they do not satisfy the months of residence criterion. CILSS always excludes servants and boarders from household membership because they are considered to be separate households.
+#+end_quote
+
+(The " w ho" and the doubled spaces are in the source; quoted as printed.)
+
+Note for consumers of =household_roster=: this file's REL code table maps
+code 11 to =Servant=, which sits oddly beside "CILSS always excludes
+servants and boarders from household membership".  The two are
+reconciled by the first sentence above -- the roster *lists* people who
+"cannot otherwise be considered household members" -- so a servant row can
+legitimately be present in the roster while being outside CILSS's own
+household-membership definition.  Anyone computing household size or
+per-capita quantities from this table should decide explicitly whether to
+keep those rows.  The library does not decide it for you.
+
+*** 1.3 Sub-samples and sub-populations inside each wave
+
+Three, and all three matter before pooling.
+
+**** (a) A one-woman-per-household fertility sub-sample
+
+Verbatim, =sampling_procedure=, section ">> Selection of the Respondent
+for the Section on Fertility":
+
+#+begin_quote
+The survey collected fertility information for one woman per household. The woman, aged 15 or older, was selected at random from among household members, so that each eligible woman in a household had the same probability of being selected.
+#+end_quote
+
+The fertility module's universe is therefore *not* the wave's universe: it
+is one randomly chosen woman aged 15+ per household, which is a
+size-biased sample of women (a woman in a household with four eligible
+women has a quarter the selection probability of a lone eligible woman).
+No fertility feature is currently wired for these waves, but if one is
+added it must not be pooled with household-level tables without
+reweighting.
+
+**** (b) A rotating half-panel, not a four-wave panel
+
+Verbatim, =sampling_procedure=:
+
+#+begin_quote
+A two-stage sampling procedure was used. In the first stage, 100 Primary Sampling Units (PSUs) were selected across the country from a list of all PSUs available in the sampling frame. At the second stage, a cluster of 16 households was selected within each PSU. This led to a sample size of 1600 households a year, in 100 cluster s of 16 households each. Half of the households were replaced each year while the other half (the panel households in 1986, 1987 and 1988) were interviewed a second time.
+#+end_quote
+
+*This CONTRADICTS a claim already in this file.*  The existing
+"1985-89 Waves (CILSS EPAM) > Sampling Design" section says:
+
+#+begin_quote
+Panels: these are longitudinal (same households followed across 4 waves)
+but household IDs may change -- no panel_ids implemented yet
+#+end_quote
+
+The documentation says each household was interviewed *at most twice*
+(half replaced each year, the retained half "interviewed a second time").
+It does not describe households followed across four waves.  The
+documented design is a rotating two-year panel.  This is flagged, not
+silently corrected: whoever implements =panel_ids= for these waves should
+resolve it against the data and the 1996 BID and then fix whichever
+statement is wrong.
+
+**** (c) The Block 1 / Block 2 frame break, which splits 1987-88 down the middle
+
+Verbatim, =sampling_procedure=:
+
+#+begin_quote
+It is important to note that there was a change in the sampling procedures (the sampling frame, PSU selection process and listing procedures), used to select half of the clusters/households interviewed in 1987 (the other half were panel households retained from 1986), and all of the clusters/households interviewed in 1988.
+#+end_quote
+
+#+begin_quote
+Households selected on the basis of the first set of sampling procedures will henceforth be referred to as Block 1 data while households based on the second set of sampling procedures will be referred to as Block 2 data.
+#+end_quote
+
+#+begin_quote
+The sampling frame for Block 2 data was established from a list of places from the results of the Census of inhabited sites (RSH) performed in preparation for the 1988 Population Census.
+#+end_quote
+
+The documentation speaks in survey years; this repo's wave labels span
+two.  Survey year 1985 = wave =1985-86=, 1986 = =1986-87=, 1987 =
+=1987-88=, 1988 = =1988-89= (the same mapping the =WEIGHT85..88= source
+files follow).  On that mapping, the library's =1987-88= wave is *one
+wave containing two differently drawn sub-samples*: Block 1 panel
+households retained from 1986, and Block 2 households drawn from an
+entirely new frame with a new within-PSU selection unit (the « îlot »
+rather than the PSU).  1985-86 and 1986-87 are Block 1 throughout;
+1988-89 is Block 2 throughout.  A reader pooling
+CotedIvoire across the CILSS years is pooling across a frame break that
+falls *inside* one of the waves.
+
+*** 1.4 Universe vs. what the weights represent
+
+The documentation is unusually candid that the realized sample does not
+cleanly represent the claimed universe, and that the weights only
+partially repair it.  All quotes verbatim from =sampling_procedure=.
+
+Selection bias toward large households (section ">> Bias in the Selection
+of Households within PSUs, Block 1 Data"):
+
+#+begin_quote
+Analysis of the four years of the CILSS data revealed that household size (unweighted), dropped by 24 percent between 1985 and 1988. Three possible explanations were considered: (1) area l demographic change; (2) non-sampling measurement errors were involved; or (3) some sort of sampling bias. Investigation ruled out the first two possibilities. The third possibility clearly was an issue because the sampling frame and listing procedures had indeed changed in midstream and this was likely to have had an effect.
+#+end_quote
+
+#+begin_quote
+One set of weights is provided to reconcile this bias (Household Size Weights).
+#+end_quote
+
+A correction that *cannot* be made at all (section ">> Problems Due to
+Inaccurate Estimates of PSU Population"):
+
+#+begin_quote
+However, it is not possible to calculate these weights either for Block 1 data (m' I is not available since only 64 households per cluster were listed); or for Block 2 data (m' i is not available since the enumeration area was the îlot and not the PSU).
+#+end_quote
+
+#+begin_quote
+[Note: Omission of this weight has two effects: (1) a bias in favor of PSUs whose population has grown relatively slowly (or diminished) since the census, and against those that have grown exceptionally fast; and (2) a bias in favor of PSUs whose current mean household size is relatively large (Chris Scott, personal communication).]
+#+end_quote
+
+Non-response was handled by *substitution*, not by weighting (section
+">> Non-Response and Replacement of Households"):
+
+#+begin_quote
+In order to maintain the size of the sample, the 1985 CILSS instituted a procedure by which households in the original sample that refused or were unavailable were replaced by one of the 48 remaining households in the same cluster, enumerated during the pre-survey. [...] During the first year of the survey, a total of 124 of the 1600 original sample households (7.8 percent) were not interviewed and were thus replaced by other households.
+#+end_quote
+
+#+begin_quote
+In the second and subsequent years, the effort to replace non-responding households with other like households was abandoned. Households were replaced by the first household on the list of those remaining from the pre-survey or listing operation.
+#+end_quote
+
+("[...]" marks an elision of two intervening sentences; the quoted
+fragments are consecutive text otherwise.)
+
+*Open question, not resolved here.*  This repo's config uses a single
+weight variable for these waves -- see
+[[*Sampling Design][1985-89 Waves (CILSS EPAM) > Sampling Design]],
+"Weight variable: ALLWAITN (normalized all-household weight)".  The
+documentation describes more than one weight set, including the
+"Household Size Weights" quoted above.  *No document consulted states
+which distributed variable corresponds to which documented weight set*,
+and no such correspondence is asserted here.  Anyone using CILSS weights
+for published estimates should establish it from the 1996 BID's variable
+documentation first.
+
+** 2. EHCVM 2018-19
+
+*** 2.1 The declared universe
+
+This is the one Côte d'Ivoire wave with a formally labelled =Universe=
+field.  Verbatim, catalog 4292, =study_desc.study_info.universe=
+(re-verified character-for-character against the API record 2026-07-21):
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.
+#+end_quote
+
+Verbatim, =study_info.geog_coverage=:
+
+#+begin_quote
+National coverage
+#+end_quote
+
+Verbatim, opening sentence of =method.data_collection.sampling_procedure=:
+
+#+begin_quote
+The Cote d'Ivoire EHCVM 2018/19 sample covers all regions with urban and rural areas surveyed in all regions.
+#+end_quote
+
+The catalog metadata is in *English* although the instruments are in
+French.  *No French-language universe statement was found* in any
+accessible document -- so unlike Burkina Faso, Niger or Guinea-Bissau,
+there is no INS-authored « champ de l'enquête » text here to compare the
+English against.
+
+*** 2.2 BOILERPLATE WARNING -- do not over-read the universe sentence
+
+The sentence quoted in 2.1 is *World Bank NADA template text*.  The
+cross-country survey behind GH #601 found it appearing verbatim in *15
+waves*: Benin (x2), Burkina Faso 2018-19 and 2021-22, Côte d'Ivoire,
+Guinea-Bissau, Mali, Niger, Senegal, Togo -- and also Ethiopia 2018-19 and
+2021-22 and Nigeria 2015-16, 2018-19 and 2023-24, which are not EHCVM at
+all.
+
+Its presence tells you *which metadata template was used*.  It does not
+independently attest that the Institut National de la Statistique made
+that claim about this survey.  It should be recorded as what it is: the
+strongest statement available for this wave, and simultaneously the least
+survey-specific sentence in the corpus.
+
+*** 2.3 Exclusions
+
+Verbatim exclusion clause, from the =Universe= field:
+
+#+begin_quote
+excluding prisons, hospitals, military barracks, and school dormitories
+#+end_quote
+
+That is an institutional-population exclusion and nothing more.
+
+*No geographic or regional exclusion is stated*, and the Sampling
+Procedure states the opposite: "The Cote d'Ivoire EHCVM 2018/19 sample
+covers all regions with urban and rural areas surveyed in all regions."
+This is worth noting because sibling EHCVM waves *do* carry such
+carve-outs -- Guinea-Bissau's excludes rural coverage in the autonomous
+sector of Bissau, Benin's excludes rural coverage in Littoral -- and
+Côte d'Ivoire's does not.  Pooling EHCVM countries without checking this
+per-country sentence will silently mix different geographic universes.
+
+Note also what the boilerplate does *not* mention, and what neighbouring
+EHCVM countries' French-language documents do: diplomatic households and
+the homeless (Burkina Faso's own French report excludes « les ménages
+ayant un statut diplomatique et les sans domiciles fixes »).  Whether
+those are also out of scope for Côte d'Ivoire is *not documented in any
+source consulted*.  Recorded as a gap, not as an exclusion.
+
+*** 2.4 Sub-samples inside the wave
+
+The wave contains a *two-vague (two-round) split*, already described in
+[[*Sampling Design][2018-19 Wave (EHCVM) > Sampling Design]] and repeated
+here only for its universe implications.  Verbatim,
+=sampling_procedure=:
+
+#+begin_quote
+Upon deciding on the sample size and repartition, the survey design team implemented a 2-stage sampling methodology. At the first stage, 1084 enumeration areas (EAs) were selected from the sample frame. In the second stage, 12 households were selected in each enumeration area randomly.
+#+end_quote
+
+#+begin_quote
+The total survey sample size is 12992 households - 5275 from urban areas and 7717 from rural areas. After that, the survey design randomly divided each enumeration area into two equal groups. The survey team interrogated the first group in wave 1 and the other in wave 2. Finally, for various reasons, including availability and quality monitoring, the final sample size comprises slightly more households (twelve) in round 2 than in round 1. In wave one, the survey teams interviewed 6490 households (2744 in urban areas and 3746 in rural areas. In wave two, the teams interviewed 6502 households (2531 in urban areas and 3971 in rural areas).
+#+end_quote
+
+(Unbalanced parenthesis and the odd "(twelve)" gloss are in the source;
+quoted as printed.)
+
+The two vagues are *seasonal*, and each household is in exactly one of
+them.  They are a random split of each EA, so each vague is a probability
+sample of the same universe -- but they are *not* interchangeable for
+anything seasonal (food acquisition, agriculture, prices).  A user
+subsetting to one vague has a half-size national sample restricted to one
+season, not a national annual estimate.
+
+*No oversample, booster sample, or targeted sub-population* is documented
+for this wave: no urban booster, no poor-household oversample, no
+refugee/migrant module subsample.  Searched: the full catalog 4292 study
+description and the catalog-hosted BID.
+
+** 3. Gaps, recorded as gaps
+
+- 1985-86, 1986-87, 1987-88, 1988-89 :: *no universe statement exists.*
+  Not in the catalog (=study_info.universe= is =null= in all four API
+  records, checked 2026-07-21), not in the 1996 Basic Information
+  Document's sample-design chapter, and not searchable in the twelve
+  local questionnaire PDFs because they are image-only scans with no text
+  layer and no OCR tool was available.  The GH #601 survey tags all four
+  =national-claimed=: a coverage claim exists, a population statement does
+  not.  *If OCR becomes available, the twelve scans are the one unsearched
+  local source* -- though a universe statement would be unusual in a
+  questionnaire.
+- 2018-19 :: a universe statement exists but is template text (2.2), and
+  no French-language original was found to corroborate it.
+- All five waves :: nothing in this repository states a universe.  Pulling
+  the two catalog-hosted documents named at the top of this section into
+  =Documentation/= is the cheapest way to change that.
+
+** 4. Cross-references within this file
+
+- Region and urban/rural classification for 1985-89, and the ALLWAITN
+  weight variable: "1985-89 Waves (CILSS EPAM) > Sampling Design".  Its
+  five-region classification agrees with the documentation's Sampling
+  Procedure section and disagrees with the same catalog record's
+  =Domains= field (see 1.1, point 3).
+- The four-wave-panel claim in that same section is *contradicted* by the
+  documentation; see 1.3(b).
+- Vague split, weights and strata for 2018-19: "2018-19 Wave (EHCVM) >
+  Sampling Design".  Consistent with the catalog; see 2.4.
+- Residency/membership rules: "Household Presence / MonthsSpent".  The
+  CILSS three-month membership rule quoted in 1.2 is the 1985-89 analogue
+  of the EHCVM =s01q12= / =s01q13= binaries described there, and that
+  section's statement that the 1985-89 waves lack a continuous
+  months-present variable should be read against the documentation's claim
+  that "the number of months the person was resident in the household is
+  recorded" -- the questionnaire says it was collected; whether it reaches
+  the distributed extract is a separate, undetermined question.
+
 * Household Presence / MonthsSpent
 
 The EHCVM questionnaire (used in the 2018-19 wave) does NOT ask

--- a/lsms_library/countries/Ethiopia/_/CONTENTS.org
+++ b/lsms_library/countries/Ethiopia/_/CONTENTS.org
@@ -399,6 +399,449 @@ The household identifier variable changes across waves:
 | 2018-19 | =household_id=   | New ID scheme                    |
 | 2021-22 | =household_id=   | Continues wave 4 ID scheme       |
 
+* Sampling universe, exclusions and sub-samples
+
+# ASCII EXCEPTION (deliberate).  Every #+begin_quote block below is a VERBATIM
+# transcription of survey documentation.  The Basic Information Document and the
+# ESS3 survey report use typographic quotation marks around "other region"; they
+# are preserved as printed.  All prose OUTSIDE the quote blocks is ASCII.
+
+Evidence gathered for GH #601 / #603 (documentation sweep, 2026-07-21) and
+re-verified against the cited files before being written here.  This section
+records *what the ESS documentation claims the sample represents*.  Nothing
+here is inferred from the =.dta= files -- that separation is the whole point:
+what a survey claims and what its microdata look like are two different facts.
+
+This is the documentary counterpart to =* Sampling Design= above, which records
+the *mechanics* (PSU variable, strata construction, weight variables, household
+counts).  Read them together; where they disagree the disagreement is flagged
+explicitly in "Relation to =* Sampling Design=" at the end of this section.
+
+** Summary
+
+| Wave    | Survey | Declared universe (compressed -- see quotes below) | Statement lives in                          |
+|---------+--------+----------------------------------------------------+---------------------------------------------|
+| 2011-12 | ERSS / ESS1 | Rural + small-town areas only; 9 zones out of frame | repo (DDI, and the ESS3 BID retrospectively) |
+| 2013-14 | ESS2   | Rural + small town + all urban; 9 zones out of frame | repo (DDI, and the ESS3 BID)                |
+| 2015-16 | ESS3   | Rural + urban (small and large towns); 9 zones out of frame | repo (DDI =UNIVERSE= field + BID)   |
+| 2018-19 | ESS4   | All de jure households, institutional pop. excluded (NADA boilerplate) | *WB catalog only*         |
+| 2021-22 | ESPS-5 | Same boilerplate, *minus Tigray* (also excluded from the weights) | *WB catalog only*            |
+
+Two facts to carry into any pooling of these five waves:
+
+1. *ESS1 is not a national sample.*  It excludes urban areas above 10,000
+   people by design.  Waves 2 onward are national in the sense that all
+   households have positive selection probability -- but see (2).
+2. *No ESS wave has a truly national frame.*  Nine zones of Afar and Somali
+   region are outside the population frame in every wave of Panel I, and the
+   ESS4/ESPS-5 catalog records do not say the frame was changed.  ESPS-5
+   additionally drops Tigray from the represented population.
+
+** Wave by wave
+
+*** 2011-12 (ERSS / ESS1) -- rural and small towns only
+
+The wave's own DDI has no field labelled =UNIVERSE=; the closest statement is
+the opening of "Sampling Procedure", verbatim
+(=lsms_library/countries/Ethiopia/2011-12/Documentation/ddi-documentation-english_microdata-2053.pdf=,
+PDF p. 3, "Sampling" > "Sampling Procedure"):
+
+#+begin_quote
+The ERSS sample is designed to be representative of rural and small town areas of Ethiopia. The ERSS rural sample is a sub-sample of the AgSS while the small town sample comes from the universe of small town EAs. The ERSS sample size provides estimates at the national level for rural and small town households. At the regional level, it provides estimates for four regions including Amhara, Oromiya, SNNP, and Tigray.
+#+end_quote
+
+The explicit *frame* statement for wave 1 is not in the wave-1 documentation at
+all.  It is in the ESS3 Basic Information Document, which describes wave 1
+retrospectively -- quoted here as such, not merged into the above
+(=lsms_library/countries/Ethiopia/2015-16/Documentation/basic_information_document_wave__3_dec19.pdf=,
+section "3.1 Wave 1 coverage, Rural and small towns (ESS1)", printed p. 13):
+
+#+begin_quote
+In wave 1, the ESS1 sample was designed to be representative of rural and small town areas in Ethiopia.8 The ESS sample is drawn from a population frame that includes all areas of Ethiopia except for three zones of Afar and six zones of Somalie region.9 The frame for rural areas is the 2011/2012 Agricultural Sample Survey (AgSS), so the ESS rural sample is a complete subset of the AgSS sample. The small town and urban area samples come from the universe of small town and urban EAs, excluding the same three zones of Afar and six zones of Somalie. The wave 1 sample design provides representative estimates for all rural-area households and for the combination of rural-area and small-town households (excepting the 9 zones excluded from the frame).
+#+end_quote
+
+The WB catalog's GEOGRAPHIC COVERAGE field for catalog id 2053 reads, in full:
+"Rural and small towns".  The catalog record has *no* =universe= field.
+
+"Small town" is a defined term (BID footnote 8, printed p. 13):
+
+#+begin_quote
+The CSA defines small towns based on population estimates from the 2007 Population Census; a town with the population of less than 10,000 is a small town.
+#+end_quote
+
+**** Exclusions (2011-12)
+
+- *Geographic, by frame* -- nine zones, permanently.  BID footnote 9,
+  printed p. 13:
+
+  #+begin_quote
+  Zones excluded from the sampling frame include Zones 2, 4, and 5 in the Afar Region and Zones 3, 4, 5, 6, 7, and 8 in the Somali Region.
+  #+end_quote
+
+- *Geographic, by design* -- every town of 10,000 people or more.  ESS1 has no
+  large-town sample at all; the "national" estimates it supports are national
+  *for rural and small-town households*, which is not the same thing.
+
+- *Precision, not exclusion* -- the six small regions.  DDI, same page as the
+  quote above:
+
+  #+begin_quote
+  The sample is not representative for each of the small regions including Afar, Benshangul Gumuz, Dire Dawa, Gambella, Harari, and Somalie regions. However, estimates can be produced for a combination of all smaller regions as one "other region" category.
+  #+end_quote
+
+  These six regions are *in* the sample; what is missing is the precision to
+  report them separately.  Do not confuse this with the nine-zone frame
+  exclusion above, which is a genuine removal from the universe.
+
+*** 2013-14 (ESS2) -- urban supplement added
+
+The DDI for this wave has *no* =UNIVERSE= heading (verified by grep over the
+full text extraction), and neither does WB catalog id 2247 (the JSON
+=study_info.universe= field is null).  The closest statement is GEOGRAPHIC
+COVERAGE, verbatim
+(=lsms_library/countries/Ethiopia/2013-14/Documentation/ddi-documentation-english_microdata-2247.pdf=,
+PDF p. 5, "Coverage" > "GEOGRAPHIC COVERAGE"):
+
+#+begin_quote
+The Ethiopia Socioeconomic Survey 2013/2014 (ESS2) covered all regional states including the capital, Addis Ababa. The majority of the sample comprises rural areas as it was carried over from ESS1. The ESS2 was implemented in 433 enumeration areas (EAs) out of which 290 were rural, 43 were small town EAs from ESS1, and 100 were new EAs from major urban areas.
+#+end_quote
+
+The frame statement for the urban expansion is again in the ESS3 BID, section
+"3.2 Wave 2 and 3 coverage, Rural and all urban areas (ESS2 and ESS3)",
+printed p. 14:
+
+#+begin_quote
+The population frame for the urban expansion consists of all households in towns with population greater than 10,000 people. This population cut off of 10,000 people is the same threshold that is used to define small towns.12 In addition to the existing sample of rural and small towns, this expansion means now that all households in Ethiopia have some positive probability of selection into the expanded ESS2 sample.13
+#+end_quote
+
+Footnote 13 -- the exception attached to that "all households" claim -- is the
+nine zones again, and it is why the claim is not literally true (BID, printed
+p. 14):
+
+#+begin_quote
+There is an exception to this statement. The ESS and the AgSS surveys both exclude 9 zones from the population frame -- zones 2, 4, and 5 in the Afar Region and zones 3, 4, 5, 6, 7, and 8 in the Somali Region.
+#+end_quote
+
+**** Exclusions (2013-14)
+
+- Nine zones of Afar and Somali, as above (footnote 13, quoted verbatim).
+- The six small regions remain unreportable separately.  The wave's own DDI
+  carries the sentence locally (PDF p. 6, "Sampling Procedure") -- so this
+  exclusion does *not* depend on the catalog:
+
+  #+begin_quote
+  The sample is not representative for each of the small regions including Afar, Benshangul Gumuz, Dire Dawa, Gambella, Harari, and Somalie regions. However, estimates can be produced for a combination of all smaller regions as one "other region" category.
+  #+end_quote
+
+*** 2015-16 (ESS3) -- the only wave with a local =UNIVERSE= field
+
+Verbatim from
+=lsms_library/countries/Ethiopia/2015-16/Documentation/ddi-documentation-english_microdata-2783.pdf=,
+PDF p. 3, "Coverage" > "UNIVERSE":
+
+#+begin_quote
+ESS uses a nationally representative sample of over 5,000 households living in rural and urban areas. The urban areas include both small and large towns.
+#+end_quote
+
+GEOGRAPHIC COVERAGE, same page, immediately above:
+
+#+begin_quote
+National Coverage. ESS2 and ESS3 covered all regional states including the capital, Addis Ababa. The majority of the sample comprises rural areas as it was carried over from ESS1. The ESS2 and ESS3 were implemented in 433 enumeration areas (EAs) out of which 290 were rural, 43 were small town EAs from ESS1, and 100 were EAs from major urban areas.
+#+end_quote
+
+This is the *only* Ethiopia wave whose local documentation carries a field
+actually labelled =UNIVERSE=.  Its text is byte-identical to the WB catalog
+=study_info.universe= for id 2783, so local and catalog agree.  Note what the
+field does and does not do: it describes the *sample* ("uses a nationally
+representative sample of over 5,000 households"), not the set of units the
+sample stands for.  It is a representativeness claim wearing a universe label.
+
+**** Exclusions (2015-16)
+
+- Nine zones of Afar and Somali (BID footnotes 9 and 13, quoted above; the BID
+  ships in *this* wave's =Documentation/= and is the richest frame document in
+  the whole Ethiopia tree -- it covers ESS1, ESS2 and ESS3).
+- The six small regions, restated by the BID as a precision limit (printed
+  p. 13):
+
+  #+begin_quote
+  The sample size is insufficient to support region-specific estimates for each of the small regions including Afar, Benshangul Gumuz, Dire Dawa, Gambella, Harari, and Somalie regions. However, estimates can be produced for a combination of all smaller regions as one “other region” category.
+  #+end_quote
+
+  and by the survey report
+  (=lsms_library/countries/Ethiopia/2015-16/Documentation/9331_ethiopia_survey_report_web_final.pdf=;
+  the quote is reassembled across the report's hyphenated line breaks, wording
+  unaltered):
+
+  #+begin_quote
+  The results presented have been weighted to be nationally representative for rural areas, small towns, and large towns. For regional estimates, results are presented for five regions and the remaining six regions (Afar, Benshangul-Gumuz, Dire Dawa, Gambella, Harari and Somali regions) are grouped into an “other region” category.
+  #+end_quote
+
+*** 2018-19 (ESS4) -- catalog only, and the statement is template text
+
+*The universe statement for this wave exists in no file this repo ships.*  The
+local DDI (=ddi-documentation-english_microdata-3823.pdf=, 14 pp.) is a stub:
+it contains only the documentation/questionnaire listing and a variable index,
+with no Overview or Coverage section.  The ESS4 Basic Information Document,
+which the catalog and the local DDI both reference, is *not in the repo*.
+
+Verbatim from WB Microdata catalog entry 3823
+(https://microdata.worldbank.org/index.php/catalog/3823 , JSON field
+=study_desc.study_info.universe=):
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.
+#+end_quote
+
+*BOILERPLATE WARNING.*  That sentence is World Bank NADA template text.  It
+appears verbatim in *15 waves* across this library -- the eight WAEMU/EHCVM
+countries, Nigeria 2015-16 / 2018-19 / 2023-24, and both Ethiopia Panel II
+waves.  It attests which metadata template the catalogue entry was filled from.
+It does *not* independently attest that the Ethiopian Statistical Service made
+that claim about this survey.  Do not treat it as a statistical office's
+declaration of the ESS4 universe.
+
+The substantive coverage statement in the same record
+(=series_statement.series_info=) is more informative and is Ethiopia-specific:
+
+#+begin_quote
+The 2018/19 ESS (ESS4) is a new panel. It is not a follow-up of the previous ESS waves. It is a baseline survey for the next ESS waves. It covers all nine regional states and two administrative cities, Addis Ababa and Dire Dawa. ESS4 is conducted in 565 EAs and of which 316 are rural and 219 are urban. The difference between ESS4 and previous ESS waves is that its coverage; ESS4 is representative at regional level in addition to rural and urban level.
+#+end_quote
+
+(=study_info.geog_coverage= reads, in full: "National / Regional / Urban and
+Rural".)
+
+**** Exclusions (2018-19)
+
+- *Population* -- prisons, hospitals, military barracks and school dormitories,
+  per the boilerplate universe sentence above.  This is the only ESS wave whose
+  documentation states an institutional-population exclusion at all; whether
+  Panel I excluded them too is *not recorded anywhere we could find* and must
+  not be assumed.
+- *Not a design exclusion* -- 30 EAs were dropped in the field.  The catalog's
+  =method.analysis_info.response_rate= is explicit that this is an
+  implementation shortfall:
+
+  #+begin_quote
+  ESS4 planned to interview 7,527 households from 565 enumeration areas (EAs) (Rural 316 EAs and Urban 249 EAs). A total of 6770 households from 535 EAs were interviewed for both the agriculture and household modules. The household module was not implemented in 30 EAs due to security reasons (See the Basic Information Document for additional information on survey implementation).
+  #+end_quote
+
+- *No statement found* on whether the nine Afar/Somali zones remain outside the
+  ESS4 frame.  The ESS4 frame is described as "the updated 2018 pre-census
+  cartographic database of enumeration areas", and neither the catalog record
+  nor any local file says whether the Panel I zone exclusion carried over.
+  Searched: the wave's =Documentation/= (SOURCE.org, LICENSE.org, the DDI stub,
+  all four questionnaire sidecars) and the full catalog JSON for id 3823.  The
+  ESS4 BID would answer it and is not in the repo.  *Recorded as a gap, not
+  resolved by inheritance from ESS1-ESS3.*
+
+*** 2021-22 (ESPS-5) -- catalog only, and Tigray is outside the represented population
+
+*This wave has no local documentation whatsoever* -- its =Documentation/=
+directory contains only =LICENSE=, =SOURCE= and =SOURCE.org=, no PDFs and no
+=.dvc= sidecars for any document.  The WB catalog is the sole source, which
+makes the record for this wave a moving target rather than something the
+library holds.  The ESPS-5 BID (referenced repeatedly by the catalog) is not in
+the repo and should be acquired.
+
+Verbatim from WB Microdata catalog entry 6161
+(https://microdata.worldbank.org/index.php/catalog/6161 ,
+=study_desc.study_info.universe=) -- *the same NADA boilerplate as ESS4; the
+warning above applies identically*:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.
+#+end_quote
+
+=series_statement.series_info=, same record:
+
+#+begin_quote
+ESPS-5 covers all regions of the country except Tigray. Therefore, the survey is nationally representative and provides national and regional estimates for rural and urban areas except for Tigray.
+#+end_quote
+
+**** Exclusions (2021-22)
+
+- *Tigray -- and it is a universe exclusion, not non-response.*  It takes the
+  weighting statement to establish this.  =method.data_collection.weight=:
+
+  #+begin_quote
+  Accordingly, ESPS-5 cross-sectional weights were calculated to represent the 2021/22 Ethiopia population (excluding Tigray) at regional and rural/urban levels.
+  #+end_quote
+
+  The weights do not attempt to reweight Tigray back in.  Tigray is outside the
+  *represented* population of this wave.  Anyone pooling 2021-22 with earlier
+  waves, or differencing against 2018-19, is comparing two different
+  populations unless they drop Tigray from the other waves too.
+
+- *Sample carried forward minus Tigray* --
+  =method.data_collection.sampling_procedure=:
+
+  #+begin_quote
+  The ESPS-5 kept all the ESPS-4 samples except for those in the Tigray region and a few other places.
+  #+end_quote
+
+  Note "and a few other places" is not itemised anywhere in the catalog record.
+
+- *Afar, Amhara and Oromia -- fieldwork shortfall, NOT frame exclusion.*  The
+  catalog is careful about the distinction and so should we
+  (=method.analysis_info.response_rate=):
+
+  #+begin_quote
+  ESPS-5 planned to interview 7,527 households from 565 enumeration areas (EAs) (Rural 316 EAs and Urban 249 EAs). However, due to the security situation in northern Ethiopia and to a lesser extent in the western part of the country, only a total of 4999 households from 438 EAs were interviewed for both the agriculture and household modules. The security situation in northern parts of Ethiopia meant that, in Tigray, ESPS-5 did not cover any of the EAs and households previously sampled. In Afar, while 275 households in 44 EAs had been covered by both the ESPS-4 agriculture and household modules, in ESPS-5 only 252 households in 22 EAs were covered by both modules. During the fifth wave, security was also a problem in both the Amhara and Oromia regions, so there was a comparable reduction in the number of households and EAs covered there.
+  #+end_quote
+
+- *Population* -- the institutional exclusion, from the boilerplate sentence.
+
+** Sub-samples and oversamples INSIDE a wave
+
+Ethiopia's specialization is entirely internal to waves.  There is no
+special-population wave; there are three distinct structures living inside the
+ordinary ones, and a user who averages across them without noticing will get
+the wrong answer.
+
+*** 1. Every rural EA is 10/12 agricultural BY DESIGN (all five waves)
+
+The rural sample is not a simple draw of rural households.  It is drawn from
+the Agricultural Sample Survey's household sample, topped up with exactly two
+non-agricultural households.  ESS1 DDI (2053), PDF p. 3, verbatim:
+
+#+begin_quote
+The second stage of sampling was the selection of households to be interviewed in each EA. For rural EAs, a total of 12 households are sampled in each EA. Of these, 10 households were randomly selected from the sample of 30 AgSS households. The AgSS households are households which are involved in farming or livestock activities. Another 2 households were randomly selected from all other households in the rural EA (those not involved in agriculture or livestock). In some EAs, there is only one or no such households, in which case, less than two non-agricultural households were surveyed and more agricultural households were interviewed instead so that the total number of households per EA remains the same.
+#+end_quote
+
+The same 10 + 2 structure is still in force in ESPS-5, per catalog 6161
+=sampling_procedure=:
+
+#+begin_quote
+From the rural EAs, 10 agricultural households are selected as a subsample of the households selected for the AgSS, and 2 non-agricultural households are selected from the non-agriculture households list in that specific EA.
+#+end_quote
+
+So farm households are *structurally oversampled within every rural EA*, in
+every wave, and the fallback rule above means the agricultural share rises
+above 10/12 in sparse EAs.  Unweighted rural means are not rural-population
+means.  Small-town and urban EAs have no such stratification (12 per small-town
+EA, 15 per large-town EA, drawn without regard to economic activity).
+
+*** 2. ESS2/ESS3 carry a panel AND a fresh urban cross-section in one wave
+
+The 100 large-town EAs added in ESS2 are a new independent draw, not a
+follow-up.  ESS2 DDI (2247), PDF p. 6, "Sampling Procedure", verbatim:
+
+#+begin_quote
+ESS is designed to collect panel data in rural and urban areas on a range of household and community level characteristics linked to agricultural activities. The first wave was implemented in 2011-12 and the second wave is implemented in 2013-14. The first wave, ERSS, covered only rural and small town areas. The second wave, ESS, added samples from large town areas. The second wave is nationally representative. The existing panel data (2011/12-2013/14) is only for rural and small towns. Large towns were added during the second wave and, so far, there is only one round.
+#+end_quote
+
+Same page: "A total of 3,776 panel households and 1,486 new households (total
+5,262 households) were interviewed with a response rate of 96.2 percent."  So a
+single library wave =2013-14= mixes a rural/small-town *panel* cohort with an
+urban *refreshment* cohort that has no wave-1 antecedent.
+
+This is visible in the config, and is already documented elsewhere in this
+file: see "GH #323 ... individual_education (2013-14, 2015-16)", where
+=household_id= / =individual_id= are blank for exactly that urban refreshment
+sample (5,248 of 23,785 rows in =sect2_hh_w2.dta=).  The documentary statement
+above is the *reason* those ids are blank.  Cross-reference, do not duplicate.
+
+*** 3. ESS4 is a NEW panel -- Panel I and Panel II do not link
+
+Catalog 3823, =series_info=: "The 2018/19 ESS (ESS4) is a new panel. It is not
+a follow-up of the previous ESS waves. It is a baseline survey for the next ESS
+waves."  The same record names the two panels: "The ESS panel from ESS1, ESS2
+and ESS3 is referred as Panel I and the subsequent rounds as Panel II."
+
+Consequence for this library: 2011-12 / 2013-14 / 2015-16 form one panel and
+2018-19 / 2021-22 form another.  The five waves are *not* one five-round panel,
+whatever =panel_ids= manages to chain together within each half.
+
+** Universe vs. what the weights represent
+
+The documents keep these apart, and for Ethiopia they come apart in two places:
+
+| Wave    | Declared universe                        | What the weights are stated to represent                      |
+|---------+------------------------------------------+---------------------------------------------------------------|
+| 2013-14 | (no universe field in DDI or catalog)    | "the national-level population of rural, small and large town households" (DDI 2247, "Weighting", PDF p. 7) |
+| 2021-22 | "all de jure households excluding prisons, hospitals, military barracks, and school dormitories" | "the 2021/22 Ethiopia population (excluding Tigray)" (catalog 6161, =weight=) |
+
+The 2021-22 row is the sharp one: the universe sentence says "all de jure
+households" and the weighting sentence says "excluding Tigray".  Both are in
+the same catalog record.  Taking only the =universe= field would record this
+wave as covering a population it explicitly does not cover.
+
+** Where the statements live
+
+| Wave    | Local file in this repo?            | Field actually labelled "Universe"? |
+|---------+-------------------------------------+-------------------------------------|
+| 2011-12 | yes -- DDI 2053 (partial print, 16 pp.) | no (Sampling Procedure only)    |
+| 2013-14 | yes -- DDI 2247                     | no (Geographic Coverage only)       |
+| 2015-16 | yes -- DDI 2783 + BID + survey report | *yes*                             |
+| 2018-19 | *no* -- local DDI is a stub          | catalog only                       |
+| 2021-22 | *no* -- no documentation at all       | catalog only                       |
+
+Two documents would close most of the remaining gaps and are *not* in the repo:
+
+- ESS4 Basic Information Document ("Basic Information Document, Ethiopia
+  Socioeconomic Survey 2018-19 V2.pdf", catalog 3823, Related Materials).
+- ESPS-5 Basic Information Document (catalog 6161 refers to "Section 3 of the
+  Basic Information Document provided under the Related Materials tab").
+
+Worth acquiring: they are the only plausible source for (a) whether the
+nine-zone frame exclusion survives into Panel II, and (b) the ESPS-5
+longitudinal-weight construction.
+
+** Relation to =* Sampling Design= above
+
+Three points of contact.  None of them is silently reconciled here.
+
+1. *Extends.*  The =* Sampling Design > Overview= paragraph says the ESS covers
+   "rural and small-town areas in waves 1-3, expanding to include all urban
+   areas from wave 2 onward".  The two halves of that sentence pull against
+   each other, and the documentation supports only the second: the rural /
+   small-town-only restriction applies to *wave 1 alone*.  ESS3's own DDI says
+   "ESS2 and ESS3 covered all regional states including the capital, Addis
+   Ababa" (2783, PDF p. 3) and its =UNIVERSE= field says the urban areas
+   "include both small and large towns".  Suggested reading of that sentence:
+   "covering rural and small-town areas in wave 1, expanding to include all
+   urban areas from wave 2 onward".  Flagged, not edited.
+
+2. *Corroborates.*  The strata table's "2021-22 ... Tigray excluded (conflict)"
+   and the household-count table's "4959 | Tigray excluded due to conflict" are
+   both confirmed by the catalog -- and strengthened: Tigray is excluded from
+   the *represented population*, not merely from fieldwork (see the weighting
+   quote above).  The parenthetical "(conflict)" is right about the cause and
+   understates the consequence.
+
+3. *Tension, unresolved.*  =* Sampling Design > Sampling Weights= states "Each
+   wave provides a single weight variable; there is no separate panel weight",
+   and the =sample= table accordingly carries the same values in =weight= and
+   =panel_weight=.  The ESPS-5 catalog record says otherwise about the
+   *release*:
+
+   #+begin_quote
+   In order to cater to both kinds of analysis, separate cross-sectional and longitudinal weights were calculated and included in the ESPS-5 data.
+   #+end_quote
+
+   (catalog 6161, =method.data_collection.weight=).  These are not necessarily
+   in contradiction -- the CONTENTS claim is about the columns the config reads
+   from the cover file, the catalog claim is about what the ESPS-5 release
+   contains -- but if a longitudinal weight ships in the 2021-22 data and the
+   config is reading only =pw_w5=, then =panel_weight= for that wave is wrong.
+   *Someone should check which weight variables the ESPS-5 release actually
+   carries.*  Recorded as an open question; not resolved here, and deliberately
+   not settled by opening the =.dta=, which is a different exercise from
+   reading what the survey claims.
+
+** Verification note
+
+Quotes above were re-extracted from the cited PDFs and the cited catalog JSON
+on 2026-07-21 and matched character-for-character, with two declared repairs:
+the ESS3 survey-report quote is reassembled across the report's hyphenated line
+breaks, and all quotes have justified-text whitespace collapsed.  The BID's
+footnote 13 really does use a double hyphen ("frame -- zones 2, 4, and 5"), not
+a dash; it is reproduced as printed.  Two exclusion sentences that the original
+sweep attributed to the WB catalog (the 2013-14 "small regions" sentence) were
+found to exist *locally* in the wave's own DDI and are cited to the local file
+here instead.
+
 * plot_features (GH #167)
 
 ESS land characteristics, one row per FIELD, index =(t, i, plot_id)=.

--- a/lsms_library/countries/EthiopiaRHS/_/CONTENTS.org
+++ b/lsms_library/countries/EthiopiaRHS/_/CONTENTS.org
@@ -260,6 +260,388 @@ files are the R6 slice.
   R6/R7 area_output PAs 21-23 (extra Debre-Birhan sub-sites not in the
   erhs_village_* Code tables -> NaN Region/Woreda/v).
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered for GH #601 (population statements).  This section records
+what the ERHS documentation *claims* about the population its samples
+represent.  It is deliberately kept apart from what the data look like: no
+statement below is inferred from a =.dta=.  Nothing here proposes a schema --
+representation is GH #603's question, not this section's.
+
+** Where the statement lives
+
+All eight waves' universe evidence comes from ONE document, held in this
+repository:
+
+- Title :: "The Ethiopian Rural Household Surveys 1989-2009: Introduction",
+     Stefan Dercon and John Hoddinott, July 20, 2011.
+- Path :: =<wave>/Documentation/Overview and Acknowledgements and Data Description.pdf=
+- Note :: the file is byte-identical in all eight wave =Documentation/=
+     directories (md5 =bd61f8994668f4fb143daae09ad6d34b=, verified), and it
+     covers rounds 1989-2009 as a single narrative.
+
+Two consequences worth stating plainly:
+
+1. *This is local documentation, not catalog metadata.*  ERHS is not a World
+   Bank survey (=discoverable=False= in =_COUNTRY_CATALOG=; provenance is the
+   IFPRI Dataverse DOI =10.7910/DVN/T8G8IV=, see "Data Source" above).  There
+   is therefore no WB NADA record to fall back on -- and, correspondingly,
+   *none of the WB NADA boilerplate.*  In particular the corpus-wide template
+   sentence "The survey covered all de jure households excluding prisons,
+   hospitals, military barracks, and school dormitories" (verbatim in 15 waves
+   elsewhere in the library) does NOT appear here.  What is quoted below is an
+   authored statement by the survey's own principal investigators.
+2. *The universe is stated once, for the series, not once per round.*  Only
+   1989 and 1999 have any round-specific coverage language.  For 1994b, 1995,
+   1997, 2004 and 2009 the statement below is inherited, not restated -- see
+   "Gaps" at the end of this section.
+
+All quotes are verbatim from the PDF text layer, with typographic apostrophes
+normalized to ASCII =\'= per the repo's ASCII convention; no other change.
+
+** The declared universe (1994 onward: rounds R1-R7)
+
+Section 3 "Overview of the surveys", printed p. 8, the paragraph immediately
+preceding Table 1:
+
+#+begin_quote
+To be clear, these data are not nationally representative. However, they can be
+considered broadly representative of households in non-pastoralist farming
+systems as of 1994. With only 15 communities, but relatively large samples
+within each village, the interpretation of the results in terms of rural
+Ethiopia as a whole has to be done with care.
+#+end_quote
+
+This is one of only three waves-worth of documentation in the whole library
+that *denies* a well-defined national universe outright (the others being China
+1995-97 and Albania 1996).  It is not a hedge appended to a national claim; it
+is the claim.  *Anyone pooling EthiopiaRHS with nationally representative LSMS
+waves is pooling across that denial*, and the documentation says so before it
+says anything else about representativeness.
+
+The positive claim it does make -- "broadly representative of households in
+non-pastoralist farming systems as of 1994" -- is (a) a *farming-system*
+universe, not an administrative or national one, and (b) explicitly anchored to
+*1994*, i.e. it is not restated for the later rounds.
+
+Frame construction, same document, Section 1 (p. 2) and Section 3 (pp. 6-7):
+
+#+begin_quote
+In 1994, the survey was expanded to cover 15 villages across the country.1 An
+additional round was conducted in late 1994, with further rounds in 1995, 1997,
+1999, 2004 and 2009. In addition, nine new villages were selected giving a
+sample of 1477 households. The nine additional communities were selected to
+account for the diversity in the farming systems in the country, including the
+grain-plough areas of the Northern and Central highlands, the enset-growing
+areas and the sorghum-hoe areas.
+#+end_quote
+
+Footnote 1 (p. 2) fixes the unit that "village" denotes throughout:
+
+#+begin_quote
+In Ethiopia, the smallest unit of aggregation is the Peasant Association, an
+administrative unit of one or a small number of villages. In this
+documentation, we use "Peasant Association" and "village" interchangeably.
+#+end_quote
+
+Sampling within the frame, Section 3, p. 7:
+
+#+begin_quote
+A list of all households was constructed with the help of the local Peasant
+Association (PA) officials. ... In virtually all villages, therefore, there were
+good lists of the households in the village which could be used as a sampling
+frame.
+#+end_quote
+
+#+begin_quote
+Within each village, random sampling was used, stratified by female headed and
+non-female headed households, including (as explained above) an attempt to
+re-randomize the 1989 study villages, via extra sampling from new entrants,
+splits and newly formed households.
+#+end_quote
+
+And the document's own scale caveat on the village frame (Section 3, p. 7):
+
+#+begin_quote
+While in the context of sampling theory, one could argue that the sampling
+frame to select the villages was strictly stratified in the main agro-ecological
+zones and sub-zones, and one to three villages per strata was selected, it
+should be remembered that we have sampled only 15 of the thousands of villages
+in rural Ethiopia.
+#+end_quote
+
+** The declared universe (1989: the pre-expansion IFPRI round)
+
+1989 is a *different frame* with a *different purpose*, and the document says so
+directly.  Section 3, printed p. 6, first paragraph (the same sentences appear
+in Section 1, p. 2):
+
+#+begin_quote
+In 1989, IFPRI conducted a survey in seven Peasant Associations located in the
+regions Amhara, Oromiya and the Southern Ethiopian People's Association (now
+called SNNPR), see Webb, von Braun and Yohannes (1992). Civil conflict prevented
+survey work from being undertaken in Tigray. Under extremely difficult field
+conditions, household data were collected in order to study the response of
+households to food crises. The study collected consumption, asset and income
+data on about 450 households. Households were randomly selected within each
+Peasant Association, while the Peasant Associations selected were mainly areas
+that had suffered from the 1984-1985 famine and other droughts that followed
+between 1987 and 1989. At least four of the areas are considered particularly
+vulnerable, while two (Debre Berhan and Adele Keke) may be less vulnerable but
+still suffered from the famine (See also Dercon and Krishnan 1995).
+#+end_quote
+
+The 1989 village selection is therefore *purposive and famine-targeted*
+("mainly areas that had suffered from the 1984-1985 famine"), with random
+selection only *within* the chosen Peasant Associations.  1989 is NOT covered by
+the 1994 self-weighting-by-farming-system design (see below), and the document
+states its frame deviates from population shares -- Section 3, p. 8:
+
+#+begin_quote
+For the 1989 sample, however, the sampling proportions deviate from the
+population shares due to the absence of Northern Highland villages that were
+inaccessible because of war activity.
+#+end_quote
+
+** Exclusions
+
+These are what a reader pooling this country most needs before averaging
+anything.
+
+| Wave       | Exclusion                                                    | Basis stated in the document           |
+|------------+--------------------------------------------------------------+----------------------------------------|
+| 1989       | Tigray region entirely                                       | civil conflict / war activity          |
+| 1989       | Northern Highland villages                                   | inaccessible because of war activity   |
+| 1994a-2009 | pastoralist farming systems (~10% of the rural population)   | universe is non-pastoralist systems    |
+| 1994a-2009 | one 1989 village, semi-pastoralist, Southern Ethiopia        | violent conflict in the area           |
+| 2004       | the three villages added in 1999 (Oda Dawata, Bako Tibe, Somodo) | insufficient funding              |
+| all        | urban Ethiopia (in fact; see the caveat below)               | *not stated as a universe exclusion*   |
+
+Verbatim, in order.
+
+Security / conflict, 1989 (Section 3, p. 6; also Section 1, p. 2):
+
+#+begin_quote
+Civil conflict prevented survey work from being undertaken in Tigray.
+#+end_quote
+
+Security / conflict, at the 1994 restart (Section 3, pp. 6-7):
+
+#+begin_quote
+In 1994, CSAE and Economics/AAU started a panel survey incorporating six of the
+seven villages earlier surveyed in 1989 by IFPRI. (The remaining village in a
+semi-pastoralist area in Southern Ethiopia could not be revisited again because
+of violent conflict in the area).
+#+end_quote
+
+Population exclusion -- pastoralists.  The universe sentence excludes them by
+construction ("non-pastoralist farming systems"), and the footnote to Table 1
+(p. 8) sizes what that leaves out:
+
+#+begin_quote
+percentage of rural sedentary population;  pastoralist   population is about 10
+percent of total rural pop.
+#+end_quote
+
+That is: the population shares against which the sample is benchmarked in
+Table 1 are shares of the *rural sedentary* population, and the pastoralist
+population -- about a tenth of rural Ethiopia -- is outside the declared
+universe altogether.
+
+Funding exclusion, 2004 (Section 2 viii "The number of villages (2)", p. 6):
+
+#+begin_quote
+There was not sufficient funding to re-survey these villages in 2004.
+#+end_quote
+
+*Urban -- a deliberate non-claim.*  Every ERHS village is rural and the survey
+is titled "Rural Household Survey", but the documentation never states an
+urban exclusion as a universe statement; the closest it comes is calling the
+data "broadly representative of households in non-pastoralist farming systems".
+That distinction is preserved here on purpose: what the survey covers in fact
+and what it declares are two different facts, and the library's =sample=
+table already sets =Rural = 'Rural'= for every ERHS household as a *survey
+property* (see the Status notes above), which is an in-repo assertion, not a
+quotation.
+
+** Oversamples and sub-populations
+
+Specialization in ERHS lives *inside* the series rather than as a whole wave,
+which is the pattern the #601 sweep found across the library.  Four items, all
+documented:
+
+1. *Stratified oversampling of female-headed households, within every village*
+   (Section 3, p. 7).  This is a design stratum, not an incidental split:
+
+   #+begin_quote
+   Similarly, we made sure that an exact proportion of female headed households
+   were included via stratification.
+   #+end_quote
+
+2. *Stratified inclusion of landless households, within every village*
+   (Section 3, p. 7):
+
+   #+begin_quote
+   It had been suggested that in some areas landlessness is increasing, since
+   with the absence of redistribution and a ban on land sales and rental against
+   fixed payment no legal mechanisms exist for young households to acquire land
+   in land constrained areas. To make sure that these households were properly
+   represented we stratified the sample within each village to ensure a
+   representative number of landless households to be included. In practice, in
+   most areas this resulted only in a very small number of landless households to
+   be included.
+   #+end_quote
+
+3. *1999 (R5) carries three extra villages that no other round has*, added for a
+   round-specific purpose and dropped afterwards (Section 2 viii, p. 6):
+
+   #+begin_quote
+   In 1999, three additional villages - Oda Dawata, Bako Tibe and Somodo were
+   surveyed. The principal focus of the 1999 survey round was agricultural
+   productivity interest and it was felt that adding villages in higher
+   productivity villages would be informative. There was not sufficient funding
+   to re-survey these villages in 2004.
+   #+end_quote
+
+   The document gives the *rationale* for the extension but does NOT restate a
+   revised universe for the enlarged 1999 sample.  So 1999's recorded universe
+   is the series statement PLUS this documented, high-productivity, purposively
+   added three-village extension -- an extension that is, on the document's own
+   account, selected for being *unrepresentative* of the panel villages.  A
+   1999-vs-other-round comparison that does not hold the village set fixed is
+   comparing different frames.
+
+4. *The 1994 round is partly a panel continuation and partly a fresh draw*, and
+   the two halves have different histories: six villages carried over from the
+   purposive 1989 famine-vulnerability frame (with a re-randomization attempt),
+   plus nine newly selected villages.  Section 3, pp. 6-7:
+
+   #+begin_quote
+   In these villages, an attempt was made to re-randomize the sample by including
+   an exact proportion of newly formed or arrived households in the sample, as
+   well by replacing the lost households by households which were considered by
+   village elders and officials as broadly similar to in demographic and wealth
+   terms as the households which could not be traced.
+   #+end_quote
+
+   Tracing rule (Section 3, p. 6):
+
+   #+begin_quote
+   the tracing rule was based on the definition of a panel household, a household
+   that had still members of the 1989 household living in the village.
+   #+end_quote
+
+** Universe vs. what the weights represent
+
+The documentation and the library's =sample= table come apart here, and the gap
+is worth naming explicitly rather than leaving to be rediscovered.
+
+What the document claims (Section 3; the sentence straddles the printed p. 7 /
+p. 8 break) is a design property, not a set of expansion factors:
+
+#+begin_quote
+Sampling size in each village was governed by an attempt to obtain a
+self-weighting sample, when considered in terms of farming system: each person
+(approximately) represents the same number of persons from the main farming
+systems. The advantage is that pooling of the data is simplified, although
+alternative procedures could easily have been implemented.
+#+end_quote
+
+And it states plainly that the ingredients for weighting are missing
+(Section 3, p. 7):
+
+#+begin_quote
+The information available for ex-ante or ex-post weighing of the sample when
+pooled is limited. The available population figures for Ethiopia at the time of
+the survey were based on a questionable census of 1984, while linking farming
+systems to population figures turned out not to be straightforward.
+#+end_quote
+
+This *corroborates* -- it does not contradict -- the decision recorded in the
+Status section above, that =weight= / =panel_weight= are set to a uniform 1.0
+and are "Explicitly NOT expansion factors".  The documentary basis for that
+choice is the two quotes here; cross-reference rather than duplicate.  Note the
+scope, though: self-weighting is claimed *in terms of farming system*, and
+*for the 1994 frame only*.  It is not claimed for 1989, whose sampling
+proportions the document says deviate from population shares (quoted above).
+
+The library's =sample()= covers 1989 on the same uniform-1.0 basis as the
+1994+ waves; the documentation gives no warrant for treating the 1989 draw as
+self-weighting, so a pooled 1989 + 1994-onward computation is mixing a
+purposive famine-targeted frame with a self-weighted-by-farming-system one.
+
+** Gaps -- recorded as gaps
+
+Recorded per the repo's standing rule against unevidenced claims.  "No
+statement found" below means *searched and not present*, not *does not exist*.
+
+- 1994b (R2), 1995 (R3), 1997 (R4), 2004 (R6) :: no round-specific universe
+     statement exists in any file in this repo.  These waves inherit the single
+     series statement quoted above.  Searched, per wave: the full
+     =<wave>/Documentation/= listing; =Overview and Acknowledgements and Data
+     Description.pdf= (identical copy, extracted in full and grepped for
+     represent / sampl / universe / population / random / stratif); the wave's
+     =ERHS_hhquestionnaire_<wave>.pdf= front matter; =Table of Contents.pdf=;
+     =Documentation/SOURCE.org=; this file.  The document treats the later
+     rounds as revisits, and what it says changes across rounds is *attrition*,
+     not universe (Section 2 ix, p. 6: "Just under 8 per cent of the sample was
+     lost between 1994 and 1999, and a further 5.2 percent were lost from 1999
+     and 2004.").
+- 2009 (R7) :: *medium confidence, and the reason matters.*  The document is
+     dated July 20, 2011, its title spans 1989-2009, and Section 1 (p. 2) lists
+     2009 among the rounds -- so the series universe statement is documented as
+     covering R7.  But the body of the document predates the 2009 release; at
+     Section 2 v "Other survey rounds" (p. 5) it says only:
+
+     #+begin_quote
+     Data have also been collected in 2009. This data will be made available in
+     the future.
+     #+end_quote
+
+     There is *no* 2009-specific description of coverage, village count, or
+     exclusions anywhere in this repository.  Whether the 15-village frame was
+     re-surveyed in full in 2009 is *not stated in any document we hold*.  The
+     nearest thing to a 2009 coverage statement is =Table of Contents.pdf=,
+     which records "19 files in Excel format with data on the 15 communities
+     surveyed in Round 7 (2009) of the survey" -- a file-inventory line about the
+     community module, not a household universe.  Searched: full
+     =2009/Documentation/= listing; the overview PDF extracted in full (3421
+     lines) and grepped, including for "2009"; =ERHS_hhquestionnaire_2009.pdf=
+     front matter (cover + interview log); =Table of Contents.pdf=;
+     =Documentation/SOURCE.org=; =EthiopiaRHS/2009.txt=; this file.
+- 1989 questionnaire :: =ERHS_hhquestionnaire_1989.pdf= yields no extractable
+     text (scanned image), so it could not be searched for a universe or
+     eligibility statement.  Recorded so a future reader with OCR knows this
+     stone is unturned.
+- Module-level sub-universes :: not documented.  The overview notes only that
+     "The data collection was a complicated process, using different
+     questionnaires - which contained common parts - for the different Peasant
+     Associations" (Section 4, p. 12), which is an instrument-variation
+     statement, not a per-module universe.  Whether particular modules were
+     administered to sub-samples is unrecorded either way.
+- Community-level unit :: the 2004 community instrument does define its own
+     unit -- "For this questionnaire, the community is defined as the peasant
+     association (PA), but we want to know information about locally well-defined
+     neighborhoods as well" (=ERHS_Community Questionnaire 2004.pdf=,
+     "Instructions to enumerators", p. 1) -- but this is the community module's
+     observation unit, not the household universe.
+
+** Two numeric discrepancies noticed while checking (not resolved here)
+
+Flagged, not fixed; both are in the source or in this file's own earlier prose,
+and neither is settled by the evidence gathered for #601.
+
+1. *Household count.*  The documentation says the 1994 expansion gives "a sample
+   of 1477 households" (Section 1, p. 2, and Section 3, p. 7 -- 1477 in both
+   places).  The "Survey Program" section above says "~1,494 households".  The
+   documentation's figure is 1477; where 1,494 came from is not recorded.
+2. *1989 village count.*  The document is internally inconsistent: Section 1
+   (p. 2) says "a team visited 6 farming villages in Central and Southern
+   Ethiopia" and then, two sentences later, "IFPRI conducted a survey in seven
+   Peasant Associations".  The "6--7 villages" phrasing in the "Survey Program"
+   section above faithfully tracks that inconsistency; it is the document's, not
+   ours.
+
 * food_acquired grain: repeat lines, double-punches (GH #323)
 
 The q36 food module is a ONE-ROW-PER-FOOD-ITEM roster.  All 27 source

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -102,6 +102,601 @@ NaN for that wave.  The cluster-level =loc2= is available in
 | GLSS6 | =PARTA/g6loc_edt.dta= | =HID= | =clust= | =weight= | =region= | =loc2= |
 | GLSS7 | =g7sec0.dta=     | =[clust,nh]= | =clust= | =WTA_S= | =region= | =urbrur= |
 
+* Sampling universe, exclusions and sub-samples
+
+# ASCII EXCEPTION (deliberate): the blocks inside #+begin_quote below are
+# VERBATIM transcriptions of GSS survey documentation.  One of them carries a
+# non-ASCII character as printed: the en dash in the GLSS6 SADA sentence
+# ("respectively -an").  It is NOT normalised, because normalising it would
+# destroy the one property that makes the quote evidence.  Everything else in
+# this section, inside quotes and out, is ASCII.
+
+Evidence gathered for GH #601 (the population record) from a documentation
+sweep on 2026-07-21; see =slurm_logs/POPULATION_STATEMENTS_2026-07-21.org= on
+branch =docs/601-population-statements= for the cross-country context.  Every
+quote below was re-verified against its cited source file before being written
+here.
+
+Three rules govern this section, and they are what make it usable:
+
+- *Verbatim or nothing.*  Source typography is preserved as printed, including
+  the sic spellings (="Education :"=, ="Agriculture:holders"=, ="covers region ,
+  zones"=) and the missing spaces (="(PSUs).The universe"=).  Nothing was
+  silently corrected.
+- *Nothing is inferred from the data.*  No =.dta= file was opened.  What a
+  survey /claims/ its sample represents and what its microdata look like are
+  two different facts, and this section records only the first.
+- *Gaps are recorded as gaps*, with what was searched, so the claim is
+  falsifiable.
+
+/Transcription note, applying to every quote below./  These are PDF and =.docx=
+sources.  Where a PDF's justified line-wrapping produced runs of spaces or
+split a word across lines (=socio- economic=), the whitespace was rejoined; and
+superscript footnote markers were dropped.  Nothing else was changed: wording,
+punctuation, sic spellings, missing spaces and stray spaces are exactly as
+printed.  One source (GLSS1) required a font decode; that is declared at the
+point of use.
+
+This section is about what the *documentation declares*.  It is deliberately
+separate from, and complementary to, =Sampling Design= above (which describes
+the mechanics as implemented in the data) and =Panel Linkage (GLSS1 to GLSS2)=
+below (which is derived from =PANELC.DAT=, not from documentation).  Where the
+documentation and those sections come apart, see /Tensions with the existing
+text/ at the end -- flagged, quoted on both sides, and *not* resolved here.
+
+No schema is proposed.  GH #603 decides how the library represents any of this.
+
+** Summary
+
+| Wave    | Round | Declared unit of the universe   | Where the statement lives           | Explicit exclusion?     | Confidence |
+|---------+-------+---------------------------------+-------------------------------------+-------------------------+------------|
+| 1987-88 | GLSS1 | persons ("all household members") | local DDI overview PDF (in repo)  | none found              | high       |
+| 1988-89 | GLSS2 | persons (circular -- see below)  | local DDI PDF (in repo)             | none found              | high       |
+| 1991-92 | GLSS3 | persons, per module              | local DDI PDF (in repo)             | yes -- 1 EA, chiefs     | high       |
+| 1998-99 | GLSS4 | households (coverage claim only) | local DDI PDF (in repo)             | none found              | high       |
+| 2005-06 | GLSS5 | population in private households | local DDI PDF (in repo)             | yes -- institutional    | high       |
+| 2012-13 | GLSS6 | population in individual households | local main report (in repo)      | yes -- institutional    | high       |
+| 2016-17 | GLSS7 | persons in private households    | local interviewers' manual (in repo) | none found             | medium     |
+
+Two facts about this table are worth stating plainly.
+
+*Every GLSS universe statement is in a file this repository ships.*  None of
+the seven waves is in the position of the 41-of-111 waves elsewhere in the
+library whose only population statement lives in World Bank catalog metadata.
+That matters: the record here is something the library holds, not a moving
+target on someone else's server.  Note also that for four of the seven waves
+the *World Bank* catalog entry named in =SOURCE.org= (2313, 2314, 2315, 2331)
+carries *no* Universe field at all -- the statements come from the Ghana
+Statistical Service NADA DDI PDFs shipped in each wave's =Documentation/=.
+
+*None of these is World Bank NADA boilerplate.*  The single most-repeated
+sentence in the cross-country corpus ("The survey covered all de jure
+households excluding prisons, hospitals, military barracks, and school
+dormitories.", verbatim in 15 waves) appears in *no* GLSS round.  Every
+sentence quoted below is GSS's own text about this survey.
+
+** The declared universe, per wave
+
+*** 1987-88 (GLSS1)
+
+Source: =1987-88/Documentation/GLSS 1987-88 Report.pdf=, section "Scope &
+Coverage" -> "Universe", PDF page 10 (printed "- 2 -").  Despite the filename,
+this file is the GSS NADA DDI study-documentation overview for GLSS 1, not a
+substantive report.
+
+#+begin_quote
+Universe
+
+The survey covered all household members of all age and sex category who reside in Ghana.
+#+end_quote
+
+/Transcription caveat:/ this PDF's text layer is a CID-encoded subset font with
+no ToUnicode map, so naive extraction yields =(cid:NN)= garbage.  The glyph map
+was reconstructed from cribs and the page decoded; the decode was reproduced
+independently during verification, and the resulting sentence is
+character-for-character identical to the Universe field on the live GSS NADA
+catalog page for study id 7.
+
+Note the unit: *persons*, not households.  Most waves across the library state
+their universe in households; GLSS1 is one of the few that states it in
+individuals.  The unit is not stable within GhanaLSS's own series either --
+compare GLSS5 ("the population living within private households"), GLSS6 ("the
+population living within individual households") and GLSS4 ("nationally
+representative household survey").
+
+The joint LSMS Basic Information Document
+(=1987-88/Documentation/technical document/GHA_1987_GLSS_Basicinfo_EN.pdf=,
+which covers both the 1987-88 and 1988-89 rounds) contains *no*
+universe/target-population statement.
+
+*** 1988-89 (GLSS2)
+
+Source: =1988-89/Documentation/ddi-documentation-english-4.pdf=, "Coverage"
+block -> UNIVERSE field, PDF page 6 (document ID =DDI-GHA-GSS-GLSS2-2008-v2.0=).
+
+#+begin_quote
+UNIVERSE
+
+The survey covered all household members in the nationally representative sample. Different sections of the instruments have individual universes.
+#+end_quote
+
+*This statement is circular and should not be leaned on.*  "all household
+members in the nationally representative sample" describes the *sample*, not
+the set of units the sample stands for.  It is one of the corpus's clearest
+examples of a universe field that does not define a universe.
+
+The second sentence is a pointer, not a specification: the per-section
+universes are *not* enumerated for GLSS2.  (They are enumerated for GLSS3 --
+see below -- so the GLSS3 list is the nearest thing to a substantive reading,
+but it is GLSS3's list and is not asserted here for GLSS2.)
+
+*** 1991-92 (GLSS3)
+
+Source: =1991-92/Documentation/ddi-documentation-english-12.pdf=, "Coverage"
+block -> UNIVERSE field, PDF pages 5-6.
+
+#+begin_quote
+UNIVERSE
+
+The survey is nationally representative. It has the following sub-universes:
+
+Household roster: all usual household members
+
+Education : usual household members 5 years and older
+
+Health: all usual household members
+
+Employment and time use: usual household members 7 years and older
+
+Migration: usual household members 15 years and older
+
+Housing: heads of households
+
+Agriculture:holders
+#+end_quote
+
+Source typography preserved as printed: ="Education :"= (space before the
+colon) and ="Agriculture:holders"= (no space after it).
+
+This is the most granular universe statement of any GLSS round, and one of the
+few in the entire cross-country corpus that declares *per-module* universes.
+Anyone computing a denominator from a GLSS3 module should use the module's own
+sub-universe, not the household roster.
+
+The GLSS3 main report (=1991-92/Documentation/pdf/G3report.pdf=) has no
+"universe" heading; its Appendix 1 is about design, and is quoted under
+/Sub-samples/ below.
+
+*** 1998-99 (GLSS4)
+
+Source: =1998-99/Documentation/ddi-documentation-english-14.pdf=, "Coverage"
+block -> UNIVERSE field, PDF page 6.
+
+#+begin_quote
+UNIVERSE
+
+The survey is nationally representative household survey that covers region , zones and urban/rural residence.
+#+end_quote
+
+Typography preserved as printed: ="covers region , zones"= (space before the
+comma).
+
+*This is a coverage claim, not a universe declaration.*  It names the domains
+of analysis; it does not name the set of units the sample represents.
+
+The main report (=GHA_1998_GLSS_Report_EN.pdf=, content-identical to
+=glss4_report.pdf=) opens its Appendix 1 "SAMPLE DESIGN FOR ROUND 4 OF THE
+GLSS" with "A nationally representative sample of households was selected in
+order to achieve the survey objectives." (printed page 114) -- again a coverage
+claim.  Section 1.1 of that report presents estimates for "the total number of
+persons in private households in Ghana", which *implies* a private-household
+universe; the documentation never states that as a universe definition, and an
+implication is not recorded here as a claim.
+
+*** 2005-06 (GLSS5)
+
+*This wave carries two distinct universe statements in one document, and they
+are not the same thing.*  Both are recorded.
+
+(1) The DDI UNIVERSE field -- =2005-06/Documentation/ddi-documentation-english-5.pdf=,
+"Coverage" block, PDF page 4 (document ID =DDI-GHA-GSS-GLSS-2005-v2.0=,
+version 2.0, November 2008):
+
+#+begin_quote
+UNIVERSE
+
+The survey covered all de jure household members (usual residents) who have not been away from their usual residents for more than 6 months. This excludes heads of households.
+#+end_quote
+
+(2) The target population proper -- same file, "Sampling" -> "Sampling
+Procedure" -> "Sampling Frame and Units", PDF page 5:
+
+#+begin_quote
+As in all probability sample surveys, it is important that each sampling unit in the surveyed population have a known, non-zero probability of selection. To achieve this, there has to be an appropriate list, or sampling frame of the primary sampling units (PSUs).The universe defined for the GLSS 5 survey is the population living within private households in Ghana.
+#+end_quote
+
+Typography preserved: ="(PSUs).The universe"= (no space after the period) is as
+printed.
+
+Reading: (2) is the population record -- "the population living within private
+households in Ghana".  (1) is a *respondent-eligibility rule* (a de jure
+residence test), not a target population.
+
+The trailing clause of (1), ="This excludes heads of households."=, is quoted
+verbatim and is *not* interpreted here.  Its intended meaning is unclear (heads
+are certainly enumerated in the data).  Do not act on it without going back to
+the questionnaire.
+
+*** 2012-13 (GLSS6)
+
+Source: =2012-13/Documentation/REPORTS/GLSS6_Main Report.pdf=, "APPENDIX 1:
+METHODOLOGY OF THE SURVEY", section 6.2 "Sampling Frame and Units", printed
+page 204.  No DDI PDF is shipped for this wave.
+
+#+begin_quote
+6.2 Sampling Frame and Units
+
+The GLSS6 is a household probability sample survey designed to cater for a variety of analyses at the various domains of interest. As in all probability sample surveys, it is important that each sampling unit in the target population has a known, non-zero probability of being included in the sample. To achieve this, an appropriate list, or sampling frame of the PSUs is required. The list of standardized census EAs - together with their respective population and household sizes - obtained from the 2010 Population and Housing Census (PHC) conducted by the Ghana Statistical Service was used as the sampling frame for the GLSS6.
+
+However, the unit of measurement was the population living within individual households.
+#+end_quote
+
+Whitespace normalised from the report's justified line-wrapping; wording
+unaltered.
+
+The GSS NADA catalog entry for this study (id 72, the URL in =SOURCE.org=) does
+carry a UNIVERSE field, but it is uselessly terse -- "The survey covered all
+household members".  The local report is far more informative and is what is
+quoted.
+
+*** 2016-17 (GLSS7)
+
+*Confidence: medium.*  Unlike every other GLSS round, GLSS7 has *no* DDI
+Universe field anywhere -- not in the shipped
+=2016-17/Documentation/ddi-documentation-english-97.pdf= (whose Sampling,
+Questionnaires, Data Processing and Data Appraisal sections all read "No
+content available"), and not on the live GSS NADA catalog page for study id 97.
+
+The best available statement is from the interviewers' manual,
+=2016-17/Documentation/GLSS7 Final Manual.docx=, Chapter 1, closing section
+"1.2 METHODOLOGY OF THE SURVEY" (immediately after Table 1 "Regional
+Distribution of EAs and Households" and immediately before "1.3 SURVEY
+PERIOD"; the =.docx= has no page numbering in its XML, hence the section
+locator):
+
+#+begin_quote
+Basic information on all persons living in private households would be solicited.  In addition, all persons 15 years and older would be eligible for the labour force survey.  For the child labour module, the survey would solicit information from persons between the ages of 5-14 years.
+#+end_quote
+
+And, as the first sentence of section "Background" in the same chapter:
+
+#+begin_quote
+The Ghana Living Standards Survey (GLSS) is a nationally representative household survey which provides reliable, disaggregated and internationally comparable welfare and living conditions statistics in Ghana.
+#+end_quote
+
+*Why this is weaker evidence than the other six waves.*  It is a fieldwork
+instrument, not a metadata declaration, and it is written in the
+future/conditional tense ("would be solicited") because it was drafted before
+fieldwork.  It is a genuine coverage statement in an official GSS document, but
+it is not a universe field.
+
+Like GLSS3, GLSS7 states *per-module* eligibility (15+ for the labour force
+module; 5-14 for child labour) -- use those denominators for those modules.
+
+*Concrete next step if #603 needs a hardened GLSS7 record:* acquire the GLSS7
+Main Report published by GSS.  Its methodology appendix is the analogue of
+GLSS6's section 6.2 quoted above.  It is *not* in this repository's
+=2016-17/Documentation/= and was not consulted.
+
+** Exclusions
+
+Exclusions matter as much as inclusions, and only three of the seven rounds
+state one.
+
+*** Institutional population -- GLSS5 and GLSS6, explicit
+
+GLSS5, =2005-06/Documentation/ddi-documentation-english-5.pdf=, "Sampling Frame
+and Units", PDF page 5 (the sentence immediately following universe statement
+(2) above):
+
+#+begin_quote
+The institutional population (such as schools, hospitals etc), which represents a very small percentage in the 2000 Population and Housing Census (PHC), is excluded from the frame for the GLSS 5 survey.
+#+end_quote
+
+GLSS6, =2012-13/Documentation/REPORTS/GLSS6_Main Report.pdf=, section 6.2,
+printed page 204 (immediately following the GLSS6 universe quote above):
+
+#+begin_quote
+The institutional population (those who were in schools, hospitals, etc.), which represents a very small percentage of the 2010 Population and Housing Census (PHC), was excluded from the frame.
+#+end_quote
+
+The GLSS6 report carries this through into its own published estimates: the
+note to Table 2.1 (printed page 5) reads, verbatim, ="Excludes institutional
+population."=
+
+*** One enumeration area dropped -- GLSS3, explicit
+
+=1991-92/Documentation/pdf/G3report.pdf=, Appendix 1 "SAMPLE DESIGN FOR ROUND 3
+OF THE GLSS", printed page 113:
+
+#+begin_quote
+The figure of 28 rural workloads with no workload, shown in Table 2, includes one EA which had to be excluded from the final sampling frame because the local chiefs refused to allow the listing exercise to be done.
+#+end_quote
+
+This is a single-EA field-access exclusion, not a design carve-out.  It is
+recorded because it is the only named geographic exclusion in the GLSS series.
+
+*** No exclusion statement found -- GLSS1, GLSS2, GLSS4, GLSS7
+
+For these four rounds, *no* exclusion statement was found.  What was searched,
+per the standing rule against unevidenced "nothing here" claims:
+
+| Wave    | Searched                                                                                                                                                                                                 |
+|---------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1987-88 | =Documentation/= (=SOURCE.org=; =GLSS 1987-88 Report.pdf= decoded in full; =technical document/GHA_1987_GLSS_Basicinfo_EN.pdf=; listings of =technical document/=, =reports/=, =questionnaire/=); GSS NADA id 7; WB catalog 2313 |
+| 1988-89 | =Documentation/= (=SOURCE.org=; =ddi-documentation-english-4.pdf=; =technical document/GHA_1988_GLSS_Basicinfo_EN.pdf=; =technical document/GHA_1988_GLSS_Samplingrecoomendations_EN.pdf=; listings of =technical document/=, =reports/=, =questionnaire/=); GSS NADA id 4; WB catalog 2314 |
+| 1998-99 | =Documentation/= (=SOURCE.org=; =ddi-documentation-english-14.pdf=; =GHA_1998_GLSS_Report_EN.pdf=; =glss4_report.pdf=; =GHA_1998_GLSS_Data_User_Guide_EN.pdf=; =GHA_1998_GLSS_Dataentry_EN.pdf=; =questionnaire/= listing); GSS NADA id 14; WB catalog 2331 |
+| 2016-17 | =Documentation/= (=SOURCE.org=; =ddi-documentation-english-97.pdf= in full; =GLSS7 Final Manual.docx= in full, incl. a targeted scan for institutional / collective / homeless / nomadic wording -- zero hits; listings of the module =.docx= files and =Supervisors' manual_GLSS7.doc=); GSS NADA id 97.  No GLSS7 entry located in the WB catalog. |
+
+For GLSS4 and GLSS7 the "private households" phrasing in the surrounding prose
+*implies* the usual institutional-population exclusion that GLSS5 and GLSS6
+state explicitly.  That inference is deliberately *not* recorded as a claim.
+
+GLSS4's Appendix 1 does record a frame-quality caveat rather than an exclusion,
+=1998-99/Documentation/GHA_1998_GLSS_Report_EN.pdf=:
+
+#+begin_quote
+For the purposes of this survey the list of the 1984 population census Enumeration Areas (EAs) with population and household information was used as the sampling frame. ... This frame, though quite old, was considered inadequate, it being the best available at the time.
+#+end_quote
+
+(The "considered inadequate" reading is as printed; it appears to be a
+typographic error for "adequate", but it is quoted, not corrected.)
+
+** Oversamples and sub-samples
+
+*This is the part a reader pooling GLSS rounds needs before averaging
+anything.*  In this country, as in most of the corpus, specialization lives
+*inside* a wave rather than as a whole wave.
+
+*** GLSS1 -> GLSS2: a rotating panel with a half-retained sub-sample
+
+The GLSS3 main report's Appendix 1 describes the GLSS1/GLSS2 design.
+=1991-92/Documentation/pdf/G3report.pdf=, "Sample design for GLSS1 and GLSS2",
+printed page 110:
+
+#+begin_quote
+The original idea was that a rotating panel design would be used, with half of the sample being retained each year for re-interview and the other half being replaced. This design would provide a representative sample of households each year, but it also had the advantage of continuity from one year to the next, enabling more precise estimates to be made of the changes occurring in the socio-economic situation of households. Half the workloads from GLSS1 were therefore retained for GLSS2, and attempts were made to re-interview the same households. The other half of the GLSS2 sample was taken from the 100 EAs in replicate 6 of the master sample.
+#+end_quote
+
+And the master-sample construction, same appendix, printed page 109:
+
+#+begin_quote
+The Ghana Statistical Service (GSS) had created a master sample of enumeration areas (EAs), which serves as the sampling frame used for selecting households for each annual round of the GLSS. To prepare this master sample, the 12,969 EAs from the 1984 Population Census were first placed in order, by region within each location (rural/semi-urban/urban), in turn within each ecological zone (coastal/forest/savannah). A total of 800 EAs were then systematically selected from this list with probability proportional to size (PPS), and these selected EAs were then assigned systematically to eight separate replicates of 100 EAs. Each replicate thus provides a representative PPS sample of EAs. For GLSS1 two replicates (1 and 5) were used.
+#+end_quote
+
+So *GLSS2 is documented as two sub-samples in one wave*: a retained panel half
+(re-interview attempts on GLSS1 workloads) and a fresh half drawn from
+replicate 6.  This is precisely the "specialization inside a wave" shape.
+It also *contradicts* the existing =Survey Program= text -- see /Tensions/
+below.
+
+Corroborating, from GLSS1's own DDI overview (=1987-88/Documentation/GLSS
+1987-88 Report.pdf=, "Sampling Procedure", printed "- 2 -"; decoded, see the
+transcription caveat above):
+
+#+begin_quote
+The resulting list is 3200 households and 800 replacement households in something less than 200 sampling areas (specifically 178 in 1987-88 and 170 in 1988-89). Each group of 16, 32 or 48 households within a sampling area is referred to as a cluster in the GLSS data sets and in this document.
+#+end_quote
+
+That is one design document describing both rounds' realised sampling areas --
+consistent with a single master sample worked across two years, not two
+independent draws.
+
+*** GLSS3: the design breaks with GLSS1/GLSS2
+
+Same appendix, printed page 110:
+
+#+begin_quote
+For GLSS3 it was initially expected that the same sample design would be followed, with replicate 6 being retained and replicate 1 being replaced by replicate 2. A listing exercise was therefore carried out for replicate 2 in July/August 1989. However, following discussions between the GSS and the World Bank, it was decided that GLSS3 would differ substantially from GLSS1 and GLSS2, by giving much fuller attention to household expenditure and consumption, and with less attention to some of the topics covered previously. In order to obtain high quality data on household consumption and expenditure it was also decided that a larger and more widespread sample was required.
+#+end_quote
+
+(The sentence ends there; a superscript footnote marker "15" follows
+="required"= in the source and has been dropped per the transcription note.)
+
+The rotation was therefore abandoned at GLSS3.  This is the documentary basis
+for "no cross-wave linkage exists for GLSS3 onward" in =Panel Linkage= below --
+and it is a stronger basis than the ID-availability argument recorded there.
+
+*** GLSS5: regional oversample by design (a minimum-per-region floor)
+
+=2005-06/Documentation/ddi-documentation-english-5.pdf=, "Sample size and
+allocation", PDF page 5:
+
+#+begin_quote
+It was decided to sample a total sample of 8000 households nationwide .
+
+To ensure adequate numbers of complete interviews that will allow for reliable estimates at the various domains of interest, the GLSS 5 sample was designed to ensure that at least 400 households were selected from each region.
+#+end_quote
+
+Typography preserved: ="nationwide ."= (space before the period).
+
+The minimum-per-region floor *is* the oversample mechanism: it forces
+disproportionately large samples in the small regions.  GSS says so directly --
+see /Universe vs. what the weights represent/ below.
+
+*** GLSS6: sample doubled to serve the SADA (northern savannah) domain
+
+=2012-13/Documentation/REPORTS/GLSS6_Main Report.pdf=, "APPENDIX 1:
+METHODOLOGY OF THE SURVEY", "What is new?", printed page 200:
+
+#+begin_quote
+To cater for the needs of the Savannah Accelerated Development Authority (SADA) areas and also provide nationally representative quarterly labour force statistics, the number of primary Sampling Units (PSUs) and households were increased from 580 and 8,700 to 1,200 and 18,000 respectively –an increase of about 107% over the GLSS5 figures (Tables A1 and A2).
+#+end_quote
+
+The en dash and the missing space in ="respectively –an"= are as printed.
+
+Note precisely what this does and does not say.  It says the *overall* sample
+was roughly doubled in order to support SADA-area and quarterly-labour-force
+analysis.  It does not, in this sentence, quantify a SADA-specific
+disproportionality.  The disproportionality is stated separately, and
+quantified, in the weighting section -- next.
+
+*** GLSS7: fielded jointly with an Agriculture Module
+
+=2016-17/Documentation/GLSS7 Final Manual.docx=, section 1.2 "METHODOLOGY OF
+THE SURVEY":
+
+#+begin_quote
+The seventh round of the GLSS, like the previous rounds, would provide national and regional level indicators.  The survey is proposed to study about 15,000 households in 1,000 Enumeration Areas (EAs), consisting of 561 (56.1%) rural EAs and 439 (43.9%) urban EAs. The regional distribution of Enumeration Areas to be covered for the combined GLSS-7 and Agriculture Module would be as in Table 1.
+#+end_quote
+
+And, from section "Background":
+
+#+begin_quote
+The previous rounds of GLSS have always had a specific focus. In the 5th Round for instance, the Non-Farm Household Enterprises Module was made the focus and additional sections covering Tourism and Migrants & Remittances were introduced. The GLSS6 focused on Labour Force and the GLSS7, this time round, has Agriculture module as its main focus.
+#+end_quote
+
+The documentation describes a *combined* GLSS-7 + Agriculture Module fielding.
+Whether the Agriculture Module was administered to the full sample or to a
+sub-sample is *not* stated in any document in this repository, and is not
+asserted here.
+
+** Universe vs. what the weights represent
+
+The GLSS documentation is unusually explicit that these are different things,
+and says so in two rounds.
+
+GLSS5, =2005-06/Documentation/ddi-documentation-english-5.pdf=, "Weighting",
+PDF page 6:
+
+#+begin_quote
+The GLSS 5 is not a self-weighting sample design because disproportionately larger samples from regions with smaller populations were drawn. Therefore each sample household did not have the same chance of selection into the sample. Hence, weights were computed to reflect the different probabilities of selection in order to obtain the true contribution of each selected EA in the sample based on the first and second stage probabilities of selection.
+
+The household weight variable is called WEIGHT which is attached to each section data
+
+A grossing up factor (637.89) was used for the agriculture sections instead of the weight variable.
+#+end_quote
+
+GLSS6, =2012-13/Documentation/REPORTS/GLSS6_Main Report.pdf=, "9. Computation
+of Weights", printed page 207:
+
+#+begin_quote
+The GLSS6 is not a self-weighting sample design because disproportionately larger samples from regions with smaller populations were drawn. Therefore, each sample household did not have the same chance of selection into the survey sample. Hence, weights were computed to reflect the different probabilities of selection in order to obtain the true contribution of each selected EA in the sample based on the first and second stage probabilities of selection.
+#+end_quote
+
+GLSS6 quantifies the resulting disproportionality, same appendix, printed page 206:
+
+#+begin_quote
+The overall raising factor for the survey is 368. This means that, on average, the GLSS6 conducted interviews with 1 in 368 of the population of all ages per cluster. However, interviewing rates ranged from as low as 1 in 97 in Upper West Region and 1 in 158 in Upper East Region to as high as 1 in 650 in the Greater Accra Region and 1 in 703 in Ashanti Region (Table A7).
+#+end_quote
+
+Consequences a user must not miss:
+
+- The universe is national in both rounds, but the *sample* is heavily tilted
+  toward the small northern regions -- by a factor of roughly 7 between Upper
+  West and Ashanti in GLSS6.  Unweighted GLSS5/GLSS6 statistics are *not*
+  national statistics.
+- *GLSS5's agriculture sections do not use =WEIGHT=.*  GSS states a flat
+  grossing-up factor of 637.89 for them instead.  Anyone weighting GLSS5
+  agriculture data with the household =weight= variable is using a weight GSS
+  did not intend for those sections.  This is not currently reflected anywhere
+  in =Sampling Design= above.
+- For GLSS1 and GLSS2 the documentation asserts the opposite regime.  From the
+  GLSS3 report, Appendix 1, printed page 109:
+
+  #+begin_quote
+  The total sample therefore consisted of 3200 households, and the sample design provided a self-weighting sample, since each household in Ghana had an equal probability of being selected.
+  #+end_quote
+
+  This corroborates the existing =Weights= subsection's "GLSS1 and GLSS2 are
+  self-weighting" with a documentary citation, which it previously lacked.
+
+** Tensions with the existing text in this file
+
+Flagged, both sides quoted, *not* resolved.
+
+*** 1. "no rotating panel or refreshment sample mechanism"
+
+The =Survey Program= section above says:
+
+#+begin_quote
+Each round is designed as an independent nationally representative cross-section; there is no rotating panel or refreshment sample mechanism.
+#+end_quote
+
+The GLSS3 main report says (printed page 110, quoted in full under
+/Sub-samples/ above):
+
+#+begin_quote
+The original idea was that a rotating panel design would be used, with half of the sample being retained each year for re-interview and the other half being replaced. ... Half the workloads from GLSS1 were therefore retained for GLSS2, and attempts were made to re-interview the same households. The other half of the GLSS2 sample was taken from the 100 EAs in replicate 6 of the master sample.
+#+end_quote
+
+These are in direct conflict *for the GLSS1/GLSS2 pair*.  The documentation
+describes exactly a rotating panel with a refreshment half.  The =Survey
+Program= claim appears defensible from GLSS3 onward (the rotation was abandoned
+at GLSS3 -- see the printed-page-110 quote under /Sub-samples/), but not for
+1987-88/1988-89.
+
+Note that the =Panel Linkage (GLSS1 to GLSS2)= section further down already
+records the panel as an empirical fact ("Despite being designed as independent
+cross-sections, a sub-sample of GLSS1 households was re-interviewed in GLSS2 ...
+714 panel households", derived from =PANELC.DAT=).  The new evidence is that
+this was *not* an accident of fieldwork: it was the stated design.  The
+"Despite being designed as..." framing in that section is contradicted by GSS's
+own documentation.
+
+*** 2. "GLSS2 | 2xxx | 200 EAs, fresh draw"
+
+The cluster-numbering table in =Sampling Design= says:
+
+#+begin_quote
+| GLSS1     | 1xxx             | 200 EAs from 1984 census frame    |
+| GLSS2     | 2xxx             | 200 EAs, fresh draw               |
+#+end_quote
+
+The documentation says GLSS1 used master-sample replicates 1 and 5 (2 x 100
+EAs), and that GLSS2 was *half* retained GLSS1 workloads plus *half* from
+replicate 6 (100 EAs).  "Fresh draw" is therefore accurate for at most half of
+GLSS2.
+
+*** 3. "200 EAs" for GLSS1 and GLSS2
+
+GLSS1's own DDI overview says the realised figure was "something less than 200
+sampling areas (specifically 178 in 1987-88 and 170 in 1988-89)".  The design
+target was 200; the realised counts were lower.  The table's "200 EAs" is the
+design figure, not the achieved one.
+
+*** 4. "GLSS3+ Region-based (10 administrative regions from GLSS3; possibly finer in later rounds)"
+
+The "possibly finer" hedge is now resolvable for GLSS6 from documentation.
+=2012-13/Documentation/REPORTS/GLSS6_Main Report.pdf=, section 6.3
+"Stratification", printed page 204:
+
+#+begin_quote
+To enhance the precision and reliability of the survey results, the EAs were first stratified into 10 main domains according to the ten administrative regions. Within each region, the EAs were further stratified into their rural and urban categories, bringing the total number of sub-strata to 20. Again, the three ecological zones, namely 1) Coastal, 2) Forest, and 3) Savannah (SADA) were taken into consideration.
+#+end_quote
+
+The analogous GLSS5 statement, =2005-06/Documentation/ddi-documentation-english-5.pdf=,
+"Stratification", PDF page 5:
+
+#+begin_quote
+In order to take advantage of possible gains in precision and reliability of the survey estimates from stratification, the EAs were first stratified into the ten administrative regions. Within each region, the EAs were further sub-divided according to their rural and urban areas of location. The EAs were also classified according to ecological zones and inclusion of Accra (GAMA) so that the survey results could be presented according to the three ecological zones, namely 1) Coastal, 2) Forest, and 3) Northern Savannah, and for Accra.
+#+end_quote
+
+This is an enrichment of the existing table rather than a contradiction, and is
+recorded so the hedge can be retired for GLSS5 and GLSS6 at least.
+
+** Open items
+
+- *GLSS7 has no universe field anywhere.*  Acquiring the GSS-published GLSS7
+  Main Report would replace a future-tense interviewers'-manual sentence with
+  a methodology appendix.  This is the single highest-value acquisition for
+  Ghana's population record.
+- *GLSS5's ="This excludes heads of households."="* is unexplained and should be
+  checked against the GLSS5 Part A questionnaire before anyone relies on the
+  DDI universe field.
+- *Whether GLSS7's Agriculture Module was a full-sample or sub-sample module*
+  is not documented in this repository.
+
 * Panel Linkage (GLSS1 to GLSS2)
 
 Despite being designed as independent cross-sections, a sub-sample

--- a/lsms_library/countries/GhanaSPS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaSPS/_/CONTENTS.org
@@ -49,6 +49,328 @@ Ghana Food Expenditure Data with Aggregate Labels and FTC Codes:
 https://docs.google.com/spreadsheets/d/1qZhbq5gpAmCsYH1ixUn0Ix_Cb5YKSIpU-Pc2_hh2lhU/edit?usp=sharing
 
 
+* Sampling universe, exclusions and sub-samples
+
+What the GSPS documentation *claims* about the population it represents, quoted
+verbatim.  This section records the survey's own statements; it is deliberately
+*not* inferred from the microdata, and it makes no claim about what the data
+look like.  Where a wave has no statement, that is recorded as a gap together
+with what was searched.
+
+Read the two things below as separate facts, because for this survey they come
+apart:
+
+- What the documents *say* the sample represents.
+- What the repository can currently *see* (e.g. that =2013-14= carries no region
+  or urban/rural variable -- see "Files in GhanaSPS/_/ > other_features.py"
+  above).  That is a data-availability fact about the shipped extract, *not* a
+  coverage or universe claim, and must not be read as one.
+
+One structural warning up front, because it governs the whole country: GSPS is a
+*panel*, not three independent national cross-sections.  Only wave 1 has a
+documented probability sample of Ghana.  Waves 2 and 3 are follow-ups of that
+sample plus households split off from it, and *no document in the corpus states
+a universe for them*.  Anyone pooling GhanaSPS waves, or reading a wave-2/wave-3
+estimate as "nationally representative", should read this section first.
+
+** 2009-10 (Wave 1)
+
+- Statement lives in :: local documentation, in this repository (plus a
+  corroborating WB catalog field, see below).
+- Confidence :: high.
+
+*** Declared coverage, verbatim
+
+From =lsms_library/countries/GhanaSPS/2009-10/Documentation/Basic_Information_Dec_2015.pdf=,
+section "3. Sampling and Survey Design", printed p. 8 (PDF page 9):
+
+#+begin_quote
+The survey provides regionally representative data for the 10 regions of Ghana.
+In all, 5010 households from 334 Enumeration Areas (EAs) were sampled.  Fifteen
+households were selected from each of the EAs.  The distribution of the
+enumeration areas across the regions in Ghana is presented in Table 1.  The
+number of EAs for each region was proportionately allocated based on estimated
+2009 population share for each region.  EAs for Upper East and Upper West
+regions, which have relatively smaller population sizes, were over sampled to
+allow for a reasonable number of households to be interviewed in these regions.
+#+end_quote
+
+The same paragraph appears verbatim in the locally shipped WB DDI report
+=ddi-documentation-english_microdata-2534.pdf=, under "Sampling > Sampling
+Procedure".
+
+From =Baseline_Descriptive_Report.pdf=, section "2.1. Household composition",
+printed p. 5 (PDF page 15):
+
+#+begin_quote
+The data from the baseline Ghana Socio-Economic Panel Survey consists of a
+nationally representative sample of 5009 households in 334 enumeration areas
+(EAs) containing 18,889 household members.  The survey defines household as a
+person or a group of persons, who live together in the same dwelling, share the
+same house-keeping arrangements and are catered for as one unit.
+#+end_quote
+
+(The same sampling paragraph also appears in that report at section "1.3. Sample
+Design and Organization of the Survey", printed p. 2 / PDF page 12, worded "The
+survey provides a regionally representative data for the 10 regions of Ghana.
+In all, 5009 households from 334 Enumeration Areas (EAs) were *interviewed*."
+-- note "interviewed", against "sampled" in the Basic Information Document.)
+
+*** The only field actually labelled "Universe" is catalog-only
+
+No file in this repository carries a field labelled "Universe".  The locally
+shipped DDI report has a "Sampling" section but *no* Universe field.  The one
+explicit Universe statement lives in World Bank catalog metadata, i.e. outside
+the repository and revisable without notice --
+https://microdata.worldbank.org/index.php/catalog/2534/study-description,
+"Coverage" block, "Universe" field:
+
+#+begin_quote
+Nationally representative, regionally representative for all 10 regions.
+#+end_quote
+
+(Verified against the live catalog page, 2026-07-21.  This is *not* the WB NADA
+boilerplate universe sentence that recurs across other countries in this
+library; it is specific to this study.  It is nonetheless a *representativeness*
+claim, not a definition of a target population: nothing in the corpus says which
+persons or dwellings constitute the universe, only that the sample represents
+Ghana and its regions.)
+
+*** Frame and design (context, NOT the universe)
+
+- Two-stage stratified design, stratified by region.
+- Stage 1: 334 clusters (census EAs) selected by simple random sampling from an
+  updated master sampling frame constructed from the 2000 Ghana Population and
+  Housing Census; a complete household listing was conducted in 2009 in all
+  selected clusters.
+- Stage 2: simple random sampling of 15 listed households per cluster.
+- Verbatim, =Basic_Information_Dec_2015.pdf= printed p. 9 (PDF page 10): "Since
+  the design is not self-weighting, household sample weights have been computed
+  and applied for the estimation of the survey results."  So the raw sample is
+  *not* self-weighting and unweighted GSPS wave-1 means are not national means.
+
+*** Oversample
+
+The oversample is explicit and it is regional:
+
+#+begin_quote
+EAs for Upper East and Upper West regions, which have relatively smaller
+population sizes, were over sampled to allow for a reasonable number of
+households to be interviewed in these regions.
+#+end_quote
+
+(=Basic_Information_Dec_2015.pdf=, section 3, printed p. 8.)  The realised EA
+allocation is in that document's Table 1 (printed p. 9): Upper East 16 EAs
+(4.8 per cent) and Upper West 12 EAs (3.6 per cent), against e.g. Ashanti 60
+(18.0 per cent).  This is the reason the design is not self-weighting; it is
+also the reason an unweighted pooled GhanaSPS average over-represents the two
+Upper regions.
+
+No other sub-population, booster, refresh or module subsample is documented for
+this wave.
+
+*** Exclusions: no statement found
+
+No statement of excluded regions, localities, institutional or collective
+households, nomadic or homeless populations, or any security-related carve-out
+appears in any wave-1 documentation in this repository, nor in the WB catalog
+entry.  Searched: =Basic_Information_Dec_2015.pdf= (full text),
+=Baseline_Descriptive_Report.pdf= (full text),
+=ddi-documentation-english_microdata-2534.pdf= (full text), =CODE_BOOK.pdf=,
+="Aggregate documentation.pdf"=, =LICENSE.org=, =SOURCE.org=, the household
+questionnaires and the interviewers' manual; plus WB catalog study 2534.  This
+is an *absence of a statement*, not a documented claim that nothing was
+excluded.
+
+The nearest thing to a population-definition rule is a household-membership
+eligibility rule -- a person-level inclusion criterion, *not* a geographic or
+population exclusion.  Verbatim, =Basic_Information_Dec_2015.pdf=, section 2
+preamble, printed p. 3 (PDF page 4):
+
+#+begin_quote
+The survey defined a household as a person or a group of persons, who live
+together in the same dwelling, share the same house-keeping arrangements and are
+catered for as one unit under one recognized head.  A person qualifies as a
+member of a household if he/she in the last 6 months regularly participated in
+this living arrangement with the household.
+#+end_quote
+
+The 6-month residence rule matters for roster-derived counts: a person present
+in the dwelling but resident for less than 6 months is by definition not a
+household member here.
+
+*** 5010 vs 5009
+
+The Basic Information Document and the WB catalog say 5010 households were
+*sampled*; the Baseline Descriptive Report says 5009 were *interviewed*.  The
+Basic Information Document reconciles this itself, section "5. Survey
+completion", printed p. 11 (PDF page 12):
+
+#+begin_quote
+The survey completed interviews for 5009 households in all 334 enumeration areas
+(EAs) across the country, indicating that only one sampled household could not be
+included for reason of data incompleteness.
+#+end_quote
+
+** 2013-14 (Wave 2)
+
+- Statement lives in :: *no local documentation*, and *not* the World Bank
+  catalog -- GSPS Wave 2 is not in the WB Microdata Library at all.  The only
+  statement is in an external catalog entry (IHSN NADA mirror of the ISSER /
+  University of Ghana data portal), i.e. a moving target this library does not
+  hold.
+- Confidence :: medium.
+
+*** No universe statement exists for this wave
+
+Neither the local documentation nor the catalog entry contains a universe or
+target-population statement.  The strongest available statement is a coverage
+claim.  From https://catalog.ihsn.org/catalog/10354/study-description (study
+=GHA_2013_GSPS_v01_M=), "Coverage" block, "Geographic Coverage" field -- note,
+*not* a "Universe" field; that entry has none, and has no "Sampling" section at
+all:
+
+#+begin_quote
+The survey provides regionally representative data for the 10 regions of Ghana.
+#+end_quote
+
+(Verified against the live catalog page, 2026-07-21.)
+
+Local files searched and found to contain no universe statement:
+=Documentation/ISSER_Yale_Part A_WAVE II.docx= (full text),
+=ISSER_Yale_Community Survey_WAVE II.docx= (full text),
+=ISSER_Yale_Part B_WAVE II.docx=, =Data Map.xlsx=,
+=Food Consumption Unit Codes.xlsx=, =Variable Lists/=, =Variable Labels/=.  The
+wave ships no Basic Information Document, no DDI, and no descriptive report:
+every technical document in the official Harvard Dataverse distribution
+(doi:10.7910/DVN/E5QP0F) is wave-1 only.
+
+*** This wave is a panel follow-up plus split-offs, not a fresh sample
+
+This is the sub-sample structure a pooler needs.  From the same IHSN entry,
+"Abstract" field -- a description of the achieved sample, *not* a universe
+statement:
+
+#+begin_quote
+The data from the second wave of the Ghana Socioeconomic Panel Survey covered a
+sample of 4,774 households containing 16,356 household members.  The second wave
+was unique in the sense that it tracked movement of households as well as
+individual within a household.  Thus, increasing the number of households in the
+Panel Study due to the nature of the design; tracking wholly moved and split
+households.  A total of 5484 households were selected for the survey comprising
+of 5009 households from the baseline survey and 475 households from split of
+households created of which 4774 households were successfully interviewed.
+#+end_quote
+
+So the wave-2 frame is: 5009 wave-1 households + 475 split-off households
+= 5484 selected, of which 4774 interviewed.  The 475 split-off households are a
+distinct sub-population within the wave -- they enter through the tracking rule,
+not through a probability draw from a national frame.
+
+The wave-1 design anticipated this; =Basic_Information_Dec_2015.pdf=, section
+"1.1. Introduction", printed p. 2 (PDF page 3):
+
+#+begin_quote
+In subsequent waves of the panel, a sample of moved households and individuals
+who have moved out of original households to form new households or joined other
+households originally not in the panel sample, will be interviewed in addition
+to the original sample.
+#+end_quote
+
+It is *natural* to conclude that wave 2 therefore inherits wave 1's universe.
+No document in the corpus says so, and it is not asserted here.
+
+*** Exclusions: no statement found
+
+No exclusion statement of any kind (region, locality, institutional or
+collective population, nomadic households, security-related drops) appears in
+the local wave-2 documentation or in the IHSN catalog entry.  That entry's only
+metadata sections are Identification, Scope, Coverage, Producers and sponsors,
+Survey instrument, Data collection, Data Access, Disclaimer, Metadata
+production.
+
+Do not read the wave-2 *community* instrument's title, "RURAL COMMUNITY
+INSTRUMENT", as a rural restriction on the household sample: it scopes the
+community-level module only.
+
+** 2017-18 (Wave 3)
+
+- Statement lives in :: *no local documentation*, and *not* the World Bank
+  catalog -- GSPS Wave 3 is not in the WB Microdata Library either.  Only an
+  external IHSN/ISSER catalog entry.
+- Confidence :: medium.
+
+*** No universe statement exists for this wave
+
+From https://catalog.ihsn.org/catalog/10355/study-description (study
+=GHA_2018_GSPS_v01_M=), "Coverage" block, "Geographic Coverage" field -- again
+*not* a "Universe" field; that entry has none, and no "Sampling" section:
+
+#+begin_quote
+The survey is nationally representative.
+#+end_quote
+
+(Verified against the live catalog page, 2026-07-21.)  Note the wording changed
+between waves: waves 1 and 2 are catalogued as "regionally representative data
+for the 10 regions of Ghana"; wave 3 says only "nationally representative".
+Recorded as found, not reconciled -- and in particular this is *not* evidence
+that regional representativeness was retained or dropped.
+
+The wave's entire =Documentation/= directory is one file,
+=Questionnaire/HH_Questionnaire_23_10.docx=; its full text was searched for
+universe / target population / eligibility / representativeness wording and
+contains none.  The only hits are module-level respondent-eligibility rules,
+which govern *who answers a given module*, not which households are in sample,
+e.g.:
+
+#+begin_quote
+Can you confirm that [Name] is female, 18-40 years old, speaks either English,
+Asante, Akuapem, Fanti, Ewe, Dagbani, Kokomba/Likpakpa, Wali/Dagari, Frafra/Gruni
+or Dangme and is therefore eligible to be interviewed?
+#+end_quote
+
+*** Exclusions: no statement found
+
+None of any kind, in the questionnaire or the catalog entry.
+
+*** Wave-label discrepancy
+
+Recorded because it affects citation, not coverage.  This repository's directory
+is =2017-18=, but the local instrument's own cover page reads "GHANA
+SOCIO-ECONOMIC PANEL SURVEY / HOUSEHOLD INSTRUMENT / WAVE 3 (2018-2019)", and
+the IHSN/ISSER entry is titled "Socioeconomic Panel Survey 2018-2019, Wave 3"
+with collection dates 2018-2019 -- while the Yale EGC project page and the
+"Ghana Panel Creation User Guide" both describe wave 3 as conducted in
+2017/2018.  The identification of this directory with GSPS Wave 3 rests on the
+local instrument's cover page, not on the microdata.
+
+*** Not this wave: the 2019 "extremely poor" northern sample
+
+Flagged so it is never conflated with the wave-3 directory.  From the EGC "Ghana
+Panel Creation User Guide":
+
+#+begin_quote
+In 2019, the Ghana Panel Survey was also administered to a sample of
+participants in Ghana's rural north who had been classified as "extremely poor"
+through community-level focus groups.
+#+end_quote
+
+That is a separate, purposively selected sample and is *not* present in
+=GhanaSPS/2017-18/=.
+
+** Summary
+
+| Wave    | Explicit "Universe" field?      | Where the statement lives        | Exclusions stated | Oversample / sub-sample                              |
+|---------+---------------------------------+----------------------------------+-------------------+------------------------------------------------------|
+| 2009-10 | yes, WB catalog only            | local docs + WB catalog 2534     | none found        | Upper East, Upper West EAs deliberately over-sampled |
+| 2013-14 | no                              | IHSN/ISSER catalog 10354 only    | none found        | panel follow-up: 5009 wave-1 HH + 475 split-offs     |
+| 2017-18 | no                              | IHSN/ISSER catalog 10355 only    | none found        | none documented                                      |
+
+"none found" means *no statement was found*, having searched the files named
+above.  It is not a claim that nothing was excluded.  Per the repository's
+standing rule, an unevidenced "nothing excluded here" assertion must not be
+written into any config file for this country.
+
 * Files in GhanaSPS/<SOMEYEAR>/_/
 ** TODO household_characteristics.py
 ** TODO food_acquired.py

--- a/lsms_library/countries/Guatemala/_/CONTENTS.org
+++ b/lsms_library/countries/Guatemala/_/CONTENTS.org
@@ -2,6 +2,275 @@
 
 Brief table of contents and todo list.
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered 2026-07-21 (GH #601).  One wave only: Guatemala has a single
+wave directory, =2000= (ENCOVI 2000, Encuesta Nacional sobre Condiciones de Vida
+2000, INE Guatemala).  Everything below is quoted from survey documentation; no
+statement here is derived from the microdata.
+
+This section records only what the *documentation claims*.  It deliberately says
+nothing about what the distributed =.dta= files look like -- for the
+cluster/PSU variable actually present in the data see the =cluster_features=
+comment block in =Guatemala/_/data_scheme.yml= (GH #323), which is a claim about
+the data and not about the universe.
+
+** 2000 -- declared universe
+
+Confidence: high.  Source type: local documentation, corroborated against the WB
+catalog.
+
+Verbatim, Spanish (source language), from
+=Guatemala/2000/Documentation/ddi-documentation-english_microdata-586.pdf=,
+section "Sampling" -> "Sampling Procedure", block "DISEÑO DE LA MUESTRA",
+numbered item 1 (PDF page footer "3"):
+
+#+begin_quote
+1. Universo de estudio: Viviendas particulares y hogares existentes en el país,
+según ENIGFAM 98.
+#+end_quote
+
+Translation (supplied by the extracting agent, NOT source text): "Study
+universe: Private dwellings and households existing in the country, according
+to ENIGFAM 98."
+
+The DDI's dedicated =Universe= field carries the same sentence with the acronym
+spelled out.  *That field is not in the local PDF* -- the shipped PDF is a
+partial DDI that begins at "Sampling" and contains no Study-Description section
+(the string "Universe" does not occur in it at all).  It exists only in the WB
+catalog record, https://microdata.worldbank.org/index.php/catalog/586/study-description
+(field =study_desc.study_info.universe=), verbatim:
+
+#+begin_quote
+Viviendas particulares y hogares existentes en el país, según la Encuesta
+Nacional de Ingresos y Gastos - ENIGFAM 98.
+#+end_quote
+
+The two renderings are recorded separately rather than smoothed together: the
+local file has the short form "según ENIGFAM 98", the catalog the long form
+"según la Encuesta Nacional de Ingresos y Gastos - ENIGFAM 98".
+
+Geographic coverage, verbatim, Sampling-Procedure item 5 -- this sentence *is*
+in the local PDF, and is also the catalog's =Geographic Coverage= field:
+
+#+begin_quote
+5. Cobertura: ENCOVI’2000 se diseña para cubrir las áreas urbanas, áreas rurales
+y áreas indígenas del país.
+#+end_quote
+
+Translation (agent-supplied): "Coverage: ENCOVI'2000 is designed to cover the
+urban areas, rural areas and indigenous areas of the country."
+
+Sampling unit, verbatim, item 4:
+
+#+begin_quote
+4. Unidades Secundarias de Muestreo: Las Unidades Secundarias de Muestreo están
+constituidas por las viviendas particulares ocupadas y ausentes.
+#+end_quote
+
+Translation (agent-supplied): "Secondary Sampling Units: The Secondary Sampling
+Units are made up of occupied and absent private dwellings."
+
+This is *not* WB NADA boilerplate.  The universe, coverage and sampling text are
+INE Guatemala's own Spanish prose, specific to ENCOVI 2000; none of it matches
+the templated English "universe" sentence that recurs verbatim across ~15 waves
+elsewhere in this corpus.
+
+Accent caveat: =pdfminer= extraction of the local PDF silently drops every
+Spanish diacritic in the body font (it yields "DISEO DE LA MUESTRA", "en el
+pas, segn ENIGFAM 98").  Those are font-encoding artifacts, not the source
+text.  The accented spellings above were taken from the WB catalog's HTML
+rendering of the *same* DDI record, which agrees with the PDF extraction
+character-for-character on every unaccented character.  "ENCOVI’2000" uses
+U+2019 RIGHT SINGLE QUOTATION MARK in the source, not an ASCII apostrophe.
+
+** 2000 -- exclusions: none stated
+
+*No exclusion or non-coverage statement exists* -- not in any file under
+=Guatemala/2000/Documentation/=, and not in the WB catalog record.  There is no
+sentence excluding institutional or collective dwellings, nomadic or homeless
+populations, or any department or region.
+
+Searched, and what was searched:
+
+- All five PDFs in =Guatemala/2000/Documentation/=:
+  =ddi-documentation-english_microdata-586.pdf=, =FirstRound_V2.pdf=,
+  =SecondRound.pdf=, =commques.pdf=, =Capitulo7-12.pdf=.  Text extracted with
+  =pdfminer= and searched for =universe|universo|target population|población
+  objetivo|coverage|cobertura|scope|sampling|muestra|excluy|excluid|excepci|no
+  se incluy|colectiv|institucional|viviendas particulares|sobremuestra|
+  submuestra|indígena=.  The four questionnaire/manual PDFs are field
+  instruments and returned zero hits for any universe or exclusion term.
+- =Guatemala/2000/Documentation/SOURCE.org= and =LICENSE.org=.
+- WB Microdata catalog study 586, full study-description page fetched and
+  parsed.  Hit counts for =excluy=, =excluid=, =excepci=, =no se incluy=,
+  =sobremuestra=, =submuestra=: *zero in every case*.  The only occurrences of
+  =colectiv= / =institucion= are in the community-questionnaire topic list
+  ("acciones colectivas", "bienes comunales y de uso colectivo", "otras
+  instituciones") and have nothing to do with dwelling type.
+
+The only exclusion-*adjacent* language is the restriction of the frame to
+*private* dwellings, quoted verbatim above ("Viviendas particulares y hogares
+existentes en el país"; "Las Unidades Secundarias de Muestreo están constituidas
+por las viviendas particulares ocupadas y ausentes").  Whether "viviendas
+particulares" is *intended* to exclude collective or institutional dwellings is
+nowhere stated, and is not asserted here.  Recording the silence as silence.
+
+** 2000 -- oversamples and sub-populations: none documented
+
+No oversample, booster, refresh, panel or module sub-sample is documented for
+ENCOVI 2000.  The searches above found no =sobremuestra= / =submuestra= /
+=oversample= anywhere in the local documentation or the catalog record.  The
+design is described as a single stratified two-stage cluster sample of dwellings
+(item quoted under "Design context" below).
+
+Two things a reader might mistake for sub-samples, and what the documentation
+actually says about them:
+
+*** "Áreas indígenas" is a coverage claim, not a documented oversample
+
+Item 5 names =áreas indígenas= among the areas ENCOVI 2000 "se diseña para
+cubrir".  Nothing in the documentation describes an indigenous stratum, an
+indigenous oversample, or an indigenous inference domain -- and the study
+domains in item 7 are region x urban/rural only, with no indigenous domain (see
+the item-7 quote below).  The coverage sentence and the domain list are both
+quoted so that a reader can see they do not line up; no reconciliation is
+offered here because the documentation offers none.
+
+*** Round I / Round II are two visits to the SAME households
+
+The library's single wave =2000= is one sample, visited twice -- not a
+cross-section plus a panel, and not two samples pooled.  Verbatim, from the WB
+catalog record for study 586, field =Data Collection Notes= (this section is
+also in the local PDF under "DATA COLLECTION NOTES", with accents dropped by
+extraction):
+
+#+begin_quote
+La recolección de datos se realiza en dos visitas principales al hogar en
+momentos diferentes.  La recolección de datos de la información relacionada con
+las personas del hogar se lleva a cabo en la primer semana de trabajo en el
+segmento compacto.  El resto de información, es decir la referida al hogar, se
+recolecta en la tercera semana de trabajo [...]
+#+end_quote
+
+Translation (agent-supplied): "Data collection is carried out in two main visits
+to the household at different moments.  Collection of the information relating
+to the persons of the household is done in the first week of work in the compact
+segment.  The rest of the information, that is the household-level information,
+is collected in the third week of work [...]"
+
+The two questionnaire PDFs in this directory (=FirstRound_V2.pdf=,
+=SecondRound.pdf=) are the instruments for these two visits.
+
+** 2000 -- universe vs. what the weights represent
+
+The documentation states plainly that the sample is *not* self-weighting, and
+that the inference domains are region x urban/rural.  Verbatim,
+Sampling-Procedure items 7 and 8:
+
+#+begin_quote
+7. Dominios de Estudio: Los dominios de inferencia del Estudio de condiciones de
+Vida son los siguientes:
+a) Total Nacional: Urbano y rural
+b) Región Metropolitana: Urbana y Rural
+c) Región Norte: Urbana y Rural
+d) Región Nor-Oriente: Urbana y Rural
+e) Región Sur-Oriente: Urbana y Rural
+f) Región Central: Urbana y Rural
+g) Región Sur-Occidente; Urbana y Rural
+h) Región Nor-Occidente: Urbana y Rural
+i) Región Petén: Urbana y Rural.
+#+end_quote
+
+(The a)--i) list runs together in the source; line breaks inserted here only
+between the lettered items.  The stray semicolon in g) is in the source.)
+
+#+begin_quote
+8. Selección de la Muestra: Tomando en consideración que la muestra no es
+autoponderada se procedió en primera instancia al cálculo de las probabilidades
+de selección.
+#+end_quote
+
+Translation (agent-supplied): "Sample selection: Taking into account that the
+sample is not self-weighting, the selection probabilities were computed in the
+first instance."
+
+So: the declared universe is national (private dwellings and households in the
+country), the declared inference domains are the nine region x urban/rural
+domains, and unweighted household counts are *not* interpretable as a national
+sample.  Anyone pooling Guatemala with other countries must use =sample()=
+weights.
+
+Response rate, verbatim (catalog and local PDF agree):
+
+#+begin_quote
+90% dado que se esperaba que 8046 hogares contestaran pero la base de datos
+reporta 7276 hogares
+#+end_quote
+
+** 2000 -- design context (not the universe statement)
+
+Recorded because it is the frame the universe sentence points at.  Verbatim,
+same Sampling-Procedure block:
+
+#+begin_quote
+ENCOVI’2000 se aplica a una muestra que en su diseño es:
+-Bietápica
+-Estratificada
+-De conglomerados y aleatoria en su primera etapa.
+-De segmentos compactos y sistemática en su segunda etapa.
+-Sin reemplazo.
+#+end_quote
+
+#+begin_quote
+2. Marco Muestral: El marco muestral esta configurado por 11170 Unidades
+Primarias de Muestreo, que lo constituyen los sectores cartográficos del Censo
+de Población y Habitación 1994, de los cuales 3544 son urbanos y 7626 son
+rurales.
+#+end_quote
+
+#+begin_quote
+3. Unidades Primarias de Muestreo: la unidades primarias de muestreo están
+constituidas por los sectores censales, tanto urbanos como rurales.
+#+end_quote
+
+#+begin_quote
+6. Tamaño de la Muestra : Para la encuesta de condiciones de vida se seleccionó
+una muestra sin reemplazo de 8, 940 viviendas. Se espera que con una tasa de
+rechazo no mayor al 10% se obtenga una muestra total de 8,046 viviendas
+efectivas.
+#+end_quote
+
+Note the discrepancy between the *documented* frame and a claim elsewhere in
+this repository.  Item 3 above states that primary sampling units exist in the
+design (=sectores censales=); the top-level =CLAUDE.md= "Countries Without
+Microdata" table lists Guatemala with the reason "No PSU/cluster variable in
+data", while =Guatemala/_/data_scheme.yml= declares =cluster_features= with
+"v is the ENCOVI 2000 primary sampling unit: the composite
+depto-mupio-sector-segmento from CONSUMO5.DTA [...] 1,065 clusters" (GH #323).
+Those two repo claims contradict each other; neither contradicts the
+documentation quoted here, which is about the design and not about which
+identifiers survived into the distributed files.  Flagged, not resolved --
+=CLAUDE.md='s entry looks stale relative to GH #323.
+
+** Provenance of this record
+
+- Primary source held *in this repository*:
+  =Guatemala/2000/Documentation/ddi-documentation-english_microdata-586.pdf=
+  (partial DDI: Sampling, Questionnaires, Data Collection, Data Processing,
+  Related Materials).  It carries Sampling-Procedure items 1--10, the Response
+  Rate and the Weighting text.
+- Held *only* in WB catalog metadata, not in any file here: the DDI =Universe=
+  and =Geographic Coverage= fields as such, and the Abstract / Analysis-unit
+  prose.  The =Geographic Coverage= text duplicates item 5 (which is local), but
+  the long-form =Universe= sentence is catalog-only, so *that* wording is a
+  moving target the library does not hold.
+- Wave provenance keywords are recorded in
+  =Guatemala/2000/Documentation/SOURCE.org= (=#+CATALOG_ID: 586=,
+  =#+CATALOG_IDNO: GTM_2000_ENCOVI_v01_M=, =#+PROVENANCE_SOURCE: worldbank=).
+- Quotes above were re-verified against the local PDF and the catalog page on
+  2026-07-21.
+
 * Files in Guatemala/_/
 ** DONE food_items.org
 

--- a/lsms_library/countries/Guinea-Bissau/_/CONTENTS.org
+++ b/lsms_library/countries/Guinea-Bissau/_/CONTENTS.org
@@ -64,6 +64,266 @@ accident -- the five duplicated records are byte-identical, so they are
 *not* five mislabelled fixes that could be reassigned to the five
 grappes that lack one.
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence for what the Guinea-Bissau survey *claims* to represent, quoted
+verbatim from its own documentation.  This is deliberately kept separate
+from what the data look like: nothing below is inferred from any =.dta=.
+
+Guinea-Bissau has exactly one wave directory in the library, =2018-19=,
+so this section is the complete record for the country.
+
+** 2018-19 -- the declared universe
+
+Source: =lsms_library/countries/Guinea-Bissau/2018-19/Documentation/ddi-documentation-english_microdata-4293.pdf=,
+p. 3, section "Coverage".  Survey: /Inquérito Harmonizado sobre as Condiçöes
+de vide dos Agreagados Familiares 2018-2019/ (EHCVM 2018/19); WB catalog id
+4293, IDNO =GNB_2018_EHCVM_v02_M=.  Verified against the local PDF on
+2026-07-21.
+
+#+begin_quote
+GEOGRAPHIC COVERAGE
+National coverage
+
+UNIVERSE
+The survey covered all de jure households excluding prisons, hospitals,
+military barracks, and school dormitories.
+#+end_quote
+
+Language: the documentation quoted here is in English; no translation is
+needed.  (The survey's own title, quoted above, is Portuguese.  The
+non-ASCII characters in it are reproduced as printed in the catalog record,
+including the erroneous =ö= in "Condiçöes" and the misspelling
+"Agreagados".)
+
+That is the whole universe field.  It is thin: it names a unit (de jure
+households) and an institutional exclusion, and says nothing about age,
+nationality, region, or a sampling frame.  Everything else below is
+coverage or design text, *not* a universe declaration, and is labelled as
+such.
+
+Two representativeness claims from the same DDI, p. 1, verbatim -- framing,
+not universe:
+
+#+begin_quote
+SERIES INFORMATION
+The Guinea-Bissau EHCVM 2018/19 is the first edition of a nationally
+representative household survey conducted within the West Africa Economic
+Monetary Union (WAEMU) Household Survey harmonization Project (P153702) a
+joint program by the World Bank and the WAEMU Commision that aims at
+producing household survey data in member countries (Benin, Burkina Faso,
+Chad, Cote d'Ivoire, Guinea Bissau, Mali, Niger, Senegal and Togo). The
+survey covers all regions and includes approximately 5,000 households.
+#+end_quote
+
+#+begin_quote
+ABSTRACT
+[...] The EHCVM is a nationally representative survey of 5,000 households,
+which are also representative of the geopolitical zones (at both the urban
+and rural level).
+#+end_quote
+
+(The ligature glyphs =fi= / =ffi= in the PDF are transcribed as ordinary
+letters.  =[...]= marks elided abstract text, not a change of wording.)
+
+** 2018-19 -- exclusions
+
+*** Institutional populations, from the UNIVERSE field (DDI p. 3)
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals,
+military barracks, and school dormitories.
+#+end_quote
+
+*** Geographic: SAB is urban-only by design (DDI p. 4, SAMPLING PROCEDURE)
+
+This is the one exclusion a pooled analysis is most likely to trip over,
+and it is *not* in the universe field.  Verbatim:
+
+#+begin_quote
+The Guinea-Bissau EHCVM 2018/19 sample covers all regions with urban and
+rural areas surveyed in all regions apart from the autonomous sector of
+Bissau (SAB) where all respondents are from urban areas.
+#+end_quote
+
+The same sentence appears in the World Bank Basic Information Document
+(catalog 4293, download id 52550), section "Sample", p. 10, differing only
+in the hyphen of the country name:
+
+#+begin_quote
+The Guinea Bissau EHCVM 2018/19 sample covers all regions with urban and
+rural areas surveyed in all regions apart from the autonomous sector of
+Bissau (SAB) where all respondents are from urban areas.
+#+end_quote
+
+Note the tension with the ABSTRACT's claim of representativity "of the
+geopolitical zones (at both the urban and rural level)": for SAB there is
+no rural component to be representative of.  Recorded, not adjudicated.
+
+*** No other exclusion is stated
+
+No "for security reasons" carve-out, no dropped region, no nomadic /
+homeless / diplomatic clause appears anywhere in the DDI.  Searched: the
+full text of the local DDI PDF (all pages, pdfminer extraction), grepped
+for =universe=, =excl=, =de jure=, =prison=, =barrack=, =dormitor=,
+=representative=, =institutio=, =security=, =nomad=, =homeless=,
+=diplomat=; plus the WB Basic Information Document (20 pp.), grepped for
+=universe=, =population=, =excl=, =sampl=, =frame=, =target=,
+=representative=.  Absence is recorded as "not stated", never as "does not
+exist" -- some sibling EHCVM countries carry an explicit French exclusion
+of collective households, diplomats and the homeless in their national
+report, and no such national report is shipped for Guinea-Bissau.
+
+** 2018-19 -- oversamples and sub-populations
+
+*No oversample, booster, refresh panel or special sub-population is
+declared anywhere in the documentation.*  There is no MOP/Roma-style
+minority sample, no urban booster, no module subsample, no extended-vs-
+refresh split.  The design as stated is a single two-stage national draw
+(DDI p. 4 / BID p. 10, verbatim):
+
+#+begin_quote
+Upon deciding on the sample size and repartition, the survey design team
+implemented a 2-stage sampling methodology. At the first stage, 450
+enumeration areas (EAs) were selected from the sample frame. In the second
+stage, 12 households were selected in each enumeration area randomly.
+#+end_quote
+
+What *does* live inside this single library wave is a **seasonal split**,
+which a reader pooling the country must know about before averaging
+anything.  The library's =2018-19= directory contains both of the survey's
+own internal waves (its /vagues/).  DDI p. 1, verbatim:
+
+#+begin_quote
+The surveys took place in two waves with each wave covering half of the
+sample. The first wave was fielded between September 2018 and December
+2018, while the second wave occurred between April 2019 and June 2019. The
+two-wave approach was chosen to account for seasonality of consumption.
+#+end_quote
+
+DDI p. 4 / BID p. 10, verbatim:
+
+#+begin_quote
+The total survey sample size is 5351 households - 1990 from urban areas and
+3361 from rural areas. After that, the survey design randomly divided each
+enumeration area into two equal groups. The survey team interrogated the
+first group in wave 1 and the other in wave 2. Finally, for various
+reasons, including availability and quality monitoring, the final sample
+size comprises slightly more households (twenty-three) in round 2 than in
+round 1. In wave one, the survey teams interviewed 2664 households (1015 in
+urban areas and 1649 in rural areas. In wave two, the teams interviewed
+2687 households (975 in urban areas and 1712 in rural areas).
+#+end_quote
+
+(The unbalanced parenthesis after "1649 in rural areas" is in the source;
+quoted as printed.  The dash in "5351 households -" is a hyphen in the DDI
+and an en dash in the BID.)
+
+These are two seasonal visits to halves of one cross-section, *not* two
+panel rounds.  Each half is a random split of every EA, so neither half is
+a distinct sub-population -- but the two halves are fielded in different
+seasons, which matters for anything consumption- or agriculture-related.
+
+| item                   | wave 1 (Sep-Dec 2018) | wave 2 (Apr-Jun 2019) | total |
+|------------------------+-----------------------+-----------------------+-------|
+| households interviewed |                  2664 |                  2687 |  5351 |
+| of which urban         |                  1015 |                   975 |  1990 |
+| of which rural         |                  1649 |                  1712 |  3361 |
+
+(Table transcribed from the DDI sentence quoted above; not computed from
+data.)
+
+** 2018-19 -- where the statement lives
+
+Good news for this country: the universe statement is held *in the repo*,
+not only in moving WB catalog metadata.  It is in the tracked, DVC-managed
+=2018-19/Documentation/ddi-documentation-english_microdata-4293.pdf=
+(sidecar =...pdf.dvc= is committed).  The corroborating Basic Information
+Document is *not* shipped locally and was read from the WB catalog
+(4293 / download 52550); treat that second citation as off-repo and
+therefore a moving target.
+
+** Boilerplate warning
+
+The UNIVERSE sentence above is *World Bank NADA template text, not a
+statement by Guinea-Bissau's INE about this survey.*  The identical
+sentence --
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals,
+military barracks, and school dormitories.
+#+end_quote
+
+-- appears verbatim in 15 waves across the library's corpus, including
+countries outside the WAEMU/EHCVM family (Ethiopia 2018-19 and 2021-22;
+Nigeria 2015-16, 2018-19, 2023-24).  Its presence attests which metadata
+template was used.  It does *not* independently attest that a statistical
+office made that claim about this survey.  The Guinea-Bissau-specific
+coverage claim is the SAB sentence under "Exclusions", not this one.
+
+** Universe vs. what the weights represent -- not documented
+
+The DDI contains **no** =WEIGHTING=, =RESPONSE RATE=, or =DEVIATIONS FROM
+SAMPLE DESIGN= section (verified by grepping the full extracted text of the
+local PDF for those headings; zero hits).  The BID has no separate universe
+or target-population statement either; its "Sample" section reproduces the
+DDI's SAMPLING PROCEDURE text.  So for this country there is *no documented
+account of what the sample weights in =ehcvm_ponderations_gnb2018.dta=
+inflate to*, and no documented non-response adjustment.  Recorded as a gap,
+not filled by inference.
+
+** Open question -- one vague per grappe, or two?
+
+Flagging a possible conflict between this evidence and the existing
+"Sampling Design" section of this file, rather than silently overwriting
+either.
+
+Existing =_/CONTENTS.org=, "Sampling Design" (and the matching "EHCVM
+countries" note in =CLAUDE.md=):
+
+#+begin_quote
+Standard EHCVM convention: =grappe= is the cluster identifier (=v=); each
+grappe is visited in exactly one =vague=, so household identifier is
+=(grappe, menage)= without a vague level.
+#+end_quote
+
+The DDI, p. 4, quoted in full above, says instead:
+
+#+begin_quote
+[...] the survey design randomly divided each enumeration area into two
+equal groups. The survey team interrogated the first group in wave 1 and
+the other in wave 2.
+#+end_quote
+
+Read literally, the DDI has *every* EA appearing in *both* vagues (roughly
+6 households each), which is the opposite of "each grappe is visited in
+exactly one vague".  Contrast Burkina Faso, whose BID splits the EAs
+themselves between the waves ("A total of 585 EAs were selected (half (293)
+for the first wave and half (292) for the second wave)") -- i.e. the EHCVM
+family is not uniform on this point, so the repo's cross-country convention
+may not hold for Guinea-Bissau.
+
+Not resolved here, deliberately: this task is evidence-gathering about the
+declared universe, and settling it means crosstabbing =grappe= against
+=vague= in the delivered data.  Either the identifier convention is wrong
+for this country (in which case =(grappe, menage)= may not be unique), or
+the DDI sentence describes the intended design rather than the delivered
+frame.  Whoever picks this up should do that crosstab and record the answer
+in the "Sampling Design" section.  Do not treat the current convention as
+verified for Guinea-Bissau on the strength of this file.
+
+** Record hygiene
+
+One correction to the upstream evidence record, noted so it is not
+propagated: the extraction notes state that
+=2018-19/Documentation/SOURCE.org= "contains only the DOI link" with no
+=#+CATALOG_ID:= / =#+PROVENANCE_*= keywords.  That is not true of the
+tracked file, which carries the full provenance block (=#+CATALOG_ID: 4293=,
+=#+CATALOG_IDNO: GNB_2018_EHCVM_v02_M=, =#+PROVENANCE_SOURCE: worldbank=,
+=#+PROVENANCE_METHOD: doi-lookup=, =#+PROVENANCE_RECORDED: 2026-07-12=),
+committed in =6bd1f318=.  Nothing else in the record depended on that
+claim.
+
 * Household Presence / MonthsSpent
 
 The EHCVM questionnaire (used in the 2018-19 wave) does NOT ask

--- a/lsms_library/countries/Guyana/_/CONTENTS.org
+++ b/lsms_library/countries/Guyana/_/CONTENTS.org
@@ -1,5 +1,428 @@
 #+TITLE: Guyana — country notes & known data issues
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered 2026-07-21 under GH #601.  Guyana has a single wave in this
+library, =1992/=.  This section records what the *documentation claims* the
+sample represents.  It deliberately does not look at the microdata: what the
+survey claims and what the data look like are two different facts, and keeping
+them apart is the point.  Nothing here proposes a schema — GH #603 owns that.
+
+** Where the statement lives: NOT in this repository
+
+*The universe evidence for Guyana 1992 is catalog-only.*  Every quotation below
+comes from =gy92info.pdf=, the Basic Information Document ("Guyana Living
+Standards Measurements Survey (GLSMS) 1992-1993: Basic Information
+Documentation", Country Operations Division II, Department III, Latin America
+and the Caribbean Region, The World Bank, July 15, 1996), hosted by the World
+Bank Microdata catalog at
+
+: https://microdata.worldbank.org/catalog/2319/download/34615
+
+That file is *not* in =lsms_library/countries/Guyana/1992/Documentation/=.  The
+documentation this repo does ship carries no universe statement:
+
+- =ddi-documentation-english_microdata-2319.pdf= (the shipped DDI) has *no*
+  Overview, Scope, Coverage or Universe section at all.  Its entire =Sampling
+  Procedure= field reads: "The LSMS survey was administered in conjunction with
+  the third subround of the HIES.  This required an additional visit by
+  interviewers to each of the approximately 1,800 households selected in this
+  round. ..." — sample-design text, not a universe.  Verified 2026-07-21 by
+  extracting all 11 pages; the strings =Universe=, =universe= and =Coverage= do
+  not occur in the file.
+- =SOURCE.org=, =LICENSE.org= — no universe statement.
+- =GUY01.pdf=, =GUY02.pdf=, =GUY03.pdf=, =GUY09.pdf= — image-only scans (text
+  layers of 12, 42, 2 and 16 characters respectively).  See the gap note below.
+
+So the record for this country is a *moving target held by the World Bank*, not
+something the library holds.  Guyana is one of 41 of 111 waves in that position
+(see =slurm_logs/POPULATION_STATEMENTS_2026-07-21.org=, §5.1).
+
+The WB catalog study page for entry 2319 has *no* =Universe= field.  Its
+Coverage section states only:
+
+#+begin_quote
+Geographic coverage: National
+#+end_quote
+
+That is a coverage claim, not a declaration of the population.  It should not be
+laundered into one.
+
+** 1992 — the declared universe, verbatim
+
+No document that could be read contains a field or a sentence labelled
+"universe" or "target population".  The closest thing to an explicit universe
+claim is the opening of the sample-design section, and the operational
+definition of the frame that follows it.
+
+Citation: =gy92info.pdf=, Section III "Sample", paragraphs 28-30, printed p. 7
+(PDF p. 11).
+
+#+begin_quote
+28.  The objectives of the HIES and the LSMS called for a national sample
+representative of rural and urban populations at all income levels.  Based on
+the experiences of Labor Force Survey and the Survey of Living Conditions in
+Jamaica, it was decided to draw a one-percent sample of households.  The design
+called for a two-stage stratified sample.  For the first stage sample,
+Enumeration Districts (geographical areas designated during the 1991 population
+census) were selected from 16 geographical regions.  In the second, households,
+the units of inquiry, were selected from a listing of all households in the
+selected Enumeration Districts.
+#+end_quote
+
+#+begin_quote
+29.  The First Stage Sample.  Guyana is divided into 10 Administrative Regions
+(Annex F contains a map displaying their borders).  For the 1991 population
+census, each Administrative Region was divided into Enumeration Districts (EDs)
+of about 100 households each.  There were 2,610 EDs in the country, of which 616
+were selected to the sample for the HIES.
+#+end_quote
+
+#+begin_quote
+30.  The urban sampling frame contained the EDs comprised of the Georgetown
+metropolitan area (central and suburban areas), which accounts for 21 percent of
+the total population, and the EDs comprised of the other urban areas which
+include New Amsterdam, Linden, Anna Regina, and Corriverton, accounting for 11.2
+percent of the population.  The Rural sampling frame was defined as the EDs in
+all ten Administrative Regions not defined as urban.
+#+end_quote
+
+Language of the source: English.  No translation needed.
+
+*Reading (editorial, not a quote).*  Taken together these say: a national,
+urban + rural, private-household frame, built from the 2,610 Enumeration
+Districts of the 1991 population census and covering all ten Administrative
+Regions.  This is *not* an LSMS-ISA-style rural-only or region-restricted
+design.  But note that no sentence names the population — the wave is tagged
+=national-claimed=, not =national-all-households=, in the #601 survey precisely
+because "a national sample representative of rural and urban populations" is a
+*representativeness* claim about a sample, not a statement of who is in scope.
+
+*Internal inconsistency in the source (flagged, not resolved).*  ¶28 says EDs
+"were selected from 16 geographical regions"; ¶29 says Guyana has 10
+Administrative Regions.  Table 1 of the same document lists 10 rural strata plus
+6 urban strata = 16, so "16 geographical regions" in ¶28 appears to mean strata.
+That reconciliation is *my* reading; the document does not state it.
+
+** 1992 — exclusions
+
+This is the part a pooler needs.  The finding is mostly negative, and the
+negative finding is itself evidence:
+
+*No document that could be read declares a categorical exclusion* — of
+institutional population, of collective or nomadic households, of the homeless,
+or of any Administrative Region — from the frame.  Per the repo's standing rule
+against unevidenced "no module here" claims, that sentence is scoped to what was
+actually read: the BID, the shipped DDI, and the catalog study page.  Two field
+manuals could not be read (see the gap note).
+
+What the documentation *does* record are field outcomes and access constraints,
+which are a different kind of fact:
+
+*** Seasonal inaccessibility of the interior regions (design accommodation, not exclusion)
+
+=gy92info.pdf= ¶32, printed p. 7 (PDF p. 11):
+
+#+begin_quote
+32.  Table 1 presents the allocation of selected EDs.  Note that the number of
+EDs selected in each stratum is a multiple of 8.  This was to ensure that each of
+the strata would be represented by at least two EDs in each of the four calendar
+rounds.  This sub-round restriction was not applied to interior regions 1, 7, 8,
+and 9 which are not accessible during certain periods of the year.  In these
+regions, the total sample allocated was programmed to be surveyed during the
+part of the year when they were accessible.
+#+end_quote
+
+Regions 1, 7, 8 and 9 stay *in* the frame; what is dropped is their even spread
+across the four calendar rounds.  This matters for this library specifically,
+because the wave shipped here *is one of those four rounds* (see below): a
+seasonal restriction applied to whole regions interacts with a design that
+retains only the third round.
+
+*** EDs actually lost in the field
+
+=gy92info.pdf= ¶42, printed p. 10 (PDF p. 14):
+
+#+begin_quote
+42.  Of the entire sample, only two EDS had to be substituted due to
+inaccessibility, and three became casualties.  Karisparu (ED no. 364) could not
+be surveyed because the air strip was closed, making the ED inaccessible.  A
+second ED in Region 4 was found to have only institutional population (the
+Georgetown Jail) and was not included.  The third ED not included was in Region
+10 due to unsatisfactory completion of the survey by the Enumerator and his
+subsequent resignation.  There was a substantial time lag, making revisits
+impossible.
+#+end_quote
+
+*Do not over-read the jail.*  The Georgetown Jail ED was dropped as a
+single-ED field outcome.  Nothing in the document states a *frame rule*
+excluding institutional population.  Those are different claims and only the
+first is evidenced.
+
+(=EDS= is the source's own capitalisation here and in ¶39; left as extracted.)
+
+*** Non-response is substituted, not excluded
+
+=gy92info.pdf= ¶37, printed p. 8-9 (PDF p. 12-13):
+
+#+begin_quote
+37.  From each of the rearranged sample frames, twelve (12) households were
+selected circular systematically with a random start and with substitution.  If
+a sample household could not be surveyed due to the temporary absence from the
+ED, refusal to give information or for other reasons, it was substituted by the
+household with the next sample serial number of the same column of the listing
+schedule so that the substitute household had the same economic characteristics
+as the original one.  The substitute for the last household of a column would,
+however, be the first household of the same column.  If a household had been
+already selected for survey, it would not be taken as a substitute.  If there was
+no proper substitute household in the same column, the first household in the
+next column was to be taken.
+#+end_quote
+
+Scale of the substitution, ¶41 (printed p. 10, PDF p. 14): "Of the total 7,254
+households surveyed in HIES, 1,196 were substituted households, and a very small
+proportion, 0.5 percent (37 households) were casualty households, e.g., no
+interview was conducted even with a substitute household."  So roughly one
+household in six in the HIES is a substitute drawn to match the original's
+economic characteristics.  This is a *realised-sample* property, not a universe
+property, but it bears on any analysis that treats non-response as ignorable.
+
+** 1992 — sub-samples and sub-populations (read this before pooling)
+
+The specialization in Guyana lives *inside* the wave, in three distinct ways.
+
+*** 1. The whole library wave is a one-quarter subround of a larger survey
+
+=gy92info.pdf= ¶38, "Sample Design of the LSMS", printed p. 9 (PDF p. 13):
+
+#+begin_quote
+38.  The LSMS was implemented in conjunction with the HIES and drew data from
+the third round of the four-round HIES 7,000 household sample.  Because each
+round represented a national sample, it was possible to administer the LSMS in
+one round only, covering 1,795 households in 154 EDs.
+#+end_quote
+
+The full HIES is 7,392 households in 616 EDs across four calendar rounds; what
+this library holds is the *third round only* — ~1,795 households in 154 EDs.  The
+BID's warrant for calling that national is the assertion "each round represented
+a national sample."
+
+The document itself immediately qualifies that warrant, ¶55, printed p. 13
+(PDF p. 17):
+
+#+begin_quote
+55.  It should be noted that because the full HIES contained a larger sample of
+7,200 households, some differences may occur in comparing results from the full
+HIES sample and analysis of the smaller (1,800 households) linked HIES-LSMS
+sample (e.g., slight differences in consumption patterns, and regional
+distribution).  For example, average household size for the HIES four sub-rounds
+was 4.3 compared with 4.4 for the third HIES-LSMS sub-round only.  The proportion
+of household expenditures on food was 54.0 percent for the HIES survey compared
+with 55.2 percent for the HIES-LSMS sample.
+#+end_quote
+
+So the survey's own documentation says the LSMS subsample's *regional
+distribution* differs from the full HIES — while ¶32 says four of ten regions
+were surveyed only in whichever part of the year they were accessible.  Anyone
+pooling Guyana with a full-year survey should know that the wave is a single
+quarter, and that the documentation does not claim the quarter is
+distributionally identical to the year.
+
+*** 2. Disproportionate allocation by stratum (the closest thing to an oversample)
+
+=gy92info.pdf= ¶31, printed p. 7 (PDF p. 11):
+
+#+begin_quote
+31.  The 616 EDs to be sampled were allocated to different strata taking into
+consideration the relative size of the rural and urban population.  Within the
+rural sector, the sample size was reallocated to ten strata in proportion to the
+rural population with a minimum of eight EDs for each stratum.  In the urban
+sector also, the sample size was reallocated into six strata in proportion to
+the urban population.  For the bigger and comparatively more populated interior
+regions (regions 1, 7, and 9) an allocation of 16 EDs was made so as to net about
+200 households in these regions.  Within each rural and urban stratum, the
+allocated number of EDs was selected in circular systematical manner with
+probability proportional to population as available from preliminary estimates
+from the 1991 census.  For some EDs the estimates were not yet available from the
+1991 census, so the results from the 1980 census were used.
+#+end_quote
+
+There is no *named* "booster" or "oversample" in this survey.  What there is: a
+floor of eight EDs per rural stratum and a deliberate 16-ED allocation to
+interior regions 1, 7 and 9 "so as to net about 200 households" — i.e. allocation
+departs from proportionality in the sparse interior.  Allocation from Table 1
+(=gy92info.pdf=, printed p. 7):
+
+| frame | stratum                | sample EDs |
+|-------+------------------------+------------|
+| Rural | Administrative Region 1|         16 |
+| Rural | Region 2               |         32 |
+| Rural | Region 3               |         72 |
+| Rural | Region 4               |        112 |
+| Rural | Region 5               |         40 |
+| Rural | Region 6               |         72 |
+| Rural | Region 7               |         16 |
+| Rural | Region 8               |          8 |
+| Rural | Region 9               |         16 |
+| Rural | Region 10              |          8 |
+| Rural | subtotal               |        392 |
+| Urban | Georgetown             |         48 |
+| Urban | Suburbs of Georgetown  |        104 |
+| Urban | New Amsterdam          |         16 |
+| Urban | Corriverton - Rosehall |         16 |
+| Urban | Linden                 |         32 |
+| Urban | Anna Regina            |          8 |
+| Urban | subtotal               |        224 |
+| TOTAL |                        |        616 |
+
+*Region *names* are deliberately omitted from the table.*  Table 1 prints a
+geographical description beside each region number, but the PDF's text layer
+yields only nine names for the ten numbered rural rows (Barima - Waini, Pomeroon
+- Supernaam, Essequibo Island - West Demerara, Mahaica - Berbice, East Berbice -
+Corentyne, Cuyuni - Mazaruni, Potaro - Simpauni, Upper Takutu - Upper Essequibo,
+Upper Demereara - Berbice) — one name, evidently Region 4's, is dropped, which
+shifts every pairing after it by one.  Rather than propagate a wrong
+number-to-name mapping, only the numbers and counts are transcribed here; read
+the names off Table 1 itself (printed p. 7).  The *counts* are as printed.
+
+Note also that 224/616 = 36 percent of sample EDs are urban, against the ~32
+percent urban population share implied by ¶30 (21 + 11.2).
+
+*** 3. Two within-household sub-samples in the LSMS instrument
+
+Both are documented and both are narrower than the household sample:
+
+- *Fertility module — one randomly selected woman per household.*
+  =gy92info.pdf= ¶23: "This section collected information about the pregnancy,
+  birthing, and contraceptive practices of women in the household between the
+  ages 13 and 49.  Only one member of the household was interviewed for this
+  section.  The interviewer consulted a previously prepared list of randomly
+  ordered ID numbers and selected the first one corresponding to an eligible
+  member of the household being interviewed. ..."
+- *Anthropometry module — households with a child under five, third visit.*
+  =gy92info.pdf= ¶24: "During the initial LSMS interview, the interviewer
+  indicated whether any children under the age of five years were present.  For
+  households with such children, a return visit by a team of nursing students,
+  was made to collect data on the children."
+
+  And its geographic limitation, ¶50, printed p. 12 (PDF p. 16): "No follow-up
+  visits subsequent to the administration of the anthropometric module were
+  attempted in interior regions due to prohibitive logistics and transportation
+  costs."
+
+So the anthropometric sub-sample is *not* uniformly followed up across the
+country: the interior regions get no post-anthropometry follow-up visit.
+
+** Universe vs. what the weights represent
+
+The documentation supplies expansion factors, and is explicit that they were
+adjusted where the frame and the field disagreed.  =gy92info.pdf= ¶43, printed
+p. 10 (PDF p. 14):
+
+#+begin_quote
+43.  Another constraint was the difficulty in physically identifying the EDS in
+the field using the census maps.  These maps had been prepared in the seventies
+and over the years, many changes had taken place.  In some areas, there was
+non-comparability between the Census population figure and the numbers of
+persons listed by the survey enumerators.  This was addressed by modifying the
+expansion factors to be used to estimate the values of different characteristics
+in cases where the difference between the ED population as estimated from the
+census and as revealed in the listing differed by more than 20 percent.  The
+expansion factors are included with the data files.
+#+end_quote
+
+Its footnote 3, on the same page:
+
+#+begin_quote
+3.  The expansion factors are missing for ED numbers 408 and 482.
+#+end_quote
+
+Two points for anyone weighting Guyana:
+
+1. The expansion factors ship in a separate file (=WEIGHT=, described in the
+   BID's Table 2 as "Contains ED number and expansion factor"), and are keyed at
+   *ED* level, not household level.
+2. They are *missing for two EDs*, and they were built for the HIES.  The BID
+   nowhere states that they were re-scaled for the third-round LSMS subsample —
+   and ¶55 says the LSMS subsample's regional distribution differs from the
+   HIES.  Whether the shipped factors weight the LSMS subsample to the national
+   population is *not established by the documentation*.  Treat that as an open
+   question, not as a defect claim.
+
+** Gaps: what was searched and not found
+
+Recorded as gaps per the repo's standing rule.  A silent gap is
+indistinguishable from an unevidenced negative.
+
+| searched                                             | result                                                    |
+|------------------------------------------------------+-----------------------------------------------------------|
+| =Guyana/1992/Documentation/SOURCE.org=               | provenance keywords only; no universe                     |
+| =Guyana/1992/Documentation/LICENSE.org=              | WB PUF terms only; no universe                            |
+| =ddi-documentation-english_microdata-2319.pdf=       | all 11 pp. extracted; no Overview/Scope/Coverage/Universe |
+| =GUY01.pdf= (GLSMS household questionnaire)          | *image-only scan, 12-char text layer — UNREAD*            |
+| =GUY02.pdf= (HIES household schedule)                | *image-only scan, 42-char text layer — UNREAD*            |
+| =GUY03.pdf= (HIES availability of facilities)        | *image-only scan, 2-char text layer — UNREAD*             |
+| =GUY09.pdf= (means tables)                           | *image-only scan, 16-char text layer — UNREAD*            |
+| =GUY04.pdf= (HIES Field Supervisor's Manual)         | catalog-hosted; *image-only scan, 20-char — UNREAD*       |
+| =GUY05.pdf= (HIES Instruction Manual for Field Staff)| catalog-hosted; *image-only scan, 136-char — UNREAD*      |
+| WB catalog study 2319 study-description page         | Abstract, Scope, Coverage, Sampling; *no Universe field*  |
+| WB catalog related-materials page                    | 10 documents enumerated; =gy92info.pdf= is the source     |
+
+No OCR tool (tesseract) was available on the host, so the six image-only PDFs
+could not be read.  =GUY04.pdf= and =GUY05.pdf= in particular are the manuals the
+BID itself points at for the household definition and the selection procedure
+(¶33: "The selection process is described in detail in the 'Field Supervisor's
+Manual'"; ¶53: "the GBS 'Instruction Manual for Field Staff' contains a very
+detailed explanation of each instrument item").  Either could carry a
+household-definition or coverage rule that this record therefore does not cover.
+*If someone runs OCR over GUY04/GUY05, revisit this section.*
+
+Household counts in the BID are mutually inconsistent and are *not* reconciled
+here: ¶33 "7,392 households was drawn"; ¶38 "four-round HIES 7,000 household
+sample" and "covering 1,795 households"; ¶41 "total 7,254 households surveyed in
+HIES"; ¶55 "a larger sample of 7,200 households" and "(1,800 households)";
+catalog and ¶33 "approximately 1,800 households".  They are quoted as printed.
+
+** Text-fidelity caveat on the quotations above
+
+=gy92info.pdf= is a 1996 print-to-PDF whose text layer inserts spurious spaces
+inside words, especially at justified line ends — the raw extraction contains
+e.g. =Househ old=, =implement ed=, =ED s comprised=, =1,79 5=, =was no t
+applied=, =Corrivert on=, =institutional populati on=, =and hi s subsequent=.
+In every quotation above I have (a) rejoined those split words, (b) collapsed
+runs of whitespace, and (c) removed marginal paragraph numbers that the
+extractor interleaves mid-sentence.  *No word was changed, added, dropped,
+reordered or translated.*  One deliberate non-repair: the source's =EDS= (¶42,
+¶39) is left as extracted rather than normalised to =EDs=.
+
+Reproduce with:
+
+#+begin_src python
+from pdfminer.high_level import extract_text
+from pdfminer.layout import LAParams
+extract_text('gy92info.pdf', page_numbers=list(range(9, 18)),
+             laparams=LAParams(word_margin=0.2, char_margin=3.0,
+                               line_margin=0.5, boxes_flow=0.5))
+#+end_src
+
+All quotations in this section were re-extracted from a freshly downloaded copy
+of =gy92info.pdf= on 2026-07-21 and match.
+
+** Notes for maintainers
+
+- This section does not contradict anything in this file.  The only pre-existing
+  note is the =shocks= availability finding under "Known data issues", which is
+  about module coverage, not sampling; the two do not interact.
+- Correction to the #601 evidence record: it states that this wave's
+  =SOURCE.org= "contains ONLY the bare DOI link ... no =#+CATALOG_ID= /
+  =#+PROVENANCE_*= keywords."  As of the 2026-07-12 provenance backfill that is
+  no longer true — =SOURCE.org= now carries =#+CATALOG_ID: 2319=,
+  =#+CATALOG_IDNO: GUY_1992_LSMS_v01_M=, =#+PROVENANCE_SOURCE: worldbank= and
+  =#+PROVENANCE_METHOD: doi-lookup=.  The catalog id the record inferred from a
+  filename is therefore independently confirmed.
+- Nothing in this section was derived from the =.dta= files.  Every claim is the
+  documentation's claim.
+
 * Known data issues
 
 ** shocks — not available (2026-06-06)

--- a/lsms_library/countries/India/_/CONTENTS.org
+++ b/lsms_library/countries/India/_/CONTENTS.org
@@ -1,5 +1,257 @@
 #+title: Contents
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence for what the India survey CLAIMS to represent, kept deliberately
+separate from what the data look like.  One wave only (=1997-98=).  Cross-refs:
+the =sample.Rural= entry below in this file (#602) is the data-side counterpart
+of the "no rural/urban universe is claimed" finding recorded here; the two
+agree and neither should be read without the other.
+
+** 1997-98 — declared universe (verbatim)
+
+Survey: /India - Uttar Pradesh and Bihar Survey of Living Conditions 1997-1998/
+(catalog title; the questionnaire cover reads "SURVEY OF LIVING CONDITIONS /
+UTTAR PRADESH AND BIHAR").  Catalog IDNO =IND_1997_SLCUPB_v01_M=, WB Microdata
+catalog entry 276, DOI https://doi.org/10.48529/q6sh-b869.
+
+Source (held IN this repo, not catalog-only):
+=India/1997-98/Documentation/ddi-documentation-english_microdata-276.pdf=,
+printed page 3 (PDF page index 2), section "Sampling" > "Sampling Procedure",
+sub-heading "Sampling Universe:".  Byte-identical text also appears in the WB
+catalog record at
+=dataset.metadata.study_desc.method.data_collection.sampling_procedure=.
+Language: English (no translation needed).  Verified verbatim against the PDF
+2026-07-21.
+
+#+begin_quote
+Sampling Universe:
+
+The universe for the study comprised 4 statistical regions: 2 in Uttar Pradesh
+(Eastern and Southern), and 2 in Bihar (Northern and Central). Altogether,
+there were 55 districts in the area covered by the study: 24 districts in the 2
+statistical regions in Uttar Pradesh, and 31 districts in the 2 statistical
+regions covered in Bihar.
+#+end_quote
+
+Immediately preceding it, same page, sub-heading "Sampling Information:" — this
+is the frame from which the 4 regions were carved, quoted for context:
+
+#+begin_quote
+Uttar Pradesh and Bihar, the two states selected for the study, are divided
+into 8 statistical regions: 5 in Uttar Pradesh (Himalayan, Western, Central,
+Eastern, and Southern) and 3 in Bihar(Southern, Northern, and Central).
+#+end_quote
+
+[sic — ="Bihar(Southern"= is unspaced in the source.]
+
+*The universe statement is AREA-level, not unit-level.*  It names 4 statistical
+regions / 55 districts.  It never says "all private households in ...", never
+names an observation unit, and states no inclusion or exclusion rule for any
+kind of household or person.  Whatever this survey represents, the
+documentation says only /where/, never /who/.  This is subnational by
+construction: nothing here is a claim about India.
+
+** 1997-98 — exclusions
+
+*No exclusion statement exists.*  Recorded as a gap, not as "no exclusions".
+
+What was searched: the full DDI text (793,507 chars extracted with pdfminer)
+for =universe=, =target population=, =geographic coverage=, =sampling
+deviation=, =response rate=, =weighting=, =rural=, =urban=, =exclud*=,
+=omitt*=, ="not covered"=, =nomad=, =institution=; both questionnaire PDFs
+(=slc-hh97.pdf= household, =slc-cq97.pdf= village) front-matter — both are
+blank instruments, cover page plus contents, carrying no scope statement; and
+the WB NADA catalog record for =IND_1997_SLCUPB_v01_M=.  Nothing found.
+
+Structurally there is nowhere for such a statement to be: the DDI's *"Data
+Processing"* and *"Data Appraisal"* sections both read, verbatim, =No content
+available=, and the report carries no "Weighting", "Response Rate" or
+"Deviations from Sample Design" section at all.  The absence is an absence of
+documentation, not evidence of an unrestricted universe.
+
+The 8-regions-to-4 reduction quoted above is the only bound-by-remainder in the
+record: 3 of Uttar Pradesh's 5 regions (Himalayan, Western, Central) and 1 of
+Bihar's 3 (Southern) lie outside the study area.  That is a geographic
+carve-out and should be read as one, but note the document frames it as
+/selection/, never as /exclusion/.
+
+*** CAUTION — do not upgrade "rural" from inference to claim
+
+The WB catalog abstract opens "A two-part study of *rural poverty* was carried
+out in 1997-98 ...", and every PSU in the design is a "village".  These are
+strongly suggestive of a rural-only universe.  *No document in either source
+states a rural-only universe as such.*  The word =rural= does not appear
+anywhere in the front matter of the local DDI (pages 1-9: zero hits, checked).
+Do not record "rural households" as this survey's population; it is an
+inference from the study's title and its PSU vocabulary, not a claim by anyone.
+
+This is the documentation-side twin of the =sample.Rural= finding (#602, below
+in this file): the shipped data carry no urban/rural variable, and the
+documentation asserts no urban/rural universe.  Neither source supports a
+rural/urban classification, from either direction.
+
+** 1997-98 — sub-samples and oversample  [IMPORTANT for anyone pooling]
+
+*This wave contains a purposive, double-rate oversample of 30 previously-visited
+villages.*  It is not flagged anywhere in the library's tables; a naive
+unweighted pooling of India will overweight them ~2:1 at the household level.
+
+The design, verbatim, same DDI page 3, sub-heading "Sampling Strategy:":
+
+#+begin_quote
+The sampling strategy followed for the quantitative study basically involved
+dividing the sample population into four main strata:
+1) districts that were covered in the qualitative study in Bihar (i.e. 4 districts)
+2) districts that were covered in the qualitative study in Uttar Pradesh (i.e. 3 districts)
+3) remaining districts in the 2 selected regions of Bihar (i.e. 27 districts)
+4) remaining districts in the 2 selected regions of Uttar Pradesh (i.e. 21 districts)
+#+end_quote
+
+#+begin_quote
+All 12 villages in Stratum 1 that were covered in the qualitative study were
+included in the sample. Similarly, all 18 villages in Stratum 2 that were
+covered in the qualitative study were included in the sample. In each of these
+30 villages, 30 households each were picked at random for the survey.
+
+In stratums 3 and 4, 45 villages each were selected for the survey. A two-step
+procedure was used to select villages in these two strata: first, 9 districts
+were selected in each stratum using PPS. In each of the 9 districts, 5 villages
+were then selected at the second stage, again using PPS. In each of these 90
+villages altogether, 15 households each were selected for the survey.
+#+end_quote
+
+And on the qualitative phase those 30 villages come from (same page):
+
+#+begin_quote
+In the first phase of the project, qualitative field work was carried out in 30
+villages: 3 villages each from 4 districts in Bihar (Mungher, Jehanabad,
+Saharsa, and Vaishali), and 6 villages each from 3 districts in Uttar Pradesh
+(Banda, Allahabad, and Gorakhpur).
+#+end_quote
+
+What that amounts to:
+
+| stratum | area                        | villages | selection             | HH/village | households |
+|---------+-----------------------------+----------+-----------------------+------------+------------|
+|       1 | Bihar, qualitative-phase    |       12 | ALL, with certainty   |         30 |        360 |
+|       2 | UP, qualitative-phase       |       18 | ALL, with certainty   |         30 |        540 |
+|       3 | Bihar, remaining districts  |       45 | PPS two-stage         |         15 |        675 |
+|       4 | UP, remaining districts     |       45 | PPS two-stage         |         15 |        675 |
+|---------+-----------------------------+----------+-----------------------+------------+------------|
+|         | total                       |      120 |                       |            |       2250 |
+
+Two distinct things make strata 1-2 a sub-population rather than just a stratum:
+
+1. *They were taken with certainty and non-randomly.*  "All 12 villages ... were
+   included"; they are the villages the earlier qualitative phase happened to
+   visit, not a probability draw from anything.  They have no design-based
+   inclusion probability in the ordinary sense.
+2. *They were sampled at twice the household rate* (30 vs 15 per village).  They
+   are 25% of villages but 40% of households (900 / 2,250).
+
+They are also, by construction, villages that had *already been enumerated once*
+by the same project.  The documentation does not discuss whether that matters;
+recorded here as a fact of the design, not as a claim about its consequences.
+
+The strata survive into the library.  =sample.strata= carries =UP-qual=,
+=UP-other=, =B-qual=, =B-other= — the =-qual= labels are strata 2 and 1, the
+=-other= labels strata 4 and 3.  So the oversample IS separable: subset or
+weight on =strata=.  The DDI's own variable list documents this variable as
+=stratum=, "Stratum (1-4)", in both =HHLIST= and =PSULIST=.  This independently
+corroborates the #602 finding below that =stratum= is a state-x-sampling-phase
+stratum and never an urban/rural one.
+
+No other sub-population appears: no ethnic/minority booster, no poverty-targeted
+module subsample, no refresh vs extended sub-panel (this is a single
+cross-section, not a panel).
+
+** 1997-98 — universe vs. what the weights represent
+
+*The documentation never says what the weights raise to.*  The DDI variable list
+documents =weight= in both =HHLIST= ("The file contains household listing data
+including geographic area information and weighting coefficient") and =PSULIST=
+("... community listing information including geographic area and weighting
+coefficient"), with the variable label, verbatim, =Raising factor=.  There is no
+"Weighting" section in the DDI and no weighting text in the catalog record.
+
+So: a raising factor is shipped, its target population is nowhere stated, and
+the only universe statement in the record is an /area/ (4 regions, 55
+districts) rather than a /population/.  A user computing a weighted mean from
+this wave is estimating a quantity for a population that the documentation does
+not define.  That is the honest reading; do not repair it by assuming the
+weights raise to "all rural households in the 4 regions".
+
+** 1997-98 — where the statements live
+
+| statement                                   | source                        | in this repo? |
+|---------------------------------------------+-------------------------------+---------------|
+| Sampling Universe (4 regions / 55 districts)| DDI PDF p.3 = catalog         | YES           |
+| Sampling Information (8 regions)            | DDI PDF p.3                   | YES           |
+| Sampling Strategy (4 strata, oversample)    | DDI PDF p.3                   | YES           |
+| =weight= = "Raising factor"                 | DDI PDF p.11-12 variable list | YES           |
+| geographic coverage sentence                | WB catalog =geog_coverage=    | *catalog only* |
+| "study of rural poverty" abstract           | WB catalog =abstract=         | *catalog only* |
+
+The load-bearing universe statement is held locally, so it is not a moving
+target.  The two catalog-only items are NOT held in this repo and can change
+without notice; they are recorded here as quotations with that caveat attached,
+and neither is used above to establish the universe.
+
+Catalog-only text, verbatim, WB Microdata record =IND_1997_SLCUPB_v01_M=,
+=study_desc.study_info.geog_coverage=:
+
+#+begin_quote
+The survey covered south and eastern Uttar Pradesh and north and central Bihar.
+#+end_quote
+
+Same record, =study_desc.study_info.abstract= (opening; the "rural poverty"
+phrase flagged above):
+
+#+begin_quote
+A two-part study of rural poverty was carried out in 1997-98 in south and
+eastern Uttar Pradesh and north and central Bihar. This study utilized both
+qualitative methods - rapid rural appraisal (RRA) & participatory rural
+appraisal (PRA) methodologies, and semi-structured interviews - as well as
+quantitative methods drawing on data collected from household and community
+surveys modelled after the World Bank's Living Standards Measurement Study
+(LSMS) surveys.
+#+end_quote
+
+#+begin_quote
+The data being distributed are from the quantitative component of the study,
+field work for which was carried out between December 1997 and March 1998. Data
+were collected through household and village-level questionnaires in 120
+villages drawn from a sample of 25 districts in UP and Bihar states; a total of
+2,250 households were interviewed during the course of the survey (more details
+on distribution of the sample are provided in the sampling section of this
+note). Of the sample of 120 villages where the household and village surveys
+were conducted, 30 had been visited in the earlier qualitative component of the
+study, while the remaining 90 were drawn at random from the sample districts.
+#+end_quote
+
+The "25 districts" reconciles with the strategy above: 4 + 3 qualitative-phase
+districts plus 9 + 9 PPS-selected districts.  Minor documentation-internal
+discrepancy, noted so the next reader does not chase it: the abstract says
+"2,250 households", the DDI's file description gives =HHLIST= "Cases 2251".
+
+*No NADA boilerplate.*  This wave's universe text is survey-specific prose, not
+the WB NADA template sentence that recurs verbatim across 15 other waves in the
+corpus.  It attests an actual description of this study's design.
+
+** 1997-98 — what is NOT established
+
+- No unit-level universe (no "all private households", no household definition,
+  no residence rule).
+- No institutional / collective / nomadic / homeless exclusion clause, in either
+  direction.
+- No rural-only claim (see caution above).
+- No response rate, no sampling deviations, no non-response treatment.
+- No statement of the population the =Raising factor= raises to.
+
+Each of these is a gap in the record, established by the search documented
+above.  None should be filled by inspecting the =.dta= files.
+
 * sample.Rural — NOT available (2026-07-12, #602)
 
 =sample= carries no =Rural= (urban/rural) column, deliberately.

--- a/lsms_library/countries/Iraq/_/CONTENTS.org
+++ b/lsms_library/countries/Iraq/_/CONTENTS.org
@@ -1,5 +1,435 @@
 #+title: Contents
 
+* Sampling universe, exclusions and sub-samples
+
+# ASCII EXCEPTION (deliberate, per the orgmode skill's "leave a comment" rule):
+# the =#+begin_quote= blocks below are VERBATIM transcriptions of survey
+# documentation.  They carry Arabic script and typographic apostrophes and are
+# NOT normalised to ASCII, because normalising them would destroy the one
+# property this record depends on.  All prose outside the quote blocks is ASCII.
+
+Evidence gathered for GH #601 / #603 (the population record).  This section
+records only *what the documentation claims*; nothing here is inferred from the
+=.dta= files, and no =.dta= was opened to write it.  It makes no proposal about
+how the library should represent any of this -- that is #603's business.
+
+Summary of the two waves:
+
+| Wave    | Universe statement? | Where it lives                       | Exclusions stated | Sub-sample inside the wave         |
+|---------+---------------------+--------------------------------------+-------------------+------------------------------------|
+| 2006-07 | yes                 | COSIT report in this repo (Vol.1)    | none              | yes -- time use, one-third of HHs  |
+| 2012    | *no -- gap*         | n/a (nowhere: local or WB catalog)   | none stated       | yes -- three modules, one-third    |
+
+Two facts hold for *both* waves and are worth stating once:
+
+- The World Bank catalog records *no* universe for either study.  The
+  machine-readable DDI carries the element, present and empty, in both cases:
+  =<universe/>= in =<stdyDscr>/<stdyInfo>/<sumDscr>= for catalog 69 (2006-07)
+  and for catalog 2334 (2012).  Verified 2026-07-21 against
+  =https://microdata.worldbank.org/index.php/metadata/export/{69,2334}/ddi=.
+  So for 2006-07 the statement below comes from the Iraqi statistical office's
+  own report -- the stronger source -- and for 2012 the equivalent report simply
+  never makes one.
+- *Neither wave carries the WB NADA boilerplate universe sentence.*  The
+  most-repeated sentence in the cross-country corpus ("The survey covered all de
+  jure household members ...", 15 waves) does not appear here, in either
+  direction: what 2006-07 has is a locally authored claim, and what 2012 has is
+  nothing at all.  Neither is template text.
+
+** 2006-07 (IHSES-I) -- declared universe
+
+Survey: Iraq Household Socio-Economic Survey 2006-2007 (IHSES).  WB catalog id
+69, IDNO =IRQ_2006_IHSES_v02_M= (see =2006-07/Documentation/SOURCE.org=).
+
+Source: =lsms_library/countries/Iraq/2006-07/Documentation/Vol.1_Objectives_methodology.pdf=,
+chapter "4. Sample", subsection "B. Sample frame", second paragraph.  PDF page
+17 of 23; the file is a two-up spread whose sheet carries printed pages 16-17,
+and the passage is on printed page 16.  Language: English (no translation
+needed).
+
+#+begin_quote
+The population covered by IHSES included all households residing in Iraq from
+November 1, 2006, to October 30, 2007, meaning that every household residing
+within Iraq’s geographical boundaries during that period potentially could be
+selected for the sample.
+#+end_quote
+
+Transcription note: the PDF is justified, so the text layer emits this sentence
+with runs of multiple spaces; those were collapsed to single spaces.  No word,
+punctuation mark or character was otherwise changed.  The apostrophe in
+"Iraq’s" is the typographic U+2019 as printed.  (Independently re-extracted and
+character-checked against the PDF on 2026-07-21.)
+
+The unit is the *household*, and the universe is *time-bounded*: it is not "all
+households in Iraq" but all households residing there in a named twelve-month
+window.  See the fieldwork-window note below, which bears on that bound.
+
+** 2006-07 -- exclusions
+
+*No exclusion from the universe is stated anywhere.*  The sentence above is
+explicitly inclusive ("every household ... potentially could be selected"), and
+neither Vol.1 nor the DDI states any exclusion of institutional, collective,
+nomadic, camp or homeless population, and no region is excluded.  Searched, in
+Vol.1 and in =ddi-documentation-english_microdata-69.pdf=, for: =universe=,
+=exclud=, =except=, =nomad=, =institution=, =collective=, =homeless=, =camp=,
+=coverage=, =target population=.  Zero hits for =nomad=, =collective=,
+=homeless=, =camp=; the =institution= hits are all acknowledgements or
+questionnaire text.
+
+*The one "excluded" sentence in the sample chapter is about the CENSUS FRAME,
+not about the universe*, and it is quoted here in full precisely so that a later
+reader does not mistake it for a coverage exclusion.  Same subsection, the
+paragraph immediately preceding the universe sentence:
+
+#+begin_quote
+The 1997 population census frame was applied to the 15 governorates that
+participated in the census (the three governorates in Kurdistan Region of Iraq
+were excluded). For Sulaimaniya, the population frame prepared for the
+compulsory education project was adopted. For Erbil and Duhouk, the enumeration
+frame implemented in the 2004 Iraq Living Conditions Survey was updated and
+used.
+#+end_quote
+
+That is: the three Kurdistan governorates were excluded from the *1997 census*,
+so alternative frames were built for them.  They are *in* the survey.  All 18
+governorates are sampled -- Vol.1 chapter 4 subsection "A. Design" (PDF page 16,
+printed page 15):
+
+#+begin_quote
+The survey was designed to visit 18,144 households—324 households in each of 56
+strata, defined as the rural, urban, and metropolitan portions of each of Iraq’s
+18 governorates. Baghdad, with five strata, was the exception.
+#+end_quote
+
+** 2006-07 -- sub-samples, extra clusters, and module-level universes
+
+*** Time-use module: an explicit one-third sub-sample
+
+Vol.1, chapter 4, subsection "H. Time-use sample" (PDF page 18 of 23; the sheet
+is a two-up spread carrying printed pages 18-19, and this passage is in the
+right-hand half, printed page 19), verbatim:
+
+#+begin_quote
+The IHSES questionnaire on time use (Annex 3, Part 5) covered all household
+members aged 10 years and older. A subsample of one-third of the households was
+selected (the second and fifth of the six households in each sample point). The
+second and fourth visits were designated for completion of the time-use sheet,
+which covered all activities performed by every member of the household.
+#+end_quote
+
+So IHSES-I already has the shape that IHSES-II repeats (below): a module inside
+the wave administered to one third of the households.  Anyone pooling
+time-use-derived quantities across Iraq waves is pooling one-third sub-samples
+in both, and the time-use sheet additionally restricts to members aged 10+.
+
+*** Per-variable universes in the DDI
+
+The 2006-07 DDI does *not* record a study-level universe, but it does record
+*variable-level* universes (37 occurrences in
+=2006-07/Documentation/ddi-documentation-english_microdata-69.pdf=), e.g.
+verbatim =Household Members that are 12 years of age or older= (marital status,
+=q0109=) and =Household members aged 6 and above= / =Household Members Aged 6 or
+more= (labour and time-use items).  These are questionnaire skip universes, not
+sampling universes, but they are the only place the documentation says who a
+given variable is asked of.  Note that no such universe is recorded for the
+education variable the library actually reads (=q0406=, "Highest diploma
+attained"); its DDI entry gives only interviewer instructions ("Ask every
+household member who previously attended school ...") and case counts.
+
+*** Sulaimaniya and Kirkuk: extra clusters, and weights that do not follow
+
+Not an oversample in the design, but the realised sample departs from the
+allocation in two governorates, and in one of them the *weights were
+deliberately not adjusted*.  Vol.1, subsection "F. Exceptional Measures"
+(PDF page 18, printed page 18), verbatim:
+
+#+begin_quote
+The required sample size of 54 clusters in Kirkuk was obtained through two
+means. First, eight new clusters were selected in previously visited sample
+points, using the approach described above. Second, 12 clusters were selected in
+new residential areas that had not existed at the time of the original sample
+frame. [...] To account for the new residential area, the population of Kirkuk
+(used for constructing weights) was increased by 38,000, bringing the revised
+population to 1,129,000.
+
+In Sulaimaniya, a new residential area was added that had not existed at the
+time of the original sample frame. Eighteen additional clusters were selected
+from among the newly identified PSUs with the same two-phase sampling method
+used for the original clusters. This brought the total number of clusters in
+Sulaimaniya to 72. The additional 18 clusters were visited after the completion
+of wave 18. The fieldwork for these additional 18 clusters is referred to as
+waves 19 and 20. The population of Sulaimaniya (used for constructing weights)
+was not increased because the population of the new residential areas moved from
+within the same governorate.
+#+end_quote
+
+("[...]" marks an elision of exactly two sentences -- one on the sampling method
+used for the 12 new Kirkuk clusters, one recording that all 54 Kirkuk clusters
+were visited during waves 1 to 18.  Nothing else is elided.)
+
+This is *visible in the library's own configuration*: the 2006-07
+=sample.Rural= mapping in =2006-07/_/data_info.yml= contains the stratum label
+=sulaimaniya - urban center - extra=, which is the extra Sulaimaniya
+metropolitan stratum.  The WB catalog's sampling text agrees, verbatim: "h
+identifies the 57 sampling strata, defined as the rural, urban and metropolitan
+sectors of each of each of the 18 governorates, with the exception of Baghdad
+(which has three metropolitan sectors,) and Suleimaniya (which has two.)"  (sic
+"each of each of"; catalog 69 / DDI PDF.)
+
+** 2006-07 -- universe vs. what the fieldwork and the weights actually cover
+
+Three documented tensions.  None of them contradicts the universe sentence; all
+three qualify it, and a reader pooling this wave should see them.
+
+1. *The fieldwork ran past the declared window.*  The universe is bounded to
+   "November 1, 2006, to October 30, 2007".  The catalog's own collection dates
+   record a second cycle beyond it, verbatim from the DDI XML for catalog 69:
+   =<collDate date="2007-11-01" event="start" cycle="Extension of data
+   collection in Kurdistan region"/>= and =<collDate date="2007-12-15"
+   event="end" .../>=.  Vol.1 supplies the reason (PDF page 18, printed page 18,
+   verbatim):
+   "In Erbil and Duhouk governorates, waves 3, 4, and 5 could not be implemented
+   as planned for logistical reasons. The fieldwork for these three waves was
+   deferred until wave 18 was completed."  So some Kurdistan households were
+   enumerated after the universe's stated end date.
+
+2. *Security-driven cluster replacement, concentrated in two strata.*  Vol.1,
+   "F. Exceptional Measures" (PDF page 18, printed page 18), verbatim:
+
+   #+begin_quote
+   Sometimes a team could not visit a cluster during the allocated wave because
+   of unsafe security conditions. When this happened, that cluster was then
+   swapped with another cluster from a randomly selected future wave that was
+   considered more secure. If none were considered secure, a sample point was
+   randomly selected from among those that had been visited already. The team
+   then visited a new cluster within that sample point. (That is, the team
+   visited six households that had not been previously interviewed.) The
+   original cluster as well as the new cluster were both selected by systematic
+   equal probability sampling. Remarkably few of the original clusters could not
+   be visited during the fieldwork. Nationally, less than 2 percent of the
+   original clusters (55 of 3,024) had to be replaced. Of the original clusters,
+   20 of 54 (37 percent) could not be visited in the stratum of “Kirkuk/other
+   urban” and 19 of 54 (35 percent) could not be visited in “Ninevah/other
+   urban.” The other strata had far fewer clusters that could not be visited
+   (Table I-2). In the city of Baghdad, all original clusters were visited; in
+   the stratum “Baghdad/rural,” only 6 of 54 original clusters (11 percent)
+   could not be visited and had to be replaced.
+   #+end_quote
+
+   This is *replacement*, not exclusion -- the design says nothing was dropped.
+   But it is a security carve-out with a strongly non-uniform geography, and
+   two strata lost roughly a third of their original clusters.
+
+   *Unreconciled numbers, flagged not resolved.*  The report says 55 of 3,024
+   clusters were replaced.  The same report's Table I-2 lists per-stratum counts
+   (6, 8, 4, 19, 8, 2, 20) that sum to 67.  The WB catalog says, verbatim, "This
+   explains why the survey datasets only contain data from 2,876 of the 3,024
+   originally selected PSUs, whereas 55 of the PSUs contain more that the six
+   households nominally dictated by the design." (sic "more that"), which leaves
+   148 unaccounted for and attaches the number 55 to a different quantity.
+   These three accountings are not reconcilable at face value.  Recorded as an
+   open discrepancy in the documentation; *do not* pick one and treat it as the
+   fact.
+
+3. *Response rate.*  Vol.1, "I. Response rates" (PDF page 18, printed page 19),
+   verbatim:
+   "IHSES reached a total of 18,144 households. Interviews were fully carried out
+   for 98.62 percent of these households." with a governorate range from 92.4
+   percent (Duhouk) to 99.8 percent (Missan).  The catalog reports the realised
+   size as "The total effective sample size of the IHSES 2007 is 17,822
+   households."
+
+** 2012 (IHSES-II) -- NO universe statement found (gap)
+
+Survey: Iraq Household Socio-Economic Survey 2012, Second Round (IHSES-II).  WB
+catalog id 2334, IDNO =IRQ_2012_IHSES_v02_M= (see =2012/Documentation/SOURCE.org=).
+
+*No document -- local or catalog -- states a target population or universe for
+this wave.*  This is a checked gap, not an unexamined one, and it is recorded
+here so it can be falsified by anyone who finds the document that was missed.
+What was searched (2026-07-21):
+
+- In the repo, =lsms_library/countries/Iraq/2012/Documentation/=:
+  =ddi-documentation-english_microdata-2334.pdf= (read in full -- it contains
+  only Sampling / Weighting / Questionnaires / Data Collection / Related
+  Materials; *there is no Scope-Coverage-Universe section at all*, re-verified
+  by extraction: zero occurrences of =Universe=, =universe=, =Coverage=,
+  =Scope=, =Target=), =IHSES_II_2012_Arabic_Reviewed.pdf= (the official
+  IHSES-II report, Arabic only, 47 pp. -- chapter 4 "عينة المسح" read in full,
+  searched for المجتمع / المستهدف / يشمل المسح / يغطي / التغطية / جميع الأسر /
+  الشمول / استثن / النطاق), =Iraq_Poverty_Methodology_Note_Final.pdf=,
+  =Part_1_Socio_Economic_Data.pdf=, =Part_3_Income_and_Other_13_24.pdf=,
+  =SOURCE.org=.
+- Catalog-hosted documents not shipped in this repo:
+  =Sampling_and_fieldwork_2012.pdf= (catalog item 34769, read in full -- zero
+  occurrences of "universe" or "target population"),
+  =Iraq_2012_IHSES_Users_Note.pdf= (34770, read in full),
+  =IHSES_2012_Manual_English.pdf= (34768, enumerator manual, grepped).
+- The catalog study description page and the DDI XML export: the Scope section
+  carries only a topic list, Coverage carries only "Geographic Coverage:
+  National coverage", and the DDI's =<universe/>= is empty.
+
+*Closest available statements -- these are SAMPLE-SIZE and SAMPLE-FRAME
+statements, NOT universe statements.*  They are recorded because they are the
+nearest thing that exists, and labelled because promoting either to a universe
+would be an inference rather than a claim the documentation makes.  Both are
+from =2012/Documentation/IHSES_II_2012_Arabic_Reviewed.pdf=, chapter
+"4. عينة المسح".
+
+Subsection "أ. تصميم العينة" (sample design), PDF page 29:
+
+#+begin_quote
+بلغ حجم العينة المختارة (25488) أسرة من جميع محافظات العراق، (216) أسرة من كل من أقضية العراق البالغة (118).
+#+end_quote
+
+Translation (not part of the quote): "The selected sample size amounted to
+(25,488) households from all governorates of Iraq, (216) households from each of
+Iraq's (118) districts."
+
+Subsection "ب. إطار العينة:" (sample frame), PDF page 30:
+
+#+begin_quote
+اعتمدت نتائج الحصر والترقيم المنجزة في إطار التعداد العام للسكان والمساكن للفترة 2009-2010 في جميع محافظات العراق بما فيها إقليم كردستان كإطار لتحديد الأسر، وقد تم اختيار العينة وسحبها في مرحلتين:
+#+end_quote
+
+Translation (not part of the quote): "The results of the listing and numbering
+carried out within the framework of the general population and housing census
+for the period 2009-2010 in all governorates of Iraq including the Kurdistan
+Region were adopted as a frame for identifying households, and the sample was
+selected and drawn in two stages:".
+
+*Why these are not promoted to a universe.*  The frame sentence says what the
+sampling frame was built from ("all governorates of Iraq including the Kurdistan
+Region").  That constrains coverage, but it does not name the set of units the
+sample stands for, says nothing about which residents of those governorates are
+in or out, and is silent on institutional, collective, nomadic and homeless
+population.
+
+*** Two transcription caveats on the Arabic above -- read before relying on it
+
+Recorded so a later reader re-verifies rather than trusts the transcription.
+
+1. *Bidi.* =pdfminer= returns this PDF's Arabic in visual order and is unusable
+   raw.  The quotes come from a per-character reconstruction (group =LTChar= by
+   y, sort by x, reverse Arabic runs only).  Two independent reconstruction
+   passes (the GH #601 sweep's, and a fresh one run while checking it) agree on
+   the letter sequences.  Arabic ligature / hamza normalisation is *not*
+   guaranteed: the raw stream renders lam-alef via presentation forms, so the
+   two passes differ on exactly that -- one yields "بالإمكان" where the other
+   yields the presentation-form spelling.  The quotations above use the
+   normalised orthography, which may differ from the source in code points
+   while being identical in letters.
+2. *The numerals are glyph-substituted in this PDF and have been decoded.*  The
+   raw extracted digits are "45288", "406", "008", "4834", "4101-4119".
+   Cross-checking against internally consistent design facts (25,488 = 118
+   qadhas x 24 EAs x 9 households; 216 per qadha; 2,832 clusters; response rate
+   98.6%) yields the glyph map 0->1, 1->0, 2->4, 4->2 (others identity), giving
+   25488 / 216 / 118 / 2832 / 2009-2010.  The *decoded* digits are substituted
+   into the quotes above.  The census-period range in particular decodes to the
+   character sequence "2010-2009", which is how a right-to-left range renders;
+   it is written "2009-2010" above because that is how it reads.  *That part is therefore not strictly verbatim*: the
+   Arabic letters are the verbatim part; anyone re-deriving the numbers must
+   repeat the decode.
+
+** 2012 -- exclusions
+
+*No exclusion from a universe is stated anywhere* -- no statement about
+institutional, collective, nomadic or homeless population, and no excluded
+governorate or region.  (Searched as listed above.)
+
+The only recorded coverage shortfall is a *fieldwork* deviation, not a design
+exclusion.  =IHSES_II_2012_Arabic_Reviewed.pdf=, PDF page 31, section
+"ز. إجراءات استثنائية:" (exceptional procedures):
+
+#+begin_quote
+اما العناقيد المؤجلة التي لم يكن بالإمكان شمولها بسبب عدم تحسن الوضع الأمني فيها فقد بلغت (5) عناقيد فقط في كركوك.
+#+end_quote
+
+Translation (not part of the quote): "As for the postponed clusters that could
+not be covered because the security situation there did not improve, they
+amounted to only (5) clusters in Kirkuk."  The preceding sentence describes the
+same swap-to-a-later-wave procedure as IHSES-I.  Same two transcription caveats
+as above apply.
+
+** 2012 -- sub-sample: three modules administered to one third of households
+
+*This is the specialization inside the wave, and it must be known before
+anything from those modules is pooled or averaged.*  Source:
+=Sampling_and_fieldwork_2012.pdf= ("Iraq Household Socio-Economic Survey 2012
+(IHSES-II) Sampling design and fieldwork organization", Beirut, July 2011
+(updated, November 2011)), section "Subsamples".  *This document is NOT in this
+repo* -- it is catalog-only (WB catalog 2334, item 34769); see the "where the
+statement lives" note below.  Verbatim:
+
+#+begin_quote
+Most questionnaire modules will be administered to all households. However, in
+order to reduce some of the fieldwork effort, three of the modules will be
+administered in subsamples, each composed of three of the nine households
+visited in each Gadha. The three modules are: Anthropometrics (Section 7), Time
+use (Section 21), and Food consumption by recall (Section 24).
+#+end_quote
+
+("Gadha" as printed; the bullet glyphs before the three module names are
+dropped.  Note the document says "the nine households visited in each Gadha"
+while its own design allocates 216 households per gadha in 24 clusters of nine,
+i.e. nine per enumeration area -- the sentence is read most naturally as nine
+per cluster, but that reading is *not* asserted here, only flagged.)
+
+*Two caveats on this source, both material.*
+
+- It is a *prospective design document*, written in the future tense ("will be
+  administered"), describing "the fieldwork procedures that could be put in
+  place".  It is not a report of what was done.
+- It *argues against its own Section 7 plan* two paragraphs later, verbatim:
+  "This suggests that it may be better to administer Section 7 to children from
+  all households in the cluster."  So whether the anthropometrics sub-sample was
+  implemented as designed is *not* attested by any document located.  Do not
+  treat the s7 sub-sample as established fact; treat it as a design intention
+  with a documented internal objection.
+
+*Which of Iraq's wired tables this touches: as of this writing, none.*  Reading
+=2012/_/data_info.yml= and =_/data_scheme.yml= (configuration, not data), the
+2012 tables the library builds come from sections 1 (roster), 4 (housing), 5
+(education), 18 (durables/assets), 20 (shocks), 23 (life satisfaction) and the
+cover page -- none of 7, 21 or 24.  The 2006-07 tables come from sections 1, 3,
+4, 16 and the cover page -- not the time-use sheet.  *This must be re-checked
+whenever a feature is added to Iraq*, in particular anything anthropometric,
+time-use, or food-consumption-by-recall: those would be built on a one-third
+sub-sample in both waves.
+
+** Where these statements live (and what that means for the record)
+
+- 2006-07 :: the universe statement *is in this repo*, in
+     =2006-07/Documentation/Vol.1_Objectives_methodology.pdf= (DVC-tracked;
+     materialise with =get_dataframe= / =data_access.get_data_file=, never the
+     =dvc= CLI).  The library therefore holds this claim rather than pointing at
+     a moving target.  The WB catalog does *not* carry it.
+- 2012 :: there is no statement to hold.  The nearest statements are in
+     =IHSES_II_2012_Arabic_Reviewed.pdf=, which *is* in this repo -- but the
+     *sub-sample* statement, which is the operationally important one, is
+     *catalog-only*: =Sampling_and_fieldwork_2012.pdf= is hosted on the WB
+     catalog and is not among this wave's DVC-tracked documentation.  It is
+     therefore a moving target: if the catalog record is revised or the item is
+     withdrawn, the only surviving copy of the one-third-sub-sample claim is the
+     verbatim quotation above.
+
+** How to re-verify this section
+
+Every quote above was re-extracted from the cited PDF on 2026-07-21 and checked
+character-by-character against the extraction, not copied from an intermediate
+summary.  The Vol.1 text layer has a known font defect: the letter "v" is
+sometimes emitted as =U+0018= (visible as "Goernorate", "isit", "Surey" in raw
+extraction).  Every "v" in the quotations above was restored from context and
+verified against the surrounding printed word; no other repair was made.  The
+Arabic caveats are stated in full at the point of use rather than here, because
+they change what the quote can be used for.
+
+The upstream evidence record for both waves is
+=slurm_logs/POPULATION_STATEMENTS_2026-07-21.org= (GH #601), sections "Iraq
+2006-07" and "Iraq 2012".  Two items in this section are *not* in that record
+and were found while checking it: the 2006-07 time-use one-third sub-sample, and
+the 2006-07 Sulaimaniya extra clusters with unadjusted weights.
+
 * Food security (non-FIES families, GH #332) --- not wired
 
 The IHSES 2012 questionnaire has no standard food-insecurity-experience

--- a/lsms_library/countries/Kazakhstan/_/CONTENTS.org
+++ b/lsms_library/countries/Kazakhstan/_/CONTENTS.org
@@ -1,5 +1,319 @@
 #+TITLE: Kazakhstan — country notes & known data issues
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence assembled for GH #601 (the population record); see
+=slurm_logs/POPULATION_STATEMENTS_2026-07-21.org= for the full cross-country
+sweep.  This section records only what the *documentation claims*.  Nothing here
+is inferred from the =.dta= files, and nothing here proposes a schema (that is
+GH #603's business).
+
+Kazakhstan ships exactly one wave, =1996/=.  Everything below is that wave.
+
+** 1996 -- the declared universe
+
+The survey documentation *never uses the words "universe" or "target
+population"*, and the WB DDI's only sampling content is a sample size.  What the
+final report does say, verbatim:
+
+- Source :: =1996/Documentation/finrep1.pdf= -- "Living Standards Measurement
+     Survey 1996: Final Report (Part 1)", GOSKOMSTAT and SIGMA Institute Berlin,
+     Dec. 1996.  The PDF is an image-only scan with no text layer; page images
+     were rendered and read visually (see the verification note below).
+- Confidence :: medium (the statements are coverage/aim statements, not a
+     formally labelled universe definition).
+
+#+begin_quote
+[finrep1.pdf, PREFACE, p. II (PDF page 3)]
+
+"The survey "Living Standards Measurement Survey" (LSMS) carried out by
+"Sigma-Institute" of Berlin under the World Bank Technical Assistance Project
+named "Social Protection" was a multipurpose probability sample which covered
+2000 households of the Republic of Kazakstan."
+#+end_quote
+
+#+begin_quote
+[finrep1.pdf, sec. 1.1 "Verification of the status of living standards", p. IV
+(PDF page 5)]
+
+"The aim of this survey was to select objective, representative and as far as
+possible, total information, which would enable users to draw up a picture of
+the actual status of living standards of the population of the Republic of
+Kazakstan."
+#+end_quote
+
+#+begin_quote
+[finrep1.pdf, sec. 2 "Sampling", p. IV (PDF page 5)]
+
+"A Sample designed for LSMS had to assist to:
+
+- reflect the realistic picture of social and territorial distribution of the population in the Republic
+  of Kazakstan (representativeness); and
+- compare the outcome of LSMS in Kazakstan with the results of LSMS in other countries, which
+  were performed based on possible sample principals (comparability)."
+#+end_quote
+
+The nearest thing to a definition of the units surveyed:
+
+#+begin_quote
+[finrep1.pdf, sec. 3.1, under heading "3. Context of the survey", p. XV (PDF
+page 16)]
+
+"Households (h/h) are subjects of the survey (interviewing)."
+#+end_quote
+
+*The frame, which is where the coverage claim actually has teeth.*  The sample
+was built from three exhaustive administrative lists, each described as covering
+its units "without exception":
+
+#+begin_quote
+[finrep1.pdf, sec. 2, p. V (PDF page 6)]
+
+"To create a basis to design a probability sample GOSCOMSTAT and its oblast
+branches in May 1996 have delivered the most actual numerical material
+concerning population (01.01.1996). It contains the following information:
+
+- a list of all 2534 agricultural regions without exception with the measurement of their quantity (number
+  of households and number of inhabitants). This data has been received from rural administrations where
+  total registration is carried out;
+- a list of all 263 villages, small and middle-size cities without exception with the measurement of their
+  quantity (number of households and number of inhabitants). This data has been received from village
+  councils and from householding administration bodies for the cities where the total registration is carried
+  out.
+
+- a list of all 24 large cities without exception with measurement of their quantity (number of households
+  and number of inhabitants). This data has been received from householding administration bodies (e.g.
+  Technical Inventory Bureau, Householding Administrations, Cooperatives, Street Committees, Branch
+  Agencies and Dormitories)."
+#+end_quote
+
+#+begin_quote
+[finrep1.pdf, sec. 2, p. VIII (PDF page 9)]
+
+"We have thus accepted as a basis to define samples:
+
+- number of households and inhabitants in rural areas;
+- number of households and inhabitants in villages, small/middle-size cities;
+- extrapolated number of households and inhabitants in large cities."
+#+end_quote
+
+Table 2 on the same page gives the frame totals under the column header "Total
+within the Republic of Kazakhstan": approximately 16.432 399 inhabitants and
+4.708 277 households (source punctuation preserved).  So the frame is stated as
+the whole country's households, and the "national" claim in the WB catalog
+(Geographic Coverage: "National", catalog entry 2292) is at least consistent
+with the report.
+
+*Caution for a reader skimming the Preface.*  The Preface's other household
+figure is NOT this survey:
+
+#+begin_quote
+[finrep1.pdf, PREFACE, p. II (PDF page 3)]
+
+"The main resources of information concerning social and economic indicators of
+living standard of population of the Republic of Kazakstan, are 6000 households
+which represent a republican network."
+#+end_quote
+
+That 6000 is the standing official household-statistics network, contrasted with
+(not describing) the 2000-household LSMS sample.
+
+** 1996 -- exclusions: NO STATEMENT FOUND
+
+*No document in this repo excludes any population group* -- no institutional or
+collective population carve-out, no nomadic-household carve-out, no dropped
+oblast, no security exclusion.  This is recorded as a *gap*, not as a claim that
+no exclusions existed.
+
+What was searched (so the gap is falsifiable):
+
+- =1996/Documentation/finrep1.pdf=, the whole methodological front matter,
+  pp. I-XVII (PDF pages 1-19): Preface, Acknowledgements, sec. 1 Aims, sec. 2
+  Sampling (incl. 2.1 large cities, 2.2 rural, 2.3 villages and small/middle-size
+  cities), sec. 3 Context of the survey, sec. 4 Training, sec. 5 Data Collection
+  and Entry.
+- =1996/Documentation/ddi-documentation-english_microdata-2292.pdf= in full: it
+  has *no* universe or coverage field at all; its entire "Sampling / Sampling
+  Procedure" section reads "Sample size is 1,996 households", and
+  "Questionnaires", "Data Processing" and "Data Appraisal" each read "No content
+  available".
+- =1996/Documentation/SOURCE.org= and =LICENSE.org=.
+- The WB catalog page https://microdata.worldbank.org/index.php/catalog/2292
+  (Geographic Coverage: "National"; no universe statement).  The JSON API
+  endpoint returned HTTP 400.
+- NOT searched exhaustively :: =finrep2.pdf=, =finrep3.pdf= (Parts 2-3 of the
+     same report -- findings, not methodology), and the questionnaire scans
+     =hhq01.pdf=, =hhq02.pdf=, =KAZ02.pdf=.  These are image-only scans with no
+     text layer and no OCR was available; a cover page or instruction could in
+     principle carry coverage language this sweep did not see.
+
+*Three near-misses, quoted so nobody later promotes them into an exclusion.*
+None of these is an exclusion statement:
+
+#+begin_quote
+[finrep1.pdf, sec. 2, p. V (PDF page 6) -- a frame-QUALITY caveat, not an
+exclusion]
+
+"b) Quality of the data which had been received from some cities was not fully
+acceptable (Almaty, Akmola, Ecibastuz, Zhambyl, Kostanai and Arcalyk). It was
+noted that underregistration was up to 25% in those cities. It was impossible
+therefore to find out the precise number of households, and as a result
+extrapolation was performed."
+#+end_quote
+
+#+begin_quote
+[finrep1.pdf, p. VI (PDF page 7) -- a precision caveat, not an exclusion]
+
+"Whilst an inaccuracy up to 5 per cent /migration, underegistration/ is assumed.
+See Table 1."
+#+end_quote
+
+#+begin_quote
+[finrep1.pdf, sec. 5.2, p. XVII (PDF page 18) -- an instrument-level respondent
+restriction, not a sample-universe exclusion]
+
+"Questions from the Individual Questionnaire were discussed with all grown up
+members of a family (over 16 years old). An individual who was the most familiar
+with specific aspect of child life answered on their behalf (usually mother)."
+#+end_quote
+
+Note in passing that the large-city frame's listed sources explicitly include
+"Dormitories" (p. V, quoted above), i.e. the report gives no sign of excluding
+collective dwellings from the frame -- but it makes no positive statement about
+them either, so this is context, not evidence of inclusion.
+
+** 1996 -- oversamples and sub-samples
+
+*No oversample of a named sub-population is declared* -- no Roma/minority
+booster, no poverty-register sample, no module administered to a sub-sample of
+households, no cross-section-plus-panel wave.  Kazakhstan is a single
+cross-section.  What a pooling user does need to know is that specialization
+lives in the *stratum allocation and the within-city selection*:
+
+- Three design strata, allocated by household share, not by population share ::
+     Table 2 (p. VIII) gives portions of households 45,23% large cities /
+     18,75% villages, middle-size and small cities / 36,02% rural regions,
+     realized as 90 / 38 / 72 PSUs out of 200, with 2000 households at roughly
+     10 interviews per PSU (p. VIII: "Since we had to interview 2000 households
+     using group sample (10 interviews net in one area of interview), and we had
+     to select 200 probability selection units (PSU). See Table 2.").
+- All 24 large cities are self-representing ::
+     #+begin_quote
+     [finrep1.pdf, sec. 2.1 "Selection in large cities", p. IX (PDF page 10)]
+
+     "Cities of Almaty, Akmola, Karaganda, Temirtau, Ust-Kamenogorsk, Pavlodar,
+     Ekibastuz, Shymkent, Zhambyl, Aktobe, Uralsk, Kokshetau, Rudnyi, Kostanai,
+     Semipalatinsk, Petropavlovsk, Taldykorgan, Atyrau, Aktau, Kzyl-Orda,
+     Zheskazgan, Balhash, Arkalyk and Turkestan were involved in sample since
+     more 23666 households (sampling fraction) live in each of this cities."
+     #+end_quote
+     A footnote on p. V makes the criterion explicit: ""Large city" according to
+     our sample is a city which automatically will be included in a sample due to
+     the large number of households, which has to exceed selection pace."  This
+     is a *design* statement (certainty selection), not an exclusion of anything.
+- Within a large city, households were selected by DWELLING-TYPE QUOTA ::
+     This is the closest thing Kazakhstan 1996 has to an internal sub-population
+     structure, and it is worth knowing before averaging anything urban:
+     #+begin_quote
+     [finrep1.pdf, sec. 2.1, p. IX (PDF page 10)]
+
+     "Once the number of interviews in one city has been defined, per cent
+     portions of interviews in separate segments have been specified using table
+     of type of living distribution, i.e. municipal houses, cooperative houses,
+     private houses, etc."
+     #+end_quote
+     #+begin_quote
+     [finrep1.pdf, p. X (PDF page 11), worked example for Ust-Kamenogorsk]
+
+     "The following households therefore were subject to interview:
+
+     70% households in municipal houses = 35 households;
+     26% households in private houses = 13 households;
+     2,8% households in cooperative houses = 1 household;
+     1,8% households in company houses = 1 household.
+
+     These quotas have been inserted on a supervisor's list. A supervisor was
+     responsible for the distribution of interviewers to different segments."
+     #+end_quote
+     Flagged because the same report's Preface names quota sampling as a defect
+     of household statistics ("A significant fault of household statistics in
+     many countries is the application of quota method during sampling
+     selection.", p. II) while the large-city stage uses dwelling-type quotas
+     within PSUs.  Both sentences are the survey's own; the tension is theirs,
+     not an editorial reading.
+- The community instrument has its own, DIFFERENT coverage ::
+     #+begin_quote
+     [finrep1.pdf, sec. 3.1, p. XV (PDF page 16)]
+
+     "Community questionnaire was administered in all villages.
+
+     Additionally to compare rural and city community standards and different
+     ways of interactions between households and community units, we did not
+     follow standard guidelines for LSMS and administered it also in the villages
+     and those city regions, where PSU have been located."
+     #+end_quote
+     So community-level material (=cluster_features=, and the =KOMMU= file the
+     "Known data issues" section below refers to) does not have the same
+     coverage as the household instrument.
+
+** 1996 -- where the statement lives, and how solid it is
+
+- Source type :: =local-documentation=.  The statements are in a file this repo
+     ships (DVC-tracked =finrep1.pdf=), *not* only in WB catalog metadata.  This
+     wave is therefore NOT one of the 41 catalog-only waves whose population
+     record is a moving target.
+- Not WB boilerplate :: none of the quoted text is the WB NADA template sentence
+     that recurs verbatim across 15 other waves in the corpus.  This is a
+     statistical office's / contractor's own prose, in its own (sometimes
+     ungrammatical) English.
+- But the catalog holds nothing :: the DDI's universe/coverage content is
+     *absent*, not merely thin -- the only sampling text is "Sample size is
+     1,996 households".  If =finrep1.pdf= were ever lost from the repo, the
+     population record for Kazakhstan would go to zero.
+- Sample size, two numbers :: the DDI says "Sample size is 1,996 households";
+     the Preface says the sample "covered 2000 households".  2000 is the design
+     target (p. VIII), 1,996 the realized count -- consistent with the 1996
+     households noted in the =subjective_well_being= entry elsewhere in this
+     file.  Not a contradiction, but do not quote 2000 as an achieved sample.
+
+** 1996 -- universe versus what the weights represent
+
+The report documents *sampling fractions*, not weights: Table 2 (p. VIII) gives
+23 666 (large cities) and 23 545 (both other strata) as "Number of households of
+totally surveyed / Number of interviewed areas (PSU)", and pp. IX-X derive per
+city PSU and interview counts.  No weight variable is described anywhere in
+=finrep1.pdf= pp. I-XVII or in the DDI.
+
+Correspondingly, this country's =sample= table (=1996/_/data_info.yml=) supplies
+=v= and =Rural= only -- *there is no =weight= or =panel_weight= column for
+Kazakhstan 1996* (both are declared =optional= in
+=lsms_library/data_info.yml=).  A user pooling Kazakhstan with weighted
+countries is therefore combining an unweighted cross-section, drawn under an
+approximately self-weighting three-stratum design with quota allocation inside
+large cities, with weighted samples.  That is a fact about this wave's
+documentation and config, and it is the thing most likely to bite.
+
+** Verification note (2026-07-21)
+
+The quotes above were re-checked against the source rather than taken on trust.
+=finrep1.pdf= has no text layer, so its page images were extracted with
+pdfminer's =ImageWriter= and read directly.  Pages verified character-for-
+character this round: II (PDF 3), IV (PDF 5), V (PDF 6), VIII (PDF 9), IX
+(PDF 10), X (PDF 11), XV (PDF 16).  The DDI PDF's full text was extracted and
+read.  Pages VI (PDF 7) and XVII (PDF 18) are carried from the #601 sweep
+without independent re-verification and are marked as such where quoted.
+
+- Locator correction :: the #601 sweep placed the 24-large-cities sentence at
+     p. X.  It is on *p. IX* (PDF page 10), in sec. 2.1 "Selection in large
+     cities"; p. X is the within-PSU address-selection text and sec. 2.2.  The
+     wording of the quote itself checks out exactly.
+- Sic spellings are the source's :: "Kazakstan" (Preface, secs. 1-2) vs.
+     "Kazakhstan" (Table 2 header); "Ecibastuz" / "Arcalyk" (p. V) vs.
+     "Ekibastuz" / "Arkalyk" (p. IX); "underegistration" (p. VI);
+     "principals" for "principles"; "more 23666 households".  None of these are
+     transcription errors introduced here.
+- Nothing in this section was derived from a =.dta= file.
+
 * assets — durable goods (2026-06-08, #342)
 Source: =KZ96HSG_PUF.dta= block =b37=, a WIDE durable-goods roster (16 items x
 4 attributes, one column per (item, attribute)):

--- a/lsms_library/countries/Kosovo/_/CONTENTS.org
+++ b/lsms_library/countries/Kosovo/_/CONTENTS.org
@@ -1,5 +1,254 @@
 #+title: Contents
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered 2026-07-21 for GH #601.  Kosovo has a single wave in this
+repository (=Country('Kosovo').waves == ['2000']=), so everything below is
+about that wave.  Nothing here is inferred from the =.dta= files; every claim
+is either a quotation from a named document at a named page, or is explicitly
+labelled as an observation.
+
+** 2000 -- the declared universe (verbatim)
+
+#+begin_quote
+The  unit  of  analysis  and  the  unit  of  observation  is  the  household.    The  universe  under  study
+consists of all the households in Kosovo, except those inhabited by members of the international
+community.
+#+end_quote
+
+Source: /Kosovo Living Standards Measurement Survey 2000: Basic Information/
+(Basic Information Document; Poverty and Human Resources Development Research
+Group, The World Bank, October 2001), Appendix F, "RECOMMENDATIONS AND
+IMPLEMENTATION OF THE SAMPLE DESIGN FOR THE KOSOVO LSMS SURVEY, 2000", opening
+paragraph -- printed p. 43 (PDF p. 46).  English original; no translation
+needed.  The doubled inter-word spacing is the source PDF's own text layer and
+is reproduced as extracted.
+
+This is a **national, all-household** universe: both urban and rural areas are
+in scope by design (see the domains below).  It is *not* NADA template
+boilerplate -- it is a statistician's sample-design appendix written for this
+survey.  Compare the WB NADA template sentence that recurs verbatim across
+~15 waves elsewhere in the corpus; nothing of that shape appears here.
+
+** 2000 -- exclusions
+
+*** Universe-level (the only one the documentation states)
+
+Households "inhabited by members of the international community" -- see the
+quotation above.  In 2000 Kosovo this is a materially large group (UNMIK,
+KFOR, NGO and contractor staff), not a nominal carve-out.
+
+*** Frame / eligibility-level (narrower than the universe, stated separately)
+
+The dwelling-unit listing kept only permanently-occupied units.  Same document,
+Appendix F, printed p. 54 (PDF p. 57), section on listing dwelling units.  The
+enumerator recorded one of six occupancy statuses:
+
+#+begin_quote
+1.  Occupied permanently.
+2.  Under construction (occupied)
+3.  Under construction (not occupied).
+4.  Vacant.
+5.  Seasonally occupied
+6.  Demolished or being demolished.
+#+end_quote
+
+#+begin_quote
+Afterwards, in the office, a determination of the "valid" dwelling units will be carried out, that is,
+those units that are occupied permanently (the first and fourth categories mentioned above) and
+these are the only ones that will be used during the selection process.
+#+end_quote
+
+Note as printed: the text says "the first and fourth categories" while category
+4 in its own list is "Vacant".  That is what the document says; it is quoted
+here unaltered rather than silently repaired.  The operative rule stated in the
+main body of the same appendix is narrower and consistent -- printed p. 45
+(PDF p. 48): units "that are occupied permanently, since these are the valid
+ones under the coverage requirements."  Either way, seasonally-occupied
+dwellings are outside the selection frame.
+
+*** Not exclusions -- recorded here so nobody later mistakes them for exclusions
+
+- *Rural frame coverage.*  "A  Housing  Damage  Assessment  Survey  (HDAS)  was
+  conducted  in  February  1999  and updated  in  June  1999  by  the
+  International  Management  Group  (IMG)  and  the  United  Nations High
+  Commissioner for Refugees (UNHCR) in the rural areas.  The survey covered 95
+  percent of the Albanian rural areas and provided the basis for the rural
+  sampling frame, after updating." (BID, printed p. 5, PDF p. 8; also
+  verbatim in the WB catalog =method/data_collection/sampling_procedure=.)
+  That is a *frame-coverage limitation*, not a declared universe exclusion.
+- *A security incident in the field.*  "Some zones in North Mirovica were
+  deemed too dangerous to be listed  systematically  and  the  names  were
+  taken  from  a  dweller. ... As  a  result,  the team was pulled out of the
+  field and alternative EAs had to be selected." (BID, printed p. 11, PDF
+  p. 14.)  This is fieldwork, and the EAs were *replaced*, not dropped.  There
+  is no "for security reasons" carve-out from the stated universe.
+- *Non-response replacement.*  "Households  from  the  original  sample
+  selection  which  could  not  be  interviewed  were replaced  by  reserve
+  households  to  reach  the  final  sample  size." (BID, printed p. 7, PDF
+  p. 10.)  Non-response rates were 11.8% (rural Albanian), 20.8% (urban
+  Albanian), 14.2% (rural Serb) and 39.2% (urban Serb).  Relevant to what the
+  weights mean; not an exclusion.
+
+** 2000 -- domains, sub-populations and disproportionate allocation
+
+The specialization in this wave lives *inside* the wave, as an explicit ethnic
+stratum with its own sampling frame.  Anyone pooling Kosovo with other
+countries, or computing an unweighted Kosovo mean, needs to know this.
+
+Design statement, BID printed p. 6 (PDF p. 9), also verbatim in the WB catalog
+=method/data_collection/sampling_procedure=:
+
+#+begin_quote
+The  sample  was  preset  at  2,880  households  in  order  to  allow  analyses  in  the  following
+breakdowns:  (a) Kosovo as a whole; (b) by area of responsibility, (c) by urban/rural locations.
+In addition, the survey data can be used to derive separate estimates for the Serbian minority.
+#+end_quote
+
+Catalog =study_info/geog_coverage= (WB DDI, idno =KSV_2000_LSMS_v01_M=):
+
+#+begin_quote
+Kosovo.
+Domains: Urban/rural; Area of Responsibility (American, British, French, German, Italian); Serbian minority
+#+end_quote
+
+Allocation, BID Table 1 (printed p. 6, PDF p. 9) and the sentence following it
+(printed p. 7, PDF p. 10):
+
+#+begin_quote
+The final sample size was 1,200 rural and urban Albanian households and 240 rural and
+urban Serb households, for a total sample size of 2,880 households.
+#+end_quote
+
+| Location | Ethnicity           | Areas of Responsibility                       | HH per domain |
+|----------+---------------------+-----------------------------------------------+---------------|
+| Rural    | Serb                | not applicable (one domain)                   | 240           |
+| Rural    | Albanian and others | American, British, French, German, Italian    | 240 each      |
+| Urban    | Serb                | not applicable (one domain)                   | 240           |
+| Urban    | Albanian and others | American, British, French, German, Italian    | 240 each      |
+
+(Table transcribed from BID Table 1, "Domains for the Sample And Number of
+Respondent Households".  12 domains x 240 = 2,880.  The prose sentence quoted
+above reads oddly against the table -- 1,200 is the per-location Albanian
+total, not the Albanian total -- and is quoted as printed.)
+
+The Serb sample had a *separate frame*, built by a separate enumeration
+operation (BID, printed p. 10, PDF p. 13):
+
+#+begin_quote
+Enumeration of the Serbs as a separate frame required counting households in all Serbian
+villages and urban zones.  The  rural Serb population in Kosovo numbers about 80,000, of which
+20,000  live  in  the  Northern  part  of  Kosovo  (3  municipalities)  and  the  rest  is  scattered  in  the
+"enclaves" of Southern and Central Kosovo and in the southern municipality of Strepce (Evans,
+2000).  Of the 30 selected villages, 8 are in Northern Kosovo.  Twenty-four of the urban EAs are
+also located there, because of the larger urban areas of Mitrovica and Zvecan.
+#+end_quote
+
+And, because the HDAS frame covered only Albanian rural areas (BID, printed
+p. 5, PDF p. 8):
+
+#+begin_quote
+Since the HDAS did not cover Serbian villages, a quick counting4 of housing units was
+performed in these villages, following a procedure similar to the one in the urban areas.
+#+end_quote
+
+*Observation (not a quotation):* equal allocation of 240 households to each of
+twelve domains, one of which is a minority numbering on the order of 80,000
+rural persons, is allocation disproportionate to population share -- i.e. the
+Serb stratum is an oversample in the ordinary sense.  The documentation
+nowhere uses the words "oversample" or "booster"; what it does say is quoted
+above, and the correction is carried by =WEIGHT=.  This is why the
+=2000/Data/= directory carries parallel =R_*= / =U_*= / =Serb_*= community
+files.
+
+** 2000 -- universe vs. what the weights represent
+
+These come apart, and the difference is not hypothetical.  The design claims
+twelve analysable domains (above); the weights section claims validity at two
+levels only.  BID, printed p. 10 (PDF p. 13):
+
+#+begin_quote
+Weights (expansion factors) have been calculated that should be used in analyses of the
+data in order to have estimates that are valid at the national and  urban/rural levels.  The weight
+variable, WEIGHT, is found in data set ID.
+#+end_quote
+
+So: the *universe* is all Kosovo households bar the international community;
+the *weights* are attested by the documentation only for national and
+urban/rural estimates.  Estimates by Area of Responsibility, or separate
+estimates for the Serbian minority, are stated as design intentions in the
+sampling section but are not covered by the weights sentence.  Do not read
+the weights sentence as licensing AR-level or Serb-minority-level inference
+without going back to the design.  (Kosovo's =sample= table exposes =weight=;
+there is no panel dimension -- single wave, no =panel_weight=.)
+
+** 2000 -- the community questionnaire has NO universe
+
+The documentation explicitly *denies* a well-defined universe for the community
+instrument.  BID, printed p. 4 (PDF p. 7); also verbatim in the WB catalog
+=method/data_collection/coll_situation=:
+
+#+begin_quote
+The data from community questionnaire are not a representative sample of communities
+in  Kosovo.    These  data  are  intended  to  provide  information  on  the  context  in  which  the
+households are located for the analyses of the household data.
+#+end_quote
+
+This bears directly on Kosovo's =cluster_features= table (declared in
+=_/data_scheme.yml= with index =(t, v)= and columns =Region=, =Rural=), which
+is built from the community files.  Community-level aggregates from Kosovo 2000
+are contextual covariates for the household data; they are *not* estimates for
+the population of Kosovo communities, and must not be averaged as if they were.
+
+** 2000 -- where the statement lives  (flag: NOT in this repository)
+
+| Fact                                              | Status                                                            |
+|---------------------------------------------------+-------------------------------------------------------------------|
+| Universe statement in a file under =Kosovo/2000/=  | *No.*  Documentation/ holds only comeng.pdf, hheng.pdf, hhalb.pdf |
+| Universe field in the WB DDI / catalog record      | *No.*  Zero occurrences of "universe" in the exported DDI JSON    |
+| Universe statement anywhere reachable              | Yes -- BID PDF, a *related material* of catalog study 77          |
+
+The three PDFs the repository does ship are bare questionnaire instruments.
+Text-searched all three (pdfminer): "universe" 0 hits in each; "sampling frame"
+0 hits in each; "population" appears twice in comeng.pdf, both inside question
+text about local economic conditions, and 0 times in either household
+questionnaire.  There is no target-population or sample-design statement in any
+file this repository holds.
+
+The BID was obtained from
+https://microdata.worldbank.org/index.php/catalog/77/download/11570 (reachable
+via catalog study 77 -> Related Materials, titled "Kosovo Living Standards
+Measurement Survey 2000: Basic Information").  It is *not* DVC-tracked here.
+That makes Kosovo's universe record a moving target: it depends on a World Bank
+URL, not on anything the library holds.  Consider acquiring the BID into
+=Kosovo/2000/Documentation/=.
+
+The catalog record's own metadata (=study_info=: abstract, coll_dates, nation,
+geog_coverage, analysis_unit, data_kind, notes; =method=: sampling_procedure,
+coll_mode, research_instrument, coll_situation, method_notes) has no universe
+field at all; =analysis_unit= is "- Households / - Individuals / - Community".
+The sampling_procedure text reproduces the BID's sample-design section verbatim,
+which is what corroborates the BID as the catalog's own account.
+
+** Verification notes (2026-07-21)
+
+- Every quotation above was re-extracted from the BID PDF and matched
+  character-for-character; the page locators were independently re-derived from
+  the PDF's printed page numbers.
+- *Correction to the gathered evidence record:* the "valid dwelling units"
+  quotation was recorded at printed p. 51 / PDF p. 54.  It is at printed p. 54
+  / PDF p. 57 -- three pages later.  The related but distinct sentence quoted
+  above ("...since these are the valid ones under the coverage requirements")
+  is at printed p. 45 / PDF p. 48.  Both corrected here.
+- *Second correction:* the evidence record noted that
+  =2000/Documentation/SOURCE.org= lacked the =#+CATALOG_ID:= / =#+CATALOG_IDNO:=
+  provenance keywords.  It has them (backfilled 2026-07-12, =PROVENANCE_METHOD:
+  doi-lookup=, =CATALOG_ID: 77=, =CATALOG_IDNO: KSV_2000_LSMS_v01_M=).  No
+  action needed.
+- No =.dta= file was opened in preparing this section, by design: what the
+  survey *claims* to cover and what the data happen to look like are kept apart
+  deliberately.
+
 * shocks — not available (2026-06-07, verified)
 
 =shocks= (a household adverse-events-and-coping roster, index =(t, i, Shock)=)

--- a/lsms_library/countries/Liberia/_/CONTENTS.org
+++ b/lsms_library/countries/Liberia/_/CONTENTS.org
@@ -6,6 +6,318 @@ Liberia 2018-19 is the **National Household Forest Survey (NHFS) 2018-2019**
 survey. Confirmed from the WB DDI (catalog 3787) and the household
 questionnaire (`liberia_hh_forestry_qx_final.pdf`).
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered 2026-07-21 for GH #601.  This section records *what the
+survey documentation claims* about the population it represents.  Nothing here
+is inferred from the microdata; no =.dta= file was opened.  It extends (and
+does not contradict) the "Survey identity" section above.
+
+** Liberia 2018-19 (National Household Forest Survey, NHFS)
+
+*** The declared universe -- NOT national
+
+The NHFS universe is deliberately restricted to *forest-proximate* enumeration
+areas.  This is the single most consequential fact about the country: Liberia
+2018-19 must not be pooled with the national household surveys of other
+countries as though it represented the Liberian population.
+
+Verbatim, WB catalog 3787 study description, Coverage > Universe (identical to
+the DDI XML =<universe>= element,
+https://microdata.worldbank.org/index.php/metadata/export/3787/ddi):
+
+#+begin_quote
+All EAs within 2.5 kilometers of forests except for the EAs from the urban part
+of the Montserrado county.
+#+end_quote
+
+Verbatim, same page, Coverage > Geographic Coverage (DDI =<geogCover>=):
+
+#+begin_quote
+The NHFS is focused on forest proximate households. Therefore, the sample is
+limited to enumeration areas which fall within 2.5km of the nearest forest, as
+defined using Metria and Geoville (2019) land cover data. The final sample
+includes enumeration areas from all 15 of Liberia's counties, but excludes
+urban areas of Montserrado.
+#+end_quote
+
+The *definition of "forest"* is itself part of the universe definition -- the
+eligibility rule is geometric, not administrative.  Verbatim, Basic
+Information Document (=liberia__nhfs_basicinformationdocument_v1.pdf=, World
+Bank, 2020-08), s2.3 DEFINITION OF FOREST, p. 9:
+
+#+begin_quote
+Given the focus of the NHFS on the population living in close proximity to
+forests4, a first step was to clearly define forest for the purposes of the
+survey. Building on the national definition of forest used in Liberia, and
+modifying it in order to minimize the impact of small urban forests and
+facilitate survey operations, the NHFS employed the following definition:
+
+Forest = area with at least 30 percent tree canopy cover, with trees higher
+than 5 meters and at least 50 hectares in size5
+
+The forest cover was determined using high-resolution forest cover data
+produced in 2019 based on satellite information on forest cover in Liberia for
+2015.6 All EAs within 2.5 kilometers of forests identified with this
+definition were deemed eligible for inclusion in the NHFS.7 EAs from the
+Montserrado county (part of Greater Monrovia) were excluded from the sample
+universe due to the high rate of urbanization. However, rural parts of
+Montserrado county were included in the sample universe.
+#+end_quote
+
+Footnote 5 to that definition, verbatim (BID p. 9), adds a further eligibility
+restriction:
+
+#+begin_quote
+In addition, any forest patch with a perimeter to area ratio more than 0.02 was
+excluded. This restriction was imposed to focus on non-fragmented and
+relatively large forest areas capable of providing both consumptive and
+non-consumptive goods and services.
+#+end_quote
+
+Footnote 7, verbatim (BID p. 9), fixes how the 2.5 km is measured:
+
+#+begin_quote
+Distance from enumeration area to the nearest forest is computed from the
+centroid of the enumeration area.
+#+end_quote
+
+For scale of the covered population -- this is the survey team's own framing,
+quoted verbatim from the Policy Note abstract reproduced in the in-repo DDI
+export (=Documentation/ddi-documentation-english_microdata-3787.pdf=, p. 10),
+*not* a universe statement:
+
+#+begin_quote
+In 2019, 47.5 percent of the Liberian households (HHs) lived in proximity to
+and were significantly dependent on the country's forests.
+#+end_quote
+
+*** Exclusions
+
+Two exclusions are by design, and both are load-bearing.
+
+| Kind                | What is excluded                                    | Stated reason                   |
+|---------------------+-----------------------------------------------------+---------------------------------|
+| Geographic (urban)  | Urban part of Montserrado county (Greater Monrovia) | "high rate of urbanization"     |
+| Geographic (design) | Every EA more than 2.5 km from a qualifying forest  | survey's forest-proximate focus |
+
+Rural Montserrado is *in*; only the urban part is out.  Verbatim, BID s2.3,
+p. 9:
+
+#+begin_quote
+EAs from the Montserrado county (part of Greater Monrovia) were excluded from
+the sample universe due to the high rate of urbanization. However, rural parts
+of Montserrado county were included in the sample universe.
+#+end_quote
+
+Verbatim, catalog Geographic Coverage:
+
+#+begin_quote
+The final sample includes enumeration areas from all 15 of Liberia's counties,
+but excludes urban areas of Montserrado.
+#+end_quote
+
+Note the trap in that sentence: "all 15 of Liberia's counties" is about which
+counties are *represented*, not about coverage *within* them.  Within every
+county, only EAs within 2.5 km of a qualifying forest are in the universe.
+
+Verbatim, BID p. 13 (map note; the sentence has a broken cross-reference in the
+original, reproduced here as printed):
+
+#+begin_quote
+Finally, the map provided in illustrates the degree of forest cover in each of
+the three clusters. The NHFS sample is weighted to reflect the population in
+all areas of the map except for the areas in white, which represent areas more
+than 2.5km from an EA center.
+#+end_quote
+
+No population-type exclusion (institutional, collective, nomadic, homeless) is
+stated anywhere in the catalog metadata or the BID.  *No statement found* --
+recorded as a gap, not as an absence: searched the WB catalog 3787 study
+description (all Coverage / Methodology fields), the DDI XML export (all of
+=<universe>=, =<geogCover>=, =<sampProc>=, =<weight>=), the full text of the
+BID, the in-repo DDI export PDF, and the full text of both questionnaires
+(=liberia_hh_forestry_qx_final.pdf=, =liberia_comm_forestry_qx_final.pdf=).
+
+*** Sub-samples, strata and oversamples
+
+There is *no* booster, ethnic, or programme sub-sample, and no panel/refresh
+split -- Liberia has a single wave.  But the wave does carry two structures a
+pooling analyst must know about.
+
+**** 1. The distance-to-forest stratification was ABANDONED after fieldwork
+
+The sample was *drawn* under a purposeful (non-proportional) allocation across
+three distance-to-forest strata, then that stratification was discarded because
+the stratifying variable was computed wrongly.  Verbatim, BID s2.6
+POST-FIELDWORK ADJUSTMENT, p. 11:
+
+#+begin_quote
+Upon post-data collection analysis, it was discovered that the initial variable
+that was used to stratify EAs by distance to forest was incorrectly computed.
+Despite thorough attempts to understand the nature and source of the error, it
+was determined that a mechanical error must have occurred during the process of
+the distance calculations. This error rendered the stratification incorrect.
+Therefore, the stratification by distance to forest has been abandoned and the
+sample weighted to reflect only geographic clusters, not distance to forest.
+This was determined to be the most appropriate way forward following
+consultation with sampling experts.
+#+end_quote
+
+The design allocation, verbatim, BID s2.4 FIRST STAGE SELECTION, pp. 9-10
+(recorded as *sample design*, not as universe):
+
+#+begin_quote
+Based on the forest definition defined above, the distance from each EA in the
+country (except urban Montserrado) to the nearest forest was computed. That
+distance was subsequently used to assign each EA to one of the following
+strata: S1 (less than 2km from forest); S2 (two to 7 km from forest); S3 (7 to
+15 km from forest).
+
+Following strata classification, a total of 250 EAs were selected through a
+Probability Proportional to Size (PPS) sampling approach within each stratum,
+with the following purposeful allocation across strata: 90 EAs in S1; 90 EAs in
+S2; 70 EAs in S3.8 The measure of size for each EA was based on the total
+number of households listed in the 2008 PHC.
+#+end_quote
+
+The 90/90/70 allocation across S1/S2/S3 *is* the survey's oversample --
+disproportionate by distance-to-forest -- and it is exactly the thing the
+weights no longer correct for by stratum.  The stratum variable is not shipped.
+Verbatim, BID s2.6, p. 12:
+
+#+begin_quote
+The NHFS dataset includes only the cluster variable (reg_cluster), not the
+original stratification variable.
+#+end_quote
+
+This is consistent with the library config: =_/data_scheme.yml= declares
+=sample.strata= as =optional=, and =2018-19/_/data_info.yml= does not populate
+it (it maps only =v: ea_code=, =weight: hhweight=, =Rural: locality=).  The
+missing =strata= is the survey's, not a config oversight.
+
+**** 2. The weighting domain is three geographic CLUSTERS, not counties
+
+Verbatim, BID s2.6, p. 12:
+
+#+begin_quote
+In lieu of the distance stratification, the data has been weighted to reflect
+geographic clusters (weighting is discussed in detail in Section 6). These
+clusters were defined based on similarity in the intrinsic and exogenous
+factors relevant to the interaction between HHs and forests, such as the level
+of overall socioeconomic development, the extent of forest cover, and the
+vulnerability to forest loss and degradation. Each cluster includes multiple
+counties, as illustrated in Table 5.
+#+end_quote
+
+Cluster composition, transcribed from BID Table 5, p. 12:
+
+| Cluster | Counties                                                      |
+|---------+---------------------------------------------------------------|
+| Western | Bomi; Gbarpolu; Grand Cape Mount; Lofa                        |
+| Central | Bong; Grand Bassa; Margibi; Rural parts of Montserrado; Nimba |
+| Eastern | Grand Gedeh; Grand Kru; Maryland; River Cess; River Gee; Sinoe |
+
+Note "Rural parts of Montserrado" appearing as a cluster member -- the urban
+exclusion is carried through into the weighting domains.
+
+**** 3. Two analysis units in one wave
+
+The catalog records Analysis unit as =Household; Community= (DDI =<anlyUnit>=)
+and Kind of data as =Sample survey data [ssd]= (=<dataKind>=).  Design was 250
+EAs x 12 households = 3,000; realized 2,986 households and 245 usable community
+questionnaires of 250 (BID s2.5 SECOND STAGE SELECTION and Table 4, p. 10).
+The community
+instrument's universe is the *selected EAs*, not a separate population.
+
+*** Universe vs. what the weights represent
+
+These come apart here, and in an unusual direction: *the represented universe
+was fixed after data collection, from the achieved sample*.  The 2.5 km radius
+in the universe statement is not a design parameter -- the design used 15 km
+strata -- it is the observed upper bound of the selected EAs' recomputed
+distances.  Verbatim, BID s2.6, p. 11:
+
+#+begin_quote
+The resulting sample, therefore, is weighted to reflect all EAs in Liberia
+(with the exception of urban Montserrado) that fall within 2.5 km of the
+nearest forest, which was the upper bound of the distances for the selected
+EAs. The distribution of the distance from the center points of the selected
+EAs to the nearest forest, as recomputed by the World Bank following data
+collection, is presented in Figure 1.
+#+end_quote
+
+Verbatim, catalog 3787 Methodology > Weighting (DDI =<weight>=):
+
+#+begin_quote
+Sample weights are constructed to reflect the population in EAs within 2.5 kms
+of the forests, for three geographic clusters. The weights are also adjusted to
+reflect population estimates as of 2016.
+
+For more information on weighting please refer to the Basic Information
+Document in the External Resources
+#+end_quote
+
+The 2016 benchmark, verbatim, BID s6 WEIGHTING (section begins p. 18), p. 19:
+
+#+begin_quote
+In order to account for the outdated nature of the 2008 PHC frame and the
+erroneous distance-based stratification, the basic weights were then adjusted
+for: (i) cluster level populations, and (ii) population growth since 2008.
+First, the EAs were categorized by cluster (as defined in Section 2.6). Then, a
+weight adjustment factor was computed based on the Liberia 2016 HIES population
+estimates, assuming the cluster level population growth rate from the 2008 PHC
+to the 2016 HIES population estimates.
+#+end_quote
+
+So the frame is the 2008 PHC, the population benchmark is the 2016 HIES, the
+data are 2018-09 to 2019-01, and the domain is three post-hoc geographic
+clusters within a post-hoc 2.5 km band.  =hhweight= is a cross-sectional weight
+for that domain and nothing wider.  There is no =panel_weight= (single wave).
+
+*** Where the statement lives -- NOT in this repository
+
+*The universe statement is not held by the library.*  It exists only in live WB
+catalog metadata plus a Basic Information Document that is not mirrored here.
+This is one of the waves whose population record is a moving target.
+
+- The in-repo DDI export,
+  =lsms_library/countries/Liberia/2018-19/Documentation/ddi-documentation-english_microdata-3787.pdf=,
+  has *no* Universe, Sampling Procedure, or Weighting text at all.  Verified by
+  text extraction: the study-description pages carry no text (content streams
+  are header/footer only), and a full-text search for =Universe=, =universe=,
+  =Sampling Procedure= and =Weighting= returns zero hits.  Only the
+  documentation-listing pages and the Policy Note abstract have text.
+- The two DVC-tracked questionnaires carry no universe statement (full-text
+  searched).
+- The Basic Information Document (=liberia__nhfs_basicinformationdocument_v1.pdf=)
+  is listed as a Technical document by the DDI but is *not* among the repo's
+  tracked =Documentation/= files.  It was retrieved from
+  https://microdata.worldbank.org/catalog/3787/download/50661 .
+- Every quote above therefore comes from the live catalog study description /
+  DDI XML export, or from that externally-fetched BID.  All quotes in this
+  section were re-verified against those two sources on 2026-07-21.
+
+Acquiring the BID into =2018-19/Documentation/= would move this wave from
+"catalog-only" to a record the library actually holds.
+
+*** Boilerplate check
+
+Not boilerplate.  The Universe text here is survey-specific -- it names the
+2.5 km radius and the Montserrado carve-out -- and is *not* the WB NADA
+template sentence that recurs verbatim across other waves in the corpus.  It
+attests a real design decision.
+
+*** Provenance keyword note
+
+An earlier pass recorded that =2018-19/Documentation/SOURCE.org= carried only a
+bare DOI with none of the =#+CATALOG_ID= / =#+PROVENANCE_*= keywords.  That is
+*no longer true*: the file now carries =#+CATALOG_ID: 3787=, =#+CATALOG_IDNO:
+LBR_2018_NHFS_v01_M=, =#+PROVENANCE_SOURCE: worldbank=, =#+PROVENANCE_METHOD:
+doi-lookup=, =#+PROVENANCE_RECORDED: 2026-07-12=.  It still has no
+=#+PROVENANCE_VALIDATION=.  Recorded here only so the stale claim is not
+propagated; no action taken.
+
 * Known data issues
 
 ** housing — not available (2026-06-06)

--- a/lsms_library/countries/Malawi/_/CONTENTS.org
+++ b/lsms_library/countries/Malawi/_/CONTENTS.org
@@ -760,6 +760,617 @@ The =reside= column appears in all cover page files but with varying
 case: "Rural"/"Urban", "rural"/"urban", "RURAL"/"URBAN". Harmonized to
 "Rural"/"Urban" via the =Rural= table in =categorical_mapping.org=.
 
+** Sampling universe, exclusions and sub-samples
+
+Evidence gathered for GH #601 (population statements).  This section records
+what the survey documentation *claims* the sample represents, verbatim, with
+citations.  It deliberately says nothing about how the library should represent
+any of it -- that is GH #603's decision.
+
+All quotes below were re-extracted from the cited PDFs (pdfminer) and from the
+World Bank DDI XML exports on 2026-07-21 and match character-for-character
+apart from whitespace: the justified PDFs emit runs of spaces inside sentences,
+which have been collapsed to single spaces.  No words were added, removed or
+reordered.  En dashes and =•= bullets inside quotes are as printed in the
+source, so the ASCII-source house preference yields to the verbatim rule here.
+
+*** At a glance
+
+| Wave    | Survey(s) in this library wave      | Catalog | Universe statement lives    | Likoma      | Institutional pop. |
+|---------+-------------------------------------+---------+-----------------------------+-------------+--------------------|
+| 2004-05 | IHS2 cross-section                  | 2307    | local PDF only (no field)   | EXCLUDED    | not stated         |
+| 2010-11 | IHS3 cross-section                  | 1003    | local PDF + catalog         | EXCLUDED    | excluded           |
+| 2013-14 | IHPS 2013 panel                     | 2248    | *catalog only*              | EXCLUDED    | excluded           |
+| 2016-17 | IHS4 cross-section + IHPS 2016      | 2936 + 2939 | local PDFs + catalog    | IHS4: in; IHPS: out | excluded   |
+| 2019-20 | IHS5 cross-section + IHPS 2019      | 3818 + 3819 | local PDF (IHS5); catalog (IHPS) | IHS5: in; IHPS text says out | excluded |
+
+Two structural facts a reader must have before pooling Malawi:
+
+1. *Likoma district moves in and out of the frame.*  IHS2 and IHS3 exclude it by
+   design; IHS4 is the first round to include it; IHS5 includes it but does not
+   treat it as a domain of analysis.  The IHPS panel universe text continues to
+   exclude it throughout.
+2. *2016-17 and 2019-20 are each one library wave carrying two different
+   declared universes* -- a national cross-section and a tracking-defined panel.
+   See "Two universes in one wave" below.
+
+*** 2004-05 (IHS2, catalog 2307)
+
+**** Declared universe -- and a caveat about its strength
+
+There is *no field or heading labelled "Universe"* anywhere in this wave's
+documentation, and the World Bank DDI XML for study 2307 has *no =<universe>=
+element at all* (verified 2026-07-21: =grep= over the fetched DDI returns zero
+matches).  The nearest statement is embedded in the Sampling Procedure
+narrative:
+
+#+begin_quote
+The sample for IHS-2 was drawn using a two-stage stratified sampling procedure
+from a sample frame using the 1998 Population Census Enumeration Areas (EAs).
+The population covered by the IHS-2 was all individuals living in selected
+households. The sample frame includes all three regions of Malawi: north, centre
+and south.
+#+end_quote
+
+Source :: =2004-05/Documentation/ddi-documentation-english_microdata-2307.pdf=,
+PDF p. 3, "Sampling" -> "Sampling Procedure".  Identical text is in the catalog
+DDI's =<sampProc>= element.
+
+*This statement is circular* and should not be treated as a universe.  "all
+individuals living in selected households" describes the *sample*, not the
+population the sample stands for.  Malawi IHS2 is one of the corpus's named
+examples of circular documentation (alongside GhanaLSS 1988-89).  Note also that
+the unit named here is *individuals*, not households.
+
+**** Exclusions
+
+#+begin_quote
+Each of the twenty-seven districts was considered as a separate sub-stratum of
+the main rural stratum (for IHS-2, Likoma District was excluded because of
+difficulty in travel to the island, so only twenty-six administrative districts
+were considered). Thus the total number of strata in the survey was thirty:
+twenty-six districts and four urban centers.
+#+end_quote
+
+Source :: same PDF, p. 3.
+
+- *Geographic* :: Likoma District excluded, on stated travel/logistics grounds.
+  This is the one hard, design-level exclusion documented for IHS2.
+- *Population* :: NO institutional-population exclusion is stated for IHS2.
+  IHS3 onward state one; IHS2's documentation is silent.  Recorded as silence,
+  not as evidence of inclusion.
+
+**** Sub-samples
+
+None.  IHS2 is a single cross-section, and it is *not* a panel baseline:
+
+#+begin_quote
+The IHPS sample does NOT have any links to the IHS2 sample. The IHS3 serves as a
+baseline ONLY for the panel subsample.
+#+end_quote
+
+Source :: =2016-17/Documentation/ihps_2016_bid_updated_final.pdf=, p. 4,
+footnote 1.
+
+The library's 2004-05 config reads the flat =2004-05/Data/= directory; there is
+no panel half to mix in.
+
+*** 2010-11 (IHS3, catalog 1003)
+
+**** Declared universe
+
+#+begin_quote
+The sampling frame for the IHS-3 is based on the listing information and
+cartography from the 2008 Malawi Population and Housing Census. The target
+universe for the IHS-3 includes individual households and persons living in
+those households within all the districts of Malawi except for Likoma. Also
+excluded from this survey is the population living in institutions, such as
+hospitals, prisons and military barracks.
+#+end_quote
+
+Source :: =2010-11/Documentation/IHS3_Report.pdf=, Chapter 1, s. "1.2 Sample
+design and coverage", PDF p. 19 (printed p. 2).  Verified 2026-07-21.
+
+This is a genuine target-universe statement (it uses the words "target
+universe"), and its unit is *both* households and persons.
+
+**** Exclusions
+
+Two mutually consistent layers.
+
+(a) Frame-level, with the reason given:
+
+#+begin_quote
+It was decided to exclude the island district of Likoma from the IHS3 sampling
+frame, since it only represents about 0.1% of the population of Malawi, and the
+corresponding cost of enumeration would be relatively high. The sampling frame
+further excludes the population living in institutions, such as hospitals,
+prisons and military barracks. Hence, the IHS3 strata are composed of 31
+districts in Malawi.
+#+end_quote
+
+Source :: =2010-11/Documentation/ddi-documentation-english_microdata-1003.pdf=,
+PDF p. 3, "Sampling" -> "Sampling Procedure".
+
+(b) Household-level ineligibility rules.  These are *NOT in either local PDF* --
+they exist only in the World Bank catalog DDI's =<universe>= element for study
+1003 (verified by fetching https://microdata.worldbank.org/index.php/metadata/export/1003/ddi
+on 2026-07-21):
+
+#+begin_quote
+Members of the following households are not eligible for inclusion in the
+survey:
+• All people who live outside the selected EAs, whether in urban or rural areas.
+• All residents of dwellings other than private dwellings, such as prisons,
+hospitals and army barracks.
+• Members of the Malawian armed forces who reside within a military base. (If
+such individuals reside in private dwellings off the base, however, they should
+be included among the households eligible for random selection for the survey.)
+• Non-Malawian diplomats, diplomatic staff, and members of their households.
+(However, note that non-Malawian residents who are not diplomats or diplomatic
+staff and are resident in private dwellings are eligible for inclusion in the
+survey. The survey is not restricted to Malawian citizens alone.)
+• Non-Malawian tourists and others on vacation in Malawi.
+#+end_quote
+
+Two things worth pulling out: the survey explicitly is *not* restricted to
+Malawian citizens; and this list is a set of *ineligibility* rules, so read as a
+universe field it defines the population only by negation.
+
+**** Representativeness (what the weights claim)
+
+#+begin_quote
+As noted above, the IHS3 data are representative at the national, urban/rural,
+regional and district-level.
+#+end_quote
+
+Source :: =ddi-documentation-english_microdata-1003.pdf=, PDF p. 3, "Weighting".
+The weight variable named there is =hhwght=; this wave's cover page in this repo
+carries =hh_wgt= (see the *Weights* table above).
+
+**** Sub-samples: the 204-EA panel baseline is drawn INSIDE this wave
+
+#+begin_quote
+A sub-sample of IHS3 sample enumeration areas (EAs) (i.e. 204 EAs out of 768
+EAs) was selected prior to the start of the IHS3 field work with the intention
+to (i) visit a total of 3,246 households in these EAs twice to reduce recall
+associated with different aspects of agricultural data collection and (ii) to
+track and resurvey these households in 2013 [...]
+#+end_quote
+
+Source :: =2016-17/Documentation/ihps_2016_bid_updated_final.pdf=, p. 4.
+
+This is the canonical "specialization lives inside a wave" case for Malawi: the
+IHPS baseline is a purposively-timed sub-sample of the IHS3 cross-section,
+*selected before fieldwork*, whose households were visited twice.  Its own
+representativeness is stated separately (see 2013-14 below) and is coarser than
+IHS3's.
+
+*Library note*: =2010-11/Data/= contains both =Full_Sample/= and =Panel/=, but
+the 2010-11 config reads only =Full_Sample/= (32 references vs. 0).  So this
+library wave carries the IHS3 cross-section alone -- unlike 2016-17 and 2019-20.
+
+*** 2013-14 (IHPS 2013, catalog 2248)
+
+**** Declared universe -- lives ONLY in World Bank catalog metadata
+
+The universe statement for this wave is *not present in any file in this
+repository under this wave*.  The local DDI report PDF
+(=2013-14/Documentation/ddi-documentation-english_microdata-2248.pdf=, 1,889 pp.)
+contains neither the word "universe" nor the phrase "neither servants"; it has
+only a Sampling Procedure narrative.  The statement is the catalog DDI's
+=<universe>= element, fetched and verified verbatim on 2026-07-21 from
+https://microdata.worldbank.org/index.php/metadata/export/2248/ddi:
+
+#+begin_quote
+The IHPS attempted to track all baseline households (from the IHS3) as well as
+individuals that moved away from the baseline dwellings between 2010 and 2013 as
+long as they were neither servants nor guests at the time of the IHS3; were
+projected to be at least 12 years of age and were known to be residing in
+mainland Malawi but excluding those in Likoma Island and in institutions,
+including prisons, police compounds, and army barracks.
+#+end_quote
+
+Because this lives only in the catalog, *the record is a moving target*: it can
+be revised upstream without anything in this repo changing.
+
+Near-identical wording *is* held locally, but filed under other waves:
+
+#+begin_quote
+The IHPS 2013 attempted to track all baseline households as well as individuals
+that moved away from the baseline dwellings between 2010 and 2013 as long as
+they were neither servants nor guests at the time of the IHS3; were projected to
+be at least 12 years of age and were known to be residing in mainland Malawi but
+excluding those in Likoma Island2 and in institutions, including prisons, police
+compounds, and army barracks.
+#+end_quote
+
+Sources :: =2016-17/Documentation/ihps_2016_bid_updated_final.pdf=, s. "1.20
+INTEGRATED HOUSEHOLD PANEL SURVEY (IHPS)", p. 5; and
+=2019-20/Documentation/the_integrated_household_panel_survey_2010_2019_report.pdf=,
+s. "1.1 Integrated Household Panel Survey", PDF p. 20 (printed p. 2).  ("Likoma
+Island2" is the footnote marker, as printed.)  Both verified 2026-07-21.
+
+*This is a TRACKING universe, not a fresh-draw universe.*  The target population
+is defined relative to the IHS3 2010 baseline sub-sample, not to Malawi.
+
+**** Exclusions
+
+- *Geographic* :: Likoma Island, and anything outside mainland Malawi.  The
+  reason is given in a footnote:
+
+  #+begin_quote
+  The exclusion of the Likoma Island is rooted in the traditional exclusion of
+  the district for IHS purposes, largely due to logistical considerations.
+  #+end_quote
+
+  Source :: =2016-17/Documentation/ihps_2016_bid_updated_final.pdf=, p. 5, fn. 2.
+
+- *Population* :: institutions -- prisons, police compounds, army barracks.
+  (Note "police compounds" appears in the IHPS wording but not in the IHS
+  cross-section wording.)
+- *Age rule* :: split-off individuals were tracked only if "projected to be at
+  least 12 years of age".  Under-12 movers are outside the tracking universe.
+- *Status rule* :: individuals who were "servants" or "guests" at baseline are
+  outside the tracking universe.
+
+The age and status rules are easy to miss and are a genuine part of the declared
+universe, not an operational detail.
+
+**** Representativeness (coarser than IHS3's, and stated at baseline)
+
+#+begin_quote
+At baseline, the IHPS sample was selected to be representative at the national-,
+regional-, urban/rural levels and for each of the following 6 strata: (i)
+Northern Region – Rural, (ii) Northern Region – Urban, (iii) Central Region –
+Rural, (iv) Central Region – Urban, (v) Southern Region – Rural, and (vi)
+Southern Region – Urban.
+#+end_quote
+
+Source ::
+=2019-20/Documentation/the_integrated_household_panel_survey_2010_2019_report.pdf=,
+p. 20 (verified); the same sentence, phrased "the IHPS sample (known as the IHPS
+2010) had been selected, out of the overall IHS3 sample as described above, to be
+representative at ...", is at =ihps_2016_bid_updated_final.pdf= p. 5.
+
+Note the claim is about the *baseline*.  It is not a claim about the 2013
+interviewed sample after tracking and split-off accretion.
+
+**** Sample composition (design detail, not universe)
+
+#+begin_quote
+Once a split-off individual was located, the new household that he/she
+formed/joined since 2010 was also brought into the IHPS sample. In view of the
+tracking rules, the final IHPS 2013 sample, therefore, included a total of 4,000
+households that could be traced back to 3,104 baseline households
+#+end_quote
+
+Source :: =ihps_2016_bid_updated_final.pdf=, p. 5.
+
+The 4,000-vs-3,104 gap is households *created by the tracking rule*.  A user
+weighting this wave should use =panelweight= and should not read the 4,000 as
+4,000 independent draws.  This is also the mechanism behind the 765 contested
+cluster-attribute cells documented under *GH #323: 2013-14 (IHPS): the GPS is
+the proof* above -- movers, not a broken key.
+
+*** 2016-17 (IHS4, catalog 2936 + IHPS 2016, catalog 2939)
+
+**** Two universes in one library wave
+
+The library's 2016-17 config reads *both* =../Data/Cross_Sectional/= (IHS4, 55
+references) and =../Data/Panel/= (IHPS 2016, 25 references).  Rows in this wave
+therefore come from two different declared target populations, with different
+geographic frames (Likoma in vs. out) and different analysis domains.  Anyone
+averaging over this wave is averaging over both.
+
+**** [A] IHS4 cross-section -- declared universe
+
+The DDI's "Universe" field contains only the ineligibility list:
+
+#+begin_quote
+Members of the following households are not eligible for inclusion in the
+survey:
+• All people who live outside the selected EAs, whether in urban or rural areas.
+• All residents of dwellings other than private dwellings, such as prisons,
+hospitals and army barracks.
+• Members of the Malawian armed forces who reside within a military base. (If
+such individuals reside in private dwellings off the base, however, they should
+be included among the households eligible for random selection for the survey.)
+• Non-Malawian diplomats, diplomatic staff, and members of their households.
+(However, note that non-Malawian residents who are not diplomats or diplomatic
+staff and are resident in private dwellings are eligible for inclusion in the
+survey. The survey is not restricted to Malawian citizens alone.)
+• Non-Malawian tourists and others on vacation in Malawi.
+#+end_quote
+
+Source :: =2016-17/Documentation/ddi-documentation-english_microdata-2936.pdf=,
+PDF p. 12, heading "Universe" (immediately under "Geographic Coverage:
+National").  Verified 2026-07-21; byte-equal to the catalog DDI =<universe>=.
+
+**** [A] IHS4 -- Likoma enters the frame
+
+#+begin_quote
+This is the first round of the survey to include the island district of Likoma
+in the sampling frame. The sampling frame further excludes the population living
+in institutions, such as hospitals, prisons and military barracks. Hence, the
+IHS4 strata are composed of 32 districts in Malawi.
+#+end_quote
+
+Source :: World Bank catalog DDI for study 2936, =<sampProc>= (fetched and
+verified 2026-07-21).  The same paragraph is in the local DDI PDF's Sampling
+Procedure section.
+
+This is a *real break* from 2004-05 and 2010-11: 32 districts, not 26 or 31.
+
+**** [B] IHPS 2016 panel -- declared universe
+
+#+begin_quote
+The IHPS 2016 attempted to track all IHPS 2013 households stemming from 102 of
+the original 204 baseline panel enumeration areas as well as individuals that
+moved away from the 2013 dwellings between 2013 and 2016 as long as they were
+neither servants nor guests at the time of the IHPS 2013; were projected to be
+at least 12 years of age and were known to be residing in mainland Malawi but
+excluding those in Likoma Island and in institutions, including prisons, police
+compounds, and army barracks.
+#+end_quote
+
+Source ::
+=2016-17/Documentation/Panel/ddi-documentation-english_microdata-2939.pdf=,
+PDF p. 5, heading "Coverage" -> "UNIVERSE".  Verified 2026-07-21.
+
+Same tracking / 12+ / servant-or-guest / Likoma / institution rules as 2013-14,
+now narrowed to *102 of the 204* baseline EAs.
+
+**** [B] IHPS 2016 -- the sample is halved, and the domains change
+
+#+begin_quote
+Given the increasing numbers of households to be tracked, as well as
+budget/resource constraints, starting in 2016, the IHPS target household sample was
+adjusted as the households that have been associated with 102 out of 204
+baseline EAs. Although the IHPS 2016 cannot be tabulated by region, the
+stratification of the IHPS 2010 sample by region, urban and rural strata was
+still maintained with a proportional allocation of the sample across the
+regions, based on the distribution of the sampling frame from the 2008 Malawi
+Census. [...] Thus, starting in 2016, the IHPS domains of analysis will be
+limited to the national, urban and rural areas.
+#+end_quote
+
+Source :: =2016-17/Documentation/ihps_2016_bid_updated_final.pdf=, p. 5.
+Verified 2026-07-21.  (The bracketed elision drops two sentences about Table 1.1
+and urban sample size.)
+
+This is the clearest *universe-vs-weights* divergence in the Malawi series: the
+strata still carry region, but the documentation says the survey no longer
+supports regional tabulation.  Region is present in the data and is *not* an
+analysis domain from 2016 onward.
+
+The two halves' claims side by side:
+
+#+begin_quote
+The IHS4 cross-section collected information from a sample of 12,480 households
+statistically designed to be representative at both national, district, urban
+and rural levels while the IHPS 2016 collected information from a sample of all
+households and split-off individuals stemming from 102 out of the 204 original
+baseline EAs representative at the national and urban/rural levels.
+#+end_quote
+
+Source :: =ihps_2016_bid_updated_final.pdf=, p. 4.  Verified 2026-07-21.
+
+**** Overlap warning
+
+EA =30305580= is sampled in *both* the Cross_Sectional and the Panel halves of
+this wave -- a genuine shared EA, not a code collision.  See *GH #323: 2016-17
+(IHS4 + IHPS4)* above for the measurement.  Relevant here because it means the
+two universes are not merely adjacent in this wave, they touch.
+
+**** Where these statements live
+
+Both universes are held *locally* (the two DDI PDFs plus the IHPS BID), so this
+wave is not catalog-dependent.  But note that
+=2016-17/Documentation/SOURCE.org= records catalog id *2936 only*; the IHPS 2016
+entry (2939), whose DDI PDF sits in =Documentation/Panel/=, is not recorded in
+any SOURCE.org in this repo.
+
+*** 2019-20 (IHS5, catalog 3818 + IHPS 2019, catalog 3819)
+
+**** Two universes in one library wave (again)
+
+The 2019-20 config reads both =../Data/Cross_Sectional/= (IHS5, 53 references)
+and =../Data/Panel/= (IHPS 2019, 26 references).
+
+**** [A] IHS5 cross-section -- declared universe
+
+#+begin_quote
+The sampling frame for the IHS5 is based on the cartography and data from the
+2018 Malawi Census of Population. This will provide a very updated frame for the
+first sampling stage compared to the IHS-4, which was based on the 2008 Census.
+The target universe for the IHS5 includes the individual households and persons
+living in these households within all the districts of Malawi, including the
+small island district of Likoma, which had also been included in IHS-4, but not
+in the previous surveys. The sampling frame excludes the population living in
+institutions, such as school dormitories, hospitals, prisons and military
+barracks.
+#+end_quote
+
+Source ::
+=2019-20/Documentation/fifth_integrated_household_survey_ihs5_2019_2020_basic_information_document.pdf=,
+s. "2.0 SURVEY DESIGN" -> "2.1 Sampling Frame and Sampling Units for the Malawi
+IHS5", printed p. 7.  Verified 2026-07-21.
+
+Note *school dormitories* are added to the institutional exclusion list here;
+IHS3 and IHS4 name only hospitals, prisons and military barracks.
+
+**** [A] IHS5 -- Likoma is in the frame but is NOT a domain of analysis
+
+#+begin_quote
+Because of the small size of Likoma, for stratification purposes it was combined
+with the district of Nkhata Bay. Although it will be represented in the
+national-level survey results, Likoma will not be considered a domain of
+analysis for the IHS5.
+#+end_quote
+
+Source :: same BID, p. 7.  Verified 2026-07-21.
+
+So Likoma's status is *three-valued* across the series: excluded from the frame
+(IHS2, IHS3), in the frame and a district (IHS4), in the frame but folded into
+Nkhata Bay for stratification and not a domain (IHS5).
+
+**** [A] IHS5 -- realised coverage fell short of the universe (COVID-19)
+
+This is *not* a design exclusion, and must not be recorded as one.  The universe
+did not change; fieldwork stopped.
+
+#+begin_quote
+Due to the COVID-19 pandemic, the data collection for IHS5 was suspended around
+10 April 2020 before the end of the fourth quarter. For this reason, it was
+necessary to adjust the basic design weights described above to account for
+sample EAs that were not enumerated because the data collection was suspended.
+#+end_quote
+
+#+begin_quote
+[...] in the case of the 51 sample EAs in the fourth quarter that were not
+enumerated, the weights were calculated as 0 since there were no households
+interviewed. These missing EAs were represented by the weight adjustment for the
+enumerated EAs in the stratum and quarter [...]
+#+end_quote
+
+Source :: same BID, pp. 41-42.
+
+#+begin_quote
+12, 288 households from 768 Enumeration Areas were selected. Due to COVID-19, 51
+Enumeration Areas were unable to be visited at the end of the 12-month fieldwork
+period. Due to this, the final response rate was 93 percent.
+#+end_quote
+
+Source :: World Bank catalog DDI for study 3818, =<respRate>= (fetched and
+verified 2026-07-21; the stray space in "12, 288" is as published).
+
+*Universe vs. weights*: the declared universe is the full 32-district
+population; the weights make the enumerated EAs stand in for the 51 unenumerated
+ones within stratum and quarter.  Since IHS5 deliberately enumerates a
+nationally representative subsample each quarter to capture seasonality, the
+loss is concentrated in the final quarter and the reweighting is a within-
+stratum-and-quarter adjustment, not a national one.  Anyone using IHS5 for
+seasonal analysis should read the BID before trusting Q4.
+
+**** [B] IHPS 2019 panel -- declared universe (catalog only, and internally odd)
+
+#+begin_quote
+The IHPS 2016 and 2019 attempted to track all IHPS 2013 households stemming from
+102 of the original 204 baseline panel enumeration areas as well as individuals
+that moved away from the 2013 dwellings between 2013 and 2016 as long as they
+were neither servants nor guests at the time of the IHPS 2013; were projected to
+be at least 12 years of age and were known to be residing in mainland Malawi but
+excluding those in Likoma Island and in institutions, including prisons, police
+compounds, and army barracks.
+#+end_quote
+
+Source :: World Bank catalog DDI for study 3819, =<universe>= (fetched and
+verified verbatim 2026-07-21 from
+https://microdata.worldbank.org/index.php/metadata/export/3819/ddi).  *Not
+present in any local file*, and catalog id 3819 is *not recorded in
+=2019-20/Documentation/SOURCE.org=*, which lists only 3818.
+
+Read it carefully: it says "2016 and 2019 attempted to track ... individuals
+that moved away from the 2013 dwellings between 2013 and 2016".  The 2016
+wording was extended in place rather than rewritten, so as published the field
+does not describe the 2016-2019 tracking operation at all.  The local report
+does:
+
+#+begin_quote
+The IHPS4 (2019), attempted to track households and individuals that moved away
+from the dwellings they were living during IHPS 2016. The areas of analysis were
+limited to the national, urban and rural areas since the number of EAs was
+halved during IHPS3 (2016).
+#+end_quote
+
+Source ::
+=2019-20/Documentation/the_integrated_household_panel_survey_2010_2019_report.pdf=,
+p. 20.  Verified 2026-07-21.
+
+**** [B] IHPS 2019 -- Likoma: the two sources disagree
+
+The catalog =<universe>= excludes Likoma Island.  The local 2019 panel report,
+at the same point in the same sentence, carries footnote 2 reading:
+
+#+begin_quote
+Likoma is included in the list of the districts.
+#+end_quote
+
+Source :: same report, p. 20, fn. 2.  (Compare the 2016 BID's footnote 2 at the
+identical position, which says the opposite: "The exclusion of the Likoma Island
+is rooted in the traditional exclusion of the district for IHS purposes".)  Both
+are recorded; neither is adjudicated here.  Since the IHPS frame is the 2010
+IHS3 baseline EAs, which excluded Likoma, no IHPS household can be from Likoma
+by construction regardless of which footnote is right -- but the *statements*
+differ and a reader should know.
+
+**** [B] IHPS 2019 -- composition
+
+#+begin_quote
+The survey collected data from 102 Enumeration with number of households
+increasing from 2,508 in 2016 to 3,178 in 2019 which could be traced back to
+2,370 households.
+#+end_quote
+
+Source :: same report, PDF p. 20 (sentence as printed, including "102
+Enumeration").  Verified 2026-07-21.
+
+*** Cross-wave: what to check before pooling
+
+- *Frame vintage changes twice.*  1998 census EAs (IHS2), 2008 census EAs
+  (IHS3/IHS4 and the IHPS baseline), 2018 census EAs (IHS5).  This is already
+  documented above under *GH #323* for the =v= codes: 2004-05 shares only 3
+  codes with 2010-11.  A cross-wave join on =v= is meaningful from 2010-11
+  onward and not before, and the *universe* changes with the frame too.
+- *Likoma*: out / out / out / in / in-but-not-a-domain (IHS2, IHS3, IHPS, IHS4,
+  IHS5).  Any district-level Malawi panel must decide what to do about this.
+- *Institutional exclusion* is stated from IHS3 onward and is silent for IHS2.
+  IHS5 adds school dormitories.
+- *The IHPS half of 2016-17 and 2019-20 is not nationally-by-region
+  representative* from 2016 onward, by the survey's own statement, even though
+  region is present in the data.
+- *The 12+ and servant/guest tracking rules* mean the IHPS "universe" is not a
+  population of Malawi at all -- it is a population defined by who was in the
+  2010 (later 2013) baseline and who was old enough and not a servant or guest.
+
+*** Boilerplate check
+
+Malawi's universe text is *not* the World Bank NADA template sentence ("The
+survey covered all de jure households excluding prisons, hospitals, military
+barracks, and school dormitories") that appears verbatim in 15 waves elsewhere
+in the corpus.  Malawi's statements are survey-specific.
+
+However, one block *is* reused verbatim within Malawi: the five-bullet
+ineligibility list is character-identical across the =<universe>= elements of
+catalog 1003 (IHS3), 2936 (IHS4) and 3818 (IHS5).  It is an IHS-series-standard
+metadata block, not three independent claims.  Treat it as attesting one
+editorial decision by the series' documenters, and note that as a "universe" it
+is purely negative: it lists who is ineligible and never states who is in.
+
+*** Corrections to the upstream evidence record (verified 2026-07-21)
+
+Three claims in the GH #601 per-wave record for Malawi did not survive
+re-checking against the cited sources.  Recorded here so they are not
+propagated.
+
+1. *"the WB catalog record for IHS5 (3818) has an EMPTY =<universe>= element"*
+   -- FALSE as fetched on 2026-07-21.  Study 3818's =<universe>= contains the
+   same five-bullet ineligibility list as 1003 and 2936 (delivered in a CDATA
+   section, which may be what defeated the earlier parse).  The substantive
+   point the record was making still stands and is stated above: IHS5's positive
+   target-universe sentence comes from the local Basic Information Document, not
+   from the catalog, and the catalog carries only the negative list.
+2. *"SOURCE.org for [2016-17] lists catalog 2936 AND 2248"* -- FALSE.
+   =2016-17/Documentation/SOURCE.org= lists 2936 only.  No SOURCE.org in this
+   repo records 2939 (IHPS 2016) or 3819 (IHPS 2019), which is the real gap.
+3. *"2016-17 ... Cross_Sectional (16 references) / Panel (17 references)"* and
+   *"2019-20 ... (21 / 18)"* -- the reference counts differ from a fresh =grep=
+   over =<wave>/_/= (2016-17: 55 / 25; 2019-20: 53 / 26; 2010-11: =Full_Sample=
+   32 / =Panel= 0).  The counts are incidental; the load-bearing conclusion --
+   2016-17 and 2019-20 read both halves, 2010-11 reads only =Full_Sample/= --
+   is confirmed.
+
 * Files in Malawi/<SOMEYEAR>/_/
 ** RETIRED household_characteristics.py
 Now derived at API time via =transformations.roster_to_characteristics=

--- a/lsms_library/countries/Mali/_/CONTENTS.org
+++ b/lsms_library/countries/Mali/_/CONTENTS.org
@@ -23,6 +23,377 @@ need for =vague= in the index.  See CLAUDE.md "EHCVM countries"
 note for the wider pattern across Senegal, Niger, Burkina Faso,
 Benin, Togo, and Guinea-Bissau.
 
+* Sampling universe, exclusions and sub-samples
+
+# ASCII EXCEPTION (deliberate, per the orgmode skill's "leave a comment" rule):
+# every #+begin_quote block below is a VERBATIM transcription of survey
+# documentation.  Most of it is French and carries accented characters,
+# typographic apostrophes and the sources' own sic spellings.  It is NOT
+# normalised to ASCII, because normalising it would destroy the one property
+# this section exists to preserve.  All prose OUTSIDE the quote blocks is ASCII.
+
+Evidence gathered for GH #601 / #603.  This section records *what each wave's
+documentation says its sample represents*, verbatim.  It deliberately proposes
+no schema and resolves nothing: #603 is deciding how the library should
+represent this, and until it does, the honest thing to hold is the quotes.
+
+Three rules were followed, and they are why this is usable as evidence:
+
+- Quotes are verbatim, in the source language, with a file + page citation.
+  Translations are on separate, clearly labelled lines.
+- Gaps are recorded as gaps, naming exactly what was searched.  No gap is
+  filled by adjacency or by a sibling wave.
+- *Nothing here was inferred from the data.*  No =.dta= was opened.  A survey's
+  universe is a claim its documentation makes; it is not something to
+  reverse-engineer from the microdata.
+
+Read it alongside the =Sampling Design= section above, which covers the
+*index* convention (=v: grappe=, =i: (grappe, menage)=).  That section is about
+identifiers; this one is about what the sample stands for.  The two do not
+overlap and neither supersedes the other.
+
+*One correction to the Overview above.*  The Overview opens "Mali EHCVM
+(Enquête Harmonisée sur les Conditions de Vie des Ménages) [...] Four waves are
+configured", which reads as though all four waves are EHCVM.  They are not.
+Only *2018-19 and 2021-22* are EHCVM; *2014-15 and 2017-18 are EAC-I* (Enquête
+Agricole de Conjoncture Intégrée), a different survey with a different frame, a
+different second-stage design and -- in 2014-15 -- a different observation unit
+in rural areas.  The =plot_features= section further down already says this
+("the pre-EHCVM EACI waves (2014-15, 2017-18) use a different agriculture
+instrument"), and the =Household Presence= section suspects it ("The 2017-18
+wave may also predate the EHCVM template"); the documentation confirms it.  The
+Overview's opening line is the only place in this file that blurs the two, and
+it should be amended when someone next touches it.
+
+** Summary
+
+| Wave    | Survey                | Labelled UNIVERSE?          | Statement lives in      | Geographic exclusion             |
+|---------+-----------------------+-----------------------------+-------------------------+----------------------------------|
+| 2014-15 | EAC-I 2014            | no -- coverage stmt only    | WB catalog only (!)     | Kidal                            |
+| 2017-18 | EAC-I 2017            | no -- coverage stmt only    | local Documentation.pdf | Kidal; Menaka/Taoudenit not yet regions |
+| 2018-19 | EHCVM-1 2018/19       | yes (but NADA boilerplate)  | local Documentation.pdf | Kidal, Bamako, Taoudenit, Menaka -- varies by vague |
+| 2021-22 | EHCVM-2 2021/22       | *none found*                | --                      | (not stated; design inherited)   |
+
+Two facts about this table matter more than the quotes themselves:
+
+1. *Only 2018-19 has a field labelled UNIVERSE at all*, and that field's text is
+   World Bank NADA template boilerplate (see below).  The other three waves offer
+   coverage / representativeness statements, which say where the sample was drawn
+   and what it estimates -- not what set of units it stands for.
+2. *2014-15's statement is not in this repository.*  It exists only in a
+   catalog-hosted Basic Information Document.  The record for that wave is a
+   moving target held by a third party, not something the library carries.
+
+** 2014-15 -- EAC-I 2014 (Enquete Agricole de Conjoncture Integree 2014)
+
+*The statement exists ONLY in WB catalog metadata, not in any file this repo
+ships.*  The wave's local =Documentation/Documentation.pdf= (the NADA-generated
+DDI report) has no =Universe= field; its Coverage section reads only "GEOGRAPHIC
+COVERAGE / National".  The text below comes from the Basic Information Document
+attached to WB catalog entry 2583 (resource 47801,
+https://microdata.worldbank.org/catalog/2583/download/47801), Section 4
+"Sample", printed page 5 (PDF page 8), first two paragraphs:
+
+#+begin_quote
+The EAC-I 2014 has been designed to have national coverage, including both urban and rural areas in all the regions of the country except Kidal. The domains were defined as the entire country, district of Bamako, other urban areas, and rural areas; and in the rural areas: agricultural zones, agro-pastoral zones and pastoral zones. Taking this into account, 51 explicit sample strata were selected.
+
+The target population was drawn from households in all regions of Mali except Kidal which was not accessible for security reasons. Kidal also has very low population density.
+#+end_quote
+
+Source is English; no translation needed.  Fidelity: the PDF's justified
+multi-space runs were collapsed to single spaces and hard line-breaks removed.
+No word was added, removed or reordered.
+
+*** Exclusion: Kidal, for security reasons
+
+: "...all the regions of the country except Kidal."
+: "...all regions of Mali except Kidal which was not accessible for security reasons."
+
+This is a *by-design* geographic exclusion with a stated cause, and it is the
+single most important fact in this section: it holds across every Mali wave in
+the library in some form.  Anyone pooling Mali with other countries, or
+comparing Mali across time, is comparing a country-minus-Kidal.
+
+*** Sub-population: the observation unit is not the same in town and country
+
+The local =Documentation.pdf= carries no universe, but its Sampling Procedure
+section does define the *observation units*, and they differ by stratum.
+Verbatim (French; local
+=lsms_library/countries/Mali/2014-15/Documentation/Documentation.pdf=, Sampling
+Procedure, printed p.5; identical text on WB catalog page 2583):
+
+#+begin_quote
+L'EAC-I est une enquête par sondage. Elle se distingue d'un recensement en ce sens que tous les ménages/exploitations ne sont pas enquêtés. Elle s'effectue auprès d'un nombre restreint d'unités d'observations (exploitations agricoles en milieu rural, ménage en milieu urbain) sélectionnées parmi l'ensemble plus vaste de toutes les unités du domaine d'intérêt en question. Ce nombre restreint d'unités d'observations constitue l'échantillon. Il est déterminé de telle sorte qu'il soit un format réduit de la population étudiée.
+#+end_quote
+
+Translation (supplied here; NOT source text):
+
+#+begin_quote
+The EAC-I is a sample survey. It differs from a census in that not all households / holdings are surveyed. It is carried out on a restricted number of observation units (agricultural holdings in rural areas, households in urban areas) selected from the much larger set of all units in the domain of interest. This restricted number of observation units constitutes the sample. It is determined so as to be a reduced-scale version of the population studied.
+#+end_quote
+
+So *in rural Mali the EAC-I unit is the agricultural holding
+(=exploitation agricole=); in urban Mali it is the household.*  That is a
+unit-of-observation shift inside a single survey, and it is unusual enough that
+the cross-country sweep singled Mali out for it.  A consumer who reads
+=household_roster= or =food_acquired= for 2014-15 as "a household sample
+throughout" is reading past a documented distinction.
+
+*** Sample design (context, NOT a universe statement)
+
+Two-stage; 1,070 EAs selected PPS from the 2009 Census of Population; 3
+households per rural EA and 9 per urban EA; total planned sample 4,218.
+
+** 2017-18 -- EAC-I 2017
+
+Local documentation, and it corroborates (does not contradict) the existing
+note in the =Household Presence / MonthsSpent= section below that "the 2017-18
+wave may also predate the EHCVM template": it does.  2017-18 is EAC-I, a
+revisit of the 2014 EAs, not EHCVM.
+
+No labelled UNIVERSE exists for this wave in either the local documentation or
+the DDI XML (=<sumDscr><universe/>= for catalog 3409 is *empty*; only
+variable-level =<universe>= tags such as "Individus âgés de 4 ans et plus"
+exist).  The closest coverage statement, from
+=lsms_library/countries/Mali/2017-18/Documentation/Documentation.pdf=, section
+"Sampling" > "Sampling Procedure", printed page 4, first bullet:
+
+#+begin_quote
+• L'échantillon est représentatif au niveau national et couvre toutes les régions et zones (urbaines et rurales) à l'exception de Kidal.
+#+end_quote
+
+Translation (supplied here; NOT source text):
+
+#+begin_quote
+The sample is representative at the national level and covers all regions and zones (urban and rural) with the exception of Kidal.
+#+end_quote
+
+The English Basic Information Document (WB catalog 3409, resource 47785; NOT
+present in this repo), Section 4 "Sample", printed p.7 (PDF p.10), states the
+same thing at more length:
+
+#+begin_quote
+The EAC-I 2017 replicates the same sampling design as the first edition, visiting the same EAs. The sample is nationally representative and cover all regions and areas (urban and rural) except Kidal4. The domains were defined as the entire country, district of Bamako, other urban areas, and rural areas; and in the rural areas: agricultural zones, agro-pastoral zones and pastoral zones. Taking this into account, 51 explicit sample strata were selected.
+#+end_quote
+
+("cover" for "covers" is as printed.)
+
+*** Exclusions
+
+Kidal, as in 2014-15.  Plus a frame-vintage exclusion, from footnote 4 of the
+same BID, verbatim:
+
+#+begin_quote
+At the time of the sample selection, the new regions (Menaka and Taoudénit) were not officially announced. Thus, the sample does not take into consideration these new divisions.
+#+end_quote
+
+And an *unplanned* coverage loss, distinct from the by-design exclusion above --
+same BID, Section 4, verbatim:
+
+#+begin_quote
+The total estimated size of the sample for the survey was 9630. Because of security reasons in the country not all the enumeration areas were visited: 8711 households were interviewed in the first visit; whereas 8658 household were reached during the second visit. The final sample was refined on the base of quality data assessment. The final sample size comprises 8390 households.
+#+end_quote
+
+This is the documentation coming apart from itself in a way worth naming: the
+sample is *declared* nationally representative ex-Kidal, but the document
+concedes that unnamed EAs elsewhere were not visited for security reasons.  What
+the weights represent and what the fieldwork reached are not the same set, and
+the document does not say which EAs were lost.
+
+*** Sub-sample: the Lourd / Leger split INSIDE rural EAs
+
+This is the specialization-inside-a-wave case for Mali, and it is easy to miss.
+From the same BID, Section 4 (verbatim, second stage):
+
+#+begin_quote
+-  9 households were selected with equal probability in each of the urban EAs
+-  9 households were selected with equal probability in each of the rural EAs, then in rural areas:
+
+o  Households # 3, 6, and 9 are administered the version Lourd
+o  Households # 1, 2, 4, 5, 7, 8 are administered the version Léger
+#+end_quote
+
+So in rural areas *one third of sampled households got the long ("Lourd")
+questionnaire and two thirds the short ("Léger") one.*  Any table sourced from a
+Lourd-only module is a one-third rural subsample, not the wave.  Planned n =
+9,630; achieved 8,390.  (The 2014-15 instruments shipped in that wave's
+=Documentation/= are named =EACI2014_..._LOURD_...=, consistent with the 2014
+design's 3-per-rural-EA figure, but no statement was found declaring a 2014
+Lourd/Leger split, so none is asserted here.)
+
+** 2018-19 -- EHCVM-1 2018/19
+
+The only Mali wave with an explicit, labelled UNIVERSE.  From
+=lsms_library/countries/Mali/2018-19/Documentation/Documentation.pdf=, section
+"Coverage" > heading "UNIVERSE", printed page 3:
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.
+#+end_quote
+
+It appears identically in three renderings of the *same* NADA metadata record:
+the local Documentation.pdf p.3; the WB catalog 4295 study-description page
+under "Universe"; and the DDI XML =<sumDscr><universe>= element.  Those are one
+source, not three.
+
+*** BOILERPLATE WARNING -- this sentence attests a template, not a claim about Mali
+
+That exact sentence is *World Bank NADA template text*.  The cross-country sweep
+found it verbatim in *15 waves* -- across Benin, Burkina Faso, Cote d'Ivoire,
+Guinea-Bissau, Mali, Niger, Senegal, Togo, and also Ethiopia 2018-19 / 2021-22
+and Nigeria 2015-16 / 2018-19 / 2023-24.  Its presence tells you which metadata
+template was used.  It does *not* independently attest that Mali's INSTAT made
+that claim about this survey.  Treat it as weaker evidence than its
+"UNIVERSE"-labelled prominence suggests.
+
+*** Exclusions
+
+Institutional/collective quarters, per the boilerplate: prisons, hospitals,
+military barracks, school dormitories.
+
+Geographic exclusions are *not* in the universe field.  They are in the SAMPLING
+PROCEDURE section of the same document (printed p.4), and they are statements
+about where data were *collected*, which is a different kind of claim:
+
+#+begin_quote
+The survey collected data in rural and urban areas in all regions in each of the two waves, except Kidal, Bamako, Toaudénit, and Menaka. More specifically, during the first wave, the survey did not collect data in rural Kidal. Moreover, due to Bamako's purely urban nature, no rural area data are available for this district. Likewise, concerning Taoudenit and Menaka, the survey did not collect data for those regions during the first wave. In addition, there is no urban data for Taoudenit in wave 2.
+#+end_quote
+
+Note two things, quoted as printed:
+
+- The document spells the region *both* "Toaudénit" and "Taoudenit", two
+  sentences apart.  Neither spelling was corrected here.
+- The exclusions are *vague-specific* (=vague= = round).  Rural Kidal missing in
+  vague 1; Taoudenit and Menaka absent in vague 1; no urban Taoudenit in vague 2.
+  Since the library's EHCVM convention collapses =vague= out of the index (each
+  =grappe= is visited in exactly one =vague= -- see =Sampling Design= above), *the
+  index carries no trace of which coverage regime a given household fell under.*
+  Anyone computing a national aggregate from this wave should know that the
+  geographic coverage is not constant across the households being pooled.
+
+Fidelity: pdfminer renders this PDF's "fi" ligature as a single glyph, so raw
+extraction shows "speciﬁcally" / "ﬁrst"; ordinary letters are used above,
+matching the byte-identical catalog rendering.  Whitespace normalized; no words
+changed.
+
+*** Supplementary sample inside the wave
+
+Sample design (context, NOT a universe statement): frame = 6th edition of the
+2017/18 EMOP, itself derived from the 2009 RGPH, 1,153 EAs; two-stage stratified
+without replacement; 500 EAs PPS, *plus 51 additional EAs added in vague 2 to
+cover Menaka and Taoudenit*; 12 households per EA; planned n = 6,603 (2,752
+urban / 3,851 rural).  Those 51 EAs are a top-up to reach regions vague 1 could
+not, i.e. a supplement inside the wave rather than a uniform draw.
+
+** 2021-22 -- EHCVM-2 2021/22 -- NO UNIVERSE STATEMENT FOUND
+
+*Recorded as a gap, deliberately.*  No universe / target-population statement
+exists in any Mali 2021-22 documentation examined.  This is positive evidence of
+absence, not a failure to look:
+
+- The DDI XML for WB catalog 6275 contains *no* =<universe>= element at all
+  inside =<sumDscr>= (2018-19's catalog 4295 does contain one).
+- The catalog study-description page's Coverage section has only "Geographic
+  Coverage / National coverage" and no Universe field.
+- =lsms_library/countries/Mali/2021-22/Documentation/ddi-documentation-english_microdata-6275.pdf=
+  -- read in full (15,827 characters).  Coverage section: GEOGRAPHIC COVERAGE /
+  National coverage.  No UNIVERSE heading.
+- =lsms_library/countries/Mali/2021-22/Documentation/mli_ehcvm2_information_de_base_eng.pdf=
+  (English BID) -- Section 4 "Sampling" / 4.1 "Household and Community Sampling",
+  PDF pp.10-11, read in full.  No universe statement.
+- The French BID (catalog 6275, resource 100367), Section 4 "Échantillonnage" /
+  4.1 "Volet ménage et communautaire" -- read in full.  No =population cible=, no
+  =champ de l'enquête=.
+- All of the above were additionally grepped for
+  =univers|popul|champ|couvre|couverture|exclu|cible|de jure|target population|barracks|prison|Kidal=.
+- Not opened: =mli_ehcvm2_qnr_men_excel_vague{1,2}.pdf= (questionnaires --
+  instruments, not universe statements).
+
+*** The inference that was available, and was declined
+
+2021-22 is a panel revisit of the 2018/19 clusters, so its documentation
+describes the 2018/19 design instead of declaring its own universe.  Local
+English BID, Section 4.1, verbatim:
+
+#+begin_quote
+The sampling frame for the 2018/2019 survey is based on the 2009 general population and housing census (RGPH). In 2021/2022, an enumeration was conducted in the same clusters.
+
+The survey is a panel cluster survey, and the sampling plan is based on that of the 2018/2019 survey. Therefore, it is appropriate to describe the 2018/2019 plan.
+
+In 2021/2022, the strategy is to revisit the same clusters. This involves either surveying the 12 households from 2018/2019 if they are found (after the enumeration phase), or surveying the found households and completing the sample to 12 in clusters where fewer households are found during the enumeration phase (either because there were fewer than 12 households in the final 2018/2019 database or because some households were not found).
+#+end_quote
+
+French BID, 4.1 "Base de sondage", verbatim:
+
+#+begin_quote
+La base de sondage de l'enquête de 2018/2019 est le recensement général de la population et de l'habitat (RGPH) de 2009. En 2021/2022, il a été procédé à un dénombrement dans les mêmes grappes.
+#+end_quote
+
+It would be *defensible* to inherit the 2018-19 universe sentence ("all de jure
+households excluding prisons, hospitals, military barracks, and school
+dormitories") for 2021-22 on the strength of that panel linkage.  *That is an
+inference, not a documented claim for this wave, and it is recorded here only as
+such.*  It is left for #603 to decide whether the library may inherit; it is not
+decided here.
+
+*** Sub-samples INSIDE the 2021-22 wave -- two of them, both documented
+
+1. *A regional booster.*  Local English BID, Section 4.1, note beneath Table 2,
+   verbatim:
+
+   #+begin_quote
+   Note: For the regions of Kidal and Timbuktu, an additional sample was added to include rural Kidal and Taoudeni in the survey. The relative error in Table 1 concerns the initial sample.
+   #+end_quote
+
+   French original, verbatim:
+
+   #+begin_quote
+   Nb :  Pour  la  région  de  Kidal  et  Tombouctou,  un  échantillon  supplémentaire  a  été  ajouté  pour  intégrer  Kidal  rural  et Taoudéni à l'enquête. L'erreur relative dans le tableau 1 concerne l'échantillon initiale.
+   #+end_quote
+
+   (Justified spacing as printed in the French; "l'échantillon initiale" is the
+   source's own agreement error, quoted as printed.)  So *the 2021-22 wave is not
+   a uniform draw*: rural Kidal -- excluded by design in every earlier Mali wave
+   in this library -- is present here via an added sample, and the BID says
+   explicitly that the published relative errors do *not* cover it.
+
+2. *Panel households and top-up households in one wave.*  Per the revisit
+   strategy quoted above, a 2021-22 cluster contains the 2018/19 households that
+   were found *plus* freshly enumerated replacements to bring the cluster back to
+   12.  Those two groups do not represent the same thing, and the library's
+   =(grappe, menage)= index does not distinguish them.
+
+Sample design (context, NOT a universe statement): planned n = 6,708 (3,528
+urban / 3,180 rural); achieved 2,732 urban and 3,411 rural.
+
+** What a consumer pooling Mali should carry away
+
+- *Kidal is out of 2014-15, 2017-18 and 2018-19 by design*, and is partially back
+  in for 2021-22 via an explicit booster.  "Mali" in this library is not a
+  constant territory across waves.
+- *The 2014-15 rural observation unit is the agricultural holding, not the
+  household.*  Documented, and unusual.
+- *2017-18 rural households split one-third Lourd / two-thirds Leger.*  A
+  Lourd-sourced table is a subsample of the wave.
+- *2018-19's geographic coverage differs between vague 1 and vague 2*, and the
+  library's index does not record which vague a household was in.
+- *2021-22 has no universe statement of its own*, and mixes panel and
+  replacement households.
+- *2018-19's UNIVERSE field is WB NADA boilerplate shared with 14 other waves.*
+  It is the only labelled universe Mali has, and it is the weakest kind of
+  evidence dressed as the strongest.
+
+** Provenance of this section
+
+Assembled 2026-07-21 from a per-country documentation sweep (GH #601), against
+the local =Documentation/= trees for all four waves and against WB catalog
+entries 2583, 3409, 4295 and 6275 (rendered study-description pages, JSON
+metadata exports, and DDI XML exports -- the XML matters, because it
+distinguishes a *missing* =<universe>= element from a *present but empty* one,
+and Mali has one of each).  Questionnaire PDFs were not treated as universe
+sources.  No =.dta= file was opened.  Full evidence record, including the search
+transcript for every gap: =slurm_logs/POPULATION_STATEMENTS_2026-07-21.org=.
+
 * Files configured
 
 (Per =data_scheme.yml=: sample, cluster_features, household_roster,

--- a/lsms_library/countries/Nepal/_/CONTENTS.org
+++ b/lsms_library/countries/Nepal/_/CONTENTS.org
@@ -71,6 +71,520 @@ There is no rotating panel or refreshment sample in the NLSS series.
 - NLSS II: https://microdata.worldbank.org/index.php/catalog/74
 - NLSS III: https://microdata.worldbank.org/index.php/catalog/1000
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered for GH #601 (population / universe statements).  This
+section records *what the survey documentation claims* about the population
+each NLSS round was meant to represent, and what it says was left out.  It
+extends --- it does not replace --- the "Sampling Design" section above,
+which records the *mechanics* (PSU/strata/weight variables).  Read the two
+together; where they disagree, see "Caveats and one contradiction with the
+existing text" at the end.
+
+Method and limits of this record:
+
+- Nothing here is inferred from microdata.  It could not be: as recorded
+  under "Data Acquisition Status" above, no Nepal =.dta= is in this
+  repository (NSO-hosted, not WB).  Every claim below is a quotation from a
+  document with a locator, or an explicit statement that no such quotation
+  was found.
+- Quotes are transcribed from the PDF text layer.  Runs of whitespace are
+  normalised to single spaces; wording, punctuation, spelling and
+  capitalisation are unaltered, with =[sic]= marking oddities in the source.
+- All three sources are in English; no translation is involved.
+- World Bank catalog fields were re-read live on 2026-07-21 via
+  =https://microdata.worldbank.org/index.php/api/catalog/{id}?id_format=id=
+  (=dataset.metadata.study_desc.study_info=).
+
+Summary:
+
+| Wave    | Catalog | Universe statement?      | Lives in                    | Stated exclusions            | Sub-samples inside the wave     |
+|---------+---------+--------------------------+-----------------------------+------------------------------+---------------------------------|
+| 1995-96 |    2301 | yes, one sentence        | *WB catalog only*           | none stated                  | Far-Western oversample          |
+| 2003-04 |      74 | *none found*             | ---                         | none stated (see gap line)   | cross-section + NLSS-I panel    |
+| 2010-11 |    1000 | yes, full =Coverage= sec | local report *and* catalog  | diplomatic + institutional   | cross-section + NLSS-I/II panel |
+
+** 1995-96 (NLSS I) --- universe exists only in World Bank catalog metadata
+
+*** Declared universe (verbatim)
+
+#+begin_quote
+The survey covered all modified de jure household members (usual residents).
+#+end_quote
+
+Citation: World Bank Microdata Library catalog id *2301*, Study Description >
+Scope > =Universe=.  Re-verified 2026-07-21 against the catalog JSON API
+(=study_info.universe=), character for character.
+
+*** Where the statement lives --- and does not
+
+This statement exists *only in World Bank catalog metadata*.  It is not in
+any document held in this repository.  Searched, with no universe/target
+population sentence found:
+
+- =1995-96/Documentation/SOURCE.org= --- bare catalog URL plus provenance
+  keywords only;
+- =1995-96/Documentation/ddi-documentation-english_microdata-2301.pdf= ---
+  contains only Sampling / Questionnaires / Data Collection; it has no
+  Universe, Coverage or Scope section;
+- =1995-96/Documentation/Nepal Living Standards Survey 1995-96 Report Vol
+  1.pdf= --- Chapter 1 (Methodology, Sample Design, pp. 1-3) read in full.
+  A full-text search of the volume for =de jure=, =de facto=, =usual
+  resident=, =usual place=, =universe=, =diplomatic=, =homeless= and =nomad=
+  returns *zero hits* for every one of those terms.
+
+Consequence for the library: for this wave the universe is a *moving
+target* --- it is whatever the WB catalog record says today, and the repo
+holds no copy of the claim.  It is also a NADA metadata slot rather than a
+sentence the Central Bureau of Statistics wrote in its own report.
+
+Boilerplate check (it is *not* the boilerplate): the single most repeated
+universe sentence in the cross-country corpus --- "The survey covered all de
+jure households excluding prisons, hospitals, military barracks, and school
+dormitories.", which appears verbatim in 15 waves and is WB NADA template
+text --- is *not* what Nepal 1995-96 carries.  Nepal's wording ("all
+*modified* de jure household members (usual residents)") is distinct and
+appears in this corpus only here.  So it is catalog-sourced but not
+template-sourced.  Note in passing that "de jure" is therefore used in two
+different senses across the corpus.
+
+*** Exclusions --- none stated (recorded as a gap)
+
+No statement of excluded populations (institutional, collective, diplomatic,
+nomadic, homeless) was found for this wave, in either the catalog record or
+the local report --- see the search list above, which included explicit
+greps for =institutional=, =diplomatic=, =homeless= and =nomad=.  Absence of
+a statement is recorded here as absence of a statement; it must not be read
+as an assertion that no population was excluded, and NLSS-III's exclusions
+(below) must not be back-propagated to this wave.
+
+*** Districts not represented --- a frame outcome, not a declared exclusion
+
+#+begin_quote
+The sample frame considered all the 75 districts in the country, and indeed
+73 of them were represented in the sample.[fn1]
+#+end_quote
+
+#+begin_quote
+[fn1] The two districts not selected in the sample due to their low
+population were Rasuwa and Mustang.
+#+end_quote
+
+Citation: Report Vol 1, Chapter 1, "Sample Design", printed pp. 2-3;
+footnote 1 at the foot of p. 3.
+
+Read this correctly: Rasuwa and Mustang were in the frame and simply were
+not drawn (low population).  This is a *selection outcome*, not a declared
+carve-out from the universe.  It is recorded here because a reader looking
+for district coverage will otherwise be surprised by it.
+
+*** Oversample: the Far-Western Development Region
+
+#+begin_quote
+[fn2] After the selection of the wards, it was decided to interview 16
+instead of 12 households in each selected ward in the Far-Western
+Development Region to increase the number of observations for that region.
+#+end_quote
+
+Citation: Report Vol 1, Chapter 1, "Sample Design", footnote 2 at the foot
+of printed p. 3.
+
+This is a genuine within-wave oversample, and it *breaks the self-weighting
+claim made two paragraphs earlier in the same section*:
+
+#+begin_quote
+It simplified the analysis by providing a self-weighted sample.
+#+end_quote
+
+(Report Vol 1, p. 3.)  Anyone pooling or averaging NLSS-I households must
+weight; the design is self-weighting *within* stratum but the Far-West wards
+carry 16 rather than 12 households.
+
+Sample design, for context only (not the universe): 3,388 households in 275
+wards; four strata --- Mountains (424 households), Hills (Urban) (604),
+Hills (Rural) (1,136), Terai (1,224); two-stage, wards drawn PPS on number
+of households, then a fixed number of households with equal probability.
+The catalog's =geog_coverage= field reads "National coverage" plus those
+four strata.
+
+** 2003-04 (NLSS II) --- NO universe statement found (checked gap)
+
+*** Gap line
+
+*No universe / target-population statement was found for this wave, in any
+source.*  This is a checked gap, not an unsearched one.  Searched:
+
+- =2003-04/Documentation/SOURCE.org= (and the older duplicate =Source.org=)
+  --- bare catalog URL plus provenance keywords;
+- =2003-04/Documentation/ddi-documentation-english_microdata-74.pdf= ---
+  Sampling / Questionnaires / Data Collection only; no Universe, Coverage or
+  Scope section;
+- =2003-04/Documentation/NLSSIIReportVol1.pdf= --- CHAPTER I: METHODOLOGY
+  read end to end (chapter preamble and Table 1.0, 1.1 Background, 1.2
+  Objectives, 1.3 Survey methodology, 1.3.1 Sample design, 1.3.2 Sample
+  frame, 1.3.3 Stratification, 1.5 Survey difficulties, 1.7 Survey
+  limitations, 1.8 Contents; printed pp. 1-17).  There is no "Coverage" and
+  no "Statistical Unit" section of the kind NLSS-III has.  Full-text search
+  of the volume for =universe=, =Universe=, =de jure=, =usual place=,
+  =diplomatic= and =institutional= returns *zero hits for every term*;
+- =2003-04/Documentation/NLSSIIReportVol2.pdf= and
+  =NepalPovertyTrendsforPovertyAssessment.pdf= --- same search, zero hits;
+- =2003-04/Documentation/nlss2_hh_questionnaire.pdf=;
+- WB catalog id *74*: re-verified live 2026-07-21 --- =study_info= carries
+  the keys =abstract=, =coll_dates=, =nation=, =geog_coverage=,
+  =analysis_unit=, =data_kind=, =notes=.  *The =universe= key is absent
+  altogether*, unlike ids 2301 and 1000, which both have it.
+
+Not opened: =nlss2_rural.pdf=, =nlss2_urban.pdf= (community questionnaires).
+
+*Do not import NLSS-III's universe wording into this wave.*  It was not
+stated here, and the institutional/diplomatic exclusions NLSS-III declares
+are not attested for NLSS-II.
+
+*** Sub-samples inside the wave: a cross-section AND a panel
+
+#+begin_quote
+The sampling design of the NLSS II included two components. The first one
+was nationally representative random cross-section sample of 4008 households
+from six explicit strata of the country. The second one was panel sample of
+1232 households drawn from those households interviewed in NLSS I.
+#+end_quote
+
+Citation: NLSSIIReportVol1.pdf, Section 1.3.1 "Sample design", printed p. 3.
+
+#+begin_quote
+The NLSS II panel sample is composed of 100 of the 275 PSUs visited by the
+NLSS I in 1995/96. The panel PSUs were selected with equal probability
+within each of the four strata defined by NLSS I, as follows: 12 (out of 33)
+in the Mountains, 18 (out of 50) in the Urban Hills, 33 (out of 92) in the
+Rural Hills and 37 (out of 100) in the Tarai.
+#+end_quote
+
+Citation: same file, Section 1.3.3 "Stratification", printed pp. 3-4.
+
+What was actually enumerated, and the panel's composition:
+
+#+begin_quote
+NLSS II enumerated 3912 households from 326 Primary Sampling Units (PSU) in
+the cross-sectional sample. In addition, this survey interviewed 1160
+households from 95 panel PSUs (962 out of 1160 households were panel
+households that were also interviewed in 1995/96). This report is based on
+results from cross-sectional household data.
+#+end_quote
+
+#+begin_quote
+*Only 962 households were tracked from NLSS I. Remaining 198 households were
+new households from panel PSUs.
+#+end_quote
+
+Citation: NLSSIIReportVol1.pdf, CHAPTER I preamble and the footnote to Table
+1.0 "Summary statistics", printed p. 1.
+
+*This is the thing a pooling user needs to know*: one library wave holds two
+differently-drawn samples.  The cross-section is the nationally
+representative draw; the panel PSUs are a re-visit of NLSS-I clusters, and
+198 of the 1,160 panel households are *new* households in those clusters,
+not tracked NLSS-I households.  The CBS report itself tabulates the
+cross-section only.
+
+*** Non-enumeration during the conflict --- implementation, NOT a design exclusion
+
+#+begin_quote
+It should be noted that 96 out of 4008 households (8 out of 334 PSUs), mostly
+from the Far Western development region, were not enumerated as a result of
+ongoing conflict in those areas.
+#+end_quote
+
+Citation: NLSSIIReportVol1.pdf, CHAPTER I preamble, printed p. 1
+(immediately above Table 1.0).
+
+#+begin_quote
+As already noted above, the survey was unable to reach/interview all the
+sampled PSUs and their households. With the consultation of the design
+experts it was decided not to replace the affected PSUs for enumeration and
+ultimately they were dropped.
+#+end_quote
+
+Citation: same file, Section 1.7 "Survey limitations", printed p. 16.
+
+*Warning, and it matters.*  This is an *implementation outcome* --- PSUs
+that could not be reached during the Maoist conflict --- and *not* a
+declared exclusion of the Far-Western region from the survey's scope.  The
+region was in the frame and in the sample; some of its PSUs went
+unenumerated and were dropped rather than replaced.  Do not record this as
+"Far-Western Nepal is out of universe".  It does, however, bear on what the
+realised sample represents, since the dropped PSUs were not replaced.
+
+Supporting detail, same volume:
+
+#+begin_quote
+Out of a total of 434 PSUs, 407 PSUs were completed in the first attempt, 14
+PSUs were enumerated in the second attempt but 13 could not be enumerated at
+all.
+#+end_quote
+
+#+begin_quote
+Some conflict-affected areas especially in the rural areas posed a great
+challenge for the CBS to conduct such an integrated household survey. The
+interviewers were on high alert in these areas, kept themselves in a very
+low profile, and in many instances were assisted by the local people. 12
+PSUs could not be enumerated even after repeated attempts.
+#+end_quote
+
+#+begin_quote
+Altogether 13[fn3] rural enumeration areas (PSUs) could not be interviewed
+constituting 8 from the cross-section and 5 from the panel sample. The
+missing PSUs include 2 from Central Hills, 2 from Mid Western Mountains, 2
+from Far Western Mountains, 6 from Far Western Hills and 1 from Far Western
+Tarai.
+#+end_quote
+
+#+begin_quote
+[fn3] One of the panel PSUs from the Far Western Tarai vanished completely
+due to the merging of enumeration area to the Royal Shukla Phanta Wildlife
+Reserve by the government.
+#+end_quote
+
+Citations: Section 1.4.4 "Data collection" (p. 15), Section 1.5 "Survey
+difficulties" and Table 1.5 "Affected enumeration areas (PSUs) by sample,
+urban/rural, zone and region" (p. 15), and the paragraph following that
+table with its footnote 3 (p. 16).
+
+Reconciling the counts, since the report is not internally consistent: 13 =
+8 cross-section + 5 panel, and Table 1.5 lists exactly those 13 enumeration
+areas by name; the preamble's "8 out of 334 PSUs" counts the cross-section
+only, consistent with the report being cross-section based.  Section 1.5's
+"12 PSUs" disagrees with the "13" given twice elsewhere; quoted as printed,
+unresolved.  (The "13[fn3]" above renders in the PDF text layer as "133" ---
+the trailing 3 is the superscript footnote marker, not a digit.)  The DDI
+PDF for catalog 74 states the same facts with different arithmetic again
+("Five PSUs out of 434 PSUs for the survey could not be carried due to
+unavoidable reasons. Thus the response rate is 98.5%.").
+
+Sample design, for context only: cross-section 4,008 households = 12
+households in each of 334 PSUs, drawn PPS on number of households from six
+explicit strata --- Mountains (408 households in 34 PSUs), Kathmandu valley
+urban area (408 in 34), Other Urban areas in the Hills (336 in 28), Rural
+Hills (1,224 in 102), Urban Tarai (408 in 34), Rural Tarai (1,224 in 102);
+frame = 36,067 enumeration areas from the 2001 Population Census.  Catalog
+=geog_coverage= = "National / Domains: Urban/rural; ecological zones
+(Mountains, Kathmandu Valley (urban), Hills (urban), Hills (rural), Tarai
+(urban), Tarai (rural))."
+
+** 2010-11 (NLSS III) --- universe stated in the CBS report itself
+
+*** Declared universe (verbatim)
+
+Section 1.5 "Coverage" opens:
+
+#+begin_quote
+The survey in principle covers the whole country, including both rural and
+urban areas. A brief description of the geographical and administrative
+division of the country follows. The country is divided into 75
+administrative districts. These 75 districts are grouped into three
+ecological belts running from north to south - the mountains, the hills and
+the Tarai. Each ecological belt is further divided into five development
+regions - eastern, central, western, mid-western and far-western region.
+Thus 15 eco-development regions (or inter-regions) are formed by the cross
+combination of three ecological belts and five development regions (Box
+1.1).
+#+end_quote
+
+and closes:
+
+#+begin_quote
+All households in the country were considered eligible for selection in the
+survey. The survey, however, excluded the households of diplomatic missions.
+The institutional households (like people living in schools hostels [sic],
+prisons, army camps and hospitals) were also excluded from the survey. The
+household members were determined on the basis of the usual place of their
+residence. Foreign nationals whose usual place of residence is within the
+country were included in the survey.
+#+end_quote
+
+Citation: =2010-11/Documentation/Statistical_Report_Vol1.pdf= (Nepal Living
+Standards Survey 2010/11, Statistical Report Volume One, CBS), Chapter I,
+Section 1.5 "Coverage", printed p. 5.  These are the first and last
+paragraphs of the section, quoted whole; nothing has been elided from within
+either.  "schools hostels" is as printed.
+
+The statistical unit, from the immediately preceding section:
+
+#+begin_quote
+The statistical unit or the enumeration unit of a survey is the basic entity
+for which the required data items are gathered. NLSS-III is basically a
+household survey and the enumeration unit of the survey is the household.
+The definition of a household for the survey is primarily adopted from the
+guidelines laid down by the United Nations in its "Principles and
+Recommendations for Population and Housing Censuses, Rev 2" (UN, 2008).
+#+end_quote
+
+Citation: same file, Section 1.4 "Statistical Unit", printed p. 5.
+
+*** Exclusions (stated, by design)
+
+- *Households of diplomatic missions* --- excluded.
+- *Institutional households* --- "(like people living in schools hostels
+  [sic], prisons, army camps and hospitals)" --- excluded.
+- *Included, explicitly*: foreign nationals whose usual place of residence
+  is within Nepal.
+
+No geographic region is excluded by design, and no "for security reasons"
+carve-out appears; unlike NLSS-II, no conflict-related non-enumeration is
+reported for this wave.
+
+*** Where the statement lives
+
+*Both* locally and in the catalog --- this is the one Nepal wave the repo
+actually holds the claim for.  The same text is the =Universe= field of WB
+catalog id *1000*.  Precisely: the catalog field reproduces the *closing
+paragraph* verbatim ("All households in the country were considered eligible
+... were included in the survey.") and omits the opening "The survey in
+principle covers the whole country ..." sentence and the geography
+description.  Re-verified live 2026-07-21.
+
+*** Districts not selected --- again a frame outcome, not a declared exclusion
+
+Box 1.1 ("Distribution of sample districts by ecological belt and
+development region", printed p. 6) marks districts with these notes,
+verbatim:
+
+#+begin_quote
+Note: [a] District not selected in the survey [b] District not selected only
+in the cross section sample [c] District not selected only in the panel
+sample
+#+end_quote
+
+(superscript letters rendered in brackets).  Carrying =[a]= --- not selected
+in the survey at all --- are *Mustang (42), Dolpa (62) and Humla (66)*.
+Manang (41) carries =[b]= (not in the cross-section).  A long list carries
+=[c]= (not in the panel).  Mustang is thus absent from NLSS-I and NLSS-III
+alike, for the same low-population reason in NLSS-I's case.  As before: a
+selection outcome, *not* a stated exclusion from the universe --- Section
+1.5 says all households in the country were eligible.
+
+*** Sub-samples inside the wave: two independent samples
+
+#+begin_quote
+For the NLSS-III, two independent samples were selected: the first was a
+cross sectional sample and the second was a panel. The panel sample
+consisted of PSUs and households previously enumerated in one or both of the
+past two rounds of the survey.
+#+end_quote
+
+Citation: Section 1.7.3 "Sample Design", printed p. 7.
+
+#+begin_quote
+The panel sample of the NLSS-III is composed of all households visited by
+the NLSS-II in 100 of its primary sampling units (PSU). Fifty of them were
+taken from the cross-sectional component of the NLSS-II, and the remaining
+fifty from its panel component. In other words, one half of the NLSS-III
+panel households were households visited for the first time during the
+NLSS-II, whereas the other half were the households visited during both the
+NLSS-I and the NLSS-II.
+#+end_quote
+
+Citation: Section 1.7.5 "Panel Sample", printed p. 9.
+
+#+begin_quote
+The survey enumerated 5988 sample households from 499 primary sampling units
+(PSUs) from the cross section sample. As regards to panel sample, from 100
+PSUs 1032 households were tracked and enumerated (out of which 513
+households were the households enumerated in the NLSS-II and the rest were
+the households enumerated in both of NLSS-I & II). Thus, in total 7020
+households were enumerated in the survey.
+#+end_quote
+
+Citation: Section 1.7.7 "Enumeration Status", printed p. 10.
+
+So the 2010-11 library wave, like 2003-04, is *one wave holding two
+samples*: a 6,000-household national cross-section (500 PSUs) and a
+1,200-household panel re-visit (100 PSUs), enumerated as 5,988 + 1,032 =
+7,020.  Pooling them without regard to which sample a household came from
+mixes a fresh national draw with a re-visit of clusters last seen in 1995-96
+and 2003-04.
+
+Sample design, for context only: the cross-section is a sub-sample of the
+2008 NLFS-II design --- 500 of NLFS-II's 800 PSUs, the NLFS-II's six strata
+regrouped into *14 explicit strata* for NLSS-III, 12 households per PSU by
+equal probability, plus "An additional 6 households were selected in each
+PSU, to be used as replacement household for non-response among the 12
+originally selected households" (Section 1.7.4, p. 8).
+
+*** Universe vs. what the estimates are claimed to support
+
+The declared universe is national ("the whole country"), but the report
+declines to claim estimates at the 14-stratum level:
+
+#+begin_quote
+The original idea was to provide an estimate for each of 14 strata formed
+for selecting the PSUs. However, it was felt that the number of sample
+households in some of these strata was insufficient for the required
+precision of the estimate. Based on experience and statistical theory, it is
+estimated that the sample can provide desegregated [sic] estimates for the
+following 12 areas (called the analytic domains): [Mountains; Urban areas of
+the Kathmandu valley; Other urban areas of the hills; Eastern rural hills;
+Central rural hills; Western rural hills; Mid-western and far-western rural
+hills; Urban areas of the Tarai; Eastern rural Tarai; Central rural Tarai;
+Western rural Tarai; Mid-western and far-western rural Tarai]
+#+end_quote
+
+Citation: Section 1.10 "Analytic Domains", printed p. 18.  The 12 domains
+are a list in the source, inlined here in brackets.
+
+That is the universe/represented-estimates split for this wave, in the
+survey's own words: national universe, 14 sampling strata, but only 12
+domains the CBS is willing to publish disaggregated estimates for
+(mid-western and far-western hills are pooled, and mid-western and
+far-western Tarai are pooled).
+
+** Caveats and one contradiction with the existing text
+
+1. *Contradiction with "Sampling Design > Weight types" above.*  That
+   section currently states:
+
+   #+begin_quote
+   There is no rotating panel or refreshment sample in the NLSS series.
+   #+end_quote
+
+   Narrowly, "rotating" and "refreshment" are the right words to deny.  But
+   as written the sentence reads as "the NLSS series has no panel", and the
+   documentation says otherwise for two of the three waves: NLSS-II drew a
+   panel sample of 1,232 households from 100 of NLSS-I's 275 PSUs (Report
+   Vol 1 §1.3.1, §1.3.3), and NLSS-III drew a panel of 100 PSUs / ~1,200
+   households as one of "two independent samples" (Statistical Report Vol 1
+   §1.7.3, §1.7.5), enumerating 1,032 of them.  This bears directly on the
+   adjacent decision recorded there --- that "both =weight= and
+   =panel_weight= map to =wt_hh=" --- because in NLSS-II and NLSS-III the
+   panel households are a *separately drawn sample*, not the same households
+   re-weighted.  Neither statement is settled here (no microdata is
+   available to check what =wt_hh= actually covers); flagged so whoever
+   acquires the data resolves it rather than inheriting the claim.  Also
+   note the NLSS-II panel is not purely a re-visit: 198 of its 1,160
+   enumerated households were *new* households in panel PSUs.
+
+2. *Catalog-id error in "Data Acquisition Status" above.*  That section
+   lists "2003-04 (NLSS II) --- WB catalog 1000" and "2010-11 (NLSS III) ---
+   WB catalog (check SOURCE.org)".  The "BID references" table lower in the
+   same file is correct and the =SOURCE.org= files agree with it: NLSS I =
+   *2301*, NLSS II = *74*, NLSS III = *1000*.  Catalog 1000 is NLSS-III, not
+   NLSS-II.  Worth correcting when that section is next touched --- the ids
+   matter here because the presence or absence of the catalog =Universe=
+   field differs by id.
+
+3. *Do not back-propagate NLSS-III's exclusions.*  The diplomatic-mission
+   and institutional-household exclusions are attested for 2010-11 only.
+   1995-96 states a universe with no exclusions; 2003-04 states no universe
+   at all.  Whatever GH #603 decides for representation, these are three
+   different evidentiary situations and should not be flattened into one.
+
+4. *The three waves' universes are not stated in commensurable terms.*
+   1995-96's is about *household members* ("all modified de jure household
+   members (usual residents)"); 2010-11's is about *households* ("All
+   households in the country were considered eligible for selection").
+   2003-04 has neither.  A cross-wave Nepal universe does not exist in the
+   documentation; only three separate claims, one of them empty.
+
 * Features configured (pending data)
 ** sample
 ** household_roster

--- a/lsms_library/countries/Niger/_/CONTENTS.org
+++ b/lsms_library/countries/Niger/_/CONTENTS.org
@@ -15,6 +15,324 @@ See CLAUDE.md "EHCVM countries" for the cross-country pattern.
 Pre-EHCVM waves (2011-12, 2014-15) follow their own conventions;
 see the wave-level =data_info.yml= files for index definitions.
 
+* Sampling universe, exclusions and sub-samples
+
+What each Niger wave's *own documentation* says its sample represents.  This
+records claims, not data: no =.dta= file was opened for it, and nothing here is
+reverse-engineered from the microdata.  Where a wave has no statement, that is
+recorded as a gap together with what was searched.
+
+Read this alongside =Sampling Design= above, which is about *identifiers*
+(=grappe= / =menage= / =vague=); this section is about *what population the
+sample claims to stand for*.  Evidence gathered 2026-07-21 for GH #601; the
+full cross-country sweep, with the search record for every wave, is
+=slurm_logs/POPULATION_STATEMENTS_2026-07-21.org= (GH #603 will decide how the
+library represents any of this -- nothing here proposes a schema).
+
+# ASCII EXCEPTION: the #+begin_quote blocks below are verbatim transcriptions of
+# survey documentation and keep their original accents, ligature-repaired
+# spellings and sic errors.  Prose outside the quote blocks is ASCII.
+
+| Wave    | Declared universe                       | Where the statement lives                          | Confidence |
+|---------+-----------------------------------------+----------------------------------------------------+------------|
+| 2011-12 | "target population" sentence; no =UNIVERSE= field | in-repo DDI PDF + Basic Information Document | high       |
+| 2014-15 | stated only by reference to the 2011 design       | in-repo DDI PDF                              | high       |
+| 2018-19 | explicit DDI =UNIVERSE= field (NADA boilerplate)  | in-repo DDI PDF; matches WB catalog          | high       |
+| 2021-22 | *none found*                                      | nothing local beyond =SOURCE.org=            | gap        |
+
+** 2011-12 -- ECVM/A 2011 (WB catalog 2050)
+
+There is *no DDI =UNIVERSE= field* for this wave, in the shipped DDI report or
+in the catalog DDI/XML export for id 2050.  The nearest thing to a universe
+statement is the "target population" sentence inside the Sampling Procedure,
+quoted here in full with the paragraph that precedes it.
+
+Source: =lsms_library/countries/Niger/2011-12/Documentation/ddi-documentation-english_microdata-2050.pdf=,
+section "Sampling" > "Sampling Procedure", PDF p. 3.  The identical passage is
+in =ECVMA_Information_de_Base_V9_eng.pdf=, section "3. SAMPLING", printed
+pp. 3-4 (PDF pp. 6-7).  Both files are DVC-tracked in this repo.  Language:
+English -- the shipped Basic Information Document is explicitly the =_eng=
+translation; no French original ships in this wave's =Documentation/=.
+
+#+begin_quote
+The ECVM/A 2011 has been designed to have national coverage, including both urban and rural areas in all the regions of the country. The domains are defined as the entire country, the city of Niamey; and other urban areas, rural areas, and in the rural areas, agricultural zones, agro-pastoral zones and pastoral zones. Taking this into account, 26 explicit sampling strata were selected: Niamey, and urban, agriculture, agro-pastoral and pastoral zones of the seven regions other than Niamey.
+
+The target population is drawn from households in all 8 regions of the country with the exception of certain strata found in Arlit (Agadez Region) because of difficulties in going there, the very low population density, and collective housing. The portion of the population excluded from the sample represents less than 0.4% of the total population of Niger. Of a total of 36,000 people not included in the sample design, about 29,000 live in Arlit and 7,000 in collective housing.
+#+end_quote
+
+*Exclusions* (same passage, quoted again on its own because this is the part
+that makes "national coverage" not mean what it appears to mean):
+
+#+begin_quote
+with the exception of certain strata found in Arlit (Agadez Region) because of difficulties in going there, the very low population density, and collective housing. The portion of the population excluded from the sample represents less than 0.4% of the total population of Niger. Of a total of 36,000 people not included in the sample design, about 29,000 live in Arlit and 7,000 in collective housing.
+#+end_quote
+
+Two distinct exclusions, both stated at the *sampling-frame* level -- i.e. by
+design, not as fieldwork non-response:
+
+- geographic :: certain strata in Arlit, Agadez Region (~29,000 people).
+- population :: collective housing (~7,000 people).
+
+The documented size of the excluded population is under 0.4% of Niger; that is
+the survey's own figure, quoted, not a check of ours.
+
+** 2014-15 -- ECVM/A 2014, Wave 2 Panel Data (WB catalog 2676)
+
+This wave has no separately stated universe and no =UNIVERSE= field.  Its
+documentation states the universe *by reference to the 2011 design*, and its
+own "GEOGRAPHIC COVERAGE" field says only that it is a panel of the 2011
+survey.
+
+Source: =lsms_library/countries/Niger/2014-15/Documentation/ddi-documentation-english_microdata-2676.pdf=,
+"Sampling" > "Sampling Procedure" > subsection "2011 Survey", PDF p. 6; the
+GEOGRAPHIC COVERAGE sentence is under "Coverage", PDF p. 4.  Language: English.
+
+#+begin_quote
+The ECVM/A 2011 was been designed to have national coverage, including both urban and rural areas in all the regions of the country. The domains are defined as the entire country, the city of Niamey; and other urban areas, rural areas, and in the rural areas, agricultural zones, agro-pastoral zones and pastoral zones. Taking this into account, 26 explicit sampling strata were selected: Niamey, and urban, agriculture, agro-pastoral and pastoral zones of the seven regions other than Niamey.
+
+The target population was drawn from households in all 8 regions of the country with the exception of certain strata found in Arlit (Agadez Region) because of difficulties in going there, the very low population density, and collective housing. The portion of the population excluded from the sample represents less than 0.4% of the total population of Niger. Of a total of 36,000 people not included in the sample design, about 29,000 live in Arlit and 7,000 in collective housing.
+#+end_quote
+
+GEOGRAPHIC COVERAGE (PDF p. 4), verbatim:
+
+#+begin_quote
+The ECVM/A 2014 is a panel survey with the ECVM/A 2011. The ECVM/A 2011 was designed to have national coverage, including both urban and rural areas in all the regions of the country. The domains are defined as the entire country, the city of Niamey; and other urban areas, rural areas, and in the rural areas, agricultural zones, agro-pastoral zones and pastoral zones.
+#+end_quote
+
+Transcription notes: "was been designed" is *sic* in the source.  The PDF's
+=fi= / =ffi= ligature glyphs are rendered as ordinary letters above; the
+document reads "defined" / "difficulties".
+
+*Exclusions.*  The 2011 frame exclusions (Arlit strata, collective housing) are
+restated verbatim and so carry into this wave.  On top of them, a
+panel-specific tracking rule bounds who could enter the 2014 sample at all
+(same section, subsection "2014 Survey"):
+
+#+begin_quote
+In the ECVM/A 2014, all households that had been interviewed in 2011 were tracked. Households that did not move were interviewed in their existing location. Households that had moved to other locations in Niger were followed and interviewed in their new locations if they could be found in the new location. Households that moved outside of Niger were not followed.
+#+end_quote
+
+International out-migrants are therefore out of scope by design.  Within-Niger
+movers are in scope *conditional on being found*, which is a coverage bound the
+documentation does not quantify.
+
+** 2018-19 -- EHCVM 2018/19 (WB catalog 4296; DOI 10.48529/ggam-ax39)
+
+The only Niger wave with an explicit DDI =UNIVERSE= field.  Source:
+=lsms_library/countries/Niger/2018-19/Documentation/ddi-documentation-english_microdata-4296.pdf=,
+section "Coverage", PDF p. 3.  Language: English.  Verbatim:
+
+#+begin_quote
+GEOGRAPHIC COVERAGE
+National coverage
+
+UNIVERSE
+The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories.
+#+end_quote
+
+The same sentence is in the WB catalog DDI/XML export for id 4296
+(=<universe><![CDATA[...]]></universe>), so local and catalog agree.
+
+*BOILERPLATE WARNING.*  That =UNIVERSE= sentence is *World Bank NADA template
+text*, not a claim written for this survey.  The cross-country sweep found it
+verbatim in *15 waves* -- across Benin, Burkina Faso, Cote d'Ivoire,
+Guinea-Bissau, Mali, Niger, Senegal and Togo (where a shared WAEMU/EHCVM
+template is expected) but also Ethiopia 2018-19 / 2021-22 and Nigeria 2015-16 /
+2018-19 / 2023-24.  Its presence attests *which metadata template was used*.
+It does not independently attest that Niger's Institut National de la
+Statistique made that claim about this survey.  Treat it as weaker evidence
+than the 2011-12 / 2014-15 target-population text, which is survey-specific.
+
+*Exclusions.*  Institutional populations only:
+
+#+begin_quote
+excluding prisons, hospitals, military barracks, and school dormitories
+#+end_quote
+
+No geographic exclusion is stated for this wave in any source consulted (the
+in-repo DDI PDF, the catalog record, the catalog DDI/XML).  *Do not read the
+ECVMA-era Arlit exclusion forward into it* -- and equally, no document consulted
+says the Arlit exclusion was lifted.  The honest statement is that this wave's
+documentation is silent on Arlit.
+
+*Within-wave structure (matters before pooling).*  The single library wave
+directory =2018-19/= holds *both* seasonal visits of the survey, each covering
+half of every EA.  Verbatim, same PDF, "Sampling" > "SAMPLING PROCEDURE",
+PDF p. 4:
+
+#+begin_quote
+Upon deciding on the sample size and repartition, the survey design team implemented a 2-stage sampling methodology. At the first stage, 504 enumeration areas (EAs) were selected from the sample frame. In the second stage, 12 households were selected in each enumeration area randomly.
+
+The total survey sample size is 6024 households - 1577 from urban areas and 4447 from rural areas. After that, the survey design randomly divided each enumeration area into two equal groups. The survey team interrogated the first group in wave 1 and the other in wave 2. Finally, for various reasons, including availability and quality monitoring, the final sample size comprises slightly more households (fifty-eight) in round 2 than in round 1. In wave one, the survey teams interviewed 2983 households (715 in urban areas and 2268 in rural areas. In wave two, the teams interviewed 3041 households (862 in urban areas and 2179 in rural areas).
+#+end_quote
+
+Sic: the unclosed parenthesis in "(715 in urban areas and 2268 in rural areas."
+is in the source.  Data collection dates, same PDF: first visit 2018-10 to
+2018-12, second visit 2019-04 to 2019-07.  These two =vague= are *seasonal
+halves of one cross-section*, not two panel rounds -- see =Sampling Design=
+above for why =v= is =grappe= alone and not =(vague, grappe)=.
+
+** 2021-22 -- EHCVM 2021/22 (WB catalog 6276; NER_2021_EHCVM-2_v01_M) -- GAP
+
+*No universe or target-population statement was found for this wave, anywhere.*
+Recorded as a gap rather than filled by adjacency.
+
+What was searched (2026-07-21): =lsms_library/countries/Niger/2021-22/Documentation/=,
+which contains *only* =SOURCE.org= -- no PDFs, no DVC-tracked documentation of
+any kind; then WB catalog 6276: the study-description page, the full DDI/XML
+metadata export (the string "universe" does not occur anywhere in the 1.8 MB
+XML), the related-materials listing (2 household questionnaires + Basic
+Information Document in English and French), and both Basic Information
+Documents, grepped for =universe|univers|population cible|target
+population|base de sondage|champ|couvre|excluant|exclu|represent|coverage|frame=.
+
+*Where the (non-)statement lives.*  Nothing for this wave exists in this repo
+beyond the catalog URL in =SOURCE.org=.  Everything below is WB catalog
+metadata, i.e. a moving target that the library does not hold a copy of.
+
+The strongest available claims, verbatim from the catalog study description at
+https://microdata.worldbank.org/index.php/catalog/6276 -- *these are coverage
+and representativeness claims, NOT universe declarations, and must not be
+laundered into one*:
+
+#+begin_quote
+[Coverage > Geographic Coverage:] National coverage
+
+[Series Information:] The Niger EHCVM 2021/22 is the second edition of a nationally representative household survey conducted within the West Africa Economic Monetary Union (WAEMU) Household Survey harmonization Project (P153702) a joint program by the World Bank and the WAEMU Commision that aims at producing household survey data in member countries (Benin, Burkina Faso, Chad, Cote d'Ivoire, Guinea Bissau, Mali, Niger, Senegal and Togo). The survey covers all regions and includes approximately 6,000 households.
+
+[Abstract:] The EHCVM is a nationally representative survey of 6,000 households, which are also representative of the geopolitical zones (at both the urban and rural level).
+#+end_quote
+
+Sic: "Commision".  "Covers all regions" describes where the sample was drawn;
+it does not name the set of units the sample stands for.
+
+*Exclusions: none stated.*  No institutional-population exclusion, no dropped
+region, no security carve-out appears in the catalog metadata, the DDI/XML, or
+either language version of the Basic Information Document.  That is an absence
+of a statement -- it is not evidence that nothing was excluded.
+
+*The 2021-22 Basic Information Document is a visibly incomplete template.*  Its
+French version's sampling-frame paragraph reads, verbatim, with the placeholder
+unfilled:
+
+#+begin_quote
+Base de sondage -- La base de sondage de l'enquête de 2018/19 était le recensement général de la population et de l'habitat (RGPH) de [PRECISER L'ANNÉE]. En 2021/22, il a été procédé à un dénombrement dans les mêmes grappes.
+#+end_quote
+
+Translation (ours, not source text): "Sampling frame -- The sampling frame of
+the 2018/19 survey was the general population and housing census (RGPH) of
+[SPECIFY THE YEAR].  In 2021/22, an enumeration was carried out in the same
+clusters."
+
+The English version carries the matching unfilled placeholders, e.g. "For a
+sample size of [xxxxx households], the precision was [...] at the national
+level and varied from [...] to [...] for the regions." and "the general
+population and housing census (RGPH) of [SPECIFY THE YEAR]".  A document with
+unfilled template slots in its sampling chapter is weak evidence about anything
+in that chapter.
+
+*The inference that was available and was declined.*  2021-22 is a cluster
+panel on the 2018/19 frame, so inheriting the 2018-19 universe sentence ("all
+de jure households excluding prisons, hospitals, military barracks, and school
+dormitories") would be defensible.  *No document says so*, so it is not
+recorded here as this wave's universe.  The same inference was available and
+declined for Mali 2021-22 and Senegal 2021-22; Burkina Faso 2021-22 is the
+sibling that *does* carry the sentence explicitly.
+
+** Oversamples and sub-populations
+
+*No oversample, booster sample, or special sub-population sample is documented
+for any Niger wave* in the sources listed above.  Niger has nothing of the
+Serbia/Montenegro MOP-Roma or Azerbaijan three-sub-population shape.
+
+Four structural facts do have to be known before pooling, none of which is an
+oversample:
+
+1. *Stratification is not oversampling, and nothing says which it is.*  The
+   2011-12 / 2014-15 design uses 26 explicit strata built from Niamey, other
+   urban, agricultural, agro-pastoral and pastoral zones.  Pastoral and
+   agro-pastoral zones are named strata; *no source consulted states whether
+   the allocation across them was proportionate or disproportionate*, and that
+   was not checked against the data.  Recorded as unknown.
+2. *2014-15 is a whole-wave panel*, not a fresh draw: it re-interviews the 2011
+   households under the tracking rule quoted above.  Split-offs are carried
+   (the wave's household key is =GRAPPE + MENAGE + EXTENSION=, with
+   =EXTENSION= 0 = non-mover, 1 = whole household moved, 2 = split-off
+   individual in a new household).
+3. *2018-19 and 2021-22 each pack two seasonal visits into one library wave.*
+   For 2018-19 this is quoted verbatim above (each EA split in half, visited
+   Oct-Dec 2018 and Apr-Jul 2019).
+4. *2021-22 mixes panel households with replacements inside a single wave.*
+   The sweep records, from BID section 4 and the catalog Sampling Procedure --
+   *as summary, not as a verbatim quote, so treat it as secondary* -- that the
+   same clusters are revisited, the 2018/19 households re-interviewed where
+   found, and the cluster topped back up to 12 households where fewer are
+   found; final sample 6,622 households (2,511 urban, 4,111 rural), visit 1 =
+   3,303 HH (17 Nov 2021 - 13 Feb 2022), visit 2 = 3,319 HH (3 Jun - 31 Aug
+   2022).  So a 2021-22 row is either a panel household or a top-up
+   replacement, and the documentation gives no flag distinguishing the two.
+
+** Universe versus what the weights represent
+
+*Gap.*  None of the sources listed in this section states what the survey
+weights are calibrated to represent, for any of the four waves.  This was not
+separately hunted beyond the documents named above, and no claim is made in
+either direction.  See =Sampling Design= above and the =sample= table for the
+two weight columns the library carries (=weight=, =panel_weight=); their
+meaning here rests on the library's cross-country convention, not on a Niger
+document anyone has quoted.
+
+** Membership rule (adjacent evidence, deliberately not claimed as Niger's universe)
+
+The =Household Presence / MonthsSpent= section below records that the EHCVM
+instrument establishes household membership through two binary six-month
+filters (=s01q12=, =s01q13=) rather than a continuous months-present variable.
+That is the *operational* membership rule standing behind the phrase "de jure
+households".
+
+The WAEMU-common EHCVM-2 enumerator manual states that rule and one further
+scope exclusion explicitly.  *That manual is shipped in Burkina Faso's wave
+directory, not Niger's* --
+=lsms_library/countries/Burkina_Faso/2021-22/Documentation/manuelagent_ehcvm2_version_v2.pdf=,
+printed p. 4 (PDF p. 7).  It is regional instrument boilerplate (its worked
+examples name Dosso and Niamey, i.e. Niger), which is exactly why it is
+recorded here as *adjacent evidence* and not as a Niger universe statement:
+
+#+begin_quote
+Attention : le personnel diplomatique ne fait pas partie du champ de l'enquête. En effet la résidence d'un diplomate est considérée comme extraterritorial, c'est-à-dire que juridiquement hors du pays concerné. Cependant les autres personnes travaillant dans ces organisations font partie du champ de l'enquête, tout comme les étrangers n'ayant pas de statut de personnel diplomatique.
+#+end_quote
+
+Translation (ours, not source text): "Note: diplomatic personnel are not part
+of the scope of the survey.  A diplomat's residence is considered
+extraterritorial, that is, legally outside the country concerned.  However,
+other people working in these organisations are part of the survey's scope, as
+are foreigners without diplomatic-personnel status."
+
+#+begin_quote
+Membre du ménage. Un membre du ménage est une personne résidant habituellement dans le ménage. Un individu réside habituellement dans le ménage dans deux situations : (i) il vit dans ce ménage depuis au moins 6 mois ; (ii) Il est arrivé dans le ménage depuis moins de 6 mois, mais avec l'intention d'y rester au moins 6 mois.
+#+end_quote
+
+Translation (ours, not source text): "Household member.  A household member is
+a person usually resident in the household.  An individual is usually resident
+in the household in two situations: (i) they have lived in this household for
+at least 6 months; (ii) they arrived in the household less than 6 months ago,
+but with the intention of staying at least 6 months."
+
+** Pooling caution
+
+The declared universe *changes across this country's own series*, so pooling
+all four Niger waves pools more than one declared population:
+
+- 2011-12 and 2014-15 :: national minus certain Arlit (Agadez) strata, minus
+  collective housing -- a documented, quantified geographic-plus-population
+  subtraction.
+- 2018-19 :: "all de jure households" minus institutional populations, with no
+  geographic subtraction stated -- and the statement is NADA boilerplate.
+- 2021-22 :: no declared universe at all.
+
+Nothing in the documentation reconciles these, and nothing here reconciles them
+either.
+
 * Cluster coordinates: the 2011-12 GPS is in =NER_EA_Offsets.dta= (GH #323)
 
 =cluster_features= Latitude/Longitude by wave:

--- a/lsms_library/countries/Nigeria/_/CONTENTS.org
+++ b/lsms_library/countries/Nigeria/_/CONTENTS.org
@@ -129,6 +129,490 @@ weights but not longitudinal panel weights.
 - Wave 5: =ghs_panel_wave_5_basic_information_document_v1.pdf=
   (in =2023-24/Documentation/=)
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence for GH #601 / #603.  This records *what the GHS-Panel documentation
+says the sample represents* -- verbatim, with citations.  It is deliberately
+separate from the mechanical description in [[*Sampling Design][Sampling Design]] above, which
+documents how the library BUILDS =sample= / =cluster_features= (=v=, strata,
+weight variable names, counts).  Nothing here is inferred from the =.dta=
+files; a universe is a claim the documentation makes, not something to be
+reverse-engineered from microdata.
+
+Transcription note (declared repairs, nothing silently corrected): quotes are
+taken from PDF text layers, so runs of whitespace are collapsed and words split
+by line-breaking are rejoined (e.g. the source prints "post- planting" across a
+line break).  Typographic quotation marks in the sources are transcribed as
+ASCII straight quotes.  Wording, spelling and punctuation are otherwise
+unaltered.
+
+** Where each wave's universe statement lives
+
+Only *one of five* Nigeria waves holds its universe statement in a file this
+repository ships.  For the other four the statement is World Bank catalog
+metadata -- a live web page, i.e. a moving target the library does not hold.
+
+| Wave    | GHS-Panel | Catalog | Universe statement                                     | In-repo? |
+|---------+-----------+---------+--------------------------------------------------------+----------|
+| 2010-11 | W1        |    1002 | *none* -- catalog page has no Universe field at all      | n/a      |
+| 2012-13 | W2        |    1952 | catalog Universe field only                            | no       |
+| 2015-16 | W3        |    2734 | catalog Universe field only (local DDI PDF has none)   | no       |
+| 2018-19 | W4        |    3557 | local DDI PDF, =ddi-documentation-english_microdata-3557.pdf=, p. 4 | *yes*  |
+| 2023-24 | W5        |    6410 | catalog Universe field only (local BID + report: none) | no       |
+
+Verified 2026-07-21 against the live catalog pages and against the local PDFs.
+
+** Boilerplate warning (W3, W4, W5)
+
+The universe sentence carried by waves 3, 4 and 5 --
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals,
+military barracks, and school dormitories.
+#+end_quote
+
+-- is *World Bank NADA template text*, not a claim traceable to the Nigerian
+National Bureau of Statistics.  The identical sentence appears verbatim in 15
+waves across the library's corpus, including the eight WAEMU/EHCVM countries
+and Ethiopia 2018-19 / 2021-22 (see =slurm_logs/POPULATION_STATEMENTS_2026-07-21.org=,
+section 5.6).  Its presence attests which metadata template was used.  It does
+not independently attest that a statistical office made that claim about the
+GHS-Panel.
+
+It is, however, *corroborated for Nigeria* by an NBS-authored document -- see
+the W3 entry below, where the same exclusion is stated in the panel's own
+weighting appendix in the NBS's own words.  That corroboration is what makes
+the exclusion credible for this country; the boilerplate alone would not.
+
+** Wave by wave
+
+*** 2010-11 (GHS-Panel Wave 1, catalog 1002) -- NO universe statement
+
+No universe statement was found for this wave.  The nearest inclusion claim,
+verbatim from the Wave 1 Basic Information Document, section 1.3 "Coverage and
+Scope", printed p. 3:
+
+#+begin_quote
+The revised GHS with the panel component, while having an intensive focus on
+agriculture, is a national survey. The survey covered all the 36 states and the
+Federal Capital Territory (FCT), Abuja. Both urban and rural enumeration areas
+(EAs) were canvassed.
+#+end_quote
+
+That is a *coverage* claim, not a universe declaration: it says where the sample
+was drawn, not what set of units it stands for.  Recorded as such.
+
+Catalog 1002, "Geographic coverage", verbatim: "National, the survey covered all
+the 36 states and Federal Capital Territory (FCT)."  Catalog 1002, "Sampling
+procedure" > "Sample Framework", verbatim:
+
+#+begin_quote
+The sample frame includes all thirty-six (36) states of the federation and
+Federal Capital Territory (FCT), Abuja. Both urban and rural areas were covered
+and in all, 500 clusters/EAs were canvassed and 5,000 households were
+interviewed. These samples were proportionally selected in the states such that
+different states have different samples.
+#+end_quote
+
+Representativeness, verbatim from the same BID, section 3.0 "Sample Design",
+printed p. 11: "The sample is designed to be representative at the national
+level as well as at the zonal level. The sample size of the GHS-Panel (unlike
+the full GHS) is not adequate for state-level estimates."  *State-level
+estimates from this panel are not supported by its own design document.*
+
+- Exclusions :: NONE STATED for this wave.  The Wave 1 BID contains no
+  occurrence of "universe", "de jure" or an institutional-population exclusion
+  (full-text searched); catalog 1002 has no Universe field.  The institutional
+  exclusion quoted under 2015-16 below applies to the same NISH / 2006-census
+  frame and is very likely to hold here too -- but *no Wave 1 document says so*,
+  and the inference is explicitly not made.
+- Searched :: =2010-11/Documentation/= (=SOURCE.org=, =Access and disclaimer.org=,
+  =LICENSE.org=, and =.dvc= stubs for the household / agriculture / community
+  questionnaires -- questionnaires only, no BID or report is shipped in-repo);
+  catalog 1002 study-description and related-materials pages; the Wave 1 BID PDF
+  in full (catalog 1002 -> =download/48233=), searched for "universe",
+  "de jure", "target population", "institutional", "sample frame",
+  "represent".
+
+*** 2012-13 (GHS-Panel Wave 2, catalog 1952) -- catalog and BID disagree
+
+The catalog carries a universe far narrower than any other GHS-Panel wave's.
+Verbatim from catalog 1952, study description > Coverage:
+
+#+begin_quote
+Universe: Agricultural farming household members.
+#+end_quote
+
+Adjacent fields on the same page, verbatim: "Geographic coverage: National Zone
+State Sector"; "Analysis unit: Agricultural Households."
+
+*This is inconsistent with the wave's own Basic Information Document*, which
+describes a re-interview of ALL Wave 1 households, agricultural or not.
+Verbatim from the Wave 2 BID (=Basic Information Document, Nigeria General
+Household Survey-Panel 2012/13=, February 10, 2015), section 3.0 "Wave 2 Sample
+and Weights", printed p. 23:
+
+#+begin_quote
+The GHS-Panel sample is designed to be representative at the national level as
+well as at the zonal level. The sample size of the GHS-Panel is not adequate
+for state-level estimates. The complete sampling information for the GHS-Panel
+Wave is described in the Basic Information Document for GHS-Panel 2010/2011.
+The objective of the GHS-Panel Wave 2 was to re-interview all of the Wave 1
+households.
+#+end_quote
+
+And from the Wave 2 survey report (=General Household Survey Panel 2012/2013=,
+NBS / FMARD / World Bank, 2014), Executive Summary, "Survey Objectives and
+Design" (PDF p. 9; the page carries no printed number): "The GHS-Panel is a nationally
+representative survey of 5,000 households which are also representative at the
+zonal (urban and rural) levels. The households included in the GHS-Panel are a
+sub-sample of the GHS sample households."
+
+Both statements are recorded; *this file does not adjudicate between them*.  A
+user pooling Nigeria W2 with the other waves should know that the only field in
+the corpus literally labelled "universe" for this wave says
+"agricultural farming household members", while every substantive document for
+the same wave describes a general household panel.
+
+- Exclusions :: NONE STATED.  The Wave 2 BID contains no occurrence of
+  "universe", "de jure" or "institutional" (full-text searched); the catalog
+  entry states no exclusion.
+- Searched :: =2012-13/Documentation/= (=SOURCE.org=, =Access and
+  disclaimer.org=, =LICENSE.org=, =.dvc= stubs for the six PP/PH questionnaires
+  -- no BID or report shipped in-repo); catalog 1952 study-description and
+  related-materials; the Wave 2 BID PDF in full (catalog 1952 ->
+  =download/48250=); the Wave 2 survey report PDF (=download/48253=).
+
+*** 2015-16 (GHS-Panel Wave 3, catalog 2734) -- has a conflict-area OVERSAMPLE
+
+Universe, verbatim from catalog 2734, study description > Coverage > Universe
+(preceded on the same page by "Geographic coverage: National coverage"):
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals,
+military barracks, and school dormitories.
+#+end_quote
+
+This is the NADA boilerplate (see above).  It is *not* in the DDI PDF this repo
+ships for the wave: =2015-16/Documentation/ddi-documentation-english_microdata-2734.pdf=
+has Sampling / Questionnaires / Data Collection / Data Processing / File
+Description sections but no Coverage > Universe block, and full-text search
+finds neither "universe" nor "de jure" in it.
+
+**** Exclusions -- corroborated in NBS's own words
+
+Verbatim from the Wave 3 BID, Appendix 5 "Sampling Details" (=Final Weighting
+Procedures for Nigeria Panel Survey by Wave and Visit=), section 2 "Summary of
+Sample Design for the 2010 GHS and Panel Survey", printed p. 55:
+
+#+begin_quote
+The institutional population living in prisons, hospitals, military barracks,
+school dormitories, etc. are excluded from the universe defined for the
+household surveys.
+#+end_quote
+
+The exclusion is a property of the NISH master frame (built on the 2006 Housing
+and Population Census enumeration areas), so it is structural to every GHS-Panel
+wave -- though only W3 states it in a Nigerian document.
+
+**** Oversample: 5 extra households per conflict-area EA
+
+*This is a within-wave sub-sample and the reader pooling Nigeria must know about
+it.*  Verbatim, same appendix, printed p. 54:
+
+#+begin_quote
+In Wave 3 a conflict module was added to the Panel Survey. The sample EAs in the
+Panel Survey that are located in areas classified as conflict areas were
+identified, and a supplemental sample of 5 households was selected in each of
+these EAs, after a new listing was conducted. The purpose of this expanded
+sample was to increase the number of sample households in the conflict areas in
+order to improve the precision of indicators related to the effects of the
+conflicts.
+#+end_quote
+
+Unweighted W3 statistics therefore *over-represent conflict-area households by
+design*.  The appendix states that weights covering the expanded sample are
+provided ("The weighting procedures for this full sample including the
+additional households in the conflict areas are also described in this
+report").  The library surfaces =wt_wave3= / =wt_w1_w2_w3= (see the Weight
+variables table above); no in-repo check has been done of which of the published
+weight variables corresponds to the conflict-supplemented sample, so *do not
+assume* the shipped =weight= column absorbs the supplement.
+
+**** Panel attrition, verbatim (design context, not universe)
+
+Catalog 2734, "Sampling procedure": "A multi-stage stratified sample design was
+used for the GHS and the Panel Survey. The GHS-Panel sample is fully integrated
+with the 2010 GHS Sample. ... Out of these 22,000 households, 5,000 households
+from 500 EAs were selected for the panel component and 4,916 households
+completed their interviews in the first wave. Given the panel nature of the
+survey, some households had moved from their location and were not able to be
+located by the time of the Wave 3 visit, resulting in a slightly smaller sample
+of 4,581 households for Wave 3."
+
+(The elided passage contains the source's own arithmetic slip -- it computes a
+GHS sample of "22,200 households" and then refers to "these 22,000 households"
+one sentence later.  Quoted as printed.)
+
+*** 2018-19 (GHS-Panel Wave 4, catalog 3557) -- the Borno rural exclusion
+
+Universe, verbatim from the *locally held* DDI PDF
+=2018-19/Documentation/ddi-documentation-english_microdata-3557.pdf=, "Coverage"
+section, p. 4 (immediately after "GEOGRAPHIC COVERAGE: National"):
+
+#+begin_quote
+UNIVERSE
+The survey covered all de jure households excluding prisons, hospitals,
+military barracks, and school dormitories.
+#+end_quote
+
+(NADA boilerplate again; the same sentence is on catalog 3557's page.  This is
+the one Nigeria wave whose universe statement the repository actually holds.)
+
+**** Exclusion by design: rural Borno, and inaccessible urban EAs
+
+Verbatim, same PDF, "Sampling" > "Deviations from Sample Design", pp. 5-6:
+
+#+begin_quote
+While the combined sample generally maintains both national and Zonal
+representativeness of the original GHS-Panel sample, the security situation in
+the North East of Nigeria prevented full coverage of the Zone. Due to security
+concerns, rural areas of Borno state were fully excluded from the refresh sample
+and some inaccessible urban areas were also excluded. Security concerns also
+prevented interviewers from visiting some communities in other parts of the
+country where conflict events were occurring. Refresh EAs that could not be
+accessed were replaced with another randomly selected EA in the Zone so as not
+to compromise the sample size. As a result, the combined sample is
+representative of areas of Nigeria that were accessible during 2018/19. The
+sample will not reflect conditions in areas that were undergoing conflict during
+that period. This compromise was necessary to ensure the safety of interviewers.
+#+end_quote
+
+Note what this does: *the document withdraws the national universe it declared
+two pages earlier.*  The Universe field says "all de jure households"; the
+sampling section says the sample represents "areas of Nigeria that were
+accessible during 2018/19".  Rural Borno is excluded by design -- not
+non-response -- and inaccessible EAs were REPLACED, so the sample size gives no
+signal that anything is missing.  Any W4 estimate presented as national is
+national-conditional-on-accessibility.
+
+**** Sub-samples: "refresh" and "long panel" (a partial refresh, not a new wave)
+
+Verbatim, same PDF, "Sampling Procedure", p. 5:
+
+#+begin_quote
+The original GHS-Panel sample of 5,000 households across 500 enumeration areas
+(EAs) and was designed to be representative at the national level as well as at
+the zonal level. ... However, after a nearly a decade of visiting the same
+households, a partial refresh of the GHS-Panel sample was implemented in Wave 4.
+
+For the partial refresh of the sample, a new set of 360 EAs were randomly
+selected which consisted of 60 EAs per zone. The refresh EAs were selected from
+the same sampling frame as the original GHS-Panel sample in 2010 (the "master
+frame"). A listing of all households was conducted in the 360 EAs and 10
+households were randomly selected in each EA, resulting in a total refresh
+sample of approximated 3,600 households.
+
+In addition to these 3,600 refresh households, a subsample of the original 5,000
+GHS-Panel households from 2010 were selected to be included in the new sample.
+This "long panel" sample was designed to be nationally representative to enable
+continued longitudinal analysis for the sample going back to 2010. The long
+panel sample consisted of 159 EAs systematically selected across the 6
+geopolitical Zones. ... In all, interviewers attempted to interview 1,507
+households from the original panel sample.
+
+The combined sample of refresh and long panel EAs consisted of 519 EAs. The
+total number of households that were successfully interviewed in both visits was
+4,976.
+#+end_quote
+
+(Sic: "and was designed", "approximated 3,600", "after a nearly a decade" --
+quoted as printed.)
+
+So a single library wave =2018-19= contains *two differently-drawn samples*
+pooled into one table: a fresh 360-EA cross-sectional draw and a 159-EA
+longitudinal subsample of the 2010 panel.  Each is separately claimed to be
+nationally representative, and each has its own weight (below).  The
+=Coverage counts= table in [[*Sampling Design][Sampling Design]] above (=panel_weight= non-null for
+1425/5263 rows) is the data-side shadow of exactly this split.
+
+*** 2023-24 (GHS-Panel Wave 5, catalog 6410)
+
+Universe, verbatim from catalog 6410, study description > Coverage > Universe
+(with "Geographic coverage: National"):
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals,
+military barracks, and school dormitories.
+#+end_quote
+
+Identical to W3 and W4; NADA boilerplate.  *It is not in any file this repo
+ships for the wave.*  Both locally held documents --
+=ghs_panel_wave_5_basic_information_document_v1.pdf= and
+=ghs_panel_wave_5_survey_report.pdf= -- were text-extracted in full and contain
+zero occurrences of "universe", "de jure", "institutional", "prison",
+"barrack", "dormitor", "36 states" or "nomad".
+
+**** Exclusion: eight EAs unvisited for conflict
+
+Verbatim from the local BID, "Wave 5 Sample and Weights", pp. 32-33:
+
+#+begin_quote
+Although 518 EAs were identified for the post-planting visit, conflict events
+prevented interviewers from visiting eight EAs in the North West zone of the
+country. Therefore, the final number of EAs visited both post-planting and
+post-harvest comprised 157 long panel EAs and 354 refresh EAs.
+#+end_quote
+
+The catalog's "Deviations from the Sample Design" carries the same sentence and
+*names the states* -- verbatim: "The EAs were located in the states of Zamfara,
+Katsina, Kebbi and Sokoto."  That geographic detail exists only in the catalog
+metadata, not in the in-repo BID.
+
+Unlike W4, no replacement of inaccessible EAs is described: 518 identified,
+511 visited.
+
+**** Sub-samples: long panel (1,590 -> 1,376) and refresh
+
+Verbatim, local BID, p. 32:
+
+#+begin_quote
+In addition to these 3,600 refresh households, a subsample of the original 5,000
+GHS-Panel households from 2010 were selected to be included in the new sample.
+This "long panel" sample of 1,590 households was designed to be nationally
+representative to enable continued longitudinal analysis for the sample going
+back to 2010. The long panel sample consisted of 159 EAs systematically selected
+across Nigeria's six geopolitical zones. The combined sample of refresh and long
+panel EAs in Wave 5 that were eligible for inclusion consisted of 518 EAs based
+on the EAs selected in Wave 4. The combined sample generally maintains both the
+national and zonal representativeness of the original GHS-Panel sample. Due to
+attrition, the number of households from the long panel interviewed in Wave 5
+was 1,376.
+#+end_quote
+
+Final composition, verbatim (BID p. 32): "The final sample consisted of 4,715
+households, of which 1,376 were from the long panel sample and 3,339 from the
+refresh sample."  Attrition since 2010 in the retained EAs is 13.5 percent, and
+the BID states it is "highly variable across zones and sectors" -- highest in
+rural South West (28.8 percent), lowest in rural North Central (5.3 percent),
+and higher among urban (17.8 percent) than rural (11.4 percent) households.
+
+**** The community data disclaim a community universe
+
+Footnote 1 of the local BID, p. 6, verbatim:
+
+#+begin_quote
+The Community Questionnaire does not collect information from communities in the
+sociological sense. The data cannot be used to represent communities in Nigeria.
+The data collected at the community level represent information that is common
+to the households selected for inclusion in the selected sample enumeration
+areas (EAs).
+#+end_quote
+
+*This bears directly on =community_prices=* (documented below), which is
+cluster-level, keyed on =v= = the EA.  Per the survey's own documentation, an EA
+is not a community and these rows do not represent Nigerian communities; they
+represent the sampled households' shared price environment.  A cross-EA average
+of =community_prices= is not an estimate for "communities in Nigeria".
+
+** Universe vs. what the weights represent
+
+Two places where the documents come apart, and one correction to this file.
+
+*** W5 ships THREE weights, and =wt_wave5= is not a "general wave weight"
+
+Verbatim, W5 BID, weighting subsection, p. 35:
+
+#+begin_quote
+1. Longitudinal weights to be applied to the long panel sample: used for
+analysis that seeks to track dynamics within long panel households across the 5
+waves of the GHS-Panel
+2. Longitudinal weights to be applied to the combined sample: used for analysis
+that seeks to track dynamics within all wave 5 households (long panel + refresh)
+between waves 4 and 5
+3. Cross-sectional weights to be applied to the combined sample: used for
+analysis that seeks to provide representative estimates of the current
+population of Nigerian households at the time of wave 5 (2023/24).
+#+end_quote
+
+And the variable names, verbatim (same section):
+
+#+begin_quote
+All three weights can be found in the cover page data files for both the
+post-planting (secta_plantingw5.dta) and post-harvest (secta_harvestw5.dta). The
+variable names in both data files are wt_wave5 for the longitudinal weights
+applied to the combined samples, wt_longpanel_wave5 for the long-panel
+longitudinal weights, and wt_cross_wave5 for the cross-sectional weights.
+#+end_quote
+
+*Correction to the [[*Sampling Design][Sampling Design]] table above*, which annotates the 2023-24 row
+"Also has =wt_wave5= (general wave weight)".  Per the BID just quoted,
+=wt_wave5= is the *longitudinal weight for the combined (long panel + refresh)
+sample, waves 4 to 5* -- not a general-purpose wave weight.  The library's
+=weight= = =wt_cross_wave5= and =panel_weight= = =wt_longpanel_wave5= mappings
+are correct as they stand; the third weight is simply not surfaced, and the
+one-line note should be amended rather than the mapping.
+
+Note also that only the *cross-sectional* weight is claimed to estimate "the
+current population of Nigerian households"; the two longitudinal weights
+represent a 2010 (or 2018) population followed forward.  =panel_weight= is not a
+current-population weight.
+
+*** Weights are pinned to the ORIGINAL EA, which is why =Moved= is a sentinel
+
+Verbatim, W3 BID, printed p. 22:
+
+#+begin_quote
+All households were assigned weights based upon the EA they resided in during
+the sample selection. Therefore, a tracked household that moved from EA "A" to
+EA "B" would still be considered a part of EA "A" for the purpose of survey
+weight determination.
+#+end_quote
+
+This is the documentary basis for the =Moved= sentinel handling described in
+[[*Cluster (PSU) identifier][Cluster (PSU) identifier]] above: a moved household's =ea = 0= carries no
+cluster information, and the survey itself does not treat the destination EA as
+its cluster.  The library's per-household singleton =v= (=moved-{hhid}=) keeps
+such households out of every real cluster while keeping them in the table, which
+is consistent with -- though not identical to -- the survey's own convention of
+attributing them to the origin EA.
+
+** Summary: exclusions and sub-samples
+
+| Wave    | Institutional excl. | Geographic / security exclusion              | Within-wave sub-samples                          |
+|---------+---------------------+----------------------------------------------+--------------------------------------------------|
+| 2010-11 | none stated         | none stated                                  | none                                             |
+| 2012-13 | none stated         | none stated                                  | none stated (re-interview of all W1 households)  |
+| 2015-16 | stated (BID app. 5) | none stated                                  | *conflict-area OVERSAMPLE*: +5 HH per conflict EA  |
+| 2018-19 | stated (boilerplate)| *rural Borno fully excluded*; inaccessible urban EAs excluded; unreachable EAs replaced | *refresh (360 EAs) + long panel (159 EAs)*         |
+| 2023-24 | stated (boilerplate)| 8 EAs unvisited (Zamfara, Katsina, Kebbi, Sokoto); not replaced | *refresh + long panel* (1,376 + 3,339 HH)          |
+
+Practical consequences for anyone pooling Nigeria:
+
+1. W3 is conflict-oversampled; W4 excludes rural Borno by design.  Unweighted
+   pooling across Nigeria waves therefore mixes different implicit populations,
+   and the direction of the bias *reverses* between W3 (conflict areas
+   over-represented) and W4 (conflict areas removed).
+2. From W4 on, one library wave holds two differently-drawn samples.  Which
+   weight is correct depends on the question, and =panel_weight= is NaN for the
+   refresh households by construction (see the Coverage counts table above).
+3. Four of five waves' universe statements live only on a World Bank web page.
+   If a statement matters to an analysis, capture it at the time of use; the
+   repository does not hold it.
+
+** Documentation gaps (recorded as gaps)
+
+- 2010-11 :: no universe statement in any document found; the BID and catalog
+  both lack one.  The institutional exclusion is *not* asserted for this wave.
+- 2012-13 :: no universe statement in any Nigerian document; the only
+  "universe" field in existence for the wave is the catalog's "Agricultural
+  farming household members.", which its own BID contradicts.
+- 2015-16, 2023-24 :: universe statement exists only as WB catalog metadata; the
+  DDI PDF / BID / survey report shipped in-repo contain none.
+- All waves :: no statement was found about nomadic, homeless or
+  diplomatic-household populations, in either direction.  This is silence, not a
+  finding.
+
 * plot_features (GH #167)
 
 Lasting plot characteristics from the post-planting Agriculture

--- a/lsms_library/countries/Pakistan/_/CONTENTS.org
+++ b/lsms_library/countries/Pakistan/_/CONTENTS.org
@@ -1,5 +1,260 @@
 #+TITLE: Pakistan — country notes & known data issues
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered 2026-07-21 for GH #601 / #603.  This section records *what the
+survey documentation claims the sample represents*.  Nothing here is inferred
+from the =.dta= files; no microdata was opened for it.
+
+Pakistan ships exactly one wave directory, =1991/= (PIHS 1991).  There is no
+second wave, so everything below is about that single cross-section.
+
+** Where the statement lives: WB catalog only, and the DDI universe field is empty
+
+The library holds *no* file that states a universe for this wave.  The frame
+statement and every exclusion quoted below come from the World Bank Microdata
+Library catalog record named in =1991/Documentation/SOURCE.org=
+(=#+CATALOG_IDNO: PAK_1991_IHS_v01_M=, catalog id 543, DOI
+https://doi.org/10.48529/azv8-cf20).  That record is a *moving target*: it is
+maintained upstream and is not versioned in this repository.  Retrieved
+2026-07-21 from
+https://microdata.worldbank.org/index.php/api/catalog/PAK_1991_IHS_v01_M .
+
+Two facts about that record matter, and both were re-verified against the live
+API and the DDI 2.5 XML export on 2026-07-21:
+
+- The catalog has *no populated universe field.*  =study_desc.study_info= holds
+  only =abstract=, =coll_dates=, =nation=, =geog_coverage=, =analysis_unit=,
+  =data_kind= and =notes=.  In the DDI XML export
+  (https://microdata.worldbank.org/index.php/metadata/export/543/ddi) the
+  element =<universe/>= occurs exactly twice --- once in =<sumDscr>= and once
+  inside =<sampleFrame>= --- and is *present but empty* in both places.  So the
+  universe was not omitted by accident of export; the field exists in the record
+  and was left blank.
+- Consequently the frame-and-exclusions text below is quoted from
+  =study_desc.method.data_collection.sampling_procedure=, which is where this
+  record actually states the frame and what it leaves out.
+
+*Not boilerplate.*  The =sampling_procedure= text is survey-specific FBS/World
+Bank prose (named provinces, named cities, an 88-stratum table, the 1981 Census
+and the 1988 Census of Establishments).  It is not the WB NADA template sentence
+that recurs verbatim across 15 waves elsewhere in the corpus.
+
+** The declared frame (1991)
+
+Verbatim, from =sampling_procedure=, opening paragraph and the =SAMPLE FRAME:=
+paragraph.  Language: English; no translation needed.
+
+#+begin_quote
+The sample for the PIHS was drawn using a multi-stage stratified sampling
+procedure from the Master Sample Frame developed by FBS based on the 1981
+Population Census.
+
+SAMPLE FRAME:
+
+This sample frame covers all four provinces (Punjab, Sindh, NWFP, and
+Balochistan) and both urban and rural areas. Excluded, however, are the
+Federally Administered Tribal Areas, military restricted areas, the districts of
+Kohistan, Chitral and Malakand and protected areas of NWFP. According to the
+FBS, the population of the excluded areas amounts to about 4 percent of the
+total population of Pakistan. Also excluded are households which depend entirely
+on charity for their living.
+#+end_quote
+
+Read strictly, this is a statement about the *frame*, not about a target
+population.  The survey documents never name the set of units the sample stands
+for; they name the list it was drawn from and what that list omits.
+
+*** What the local documentation says (and does not say)
+
+=1991/Documentation/pak08a.pdf= --- "PAKISTAN INTEGRATED HOUSEHOLD SURVEY, Final
+Results, 1991" (FBS / World Bank / UNDP, March 1992, rev. 7/92) --- contains no
+universe or target-population sentence.  Its closest statement is section I.C
+"Sample Design", report page 3 (= page 13 of 55 in the PDF).  The PDF is a scan
+with no text layer, so this is a transcription read off the rendered page image;
+it was independently re-read and confirmed character-for-character on
+2026-07-21:
+
+#+begin_quote
+PIHS survey teams were scheduled to visit 4800 households residing in 300 urban
+and rural communities between January and December, 1991.  Each team visited
+approximately 20 communities (denoted Primary Sampling Units, or PSUs) and
+interviewed 16 households (denoted Secondary Sampling Units, or SSUs) in each.
+The sample is drawn from the master sample frame maintained by FBS.
+
+The sample is divided equally between Pakistan's urban and rural areas, with
+provincial shares roughly approximating population shares.  The sampling scheme
+is expected to yield sufficient observations within each province (with the
+possible exception of Balochistan) and within urban/rural segments to provide
+adequate statistical accuracy and sufficient variation in key economic variables
+for policy analysis.
+#+end_quote
+
+That passage names the frame but states *no exclusions*.  Table A.1 on the same
+page gives the realised sample: 4,794 households, 36,071 individuals, 300 PSUs,
+broken out by Punjab / Sindh / N.W.F.P. / Balochistan and urban / rural.
+
+** Exclusions (1991) --- recorded in catalog metadata only
+
+The exclusion clause, verbatim (same catalog field as above):
+
+#+begin_quote
+Excluded, however, are the Federally Administered Tribal Areas, military
+restricted areas, the districts of Kohistan, Chitral and Malakand and protected
+areas of NWFP. According to the FBS, the population of the excluded areas
+amounts to about 4 percent of the total population of Pakistan. Also excluded
+are households which depend entirely on charity for their living.
+#+end_quote
+
+| kind       | excluded                                                    |
+|------------+-------------------------------------------------------------|
+| geographic | Federally Administered Tribal Areas (FATA)                  |
+| geographic | military restricted areas                                   |
+| geographic | districts of Kohistan, Chitral and Malakand (NWFP)          |
+| geographic | protected areas of NWFP                                     |
+| population | households which depend entirely on charity for their living |
+
+The catalog's own sizing of the geographic exclusions is "about 4 percent of the
+total population of Pakistan"; no size is given for the charity-dependent
+exclusion.
+
+Two things a pooling user needs to know.  First, *these exclusions exist nowhere
+in this repository* --- not in =SOURCE.org=, not in =LICENSE.org=, not in any of
+the five DVC-tracked PDFs.  Drop the network and the exclusions are unknowable
+from the shipped tree.  Second, the charity-dependent exclusion is a
+*population* exclusion at the destitute tail, which is exactly the tail an LSMS
+poverty analysis is usually about.
+
+** Oversamples and sub-samples (1991)
+
+There is *one* deliberate oversample, and the documentation is explicit about it.
+
+*Urban strata are oversampled by design.*  Half the sample is urban although
+urban areas held under a third of the population.  Verbatim, from
+=study_desc.method.data_collection.weight=:
+
+#+begin_quote
+To allow adjustment to be made for over-sampling of certain strata in the PIHS
+sample, sampling weights have been calculated, and have been incorporated into
+the PIHS data sets that are distributed. These raising factors should be used to
+weight data in order to obtain nationally representative statistics.
+#+end_quote
+
+and, in the same field:
+
+#+begin_quote
+Half the sample was picked from strata in urban areas even though they
+constituted less than 32 percent of the country s estimated population in 1991.
+#+end_quote
+
+("country s" is as printed in the source --- an apostrophe lost in the
+catalog's own encoding.)  The local report states the same design at page 3 in
+the passage quoted above: "The sample is divided equally between Pakistan's
+urban and rural areas".
+
+*Consequence:* an unweighted pooled tabulation of Pakistan 1991 is roughly
+half-urban and will not describe Pakistan.  Use the supplied raising factors.
+
+*Self-representing cities are a certainty stratum.*  Ten cities enter the sample
+with certainty rather than by chance.  Verbatim, from =sampling_procedure=:
+
+#+begin_quote
+(a) Self-representing cities: All cities with a population of 500,000 or more
+are classified as self-representing cities. These include Karachi, Lahore,
+Gujranwala, Faisalabad, Rawalpindi, Multan, Hyderabad and Peshawar. In addition
+to these cities, Islamabad and Quetta are also included in this group as a
+result of being the national and provincial capitals respectively.
+#+end_quote
+
+The remaining two domains, verbatim from the same field: "(b) Other urban areas:
+All settlements with a population of 5,000 or more at the time of the 1981
+Population Census are included in this group (excluding the self-representing
+cities mentioned above)." and "(c) Rural areas: Villages and communities with
+population less than 5,000 (at the time of the Census) are classified as rural
+areas."  The frame is 88 strata in total (10 self-representing cities + 20 other
+urban + 58 rural), with Balochistan's rural strata defined at division rather
+than district level "as a result of the relatively sparse population of the
+districts".
+
+*What is NOT here.*  Unlike Serbia/Montenegro (MOP, Roma), Azerbaijan (three
+sub-populations), or Iraq 2012 (a one-third module subsample), PIHS 1991 carries
+no booster sample of a named sub-population, no module administered to a random
+subsample, and no panel or refresh component --- it is a single 1991
+cross-section, one wave directory, one =t=.  The male/female split of the
+household questionnaire (=pak-male.pdf= / =pak-fem.pdf=, female sections
+administered by female interviewers) is an *instrument* design feature, not a
+sub-sample: both are administered in the same households.
+
+** Universe vs. what the weights represent
+
+The documents come apart on this, and the gap is worth naming before anyone
+pools the wave.
+
+- The catalog asserts =geog_coverage: National=, and the abstract calls PIHS
+  "This nationwide survey" --- but the frame it was drawn from excludes about
+  4 percent of the population by the catalog's own reckoning.  "National"
+  here is a coverage claim about the frame, not a universe statement about
+  Pakistan.  The raising factors raise to the *frame*, not to the country.
+- The catalog is explicit that representativity stops at two levels.  Verbatim,
+  from =study_desc.method.analysis_info.sampling_error_estimates=:
+
+  #+begin_quote
+  The PIHS sample was designed to yield representative statistics at the
+  national and urban/rural) levels. Care however should be taken when
+  interpreting results for smaller analytic domains as the sample was not
+  designed to be representative at a more disaggregated level. Thus, even with
+  the use of the sampling weights, statistics for the smaller provinces such as
+  Balochistan are likely to have high standard errors given the relatively small
+  sample size in these domains.
+  #+end_quote
+
+  (The stray ")" after "urban/rural" is in the source.)
+
+- *Tension, flagged not resolved.*  The 1992 FBS/WB report expects the design to
+  "yield sufficient observations within each province (with the possible
+  exception of Balochistan)" (pak08a.pdf p.3), while the catalog says the sample
+  "was not designed to be representative at a more disaggregated level" than
+  national and urban/rural.  These are not flatly contradictory --- adequacy of
+  observations is not the same claim as designed representativity --- but a user
+  producing province-level estimates is relying on the more permissive of the
+  two, and should say so.
+
+- Estimates are cluster-correlated: the design is multi-stage stratified with
+  16 households per PSU, and the catalog warns that textbook simple-random
+  standard errors "underestimate the true magnitude of errors".  Cluster on the
+  PSU.
+
+** Search record for the gaps
+
+Recorded so the negative claims above are falsifiable.
+
+- *Searched:* every file under =lsms_library/countries/Pakistan/= --- the single
+  wave dir =1991/= plus =_/= and =var/=.  In =1991/Documentation/=:
+  =SOURCE.org= (one DOI URL and the =#+CATALOG_*= / =#+PROVENANCE_*= keywords,
+  no universe text), =LICENSE.org= (generic WB public-use-file terms), and five
+  DVC-tracked PDFs, all materialised via =lsms_library.data_access.get_data_file()=
+  --- =pak08a.pdf= (55 pp), =pak08b.pdf= (55 pp), =pak-male.pdf= (91 pp),
+  =pak-fem.pdf= (72 pp), =pakhh-com.pdf= (20 pp).  =pak08a= / =pak08b= are
+  scans with no text layer; their pages were rendered to images (pdfminer
+  =ImageWriter= + PIL) and read visually.  Read in full: =pak08a.pdf= title
+  page, table of contents, list of tables, and the whole Introduction (I.A
+  Design of the Survey p.1, I.B Management and Field Implementation p.2, I.C
+  Sample Design p.3, I.D The Questionnaires p.4).  =pak08b.pdf= is the
+  continuation of the statistical tables from report p.46 and carries no
+  methodological text.  The three questionnaire PDFs have text layers; grepped
+  for =universe|target population|sample is drawn|coverage|nomad|institutional|excluded|represent=.
+  The only hit is the cover-page identification-box label =SUB-UNIVERSE=, which
+  is a sampling-frame code field, not a universe statement.
+  =_/CONTENTS.org= carries no population statement.
+- *Not found in the repo:* any universe or target-population sentence, and any
+  statement of the exclusions.  Both exist only in the upstream catalog record.
+- *Not found anywhere:* a populated DDI =<universe>= element (present, empty,
+  twice); any statement about institutional, collective, nomadic or homeless
+  populations beyond the charity-dependent clause; any security-related carve-out
+  other than "military restricted areas".
+- *No inference was made from the microdata.*  No =.dta= file was opened for this
+  section, and no =dvc= CLI command was run.
+
 * Known data issues
 
 ** individual_education — only primary grade available (2026-06-06)

--- a/lsms_library/countries/Panama/_/CONTENTS.org
+++ b/lsms_library/countries/Panama/_/CONTENTS.org
@@ -2,6 +2,524 @@
 
 Brief table of contents and todo list.
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence for GH #601 / #603.  This section records *what the survey
+documentation claims* about the population each ENV wave represents.  It
+is deliberately quote-first: every universe statement below is reproduced
+verbatim in Spanish, with a separate, clearly-marked English rendering.
+No claim here is inferred from the microdata, and nothing here proposes a
+schema.
+
+** Provenance warning: none of these statements is held in this repository
+
+All three Panama waves are in the "catalog-only" position.  Not one
+=Documentation/= directory in this repo contains a universe statement;
+what is checked in is questionnaires, =LICENSE.org=, and a =SOURCE.org=
+holding only the catalog id + DOI.  The universe text lives inside
+technical reports hosted on the World Bank Microdata catalog, which are
+*not mirrored here*.  The record is therefore a moving target: if the WB
+re-issues a study record, the text below is what was read on 2026-07-21
+and nothing in this repository would detect the change.
+
+| Wave | Catalog id | Document carrying the universe                   | Mirrored in repo? | Local =Documentation/= holds                                                                        |
+|------+------------+--------------------------------------------------+-------------------+-----------------------------------------------------------------------------------------------------|
+| 1997 |        598 | =pn97bif.pdf= (Documento de Información Básica)  | no                | =pn97hhq.pdf=, =pn97com.pdf=, =pn97ant.pdf=, =caratula.pdf=, =Formulario_Precios.pdf=, =LICENSE.org= |
+| 2003 |       2346 | =pan03bif.pdf= (Informe Técnico de la ENV 2003)  | no                | =ddi-documentation-english_microdata-2346.pdf=, =FormulariodeHogares_V2.pdf=, poverty-map report      |
+| 2008 |         70 | =muestra.pdf= (Diseño Muestral de la ENV, 2008)  | no                | =hogar_V2.pdf=, =comunidad.pdf=, =precios.pdf=, =LICENSE.org=                                        |
+
+Two further facts about where the statements sit:
+
+- *The 2003 catalog record has no Universe field at all.*  The
+  study-description page for id 2346 carries only =Geographic Coverage:
+  National= and =Sampling Procedure: Sample size is 8,000 households=.
+  The shipped DDI PDF (=ddi-documentation-english_microdata-2346.pdf=,
+  which *is* in this repo) likewise has no Overview/Universe section --
+  its page 3 sampling metadata is the single sentence "Sample size is
+  8,000 households", and pages 4 and 6 read "No content available".  So
+  for 2003 the universe exists *only* inside a catalog-hosted PDF.
+- *None of these is NADA boilerplate.*  All three universe statements are
+  Panamanian statistical-office prose (MIPPE 1997; MEF/Dirección de
+  Políticas Sociales 2003; Contraloría General / DEC 2008), not the WB
+  NADA template sentence that recurs across other countries in the
+  corpus.  For 1997 and 2008 the catalog Universe field is a verbatim
+  copy of the national document.
+
+** ENV-97 -- Encuesta de Niveles de Vida 1997
+
+*** Declared universe (verbatim, Spanish)
+
+Source: =pn97bif.pdf=, section 6 "DISEÑO DE LA MUESTRA", sub-section
+"A. Universo de Estudio", printed p. 8 / PDF p. 12.  (Also reproduced as
+the Coverage > Universe field of catalog 598.)
+
+#+begin_quote
+A.  Universo de Estudio
+
+Lo constituyen el conjunto de viviendas particulares existentes en el país
+según el Censo de 1990 (Cuadro No. 1), existen 525,236 viviendas particulares
+ocupadas, de las cuales 295,156 (56.2%) integran el área urbana y 230,080 (43.8%)
+pertenecen al área rural, de estas últimas 198,016 viviendas se ubican en el área rural
+no indígena, 25,141 en el área rural indígena y 6,923 en el área rural de difícil acceso.
+#+end_quote
+
+English rendering (*not* source text; supplied by the extractor):
+
+#+begin_quote
+A. Study universe.  It is constituted by the set of private dwellings existing
+in the country according to the 1990 Census (Table No. 1); there are 525,236
+occupied private dwellings, of which 295,156 (56.2%) make up the urban area and
+230,080 (43.8%) belong to the rural area; of the latter, 198,016 dwellings are
+located in the non-indigenous rural area, 25,141 in the indigenous rural area and
+6,923 in the hard-to-reach rural area.
+#+end_quote
+
+Note the benchmark: the universe is pinned to the *1990* Census even
+though fieldwork ran in 1997.
+
+*** Exclusions
+
+*No exclusion statement was found.*  The ENV-97 documentation makes the
+opposite, explicitly inclusive claim (=pn97bif.pdf=, section 1
+"INTRODUCCION", printed p. 1 / PDF p. 5):
+
+#+begin_quote
+La encuesta tiene cobertura nacional, regional, urbana y rural e incluye, por
+primera vez, las poblaciones indígenas, el área rural dispersa y alejada y las
+poblaciones de difícil acceso.
+#+end_quote
+
+English rendering: "The survey has national, regional, urban and rural
+coverage and includes, for the first time, the indigenous populations, the
+dispersed and remote rural area and the hard-to-reach populations."
+
+The catalog's Geographic Coverage field for id 598 reads, in full: "Se
+cubre la totalidad del territorio nacional."
+
+The only restriction is carried by the universe *unit* itself --
+=viviendas particulares= (private dwellings), which by Panamanian census
+convention would exclude collective and institutional dwellings.  *The
+documentation does not say so*, and it is not asserted here as a
+documented exclusion.
+
+*** Sub-populations and oversamples
+
+ENV-97 partitions the country into five study domains, of which two are
+explicitly special-interest sub-populations.  Verbatim
+(=pn97bif.pdf=, Cuadro No. 1 footnote (a), PDF p. 12):
+
+#+begin_quote
+(a) Los Dominios, como se verá más adelante, son los niveles para los que la
+muestra permite obtener resultados independientes o estimaciones separadas. Los
+Dominios son agrupaciones que incluyen las Regiones de Planificación - unión de
+varias provincias - (Metropolitana, Occidental y Central) y las áreas de interés
+para la ENV (área indígena y de difícil acceso), cuyos límites geográficos y
+físicos no coinciden con las Regiones de Recolección que se crearon en forma
+"ad-hoc" para el operativo de campo.
+#+end_quote
+
+English rendering: "The Domains, as will be seen below, are the levels for
+which the sample permits independent results or separate estimates.  The
+Domains are groupings that include the Planning Regions -- a union of
+several provinces -- (Metropolitana, Occidental and Central) and the areas
+of interest for the ENV (indigenous area and hard-to-reach area), whose
+geographic and physical boundaries do not coincide with the Collection
+Regions created ad hoc for fieldwork."
+
+The regional (province-grouping) domains therefore *exclude* the indigenous
+and hard-to-reach areas by construction -- the same footnote is stated
+directly on the frame table as "(b) No incluye Indígena, ni Difícil
+Acceso."  A user who wants "Región Central" from ENV-97 is getting the
+non-indigenous, non-hard-to-reach part of it.
+
+The "difícil acceso" domain is defined verbatim (=pn97bif.pdf=, PDF p. 12):
+
+#+begin_quote
+Difícil Acceso. Se incluyen aquí las comunidades rurales más alejadas y dispersas del
+país a las que se llega principalmente a pie, a caballo o en canoa, muchas veces sólo
+en determinadas épocas del año (verano).
+#+end_quote
+
+English rendering: "Hard access.  Included here are the country's most
+remote and dispersed rural communities, reached principally on foot, on
+horseback or by canoe, often only in certain seasons of the year (summer)."
+
+Sample design, for context (=pn97bif.pdf=, sections B-D):
+
+- Frame: 14,203 PSUs from 1990 Census cartography -- 10,850 urban and
+  3,353 rural, the latter split 2,508 non-indigenous / 396 indigenous /
+  449 hard-to-reach.
+- "El tamaño muestral estimado ascendió a 5,591 viviendas, se calculó una
+  tasa de respuesta total del 90% lo que permite obtener al final una
+  muestra efectiva de 5,000 viviendas" (printed p. 11).  Achieved: 4,945
+  households.
+- Cuadro No. 3 allocates the 5,591 dwellings / 495 PSUs across the five
+  domains.  The PDF text layer of this table is *column-garbled*; the
+  indigenous and hard-to-reach rows appear to read 40 PSUs / 440
+  dwellings and 20 PSUs / 120 dwellings respectively, but this has *not*
+  been confirmed against the rendered table and should not be quoted as
+  fact.
+
+Arithmetic (mine, from the verbatim figures above, *not* a documentation
+claim): the indigenous rural area is 25,141/525,236 = 4.8% of the universe
+and hard-to-reach 6,923/525,236 = 1.3%.  If the tentative Cuadro No. 3
+reading holds, both are sampled well above their population share -- i.e.
+an oversample -- and *anyone pooling ENV-97 unweighted will over-represent
+indigenous and remote-rural households*.
+
+** ENV-03 -- Encuesta de Niveles de Vida 2003
+
+*** Declared universe (verbatim, Spanish)
+
+Source: =pan03bif.pdf= -- title page reads "INFORME TÉCNICO DE LA ENCUESTA
+DE NIVELES DE VIDA DE 2003", MEF / Dirección de Políticas Sociales,
+Panamá, Agosto 2005 (the WB catalog lists this resource under the
+misspelled label "Informe Techico ...").  Section "B. LA MUESTRA" > "1. LA
+MUESTRA" > "a. Universo", printed p. 11 / PDF p. 14.
+
+#+begin_quote
+a.  Universo
+
+El Universo de estudio de esta muestra fueron las viviendas particulares de los Censos
+Nacionales de Población y Vivienda del año 2000. En el año de referencia había un total de
+790,813 viviendas particulares, de las cuales 681,803 estaban ocupadas al momento de los
+censos. De éstas, 653,211 estaban ubicadas en áreas no indígenas y 28,592 en áreas
+indígenas.
+#+end_quote
+
+English rendering (*not* source text):
+
+#+begin_quote
+a. Universe.  The study universe of this sample was the private dwellings of the
+National Population and Housing Censuses of the year 2000.  In the reference year
+there was a total of 790,813 private dwellings, of which 681,803 were occupied at
+the time of the censuses.  Of these, 653,211 were located in non-indigenous areas
+and 28,592 in indigenous areas.
+#+end_quote
+
+*** Exclusions
+
+**** Domain-level: the province domains exclude indigenous areas
+
+=pan03bif.pdf=, section "2. DISEÑO DE LA MUESTRA", printed p. 13 / PDF
+p. 16:
+
+#+begin_quote
+Es necesario destacar que el dominio provincia excluye de éstas, las áreas habitadas
+mayoritariamente por pueblos indígenas.  Por consiguiente, las estimaciones de este dominio se
+refieren a características de la población residente en áreas no indígenas de las provincias.  Por
+otra parte, el dominio área indígena está conformado por los territorios de las Comarcas Indígenas
+de Kuna Yala, Ngöbe Buglé y Emberá más áreas específicas habitadas mayoritariamente por
+población indígena, ubicadas en cinco provincias del país.  Este mismo criterio se aplicó en la
+ENV de 1997.
+#+end_quote
+
+English rendering: "It must be stressed that the province domain excludes
+from these the areas inhabited mainly by indigenous peoples.
+Consequently, the estimates for this domain refer to characteristics of
+the population resident in the non-indigenous areas of the provinces.  On
+the other hand, the indigenous-area domain is made up of the territories
+of the Indigenous Comarcas of Kuna Yala, Ngöbe Buglé and Emberá plus
+specific areas inhabited mainly by indigenous population, located in five
+provinces of the country.  This same criterion was applied in the ENV of
+1997."
+
+This is *the* thing to know before aggregating Panama by province: a
+province figure is a non-indigenous-areas-of-that-province figure, in both
+2003 and (per this sentence) 1997.
+
+**** Module-level: the prices questionnaire excludes the two largest urban districts
+
+=pan03bif.pdf=, printed p. 11 / PDF p. 14:
+
+#+begin_quote
+j.  Precios en establecimientos. Cotización de precios de un conjunto de artículos
+de consumo cotidiano: alimentos, bebidas y tabaco (48 artículos), y bienes de
+aseo personal y del hogar (20 artículos) en áreas urbanas (a excepción de la
+Ciudad de Panamá y el Distrito de San Miguelito) rurales e indígenas de todo el
+país.
+#+end_quote
+
+English rendering: "j. Prices in establishments.  Price quotations for a
+set of everyday consumption articles: food, drink and tobacco (48
+articles), and personal and household hygiene goods (20 articles) in urban
+(*with the exception of Panama City and the District of San Miguelito*),
+rural and indigenous areas of the whole country."
+
+Consequence for this library: any price table built from the ENV-03 prices
+instrument has *no urban price observations for Panama City or San
+Miguelito* -- the country's largest urban agglomeration.  This is a
+module-level hole, not a household-sample hole.
+
+**** Module-level: agriculture asked only in rural and indigenous areas
+
+Same page:
+
+#+begin_quote
+i.  Actividad Agropecuaria (sólo para las áreas rurales e indígenas). Actividades
+principales de producción agropecuaria, mercadeo, venta, proyectos de
+reforestación.
+#+end_quote
+
+English rendering: "i. Agricultural activity (*only for rural and
+indigenous areas*).  Main activities of agricultural production,
+marketing, sale, reforestation projects."
+
+**** Not found
+
+*No statement excluding any geographic region from the household sample
+itself was found* in =pan03bif.pdf= (searched for
+=universo|población objetivo|marco muestral|cobertura geográfica|excluy|difícil acceso|dominio=),
+nor in the catalog record, nor in the shipped DDI PDF.
+
+*** Sub-populations and oversamples
+
+ENV-03 declares 15 inference domains (=pan03bif.pdf=, printed pp. 12-13);
+domain 15 is "Área Indígena".  The footnote to the sample-allocation table
+(printed p. 13) states verbatim:
+
+#+begin_quote
+1/  La muestra en Área Indígena se diseñó para ser seleccionada entre las
+Comarcas Indígenas y también en áreas habitadas mayoritariamente por
+población indígena en algunas provincias, por lo que el tamaño de la muestra
+en provincias está contemplado para la selección entre las áreas no indígenas.
+#+end_quote
+
+English rendering: "1/ The sample in the Indigenous Area was designed to be
+selected among the Indigenous Comarcas and also in areas inhabited mainly
+by indigenous population in some provinces, so that the sample size in
+provinces is intended for selection among the non-indigenous areas."
+
+Designed allocation (same table): gran total *7,900 dwellings in 790 PSUs*;
+Área Indígena *550 dwellings in 55 PSUs*.
+
+Arithmetic (mine, not documentation): indigenous areas are
+28,592/681,803 = 4.2% of the occupied-dwelling universe but 550/7,900 =
+7.0% of the designed sample -- an oversample of roughly 1.7x.  *Pool
+unweighted and you over-represent the comarcas.*
+
+*** A number that does not reconcile
+
+The catalog Sampling Procedure field for id 2346 says "Sample size is
+8,000 households"; the technical report's own allocation table totals
+*7,900* designed dwellings.  Both are recorded here as read; neither is
+corrected.
+
+** ENV-08 -- Encuesta de Niveles de Vida 2008
+
+*** Declared universe (verbatim, Spanish)
+
+Source: =muestra.pdf= ("DISEÑO MUESTRAL DE LA ENCUESTA DE NIVELES DE VIDA,
+JULIO 2008", Contraloría General de la República / Dirección de
+Estadística y Censo), section "1. UNIVERSO DE ESTUDIO", PDF pp. 1-2.
+Reproduced verbatim as the Coverage > Universe field of catalog 70.
+
+#+begin_quote
+1. UNIVERSO DE ESTUDIO
+
+La encuesta de niveles de vida, consideró como universo de estudio a la
+población total residente en las viviendas particulares ocupadas del país, según el
+Censo de Población y Vivienda del 2000.
+
+El universo, de acuerdo al objetivo de la investigación, se dividió en un sub-universo
+no indígena y en otro indígena; este último constituido por las comarcas
+del país y por las áreas rurales indígenas fuera de las áreas comarcales, y que
+mantienen sus patrones socio culturales.
+
+Tal como se observa en el cuadro, el total de viviendas particulares en el país,
+según el Censo, ascendió a 790,858 unidades habitacionales particulares, de las
+cuales 496,971 se localizan en el área urbana (62.8%) y 293,887 pertenecen al
+área rural (37.2%).  Las viviendas ocupadas representan el 86.2% de las viviendas
+particulares totales.  El universo no indígena, por su parte, constituye un 95.8% y
+el indígena un 4.2% de las viviendas particulares totales del país.  (ver anexo 1,
+distribución del universo por provincia y área)
+#+end_quote
+
+English rendering (*not* source text):
+
+#+begin_quote
+1. Study universe.  The living standards survey took as its study universe the
+total population resident in the country's occupied private dwellings, according
+to the 2000 Population and Housing Census.
+
+The universe, in accordance with the objective of the research, was divided into a
+non-indigenous sub-universe and an indigenous one; the latter constituted by the
+country's comarcas and by the indigenous rural areas outside the comarca areas,
+which maintain their socio-cultural patterns.
+
+As can be seen in the table, the total of private dwellings in the country,
+according to the Census, came to 790,858 private housing units, of which 496,971
+are located in the urban area (62.8%) and 293,887 belong to the rural area
+(37.2%).  Occupied dwellings represent 86.2% of total private dwellings.  The
+non-indigenous universe, for its part, constitutes 95.8% and the indigenous 4.2%
+of the country's total private dwellings.  (see annex 1, distribution of the
+universe by province and area)
+#+end_quote
+
+Two textual notes.  (i) In =muestra.pdf= the third paragraph is separated
+from the second by the table "Viviendas Particulares y Viviendas Ocupadas
+en la República, según Tipo de Universo: Censo 2000", and begins "Tal como
+se observa en el cuadro, el total ..."; the catalog Universe field for id
+70 drops that lead-in and starts "El total de viviendas particulares ...".
+The fuller PDF text is quoted above.  (ii) Whitespace is normalised
+throughout (the PDF is justified and text extraction doubles spaces); no
+word, figure or punctuation mark was altered.
+
+*** Exclusions
+
+*No geographic exclusion from the household sample was found.*  The
+Geographic Coverage field of catalog 70 reads, in full:
+
+#+begin_quote
+National coverage.
+Domains: Urban/rural; Panama City; Rest of Panama District; San Miguelito; West
+Panama; East Panama; Colon; Cocle; Herrera; Los Santos; Veraguas; Bocas del Toro;
+Chiriqui; Darien; Indigenous Area
+#+end_quote
+
+The module-level restriction clauses of ENV-03 recur word for word in the
+catalog's Scope > Notes for ENV-08 (catalog 70) -- prices "en áreas
+urbanas (a excepción de la Ciudad de Panamá y el Distrito de San
+Miguelito) rurales e indígenas de todo el país", and community agriculture
+"(sólo para las áreas rurales e indígenas)".  (The surrounding sentences
+differ slightly from 2003 -- the ENV-08 agriculture note adds "crédito,
+principales problemas" -- but the restriction clauses themselves are
+identical.)  Treat these with the same caution as in 2003: *the ENV-08
+price data have no Panama City / San Miguelito urban quotes.*
+
+As in the earlier waves, the universe unit -- =viviendas particulares
+ocupadas= -- would conventionally exclude collective and institutional
+dwellings, but the documentation does not say so and no such exclusion is
+asserted here.
+
+*** Sub-populations and oversamples -- the explicit two-sub-universe split
+
+ENV-08 is the clearest case in this country: the universe statement itself
+declares a *partition into a non-indigenous and an indigenous
+sub-universe* ("se dividió en un sub-universo no indígena y en otro
+indígena"), the indigenous one being the comarcas plus indigenous rural
+areas outside them.  This is a design partition, not an exclusion -- both
+halves are in scope -- but they are separately allocated and separately
+estimable.  From the catalog's Sampling Procedure field (= =muestra.pdf=,
+"DOMINIO DE ESTUDIO"):
+
+#+begin_quote
+Teniendo como referencia, los estudios del año 1997 y el 2003; y con el propósito
+de hacer comparativo los resultados de la investigación, se determinó que los
+dominios de estudios, para los cuales se desean estimaciones confiables estarían
+representados en primera instancia a nivel de República por área urbana y rural;
+muestra no indígena por área y muestra indígena. Las ocho provincias del país,
+igualmente se constituyen en dominios de estudios.
+#+end_quote
+
+English rendering: "Taking as reference the studies of 1997 and 2003, and
+with the purpose of making the results of the research comparable, it was
+determined that the study domains for which reliable estimates are desired
+would be represented in the first instance at Republic level by urban and
+rural area; non-indigenous sample by area and indigenous sample.  The
+country's eight provinces likewise constitute study domains."
+
+Designed allocation (=muestra.pdf=, section 6 "TAMAÑO DE LA MUESTRA"):
+*8,000 dwellings in 800 PSUs*, split 4,165 urban / 3,835 rural.  Verbatim:
+"En la muestra no indígena, las viviendas particulares seleccionadas
+ascendieron a 7,450 unidades habitacionales y en la indígena a 550
+unidades." and "El total de la muestra a investigar permitió, según el
+criterio de diseño muestral, la selección de 800 unidades primarias de
+muestreo; de las cuales 745 pertenecen a la muestra no indígena y 55 a la
+muestra indígena."
+
+Arithmetic (mine, not documentation): the indigenous sub-universe is 4.2%
+of private dwellings (documented verbatim above) but 550/8,000 = 6.9% of
+the designed sample -- an oversample of roughly 1.6x, essentially the same
+design as 2003.
+
+*** Universe vs. what the weights represent
+
+The expansion factors are defined at PSU level, separately for urban and
+rural parts of *each province p*, as the inverse selection probability
+(catalog 70, Weighting field, = =muestra.pdf= "FACTORES DE EXPANSIÓN"):
+"El proceso de estimación de los resultados de la encuesta está basado en
+la aplicación de los factores de expansión, por unidad primaria de
+muestreo; derivados del inverso de la probabilidad de selección."  The
+documented denominators are 2000-Census private-dwelling counts.  So the
+weights expand to a *2000-Census dwelling universe*, eight years stale at
+fieldwork -- the same benchmark-lag pattern as ENV-97 (1990 Census, seven
+years stale).  No post-stratification to a 2008 population projection is
+documented.
+
+Achieved coverage (catalog 70, Response Rate field): "Al final del
+Operativo de Campo de la ENV-08 se alcanzaron visitar un total de 7,274
+viviendas, lográndose encontrar 6,977 ocupadas completas.  Se obtuvo
+información completa en 7,045 hogares donde se entrevistaron 26,162
+personas. Se realizaron 781 reuniones de la Comunidad y 618 encuestas de
+Precios."  Refusal 1.4%.
+
+** Cross-wave cautions
+
+1. *Unit of the universe shifts between waves.*  ENV-97 and ENV-03 define
+   the universe as the *dwellings* ("el conjunto de viviendas
+   particulares" / "fueron las viviendas particulares"); ENV-08 defines it
+   as the *resident population in* occupied private dwellings ("la
+   población total residente en las viviendas particulares ocupadas").
+   Same practical scope, different declared object -- worth knowing before
+   comparing declared universe sizes across waves.
+
+2. *Benchmark census differs.*  1997 -> 1990 Census; 2003 and 2008 -> 2000
+   Census.  Every wave's universe is defined against a census several
+   years older than the fieldwork.
+
+3. *A census total that does not reconcile between our own two sources.*
+   The 2003 technical report gives *790,813* total private dwellings from
+   Census 2000; the 2008 sample-design document gives *790,858* for the
+   same census (and 681,799 occupied, against 2003's 681,803).  Both are
+   quoted verbatim above; neither is corrected here.
+
+4. *Province means are non-indigenous province means* in 1997 and 2003 by
+   explicit documentation, and the 2008 domain list carries "Indigenous
+   Area" as a peer of the eight provinces.  Do not read a province figure
+   as covering the comarcas.
+
+5. *Indigenous areas are oversampled in all waves for which allocation is
+   documented* (2003, 2008: ~1.6-1.7x population share; 1997 likely, on a
+   tentative table reading).  Unweighted pooling of Panama over-represents
+   indigenous households.
+
+** Gaps and what was searched
+
+- *No universe statement exists in this repository for any Panama wave.*
+  For each wave the local =Documentation/= tree was enumerated and every
+  PDF fetched via =data_access.get_data_file()= and text-extracted:
+  - 1997: =SOURCE.org= (DOI only), =LICENSE.org=, =pn97hhq.pdf=,
+    =pn97com.pdf=, =pn97ant.pdf=, =caratula.pdf=, =Formulario_Precios.pdf=
+    -- all blank forms, none contains a universe statement.
+  - 2003: =SOURCE.org= (DOI only), =ddi-documentation-english_microdata-2346.pdf=
+    (read page by page; *no Overview/Universe section at all*),
+    =InformedelMapadePobrezadePanamaAno2003.pdf= (searched
+    =universo|población objetivo|cobertura|marco muestral|excluy|comarca=;
+    it describes small-area estimation, not the survey universe),
+    =FormulariodeHogares_V2.pdf=, plus =.dvc= sidecars for
+    =Equivalencia.pdf=, =PRECIOS.pdf=, =Comunidad.pdf=.
+  - 2008: =SOURCE.org= (DOI only), =LICENSE.org=, =hogar_V2.pdf=,
+    =comunidad.pdf=, =precios.pdf= -- all blank forms, none contains a
+    universe statement.
+- Catalog search then resolved ids 598 / 2346 / 70, enumerated
+  related-materials (23 / 20 / 23 resources), and text-searched
+  =pn97bif.pdf=, =pan03bif.pdf=, =muestra.pdf= (and =antecedentes.pdf=)
+  for =universo|población objetivo|marco muestral|cobertura|excluy|excepci|difícil acceso|colectiv|dominio=.
+- *Institutional / collective-dwelling treatment is undocumented in all
+  three waves.*  Each universe is stated over =viviendas particulares=
+  with no accompanying sentence about collective quarters, homeless
+  population, or non-household population.  Recorded here as a gap, not as
+  an exclusion.
+- *The per-domain sample allocation for ENV-97 (Cuadro No. 3) is
+  unverified* -- the PDF text layer is column-garbled and the extracted
+  row totals do not sum to the stated 495 PSUs / 5,591 dwellings.  Anyone
+  needing ENV-97 domain sample sizes should read the rendered table.
+- *ENV-97 has no documented sampling-frame weighting text at hand.*
+  Weighting was read only for ENV-08 (catalog 70); the corresponding
+  ENV-97 and ENV-03 weighting documentation was not examined for this
+  note.
+
 * Files in Panama/_/
 ** TODO panama.py
 Contains code common to different rounds

--- a/lsms_library/countries/Peru/_/CONTENTS.org
+++ b/lsms_library/countries/Peru/_/CONTENTS.org
@@ -1,0 +1,604 @@
+#+title: Contents
+
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered 2026-07-21 (GH #601).  Four wave directories: =1985/=,
+=1990/=, =1991/=, =1994/= -- the four rounds of the /Encuesta Nacional de
+Hogares sobre Medicion de Niveles de Vida/ (ENNIV).  (=_/data_info.yml= labels
+the first wave =1985-1986= while the directory is =1985/=; the survey ran twelve
+months from late 1985 into 1986.)
+
+Everything below is quoted from survey documentation.  *No statement here is
+derived from the microdata*, and none should be: this section records what each
+round /claims/ to represent, which is a different fact from what the distributed
+=.dta= files contain.
+
+Spanish quotations are reproduced exactly as printed, accents, typos and all
+(the rest of this file is ASCII per house convention; the quotes are not, because
+they cannot be).  Translations are always on a separate line and are supplied by
+the extracting agent -- they are *not* source text.
+
+Read the 1985 and 1990 entries before pooling ENNIV rounds.  Two of the four
+waves do *not* declare a national universe: 1985 subtracts three departments and
+1990 is Lima-only.  Stacking all four rounds into one "Peru" panel without
+saying so averages across three different declared populations.
+
+** Where these statements live -- catalog-only, all four waves
+
+*Every one of the four universe statements exists only in World Bank Microdata
+Library catalog metadata.  None of them is in any file this repository ships.*
+
+Each wave's =Documentation/= directory holds only =SOURCE.org= (a DOI link plus
+=#+CATALOG_*= keywords) and =LICENSE.org=, alongside DVC-tracked questionnaires
+and manuals.  Those local PDFs were searched (see "What was searched" below) and
+none carries a universe or target-population statement.  The universe sentences
+were read from the catalog Study Description pages:
+
+| wave | catalog id | IDNO                   | DOI                  |
+|------+------------+------------------------+----------------------|
+| 1985 |        597 | =PER_1985_ENNIV_v01_M= | =10.48529/dsz6-gh05= |
+| 1990 |        596 | =PER_1990_ENNIV_v01_M= | =10.48529/w7v4-sz09= |
+| 1991 |        618 | =PER_1991_ENNIV_v01_M= | =10.48529/n513-d685= |
+| 1994 |        617 | =PER_1994_ENNIV_v01_M= | =10.48529/ntxg-ed63= |
+
+The ids were confirmed by DOI match against each wave's own =SOURCE.org=.  The
+practical consequence: *the record is a moving target.*  A WB metadata revision
+changes what Peru's declared universe is, with no diff in this repo.  Peru is
+one of 41 waves across the corpus in that position.
+
+*Not boilerplate.*  These four statements are original Spanish text (INE /
+Instituto Cuanto), not the World Bank NADA template sentence that recurs
+verbatim in fifteen waves elsewhere in the corpus.  They attest a statistical
+office's claim about these surveys, and each of the four is worded differently
+from the other three.
+
+** 1985 -- national, minus three departments in emergency
+
+Confidence: high.  Source type: WB catalog only.
+
+Universe, verbatim (Spanish, source language), catalog 597, Study Description,
+"Coverage" > "Universe":
+
+#+begin_quote
+la población está definida como el conjunto de todas la viviendas particulares y
+sus ocupantes residentes o no de las áreas urbana y rural del país, con la
+excepción de tres departamentos.
+#+end_quote
+
+["todas la viviendas" is the source's own agreement error, quoted uncorrected.]
+
+Translation (agent-supplied, NOT source text): "the population is defined as the
+set of all private dwellings and their occupants, resident or not, of the urban
+and rural areas of the country, with the exception of three departments."
+
+*** Exclusion: Ayacucho, Apurimac, Huancavelica
+
+The universe sentence names an exclusion without naming the departments.  The
+"Geographic Coverage" field immediately above it does, verbatim:
+
+#+begin_quote
+Cobertura nacional con la exepción de tres departamentos que se encontraban en
+emergencia, a saber:
+Ayacucho
+Apurímac
+Huancavelica
+#+end_quote
+
+["exepción" is the source's spelling, quoted uncorrected.]
+
+Translation (agent-supplied): "National coverage with the exception of three
+departments that were under a state of emergency, namely: Ayacucho / Apurimac /
+Huancavelica."
+
+This is a *design-level* subtraction of three named departments for security
+reasons -- the emergency zones of the internal conflict -- not a fieldwork
+shortfall.  ENNIV 1985-86 does not claim to represent the population of
+Ayacucho, Apurimac or Huancavelica, and a national aggregate computed from this
+wave is a national-minus-three-departments aggregate.
+
+*Provenance caveat:* this exclusion is documented *only* in the WB catalog
+record.  The local report =PER14.pdf= ("Encuesta sobre Niveles de Vida y Sector
+Informal en el Peru -- Primeros Resultados", INE / Banco Mundial, Diciembre
+1986), whose "Metodologia de la Encuesta" section was read in full, does not
+mention it.
+
+*** Frame and sample (design detail, not a universe statement)
+
+Catalog 597, "Sampling Procedure", verbatim:
+
+#+begin_quote
+La muestra de viviendas seleccionadas fue extraida de la muestra de viviendas de
+la Encuesta Nacional de Nutricón y Salud (ENNSA)
+#+end_quote
+
+["Nutricón" as printed.]  The ENNIV 1985-86 frame is thus a sub-sample of the
+1984 ENNSA sample of 19,277 dwellings.  Sample size, verbatim: "El tamaño de la
+muestra seleccionada a nivel nacional fue de 5,024 viviendas.  La muestra del
+área urbana total fue de 2,688 viviendas (incluyendo Lima Metropolitana) y del
+área rural total de 2,336 viviendas."
+
+Note a numerical disagreement between the two sources, recorded and not
+reconciled: the local =PER14.pdf= p. 2 says the survey interviewed "una muestra
+aleatoria de 5,120 viviendas", the catalog says 5,024 were selected and 4,906
+yielded information.
+
+** 1990 -- Metropolitan Lima only
+
+Confidence: high.  Source type: WB catalog for the universe sentence; the scope
+is *corroborated locally* by the instrument (below).
+
+Universe, verbatim (Spanish), catalog 596, "Coverage" > "Universe":
+
+#+begin_quote
+Todas las viviendas particulares y sus ocupantes, de todos los distritos de Lima
+metropolitana (inclutyendo Callao)
+#+end_quote
+
+["inclutyendo" is the source's typo for "incluyendo", quoted uncorrected.]
+
+Translation (agent-supplied): "All private dwellings and their occupants, in all
+the districts of metropolitan Lima (including Callao)."
+
+*** Exclusion: the whole of Peru outside Metropolitan Lima
+
+"Geographic Coverage", verbatim:
+
+#+begin_quote
+La encuesta sólamente cubre el área metropolitana de Lima, la capital del Perú
+#+end_quote
+
+["sólamente" as printed -- the accent is the source's error.]
+
+Translation (agent-supplied): "The survey only covers the metropolitan area of
+Lima, the capital of Peru."
+
+*This wave is not a national survey.*  It is the most consequential single fact
+in this section for anyone pooling ENNIV rounds: 1985, 1991 and 1994 declare
+national (or near-national) universes; 1990 declares a single metropolitan area.
+A =Feature()= call that stacks Peru's four waves and takes a mean over =t= mixes
+a Lima-only population into a national series.
+
+*** Local corroboration of the scope (a scope label, not a universe statement)
+
+The cover sheet of =Peru/1990/Documentation/pe90hhq.pdf= (p. 1) reads, verbatim:
+
+#+begin_quote
+ENCUESTA DE HOGARES / SOBRE MEDICION DE NIVELES DE VIDA / JUNIO 1990 /
+IDENTIFICACION DE LA VIVIENDA SELECCIONADA / LIMA METROPOLITANA
+#+end_quote
+
+That is a scope label printed on the instrument, not a declared universe, and it
+is recorded as corroboration only -- the universe quote itself is the catalog's.
+
+*** Sub-sample: the urbano-marginal expansion
+
+ENNIV 1990 is not a fresh draw.  Catalog 596, "Sampling Procedure", verbatim
+(sample design, not universe):
+
+#+begin_quote
+Considerando que por la encuesta anterior ENNIV 1985-6 el tamaño de la muestra
+para el dominio Lima Metropolitana fue de 1280 viviendas (128 conglomerados), en
+esta oportunidad debido al crecimiento poblacional ocurrido en la ciudad de
+Lima.  En los 144 nuevas zonas se reistraron 169144 nuevas viviendas, lo que
+determinó un incremento de 260 viviendas, lo que adicionadas al tamaño de la
+muestra original dio un total de 1540 viviendas seleccionadas (154
+conglomerados).
+#+end_quote
+
+[Quoted as printed: the first sentence is a fragment, and "reistraron" is the
+source's typo.]
+
+So the 1990 Lima sample = the 1985-86 Lima panel (1,280 dwellings / 128
+clusters) *plus* a 260-dwelling expansion drawn in 144 newly-mapped zones.  The
+1991 catalog record characterises that expansion, verbatim: "la ampliación
+muestral trabajada para ENNIV 90 (ampliación realizada en zonas urbano -
+marginales de Lima)" [sic, spacing as printed] -- it was drawn in Lima's
+marginal peri-urban settlements.  This is the closest thing in the Peru series
+to a *booster sample of a sub-population*, and it lives inside a wave rather
+than being one.  Catalog 596 also records that the 1990 sample "no es
+autoponderada".
+
+** 1991 -- "Población nacional", but see the coverage list
+
+Confidence: *medium*.  Source type: WB catalog only.  Recorded with its internal
+tension intact, because the tension is the finding.
+
+Universe, verbatim (Spanish), catalog 618, "Coverage" > "Universe" -- the
+field's entire content is two words:
+
+#+begin_quote
+Población nacional
+#+end_quote
+
+Translation (agent-supplied): "National population."
+
+*** The tension: a national claim next to a nine-domain coverage list
+
+"Geographic Coverage", verbatim:
+
+#+begin_quote
+La Población de la ENNIV 1991, es el conjunto de viviendas particulares y sus
+ocupantes de las siguientes zonas geográficas:
+Norte
+Costa Urbana
+Sierra Urbana
+Sierra Rural
+Centro
+Sierra Urbana
+Sierra Rural
+Sur
+Costa Urbana
+Sierra Urbana
+Sierra Rural
+Lima Metropolitana
+#+end_quote
+
+Translation (agent-supplied): "The Population of ENNIV 1991 is the set of
+private dwellings and their occupants of the following geographic zones: [list
+as above]."
+
+The enumerated list names Costa Urbana, Sierra Urbana and Sierra Rural (within
+Norte / Centro / Sur) plus Lima Metropolitana.  *Selva and Costa Rural do not
+appear in it.*  The catalog's "Sampling Procedure" is consistent with a
+nine-domain design: "El tamaño de la muestra fue de 2,252 viviendas distribuídas
+en 9 dominios." ["distribuídas" as printed.]
+
+*This section does NOT assert that Selva and Costa Rural were excluded.*  It
+records two things that are both true of the source: the Universe field says
+"Población nacional", and the coverage list as printed does not name those two
+domains.  Resolving that requires the INE / Instituto Cuanto technical document
+for ENNIV 1991, which is *not present in this repository* and was not located.
+Anyone relying on this wave for a national figure should resolve it first.  (The
+GH #601 sweep lists Peru 1991 as one of six waves whose sources disagree with
+themselves; it declined to adjudicate, and so does this file.)
+
+*** Field-level non-coverage (fieldwork, not design)
+
+Recorded separately from the design exclusions above because it is a different
+kind of fact -- these are places the enumerators could not reach, not places the
+frame left out.  Catalog 618, "Sampling Procedure", verbatim:
+
+#+begin_quote
+La variación en el número de caseríos seleccionados se debió a las limitaciones
+encontradas en el campo, por ejemplo, cuando se habían fusionado dos caseríos o
+cuando uno pertenecía a otro distrito o cuando por desconfianza de pobladores o
+falta de seguridad (zona roja), todo el caserío rechazaba la encuesta.  Esto
+último sucedió en los distritos de Puquina (Moquegua) y July (Puno).
+#+end_quote
+
+#+begin_quote
+Por otro lado en el departamento de Cajamarca, en los distritos de Asunción,
+Llapa y San Pablo, no se pudo visitar los caseríos, según ellos por carecer de
+la documentación apropiada para respaldar esta labor, además la policía no se
+hacía responsable de la seguridad de las encuestadoras.
+#+end_quote
+
+#+begin_quote
+En la Sierra Centro Rural fue necesario reemplazar 2 segmentos ya que a causa
+del terrorismo no había la mínima seguridad para trabajar.  Los distritos de
+Huasahuasi y San Pedro de Cajas en Tarma, se cambiaron por los distritos de
+Chupaca y Acobamba, respectivamente, de similares características a los
+originalmente seleccionados.
+#+end_quote
+
+Translation, in brief (agent-supplied, NOT source text): whole hamlets refused
+the survey for lack of security in Puquina (Moquegua) and July (Puno); hamlets
+in Asuncion, Llapa and San Pablo (Cajamarca) could not be visited; and two
+segments in the Sierra Centro Rural were *replaced* because terrorism made
+fieldwork unsafe, Huasahuasi and San Pedro de Cajas (Tarma) being swapped for
+Chupaca and Acobamba.
+
+The last of these matters for a different reason than the others: those segments
+were substituted, not dropped, so the realised sample contains clusters the
+design did not select.
+
+*** Panel content
+
+Catalog 618, "Sampling Procedure", verbatim:
+
+#+begin_quote
+En Lima Metropolitana la muestra fue la misma encuestada en la ENNIV 85-86, más
+un 15% de viviendas seleccionadas de la ampliación muestral trabajada para ENNIV
+90 (ampliación realizada en zonas urbano - marginales de Lima).  De las 1,006
+viviendas programadas, se llegaron a trabajar 801 viviendas.
+#+end_quote
+
+[sic, spacing as printed.]  In the rest of the urban area, verbatim: "En el área
+urbana se seleccionaron 64 segmentos (en 46 distritos) de los 79 trabajados en
+la ENNIV 85-86, teniendo en cuenta los mismos parámetros que para el área
+rural."
+
+** 1994 -- national, all households
+
+Confidence: high.  Source type: WB catalog only.
+
+Universe, verbatim (Spanish), catalog 617, "Coverage" > "Universe":
+
+#+begin_quote
+El universo a cubrir es la totalidad de hof¡gares en el territorio nacional
+#+end_quote
+
+["hof¡gares" is a corruption of "hogares" in the source; quoted exactly as
+printed rather than repaired.]
+
+Translation (agent-supplied): "The universe to be covered is the totality of
+households in the national territory."
+
+"Geographic Coverage", verbatim:
+
+#+begin_quote
+El ámbito geográfico de la investigación abarcó a todo el territorio nacional:
+Costa, Sierra y Selva
+#+end_quote
+
+Translation (agent-supplied): "The geographic scope of the study covered the
+whole national territory: Coast, Highlands and Jungle."
+
+*** Exclusions
+
+*No exclusion statement was found for this wave* -- neither in the catalog record
+nor in any of the nine local PDFs listed below.  This is recorded as an absence
+of evidence, not as evidence of no exclusion.  Unlike 1985, the 1994 record
+carries no emergency-zone carve-out; unlike 1991, its coverage field names all
+three natural regions including Selva.
+
+*** Sub-sample: 1994 is partly a panel on 1991
+
+Catalog 617, "Sampling Procedure", verbatim -- and the *identical sentence*
+appears in the local =Peru/1994/Documentation/m-encues.pdf= (MANUAL DEL
+ENCUESTADOR), which makes this the one scope-relevant sentence in the Peru
+series that the repository actually holds:
+
+#+begin_quote
+La muestra ha considerado las viviendas seleccionadas de la ENNIV-1991 y
+siguiendo la misma metodología, se han seleccionado las unidades muestrales en
+las áreas no estudiadas en 1991, por lo que la muestra es autoponderada ,
+probabilística, polietápica e independiente en cada dominio de estudio.
+#+end_quote
+
+[sic: the stray space before the comma in "autoponderada ," is as printed in the
+catalog rendering.]
+
+Translation (agent-supplied): "The sample took the dwellings selected for
+ENNIV-1991 and, following the same methodology, sampling units were selected in
+the areas not studied in 1991; the sample is therefore self-weighting,
+probabilistic, multi-stage and independent in each study domain."
+
+ENNIV-94 is therefore the ENNIV-1991 dwellings plus a fresh draw in "las áreas
+no estudiadas en 1991".  That phrase is the clearest available evidence that
+ENNIV 1991 did *not* in fact cover the whole national territory -- but it does
+not say which areas, so it does not resolve the Selva / Costa Rural question
+raised in the 1991 entry above.
+
+Sample size (local =m-encues.pdf=, and catalog), verbatim: "La ENNIV 1994 será
+efectuada en 3,544 viviendas en todo el País.  La muestra incluye: 820 viviendas
+en Lima Metropolitana, 1380 viviendas en el área urbana y 1344 viviendas en el
+área rural."
+
+** Universe vs. what the weights represent
+
+Two places where the documents come apart on this, both worth knowing before
+weighting anything.
+
+*** 1985: national inference levels, non-national universe
+
+Catalog 597, "Sampling Procedure", verbatim:
+
+#+begin_quote
+La muestra es autoponderada para los niveles de inferencia.  Dichos niveles de
+inferencia para resultados agregados son: Total Naci onal, Nacional Urbano,
+Nacional Rural, Lima Metropolitana y Regiones Naturales (costa, sierra y selva).
+#+end_quote
+
+["Naci onal" spacing as printed.]
+
+The design therefore offers a "Total Nacional" estimate while the universe on
+the same catalog page excludes three departments.  "Total Nacional" here means
+the national total *of the declared universe* -- Peru minus Ayacucho, Apurimac
+and Huancavelica -- not of Peru.  The weights carry no trace of that
+qualification.
+
+Note also that the inference levels name the three natural regions "(costa,
+sierra y selva)", so Selva is a 1985 inference domain even though it is absent
+from the 1991 coverage list.
+
+*** 1991 vs. 1994: the domain list changes
+
+The 1991 coverage list enumerates nine domains and does not name Selva or Costa
+Rural.  The 1994 catalog's "Weighting" section prints expansion factors over
+*seven* domains that do include them.  Reproduced from catalog 617, "Sampling" >
+"Weighting" (the source prints this as a two-column plain-text block):
+
+| DOMINIO DE ESTUDIO | FACTOR DE PONDERACION |
+|--------------------+-----------------------|
+| Costa Urbana       |            1746.48800 |
+| Costa Rural        |             787.77916 |
+| Sierra Urbana      |            1533.91460 |
+| Sierra Rural       |            1271.75410 |
+| Selva Urbana       |             706.47395 |
+| Selva Rural        |             729.41666 |
+| Lima Metropolitana |            1563.63580 |
+
+Costa Rural, Selva Urbana and Selva Rural carry weights in 1994 and are absent
+from the 1991 coverage list.  Whether that is a real change of universe between
+the two rounds or a defect in the 1991 metadata is *not settled by the evidence
+in hand*.
+
+For 1991 the catalog says only, verbatim: "La metodología de la ENNIV, considera
+el uso de un peso o factor de expansión, para cada dominio de estudio, con la
+finalidad de poder agregar los resultados a nivel del ámbito total del estudio."
+-- note "el ámbito total del estudio", the total scope of the study, which is
+not the same phrase as the national population.
+
+** Sub-sample and panel structure, across waves
+
+The ENNIV rounds are chained, and the chain is not uniform:
+
+| wave | declared universe                  | relation to earlier rounds                                                              |
+|------+------------------------------------+-----------------------------------------------------------------------------------------|
+| 1985 | national, minus 3 departments      | frame is a sub-sample of the 1984 ENNSA sample                                          |
+| 1990 | Metropolitan Lima only             | 1985-86 Lima panel + 260-dwelling urbano-marginal expansion                             |
+| 1991 | "Población nacional" (see caveat)  | Lima = the 1985-86 sample + 15% of the 1990 expansion; urban = 64 of the 79 1985-86 segments |
+| 1994 | all households, national territory | ENNIV-1991 dwellings + fresh draw in areas not studied in 1991                          |
+
+Two consequences a reader pooling this country needs before averaging anything:
+
+1. The Lima households are the most heavily re-interviewed group in the series
+   and the least representative of Peru; the 1990 wave is *entirely* that group.
+2. Peru's documentation flags no sub-population oversample as such, but the 1990
+   urbano-marginal =ampliación= functions as one -- a booster in Lima's marginal
+   settlements that then propagates into the 1991 sample at a 15% rate.
+
+** What was searched, and what was not found
+
+Recorded so that the next reader knows the shape of the gap rather than
+inheriting a silent one.
+
+- 1985 :: =Documentation/= holds =SOURCE.org=, =LICENSE.org=, and three
+     DVC-tracked PDFs: =PER01_V2.pdf= (1985 household questionnaire, INE / World
+     Bank LSMS, 9 December 1985), =PER03.pdf= (community questionnaire, Sept
+     1986) and =PER14.pdf= ("Primeros Resultados", INE / Banco Mundial, Diciembre
+     1986; Prologo, Introduccion, "Metodologia de la Encuesta" pp. 2-4 and
+     Appendices A and B were read).  *All three are image-only scans with an
+     empty text layer* (67 / 41 / 72 pages); they were rendered to page images
+     and read visually, no OCR being available on the host.  None states a
+     universe, and none mentions the three-department exclusion.
+- 1990 :: =PER19.pdf= ("Informe del Procesamiento de la ENNIV - 1990", 14 pp.,
+     image-only scan, read visually) is a data-keying report -- no universe.
+     =pe90hhq.pdf= (household questionnaire, text extracted) was grepped for
+     /universo/, /población objetivo/, /ámbito/, /cobertura/, /marco muestral/;
+     no universe statement, only the LIMA METROPOLITANA cover label quoted above.
+- 1991 :: =PER22.pdf= (community questionnaire, World Bank Poverty and Human
+     Resources Division, 6 pp., image-only scan, read visually) -- no universe.
+     =pe91hhq.pdf= (household questionnaire, text extracted, same greps) -- no
+     universe.
+- 1994 :: nine DVC-tracked PDFs, all text-extracted and grepped for the same
+     terms plus /cobertura geográfica/ and /target population/: =m-encues.pdf=
+     (Manual del Encuestador), =programa.pdf= (Programa de la Encuesta --
+     Conceptos y Definiciones), =pe94hhq1.pdf= and =pe94hhq3.pdf= (household
+     questionnaires), =cenpob94.pdf= and =dicciona.pdf= (data dictionaries),
+     =COD_BENS.pdf= and =COD_PAIS.pdf= (code lists, image-only).  The only hits
+     concerned the sampling frame and the geographic /ámbito/ of fieldwork
+     supervision.  The 1994 local documentation is the richest of the four and
+     still states scope only through sample counts, never a universe.
+
+*Residual gap.*  The image-only scans (three in 1985, one in 1990, one in 1991)
+were read by eye at page-image resolution.  A coverage sentence buried in a
+cover page or a manual introduction could in principle have been missed.  Also
+absent from this repository, and the natural place to resolve the 1991 tension:
+the INE / Instituto Cuanto technical documents for ENNIV 1990 and 1991.
+
+** Who counts as a member (not a universe statement, but it bounds the count)
+
+Recorded separately because these are residence rules, not universe
+declarations.  They decide who inside a sampled dwelling enters the data, and
+they are *not* stable -- not across rounds and, in 1994, not even within one
+round's own documentation.
+
+*** 1994: the two shipped documents give two different residence thresholds
+
+Both quotes below were re-extracted and verified against the local PDFs on
+2026-07-21, not taken on trust.
+
+=Peru/1994/Documentation/programa.pdf=, section "4.4 Hogar", verbatim:
+
+#+begin_quote
+Es la persona o conjunto de personas, sean o no parientes, que residen
+habitualmente más de 7 meses en los últimos 12 meses en una misma vivienda
+particular, ocupándola total o parcialmente y que atienden en común sus
+necesidades vitales o básicas.
+#+end_quote
+
+Translation (agent-supplied): "It is the person or set of persons, related or
+not, who habitually reside more than 7 months of the last 12 months in the same
+private dwelling, occupying it wholly or partly, and who attend in common to
+their vital or basic needs."
+
+=Peru/1994/Documentation/m-encues.pdf= (MANUAL DEL ENCUESTADOR), section "6.4
+Residente Habitual", verbatim:
+
+#+begin_quote
+Se considera que una persona es residente habitual en una determinada vivienda
+si es que ésta le sirve como domicilio permanente (come y duerme) o si reside al
+menos 3 de los últimos 12 meses.  No se considera como residentes del hogar a
+las personas separadas de la unión, aunque pasen pensión de alimentación a algún
+miembro del hogar encuestado.
+#+end_quote
+
+Translation (agent-supplied): "A person is considered a habitual resident of a
+given dwelling if it serves as their permanent domicile (they eat and sleep
+there) or if they reside there at least 3 of the last 12 months.  Persons
+separated from the union are not considered residents of the household, even if
+they pay maintenance to some member of the surveyed household."
+
+*The Programa says more than 7 of the last 12 months; the enumerator's manual --
+the document the fieldworker actually held -- says at least 3.*  Both are
+shipped in this repository, in the same wave directory.  Nothing found in either
+document reconciles them, and this file does not attempt to.  Anyone deriving a
+residence filter for Peru 1994 (cf. the =MonthsSpent= / =MonthsAway= handling
+described in =CLAUDE.md=) is choosing between two documented rules, not applying
+one.
+
+*** 1994: two categories of person are excluded from membership by rule
+
+=m-encues.pdf=, section "6.5 Miembros del Hogar", verbatim:
+
+#+begin_quote
+Son todas aquellas personas que comen y duermen habitualmente en el hogar, por
+lo menos tres de los últimos 12 meses precedentes a la encuesta, excepto los
+pensionistas y trabajadores del hogar, que nunca se considera como miembros del
+hogar.
+#+end_quote
+
+#+begin_quote
+Se considera en cambio, siempre como miembro del hogar al jefe del hogar, aunque
+no cumpla con el requisito de haber residido habitualmente por lo menos tres
+meses, y a los infantes de los miembros del hogar, menores de 3 meses.
+#+end_quote
+
+Translation (agent-supplied): members are all those who habitually eat and sleep
+in the household for at least three of the 12 months preceding the survey,
+"except lodgers/boarders (=pensionistas=) and domestic workers, who are never
+considered members of the household"; conversely the household head is always a
+member even if the three-month rule is not met, as are members' infants under 3
+months.
+
+Lodgers and live-in domestic workers are therefore *outside the counted
+population by rule*, not by chance -- the same shape of exclusion as Tanzania
+NPS's "excluding live-in servants" elsewhere in the corpus.  =m-encues.pdf=
+elsewhere adds that habitual residents absent "por un período mayor de nueve
+meses" are likewise not members.
+
+*** The other rounds, for comparison
+
+- 1985, local =PER14.pdf= p. 2 :: recorded by the GH #601 sweep as verbatim "Un
+     \"hogar\" fue definido como un grupo de individuos que han dormido
+     usualmente en la misma vivienda y han compartido las comidas, por lo menos
+     durante 3 de los 12 meses anteriores a la entrevista."  (At least 3 of the
+     last 12 months.)  *This one could not be re-verified here*: =PER14.pdf= is
+     an image-only scan with an empty text layer, so it is carried on the
+     sweep's visual reading.
+- 1991, catalog 618 "Unit of Analysis", verbatim :: "Es el hogar integrado por
+     una o más personas, sean o no parientes, que residan habitualmente en una
+     misma vivienda y que atiendan en común sus necesidades vitales."  No month
+     threshold is given, and this is catalog text rather than a survey document.
+- 1994, =m-encues.pdf= section "6.3 Hogar" :: the sentence is the same as
+     =programa.pdf= §4.4 *minus* the month clause and ending "sus alimentos"
+     rather than "sus necesidades vitales o básicas".  It is quoted only in
+     paraphrase here because pdfminer returns that particular paragraph with its
+     line fragments interleaved out of order; the reconstruction is
+     unambiguous but is not a clean verbatim extraction, so it is not presented
+     as one.
+
+Note on transcription: the 1994 PDFs' text layer contains spurious spaces inside
+words ("deter minada", "per manente", "duer me", "for mado", "pension istas",
+"miembro s") and before some punctuation ("unión ,", "hogar .").  Those are
+artifacts of the PDF's text layer, not of the printed page, and have been closed
+up in the quotations above.  No other change was made to any quoted string, and
+every quote here was verified against the PDF on 2026-07-21.
+
+** Scope of this section
+
+Per GH #601 this records *evidence only*.  It proposes no schema, no
+=data_scheme.yml= key and no code; how the library should represent a wave's
+declared universe is being decided in GH #603.

--- a/lsms_library/countries/Senegal/_/CONTENTS.org
+++ b/lsms_library/countries/Senegal/_/CONTENTS.org
@@ -33,6 +33,337 @@ rather than expecting a =MonthsSpent= column in =household_roster()=.
 Senegal has no pre-EHCVM waves in the library, so no continuous
 months-of-presence variable is available for any wave.
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence for what each Senegal wave *claims* to cover, kept deliberately
+separate from what the data look like.  Every statement below is quoted
+verbatim from a named document at a named location; anything not quoted is
+labelled as editorial.  Nothing here is inferred from the =.dta= files.
+
+Both Senegal waves are EHCVM (=Enquête Harmonisée sur les Conditions de Vie
+des Ménages=), the WAEMU/UEMOA harmonized series run by ANSD with the World
+Bank and the WAEMU Commission.  See also =Household Presence / MonthsSpent=
+above, which documents the EHCVM 6-month *membership* rule (=s01q12= /
+=s01q13=) -- that rule decides who counts as a member of a sampled household
+and is a different question from the survey's declared universe.
+
+** 2018-19 (EHCVM-1) -- universe stated, in local documentation
+
+*** Declared universe (verbatim)
+
+Source :: =lsms_library/countries/Senegal/2018-19/Documentation/ddi-documentation-english_microdata-4297.pdf=,
+PDF page 3, section =Coverage= > =UNIVERSE= (immediately below
+=GEOGRAPHIC COVERAGE / National coverage=).  Language: English.
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals,
+military barracks, and school dormitories.
+#+end_quote
+
+The same page, =GEOGRAPHIC COVERAGE=, verbatim: "National coverage".
+
+The identical string is carried in the WB catalog DDI XML export for study
+4297 (=<universe><![CDATA[...]]></universe>=), so the local file and the
+catalog agree.  This wave's statement therefore lives *in the repository*,
+not only in catalog metadata.
+
+*** WARNING: this universe sentence is WB NADA boilerplate
+
+That exact sentence is the single most repeated string in the cross-country
+population corpus -- it appears verbatim in roughly fifteen waves, including
+every WAEMU/EHCVM country (Benin, Burkina Faso, Cote d'Ivoire, Guinea-Bissau,
+Mali, Niger, Senegal, Togo) *and* in Ethiopia 2018-19 / 2021-22 and Nigeria
+2015-16 / 2018-19 / 2023-24, which are not EHCVM at all.
+
+It attests *which World Bank metadata template was filled in*.  It is not
+independent evidence that ANSD made that specific claim about this specific
+survey.  Treat it as a template default unless corroborated by a
+Senegal-specific document -- and no Senegal-specific document corroborating
+it was found (the local Basic Information Document for 4297 has a =Sample=
+section but no universe or target-population statement; see the gap note
+below).
+
+*** Exclusions
+
+- Population exclusions :: the four institutional/collective categories in
+  the quoted sentence -- prisons, hospitals, military barracks, school
+  dormitories.  Note this list is *narrower* than several sibling EHCVM
+  countries' own national-language reports, which additionally exclude
+  diplomatic households and the homeless (e.g. Burkina Faso 2018-19).  No
+  Senegal document found extends the list; recorded as it stands.
+- Geographic exclusions :: *none stated, and one document states the
+  opposite.*  DDI PDF page 4, =Sampling= > =SAMPLING PROCEDURE=, first
+  sentence, verbatim: "The Senegal EHCVM 2018/19 sample covers all regions
+  with urban and rural areas surveyed in all regions."  The same sentence
+  appears in the local Basic Information Document, =Sample= section.  There
+  is no dropped region and no urban- or rural-only restriction.  (This is
+  worth stating explicitly: Guinea-Bissau's EHCVM *does* carry such a
+  restriction -- "apart from the autonomous sector of Bissau (SAB) where all
+  respondents are from urban areas" -- so its absence here is informative,
+  not merely unrecorded.)
+- Security carve-outs :: none stated for this wave.
+
+*** Sub-sample structure: the two =vagues= are halves of every EA
+
+This is the sub-sample fact a pooling analyst needs.  The wave is not a
+single fieldwork pass: each EA was *split in half*, and the halves were
+interviewed in two seasons.  DDI PDF page 4, =SAMPLING PROCEDURE=, verbatim
+(identical text in the local BID, =Sample=, and in WB catalog 4297):
+
+#+begin_quote
+The total survey sample size is 7156 households - 3941 from urban areas and
+3215 from rural areas. After that, the survey design randomly divided each
+enumeration area into two equal groups. The survey team interrogated the
+first group in wave 1 and the other in wave 2. Finally, for various reasons,
+including availability and quality monitoring, the final sample size
+comprises slightly more households (twenty) in round 2 than in round 1. In
+wave one, the survey teams interviewed 3568 households (1961 in urban areas
+and 1607 in rural areas. In wave two, the teams interviewed 3588 households
+(1980 in urban areas and 1608 in rural areas).
+#+end_quote
+
+(Quoted as printed, including the unclosed parenthesis after "1607 in rural
+areas".)
+
+Same PDF, page 2, =ABSTRACT=, verbatim: "The surveys took place in two waves
+with each wave covering half of the sample. The first wave was fielded
+between September 2018 and December 2018, while the second wave occurred
+between April 2019 and July 2019. The two-wave approach was chosen to
+account for seasonality of consumption."
+
+Consequences for anyone pooling this wave:
+
+- The =vague= split is *seasonal*, by design.  Any within-wave comparison
+  across =vague= is confounded with season, deliberately so.
+- Because each EA is split rather than each EA being assigned wholly to one
+  =vague=, the design intent differs from the library's operating
+  assumption for EHCVM countries.  =CLAUDE.md= records the convention that
+  "each =grappe= is visited in exactly one =vague=", hence =v: grappe= and
+  =i: [grappe, menage]= rather than composites including =vague=.  The
+  documentation above says the *households* within an EA were split between
+  =vagues=, i.e. an EA appears in both.  Flagged, not adjudicated -- this is
+  a discrepancy between a documented design statement and a library
+  configuration convention, and resolving it needs someone to look at the
+  Senegal identifiers directly.
+
+*** Stated representativeness (a different claim from the universe)
+
+DDI PDF page 2, =ABSTRACT=, verbatim: "The EHCVM is a nationally
+representative survey of 7,100 households, which are also representative of
+the geopolitical zones (at both the urban and rural level)."
+
+Note the sample-size figures do not agree across documents: "approximately
+7,100" (=SERIES INFORMATION=), "7,100" (=ABSTRACT=), "7156" (=SAMPLING
+PROCEDURE= and the BID), and "7 176" / "7,176" in the *2021-22* BID's
+retrospective description of the 2018/19 sample (French and English
+respectively).  Quoted as printed in each; not reconciled here.
+
+No weighting statement was found for this wave in any source (the WB catalog
+=weight= field is empty), so there is no document saying what the weights
+are constructed to represent, as distinct from the declared universe.
+
+** 2021-22 (EHCVM-2) -- NO universe statement exists; gap recorded
+
+*** The gap
+
+*No universe or target-population statement was found for this wave in any
+local or catalog source.*  This is recorded as a gap, not filled by
+inference.  Searched, with results:
+
+| Location searched                                            | Result                                            |
+|--------------------------------------------------------------+---------------------------------------------------|
+| =Senegal/2021-22/Documentation/=                             | contains only =SOURCE.org=; no DDI PDF, no report |
+| WB catalog 6278 JSON (=api/catalog/6278?id_format=id=)       | =study_info= has no =universe= key at all         |
+| WB catalog 6278 DDI XML export (=/metadata/export/6278/ddi=) | no =<universe>= element (0 matches)               |
+| WB catalog 6278 study-description web page                   | no Universe heading under Coverage                |
+| Basic Information Document, English (=download/100388=)      | no universe / target-population statement         |
+| Basic Information Document, French (=download/100389=)       | no =champ=, =population cible=, =ménages collectifs=, =caserne=, =prison=, =internat= |
+| Household questionnaires, waves 1 and 2 (=download/100386=, =/100387=) | no universe statement                    |
+
+The method is known-good: the same =<universe>= grep against the 4297 export
+*does* return the 2018-19 sentence, so the absence at 6278 is a real absence
+and not a failed lookup.  (Independently re-verified against the live catalog
+while drafting this section.)
+
+*Do not silently inherit the 2018-19 universe for 2021-22.*  It is a
+defensible inheritance -- the 2021-22 design explicitly builds on the
+2018/19 frame (quoted below) -- but no document says so, and writing it in
+as this wave's universe would manufacture a claim.  Left open for the
+maintainer.
+
+The closest statements that exist, quoted verbatim and *not* universe
+statements:
+
+- WB catalog 6278, =study_info.geog_coverage= :: "National coverage"
+- WB catalog 6278, =series_statement.series_info= :: "The Senegal EHCVM
+  2021/22 is the second edition of a nationally representative household
+  survey conducted within the West Africa Economic Monetary Union (WAEMU)
+  Household Survey harmonization Project (P153702) ... The survey covers all
+  regions and includes approximately 7,100 households."
+- WB catalog 6278, =study_info.abstract= :: "The EHCVM is a nationally
+  representative survey of 7,100 households, which are also representative
+  of the geopolitical zones (at both the urban and rural level)."
+
+Note that the statement lives *only in WB catalog metadata plus two
+downloadable BIDs* -- the repository holds no documentation file for this
+wave beyond =SOURCE.org=.  For this wave the record is therefore a moving
+target: if the World Bank re-issues the catalog entry, nothing in this
+repository preserves what it previously said.
+
+*** Exclusions: two enumeration areas were dropped, one for security
+
+This *is* documented, and it was not in the catalog metadata -- it is only in
+the Basic Information Document.
+
+Source :: Basic Information Document (French),
+=microdata.worldbank.org/index.php/catalog/6278/download/100389=, section
+"4. Échantillonnage / 4.1. Volet ménage et communautaire", under "Plan
+d'échantillonnage".  Verbatim (whitespace normalized from the justified-text
+PDF extraction; wording, punctuation and accents unaltered):
+
+#+begin_quote
+Deux DRs n’ont pas été couverts lors de cette deuxième édition : l’un -a été
+retiré- pour des raisons de sécurité et l’autre au motif de refus des
+populations. Pour ce dernier DR, seuls trois ménages sur douze ciblés ont
+été enquêtés en 2018/2019.
+#+end_quote
+
+Translation (not source text) :: "Two DRs [=districts de recensement=,
+enumeration areas] were not covered in this second edition: one was
+withdrawn for security reasons and the other because of refusal by the
+population. For the latter DR, only three of the twelve targeted households
+had been surveyed in 2018/2019."
+
+The hyphens around "-a été retiré-" are as extracted from the PDF and are
+reproduced rather than silently cleaned.
+
+*** WARNING: the English BID mistranslates the unit of that exclusion
+
+Source :: Basic Information Document (English),
+=catalog/6278/download/100388=, same section.  Verbatim:
+
+#+begin_quote
+Two administrative regions (DRs) were not covered in this second edition:
+one was excluded due to security reasons, and the other due to refusal from
+the population. For this latter DR, only three out of the twelve targeted
+households were surveyed in 2018/2019.
+#+end_quote
+
+"DR" is =district de recensement= -- an *enumeration area*, the primary
+sampling unit.  The French BID uses "DR" interchangeably with "grappe"
+("les grappes ou districts de recensement (unités primaires de sondage)"),
+and the twelve-households-per-DR figure is the per-EA target, which settles
+it.  The English BID's "administrative regions" is wrong.  A reader working
+from the English document would conclude that two of Senegal's fourteen
+*regions* were dropped in 2021-22.  They were not: two EAs were.  Flagged
+explicitly because the error is in an official document and is
+consequential.
+
+*** Sub-samples: panel households plus a top-up, and no fresh national draw
+
+Source :: BID French, 4.1, verbatim:
+
+#+begin_quote
+L’édition 2 est une enquête de panel par grappes et le plan d’échantillonnage
+s’appuie sur celui de l’enquête de 2018/2019.
+#+end_quote
+
+#+begin_quote
+La base de sondage de l’enquête de 2018/2019 est le Recensement général de la
+Population et de l’Habitat, de l’Agriculture et de l’Elevage (RGPHAE) de
+2013. En 2021/2022, il a été procédé à un dénombrement dans les mêmes
+grappes.
+#+end_quote
+
+#+begin_quote
+En 2021/2022, la stratégie a consisté à revisiter les mêmes grappes. Il
+s’agit, en priorité pour chaque grappe, d’enquêter les -12- ménages de
+2018/2019 s’ils sont retrouvés (après la phase de dénombrement). Par la
+suite, il est question de compléter l’échantillon à 12 ménages dans les
+grappes où moins de 12 ménages ont été retrouvés pendant la phase de
+dénombrement (soit parce qu’il y a eu moins de 12 ménages dans la base de
+données finale de 2018/2019, soit parce qu’une partie des ménages n’est pas
+retrouvée généralement pour déménagement).
+#+end_quote
+
+Translation of the third quotation (not source text) :: "In 2021/2022 the
+strategy consisted of revisiting the same clusters.  The priority for each
+cluster is to survey the 12 households from 2018/2019 if they are found
+again (after the enumeration phase).  Thereafter the aim is to complete the
+sample back to 12 households in clusters where fewer than 12 households were
+found during the enumeration phase (either because there were fewer than 12
+households in the final 2018/2019 database, or because some households were
+not found, generally through having moved)."
+
+The English BID states the same, verbatim: "The second edition is a cluster
+panel survey, and the sampling plan builds upon that of the 2018/2019
+survey."
+
+So *this library wave contains two distinct sub-populations in one table*:
+(a) 2018/19 panel households re-found in their original cluster, and (b)
+replacement households drawn to top each cluster back up to twelve.  The
+documents describe the mechanism but never report how many households fall
+in each group, and never state what population group (b) is meant to
+represent.
+
+Cross-reference, repository-internal :: =Senegal/_/panel_ids.py= (docstring)
+already records the corresponding split as observed in the source file --
+the 2021-22 cover sheet =s00_me_sen2021.dta= carries a =PanelHH= flag with
+values ="Menage Panel"= (6127 rows) and ="Nouveau Ménage"= (993 rows).  That
+is a *property of the data*, recorded there, and is noted here only because
+it is the empirical counterpart of the documented top-up mechanism.  It is
+not evidence about the declared universe, and the correspondence between the
+993 "Nouveau Ménage" and the documented top-up is not asserted by any
+document.
+
+Caveat for weight users :: no weighting statement exists in any source for
+this wave either (the WB catalog =weight= and =sampling_deviation= fields are
+both empty).  Meanwhile =Senegal/2021-22/_/data_info.yml= maps both =weight=
+and =panel_weight= to the same source column =poids=.  Given that the wave
+contains a replacement component, a longitudinal weight identical to the
+cross-sectional weight is a claim no document supports.  Recorded as an open
+caveat; not resolved here, and not a licence to change the config without
+evidence.
+
+*** Sample design (context, not universe)
+
+WB catalog 6278, =method.data_collection.sampling_procedure=, verbatim:
+"The sampling base for the 2018/2019 survey was the General Census of
+Population and Housing, Agriculture, and Livestock (RGPHAE) of 2013. In
+2021/2022, a enumeration was conducted in the same clusters. ... The total
+survey sample size is 7,120 households - 3,922 from urban areas and 3,198
+from rural areas. ... In wave one, the survey teams interviewed 3,537
+households (1,946 in urban areas and 1,591 in rural areas). In wave two, the
+teams interviewed 3,583 households (1,976 in urban areas and 1,607 in rural
+areas)."
+
+Stratification, BID French 4.1, verbatim: "L’échantillon de l’enquête de
+2018/2019 a été tiré selon un plan de sondage stratifié à deux degrés. La
+strate est la combinaison région/milieu de résidence."  (Translation, not
+source text: "The 2018/2019 survey sample was drawn under a two-stage
+stratified design.  The stratum is the region/area-of-residence
+combination.")
+
+The two-=vague= seasonal split is repeated in this wave.  BID French,
+section 2.1, verbatim: "Les volets « ménage » et « communautaire » de
+l’enquête sont organisés en deux vagues. Chaque vague a porté sur la moitié
+de l’échantillon des grappes et la moitié de l’échantillon des ménages."
+Note this sentence says *half the clusters and half the households* -- which
+reads differently from the 2018-19 DDI's "randomly divided each enumeration
+area into two equal groups".  Both are quoted as printed; the two
+descriptions are not obviously consistent and are not reconciled here.
+Fieldwork dates, same section: wave 1 from 06 November 2021 to 05 January
+2022, wave 2 from 22 April to 22 July 2022.  (The catalog abstract gives
+slightly different ranges -- "November 2021 and January 2022" and "April
+2022 and September 2022" -- another unreconciled discrepancy.)
+
+** Summary table
+
+| Wave    | Universe declared?       | Where it lives                      | Geographic exclusion        | Institutional exclusion                                   | Within-wave sub-samples                                     |
+|---------+--------------------------+-------------------------------------+-----------------------------+-----------------------------------------------------------+-------------------------------------------------------------|
+| 2018-19 | yes (but NADA template)  | local DDI PDF *and* WB catalog 4297 | none; "all regions" stated  | prisons, hospitals, military barracks, school dormitories | two seasonal =vagues=, EA split in half                     |
+| 2021-22 | *no -- gap*              | n/a (no doc in repo beyond SOURCE.org) | 2 EAs dropped: 1 security, 1 refusal | none stated for this wave                        | panel re-visits + top-up replacements; two seasonal =vagues= |
+
 * plot_features (GH #167)
 
 Lasting parcel-level characteristics from the EHCVM agriculture module

--- a/lsms_library/countries/Serbia and Montenegro/_/CONTENTS.org
+++ b/lsms_library/countries/Serbia and Montenegro/_/CONTENTS.org
@@ -1,0 +1,360 @@
+#+title: Contents
+
+* Sampling universe, exclusions and sub-samples
+
+Evidence gathered 2026-07-21 for GH #601.  Both waves are documented by a
+*single* report that is shipped in *both* wave directories:
+
+- =2002/Documentation/LSMS_Project_2002_2003_text.pdf=
+- =2003/Documentation/LSMS_Project_2002_2003_text.pdf=
+
+These are the same file (identical DVC sidecar md5 =4aa224781967e012b8f6a76c7ad4cbc6=),
+and the report speaks for both years at once ("both surveys of general
+population in 2002 and 2003").  So the 2002 and 2003 universe statements below
+are *one joint statement*, not a 2002 statement copied forward.
+
+Bibliographic note: the shipped edition is /LSMS Project 2002-2003: Life in
+Serbia through the Survey Data/ (SMMRI / Strategic Marketing, Belgrade, 2007),
+the English edition, itself a translation of a Serbian original that is *not* in
+this repository.  All quotations below are verbatim from the English edition as
+shipped.  Printed page numbers equal PDF page numbers in this file.
+
+Transcription note: the PDF is justified, so text extraction yields hyphenated
+line breaks and runs of multiple spaces (=permanently  resident  population=,
+=Popu-\nlation=).  Hyphenated words have been rejoined and runs of spaces
+collapsed to one.  No word, punctuation mark or spelling has been altered; the
+same passage appears verbatim in the World Bank catalog's
+=method.data_collection.sampling_procedure=, which confirms the rejoining.
+
+*Not boilerplate.*  This universe statement is a statistical-agency /
+survey-firm methodology text, not the World Bank NADA template sentence that
+recurs verbatim across ~15 waves elsewhere in the corpus.  It attests a claim
+about *these* surveys.
+
+** Summary
+
+| Wave | Sample                        | Declared universe                                              | Confidence | Statement lives in           |
+|------+-------------------------------+----------------------------------------------------------------+------------+------------------------------|
+| 2002 | General population LSMS       | All permanent residents of Serbia, without Kosovo and Metohija | high       | repo PDF (+ WB catalog)      |
+| 2002 | Family Income Support (MOP)   | All current MOP recipients on the territory of Serbia          | high       | repo PDF (+ WB catalog)      |
+| 2003 | General population LSMS       | Same frame as 2002; realised as a *panel* subsample of 2002    | high       | repo PDF (+ WB catalog)      |
+| 2003 | Roma settlement survey        | Roma in settlements >=7% Roma per the 2002 Census, NOT all Roma | high       | repo PDF (+ WB catalog)      |
+
+** 2002 -- declared universe
+
+WB catalog 80, IDNO =SCG_2002_LSMS_v01_M=, "Living Standards Measurement Survey
+2002 (General Population, Wave 1 Panel) and Family Income Support Survey 2002".
+
+*General-population LSMS.*  Chapter "METHODOLOGY", section 1.3 "Basic
+Methodological Assumptions", subsection "Sample frame", p. 26:
+
+#+begin_quote
+Sample frame: Sample frame for both surveys of general population in 2002 and
+2003 consisted of all permanent residents of Serbia, without the population of
+Kosovo and Metohija, according to definition of permanently resident population
+contained in UN Recommendations for Population Censuses, which were applied in
+2002 Census of Population in the Republic of Serbia. Therefore, permanent
+residents were all persons living in the territory Serbia longer than one year,
+with the exception of diplomatic and consular staff.
+#+end_quote
+
+Section 1.1 "Objectives", p. 24:
+
+#+begin_quote
+LSMS represents multi-topical study of household living standard and is based on
+international experience in designing and conducting this type of research. The
+basic survey was carried out in 2002 on a representative sample of households in
+Serbia (without Kosovo and Metohija).
+#+end_quote
+
+Section 3.1 "Location and Time", "Survey location", p. 32:
+
+#+begin_quote
+The surveys were conducted on the whole territory of Serbia (without Kosovo and
+Metohija).
+#+end_quote
+
+(This last sentence is *also* the World Bank catalog's "Geographic coverage"
+field for catalog 80 and 81, verbatim -- but note it is held locally in this
+repo as well, so the record does not depend on the catalog.)
+
+*Family Income Support (MOP) survey* -- a separate frame, same page 26:
+
+#+begin_quote
+The sample frame for the survey of Family Income Support recipients included all
+current recipients of this program on the territory of Serbia based on the
+official list of recipients given by Ministry of Social Affairs.
+#+end_quote
+
+** 2002 -- exclusions
+
+- *Geographic*: "without the population of Kosovo and Metohija" (p. 26); "a
+  representative sample of households in Serbia (without Kosovo and Metohija)"
+  (p. 24); "the whole territory of Serbia (without Kosovo and Metohija)" (p. 32).
+- *Population*: "with the exception of diplomatic and consular staff" (p. 26).
+- *Duration-of-residence*: the frame is permanent residents only -- "all persons
+  living in the territory Serbia longer than one year" (p. 26).  Persons resident
+  under one year are outside the declared universe.
+- *Montenegro*: see "Country name vs. declared coverage" below.  No document
+  states an exclusion; it is an inference and is recorded as an observation, not
+  as a quotation.
+
+No statement was found excluding institutional / collective households, the
+homeless, or any region for security reasons.  Recorded as *not found*, not as
+absent -- see "What was searched".
+
+** 2002 -- sub-samples and oversamples
+
+*The 2002 wave directory holds TWO surveys with TWO different universes.*
+Anyone pooling this country must not average across them.
+
+| Files in =2002/Data/= | Survey                        | Universe                                     | Achieved   |
+|-----------------------+-------------------------------+----------------------------------------------+------------|
+| =2002 N *.dta=        | General-population LSMS       | Permanent residents of Serbia minus Kosovo   | 6,386 hh   |
+| =mop_*.dta=           | Family Income Support (MOP)   | Current MOP recipients per the Ministry list | 456 hh     |
+
+Section 1.1 "Objectives", p. 24, on why the MOP survey exists:
+
+#+begin_quote
+Along with these two comprehensive surveys, conducted on national and regional
+representative samples which were to give a picture of the general population,
+there were also two surveys with particular emphasis on vulnerable groups. In
+2002, it was the survey of living standard of Family Income Support recipients
+with an aim to validate this state supported program of social welfare.
+#+end_quote
+
+The MOP sample is *not* an oversample within the general-population frame: it is
+a separate frame drawn from an administrative list -- "the cases chosen randomly
+from the official list of recipients provided by Ministry of Social Affairs"
+(p. 30, section 2 "Designing the Sample for the Survey", subsection
+"Stratification").
+
+** 2003 -- declared universe
+
+WB catalog 81, IDNO =SCG_2003_LSMS_v01_M=, "Living Standards Measurement Survey
+2003 (General Population, Wave 2 Panel) and Roma Settlement Survey 2003".
+
+*General-population LSMS.*  The frame statement is the joint one quoted above
+under 2002 ("both surveys of general population in 2002 and 2003", p. 26).  The
+2003 sample is a panel of 2002 -- section 1.1 "Objectives", p. 24:
+
+#+begin_quote
+The survey was repeated in 2003 on a panel sample32.
+#+end_quote
+
+footnote 32, p. 24:
+
+#+begin_quote
+The households which participated in 2002 survey were interviewed
+#+end_quote
+
+*Roma settlement survey* -- a separate, explicitly imperfect frame, p. 26:
+
+#+begin_quote
+The definition of the Roma population from Roma settlements was faced with
+obstacles since precise data on the total number of Roma population in Serbia
+are not available. According to the last population Census from 2002 there were
+108,000 Roma citizens, but the data from the Census are thought to significantly
+underestimate the total number of the Roma population. However, since no other
+more precise data were available, this number was taken as the basis for
+estimate on Roma population from Roma settlements. According to the 2002 Census,
+settlements with at least 7% of the total population who declared itself as
+belonging to Roma nationality were selected. A total of 83% or 90,000
+self-declared Roma lived in the settlements that were defined in this way and
+this number was taken as the sample frame for Roma from Roma settlements.
+#+end_quote
+
+This is one of the corpus's clearest cases of documentation *qualifying* its own
+universe rather than asserting one cleanly: the frame is admitted to rest on a
+count "thought to significantly underestimate" the population it is meant to
+frame.
+
+** 2003 -- exclusions
+
+- *Geographic*: as 2002 -- "without the population of Kosovo and Metohija"
+  (p. 26); "the whole territory of Serbia (without Kosovo and Metohija)" (p. 32).
+- *Population*: as 2002 -- "with the exception of diplomatic and consular staff"
+  (p. 26).
+- *Roma sample, sub-population excluded by design.*  Section 1.1 "Objectives",
+  p. 25:
+
+  #+begin_quote
+  However, it is necessary to stress that the LSMS of the Roma population
+  comprised potentially most imperilled Roma, while the Roma integrated in the
+  main population were not included in this study.
+  #+end_quote
+
+  (British spelling "imperilled" is as printed.)  The Roma survey's universe is
+  therefore *not* "Roma in Serbia": it is Roma living in settlements that were at
+  least 7% Roma at the 2002 Census -- an estimated 83% of self-declared Roma.
+  Roma living outside such settlements are out of frame by construction.
+- *Montenegro*: see below.
+
+** 2003 -- sub-samples and oversamples
+
+*Again TWO surveys in one wave directory, with two universes.*
+
+| Files in =2003/Data/= | Survey                          | Universe                                        | Achieved   |
+|-----------------------+---------------------------------+-------------------------------------------------+------------|
+| =2003 N *.dta=        | General-population LSMS (panel) | 2002 frame, realised as a panel subsample       | 2,548 hh   |
+| =roma_*.dta=          | Roma settlement survey          | Roma in settlements >=7% Roma (2002 Census)     | 525 hh     |
+
+Panel construction, section 1.3, subsection "Planned sample", p. 26:
+
+#+begin_quote
+In 2003 the planned panel sample size was 3.000 households. In order to preserve
+the representative quality of the sample, we kept every other census block unit
+of the large sample realized in 2002. This way we kept the identical allocation
+by strata. In selected census block unit, the same households were interviewed
+as in the basic survey in 2002.
+#+end_quote
+
+So the 2003 general-population wave is *not* an independent draw from the 2003
+population: it is a half-of-the-PSUs panel follow-up of the 2002 sample, with a
+non-response correction applied (see below).
+
+** Country name vs. declared coverage: Montenegro
+
+The country directory is named =Serbia and Montenegro= -- the state union in
+existence at the time -- but *every* universe statement in the documentation
+covers *Serbia only*, minus Kosovo and Metohija:
+
+- "all permanent residents of Serbia" (p. 26)
+- "a representative sample of households in Serbia" (p. 24)
+- "the whole territory of Serbia" (p. 32)
+
+Montenegro is nowhere claimed as covered.  The single occurrence of the phrase
+"Serbia and Montenegro" in the methodology chapter is incidental and is *not* a
+coverage claim -- p. 24, on why the Roma survey was undertaken:
+
+#+begin_quote
+Since all present experiences indicated that this was one of the most vulnerable
+groups on the territory of Serbia and Montenegro, but with no ample research of
+poverty of Roma population made [...]
+#+end_quote
+
+*Neither the local documentation nor the World Bank catalog contains any
+statement that Montenegro was excluded.*  The exclusion is what the affirmative
+statements imply, not something a document says.  Recorded here as an
+observation, deliberately not dressed up as a quotation.
+
+** Universe vs. what the weights represent
+
+The report describes estimation separately from the frame, p. 32 ("System of
+estimation"):
+
+#+begin_quote
+The proposed sample plan was very complex from the aspect of estimation.
+Weighting had to be performed for each phase of selection. Special estimates
+were made for each stratum, and the total estimate was obtained by adding up the
+estimates on the level of strata.
+#+end_quote
+
+and, for 2003, p. 32:
+
+#+begin_quote
+In the repeated survey carried out in 2003 a correction was performed for
+non-response. The correction was performed by gender, age and number of
+household members.
+#+end_quote
+
+Consequences a user should know before weighting anything:
+
+- The general-population weights inflate to *Serbia minus Kosovo and Metohija*,
+  not to the state union the directory is named for.
+- The MOP (2002) and Roma (2003) samples are drawn from *different frames*.  They
+  carry no claim to represent the general population and must not be pooled with
+  it under general-population weights.
+- 2003 carries two weight columns and 2002 one.  Per =2003/_/data_info.yml=,
+  =weight: ponder= and =panel_weight: ponderl=; per =2002/_/data_info.yml=,
+  =weight: pobder= only.  This is consistent with the library convention that
+  =panel_weight= is longitudinal (see CLAUDE.md, "sample() and Cluster
+  Identity"), and with 2003 being a panel follow-up.
+
+** What the library wave currently reads
+
+Config-level observation (read from the YAML, *not* inferred from the =.dta=
+contents): the wave configs =2002/_/data_info.yml= and =2003/_/data_info.yml=
+declare sources only among the general-population files -- =2002 1
+demography.dta= / =2002 incomeconsumption.dta= and the 2003 equivalents.  No
+=mop_*.dta= or =roma_*.dta= file is referenced by any declared table.
+
+So the =.dta= files for both sub-population surveys are present in =Data/= and
+tracked by DVC, but the library's =2002= and =2003= waves currently surface the
+*general-population* sample only.  That is a coverage fact, not a defect claim;
+it is recorded so a reader does not assume the wave pools the sub-samples.  Any
+future work that wires in =mop_*= or =roma_*= must handle the distinct universes
+documented above.
+
+** Design detail (context; NOT the universe)
+
+Recorded so it is not mistaken for a universe statement.
+
+- Two-stage stratified design.  PSU = enumeration districts (census block units)
+  selected PPS to number of households; SSU = households.
+- Six territorial strata, p. 30 ("Stratification"): "Vojvodina, Belgrade,
+  Western Serbia, Central Serbia (Šumadija and Pomoravlje), Eastern Serbia and
+  South-east Serbia", each
+  further stratified into urban and rural enumeration districts.  (The caron in
+  "Šumadija" is as printed; the rest of this file is ASCII.)  Urban/rural is a
+  *stratification* dimension, not an exclusion -- both are in scope.
+- 2002: 6,500 planned; 7,491 contacted; 6,386 households interviewed in 621
+  census rounds; response rate 85.2%, or 91.1% excluding those not at home
+  (p. 31).
+- 2003: 3,000 planned; 3,119 selected; 2,548 realised; response rate 81.7%, or
+  91.5% excluding those not at home (p. 31).
+- MOP 2002 and Roma 2003: 500 households planned each; 456 and 525 achieved.
+- Roma sample design, p. 30 ("Stratification"): two-stage stratified, PSU =
+  "settlements where Roma population was represented in the percentage over 7%",
+  SSU = Roma households,
+  three territorial strata "Vojvodina, Beograd and Central Serbia".
+
+** Where the statement lives, and what was searched
+
+*Held in this repository.*  Both waves' statements come from a PDF tracked in
+the repo's own =Documentation/= directory -- this country is *not* one of the
+41 waves whose only universe evidence is World Bank catalog metadata.  The
+catalog corroborates but is not the sole source.
+
+The World Bank DDI records for catalog 80 and 81 have *no* field labelled
+=universe= (grep for "universe" in the exported JSON returns zero hits).  The
+sample-frame paragraph reproduced above appears verbatim (modulo whitespace) in
+=method.data_collection.sampling_procedure= for both, and the "whole territory of
+Serbia (without Kosovo and Metohija)" sentence is the =geog_coverage= field.
+
+Searched for 2002 -- =2002/Documentation/=: =SOURCE.org= (-> DOI
+=10.48529/kb2h-4476=), =LICENSE.org=, =LSMS_Project_2002_2003_text.pdf=,
+=LSMS_Project_2002_2003_annex.pdf=, =Poverty_Results_SerbianLSMS(PHHS).pdf=,
+=Serbhhq02e.pdf=.  All PDFs fetched via =data_access.get_data_file()=, text
+extracted with pdfminer, then grepped for "universe", "target population",
+"sample frame", "permanent resident", "covers all", "Kosovo", "representative".
+The annex PDF is tables only (no methodology text, zero hits).
+=Poverty_Results_SerbianLSMS(PHHS).pdf= is a poverty-measurement note (zero
+hits).  =Serbhhq02e.pdf= is the household questionnaire; "Kosovo and Metohija"
+appears there only as a region-code entry on the cover page, with no universe
+statement.  The WB catalog API (=metadata/export/80/json=) was also queried.
+
+Searched for 2003 -- =2003/Documentation/=: =SOURCE.org= (-> DOI
+=10.48529/h5ve-n970=), =LICENSE.org=, =LSMS_Project_2002_2003_text.pdf=,
+=serb03hhqe.pdf=.  Same extraction and grep terms.  =serb03hhqe.pdf= is the 2003
+household questionnaire; again "Kosovo and Metohija" only as a cover-page region
+code.  The WB catalog API (=metadata/export/81/json=) was also queried.
+
+*Gaps, recorded as gaps:*
+
+- No statement was found, in any searched document, about institutional or
+  collective households, military barracks, the homeless, or any security-driven
+  carve-out.  This is "not found after the search described above", *not* "the
+  survey covered them" and *not* "the survey excluded them".
+- No statement was found, in any searched document, addressing Montenegro's
+  coverage either way.
+- The Serbian-language original of the methodology report is not in this
+  repository, so the English quotations above cannot be checked against the
+  source language here.
+
+Compare: the separate =Serbia= country (2007, catalog 2291) *does* state the
+institutional/homeless exclusion explicitly ("The sampling frame also excludes
+the population living in group quarters, institutions and temporary housing
+units, as well as the homeless population").  That the 2002-2003 documentation
+does not say so is a silence in this documentation, and must not be filled in
+from the 2007 wave of a different country entry.

--- a/lsms_library/countries/Serbia/_/CONTENTS.org
+++ b/lsms_library/countries/Serbia/_/CONTENTS.org
@@ -22,6 +22,272 @@ exists declaring =household_roster= with the standard kinship index
 =household_roster= via the CLI.  However, the full Makefile-based build
 is broken.
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence for what the Serbia LSMS *claims* to represent, kept separate from
+what the data happen to look like.  Serbia has a single wave in this library
+(=Country('Serbia').waves == ['2007']).  Everything quoted below comes from
+documents that are *in this repository* under
+=lsms_library/countries/Serbia/2007/Documentation/= (DVC-tracked); nothing here
+depends on World Bank catalog metadata alone.
+
+Related but distinct: the =Serbia and Montenegro= country directory (waves 2002
+and 2003) is a different survey series with its own universe statements, its own
+Family Income Support (MOP) and Roma Settlement sub-samples, and its own entry
+in the population-statement record.  Do not carry statements across.
+
+** 2007 -- the declared universe (verbatim)
+
+Source: =2007/Documentation/ddi-documentation-english_microdata-2291.pdf=,
+p. 3, section "Sampling" > "Sampling Procedure", first two paragraphs.
+Language: English (original; no translation needed).
+
+#+begin_quote
+The population for LSMS consists of Republic of Serbia residents, excluding
+Kosovo and Metohija . The sampling frame for the LSMS was based on the
+Enumeration District (ED) delineated for the 2002 Serbia Census, excluding those
+with less than 20 households. It is estimated that the households in the
+excluded EDs only represent about 1 percent of the population of Serbia.
+
+The sampling frame also excludes the population living in group quarters,
+institutions and temporary housing units, as well as the homeless population:
+these groups also represent less than 1 percent of the population, so the
+sampling frame should cover at least 98 percent of the Serbian population.
+#+end_quote
+
+(The stray space in "Metohija ." is in the source PDF's text layer and is
+reproduced as extracted.)
+
+*** Corroborated by a second, independent in-repo document
+
+The same statement appears in the English study report
+=2007/Documentation/studijaE.pdf= ("Living Standards Measurement Study --
+Serbia 2002-2007"), section 12.3 "Sampling" > 12.3.1 "Sample description",
+*printed p. 167* (PDF page 169):
+
+#+begin_quote
+The population for LSMS consists of Republic of Serbia residents, excluding
+Kosovo and Metohija.  The sampling frame for the LSMS was based on the
+Enumeration Districts (ED) delineated for the 2002 Serbia Census, excluding
+those with less than 20 households.  It is estimated that the households in the
+excluded EDs only represent about 1 percent of the population of Serbia.
+
+The sampling frame also excludes the population living in group quarters,
+institutions and temporary housing units, as well as the homeless population;
+these groups also represent less than 1 percent of the population, so the
+sampling frame should cover at least 98 percent of the Serbian population.
+#+end_quote
+
+Two trivial differences from the DDI text, reproduced as each source has them:
+the DDI writes "Enumeration District (ED)" (singular) and a colon before "these
+groups"; the report writes "Enumeration Districts (ED)" and a semicolon.
+
+- Citation correction :: the upstream population-statement record (GH #601,
+  =slurm_logs/POPULATION_STATEMENTS_2026-07-21.org=) cites this passage as
+  "p. 166" of =studijaE.pdf=.  The printed page is *167* (the report's own table
+  of contents lists "12.3.1. Sample description ... 167"; printed p. 166 ends
+  section 12.2).  The DDI citation ("p. 3") is correct as recorded.
+
+** 2007 -- exclusions
+
+Four exclusions are declared, three of them frame exclusions and one
+geographic.  Verbatim fragments, all from the passage quoted above:
+
+| Kind                | Verbatim fragment                                                                                 | Declared size            |
+|---------------------+---------------------------------------------------------------------------------------------------+--------------------------|
+| Geographic          | "excluding Kosovo and Metohija"                                                                     | not quantified           |
+| Frame (small EDs)   | "excluding those with less than 20 households"                                                      | "about 1 percent"        |
+| Population (collective / institutional / temporary) | "the population living in group quarters, institutions and temporary housing units" | "less than 1 percent" (jointly with the homeless) |
+| Population (homeless) | "as well as the homeless population"                                                              | (as above)               |
+
+The documents' own summary of the net effect: "the sampling frame should cover
+at least 98 percent of the Serbian population" (both sources, as quoted), and,
+in the weighting chapter, "It is estimated that the LSMS sampling frame excludes
+less than 2 percent of the population of Serbia" (=studijaE.pdf=, section 12.4.4
+"RSO population projection of 2006", printed p. 171).
+
+*NOT an exclusion*: urban/rural.  Settlement type is a *stratification*
+dimension, not a carve-out -- "Type of settlement (urban and other)"
+(DDI p. 3; =studijaE.pdf= section 12.3.1, printed p. 167).  The six regional
+strata are likewise stratification, not restriction: "Region in 6 strata
+(Vojvodina, Belgrade, West Serbia, Sumadija and Pomoravlj e, East Serbia and
+South East Serbia)" (DDI p. 3; the odd spacing "Pomoravlj e" is a PDF text-layer
+artefact, rendered "Pomoravlje" in the study report).
+
+** 2007 -- sub-samples and specialised samples INSIDE the wave
+
+Two things sit inside this single wave that a user pooling Serbia with other
+countries needs to know about before averaging anything.
+
+*** A parallel UNHCR survey of internally displaced people (2,000 HH, of which 250 Roma)
+
+Source: =2007/Documentation/studijaE.pdf=, section 12.1 "Fieldwork", printed
+p. 164 (PDF page 166), under the heading "1. United Nations High Commission for
+Refugees: Survey of IDPs":
+
+#+begin_quote
+The IDP survey took place at the same time as the national sample.  The sample
+size was 2 000 households (of which 250 are Roma households) and the sample
+frame was the UNHCR database of IDPs.  The questionnaire was identical for both
+samples. A migration module, with some items specific to the IDP population (in
+both samples) was added to the LSMS questionnaire.
+#+end_quote
+
+Corroboration in the shipped instrument: the household questionnaire
+=2007/Documentation/srb07hhqe.pdf=, PDF page 7, carries a module headed
+"HOUSEHOLD OF DISPLACED PEOPLE FROM KOSOVO-METOHIA \\ (Answers relate to whole
+household)" with items MP1-MP20+.  This is the =mp*= block already noted in the
+"shocks -- not available" section of this file (=mp20= sits in this module, not
+in a shocks roster); the documentation above is what that module is.
+
+Two points of care:
+
+- The IDP sample has a *different frame* -- "the UNHCR database of IDPs" -- and
+  therefore a different universe from the national sample quoted above.  It is
+  not a stratum of the national sample and it is not an oversample of it.
+- Whether the IDP sample is present in the *released* files is *not stated
+  anywhere in the documentation held here*.  What the documents do state is that
+  the released household file has 5,557 cases (DDI, =household= file record;
+  =studijaE.pdf= section 12.2 "Data production", printed p. 166 file table), and
+  that 5,557 is the number of *interviewed national-sample* households
+  (=studijaE.pdf= Table 12.3 "Distribution of 2007 LSMS Sample households by
+  interview status": Interviewed 5 557 of 7 140 issued).  That is consistent
+  with the release being the national sample only, but no document in this repo
+  says so.  *Recorded as an open question, not as a finding.*  Resolving it
+  requires either a statement from the producer or a separate catalog entry for
+  the IDP survey; neither has been located.
+
+*** A half-sample module: Water and Sanitation Services (WSS), 2,744 HH
+
+Source: =2007/Documentation/studijaE.pdf=, section 12.1 "Fieldwork", printed
+p. 164, under the heading "2. World Bank: Water and Sanitation Services Module
+(WSS)":
+
+#+begin_quote
+The WSS module was administered to half of the national sample (all serial
+numbers ending with an even number).  Therefore the sample size for this module
+is 2744 households.
+#+end_quote
+
+Corroboration in the shipped instrument: the water questionnaire
+=2007/Documentation/srb07water_e.pdf=, cover page (PDF page 1), states "Water
+and Sanitation completed for every EVEN numbered dwelling from the "List of
+chosen dwellings" for the National Sample".
+
+This is *design, not attrition*.  It is the documentary basis for the note
+already in =2007/_/data_info.yml= under =housing= ("Administered to a sub-sample
+(~2744 of 5557 HH; rest NaN)"), which until now recorded the count without a
+citation.  Consumers of =Country('Serbia').housing()= (columns =Water=,
+=Toilet=) are working with a designed half-sample; the missing half is missing
+by construction and must not be treated as item non-response.
+
+*** No oversample is documented
+
+No document in this repo describes an oversample, a booster sample, a refresh
+panel, or a panel link to earlier waves for LSMS 2007.  Searched: the full text
+of all five Documentation PDFs for =oversampl=, =over-sampl=, =booster=,
+=subsample=, =sub-sample=, =panel= (0 hits for each in the DDI; 0 hits for the
+oversample/booster terms in the study report).  The only within-wave
+specialisation documented is the WSS half-sample module, and the only separate
+sample is the UNHCR IDP survey -- both above.
+
+In particular, there is *no separate Roma settlement sample* documented for
+2007.  Roma appear in 2007 only as the "250 Roma households" inside the UNHCR
+IDP sample quoted above.  (Contrast the =Serbia and Montenegro= 2003 wave, which
+does carry a distinct Roma Settlement Survey -- a different country directory
+and a different universe.)
+
+** Universe vs. what the weights represent -- these come apart
+
+The declared frame excludes about 2 percent of the population (above), but the
+*shipped weights were deliberately grossed up to the whole projected national
+population*, including that excluded 2 percent.  From =studijaE.pdf=, section
+12.4.5 "Adjustment of 2007 LSMS Weights Based on Projected Population", printed
+p. 171:
+
+#+begin_quote
+In order to make the weighted estimate of the total population from the 2007
+LSMS data more consistent with the projected total population for Serbia based
+on the vital registration data and demographic analysis, the RSO decided to
+adjust the weights by a constant factor of 7 411 000/6 889 332, where the
+denominator of this ratio is the preliminary weighted total population from the
+LSMS data presented in Table 5.
+#+end_quote
+
+Before that adjustment, the design weights represented the *frame*, and the
+documentation is explicit that this is what makes the comparison legitimate --
+section 12.4.1 "Comparing number of households in LSMS 2007 and Census 2002",
+printed p. 170:
+
+#+begin_quote
+The number of households from the Census frame excludes the households in EDs
+with less than 20 households, so it should be directly comparable to weighted
+estimates from the LSMS.
+#+end_quote
+
+So: =sample().weight= (source =hhweight=; =popweight = hhweight*hhsize=, per the
+DDI's =household= variable list, V663-V664) sums to the RSO's *projected total
+population*, not to the population of the declared sampling frame.  The two
+differ by roughly the excluded 2 percent plus the survey's own ~7 percent
+shortfall against projection ("the 2007 LSMS weighted estimates of total
+population are 7.0 percent lower than the corresponding projections for 2006",
+section 12.4.4, printed p. 171).  Anyone using Serbia weights for a national
+total is using a calibrated-to-projection figure; anyone using them for
+composition is on the documentation's own recommended ground ("the relative
+distribution of the population by region, urban/rural and other characteristics
+will remain the same", section 12.4.5).
+
+The documentation also warns, in its own words, about non-response bias
+(section 12.4, printed p. 169): "the characteristics of the 19.4 percent of
+sample households that did not respond may be somewhat different from those of
+the responding sample households, resulting in a corresponding bias in the
+survey results."
+
+- Response-rate discrepancy, recorded as-is :: the DDI states "Response rate was
+  78%" (p. 3) and the study report's sample description repeats "The final
+  response rate was 78%" (printed p. 167), while the weighting chapter states
+  "Excluding the sample dwelling units in category (6), the unweighted unit
+  response rate for the 2007 LSMS is 80.6 percent" (printed p. 169) -- the
+  difference being whether the 246 empty/derelict dwellings are counted.  Both
+  figures are correct on their own definitions; neither is a typo.  Noted so a
+  future reader does not "fix" one of them.
+
+** Provenance of the statement, and boilerplate check
+
+- Held locally :: yes.  The universe statement is in two DVC-tracked files in
+  this repo (the DDI PDF and the study report).  This is *not* one of the waves
+  whose only universe statement lives in World Bank catalog metadata.
+- Not NADA boilerplate :: the statement is survey-specific (it names Kosovo and
+  Metohija, the 2002 Census ED frame, the 20-household ED threshold, and gives
+  quantified shares).  It is not the repeated WB NADA template sentence found in
+  other waves of this corpus.
+- No field labelled "Universe" :: the DDI PDF has *no* section or field called
+  "Universe" (0 hits for "universe" and 0 for "coverage" in its full extracted
+  text).  What is quoted above is the "Sampling Procedure" text.  The World Bank
+  catalog page for study 2291 likewise carries no "Universe" field; its Sampling
+  Procedure text matches the DDI.  So the library's universe record for Serbia
+  2007 rests on the sampling-procedure prose, not on a declared universe field.
+- Source registration :: =2007/Documentation/SOURCE.org= records
+  =#+CATALOG_ID: 2291=, =#+CATALOG_IDNO: SRB_2007_LSMS_v01_M=,
+  =#+PROVENANCE_SOURCE: worldbank=.
+
+** Gaps and what was searched
+
+- No universe statement is missing for this country: the single wave (2007) has
+  a high-confidence, locally held, doubly-sourced statement.
+- Searched, for this section: the full extracted text of all five in-repo
+  Documentation PDFs (=ddi-documentation-english_microdata-2291.pdf=,
+  =studijaE.pdf=, =studijaS.pdf=, =srb07hhqe.pdf=, =srb07water_e.pdf=) for
+  =universe=, =coverage=, =target population=, =sampling procedure=, =Kosovo=,
+  =Metohija=, =institution=, =collective=, =excluded=, =weight=, =Roma=, =IDP=,
+  =refugee=, =oversampl=, =booster=, =subsample=, =panel=; plus
+  =2007/Documentation/SOURCE.org= and the World Bank catalog entry 2291.
+- Not established (open) :: whether the 2,000-household UNHCR IDP sample is
+  included in the released microdata (see above).  Nothing in the repo's
+  documentation answers this, and it was deliberately not settled by inspecting
+  the =.dta= files -- what the survey *claims* and what the data *contain* are
+  different facts and are kept apart here.
+
 * Build status: BROKEN
 
 The build fails for two reasons:

--- a/lsms_library/countries/South Africa/_/CONTENTS.org
+++ b/lsms_library/countries/South Africa/_/CONTENTS.org
@@ -1,5 +1,218 @@
 #+title: Contents
 
+* Sampling universe, exclusions and sub-samples
+
+South Africa is a one-wave country: =Country('South Africa').waves == ['1993']=.
+Everything below therefore concerns the single 1993 wave.
+
+** 1993 (PSLSD / WB "Integrated Household Survey 1993")
+
+*** Where the statement lives
+
+- Nothing in this repository states a universe. :: The wave's local
+  =Documentation/= holds only =.gitignore=, =LICENSE.org= (WB Public Use File
+  terms), =SOURCE.org= (the catalog stub: DOI
+  =https://doi.org/10.48529/9567-t539=, =#+CATALOG_ID: 297=,
+  =#+CATALOG_IDNO: ZAF_1993_IHS_v01_M=) and =za94hh85_V2.pdf=, which is the
+  PSLSD *household questionnaire instrument*, not a basic-information
+  document.  The full extracted PDF text was keyword-scanned
+  (=universe=, =target population=, =institutional=, =excluded=, =hostel=,
+  =old age=, =represent=, =frame=, =scope=) and contains no universe or
+  coverage statement -- the only hits are a dwelling-type response option
+  ("Hostel") and an unrelated instruction line.  =_/CONTENTS.org=,
+  =_/data_scheme.yml=, =_/categorical_mapping.org= and =1993/_/data_info.yml=
+  likewise carry none.  *The universe statement below exists only in World
+  Bank catalog metadata, and is therefore a moving target rather than
+  something the library holds.*
+
+- And not even in *this wave's* catalog record. :: The record =SOURCE.org=
+  points at, =lsms= catalog 297 (=ZAF_1993_IHS_v01_M=), has *no* =<universe>=
+  element at all (verified 2026-07-21: =grep -ci universe= over its 823 KB
+  DDI XML export returns 0).  The quoted universe comes from the twin
+  =datafirst= record, catalog 902 (=ZAF_1993_PSLSD_v01_M=,
+  "Project for Statistics on Living Standards and Development 1993").  The
+  repo already treats these as the same survey --- see
+  =lsms_library/data_access.py= and =.claude/skills/add-wave/SKILL.md=
+  ("=datafirst= 902 (=ZAF_1993_PSLSD=) is the same 1993 South African survey"
+  as =lsms= 297).  Independent corroboration: the exclusion paragraph inside
+  902's =<universe>= is reproduced character-for-character as the closing
+  paragraph of 297's =<sampProc>= (down to a shared typo; see below).  Read
+  the universe as cross-record, not as record 297 speaking.
+
+*** The declared universe (verbatim)
+
+Source: WB Microdata Library DDI XML export for study 902,
+=codeBook/stdyDscr/stdyInfo/sumDscr/universe=
+(https://microdata.worldbank.org/index.php/metadata/export/902/ddi;
+landing page https://microdata.worldbank.org/index.php/catalog/902).
+Language: English.  Retrieved and verified 2026-07-21.
+
+#+begin_quote
+All Household members.
+
+Individuals in hospitals, old age homes, hotels and hostels of educational
+institutions were not included in the sample. Migrant labour hostels were
+included. In addition to those that turned up in the selected ESDs, a sample
+of three hostels was chosen from a national list provided by the Human
+Sciences Research Council and within each of these hostels a representative
+sample was drawn on a similar basis as described above for the households in
+ESDs.
+#+end_quote
+
+Supporting coverage statements, same catalog family:
+
+- =<geogCover>= (studies 297 and 902) :: "National coverage"
+- =<geogUnit>= (study 902) :: "Enumeration Area"
+- =<anlyUnit>= (297 and 902) :: "- Households / - Individuals / - Community"
+- =<abstract>= (297 and 902), opening sentences :: "The Project for
+  Statistics on Living standards and Development was a coutrywide World Bank
+  Living Standards Measurement Survey. It covered approximately 9000
+  households, drawn from a representative sample of South African
+  households." (sic: "coutrywide")
+
+*Caveat on strength.* The inclusion side of this universe is thin.  "All
+Household members." is a three-word line of the kind NADA records use
+generically; it is not a statistical office's sentence about *this* survey.
+Neither record anywhere says "all private households in ...".  The strongest
+inclusion claims available are the three quoted above.  If a crisper
+inclusion sentence is wanted, it does not exist in the local documentation or
+in either catalog record; the SALDRU final report (SALDRU, /South Africans
+Rich and Poor: Baseline Household Statistics/, 1994) is a plausible further
+source, is *not* held in this repo, and has not been consulted.  The
+paragraph that follows that opening line, by contrast, is clearly
+survey-specific SALDRU text (it recurs verbatim in 297's =<sampProc>=) and
+carries real information --- but all of it is about *exclusions*.
+
+*** Exclusions
+
+**** By design, in the universe statement
+
+Verbatim, from 902 =<universe>= and, character-identically, the closing
+paragraph of 297 =<sampProc>=
+(=codeBook/stdyDscr/method/dataColl/sampProc=):
+
+#+begin_quote
+Individuals in hospitals, old age homes, hotels and hostels of educational
+institutions were not included in the sample. Migrant labour hostels were
+included.
+#+end_quote
+
+So: an institutional-population exclusion (hospitals, old age homes,
+hotels, student hostels) with an *explicit carve-in* for migrant labour
+hostels --- unusually important in a 1993 South African survey, since migrant
+hostel residents are a large and distinctive population.  No geographic
+region is excluded: fieldwork organisations are named in =<collSitu>= (297)
+for the former homelands as well (Transkei, Bophuthatswana, Venda, Ciskei,
+Qwa-Qwa, Lebowa, Gazankulu, KwaNdebele, KwaZulu, KaNgwane).
+
+Textual note for anyone diffing the two records: 297's =<sampProc>= copy
+reads "...on a similar basis as described abovefor the households in ESDs."
+("abovefor" run together); 902's =<universe>= copy has the space.  Otherwise
+the paragraphs are identical.
+
+**** Not by design: fieldwork failure and a post-collection deletion
+
+These are *not* universe exclusions but they remove real coverage, and a
+pooled analysis should know about them.
+
+=<weight>= (study 297), verbatim:
+
+#+begin_quote
+A number of factors intervened, however, which made it essential to use
+weights after all. Amongst these was violence, which prevented survey teams
+from conducting interviews in two clusters on the East Rand; failure to
+continue interviewing in a cluster until the required take had been
+interviewed; and systematic under-representation of whites in the sample.
+#+end_quote
+
+=<dataAppr>= (studies 297 and 902), verbatim:
+
+#+begin_quote
+The data collected in clusters 217 and 218 should be viewed as highly
+unreliable and therefore removed from the data set. The data currently
+available on the web site has been revised to remove the data from these
+clusters. Researchers who have downloaded the data in the past should revise
+their data sets. For information on the data in those clusters, contact
+SALDRU http://www.saldru.uct.ac.za/.
+#+end_quote
+
+Two clusters were therefore deleted from the distributed microdata after
+collection.  (The documentation does not say whether clusters 217/218 are the
+same as the two East Rand clusters lost to violence; do not assume they are.)
+
+*** Oversamples and sub-populations
+
+- The documentation explicitly *denies* an oversample. :: =<sampProc>=
+  (297), verbatim: "The advantage of using such a design is that it provides
+  a representative sample that need not be based on accurate census
+  population distribution.in the case of South Africa, the sample will
+  automatically include many poor people, without the need to go beyond this
+  and oversample the poor." (sic: missing space after "distribution.")  The
+  design is described as "a two-stage self-weightingdesign" (sic) --- i.e.
+  self-weighting by intent, with no booster or poverty oversample.
+
+- One genuine supplementary sub-sample: hostels. :: Per the =<universe>= text
+  quoted above, three migrant labour hostels were drawn *from a national HSRC
+  list*, i.e. from outside the ESD frame, in addition to any hostels falling
+  into selected ESDs.  This is the one sub-population in this wave that was
+  sampled by a separate mechanism, and anyone pooling household-level
+  statistics should be aware that hostel households enter through two
+  different routes.
+
+- No sub-panel, no refresh, no module subsample. :: One cross-section, one
+  library wave.  Nothing in either record describes a rotating panel, a
+  split-questionnaire subsample, or a second sample read into this wave.
+
+*** Universe versus what the weights represent
+
+The two come apart here, and the documentation says so plainly.  The sample
+was *designed* to be self-weighting (see the =<sampProc>= quote above), so in
+principle the unweighted sample would represent the universe; in practice it
+does not.  From =<weight>= (297), verbatim:
+
+#+begin_quote
+A self-weighting sample design should in principle eliminate the need for
+weighting.
+#+end_quote
+
+and, on the remedy actually applied:
+
+#+begin_quote
+Accordingly it was decided to use weights as far as possible at the level of
+the old provincial/homeland boundaries and race.
+#+end_quote
+
+So the delivered weights are post-hoc corrections benchmarked on *race x old
+provincial/homeland boundary* cells, repairing systematic white
+under-representation and shortfalls in field take --- not design weights.
+Consequence for users: the weighted estimator targets the racial/geographic
+distribution of the apartheid-era administrative geography, and the frame
+behind all of it is the *1991 census* population of 38,120,853 (=<sampProc>=)
+inflated to 1993 by an assumed growth rate that "was subsequently discovered"
+to be "slightly over-estimated" (=<sampProc>=, verbatim).
+
+Minor internal inconsistency worth flagging rather than resolving: =<sampProc>=
+computes the sampling interval by dividing the 1991 census population by "the
+300 clusters to be selected", while =<weight>= refers to "The sample of 360
+clusters of 25 households each".  Both are quoted from the same DDI record;
+the repository takes no view on which is right.
+
+*** Gaps
+
+- No universe statement of any kind exists in this repository for 1993. ::
+  Searched: all of =1993/Documentation/= (including the full extracted text
+  of =za94hh85_V2.pdf=, ~103k characters, keyword-scanned as listed above),
+  =1993/_/data_info.yml=, =_/CONTENTS.org=, =_/data_scheme.yml=,
+  =_/categorical_mapping.org=.
+- The wave's own catalog record (=lsms= 297) has no =<universe>= element. ::
+  The statement recorded here is borrowed from the =datafirst= twin record
+  (902) on the corroboration described above.  If that borrowing is ever
+  judged unacceptable, this country has *no* universe statement at all.
+- Not consulted. :: The SALDRU 1994 baseline report; any PSLSD sampling
+  appendix beyond the DDI.
+- Nothing here was inferred from the microdata. :: No =.dta= file was opened
+  in constructing this section.
+
 * shocks — not available (2026-06-07, verified)
 
 =shocks= (a household adverse-events-and-coping roster, index =(t, i, Shock)=)

--- a/lsms_library/countries/Tajikistan/_/CONTENTS.org
+++ b/lsms_library/countries/Tajikistan/_/CONTENTS.org
@@ -1,5 +1,406 @@
 #+title: Contents
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence for what each TLSS wave *claims* to represent, transcribed verbatim
+from survey documentation with citations.  Gathered under GH #601; this section
+records evidence only and proposes no schema (that is GH #603).
+
+Two standing cautions before the per-wave record:
+
+- Nothing here is inferred from the =.dta= files.  Every claim below is a
+  quotation from a document, or an explicit statement that no document was
+  found.  What the survey *claims* to represent and what the shipped data
+  actually contain are two different facts and are deliberately kept apart.
+- *No Tajikistan wave carries the World Bank NADA boilerplate universe
+  sentence* ("The survey covered all de jure households excluding prisons,
+  hospitals, military barracks, and school dormitories", which appears verbatim
+  in 15 waves elsewhere in the corpus).  In fact *no TLSS wave has a field
+  labelled "Universe" at all* -- not in the local documentation, not on the WB
+  catalog page (grep for "Universe" returns zero hits on all four study pages),
+  and not in the NADA API metadata (no =universe= key).  What is quoted below
+  as the universe statement is in every case the survey's *sample-design /
+  representativeness* statement, which is the strongest thing that exists.
+  That is a weaker kind of claim: it says what the sample was designed to
+  estimate, not who was eligible to be sampled.
+
+** Summary
+
+| wave | statement lives                       | universe as claimed                                 | oversample / sub-sample                        |
+|------+---------------------------------------+-----------------------------------------------------+------------------------------------------------|
+| 1999 | WB catalog only (not in repo)         | national; strata = oblast x urban/rural             | YES -- 15 extra PSU, 400 HH, Dangara + Varzob  |
+| 2003 | WB catalog only (not in repo)         | national; representative at 4 regions + urban/rural | YES -- Dushanbe +40%, GBAO rural +300%, GBAO urban +600% |
+| 2007 | in repo (DDI PDF) + WB catalog        | national, urban/rural, 5 oblasts                    | YES -- 7 rayons in Khatlon (for a later crop survey) |
+| 2009 | WB catalog only (not in repo)         | panel sub-sample of TLSS07; claims same representativeness | the whole wave is a 1,500-HH sub-sample of TLSS07 |
+
+Three of the four waves' universe statements exist *only in World Bank catalog
+metadata and catalog-attached technical documents that are not present in this
+repository*.  Only 2007 has its statement in a file the library ships
+(=2007/Documentation/ddi-documentation-english_microdata-72.pdf=).  For 1999,
+2003 and 2009 the =Documentation/= directories contain only =SOURCE.org= (a
+bare DOI link), =LICENSE.org=, and field instruments (questionnaires), none of
+which state a universe.  For those three waves the record is a moving target
+held by NADA, not something the library holds.
+
+** TLSS 1999
+
+*** Declared universe
+
+Source: "BASIC INFORMATION / LIVING STANDARDS SURVEY IN THE REPUBLIC OF
+TAJIKISTAN (TLSS) / JUNE 2000", technical document attached to WB Microdata
+catalog entry 279 (https://microdata.worldbank.org/catalog/279/download/11687).
+*Not present in* =lsms_library/countries/Tajikistan/1999/Documentation/=.
+Locator: section "Field work" -> "Sampling", document page 3 (PDF page 5).
+Language: English.
+
+#+begin_quote
+The TLSS sample was designed to represent the population of the country as a whole as well as the strata. The sample was stratified by oblast and by urban and rural areas.
+#+end_quote
+
+Corroborating, verbatim, same document, Introduction (document p. 2):
+
+#+begin_quote
+The TLSS was carried out between May-June of 1999. A total of 2,000 households containing 14,142 individuals were interviewed. Households were randomly selected over 125 population points, which were stratified across urban and rural areas within oblasts, to ensure a nationally representative sample.
+#+end_quote
+
+The identical first quote is reproduced word for word in the catalog's
+=study_desc.study_info.geog_coverage= ("National coverage.\nThe TLSS sample was
+designed to represent...") and =method.data_collection.sampling_procedure=.
+
+Unit of analysis, same document, section "Definitions" (document p. 4):
+
+#+begin_quote
+Households are defined as all people who normally live, eat their meals together and share expenses in a dwelling (see Instructions For Interviewers in Appendix A).
+#+end_quote
+
+*** Oversample -- Dangara and Varzob (400 households, designed to be excluded)
+
+This is the item a reader pooling Tajikistan must know about before averaging
+anything.  Same document, footnote 1 on document page 3 (PDF page 5),
+verbatim:
+
+#+begin_quote
+In addition to the main sample, the TLSS also included a secondary sample of 15 extra PSU (containing 400 households) in Dangara and  Varzob.  Data in the  oversampled areas were collected for the sole purpose of providing baseline data for the World Bank Health Project in these areas. The sampling for these additional units was carried out separately after the main sampling procedure in order to allow for their exclusion in nationally representative analysis.
+#+end_quote
+
+(The double spaces are as printed.)
+
+The oversample PSU are enumerated in the same document, *Appendix C "List of
+population points"*, document page 31 (PDF page 33).  The two block headers
+read verbatim:
+
+#+begin_quote
+Oversample
+RSS: Varzob                                (urban: 14 rural: 43-48)
+#+end_quote
+
+#+begin_quote
+Khatlon :Dangara                           (urban: 34-36 rural:121-128)
+#+end_quote
+
+with per-block totals printed as =Total: 6= (150 households) for Varzob and
+=Total: 9= (250 households) for Dangara, and a final row =TOTAL for Oversample
+15 400=; the preceding row is =TOTAL for Nat. Rep.: 125 2000=.  The same
+document, section on file structure (document p. 6), states verbatim:
+
+#+begin_quote
+Each population point is allocated a unique identifier, called a  pop_pt, ranging from 1-140, since the survey covered 140 population points.
+#+end_quote
+
+125 + 15 = 140, consistent.
+
+*Caveat, and it is a real one (this is our arithmetic on the quoted strings,
+not a quotation).*  The printed code ranges do not reconcile with the printed
+settlement counts: "urban: 14 rural: 43-48" spans 7 codes against a printed
+=Total: 6=, and "urban: 34-36 rural:121-128" spans 11 codes against a printed
+=Total: 9=.  Anyone intending to drop the oversample by =pop_pt= must read
+Appendix C of the PDF directly rather than trusting the ranges as transcribed
+here.  The library exposes =pop_pt= as =v= in this wave
+(=1999/_/data_info.yml=, =sample.myvars.v: pop_pt=), so the exclusion is
+mechanically possible once the correct code list is established.
+
+Note also that the document reports 2,000 households interviewed (the
+nationally representative sample) while stating =hhid= runs 1-2400 -- i.e.
+2,000 + 400.  Whether the oversample households are present in the =.dta=
+files shipped here has *not* been checked, and deliberately so: that is a
+question about the data, not about the declared universe.  A user who needs a
+nationally representative 1999 estimate must check it.
+
+*** Universe vs. what the weights represent
+
+The 1999 documentation supplies *no weight variable*.  Same document, section
+"Weights", verbatim:
+
+#+begin_quote
+Since the sample is nationally representative there are no weighting variables.
+#+end_quote
+
+This sits uneasily with the oversample: the stated remedy for Dangara/Varzob is
+*exclusion*, not reweighting, and no weight exists that would absorb them.
+Consistently, =1999/_/data_info.yml= declares no =weight= for the =sample=
+table in this wave (=v= and =Rural= only), unlike 2003, 2007 and 2009.
+
+*** Coverage disturbance -- Karategin Valley / United Tajik Opposition
+
+Not framed by the source as a universe exclusion, but it is a documented
+departure from the drawn sample on security/permission grounds and belongs
+here.  Same document, section "Difficulties encountered" (document p. 3),
+verbatim:
+
+#+begin_quote
+A few selected jamoats that were initially selected had to be replaced since permission to sample in those areas was not granted. Permission was obtained from the United Tajik Opposition (UTO) which control parts of the Karategin Valley.
+#+end_quote
+
+Neither the jamoats replaced nor their replacements are identified anywhere in
+the documentation examined.
+
+*** Exclusions -- nothing found
+
+No statement excluding institutional population, collective quarters, military
+barracks, dormitories, prisons, hospitals, nomads, refugees or displaced
+persons, or any region for accessibility or security reasons, was found in the
+Basic Information Document or in the catalog technical document "Methodology of
+living standard survey sampling in the Republic of Tajikistan"
+(https://microdata.worldbank.org/catalog/279/download/11689).  Searched: both
+documents grepped for =institution|collective|barrack|military|homeless|nomad|
+refugee|dormitor|prison|not covered|were excluded|does not cover|inaccessib|
+security reason=; the local =Documentation/= PDFs (=HH012007-00.pdf=,
+=com01.pdf=, =fem01.pdf=) converted and grepped for =universe|target
+population|sampling frame|all households|private household|survey
+covers|represent= -- they are field instruments and carry no universe
+statement.  *This is a recorded absence of evidence, not evidence of
+inclusion.*
+
+** TLSS 2003
+
+*** Declared universe
+
+Source: "Tajikistan Living Standards Survey, 2003 / Notes for Users of the
+Data", technical document attached to WB Microdata catalog entry 278
+(https://microdata.worldbank.org/catalog/278/download/11666).  *Not present in*
+=lsms_library/countries/Tajikistan/2003/Documentation/=.  Locator: page 1
+(unnumbered), opening paragraph; the second sentence is a standalone sentence
+four paragraphs further down the same page.  Language: English.
+
+#+begin_quote
+The Tajikistan Living Standards Survey (TLSS) for 2003 was based on a stratified random probability sample, with the sample stratified according to oblast and urban/rural settlements and with the share of each strata in the overall sample being in proportion to its share in the total number of households as recorded in the 2000 Census. ... The 2003 data are representative at the regional level (4 regions) and urban/rural.
+#+end_quote
+
+The ellipsis elides intervening sample-design text (the comparison to TLSS 1999
+and the oversample percentages quoted below, plus a paragraph naming the four
+oblasts).  The same wording appears verbatim in the catalog's
+=study_info.geog_coverage= ("National coverage. The 2003 data are
+representative at the regional level (4 regions) and urban/rural.") and in
+=method.data_collection.sampling_procedure=.
+
+*** Oversamples -- Dushanbe and GBAO (corrected by weights, not by exclusion)
+
+Same document, same opening paragraph, verbatim:
+
+#+begin_quote
+Second the TLSS 2003 over-sampled by 40 percent in Dushanbe, 300 percent  in  rural  Gorno-Badakhshan  Administrative  Oblast  (GBAO)  and  600  percent  in  urban GBAO.  Third the sample size was increased in 2003 in comparison with 1999 in order to reduce sampling  error.    In  2003,  the  overall  sample  size  was  4,156  households  compared  with  2,000 households in 1999.
+#+end_quote
+
+(Multiple spaces are PDF justification artifacts, transcribed as extracted.)
+
+Unlike 1999, *no instruction to exclude the oversampled units is given*.  The
+stated remedy is the weight.  Same document, page 1, verbatim:
+
+#+begin_quote
+The weight variable is wgt_nat.
+#+end_quote
+
+=2003/_/data_info.yml= wires exactly this variable (=weight: wgt_nat= from
+=../Data/new_expend.dta=).  Any unweighted Tajikistan 2003 statistic
+over-represents Dushanbe and GBAO by the factors quoted above.
+
+*** Not a panel with 1999
+
+Same document, page 1, verbatim:
+
+#+begin_quote
+This is not a panel survey with the Tajikistan Living Standards Survey done in 1999.
+#+end_quote
+
+*** Exclusions -- nothing found
+
+No exclusion statement of any kind (institutional population, collective
+quarters, nomads, refugees, regions dropped for security or accessibility)
+appears in the 2003 documentation examined.  Searched: local
+=2003/Documentation/= (=SOURCE.org= = DOI link only, =LICENSE.org=,
+=taj03hhq.pdf=, =taj03cmq.pdf=, =taj03fmq.pdf= -- all three converted and
+grepped, field instruments only); WB catalog entry 278 API metadata, the
+rendered study-description page (0 hits for "Universe"), and both attached
+technical documents ("Notes for Users of the Data" and "Instructions for
+Supervisors and Interviewers, TLSS 2003").  *Recorded as a gap, not as an
+absence of exclusions.*
+
+** TLSS 2007
+
+*** Declared universe -- the one wave whose statement the repo actually holds
+
+Source: =lsms_library/countries/Tajikistan/2007/Documentation/ddi-documentation-english_microdata-72.pdf=
+(local, DVC-tracked).  Locator: PDF page 3, section "Sampling" -> "Sampling
+Procedure".  The identical text appears in the Basic Information Document, TLSS
+2007 (July 2008), section "Sample Design", document page 6, and again in its
+Appendix B, document page 23.  Language: English.
+
+#+begin_quote
+The TLSS sample was designed to allow reliable estimation of poverty and most variables for a variety of other living standard indicators at the various domains of interest based on a representative probability sample on the level of:
+- Tajikistan as a whole
+- Total urban and total rural areas
+- The five main administrative regions (oblasts) of the country: Dushanbe, Rayons of Republican Subordination (RRS), Sogd, Khatlon, and Gorno-Badakhshan Autonomous Oblast (GBAO)
+#+end_quote
+
+The bullet markers in the source are typographic bullets, rendered here as
+=-=; the wording is character-for-character as printed.  The catalog's
+=study_info.geog_coverage= for this study is the single word "National".  The
+local DDI PDF has no Scope/Coverage section -- it opens at "Sampling" -- so
+this sample-design statement is the universe statement of record.
+
+*** Oversample -- 7 rayons in Khatlon (NOT flagged for exclusion)
+
+Same local DDI PDF, PDF page 3, in the list of factors determining sample size,
+verbatim:
+
+#+begin_quote
+- An oversample in 7 rayons in Khatlon
+#+end_quote
+
+The local DDI drops the footnote.  The Basic Information Document, TLSS 2007
+(https://microdata.worldbank.org/catalog/72/download/11528), document page 7,
+carries it as footnote 3, verbatim:
+
+#+begin_quote
+3  The oversample is for a crop survey that will be done at a future date.
+#+end_quote
+
+*Contrast with 1999*: no instruction is given to exclude these units from
+nationally representative analysis.  The stated remedy is the weight.  BID
+p. 12, verbatim:
+
+#+begin_quote
+Because the sample is not self weighted, the weight variable, HHWEIGHT, must be used in  analyses  of  the  data  to  have  estimates  that  are  valid  at  the  national,  urban/rural  and  oblast levels.
+#+end_quote
+
+=2007/_/data_info.yml= wires =weight: weight= from =../Data/weights.dta=.  The
+7 Khatlon rayons are *not named* in the DDI text examined.
+
+*** Two rounds plus a Sughd re-collection -- fieldwork, not universe
+
+The 2007 wave was a two-round design, and 216 Sughd households were re-fielded.
+This is a data-quality event, not a universe restriction, but it changes what
+"the 2007 sample" means and is recorded here so it is not mistaken for one.
+Local DDI PDF, verbatim:
+
+#+begin_quote
+During the monitoring process, it was discovered that data from 216 households in the Sughd Oblast had to be excluded. Information from these households was re-collected during the Second Round of data collection.
+#+end_quote
+
+and, on Second-Round coverage, verbatim:
+
+#+begin_quote
+In the Second Round, it was not possible to reach all of the households from the First Round. Of the 4,860 households in the First Round, 4,490 households were re-visited.
+#+end_quote
+
+#+begin_quote
+Three clusters or 54 households could not be revisited due to adverse conditions and 100 households could not be found. 216 households in Sughd were not revisited using the Second Round questionnaire because their First Round data had to be excluded. The Sughd households were revisited with a complete household questionnaire.
+#+end_quote
+
+Design detail from the same sources (context, *not* the universe): frame is the
+2000 census enumeration sectors as digitised for UNICEF's MICS05; 270 clusters
+x 18 households = 4,860; final cluster allocation (urban/rural) Dushanbe 50/0,
+RRP 9/45, Sogd 18/38, Khatlon 12/59, GBAO 6/33.
+
+*** Exclusions -- nothing found
+
+No statement excluding any population group or area from the survey universe
+was found.  The only "exclusion" language in the documentation is the Sughd
+data-quality event quoted above.  Searched: local =2007/Documentation/= (DDI
+PDF -- the hit; questionnaires =TLSS07HHQE.pdf=, =TLSS07HHQ2E.pdf=,
+=TLSS07HHQSE.pdf=, =TLSS07FEMQE.pdf=, =TLSS07COMQE.pdf=), WB catalog entry 72
+API metadata and study-description page (0 hits for "Universe"), and the full
+Basic Information Document.
+
+*** Not a panel with 1999 or 2003
+
+BID p. 12, verbatim:
+
+#+begin_quote
+The TLSS99, TLSS03 and TLSS07 data cannot be used as panel data. The same households were not visited in all surveys. In addition, the sample designs used in the three years were different although all three surveys are representative at the national, urban/rural and oblast levels.
+#+end_quote
+
+** TLSS 2009 -- the whole wave is a sub-sample
+
+*** Declared universe
+
+Source: "Tajikistan Living Standards Survey 2009 / Notes for Users / May 2010",
+technical document attached to WB Microdata catalog entry 73
+(https://microdata.worldbank.org/catalog/73/download/11539).  *Not present in*
+=lsms_library/countries/Tajikistan/2009/Documentation/=.  Locator: page 1,
+first and second paragraphs (the ellipsis elides only the paragraph break).
+Language: English.
+
+#+begin_quote
+The Tajikistan 2009 Living Standards Survey (TLSS09) is a panel survey of 1,500 households interviewed during the Tajikistan 2007 Living Standards Survey (TLSS07).  The households were revisited in November 2009 which is the same time period in which they were visited originally in 2007. ... The sample is representative at the national, regional level (4 regions and Dushanbe), and urban/rural.  See http://go.worldbank.org/6TUMCB3K30 for a copy of the Basic Information Document for the TLSS07 which describes in detail how the sample was designed for the TLSS07.  The same methodology was used to select the households for the TLSS09.
+#+end_quote
+
+The *first sentence only* is also present verbatim in local documentation:
+=2009/Documentation/ddi-documentation-english_microdata-73.pdf=, PDF page 5,
+"Data Collection" -> "DATA COLLECTION NOTES".  The representativeness claim
+exists only in the catalog.  The local DDI has no Scope/Coverage section; its
+entire SAMPLING PROCEDURE field reads "Sample size is 1,500 households", which
+is also the whole of the catalog's =sampling_procedure=.
+
+*** This is a 1,500-of-4,860 sub-sample and the selection rule is undocumented
+
+The universe is restricted by construction: the 2009 frame is the TLSS07
+*sample*, not the Tajik population.  The documentation asserts that the result
+is still nationally representative but *nowhere states which 1,500 of the 4,860
+TLSS07 households were retained, how they were chosen, or what happened to
+attrition*.  Searched the Notes for Users for
+=1,500|selected|attrition|replace|sub-sample|subsample|oversampl= -- the only
+hit is the sentence quoted above.  The claim "The same methodology was used to
+select the households for the TLSS09" points at the TLSS07 BID, which describes
+the *2007* design and says nothing about a 2009 sub-selection.
+
+*This is the single largest evidentiary gap in the Tajikistan record.*  A
+reader pooling TLSS09 with TLSS07 is pooling a wave with its own sub-sample and
+has no documented basis for the sub-sample's design weights beyond the wave's
+own =Weight= variable (=2009/_/data_info.yml=, =weight: Weight= from
+=../Data/weights2009.dta=).
+
+Consistent with (but not itself a statement of) the panel universe: the local
+questionnaire =2009/Documentation/TJ_Pan_09_V11.pdf=, page 1, is headed
+"TAJIKISTAN PANEL SURVEY, 2009 / MAIN QUESTIONNAIRE" and carries pre-printed
+identification fields "FROM TLSS07" and "TLSS PSU".
+
+*** Exclusions -- nothing found
+
+No exclusion statement of any kind appears in the 2009 documentation examined
+(local =SOURCE.org= = DOI link only, =LICENSE.org=, the DDI PDF, and
+=TJ_Pan_09_V11.pdf=, both converted and grepped for =universe|target
+population|scope|coverage|geographic|all households|private
+household|non-institutional|represent= -- zero hits; plus catalog entry 73 API
+metadata, study-description page with 0 hits for "Universe", and the Notes for
+Users).
+
+** What this means for pooling Tajikistan
+
+- The four waves are *four independent cross-sections plus one panel
+  sub-sample*, not a panel.  1999/2003/2007 are explicitly stated not to be
+  panel-linkable (2003 and 2007 quotes above); 2009 is a sub-sample of 2007.
+- Three of four waves carry a documented oversample, and the *prescribed remedy
+  differs between them*: 1999 says exclude (and ships no weight at all),
+  2003 and 2007 say weight.  Treating them uniformly is wrong in one direction
+  or the other.
+- The regional domain changes across waves as stated: 1999 "oblast" strata,
+  2003 "4 regions", 2007 "five main administrative regions", 2009 "4 regions
+  and Dushanbe".
+- No wave documents any institutional / collective-quarters / nomad / refugee
+  exclusion.  That is an absence of *statements*, recorded as such; it is not a
+  documented statement of full inclusion.
+
 * shocks — not available (2026-06-07, verified)
 
 =shocks= (a household adverse-events-and-coping roster, index =(t, i, Shock)=)

--- a/lsms_library/countries/Tanzania/_/CONTENTS.org
+++ b/lsms_library/countries/Tanzania/_/CONTENTS.org
@@ -82,6 +82,489 @@ count that a 2008-15 key is sound.
 Related: the Round-4 sub-panel split is a separate matter, documented
 at [[#panel-design][Panel design note]].
 
+* Sampling universe, exclusions and sub-samples
+:PROPERTIES:
+:CUSTOM_ID: sampling-universe
+:END:
+
+What the NPS *declares* it is a sample of, quoted verbatim from the
+documentation, with the exclusions and the within-wave sub-samples.  This
+records the survey's *claim*; it is deliberately not inferred from the data.
+Evidence gathered 2026-07-21 (GH #601); every quote below was re-checked
+against its cited file.
+
+This section is *evidence only*.  It does not propose a schema --- how the
+library should represent any of it is GH #603.
+
+Cross-references, so nothing here is read in isolation:
+- the *Panel design note* ([[#panel-design]]) already describes the Extended /
+  Refresh sub-panel split and the 545-household urban booster.  Everything
+  below agrees with it; this section adds the verbatim documentary basis and
+  the universe statements, which that note does not carry.
+- =.claude/skills/tanzania-panel-design.md= --- the same split, from the ID
+  side.
+- *The cluster key of =cluster_features= (GH #323, Site 2)* --- the tracking
+  design (households are followed to new addresses, carrying their original
+  sampling cluster) is the operational face of the eligibility/tracking rules
+  quoted below.
+
+** Summary
+
+| library wave | universe statement?         | where it lives                          | sub-sample structure inside the wave        |
+|--------------+-----------------------------+-----------------------------------------+---------------------------------------------|
+| 2008-09      | yes (UPD record, catalog)   | *WB catalog only* (id 3814)             | initial national cohort                     |
+| 2010-11      | yes (UPD record, catalog)   | *WB catalog only* (id 3814)             | same cohort, tracked                        |
+| 2012-13      | yes (UPD record, catalog)   | *WB catalog only* (id 3814)             | same cohort, tracked                        |
+| 2014-15      | yes (UPD + own R4 record)   | *WB catalog only* (id 3814 / 2862)      | *two disjoint sub-panels: Extended + Refresh* |
+| 2019-20      | yes                         | *in repo*: =2019-20/Documentation/TZA_2019_NPS-SDD_v06_M.xml= | Extended Panel sub-cohort only |
+| 2020-21      | *none --- gap*              | field exists and is empty (id 5639)     | Refresh Panel + *545-HH urban booster*      |
+
+Four of the six library waves have a universe statement that exists *only in
+World Bank catalog metadata*, not in any file in this repository.  For those
+the record is a moving target: it can be edited upstream without anything in
+the repo changing.  Only 2019-20's is held locally.
+
+** The declared universe
+
+*** 2008-09, 2010-11, 2012-13, 2014-15 (the =2008-15/= UPD folder)
+
+All four library waves are built from one catalog record --- the *Uniform
+Panel Dataset*, =TZA_2008-2014_NPS-UPD_v01_M=, catalog id 3814 (see
+=2008-15/Documentation/SOURCE.org=).  That record carries a single universe
+statement, which is therefore the documented universe for all four:
+
+#+begin_quote
+The universe includes all households and individuals in Tanzania with the
+exception of those residing in military barracks or other institutions.
+#+end_quote
+
+- Citation :: WB Microdata catalog DDI 1.2.2 export for catalog id 3814,
+  element =codeBook/stdyDscr/stdyInfo/sumDscr/universe=
+  (https://microdata.worldbank.org/index.php/metadata/export/3814/ddi,
+  retrieved 2026-07-21).  Language: English.  *Not present in any file in
+  this repository.*
+
+Geographic coverage, same record, element =sumDscr/geogCover=, VERBATIM:
+
+#+begin_quote
+Designed for analysis of key indicators at four primary domains of inference,
+namely: Dar es Salaam, other urban, rural, Zanzibar.
+#+end_quote
+
+*Important caveat --- the four waves do not attest this sentence equally.*
+Each round also has its own catalog record, and they disagree:
+
+| round      | catalog id | its own =<universe>=                                        |
+|------------+------------+-------------------------------------------------------------|
+| R1 2008-09 |         76 | *empty* (=<universe/>=)                                     |
+| R2 2010-11 |       1050 | *empty* (=<universe/>=)                                     |
+| R3 2012-13 |       2252 | present, but *different text* --- quoted below              |
+| R4 2014-15 |       2862 | present, *byte-identical* to the UPD sentence above         |
+
+So the UPD sentence is independently corroborated for 2014-15 only.  For
+2008-09 and 2010-11 the per-round records say nothing about a universe at
+all; what they offer instead is coverage / design language, VERBATIM:
+
+- id 76, =sumDscr/geogCover= :: "The survey covered all regions and all
+  districts of Tanzania, both mainland and Zanzibar."
+- id 76, =sumDscr/sampProc= (opening) :: "In order to monitor progress toward
+  the MKUKUTA goals, it was vital that the NPS have a nationally-representative
+  sample design. As such, in 2008/09 the NPS interviewed 3,280 households
+  spanning all regions and all districts of Tanzania, both mainland and
+  Zanzibar."
+- id 1050, =sumDscr/geogCover= :: "National Coverage: Dar es Salaam, other
+  urban areas in Mainland, rural areas in Mainland, and Zanzibar"
+
+Those are *sample-design and coverage* claims, not universe declarations, and
+are recorded here as such.
+
+The 2012-13 record's universe field is *circular* --- it describes the sample,
+not the population it is drawn from.  Catalog id 2252,
+=sumDscr/universe=, VERBATIM:
+
+#+begin_quote
+The survey covers all individuals included in the households in the sample.
+
+The eligibility requirement for the NPS is defined as any household member
+aged 15 years and above, excluding live-in servants. Households with at least
+one eligible member where completely interviewed, including any subsequent
+non-eligible members present in the household. Any household or eligible
+members that had either moved or split away from a primary household were
+tracked and interviewed in their new location.
+#+end_quote
+
+(=where= for =were= is in the source; quoted as printed.)  Its =geogCover=
+reads, VERBATIM: "Representative at the national, urban/rural and major
+ago-ecological zones levels." (=ago-= for =agro-= is in the source.)  Note
+this is a *third* representativeness claim --- agro-ecological zones ---
+different again from the four domains of inference of the UPD and R4 records.
+
+*Local documentation in this repo says nothing about a universe.*  The
+strongest statement in =2008-15/Documentation/NPS_UPD_Basic_Information_Document.pdf=
+is a representativeness claim, p. 4, section "Background", VERBATIM:
+
+#+begin_quote
+The Tanzania National Panel Survey (NPS) is a series of nationally
+representative multi-topic household surveys that collect information on
+topics including agricultural production, non-farm income generating
+activities, consumption expenditures, and a wealth of other socio-economic
+characteristics.
+#+end_quote
+
+The string "universe" does not occur anywhere in that BID (checked over the
+whole document).  The other local file,
+=ddi-documentation-english_microdata-3814.pdf=, is a stub record with no
+Scope / Coverage / Universe section at all.
+
+*** 2019-20 (NPS-SDD)
+
+#+begin_quote
+The universe includes all households and individuals in Tanzania with the
+exception of those residing in military barracks or other institutions.
+#+end_quote
+
+- Citation :: =lsms_library/countries/Tanzania/2019-20/Documentation/TZA_2019_NPS-SDD_v06_M.xml=,
+  line 74, element =codeBook/stdyDscr/stdyInfo/sumDscr/universe=.  Language:
+  English.  *This is the one Tanzania wave whose universe statement is held in
+  this repository.*  It is byte-identical to the WB catalog DDI export for
+  catalog id 3885, so local and catalog agree.
+
+Geographic coverage, same file, element =sumDscr/geogCover=, VERBATIM:
+"Designed for analysis of key indicators at the national level."  Unit of
+analysis, =sumDscr/anlyUnit=, VERBATIM: "Households; Individuals;".
+
+Note the geogCover *narrows* relative to every other NPS round: national only,
+not the four domains of inference.  That is consistent with 2019-20 following
+only the Extended Panel cohort (below) --- but the declared *universe* is
+unchanged and national.  See "Universe vs. what the sample and weights
+represent".
+
+*** 2020-21 (NPS Wave 5) --- NO UNIVERSE STATEMENT FOUND
+
+*This is a recorded gap, not a claim about the survey.*  The authoritative
+field exists and is empty.  WB catalog DDI export for catalog id 5639
+contains, VERBATIM:
+
+: <universe><![CDATA[]]></universe>
+
+Searched, and the string "universe" is *absent* from all of:
+
+- =2020-21/Documentation/ddi-documentation-english_microdata-5639.pdf= (12 pp;
+  it has Scope / Coverage / Sampling sections and *no* Universe line);
+- =2020-21/Documentation/nps_wave_5_report.pdf= (125 pp);
+- =2020-21/Documentation/executive_summary_tanzania_printfile_02b.pdf= (8 pp).
+
+The four Wave-5 questionnaire PDFs were not read for a universe statement.
+
+The nearest available statements are *not* universe statements and must not be
+promoted to one:
+
+- =sumDscr/geogCover= (id 5639; same text at local PDF p. 3, "Coverage" >
+  GEOGRAPHIC COVERAGE), VERBATIM: "Designed for analysis of key indicators at
+  four primary domains of inference, namely:\nDar es Salaam,\nOther Urban,\nRural,\nZanzibar,"
+- =nps_wave_5_report.pdf=, report p. 1 (PDF p. 21), section 1.1 Introduction,
+  VERBATIM: "The National Panel Survey (NPS) is a nationally representative
+  household survey that collects information on the living standards of the
+  population, including their consumption expenditure, non-farm income
+  generating activities, agricultural production, and other socio-economic
+  characteristics."
+
+*Do not carry the 2014-15 universe sentence onto 2020-21.*  Wave 5 follows a
+different cohort (Refresh Panel) plus a booster sample, so its realised sample
+is not the same set of units, and no document states a universe for it.
+
+** Exclusions
+
+*** Universe-level exclusion (2008-09 -- 2019-20)
+
+The only universe-level exclusion the NPS states, VERBATIM (citations as
+above, catalog id 3814 / 2862 / 3885 and the local 2019-20 DDI):
+
+#+begin_quote
+... with the exception of those residing in military barracks or other
+institutions.
+#+end_quote
+
+*No geographic exclusion.*  Nothing in any NPS document excludes a region, a
+zone, or urban or rural areas.  Zanzibar is explicitly *in* --- it is both a
+sampling stratum and one of the four domains of inference.  There is no
+"for security reasons" carve-out anywhere in the corpus.  This makes Tanzania
+unlike the LSMS-ISA waves elsewhere in the library that drop a named region
+by design.
+
+*** Household-level eligibility restriction (2012-13, 2019-20, 2020-21)
+
+Distinct from the universe: a rule about which households *qualify to be
+interviewed*.  It is stated under sampling procedure (and, in 2012-13,
+inside the universe field itself).
+
+2019-20, =2019-20/Documentation/TZA_2019_NPS-SDD_v06_M.xml=,
+=codeBook/stdyDscr/method/dataColl/sampProc=; the same text is in the local
+BID =tznps_sdd_2019_20_basic_information_document_updated_november_2022.pdf=,
+p. 7, section "Sample Design", VERBATIM:
+
+#+begin_quote
+The eligibility requirement for inclusion in the NPS is defined as any
+household member aged 15 years and above, excluding live-in servants.
+Households with at least one eligible member were completely interviewed,
+including any non-eligible members present in the household. Any household or
+eligible members that had either moved or split away from a primary household
+were tracked and interviewed in their new location.
+#+end_quote
+
+2020-21, catalog id 5639 =sampProc= (same text at
+=ddi-documentation-english_microdata-5639.pdf=, p. 3, "Sampling" > SAMPLING
+PROCEDURE), VERBATIM:
+
+#+begin_quote
+The eligibility requirement for inclusion of a household in this round of the
+NPS and all others is defined as any household having at least one member aged
+15 years and above, excluding live-in servants. Households with at least one
+eligible member were completely interviewed, including any non-eligible
+members present in the household.
+#+end_quote
+
+Two consequences worth flagging for a consumer:
+
+1. A household composed entirely of members under 15 is *out of scope by the
+   eligibility rule*, even though the declared universe says "all households
+   and individuals in Tanzania".  The universe sentence and the eligibility
+   rule do not agree, and the documentation never reconciles them.
+2. *Live-in servants are excluded from eligibility but not from the
+   interview* --- non-eligible members present in an eligible household are
+   still enumerated.  So the roster contains people the eligibility rule
+   excludes.
+
+** Oversamples and sub-samples --- specialization lives INSIDE the waves
+
+Tanzania is a strong instance of the pattern: none of the six library waves is
+a "special" wave, but three of them contain distinct sub-populations that a
+consumer must not average over blindly.  The panel-design facts are already in
+[[#panel-design]]; what follows is the documentary basis.
+
+*** 2014-15: two disjoint sub-panels inside one library wave
+
+Catalog id 3814, =codeBook/stdyDscr/method/dataColl/sampProc=, VERBATIM:
+
+#+begin_quote
+To maintain the panel concept of the NPS, the sample design for NPS 2014/2015
+consisted of a combination of the original NPS sample and a new NPS sample. A
+nationally representative sub-sample was selected to continue as part of the
+“Extended Panel” while an entirely new sample, “Refresh Panel”, was selected
+to represent national and sub-national domains. Similar to the sample in NPS
+2008/2009, the sample design for the “Refresh Panel” allows analysis at four
+primary domains of inference, namely: Dar es Salaam, other urban areas on
+mainland Tanzania, rural mainland Tanzania, and Zanzibar. This new cohort in
+NPS 2014/2015 will be maintained and tracked in all future rounds between
+national censuses.
+#+end_quote
+
+The stated *reason* for the refresh, same element, opening, VERBATIM:
+
+#+begin_quote
+While the same sample of respondents was maintained over the first three
+rounds of the NPS, longitudinal surveys tend to suffer from bias introduced by
+households leaving the survey over time; i.e. attrition. Although the NPS
+maintains a highly successful recapture rate (roughly 96% retention at the
+household level), minimizing the escalation of this selection bias, a refresh
+of longitudinal cohorts was done for the NPS 2014/15 to ensure proper
+representativeness of estimates while maintaining a sufficient primary sample
+to maintain cohesion within panel analysis.
+#+end_quote
+
+So the single library wave =2014-15= is a *pooled* Extended + Refresh sample.
+The two sub-panels even carry different cluster-id layouts in the data --- see
+the scheme table in *The cluster key of =cluster_features== (=RR D WW EEE=,
+8 chars, for the extended panel; =RR DD WWW EE CCC=, 12 chars, for the
+refresh sample).  Documentation calls *both* nationally representative; it
+gives no share.  (The "~20% sub-sample" figure in [[#panel-design]] and in
+=.claude/skills/tanzania-panel-design.md= comes from the NPS 2020/21 BID,
+pp. 7-8, and is not restated in any statement quoted here; it is not
+contradicted either.)
+
+*** 2019-20: the Extended Panel sub-cohort only
+
+Sample design, =2019-20/Documentation/tznps_sdd_2019_20_basic_information_document_updated_november_2022.pdf=,
+p. 7, section "Sample Design" (identical text in the local DDI's =sampProc=),
+VERBATIM:
+
+#+begin_quote
+The sample design for the NPS-SDD 2019/20 targeted the sub-sample of
+households from the initial NPS cohort originating in 2008/09 and subsequently
+surveyed in all four consecutive rounds, considered the “Extended Panel”. This
+consisted of 989 households from the NPS 2014/15 sample to be tracked and
+interviewed in the NPS-SDD 2019/20.
+#+end_quote
+
+Same page, on the realised sample, VERBATIM: "Ultimately, the final sample
+size for NPS-SDD 2019/20 was 5,587 individuals in 1,184 households."  (The
+1,184 figure matches the household count used in the community-price
+diagnosis elsewhere in this file.)
+
+Also on that page, two smaller top-ups that are part of the wave's sample and
+are easy to miss, VERBATIM:
+
+#+begin_quote
+It is worth mentioning that the sample design included complete households
+that could not be interviewed in NPS 2014/15, excluding those households that
+had refused to be interviewed in NPS 2014/15. This constituted an additional 8
+households. Individuals meeting the eligibility requirement that were
+interviewed as part of the NPS 2012/13, but were not located and interviewed
+during the NPS 2014/15, were also included in this round if located.
+Additionally, individuals from NPS 2014/15 who moved into another This
+constituted an additional 158 individuals assigned to their last known
+associated household.
+#+end_quote
+
+(The truncated sentence "who moved into another This constituted" is in the
+source, in both the BID and the DDI; quoted as printed.)
+
+*** 2020-21: Refresh Panel plus an explicit URBAN OVERSAMPLE
+
+Catalog id 5639, =sampProc= (same text at
+=ddi-documentation-english_microdata-5639.pdf=, p. 3), VERBATIM:
+
+#+begin_quote
+The NPS is based on a stratified, multi-stage cluster sample design which
+recognizes four analytical strata: Dar es Salaam, Other Urban areas in
+Mainland, Rural areas in Mainland, and Zanzibar. The sample design for the NPS
+2020/21 targeted the sub-sample of households from the initial NPS 2014/15
+cohort considered the “Refresh Panel”. These specific households had never
+previously been a part of the NPS sample design. This sample consisted of
+3,352 households from 419 clusters in the NPS 2014/15 that were tracked and
+interviewed in the NPS 2020/21. An additional “Booster Sample” of 545
+households from major cities and urban areas (specifically, Mbeya, Arusha,
+Mwanza, Tanga, and Dodoma) was also interviewed to allow for improved
+estimates in urban centres.
+#+end_quote
+
+And on the composition of the realised sample, same element, VERBATIM:
+
+#+begin_quote
+Ultimately, the final sample size for NPS 2020/21 was 23,592 individuals in
+4,709 households. Of these, 4,164 households allow for panel analysis as they
+have been found and interviewed in both NPS 2014/15 and NPS 2020/21, while the
+remaining 545 (in the “Booster Sample”) will only have data available in the
+NPS 2020/21.
+#+end_quote
+
+*This is the one thing in Tanzania a pooling consumer is most likely to get
+wrong.*  545 of 4,709 households (11.6%) in 2020-21 are a *purpose-built urban
+oversample of five named cities*, drawn to improve urban estimates --- not a
+national draw.  Unweighted pooling of 2020-21 with any other wave over-weights
+Mbeya, Arusha, Mwanza, Tanga and Dodoma.  These are the same 545 households
+that =cluster_features= previously deleted on a NaN =clusterid= key (see the
+GH #323 section).
+
+*** Design oversampling in the stratification itself
+
+Present identically in the 2019-20 local DDI
+(=2019-20/Documentation/TZA_2019_NPS-SDD_v06_M.xml=) and in catalog id 5639,
+element =codeBook/stdyDscr/method/dataColl/weight=, VERBATIM:
+
+#+begin_quote
+The sampling of these clusters was stratified along two dimensions: (i) eight
+administrative zones (seven on Mainland Tanzania plus Zanzibar as an eighth
+zone), and (ii) rural versus urban clusters within each administrative zone.
+The combination of these two dimensions yields 16 strata. In rural areas a
+cluster is defined as an entire village. In urban areas, a cluster is defined
+as a census enumeration area. As a general rule, the probability of selection
+was higher for clusters within strata where existing data sources showed that
+the variance of key variables of interest for the NPS (e.g., household
+consumption and maize production) were likely to be very high – implying the
+need for more observations to produce reliable estimates.
+#+end_quote
+
+That last sentence is a *variance-driven oversample built into stage 1*, not
+just a design effect: some strata are deliberately over-represented in the raw
+counts.  Weights are required for any national statement.
+
+** Universe vs. what the sample and the weights represent
+
+The documents come apart on this, and the gap is widest in 2019-20.
+
+- The *declared universe* for 2019-20 is national and unrestricted (bar
+  institutions) --- see above.
+- The *realised sample* is a longitudinal sub-cohort: 989 targeted households
+  that had been interviewed in all four prior rounds, plus split-offs.
+- The *geographic-coverage* field for that same wave drops to "national level"
+  and no longer claims the four domains of inference.
+- The *weights* are panel weights, not fresh cross-sectional weights.
+  =TZA_2019_NPS-SDD_v06_M.xml=, element
+  =codeBook/stdyDscr/method/dataColl/weight=, VERBATIM: "The methodology
+  used to calculate the panel weights for the extended panel households in NPS
+  2019/20 was developed as part of the LSMS-ISA work program. Details on the
+  methodology can be found in the paper: Himelein, Kristen. 2013. “Weight
+  Calculations for Panel Surveys with Subsampling and Split-off Tracking.”
+  Statistics and Public Policy, vol (1), pp40-45"
+
+Same file, opening of the same element, VERBATIM: "In order to produce
+nationally representative statistics with the NPS data, it is necessary to
+apply weighting or expansion factors. The panel survey weights adjust for
+differences in the probability of selection into the NPS 2008/09 sample for
+observations in various strata, 2008/09 households splitting into multiple
+households in NPS 2010/11 and NPS 2012/13, splitting even further in NPS
+2014/15, and attrition between rounds of the survey."
+
+For 2020-21 the parallel sentence, catalog id 5639, element =weight=,
+VERBATIM: "A similar practice was used for panel survey weights in NPS
+2020/21, based on their probability of selection in the NPS 2014/15 (as the
+Refresh Sample)."
+
+So: the universe sentence is about *Tanzania*; the weights are about
+*probability of selection into a specific earlier cohort*, corrected for
+attrition and splits.  Do not read the universe sentence as a statement that
+the wave's raw rows are a fresh national draw.  The library's two weight
+columns (=weight= cross-sectional, =panel_weight= longitudinal) are the place
+this distinction shows up in practice.
+
+*No Tanzania document denies a well-defined universe* (unlike, e.g., China
+1995-97 or EthiopiaRHS elsewhere in the library).  The 2020-21 case is
+silence, not denial.
+
+** Not boilerplate
+
+The Tanzania universe sentence is *not* the World Bank NADA template text.
+The most-repeated sentence in the library-wide corpus --- "The survey covered
+all de jure households excluding prisons, hospitals, military barracks, and
+school dormitories.", which appears verbatim in 15 waves across the EHCVM
+countries, Ethiopia and Nigeria --- does not occur in any Tanzania document.
+Tanzania's sentence names the country, and its exclusion clause ("military
+barracks or other institutions") is worded differently from the template's
+four-item list.  It is therefore usable as an attestation about *this* survey,
+which the boilerplate is not.
+
+The one caveat is the one already made above: the sentence is attested by the
+UPD record and by the 2014-15 round record, and is *reused* for 2008-09,
+2010-11 and 2012-13 because those waves are built from the UPD file --- the
+per-round records for those years do not contain it.
+
+** What was searched, so the gaps are falsifiable
+
+- =2008-15/Documentation/= (complete): =NPS_UPD_Basic_Information_Document.pdf=
+  (32 pp, text-extracted; "universe" absent),
+  =ddi-documentation-english_microdata-3814.pdf= (9 pp, stub record with no
+  Scope/Coverage/Universe section), =nps_upq_questionnaire.pdf= (instrument,
+  not read for universe), =SOURCE.org=, =LICENSE.org=.  Then WB catalog id
+  3814, plus per-round ids 76 / 1050 / 2252 / 2862 for corroboration.
+- =2019-20/Documentation/= (complete): =TZA_2019_NPS-SDD_v06_M.xml= (HIT),
+  =tznps_sdd_2019_20_basic_information_document_updated_november_2022.pdf=
+  (85 pp; no literal "universe" statement --- its Sample Design section, p. 7,
+  is about the Extended-Panel sub-sample), four questionnaire PDFs (not read
+  for universe), =SOURCE.org=, =LICENSE.org=.  Cross-checked against WB
+  catalog id 3885: identical.
+- =2020-21/Documentation/= (complete): =ddi-documentation-english_microdata-5639.pdf=
+  (12 pp), =nps_wave_5_report.pdf= (125 pp),
+  =executive_summary_tanzania_printfile_02b.pdf= (8 pp) --- "universe" and
+  "target population" absent from all three; four questionnaire PDFs (not read
+  for universe), =SOURCE.org=, =LICENSE.org=.  Fallback WB catalog id 5639:
+  =<universe>= element present and *empty*.
+
+Not searched: the Kiswahili instruments and interviewer manuals listed in the
+catalog records but not held in this repository.  If a universe statement for
+2020-21 exists anywhere, the Wave-5 interviewer manual is the next place to
+look.
+
 * Issues
 ** WAITING Missing food quantities in 2019-20 and 2020-21 (#112)
 :LOGBOOK:

--- a/lsms_library/countries/Timor-Leste/_/CONTENTS.org
+++ b/lsms_library/countries/Timor-Leste/_/CONTENTS.org
@@ -1,5 +1,276 @@
 #+TITLE: Timor-Leste — country notes & known data issues
 
+* Sampling universe, exclusions and sub-samples
+
+What each Timor-Leste wave *claims* to represent, quoted from its own
+documentation.  This records only what the documents say; nothing here is
+inferred from the =.dta= files.  Evidence gathered 2026-07-21 (GH #601);
+quotes re-verified against the cited PDFs and against the World Bank catalog
+DDI export before being written here.
+
+| Wave    | Universe statement?    | Where the statement lives                | Stated exclusions       | Sub-samples inside the wave        |
+|---------+------------------------+------------------------------------------+-------------------------+------------------------------------|
+| 2001    | *none found*           | -- (nearest text is catalog-only)        | *none found*            | none                               |
+| 2007-08 | yes, explicit          | local =Documentation/= (and catalog)     | institutional households| 2008 Extension; unreleased panel   |
+
+Neither catalog record has a DDI =universe= element at all.  Checked directly:
+=study_desc.study_info= for =TLS_2001_TLSS_v01_M= has keys =[abstract,
+coll_dates, nation, geog_coverage, data_kind, notes]= and for
+=TLS_2007_TLSLS_v01_M= the same plus =analysis_unit=.  There is no =universe=
+key on either.  So for 2007-08 the *only* explicit universe statement anywhere
+is in a locally held document, and for 2001 there is none anywhere.
+
+Neither wave uses the World Bank NADA boilerplate sentence ("The survey covered
+all de jure households excluding prisons, hospitals, military barracks, and
+school dormitories", which recurs verbatim in 15 waves elsewhere in the
+corpus).  The 2007-08 exclusion text below is the Timorese statistical office's
+own prose, not template text.
+
+** 2001 (TLSS) -- no universe statement found
+
+*** The gap, stated as a gap
+
+No explicit universe / target-population statement exists for this wave, in the
+locally held documentation or in the World Bank catalog metadata.  The string
+=Universe= (any case) does not occur in the local DDI report at all, and there
+is no Universe heading on the catalog page.
+
+Searched (so that a later reader can falsify this):
+
+- =2001/Documentation/ddi-documentation-english_microdata-75.pdf= -- full text
+  (296k chars, pdfminer), grepped for =universe|target population|coverage|
+  geographic coverage|scope|represent|nationally representative|national
+  coverage|Domains:=.
+- =2001/Documentation/ETPA-Vol2-Final-web.pdf= (Poverty Assessment Vol. II,
+  Technical Report) -- full text (509k chars), grepped for =universe|
+  institutional|private household|not covered by the survey|target population|
+  household is defined|definition of a household|usually live together|common
+  kitchen|common food|excluded from the survey=.
+- =2001/Documentation/timorlestehhqeng_V2.pdf= (household questionnaire) --
+  full text, grepped for =universe|household member|eligible|definition|
+  resident|usual=.
+- =2001/Documentation/SOURCE.org=, =LICENSE.org=, and this file.
+- Remote: WB Microdata catalog study 75 -- study-description page,
+  related-materials page, and the DDI JSON at
+  =https://microdata.worldbank.org/index.php/api/catalog/TLS_2001_TLSS_v01_M=.
+
+*** Nearest documented coverage statements (not universe statements)
+
+These are the closest things the documentation offers.  They are coverage and
+sample-design claims, and they are recorded here *as* such -- none of them says
+which households were eligible to be sampled.
+
+Catalog only.  WB catalog study 75, Coverage > Geographic Coverage (DDI field
+=study_info.geog_coverage=):
+
+#+begin_quote
+National coverage.
+Domains: Urban/rural; Agro-ecological zones (Highlands, Lowlands, Western Region, Eastern Region, Central Region)
+#+end_quote
+
+Catalog only.  WB catalog study 75, Abstract (=study_info.abstract=):
+
+#+begin_quote
+A second element was the Timor-Leste Living Standards Measurement Survey (TLSS). This is a household survey with a nationally representative sample of 1,800 families from 100 sucos.
+#+end_quote
+
+*Both of the above exist only in World Bank catalog metadata -- neither appears
+in any file held in this repository.*  The locally held DDI PDF is a partial
+export: it carries Sampling / Questionnaires / Data Collection / Data
+Processing / variable lists, but not the Study Description "Coverage" block.
+So "National coverage." for 2001 is a moving target hosted by the WB, not
+something the library holds.
+
+Local.  =2001/Documentation/ETPA-Vol2-Final-web.pdf=, Ch. 1 "Survey Design and
+Welfare Measurement", para. 1.2, printed p. 1 (PDF p. 15); the same text is
+verbatim in =ddi-documentation-english_microdata-75.pdf= p. 2, "Sampling >
+Sampling Procedure > SAMPLE SIZE AND ANALYTIC DOMAINS":
+
+#+begin_quote
+A survey relies on identifying a subgroup of a population that is representative both for the underlying population and for specific analytical domains of interest. The main objective of the TLSS is to derive a poverty profile for the country and salient population groups. The fundamental analytic domains identified are the Major Urban Centers (Dili and Baucau), the Other Urban Centers and the Rural Areas. ... The survey has a sample size of 1,800 households, or about one percent of the total number of households in Timor-Leste.
+#+end_quote
+
+Local.  =ddi-documentation-english_microdata-75.pdf= pp. 2-3, "SAMPLING
+STRATEGY" -- bears on what the weights mean:
+
+#+begin_quote
+This implies that the sample is approximately selfweighted within the stratum: all households in the stratum had the same chance of being visited by the survey.
+#+end_quote
+
+*** Exclusions -- none found
+
+No statement of an excluded population (institutional or collective households,
+nomadic or homeless populations, a dropped district, a security carve-out)
+appears in the local 2001 documentation or in the catalog metadata.
+
+Two nearby rules were found and are recorded because they are easy to mistake
+for universe exclusions.  They are not: the first is a *frame/listing*
+definition and the second is a *household-membership* rule.
+
+Frame concept, =ddi-documentation-english_microdata-75.pdf= pp. 3-4, "Sampling
+Procedure > HOUSEHOLD LISTING":
+
+#+begin_quote
+The improvements introduced to the PLD consisted in clarifying the concept of a household "currently living in the aldeia", both by intensive training and supervision of the enumerators and by making its meaning explicit in the form's wording (it means that the household members are regularly eating and sleeping in the aldeia at the time of the operation).
+#+end_quote
+
+Membership rule, =timorlestehhqeng_V2.pdf=, Section 1 Part A, interviewer
+instructions to QUESTION 23:
+
+#+begin_quote
+DECEASED INDIVIDUALS ARE NEVER CLASSIFIED AS HOUSEHOLD MEMBERS.
+LODGERS ARE NOT CLASSIFIED AS HOUSEHOLD MEMBERS.
+#+end_quote
+
+*** Sub-samples
+
+None within the wave.  The 2001 design is a single stratified sample; the
+strata were Major Urban Centers (450 households: 378 Dili, 72 Baucau), Other
+Urban Centers (252) and Rural Areas (1,098), with a 3-stage PPS/PPS/EP
+selection outside Urban Dili and 2-stage in Urban Dili
+(=ddi-...-75.pdf=, "SAMPLE SIZE AND ANALYTIC DOMAINS" and "SAMPLING STRATEGY").
+That is sample design, not a universe.
+
+Note for anyone pooling across waves: half of this 2001 sample was selected for
+re-interview in 2007, but that panel component was *not released* -- see the
+2007-08 entry below.
+
+** 2007-08 (TLSLS-2, and the 2008 Extension TLSLS2-X)
+
+*** Declared universe (verbatim, local document)
+
+=2007-08/Documentation/TLSLS07_Final_Statistical_Abstract.pdf= (National
+Directorate of Statistics / Ministry of Finance, July 2008), Section "1.
+Demographics -- Concepts and definitions", printed p. 15 (PDF p. 27):
+
+#+begin_quote
+The TLSLS captures the population living in private households. A household is a group of persons (or a single person) who usually live together and have a common arrangement for food, such as using a common kitchen or a common food budget.  The persons may be related to each other or may be non-relatives, including servants or other employees, staying with the employer. Students and employees residing in and having a common food arrangement with the household are considered members of the household if they have been in the household for the last year and absent for no more than one month.   If absent for longer than nine months, only infants less than three months old, newly weds or a bride who has joined her husband's family are considered household members.
+#+end_quote
+
+Supporting, catalog only.  WB catalog study 78, Coverage > Geographic Coverage
+and Scope > Unit of Analysis:
+
+#+begin_quote
+National coverage.
+Domains: Urban/rural; Regional
+#+end_quote
+
+#+begin_quote
+- Household
+- Individual
+#+end_quote
+
+*** Exclusions (verbatim)
+
+Same document, same section, immediately following the universe paragraph:
+
+#+begin_quote
+However, this does not include boarders/lodgers or boarding houses operated by the household.  Boarding houses with more than five persons are considered to be institutional households.  Institutional households are not covered by the survey.  They are defined as a group of five or more unrelated persons living together, for example, those living in boarding houses, military barracks, prisons, or student dormitories.
+#+end_quote
+
+That is a genuine universe exclusion (institutional / collective quarters).  No
+geographic exclusion and no security carve-out is stated for this wave.  Note
+that the boarder/lodger clause in the same paragraph is a *membership* rule,
+not a universe exclusion -- the document runs the two together in one
+paragraph, and a reader should not.
+
+*** Two design components, only one released
+
+=2007-08/Documentation/ddi-documentation-english_microdata-78.pdf= p. 2,
+"Sampling > Sampling Procedure > SAMPLE DESIGN FOR THE 2007-2008 SURVEY"
+(identical text on the catalog page):
+
+#+begin_quote
+The TLSLS sample was designed to have two components: (i) a cross-sectional component of 4,500 households selected with the intention of representing the current population of Timor-Leste, and (ii) a panel component of 900 households, where half of the 2001 TLSS sample of 1800 households are randomly selected and re-interviewed, with the purpose to evaluating changes in the living conditions for the same set of households between the two surveys.
+#+end_quote
+
+Immediately following, same section:
+
+#+begin_quote
+However, this panel component is not being released at this time, so it will be neither covered in the rest of the documentation nor included in the data files.
+#+end_quote
+
+*This is the single most important sentence in this section for a user of the
+library.*  The 2001-2007 panel exists by design but is *not* in the shipped
+extract, so a household appearing in both library waves is not thereby a panel
+observation.  (Consistently, neither wave's =sample= declares =panel_weight= in
+=_/data_info.yml=.)
+
+Realized cross-section, same PDF p. 3:
+
+#+begin_quote
+In fact, the cross-sectional sample only consists of only 269 (rather than 300) different EAs. This necessitated selecting a multiple of 15 households (rather than just 15 households) in the EAs that were selected more than once. The final cross-sectional sample consists of 4,477 households.
+#+end_quote
+
+*** Sub-samples inside the wave
+
+The wave directory covers two instruments.  Anyone pooling should know this
+before averaging.
+
+1. *2008 Extension (TLSLS2-X)* -- a sub-sample of the TLSLS2 sample, not a
+   fresh draw.  =ddi-...-78.pdf=, "Sampling Procedure > 2008 EXTENSION SURVEY":
+
+   #+begin_quote
+   Sampling for the TLSLS2 - Extension survey was a sub-sample of the original TLSLS2 sample. The TLSLS2 field work was divided into 52 "weeks", with each week being a random subset of the total sample. The sub-sample was chosen by randomly selecting 19 weeks from the original field work schedule. Each week contained seven Primary Sampling Units (PSUs) for a total of 133 PSUs. In each PSU the teams were to interview 12 of the original 15 households, with the remaining three to serve as replacements. The total nominal sample size was thus 1596.
+   #+end_quote
+
+   There is no separate universe statement for the extension; its universe is
+   the TLSLS2 households it re-visits.
+
+2. *A quality-driven repeat in two districts* -- effectively an oversample of
+   Manatuto and Oecussi.  Same section, immediately following:
+
+   #+begin_quote
+   Additional interviews: Following the collection and initial analysis of the data, it was determined that data from one district, Manatuto, and partially from another district, Oecussi, were of insufficient quality in certain modules. Therefore it was decided to repeat the survey in another 25 PSUs of these two districts - six in Manatuto, and 19 in Oecussi. The additional PSUs chosen were randomly selected within the two districts from the remaining non-panel PSUs in the original TLSLS2 sample.
+   #+end_quote
+
+3. *A fieldwork-driven substitution* that changes which households the released
+   sample contains.  =ddi-...-78.pdf=, "Data Collection > DATA COLLECTION NOTES
+   > 2007-2008 SURVEY FIELDWORK":
+
+   #+begin_quote
+   In order to maintain a sample for a continuous period of a year, the final TLSLS sample thus excludes the 351 households interviewed in 2006 and instead includes the 358 revisited or replaced households.
+   #+end_quote
+
+*** Universe vs. what the weights represent
+
+The universe is "the population living in private households"; the weights are
+benchmarked to a projected population total, and the representativeness claim
+is made at ten domains rather than nationally alone.
+
+Representativeness, =ddi-...-78.pdf= p. 3:
+
+#+begin_quote
+The sample can be considered representative at national level as well as at the level of the ten domains represented by the rural and urban areas of the five regions.
+#+end_quote
+
+The ten domains are urban/rural within five regions: R1 Baucau, Lautem,
+Viqueque; R2 Ainaro, Manufahi, Manatuto; R3 Aileu, Dili, Ermera; R4 Bobonaro,
+Cova Lima, Liquica; R5 Oecussi (same section, enumerated verbatim there).
+
+Weight benchmark, same PDF, "Weighting > SELECTION PROBABILITIES AND RAISING
+FACTORS FR THE 2007-2008 SURVEY" (heading typo as printed):
+
+#+begin_quote
+The household weights are further adjusted such that the population totals as estimated from the full sample match the demographic projections for mid-2007 for each stratum. This corresponds to a mid-2007 total population for Timor-Leste of 1,047, 632 persons.
+#+end_quote
+
+("1,047, 632" is as printed.)  So weighted 2007-08 totals reproduce a 2007
+demographic *projection* based on the 2004 Census, not an independent count.
+
+** Notes on quoting and provenance
+
+- Quotes above have end-of-line hyphenation rejoined and hard line breaks
+  normalized to spaces; typographic quotes and diacritics are rendered in ASCII
+  per the repository's Org conventions.  No other alteration.
+- No =.dta= file was opened in preparing this section.  Nothing here is an
+  inference from the data about what the survey covers.
+- Wave provenance: both =SOURCE.org= files carry the catalog id
+  (=#+CATALOG_ID: 75= and =78=) and DOI, and the catalog records were fetched
+  and checked against them.
+- This section does not propose any schema for representing the above; how the
+  library should *record* a universe is being decided in GH #603.
+
 * Known data issues
 
 ** shocks — not available (2026-06-06)

--- a/lsms_library/countries/Togo/_/CONTENTS.org
+++ b/lsms_library/countries/Togo/_/CONTENTS.org
@@ -13,6 +13,198 @@ each grappe is visited in exactly one =vague=, so household
 identifier is =(grappe, menage)= without a vague level.  See
 CLAUDE.md "EHCVM countries" for the cross-country pattern.
 
+* Sampling universe, exclusions and sub-samples
+
+Evidence for what the Togo wave *claims* to represent, kept deliberately
+separate from what the data look like.  Nothing here is inferred from any
+=.dta=; every claim is a quotation with a citation.  Companion to
+"Sampling Design" above (which records the =grappe=/=vague= identifier
+convention) and to "Household Presence / MonthsSpent" below (which
+records the 6-month residency filters =s01q12= / =s01q13= that operationalise
+"de jure" membership at the person level).
+
+Design representation is out of scope here --- GH #603 is deciding how the
+library should *encode* this.  This section is evidence only.
+
+** 2018 (EHCVM 2018/19)
+
+*** Declared universe (verbatim)
+
+#+begin_quote
+The survey covered all de jure households excluding prisons, hospitals,
+military barracks, and school dormitories.
+#+end_quote
+
+Source: World Bank Microdata Library catalog entry *4298*
+(=TGO_2018_EHCVM_v02_M=; the id recorded in
+=2018/Documentation/SOURCE.org= as =#+CATALOG_ID: 4298=), DDI field
+=study_desc.study_info.universe=; rendered on the study-description page
+under Coverage > Universe.  Language: English (the source text is in
+English --- no translation needed; the local questionnaires are in French).
+
+Verified 2026-07-21 by re-fetching
+https://microdata.worldbank.org/metadata/export/4298/json --- byte-identical
+to the quote above.  The same record gives:
+
+| DDI field                       | value (verbatim)                     |
+|---------------------------------+--------------------------------------|
+| =study_info.geog_coverage=      | =National coverage=                  |
+| =study_info.analysis_unit=      | =- Household  - Individual  - Community= |
+| =method...sampling_deviation=   | (absent)                             |
+| =method...weight=               | (absent)                             |
+| =method.analysis_info.response_rate= | (absent)                        |
+
+*** WARNING: this universe sentence is NADA boilerplate, not a Togolese claim
+
+The sentence quoted above is *World Bank NADA template text*.  It appears
+verbatim in 15 waves across the corpus --- all eight WAEMU/EHCVM countries
+(Benin, Burkina Faso x2, Cote d'Ivoire, Guinea-Bissau, Mali, Niger, Senegal,
+Togo) and also Ethiopia 2018-19 / 2021-22 and Nigeria 2015-16 / 2018-19 /
+2023-24, which are not EHCVM at all.  Its presence attests *which metadata
+template was used*; it does **not** independently attest that INSEED made
+that claim about this survey.  Do not treat it as a statistical office's
+statement about Togo.
+
+Corroborating this reading: the Togo Basic Information Document (INSEED /
+World Bank, June 2021; catalog download id 52590) contains **no** universe
+statement and **no** exclusion clause at all --- greps for =universe=,
+=exclud=, =prison=, =barrack=, =nomad=, =homeless=, =institution= over the
+full 20-page text return only an unrelated hit ("access to financial
+institutions", Section 6).  The exclusion of collective/institutional
+dwellings is asserted *only* by the catalog template.
+
+*** WHERE THE STATEMENT LIVES: catalog only, nothing local
+
+There is **no universe or target-population statement in any file this
+repository holds** for this wave.  =2018/Documentation/= contains only
+=SOURCE.org= (URL + provenance keywords), =LICENSE.org= (access policy and
+citation), and five DVC-tracked questionnaire spreadsheets
+(=tgo_ehcvm1_qnr_household_excel_vague{1,2}.xls=,
+=tgo_ehcvm1_qnr_community_excel_vague{1,2}.xls=,
+=EHCVM_UEMOA_MEN_TOGO_V2.xls=).  No report, no BID, no abstract PDF is
+shipped locally.  =_/CONTENTS.org= and =2018/_/notes.org= were grepped for
+=univers|populati|menage|couvert|echantill|exclu= --- only incidental hits
+on food/nonfood item labels and id-structure notes.
+
+Consequence: for Togo the population record is a *moving target held on the
+World Bank's servers*, not something the library holds.  If catalog 4298 is
+revised, this section becomes stale silently.  (Togo is one of 41 of 111
+waves in this position.)
+
+*** Geographic coverage and the Lome Commune sentence (quoted, NOT corrected)
+
+Catalog 4298, Sampling > Sampling Procedure, opening sentence --- identical
+text in the Basic Information Document, section "Sample", *PDF page 10*,
+first sentence (both verified 2026-07-21):
+
+#+begin_quote
+The Togo EHCVM 2018/19 sample covers all regions with urban and rural areas
+surveyed in all regions except Lome Commune where all respondents are from
+rural areas.
+#+end_quote
+
+*Read that twice.*  It is quoted exactly as printed in both sources.  It is
+internally implausible --- Lome Commune is the wholly urban capital district
+--- and reads like an urban/rural transposition in the source document
+(compare Guinea-Bissau's structurally identical sentence, which says the
+autonomous sector of Bissau is the one where "all respondents are from
+*urban* areas").  It is reproduced here uncorrected on purpose.  **Do not
+silently "fix" it**, and do not treat the corrected reading as documented:
+what is documented is the sentence above.
+
+Practical import either way: *Lome Commune is a single-milieu stratum*.
+Whichever milieu the source meant, one of urban/rural is absent from Lome
+Commune by design, so a rural/urban contrast computed within Lome Commune is
+not estimable, and pooled urban/rural comparisons carry a design asymmetry
+there.
+
+*** Exclusions --- summary
+
+| kind                | what is excluded                                        | evidence                                        |
+|---------------------+---------------------------------------------------------+-------------------------------------------------|
+| Population/institutional | prisons, hospitals, military barracks, school dormitories | catalog 4298 Universe field --- *NADA boilerplate*; absent from the BID |
+| Geographic (region) | none --- "National coverage"; all regions surveyed      | catalog 4298 Geographic Coverage + Sampling Procedure |
+| Geographic (milieu) | one milieu absent in Lome Commune (source says rural-only; see caveat above) | catalog 4298 Sampling Procedure; BID p.10       |
+| Security carve-out  | none stated                                             | no =sampling_deviation= field in the DDI record |
+| Nomadic / homeless / diplomatic | *not mentioned either way*                  | --- (a gap, not a "no")                          |
+
+Note what is *not* in the record: unlike sibling EHCVM documentation
+elsewhere (e.g. the French EHCVM instruments quoted under Burkina Faso,
+which exclude =les sans domiciles fixes= and =les menages ayant un statut
+diplomatique=), nothing in Togo's catalog entry or BID says anything about
+homeless, nomadic, or diplomatic households.  That is silence, not a
+documented inclusion.
+
+*** Oversamples and sub-populations: NONE FOUND
+
+No booster, no ethnic or programme sub-sample, no refresh/extended split, no
+module subsample, and no cross-section-plus-panel combination is documented
+for this wave.  The design as stated is a plain stratified two-stage draw.
+
+The one structure that could be mistaken for a sub-sample is the *two-wave
+seasonal split*, which is a fielding split of one sample, not two
+populations.  BID p.4, "Survey Characteristics" (verified verbatim):
+
+#+begin_quote
+The surveys took place in two waves with each wave covering half of the
+sample. The first wave was fielded between September 2018 and December 2018,
+while the second wave occurred between April 2019 and June 2019. The
+two-wave approach was chosen to account for seasonality of consumption.
+#+end_quote
+
+The library folds both fielding waves into the single wave directory =2018=
+(=t = "2018"=), so the seasonal half-samples are pooled by default.  Anyone
+computing consumption levels should know they are averaging a
+Sept--Dec 2018 half and an Apr--Jun 2019 half.
+
+Sample-design magnitudes --- *context, not universe* (catalog 4298 Sampling
+Procedure; identical in BID p.10): two-stage design; 540 EAs at stage 1;
+12 households per EA at stage 2; total 6,171 households (2,270 urban,
+3,901 rural); each EA split into two equal halves, one per fielding wave;
+wave 1 = 2,931 households (1,034 urban, 1,897 rural), wave 2 = 3,240
+households (1,236 urban, 2,004 rural).
+
+*** Universe vs. what the weights represent
+
+*Unresolvable from the record.*  The DDI entry for 4298 carries **no**
+=weight=, no =sampling_deviation= and no =response_rate= field, and the BID
+says nothing about what the weights are constructed to represent.  So for
+Togo the two cannot be compared: only the (boilerplate) universe is on
+record.  Do not assume the weights represent the boilerplate universe ---
+nothing states it.
+
+*** Programme context (why the sibling countries look identical)
+
+BID, Introduction, p.3, verbatim:
+
+#+begin_quote
+The EHCVM 2018/19 is the first edition of a nationally representative
+household survey conducted within the Programme d'Harmonisation et de
+Modernisation des enquetes sur les Conditions de Vie des Menages (PHMECV
+program), a joint program by the World Bank and the WAEMU Commision. The
+main aim of the program is to strengthen the capacity of its member
+countries (Benin, Burkina Faso, Cote d'Ivoire, Guinee Bissau, Mali, Niger,
+Senegal, and Togo) to conduct living conditions surveys that meet
+harmonized, regional standards and to make the collected micro-data publicly
+accessible.
+#+end_quote
+
+(Transcription notes: accents dropped and curly apostrophes replaced for
+ASCII; a footnote marker after "PHMECV program" is dropped and the
+parenthesis closed --- the PDF prints "(PHMECV program2" with an unclosed
+paren.  "Commision" is the source's own spelling.  Wording otherwise
+unaltered.)  A
+near-identical universe sentence should therefore be expected for the other
+seven EHCVM countries --- and *is* found there, which is exactly why it
+cannot be read as a Togo-specific claim.
+
+*** Gap: the =_forEthan= extracts have no documented universe
+
+=2018/Data/= additionally contains non-EHCVM extracts
+(=Togo_survey2018_*_forEthan.dta= / =.csv=) shipped with no documentation of
+their own.  No universe statement is available for those files, and none was
+inferred from their contents.  Recorded as a gap.
+
 * food_acquired units (Benin<->Togo codebook link)
 
 Togo's =s07bq03b= unit variable stores bare numeric codes (100-662): its

--- a/lsms_library/countries/Uganda/_/CONTENTS.org
+++ b/lsms_library/countries/Uganda/_/CONTENTS.org
@@ -207,6 +207,486 @@ For cross-sectional analysis within a single wave, use =weight=.
 For longitudinal/panel analysis across waves, use =panel_weight=
 (and restrict to households where it is non-null and positive).
 
+** Sampling universe, exclusions and sub-samples
+
+Evidence gathered 2026-07-21 under GH #601.  Every quote below was
+re-verified against the cited PDF at the cited page.
+
+Transcription conventions, so a later reader can tell quote from edit: runs
+of whitespace introduced by PDF justification are collapsed to single spaces;
+the source's typographic double quotes (around "wave", "tracking", "core",
+"target tracking") are transcribed as ASCII straight quotes; the =fi=/=ff=
+ligatures in the 2015-16 DDI are transcribed as ordinary ASCII letters; an
+en-dash in the 2019-20 BID is transcribed as "-".  *No words were changed,
+added, or reordered*, and nothing is elided except where marked with =...=.
+
+*** There is no declared universe for any Uganda wave
+
+No document for any of the eight waves carries a DDI =Universe= or "target
+population" field.  Searched, per wave: every local Basic Information
+Document and DDI PDF under =countries/Uganda/{wave}/Documentation/=,
+converted in full with pdfminer and grepped for =universe=, =target
+population=, =coverage=, =scope=, =excluded=, =exclusion=, =nomadic=,
+=institutional=, =sampling frame=; plus the World Bank catalog
+study-description pages for ids 1001, 2166, 2059, 2663, 3460, 3795 and 3902.
+=universe= returns *zero hits* in all of them.
+
+What exists instead, in every wave, is a *coverage claim* plus
+sampling-procedure prose:
+
+- a DDI =Geographic Coverage= field reading =National= (2009-10, 2018-19) or
+  =National coverage= (2010-11) or =National Coverage.= (2015-16); and
+- one recurring sentence about a "nationally representative sample of
+  households".
+
+Two things follow, and both matter when pooling Uganda with other countries.
+
+1. *This is not the World Bank NADA boilerplate.*  The sentence that appears
+   verbatim in 15 waves of the #601 corpus -- "The survey covered all de jure
+   households excluding prisons, hospitals, military barracks, and school
+   dormitories." -- does *not* appear anywhere in Uganda's documentation.
+   Uganda's recurring sentence is UBOS/LSMS-ISA text specific to the UNPS.
+   So it attests a real survey-programme claim, not a metadata template.
+
+2. *But it is copy-forward within the UNPS series.*  The same "carried out
+   over a twelve-month period ... on a nationally representative sample of
+   households" sentence, and the same paragraph of sampling procedure around
+   it, is reprinted essentially unchanged from 2009-10 through 2019-20 --
+   and the 2010-11 BID says so outright: "Refer to the UNPS 2009/10 Basic
+   Information Document for detailed information on the UNPS survey design"
+   (=UNPS_2010-11_Basic-Info-2014.pdf=, sec. 1.2, PDF p. 3).  There are
+   therefore effectively *two* independent coverage statements here -- one
+   for the UNHS 2005/06 baseline and one for the UNPS series -- not eight.
+   Treating agreement across waves as corroboration would be double-counting.
+
+*Gap, recorded as a gap.*  No Uganda document found states an
+institutional-population exclusion (prisons, hospitals, barracks, school
+dormitories) or a nomadic / homeless / collective-quarters exclusion.  That
+is *not* evidence that no such exclusion applies -- it is evidence that the
+question is unanswered in the documents this repo holds.  See the search
+list at the head of this subsection for exactly what was looked at.
+
+*** Declared coverage, per wave
+
+| Wave    | Statement source                                     | Held in repo? | Locator                                   |
+|---------+------------------------------------------------------+---------------+-------------------------------------------|
+| 2005-06 | UNHS 2005/06 Interviewer Manual                      | yes           | ch. 1, "SURVEY DESIGN", PDF p. 4          |
+| 2009-10 | DDI, catalog 1001                                    | yes           | Series; Coverage > Geographic Coverage    |
+| 2010-11 | Basic Information Document (rev. 2014)               | yes           | sec. 1.2 Survey Design, PDF p. 3          |
+| 2011-12 | Basic Information Document (rev. July 2014)          | yes           | sec. 1.2 Survey Design, PDF p. 6          |
+| 2013-14 | Basic Information Document                           | yes           | sec. 1.2 Survey Design, PDF p. 6          |
+| 2015-16 | DDI, catalog 3460                                    | yes           | Coverage, PDF p. 3; Sampling, PDF p. 4    |
+| 2018-19 | *WB catalog page only* -- see warning below          | *no*          | catalog 3795 Series / Coverage / Sampling |
+| 2019-20 | Basic Information Document                           | yes           | sec. 1.2 Survey Design, PDF pp. 6-7       |
+
+**** 2005-06 -- the UNHS baseline
+
+=2005-06/Documentation/UNHS.2005-06.Interviewer.Manual.FINAL.pdf=, Chapter
+One, section "SURVEY DESIGN" (PDF p. 4; printed p. 2).  The =...= elides one
+sentence about EA maps.
+
+#+begin_quote
+The UNHS 2005/06 will use the 2002 Population and Housing Census list of
+Enumeration Areas (EAs) as its sampling frame. ... A sample of about 750
+Enumeration Areas (EAs) has been selected. The selected areas will be visited
+by UBOS field workers who will list all households living in the EAs. 10
+households will be selected randomly from each EA. The UNHS sample covers the
+entire country and was selected in such a way that it will generate estimates
+for the whole of Uganda, for urban and rural Uganda, and each of the four
+(statistical) regions: Central, Eastern, Northern and Western, and for a few
+selected districts.
+#+end_quote
+
+This is a coverage/precision claim, not a universe: it says what the sample
+will /produce estimates for/, and never says what population is in scope.
+
+**** 2009-10 -- UNPS Wave 1
+
+=2009-10/Documentation/ddi-documentation-english_microdata-1001.pdf=,
+"Series" (PDF p. 14) and "Geographic Coverage" (PDF p. 16, printed "- 6 -");
+the IDP sentence quoted below is on PDF p. 17.
+The =...= elides the intervening Abstract / Objectives / Scope blocks.
+
+#+begin_quote
+The 2005-2009/10 Uganda National Panel Survey (UNPS) is the first multi-topic
+panel household survey conducted in Uganda. The UNPS is carried out annually,
+over a twelve-month period on a nationally representative sample of
+households. ... Geographic Coverage National
+#+end_quote
+
+**** 2010-11 through 2019-20 -- the recurring UNPS sentence
+
+Verbatim from =2011-12/Documentation/unps_2011_12_bid_rev2014july.pdf=,
+sec. 1.2 (PDF p. 6); the 2013-14 BID (PDF p. 6), the 2015-16 DDI (Sampling
+Procedure, PDF p. 4), the 2019-20 BID (sec. 1.2, PDF p. 6) and the catalog
+3795 page carry the same sentence, with or without the parenthetical (a
+"wave") and
+with =annually= present in 2010-11/2011-12/2013-14 and dropped from 2015-16
+onward:
+
+#+begin_quote
+The UNPS is carried out annually, over a twelve-month period (a "wave") on a
+nationally representative sample of households, for the purpose of
+accommodating the seasonality associated with the composition of and
+expenditures on consumption.
+#+end_quote
+
+**** 2018-19 -- statement exists ONLY in catalog metadata
+
+=2018-19/Documentation/= contains *no* Basic Information Document and *no*
+DDI PDF -- only =SOURCE.org=, =LICENSE.org= and four questionnaires
+(=agriculture_qx.pdf=, =unps_community.pdf=, =unps_hhq.pdf=,
+=unps_woman.pdf=).  The only population statement for this wave lives on
+https://microdata.worldbank.org/index.php/catalog/3795/study-description
+(fetched 2026-07-21), under Series Information, Coverage and Sampling:
+
+#+begin_quote
+The 2018/19 Uganda National Panel Survey (UNPS) is the seventh multi-topic
+panel household survey conducted in Uganda and follows surveys carried out in
+2009/10, 2010/11, 2011/12, 2013/14 and 2015/16. The UNPS is carried out over
+a twelve-month period on a nationally representative sample of households.
+... Coverage Geographic Coverage National
+#+end_quote
+
+*Warning.*  For this wave the library holds no copy of the claim.  The World
+Bank can revise or re-version that page at any time, so the 2018-19 record is
+a moving target rather than something this repo can reproduce.  Acquiring the
+2018-19 BID/DDI would close it.
+
+*** Exclusions
+
+**** IDP camps -- the one geographic/population exclusion, and it reverses
+
+The UNHS 2005/06 baseline *included* the internally-displaced population, by
+adding a sampling stage for it (=UNHS.2005-06.Interviewer.Manual.FINAL.pdf=,
+"SURVEY DESIGN", PDF p. 4):
+
+#+begin_quote
+However, in some districts of Northern Uganda where large populations have
+been displaced by the LRA war and are living in Internally Displaced People
+(IDP) Camps, a three-stage sampling design will be adopted, with the
+selection of the IDP as the first stage unit, the respective 'blocks' within
+the camp as the second stage selection and the households within the blocks
+as the third stage units of selection.
+#+end_quote
+
+The UNPS, which subsamples the UNHS 2005/06 frame, then *drops* those extra
+EAs.  The wording drifts across waves; each is quoted as printed:
+
+| Wave    | Verbatim                                                                                                                          | Source                              |
+|---------+-----------------------------------------------------------------------------------------------------------------------------------+-------------------------------------|
+| 2009-10 | Since IDP camps are now mostly unoccupied, the extra EAs in IDP camps are not a part of the UNPS subsample.                        | DDI 1001, Sampling, PDF p. 17       |
+| 2010-11 | -- no exclusion statement; see gap note below                                                                                     | --                                  |
+| 2011-12 | Since IDP (internally displaced people) camps are now mostly unoccupied, the extra EAs in IDP camps are not a part of the UNPS subsample. | BID sec. 1.2, PDF p. 6       |
+| 2013-14 | Since IDP camps are now mostly unoccupied, the extra EAs in IDP camps are not a part of the UNPS subsample.                       | BID sec. 1.2, PDF p. 6              |
+| 2015-16 | Since most IDP (Internally Displaced People) camps in the Northern region are currently unoccupied, the EAs that constituted IDP camps were not part of the UNPS sample. | DDI 3460, Sampling, PDF p. 4 |
+| 2018-19 | (same sentence as 2015-16)                                                                                                        | catalog 3795, Sampling Procedure    |
+| 2019-20 | Since most IDP (Internally Displaced People) camps in the Northern region are currently unoccupied, the EAs that constituted IDP camps were not part of the UNPS sample. | BID sec. 1.2, PDF p. 7 |
+
+Read plainly: from 2009-10 onward the UNPS frame is the UNHS 2005/06 frame
+*minus* its IDP-camp EAs.  The documents justify this by the camps being
+"mostly unoccupied" -- they do not claim the formerly-displaced population is
+picked up elsewhere in the frame, and they do not quantify what was dropped.
+Anyone using UNPS Northern-region estimates for the post-conflict period
+should carry that carve-out explicitly.
+
+*Gap -- 2010-11.*  Neither =UNPS_2010-11_Basic-Info-2014.pdf= nor
+=ddi-documentation-english_microdata-2166.pdf= nor the catalog 2166 page
+contains any exclusion statement for this wave; =IDP= returns *zero hits* in
+all three.  The 2010-11 BID instead defers to the 2009/10 BID for design.  So
+the IDP exclusion is not restated for 2010-11 -- inherited, not asserted.
+
+**** 2019-20 -- households whose last interview was Wave 0 or Wave 1 are out
+
+=2019-20/Documentation/unps2019_20_bid.pdf=, sec. 4.1 "Tracking" (PDF
+pp. 32-33), describing the expanded Wave 8 target-tracking scope:
+
+#+begin_quote
+All households (original, movers or split-offs) that were interviewed during
+Wave 2 and/or Wave 3 and/or Wave 4 and still live in Uganda, regardless of
+location or distance from original household location. ... "Previous wave" is
+defined as the last time that household was interviewed - in this case Wave
+7(2018/19); in others wave 6(2017/18); and/or wave 5(2015/16); and/or wave
+4(2013/14); and/or wave 3 (2011/12); and/or, Wave 2 (2010/11). If they were
+last interviewed in Wave 0 or Wave 1, they were excluded from the survey at
+this time.
+#+end_quote
+
+Wave 0 is the UNHS 2005/06 baseline and Wave 1 the UNPS 2009/10.  This is a
+panel-following rule rather than a statement about the target population, but
+it *bounds who can appear in 2019-20*: a household last seen in 2005/06 or
+2009/10 is out of scope for Wave 8 by design, not by attrition.
+
+**** Persons excluded from tracking
+
+Same source, sec. 4.1 (PDF p. 32), describing the rule in force through
+Wave 7:
+
+#+begin_quote
+Split-offs could originate from both original and shifted households, though
+the only household members eligible for target tracking as split-offs were
+the household head and individuals related to them such as spouse, biological
+children, parents of the head or spouse, etc. (codes 1-7 of Section 2
+Question 4 in the household questionnaire). Servants, other relatives and
+non-relatives (codes 8-96) were not tracked.
+#+end_quote
+
+and, for Wave 8 (PDF p. 33):
+
+#+begin_quote
+In those households, the only individuals marked for tracking are the
+previous wave's household head, spouse, and children over age 15. Other
+household members were not tracked beyond their known location from the
+previous wave - they were only included in interviews if they still lived
+with one of these "core" members.
+#+end_quote
+
+Consequence for =household_roster= / =household_characteristics=: servants,
+non-relatives and distant relatives who leave a UNPS household cannot form an
+in-sample split-off household.  Relationship categories are therefore *not*
+followed symmetrically over the panel.
+
+*** Oversamples and sub-samples inside a wave
+
+Uganda's specialisation lives *inside* waves, not as whole waves.  The
+documented sub-samples, in descending order of how much they should change
+what a reader does with the data:
+
+**** 1. Ten districts oversampled by the UNHS 2005/06, deflated in the UNPS
+
+=2011-12= BID sec. 1.2 (PDF p. 6) and =2013-14= BID sec. 1.2 (PDF p. 6),
+identical wording:
+
+#+begin_quote
+Within each stratum, the UNPS EAs were selected from the UNHS 2005/06 EAs
+with equal probability, and with implicit stratification by urban/rural and
+district (in this order), except for the rural portions of the ten districts
+that were oversampled by the UNHS 2005/06. In these districts, the
+probabilities were deflated, to bring them back to the levels originally
+intended.
+#+end_quote
+
+Restated more vaguely from 2015-16 onward (=2015-16= DDI Sampling, PDF p. 4;
+=2019-20= BID sec. 1.2, PDF pp. 6-7): "However, the probabilities of selection for the
+rural portions of ten districts that had been oversampled by the UNHS 2005/06
+were adjusted accordingly."
+
+*Gap.*  *The ten districts are never named* in any document searched (all
+eight waves' BIDs/DDIs plus the 2005/06 interviewer manual, grepped for
+=oversampl=).  So the oversample is attested but not reconstructible from
+what the repo holds; it is absorbed into the weights and cannot be identified
+in the data from documentation alone.
+
+**** 2. The 20% "target tracking" sub-sample (waves 1-4)
+
+Two households per EA -- 20% of the sample -- were designated for tracking
+movers, and *only those* were followed outside their original EA.
+=2019-20= BID sec. 4.1 (PDF p. 32):
+
+#+begin_quote
+Prior to the UNPS 2009/10 field work, 20% of households (two per EA) were
+randomly selected for purposes of tracking individuals that had moved from
+original locations since UNHS 2005/06. These were the only households tracked
+even if they had moved beyond their original EA/parish, they maintained the
+"target tracking" status during Wave 2 (2010/11), Wave 3 (2011/12) & Wave 4
+(2013/14).
+#+end_quote
+
+Same fact in the =2011-12= and =2013-14= BIDs, sec. 1.2 (both PDF p. 6):
+"Prior to the start
+of the 2009/10 field work, 2 UNPS households were also randomly selected in
+each EA for the purposes of tracking baseline individuals that moved away
+from original locations since the UNHS 2005/06."
+
+And the asymmetry between movers and split-offs (=2019-20= BID sec. 4.1,
+PDF p. 32):
+
+#+begin_quote
+In prior waves, movers were tracked and interviewed if they moved somewhere
+else within Uganda, even if they were not selected as part of the target
+tracking sample. ... In prior waves, split-offs were only tracked and
+interviewed if they moved to somewhere else within Uganda and were previously
+selected as part of the target tracking sample.
+#+end_quote
+
+*This is the sharpest sub-population fact in the Uganda record.*  Through
+Wave 4 the two groups enter on different terms: a whole household that
+shifted was followed regardless, but a split-off was eligible for interview
+only if its origin household was one of the two per EA in the target-tracking
+sample -- i.e. split-offs enter through a 20% sub-frame.  The documents do
+not quantify the resulting under-representation, and this section does not
+either.  It bears directly on the 565 movers and split-offs documented above
+under "Hybrid =v= in 2009-10 (movers and split-offs)": those households are
+outside the 2005-06 sampling frame, and the split-offs among them (368 in
+2009-10) reached the sample through that sub-frame.  Do not read split-offs
+in waves 1-4 as a representative sample of new household formation.
+
+**** 3. The one-third rotating refresh (2013-14 onward)
+
+=2015-16= DDI, "SAMPLE REFRESH" (PDF p. 4):
+
+#+begin_quote
+Starting with the UNPS 2013/14 (Wave 4) fieldwork, one third of the initial
+UNPS sample was refreshed with the intention to balance the advantages and
+shortcomings of panel surveys. Each new household will be visited for three
+consecutive waves, while baseline households will have a longer history of
+five or six years, given the start time of the sample refresh. This same
+sample was used for the UNPS 2015/16 (Wave 5) Once a steady state is reached,
+each household will be visited for three consecutive years, and at any given
+time one third of the households will be new, one third will be visited for
+the second time, and one third for the third (and last) time. The total
+sample will never be too different from a representative cross-section of the
+country, yet two-thirds of it will be a panel with a background of a year or
+two.
+#+end_quote
+
+(Sentence-boundary punctuation after "(Wave 5)" is missing in the source;
+quoted as printed.)  New households were drawn from a *different frame*:
+"New households were identified using the updated sample frames developed by
+the UBOS in 2013 as part of the preparations for the 2014 Uganda Population
+and Housing Census." (same page).  The =2013-14= BID sec. 1.2 anticipates
+this with the 2012 census: "parts of the sample will start to be replaced by
+new households extracted from the updated sample frames developed by the UBOS
+as part of the 2012 Uganda Population and Housing Census."  The refresh
+therefore mixes two sampling frames within a wave.
+
+*TENSION with "** Rotating panel and refreshment sample" above.*  That
+section states, without qualification, "Beginning in 2013-14, one-third of
+the original sample is refreshed each wave."  The documentation does not say
+that for 2015-16.  It says the refresh happened at Wave 4 and that "This same
+sample was used for the UNPS 2015/16 (Wave 5)", and it puts the each-wave
+one-third rotation in the future conditional -- "Once a steady state is
+reached".  So *each wave* is the design intent; whether it was achieved
+between W4 and W5 is contradicted by the DDI's own next sentence.  Neither
+claim should be deleted; the existing text should be read as the design and
+this quote as what the DDI reports actually happened.
+
+*Bears on the open TODO "Missing panel weight for 2019-20".*  That LOGBOOK
+entry reads "Appears to be panel-only (no refreshment sample). Confirm with
+UBOS documentation."  The 2019-20 BID does *not* support "no refreshment
+sample" -- sec. 4.1 (PDF p. 33) treats the refresh as operative: "The one-third of the
+original sample households that have been rotated out as part of the panel
+refresh are no longer tracked or interviewed at all." and "The new one-third
+of the sample rotated in as part of the panel refresh is not tracked beyond
+their location indicated during the listing exercise in late 2013."  But that
+second sentence dates the listing to *late 2013*, i.e. the Wave 4 refresh, so
+this passage is plausibly carried forward from an earlier BID rather than
+describing Wave 8 fieldwork.  Recorded as evidence bearing on the TODO, *not*
+as resolving it -- the identical-=wgt= observation in the data is not
+explained by anything found in the documentation.
+
+**** 4. The agriculture sub-sample (all UNPS waves)
+
+The Agriculture Questionnaire is not administered to the whole wave.
+=2013-14= BID sec. 1.2 (PDF p. 7) and =2019-20= BID sec. 1.2 (PDF p. 7), in
+the instrument list:
+
+#+begin_quote
+Agriculture Questionnaire, (administered to the subset of UNPS households
+engaged in agricultural activities)
+#+end_quote
+
+Any table sourced from the agriculture instrument (=crop_production=,
+=plot_features=, =plot_inputs=, =plot_labor=, =livestock=) is therefore
+defined on a self-selected subset of the wave, not on the wave.  The
+household weights are not weights for that subset.
+
+**** 5. Further within-wave subsets
+
+- *Women 15-49.*  The Woman Questionnaire covers only women of reproductive
+  age: "asking females in the households within the reproductive age of 15-49
+  years" and "birth history of eligible women in the household (15-49 years)"
+  (=2013-14= BID, sections 2A and 2B, PDF pp. 15-16).
+- *Half of each EA at Visit 1 (2019-20).*  "for half the number of households
+  in the EA, only the household roster information (Section 2) of the
+  Household Questionnaire is collected during Visit 1. In such cases, the
+  rest of the Household Questionnaire was completed approximately six months
+  later during Visit 2" (=2019-20= BID sec. 2.1, PDF p. 8).  A within-wave
+  split in *when* a household's non-roster modules were observed.
+- *Salt/oil sample collection at preselected households (2019-20).*  "Samples
+  of salt (about 20-50 grams) were collected at preselected households. A
+  100g packet of replacement salt was given to households where salt was
+  collected. Samples of oil and edible fat (about 25 mL) were also collected
+  at all households where item is available." (=2019-20= BID, sec. 2.1,
+  "Section 15: Household Consumption Expenditure", PDF p. 14.)  The
+  preselection rule is not documented.
+
+*** Universe versus what the weights represent
+
+The 2013-14 BID is unusually candid that the UNPS is trying to be two things
+at once, and that the sample is a compromise between them
+(=2013-14/Documentation/Basic Information Document.pdf=, sec. 4 "UNPS 2013/14
+Panel Weights", PDF p. 16):
+
+#+begin_quote
+The UNPS has two broad analytic goals. The first is to track the same sample
+of people from 2005/06 to 2013/14 to see how their lives have changed. The
+first goal is met by revisiting the same cases in each wave. Two-thirds of
+the original panel households (3200 household) were followed up in 2013/14
+wave. The second is to provide a cross-sectional snapshot of the Ugandan
+household population. The second goal, however, necessitates the
+incorporation new households and individuals in each wave to account for the
+changing population. The UNPS addresses this conflict by allowing for the
+inclusion of a sub-sample of split-off households in the wave and refreshing
+a third of the sample.
+#+end_quote
+
+and, on which weight answers which question (same document, sec. 4, PDF
+p. 22):
+
+#+begin_quote
+For cross-sectional estimates of population dynamics based only on the UNPS
+2013.14 data, the data users must use the variable wgt_X as part of GSEC1.dta
+of the UNPS 2013/14 package for household weight. This variable includes
+sampling weights for original as well as split-off and refreshed households
+and is generated as a result of the procedures detailed above. ... The
+variable wgt part of GSEC1.dta of the UNPS 2013/14 package for panel
+households was computed only for the interviewed both in 2011/2012 and
+2013/14.
+#+end_quote
+
+This corroborates the =weight= / =panel_weight= guidance in "** Sampling
+Weights" above from the primary source: =wgt_X= represents the Ugandan
+household population cross-sectionally; =wgt= represents only the
+2011/12-and-2013/14 panel.  They are answers to different questions about
+different populations, and the 1145 NaN panel weights recorded in the weights
+table are that by construction, not missingness.
+
+Note also the 2015-16 DDI's own hedge, quoted in full above: "The total
+sample will never be too different from a representative cross-section of the
+country" -- a claim of approximate, not exact, cross-sectional
+representativeness, made about a design that had not yet reached its steady
+state.
+
+*Numeric discrepancy in the primary sources, recorded not resolved.*  The
+size of the UNPS panel is given as *3,123* households in the 2009-10 DDI, the
+2011-12 BID, the 2013-14 BID, the 2015-16 DDI and the 2019-20 BID -- and as
+*3,200* in the 2010-11 DDI ("Out of the 7,400 households interviewed during
+the UNHS 2005/06, 3,200 households were selected for the UNPS"; abstract:
+"The survey covered 3,200 households") and in the 2013-14 BID passage quoted
+just above ("Two-thirds of the original panel households (3200 household)").
+The "** Overview" section above uses 3,123, which is the majority reading;
+the 3,200 figure is flagged here so a reader who meets it in the source
+documents knows it is a documentation inconsistency, not a second sample.
+
+*** Summary of gaps
+
+| Gap                                                          | What was searched                                                                 |
+|--------------------------------------------------------------+-----------------------------------------------------------------------------------|
+| No =Universe= / target-population field, any wave            | all 8 waves' local BIDs + DDIs (full pdfminer conversion) + 7 WB catalog pages     |
+| No institutional / nomadic / homeless exclusion statement    | same corpus, grepped =excluded=, =exclusion=, =institutional=, =nomadic=           |
+| 2005-06 -- no exclusion statement at all                     | interviewer manual (full), household questionnaire, catalog 1001                   |
+| 2010-11 -- no exclusion statement; =IDP= 0 hits              | BID (full), DDI 2166 (first 40 pp.), catalog 2166                                  |
+| 2018-19 -- no BID and no DDI held locally; catalog-only      | =2018-19/Documentation/= (questionnaires only); catalog 3795 fetched 2026-07-21     |
+| The ten oversampled districts are never named                | all 8 waves, grepped =oversampl=                                                   |
+| 2019-20 salt/oil preselection rule undocumented              | 2019-20 BID (full)                                                                 |
+
+One further note for readers of the wave list: the 2019-20 BID's own history
+enumerates "UNPS 2009/10, UNPS 2010/11, UNPS 2011/12, UNPS 2013/14, UNPS
+2015/16, UNPS 2017/18, UNPS 2018/19 & UNPS 2019/20" -- eight rounds including
+a *2017/18* (Wave 6) that this library does not carry.  Uganda's wave list
+here is not the full UNPS series.
+
 * Unit handling for =food_acquired=
 
 The =u= (unit) index level on =food_acquired= is canonical at


### PR DESCRIPTION
Records, in each country's `_/CONTENTS.org`, **what the survey documentation claims its sample represents** — the declared universe, the exclusions, and the sub-samples/oversamples that live inside a wave.

Refs #601, #603, #654.

## What this is (and is not)

This is **evidence**, not representation.

- Every universe/exclusion/sub-sample statement is **quoted verbatim**, with a file + page locator or a named catalog field, and a note on whether the statement is held **in this repo** or lives only in World Bank NADA catalog metadata (a moving target the library does not hold).
- **Gaps are recorded as gaps**, naming exactly what was searched — per the standing rule in `CLAUDE.md` against unevidenced "no module here" claims. "None found" never means "none exists".
- **Nothing is inferred from the `.dta` files.** No microdata was opened. What a survey claims and what its data contain are two different facts and are kept apart deliberately.
- **No schema is proposed.** No YAML key, no `data_scheme.yml` change, no code. #603 owns the decision about how the library *represents* any of this; this PR only makes sure the evidence exists to decide from.

Only `lsms_library/countries/*/_/CONTENTS.org` is touched — 38 files, all additions, no deletions.

## Countries

38 sections applied: Afghanistan, Albania, Armenia, Azerbaijan, Benin, Burkina Faso, Cambodia, China, Côte d'Ivoire, Ethiopia, EthiopiaRHS, GhanaLSS, GhanaSPS, Guatemala, Guinea-Bissau, Guyana, India, Iraq, Kazakhstan, Kosovo, Liberia, Malawi, Mali, Nepal, Niger, Nigeria, Pakistan, Panama, Peru, Senegal, Serbia, Serbia and Montenegro, South Africa, Tajikistan, Tanzania, Timor-Leste, Togo, Uganda.

Four had no `_/CONTENTS.org` at all and now have one: **Afghanistan, Armenia, Peru, Serbia and Montenegro**.

## How much is actually there

Counting a country as carrying the item if **at least one of its waves** has it stated in documentation (not inferred):

| | count |
|---|---|
| carry a **documented exclusion** (institutional, geographic, security, residence-duration, …) | **30 of 38** |
| record **no exclusion statement anywhere** — a checked gap, not a finding of "nothing excluded" | 8 (Cambodia, GhanaSPS, Guatemala, Guyana, India, Iraq, Kazakhstan, Tajikistan) |
| carry a documented **oversample, booster, panel/refresh split, module sub-sample or disproportionate allocation** | **31 of 38** |
| state that **no oversample is documented** | 7 (Benin, Guatemala, Guinea-Bissau, Kazakhstan, Niger, South Africa, Togo) |

Two patterns recur across the corpus and are flagged wherever they appear:

- **Specialization lives *inside* a wave, not as a whole wave.** Uganda's 20% target-tracking sub-frame, Ethiopia's structural 10-of-12 agricultural households in every rural EA, Malawi's IHPS panel drawn inside IHS3, Nigeria's conflict-area oversample (W3) then rural-Borno exclusion (W4), Mali's rural Lourd/Léger split, Iraq's one-third time-use module, India's double-rate 30-village oversample, Azerbaijan's three separately-drawn sub-populations. Unweighted country means are frequently not what they look like.
- **NADA boilerplate is not a statistical office's claim.** The sentence *"The survey covered all de jure households excluding prisons, hospitals, military barracks, and school dormitories."* appears verbatim in 15 waves, including countries with no plausible shared instrument. Every section that carries it says so explicitly and grades it as weaker evidence than survey-specific prose.

## Tensions with existing text — flagged, never overwritten

Nine countries' evidence disagrees with something already in the file. In every case **both sides are quoted in place, the disagreement is named, and nothing existing was edited or deleted**:

- **Azerbaijan** — the DDI says the 3-valued `weight` is exactly the intended three-group post-stratification factor `W` and "weighting factors must be applied"; the existing Data Quality note calls it a fallback and advises treating Azerbaijan as effectively unweighted. Resolving it needs a data check that was deliberately not run.
- **Côte d'Ivoire** — the catalog describes a *rotating two-year* CILSS panel (half replaced each year); the existing text says households were followed across 4 waves. Left for whoever implements `panel_ids`.
- **Ethiopia** — the ESS covered all urban areas from wave 2; the existing Overview's "rural and small-town areas in waves 1-3" applies to wave 1 alone. A one-word fix is suggested, not applied. Also an open question on ESPS-5 longitudinal weights.
- **GhanaLSS** — GSS's own GLSS3 report documents a rotating panel with a half-retained GLSS1→GLSS2 sample; the existing Survey Program text says there is no such mechanism (defensible from GLSS3 on, not before). Plus: GLSS5's agriculture sections use a flat grossing-up factor of 637.89, **not** `weight`.
- **Guinea-Bissau** — the DDI splits *each EA* between the two vagues, which contradicts the repo-wide EHCVM convention that each `grappe` is visited in exactly one `vague`. Settling it needs a `grappe × vague` crosstab.
- **Mali** — only 2018-19 and 2021-22 are EHCVM; 2014-15 and 2017-18 are EAC-I, a different survey (and in 2014-15 the rural observation unit is the agricultural holding, not the household). The Overview's opening line should be amended.
- **Nepal** — "no rotating panel or refreshment sample" reads as "no panel", but NLSS-II and NLSS-III each drew a *separate* panel sample; bears on the `weight`/`panel_weight` → `wt_hh` mapping. Also a catalog-id error in Data Acquisition Status (NLSS II = 74, not 1000).
- **Nigeria** — `wt_wave5` is the wave-4-to-5 longitudinal combined-sample weight, not a "general wave weight". The library's mappings are correct; only the annotation is wrong.
- **Uganda** — the 2015-16 DDI puts the each-wave one-third rotation in the future conditional; the existing text states it unqualified. Also a 3,123-vs-3,200 discrepancy *within the primary sources*, recorded so a reader who meets 3,200 knows it is documentation inconsistency, not a second sample.

## Placement

Each section went where it belongs in that file's existing structure — beside the country's own `Sampling Design` / `Survey Program` material where that exists, above the issue list otherwise — cross-referencing rather than duplicating. **Malawi** and **Uganda** are filed one level down as the last subsection of their existing `* Sampling Design`, placed so that every "…above" reference in the new prose resolves correctly.

Verified before commit: the inserted block is byte-identical to the drafted fragment in all 38 files (quotes untouched, no reflow); headings nest; `#+begin_/#+end_` blocks and drawers balance; tables are non-ragged; no stray fragment markers. Two pre-existing org level-jumps (Guinea-Bissau, Togo `plot_features`) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su5JKX3wKChyfMAdXrdCTr
