### PR TITLE
build(release): drop the vestigial local poetry build; tag last

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,9 +91,11 @@ endif
 	fi
 	$(POETRY) run pytest $(PYTEST_ARGS)
 	git tag -a "v$(v)" -m "Release $(v)"
-	$(POETRY) build
 	@echo ""
-	@echo "Tagged v$(v) and built dist/ (local sanity build)."
+	@echo "Tagged v$(v).  No local build: CI builds the sdist+wheel FROM THE TAG"
+	@echo "(publish.yml, fetch-depth 0, with a guard that fails on 0.0.0), so a"
+	@echo "local dist/ would never be published.  Tagging is the last step here"
+	@echo "so a failure cannot leave a tag behind."
 	@echo "To publish to PyPI (CI does the upload — no local twine):"
 	@echo "  git push origin v$(v)"
 	@echo "  gh release create v$(v) --title v$(v) --notes-file docs/releases/v$(v).md"


### PR DESCRIPTION
`publish.yml` (2026-06-20, `dd522ea7`) made CI the publisher — it builds the sdist+wheel **from the tag**, with `fetch-depth: 0` and a guard that fails if the version resolves to `0.0.0`.

The Makefile target was updated the same day (`915ef5f6`) — but **only its echo text**. `$(POETRY) build` survived, relabelled a "local sanity build", producing a `dist/` that is never published.

Two reasons to remove rather than keep it:

1. It is the step the release skill itself documents as fragile on Savio (broken system poetry, Linux keyring hang, outbound-network). **The one genuinely risky step in the target is also the one whose output is discarded.**
2. It ran **after** `git tag -a`, so a failure left a local tag behind and the operator had to know to delete it. With the build gone, **tagging is the last step** and cannot be orphaned.

The echo block now explains why there is no local build, so the next person does not "restore" it. `pytest` still gates the tag; behaviour is otherwise unchanged.

Found while cutting v0.9.0 — the same shape as three other things this session: documentation updated for a new reality while behaviour lagged (`CLAUDE.md`'s `.pth` guidance, the `add-feature` skill's `dvc pull`, Niger's `merge_how` comment).