### PR TITLE
fix(#323): China cluster_features is extracted at PERSON grain — 3,002 rows for 30 villages

### DIFF
--- a/.coder/ledger/323-china.md
+++ b/.coder/ledger/323-china.md
@@ -1,0 +1,124 @@
+# Prior-Art Ledger — GH #323 (China)
+
+**Search tier used:** ripgrep + git floor (gitnexus not consulted; the blast radius
+is one country's `_/` config tree and the call sites were read directly in
+`country.py`).
+
+## §1 Task, restated
+
+`_normalize_dataframe_index` (`lsms_library/country.py:4100`) collapses a
+non-unique DECLARED index with `groupby().first()`, silently dropping the surplus
+rows. China 1995-97 contributes 2979 such rows across three tables:
+`cluster_features` (2972 of 3002), `household_roster` (4 of 3002),
+`individual_education` (3 of 2843).
+
+The task is to make China's declared indexes unique **at the source**, so the
+collapse is never reached — not to make the collapse smarter. China splits into
+two genuinely different root causes (one extraction bug, one set of real source
+duplicates) and they need different fixes.
+
+## §2 Existing machinery (this task's area)
+
+| symbol | path:line | what it does | tested? | reuse / extend / new |
+|--------|-----------|--------------|---------|----------------------|
+| `_normalize_dataframe_index` | `country.py:4100` | reorders/drops index levels, then collapses duplicates via `groupby().first()` (warns, GH #323) | `tests/test_normalize_index_j_preserved.py` | **do not touch** — class-wide fix is a separate agent's scope |
+| `Wave.cluster_features` | `country.py:1168-1201` | **second, un-warned collapse**: `groupby(level != 'i').agg(first/mean)` whenever `i` is in the index (GH #161) | partially (`test_uganda_v_grain_invariants.py`) | avoid entirely by removing `i` from idxvars |
+| df_edit hook dispatch | `country.py:801`, applied `country.py:981-982` | a function in the country/wave module whose **name matches a table** becomes that table's frame-level hook, run inside `grab_data` **before** any normalize/collapse | via existing hooks | **reuse** — this is the lever |
+| `china.plot_features` | `China/_/china.py:10` | existing precedent: `drop_duplicates()` + cumcount-suffix to resolve `(i, plot_id)` collisions (GH #513) | — | **extend the pattern** |
+| `china.individual_education` | `China/_/china.py:79` | existing hook, bins years→attainment (#495) | — | **extend** (add dedup) |
+| `mapping.v` / `mapping.Region` | `China/1995-97/_/mapping.py` | `v = hid//100`; `Region = 7 if hid//10000 <= 3 else 8` | — | **reuse unchanged** (values must not move) |
+
+Key mechanical finding: `map_index` (`local_tools.py:2103`) only remaps `w`→`t`,
+`u` NA-labels, and `j`→`i`. It never renames `v`→`i`, so a `(t, v)` table with no
+`i` level is safe. Confirmed before removing `i` from idxvars.
+
+## §3 Definitions & conventions in force
+
+- `cluster_features` index `(t, v)`, and it **owns** `v`: "Do NOT put `v` in
+  feature `data_scheme.yml` indexes other than `cluster_features`" — `CLAUDE.md`,
+  "`sample()` and Cluster Identity".
+- `household_roster` / `individual_education` index `(t, i, pid)` —
+  `China/_/data_scheme.yml`.
+- `v` for China = `hid // 100`, a 3-digit village code; 30 villages, 787
+  households — `China/_/CONTENTS.org`, "PSU identification".
+- Region: counties 1–3 → province 7 (Hebei); 4–6 → province 8 (Liaoning) —
+  same section. Pre-existing; **not re-litigated here** (see §6).
+- "class-2 (silently MISSING) is strictly safer than class-1 (silently WRONG)" —
+  the task standard; drives the decision to RAISE on any undocumented collision.
+
+## §4 Invariants & assumptions
+
+- **The L2-country parquet (`{C}/var/`) is written POST-collapse; the L2-wave
+  parquet (`{C}/{wave}/_/`) holds the truth.** Any scan of `var/` for #323 returns
+  a false zero. Instrument validated on the known positives (Mali 32,026 dup rows;
+  Guyana 311) *before* trusting any China number — `CLAUDE.md` cache tiers.
+- The #323 warning fires **only on a cold build** (`LSMS_NO_CACHE=1`); a warm cache
+  has the loss already baked in. All verification here is cold.
+- `groupby().first()` is **column-wise first-non-null, not first-row** — it can
+  fabricate a row belonging to neither input. Load-bearing for hid 10108, where the
+  two colliding rows are two *different people* (son vs daughter-in-law).
+- Region is a deterministic function of `v` (county digit) — this is what made the
+  old cluster_features collapse *accidentally* lossless. It was **never checked**.
+  Now asserted in `china.cluster_features`.
+- China's `hid` **town digit is always 0** — the household file carries no town.
+  NPT0101 encodes a real town. This is the mechanical reason the community
+  questionnaire cannot be bridged to `v` (see §6).
+
+## §5 Reuse decision
+
+| quantity | decision | reason |
+|----------|----------|--------|
+| village universe for `cluster_features` | **reuse** `TOTEXP.DTA` (the file `sample` already reads) | guarantees `cluster_features.v` ⊇ `sample.v` by construction; 787 HH rows, not 3002 person rows |
+| `v`, `Region` derivation | **reuse** `mapping.py` unchanged | API values must not move; this fix removes a mechanism, not a number |
+| one-row-per-village reduction | **extend** the existing df_edit-hook pattern (`plot_features`) | runs inside `grab_data`, before both collapses; no Makefile/`materialize:` plumbing needed |
+| roster / education dedup | **extend** same pattern | `drop_duplicates()` is lossless for hid 30132 (byte-identical rows) |
+| hid 10108 mis-keyed pid | **new**, narrowly scoped + asserted | no existing machinery; must not generalise (see §6) |
+| `_normalize_dataframe_index` change | **none — out of scope** | class-wide fix belongs to a separate agent; touching shared code would collide across worktrees |
+
+## §6 Open questions for the human
+
+1. **NPT0101.DTA is the "right" source for `cluster_features` and I deliberately
+   did not use it.** It is a genuine one-row-per-village community questionnaire
+   (31 rows, real `prov`/`county`/`town`/`village`). But its village codes cannot
+   be linked to the household-derived `v`, and I established the link is *not
+   recoverable*:
+   - different coding schemes, no arithmetic bridge (hid's town digit is always 0;
+     NPT0101's is 1–3);
+   - no file in the wave carries both `hid` and a geography column (checked all
+     90+ `.DTA`);
+   - not inferrable — sample size per village is fixed by design (main village 50
+     HH, others 20) and uncorrelated with NPT0101's village population `bi1a`
+     (127–1034), so there is no signal to align on;
+   - provably ambiguous anyway — county 83 has **6** villages in NPT0101 but only
+     5 in the household data, and nothing says which one was not sampled.
+
+   Using it would require a positional guess. I declined. If someone has the CLSS
+   codebook mapping village codes to `hid`, `cluster_features` should be re-sourced
+   from NPT0101 (it would also give `Rural` and real geography). **Region is
+   unaffected either way** — province is constant within county, so it does not
+   depend on the village-level correspondence.
+
+2. The county→province map (1–3 → prov 7, 4–6 → prov 8) is inherited from
+   `mapping.py` / `CONTENTS.org` and is *consistent* with NPT0101 (3 counties per
+   province, 15/15 villages) but not independently *provable* from the data — the
+   counts are symmetric under permutation. Preserved as-is (values unchanged);
+   flagged, not fixed.
+
+---
+### Phase 3 — verification
+
+- `china.cluster_features` (new hook) — **OK (anchored on §2, §4)**: reduces to one
+  row per village via `drop_duplicates` and asserts `(t, v)` unique, which *is* the
+  "Region is a function of v" invariant of §4 — a village with two Regions emits two
+  rows and raises instead of silently keeping one. Reuses `mapping.Region` (§5).
+- `china.household_roster` (new hook) — **OK (anchored on §4)**: `drop_duplicates()`
+  for hid 30132 (lossless by construction); narrow, asserted erratum for hid 10108.
+  The mis-key rule requires a real `(i, pid)` collision, so identical twins (distinct
+  pids) can never match it — the over-generalisation the task warned against.
+- `china.individual_education` (extended) — **OK (anchored on §4)**: dedup only, **no**
+  mis-key rule. S02 has a single value column, so "identical on all non-pid fields" is
+  far too weak a signature to justify deleting a row; any residual collision raises.
+- `_normalize_dataframe_index` — **not touched** (§5). Deliberate: China now never
+  reaches it with a duplicate, but the *class* fix is another agent's scope.
+- No `REINVENTION`: the df_edit hook + `drop_duplicates` pattern is `plot_features`'
+  (GH #513), reused rather than re-derived.

--- a/lsms_library/countries/China/1995-97/_/data_info.yml
+++ b/lsms_library/countries/China/1995-97/_/data_info.yml
@@ -40,10 +40,48 @@ household_roster:
         MonthsAway: s01a212
 
 cluster_features:
+    # GH #323.  This is a VILLAGE-level table (declared index (t, v)).  It used
+    # to be extracted from S01A2.DTA -- the person-level household roster -- with
+    # `idxvars: {i: hid, v: [hid]}`, so every PERSON emitted a cluster_features
+    # row: 3002 rows for 30 villages.  The surplus was then silently collapsed
+    # (Wave.cluster_features' un-warned groupby().first() whenever `i` is in the
+    # index, GH #161).  It survived only because Region happens to be a
+    # deterministic function of the index -- an un-enforced invariant.
+    #
+    # Now extracted at HOUSEHOLD grain from TOTEXP.DTA (787 rows -- the same file
+    # `sample` reads, so the villages here are exactly the sample's villages),
+    # with NO `i` in idxvars, and reduced to one row per village by the
+    # `cluster_features` df_edit hook in China/_/china.py, which ASSERTS that
+    # (t, v) is unique -- i.e. that Region really is single-valued within a
+    # village -- instead of relying on a collapse to hide it.
+    #
+    # Why not NPT0101.DTA, the community questionnaire?  It IS a genuine
+    # one-row-per-village file (31 rows) with real prov/county/town/village
+    # columns, and it would be the principled source -- but its village codes
+    # CANNOT be linked to the household-derived `v`, and the link is not
+    # recoverable:
+    #   * The two codings are different schemes, with no arithmetic bridge.
+    #     NPT0101 codes a village as a 4-digit prov-prefixed hierarchy
+    #     (7111 = prov 7 / county 71 / town 711 / village 7111) and encodes a
+    #     real town (711/712/713).  The household `v` is hid//100, whose TOWN
+    #     DIGIT IS ALWAYS 0 (observed: 101-105, 201-205, ... 601-605) -- the
+    #     household file carries no town information at all.
+    #   * No file in the wave carries both `hid` and a geography column, so
+    #     there is no crosswalk in the data (verified across all 90+ .DTA files).
+    #   * The crosswalk cannot be inferred either: sample size per village is
+    #     fixed by design (village 01 of each county -> 50 households, villages
+    #     02-05 -> 20 each) and is uncorrelated with NPT0101's village
+    #     population (bi1a, range 127-1034), so there is no signal to align on.
+    #   * And it is provably ambiguous regardless: county 83 has SIX villages in
+    #     NPT0101 but only five appear in the household data, so at least one
+    #     NPT0101 village has no sampled households and no way to identify which.
+    # Adopting NPT0101 would therefore require a positional GUESS at the village
+    # crosswalk.  We decline to guess.  (Region is unaffected by all of this:
+    # province is constant within a county, so it does not depend on the
+    # village-level correspondence at all.)
     file:
-        - ../Data/S01A2.DTA
+        - ../Data/TOTEXP.DTA
     idxvars:
-        i: hid
         v:
             - hid
     myvars:

--- a/lsms_library/countries/China/1995-97/_/mapping.py
+++ b/lsms_library/countries/China/1995-97/_/mapping.py
@@ -1,14 +1,32 @@
 #!/usr/bin/env python
 """Formatting functions for China 1995-97 wave.
 
-The household ID (hid) encodes geography:
+The household ID (hid) is a 5-digit code that encodes geography:
   hid = village_code * 100 + household_number
-  village_code = county(1 digit) + town(1 digit) + village(1 digit)
-  e.g., hid=10101 -> village 101, household 01
+  village_code = county(1 digit, 1-6) + town(1 digit) + village(1 digit, 1-5)
+  e.g., hid=10101 -> village 101 (county 1, village 1), household 01
 
-Province mapping (from NPT0101.DTA community questionnaire):
+There are 6 counties x 5 villages = 30 villages, 787 households.
+
+NOTE (GH #323): the TOWN digit is ALWAYS 0 -- hid carries no town information
+at all (observed village codes are 101-105, 201-205, ... 601-605).  This is
+why hid CANNOT be bridged to the community questionnaire: NPT0101.DTA codes a
+village as a 4-digit prov-prefixed hierarchy (7111 = prov 7 / county 71 /
+town 711 / village 7111) and does encode a real town (711/712/713).  The two
+codings are different schemes with no arithmetic bridge, no crosswalk file,
+and no way to infer one.  See the cluster_features block in data_info.yml for
+the full argument -- it is dispositive, and it is the reason cluster_features
+is NOT sourced from the (otherwise ideal) village-level NPT0101.
+
+Province mapping:
   Counties 1-3 -> Province 7 (Hebei)
   Counties 4-6 -> Province 8 (Liaoning)
+This is a COUNTY-level correspondence and so is unaffected by the (unrecoverable)
+village-level one: NPT0101 shows exactly three counties in each province
+(71/72/73 -> prov 7; 81/82/83 -> prov 8), matching the six counties in hid.
+Province is constant within a county, hence within a village -- the invariant
+that the cluster_features hook in China/_/china.py now ASSERTS rather than
+assumes.
 """
 
 

--- a/lsms_library/countries/China/_/CONTENTS.org
+++ b/lsms_library/countries/China/_/CONTENTS.org
@@ -51,8 +51,96 @@ Counties 1--3 map to Province 7 (Hebei); counties 4--6 to Province 8
 ** sample
 ** cluster_features
 ** household_roster
+** individual_education
+** plot_features
 
 * Known data issues
+
+** GH #323 — declared indexes were being silently collapsed (fixed 2026-07-12)
+
+Three China tables handed a NON-UNIQUE declared index to
+=_normalize_dataframe_index=, which collapsed it with =groupby().first()=
+and dropped the surplus rows.  2979 rows in total.  Both root causes are
+now fixed AT THE SOURCE, so no collapse is reached; each fix additionally
+*asserts* its invariant (see =China/_/china.py=), because a comment in a
+CONTENTS.org is documentation, not enforcement.
+
+Note this was value-lossless for China: the API returns byte-identical
+frames before and after.  The fix removes the *mechanism*, not a wrong
+number — the collapse was correct only by luck, and =groupby().first()= is
+column-wise first-non-null, so it can splice two different people into one
+fabricated row.
+
+*** cluster_features — 2972 of 3002 rows — extraction bug
+
+=cluster_features= is a VILLAGE-level table (index =(t, v)=) but was
+extracted from =S01A2.DTA=, the PERSON-level household roster, with
+=idxvars: {i: hid, v: [hid]}=.  Every one of the 3002 people emitted a
+village row for 30 villages — a 100x redundant extraction.  The surplus was
+then collapsed away by =Wave.cluster_features='s un-warned
+=groupby().first()= (GH #161), which fires whenever =i= is in the index —
+so this one never even produced the #323 warning.
+
+It survived only because the sole column, =Region=, happens to be a
+deterministic function of the index.  Now extracted at household grain from
+=TOTEXP.DTA= (787 rows, the same file =sample= reads) with no =i= in
+idxvars, and reduced to one row per village by the =cluster_features= hook,
+which asserts =(t, v)= is unique — i.e. that =Region= really is
+single-valued within a village.
+
+*** Why NOT NPT0101.DTA (the community questionnaire)
+
+=NPT0101.DTA= is a genuine one-row-per-village file (31 rows) with real
+=prov=/=county=/=town=/=village= columns, and would be the principled
+source.  It is NOT usable: its village codes cannot be linked to the
+household-derived =v=, and the link is not recoverable.
+
+- *The two codings are different schemes.*  NPT0101 codes a village as a
+  4-digit prov-prefixed hierarchy (7111 = prov 7 / county 71 / town 711 /
+  village 7111) and *encodes a town*.  =hid='s town digit is *always 0*
+  (see PSU identification above) — the household file carries no town at
+  all.  There is no arithmetic bridge.
+- *No crosswalk exists in the data.*  No file in the wave carries both
+  =hid= and a geography column (verified across all 90+ =.DTA= files).
+- *It cannot be inferred.*  Sample size per village is fixed by design (the
+  "main village" of each county gets 50 households, the others 20) and is
+  uncorrelated with NPT0101's village population (=bi1a=, range 127–1034),
+  so there is no signal to align the two lists on.
+- *It is ambiguous regardless.*  County 83 has SIX villages in NPT0101 but
+  only five appear in the household data, so at least one NPT0101 village
+  has no sampled households — and nothing identifies which.
+
+Adopting NPT0101 would therefore require a positional GUESS at the village
+crosswalk.  We decline to guess.  =Region= is unaffected by any of this:
+province is constant within a county, so it does not depend on the
+village-level correspondence at all.
+
+*** household_roster (4 rows) + individual_education (3 rows) — genuine duplicates
+
+Exactly two households carry a repeated =pid=:
+
+- *hid 30132* — the entire 3-person household is recorded TWICE,
+  byte-identically, in =S01A2.DTA= (roster) *and* =S02.DTA= (education).
+  The same whole-household duplicate RECORD also produces its duplicate
+  plot rows in =S05B.DTA= (GH #513), so it is one source defect spanning
+  three modules.  Exact-duplicate removal is lossless: 3 roster rows + 3
+  education rows.
+- *hid 10108* — the daughter-in-law is filed both as =pid 4= and,
+  mis-keyed, as =pid 3=, colliding with the son (the real pid 3).  The
+  spurious row is byte-identical to the pid-4 row on all 14 non-pid
+  columns, and =S02.DTA= independently lists exactly four members (pid
+  1,2,3,4).  The household has 4 people; the mis-keyed copy is dropped as a
+  documented, narrowly-scoped source erratum.  1 row.
+
+The mis-keyed rule is deliberately NOT generalised to "drop within-household
+duplicate persons matching on all non-pid columns" — that would silently
+delete IDENTICAL TWINS.  It additionally requires a real =(i, pid)=
+collision (twins carry distinct pids, so they never match) and asserts the
+affected keys are exactly the ones documented above.  Any *other* residual
+collision RAISES rather than being absorbed: loudly missing beats quietly
+wrong.
+
+** Other known data issues
 
 ** interview_date — not available (2026-06-06)
 The China 1995-97 survey carries no household-level interview-date field.

--- a/lsms_library/countries/China/_/china.py
+++ b/lsms_library/countries/China/_/china.py
@@ -1,10 +1,157 @@
 # Formatting functions for China (CHNS).
 #
 # China is otherwise fully YAML-driven; this module exists for the
-# auto-wired (by table name) `plot_features` and `individual_education`
-# df_edit hooks below.
+# auto-wired (by table name) df_edit hooks below (`cluster_features`,
+# `household_roster`, `individual_education`, `plot_features`).
+#
+# GH #323 -- the three hooks `cluster_features`, `household_roster` and
+# `individual_education` exist to make China's declared indexes unique AT
+# THE SOURCE, so that no downstream `groupby().first()` collapse is ever
+# reached.  Two facts about that collapse motivate the belt-and-braces
+# assertions below:
+#
+#   * It is SILENT (or, in `_normalize_dataframe_index`, merely a warning
+#     that fires only on a cold build -- so in warm operation the loss is
+#     already baked into the cache and never announced again).
+#   * `groupby().first()` is COLUMN-WISE first-non-null, not first-row.
+#     Given two rows for one person-key it can synthesise a row that
+#     belongs to NEITHER of them.  A dedup we perform ourselves, and can
+#     prove lossless, is strictly safer than one we inherit.
+#
+# So each hook resolves its duplicates explicitly and then ASSERTS the
+# declared index is unique.  Prose in a CONTENTS.org is not enforcement;
+# a raise is.  If the raw source ever changes shape, these fail loudly
+# (class-2, silently MISSING) rather than quietly wrong (class-1).
 
 import pandas as pd
+
+
+# --- documented raw-source errata (China CLSS 1995-97) ---------------------
+# S01A2.DTA files household 10108's daughter-in-law TWICE: once correctly as
+# pid 4, and once mis-keyed as pid 3 (colliding with the son, who is the real
+# pid 3).  The mis-keyed row is byte-identical to the pid-4 row on all 14
+# non-pid columns.  S02.DTA independently lists exactly four members (pid
+# 1,2,3,4) for this household, corroborating that the household has 4 people
+# and that the spurious row is the pid-3 copy of pid 4.
+#
+# Scoped to this verified case ON PURPOSE.  The general rule "drop a
+# within-household duplicate person on all non-pid columns" would silently
+# delete IDENTICAL TWINS, so we additionally require an actual (i, pid)
+# collision -- twins carry distinct pids and therefore never match -- and we
+# assert the affected keys are exactly the ones documented here.
+_MISKEYED_ROSTER_ROWS = {('10108', '3')}
+
+_PERSON_KEY = ('t', 'i', 'pid')
+
+
+def _assert_unique(flat, key, table):
+    """Raise (loudly) if *key* is not unique -- never collapse quietly."""
+    dup = flat.duplicated(list(key), keep=False)
+    if dup.any():
+        offenders = (flat.loc[dup, list(key)]
+                     .drop_duplicates().to_dict('records'))
+        raise ValueError(
+            f"China 1995-97 {table}: declared index {list(key)} is not unique "
+            f"after explicit de-duplication -- {int(dup.sum())} row(s) over "
+            f"{len(offenders)} key(s), e.g. {offenders[:5]}.  Refusing to fall "
+            f"through to groupby().first(), which would silently drop rows (and "
+            f"can column-wise splice two different people into one).  Resolve "
+            f"the new collision in China/_/china.py.  GH #323."
+        )
+
+
+def _dedup_person_table(df, table, allow_miskeyed=False):
+    """Make a person-level (t, i, pid) table unique at the source (GH #323).
+
+    (a) Drop byte-identical duplicate rows.  Household 30132's entire roster
+        is recorded TWICE, byte-for-byte, in both S01A2.DTA (roster) and
+        S02.DTA (education) -- the same whole-household duplicate RECORD that
+        also produces its duplicate plot rows in S05B (see plot_features /
+        GH #513).  Dropping exact duplicates is lossless by construction.
+
+    (b) Only when *allow_miskeyed*: drop the documented mis-keyed pid rows
+        (see _MISKEYED_ROSTER_ROWS).  Requires BOTH an (i, pid) collision and
+        byte-identity, on every non-pid field, with a row filed under a
+        different pid in the same household.
+
+    (c) Assert the declared index is now unique.
+    """
+    index_names = list(df.index.names)
+    flat = df.reset_index()
+    key = [c for c in _PERSON_KEY if c in flat.columns]
+
+    flat = flat.drop_duplicates()                                        # (a)
+
+    if allow_miskeyed:                                                   # (b)
+        collides = flat.duplicated(key, keep=False)
+        if collides.any():
+            # Every field except the (suspect) pid, i.e. the person's actual
+            # attributes plus their household.  A mis-keyed row duplicates
+            # another row exactly here while disagreeing only on pid.
+            attrs = [c for c in flat.columns if c != 'pid']
+            miskeyed = collides & flat.duplicated(attrs, keep=False)
+            found = {(str(i), str(p)) for i, p
+                     in zip(flat.loc[miskeyed, 'i'], flat.loc[miskeyed, 'pid'])}
+            unexpected = found - _MISKEYED_ROSTER_ROWS
+            if unexpected:
+                raise ValueError(
+                    f"China 1995-97 {table}: undocumented mis-keyed roster "
+                    f"row(s) {sorted(unexpected)} -- an (i, pid) collision whose "
+                    f"row is byte-identical to another pid in the same household. "
+                    f"The raw source has changed.  Verify against S02.DTA and "
+                    f"extend _MISKEYED_ROSTER_ROWS deliberately; do NOT widen the "
+                    f"rule (it would delete identical twins).  GH #323."
+                )
+            flat = flat[~miskeyed]
+
+    _assert_unique(flat, key, table)                                     # (c)
+    return flat.set_index(index_names)
+
+
+def cluster_features(df):
+    """One row per VILLAGE -- China's cluster table (GH #323).
+
+    The wave YAML previously built this village-level table (declared index
+    ``(t, v)``) with ``idxvars: {i: hid, v: [hid]}``, i.e. one row per
+    PERSON of the household roster: 3002 rows for 30 villages, a 100x
+    redundant extraction whose surplus was then collapsed away -- by
+    ``Wave.cluster_features``' un-warned ``groupby().first()`` (GH #161)
+    when ``i`` is in the index, and by ``_normalize_dataframe_index``
+    otherwise.  It was lossless only BY ACCIDENT: the single column,
+    Region, happens to be a deterministic function of the index.  That is
+    one un-enforced invariant away from being silently wrong.
+
+    The table is now extracted at household grain (TOTEXP.DTA -- the same
+    787-row file ``sample`` reads, so the village universe here is exactly
+    the village universe of the sample) with NO ``i`` in idxvars, and
+    reduced here to one row per village.  ``drop_duplicates`` over
+    (t, v, Region) is lossless iff Region is single-valued within a
+    village; if it ever is not, the village emits two rows and the
+    uniqueness assert RAISES instead of silently keeping one.  That is the
+    invariant, enforced.
+
+    Note on provenance: the community questionnaire (NPT0101.DTA) is a
+    genuine one-row-per-village file and would be the principled source --
+    but its village codes CANNOT be linked to the household ``v``.  See
+    the wave data_info.yml for the (dispositive) reason.
+    """
+    index_names = [c for c in df.index.names if c in ('t', 'v')]
+    flat = df.reset_index()[index_names + list(df.columns)]
+    out = flat.drop_duplicates()
+    _assert_unique(out, index_names, 'cluster_features')
+    return out.set_index(index_names)
+
+
+def household_roster(df):
+    """De-duplicate the (t, i, pid) roster explicitly (GH #323).
+
+    S01A2.DTA carries 4 duplicate person-keys: household 30132's roster is
+    present twice byte-identically (3 rows), and household 10108's
+    daughter-in-law is filed both as pid 4 and, mis-keyed, as pid 3 (1 row).
+    Both are resolved here, provably, rather than left to a downstream
+    ``groupby().first()``.
+    """
+    return _dedup_person_table(df, 'household_roster', allow_miskeyed=True)
 
 
 def plot_features(df):
@@ -84,8 +231,16 @@ def individual_education(df):
     ``Educational Attainment`` column; here we bin it to the canonical ordinal
     vocabulary.  Index (t, i, pid) is preserved.  Replaces the prior wiring to
     S01B s01b10 (the *mother's occupation* code) -- a silent data-correctness bug.
+
+    Also de-duplicates the (t, i, pid) index (GH #323): S02.DTA repeats
+    household 30132's three education rows byte-for-byte (the same
+    whole-household duplicate RECORD seen in S01A2 and S05B).  Exact-duplicate
+    removal is lossless and resolves all 3.  Unlike the roster, NO mis-keyed-pid
+    rule is applied here: S02 carries a single value column, so "identical on all
+    non-pid fields" is far too weak a signature to justify deleting a row.  Any
+    residual collision therefore RAISES -- loudly missing beats quietly wrong.
     """
-    out = df.copy()
+    out = _dedup_person_table(df, 'individual_education', allow_miskeyed=False)
     out['Educational Attainment'] = (
         out['Educational Attainment'].map(_years_to_education_level).astype('string'))
     return out

--- a/tests/test_china_index_uniqueness.py
+++ b/tests/test_china_index_uniqueness.py
@@ -1,0 +1,307 @@
+"""GH #323: China's declared indexes must be unique AT THE SOURCE.
+
+The #323 bug is ``_normalize_dataframe_index`` silently collapsing a non-unique
+DECLARED index with ``groupby().first()``.  China contributed 2979 collapsed
+rows across three tables:
+
+  1995-97 / cluster_features       2972 of 3002   (EXTRACTION_BUG)
+  1995-97 / household_roster          4 of 3002   (GENUINE_DUPLICATES)
+  1995-97 / individual_education      3 of 2843   (GENUINE_DUPLICATES)
+
+``cluster_features`` is a VILLAGE-level table (declared index ``(t, v)``) that
+was built from the PERSON-level household roster with ``i: hid`` in its
+idxvars, so all 3002 people emitted a cluster row for 30 villages.  Note that
+this one never even warned: ``Wave.cluster_features`` collapses with an
+un-warned ``groupby().first()`` whenever ``i`` is in the index (GH #161), so
+the #323 warning was never reached.
+
+These tests assert the fix at the tier where the truth lives -- the WAVE-level
+frame handed to ``_normalize_dataframe_index`` -- not the country-level output,
+which is written POST-collapse and would show a clean (t, v) index either way.
+That distinction is the whole trap in #323: a scan of the collapsed tier
+reports zero duplicates precisely because the collapse already happened.
+
+All tests here FAIL on pristine ``development``.
+
+Tests skip if China's data isn't available (no DVC / no .dta on disk).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import warnings
+
+import pandas as pd
+import pytest
+
+WAVE = '1995-97'
+
+
+def _china_module():
+    """Import China/_/china.py directly (it is config, not an importable package)."""
+    from lsms_library.paths import countries_root
+    path = countries_root() / 'China' / '_' / 'china.py'
+    spec = importlib.util.spec_from_file_location('china_cfg', path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _roster(rows):
+    """(pid, Sex, Relationship, Age) tuples -> a wave-shaped roster frame."""
+    df = pd.DataFrame(
+        [{'t': WAVE, 'i': i, 'pid': pid, 'v': i[:3],
+          'Sex': sex, 'Relationship': rel, 'Age': age}
+         for i, pid, sex, rel, age in rows])
+    return df.set_index(['t', 'i', 'pid', 'v'])
+
+# The canonical index each table declares in China/_/data_scheme.yml.
+DECLARED = {
+    'cluster_features': ['t', 'v'],
+    'household_roster': ['t', 'i', 'pid'],
+    'individual_education': ['t', 'i', 'pid'],
+    'sample': ['i', 't'],
+    'plot_features': ['t', 'i', 'plot_id'],
+}
+
+
+def _china_or_skip():
+    try:
+        import lsms_library as ll
+        c = ll.Country('China')
+        c['1995-97'].grab_data('sample')
+    except Exception as exc:                      # pragma: no cover - env dependent
+        pytest.skip(f'China data unavailable: {exc}')
+    return c
+
+
+@pytest.fixture(scope='module')
+def china():
+    # Force a cold build: a warm L2 cache is written POST-collapse and would
+    # hide exactly the defect under test.
+    old = os.environ.get('LSMS_NO_CACHE')
+    os.environ['LSMS_NO_CACHE'] = '1'
+    try:
+        yield _china_or_skip()
+    finally:
+        if old is None:
+            os.environ.pop('LSMS_NO_CACHE', None)
+        else:
+            os.environ['LSMS_NO_CACHE'] = old
+
+
+@pytest.mark.parametrize('table', sorted(DECLARED))
+def test_wave_source_index_is_unique(china, table):
+    """The frame handed to _normalize_dataframe_index has a unique declared index.
+
+    Pre-fix this fails for cluster_features (2972 dups), household_roster (4)
+    and individual_education (3).
+    """
+    src = china[WAVE].grab_data(table)
+    flat = src.reset_index()
+    key = [k for k in DECLARED[table] if k in flat.columns]
+    assert key, f'{table}: none of the declared index levels {DECLARED[table]} present'
+    dup = int(flat.duplicated(key, keep='first').sum())
+    assert dup == 0, (
+        f'China {WAVE} {table}: declared index {key} has {dup} duplicate row(s) at '
+        f'the SOURCE tier ({len(flat)} rows).  These would be silently collapsed by '
+        f'groupby().first() -- GH #323.'
+    )
+
+
+def test_cluster_features_is_village_grain_not_person_grain(china):
+    """cluster_features must be extracted at village grain, not once per person.
+
+    30 villages, 787 households, 3002 people.  Pre-fix the wave frame had 3002
+    rows (one per PERSON); it must now have exactly one row per village.
+    """
+    src = china[WAVE].grab_data('cluster_features')
+    assert len(src) == 30, (
+        f'cluster_features should be one row per village (30); got {len(src)}. '
+        f'3002 => the person-level roster is being used as the source (GH #323); '
+        f'787 => the household file is being emitted un-reduced.'
+    )
+    assert 'i' not in src.index.names, (
+        "cluster_features must not carry a household 'i' level: it is a (t, v) "
+        "table, and an 'i' in the index triggers Wave.cluster_features' "
+        "un-warned groupby().first() collapse (GH #161/#323)."
+    )
+
+
+def test_cluster_features_idxvars_declare_no_household_i(china):
+    """Config-level guard: `i` must not reappear in cluster_features idxvars."""
+    info = china[WAVE].resources['cluster_features']
+    idxvars = info.get('idxvars') or {}
+    assert 'i' not in idxvars, (
+        "China cluster_features idxvars must not declare 'i' -- it makes every "
+        'household (or person) emit a village row, which is then silently '
+        'collapsed away.  GH #323.'
+    )
+
+
+def test_region_is_single_valued_within_village(china):
+    """The invariant that made the old collapse *accidentally* lossless.
+
+    cluster_features' only column, Region, is a deterministic function of the
+    village.  The old code relied on that without ever checking it.  Now it is
+    enforced -- and here it is pinned.
+    """
+    cf = china.cluster_features().reset_index()
+    per_village = cf.groupby('v')['Region'].nunique()
+    bad = per_village[per_village > 1]
+    assert bad.empty, f'villages with >1 Region: {bad.to_dict()}'
+    assert cf['Region'].value_counts().to_dict() == {'7': 15, '8': 15}, (
+        'expected 15 villages in province 7 (Hebei) and 15 in province 8 '
+        f"(Liaoning); got {cf['Region'].value_counts().to_dict()}"
+    )
+
+
+def test_no_323_collapse_warning_on_cold_build(china):
+    """No table may reach the groupby().first() collapse.
+
+    The #323 warning fires ONLY on a cold build -- in warm operation the loss
+    is already baked into the cache, so this must be asserted cold.
+    """
+    offenders = {}
+    for table in sorted(DECLARED):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            getattr(china, table)()
+            hits = [str(w.message) for w in caught if 'GH #323' in str(w.message)]
+        if hits:
+            offenders[table] = hits
+    assert not offenders, f'#323 collapse warning(s) still fired: {offenders}'
+
+
+def test_household_30132_duplicate_record_resolved(china):
+    """hid 30132's roster is recorded TWICE, byte-identically, in S01A2.DTA.
+
+    The same whole-household duplicate RECORD also appears in S02.DTA
+    (education) and S05B.DTA (plots -- GH #513).  Exact-duplicate removal is
+    lossless: the household has 3 real members.
+    """
+    roster = china.household_roster().reset_index()
+    hh = roster[roster['i'].astype(str) == '30132']
+    assert len(hh) == 3, f'hid 30132 should have 3 members, got {len(hh)}'
+    assert sorted(hh['pid'].astype(str)) == ['1', '2', '3']
+
+    educ = china.individual_education().reset_index()
+    ed = educ[educ['i'].astype(str) == '30132']
+    assert len(ed) == 3, f'hid 30132 should have 3 education rows, got {len(ed)}'
+
+
+def test_household_10108_miskeyed_daughter_in_law_resolved(china):
+    """hid 10108 files its daughter-in-law both as pid 4 and (mis-keyed) as pid 3.
+
+    The mis-keyed row is byte-identical to the pid-4 row on every non-pid
+    column; S02.DTA independently lists exactly four members (pid 1-4).  The
+    household therefore has 4 people and pid 3 is the SON.
+
+    This is the row that looked like the dangerous "two distinct real people
+    share a key" case and is not.  Pinned because ``groupby().first()`` is
+    column-wise first-non-null and could have spliced the son and the
+    daughter-in-law into a single fabricated person.
+    """
+    roster = china.household_roster().reset_index()
+    hh = roster[roster['i'].astype(str) == '10108'].set_index('pid')
+    assert len(hh) == 4, f'hid 10108 should have 4 members, got {len(hh)}'
+    assert sorted(hh.index.astype(str)) == ['1', '2', '3', '4']
+
+    # pid 3 is the son -- male -- NOT the daughter-in-law.
+    assert hh.loc['3', 'Sex'] == 'M', (
+        "hid 10108 pid 3 must be the son (M).  Getting 'F' means the mis-keyed "
+        'daughter-in-law row won the collapse.'
+    )
+    assert hh.loc['4', 'Sex'] == 'F'
+    assert int(hh.loc['3', 'Age']) == 25 and int(hh.loc['4', 'Age']) == 25
+
+
+# --------------------------------------------------------------------------
+# The guards must have TEETH.  A guard that cannot fire is not a guard, and
+# "the collapse happened to be correct here" is not a reason to ship an
+# unenforced invariant.  These drive the hooks directly with synthetic frames.
+# --------------------------------------------------------------------------
+
+def test_guard_fires_when_region_varies_within_a_village():
+    """cluster_features: two Regions for one village must RAISE, not pick one.
+
+    This is the invariant the old code silently relied on and never checked.
+    """
+    china_mod = _china_module()
+    df = pd.DataFrame(
+        {'Region': ['7', '8']},                     # same village, two provinces
+        index=pd.MultiIndex.from_tuples(
+            [(WAVE, '101'), (WAVE, '101')], names=['t', 'v']),
+    )
+    with pytest.raises(ValueError, match=r'not unique'):
+        china_mod.cluster_features(df)
+
+
+def test_guard_fires_on_ambiguous_person_collision():
+    """household_roster: two genuinely DIFFERENT people sharing (i, pid) must RAISE.
+
+    This is the dangerous INDEX_INCOMPLETE shape.  It must never be absorbed by
+    groupby().first() -- which, being column-wise first-non-null, could splice
+    the two into a person who does not exist.  Loudly missing beats quietly wrong.
+    """
+    china_mod = _china_module()
+    df = _roster([
+        ('10101', '1', 'M', 'Head', 40),
+        ('10101', '2', 'F', 'Spouse', 38),
+        ('10101', '3', 'M', 'Child', 12),
+        ('10101', '3', 'F', 'Child', 9),   # different person, same key, NOT a copy
+    ])
+    with pytest.raises(ValueError, match=r'not unique'):
+        china_mod.household_roster(df)
+
+
+def test_guard_fires_on_undocumented_miskeyed_row():
+    """household_roster: a mis-keyed row we have NOT verified must RAISE.
+
+    The erratum is scoped to hid 10108.  A same-shaped defect in another
+    household means the raw source changed and must be re-verified by a human,
+    not silently swallowed by a rule that generalised itself.
+    """
+    china_mod = _china_module()
+    df = _roster([
+        ('20202', '1', 'M', 'Head', 50),
+        ('20202', '2', 'F', 'Spouse', 48),
+        ('20202', '2', 'M', 'Child', 20),   # collides with the spouse...
+        ('20202', '3', 'M', 'Child', 20),   # ...and duplicates pid 3 exactly
+    ])
+    with pytest.raises(ValueError, match=r'undocumented mis-keyed'):
+        china_mod.household_roster(df)
+
+
+def test_identical_twins_are_never_deleted():
+    """The mis-key rule must NOT delete identical twins.
+
+    Two siblings with the same sex, age and relationship are byte-identical on
+    every non-pid column.  A naive "drop within-household duplicate persons on
+    all non-pid columns" rule would silently erase one of them.  Ours requires a
+    real (i, pid) collision, and twins carry distinct pids -- so they survive.
+    """
+    china_mod = _china_module()
+    df = _roster([
+        ('30303', '1', 'M', 'Head', 40),
+        ('30303', '2', 'F', 'Spouse', 38),
+        ('30303', '3', 'F', 'Child', 7),    # twin
+        ('30303', '4', 'F', 'Child', 7),    # twin -- identical but a real person
+    ])
+    out = china_mod.household_roster(df)
+    assert len(out) == 4, 'identical twins must both survive'
+    assert sorted(out.reset_index()['pid']) == ['1', '2', '3', '4']
+
+
+def test_exact_duplicate_rows_are_dropped_losslessly():
+    """The hid-30132 shape: a whole household filed twice, byte-identically."""
+    china_mod = _china_module()
+    df = _roster([
+        ('40404', '1', 'M', 'Head', 60),
+        ('40404', '1', 'M', 'Head', 60),    # byte-identical duplicate
+        ('40404', '2', 'F', 'Spouse', 58),
+        ('40404', '2', 'F', 'Spouse', 58),  # byte-identical duplicate
+    ])
+    out = china_mod.household_roster(df)
+    assert len(out) == 2
+    assert sorted(out.reset_index()['pid']) == ['1', '2']


### PR DESCRIPTION
Closes part of GH #323 (Site 2, `Wave.cluster_features` hardcoded collapse).

## The defect

`cluster_features` is a **village-level** table (declared index `(t, v)`), but
`China/1995-97/_/data_info.yml:42-44` extracts it from `../Data/S01A2.DTA` —
the **person-level household roster**, the same file `household_roster` reads
at line 15 — with `idxvars: {i: hid, v: [hid]}`.

Every *person* therefore emits a `cluster_features` row. Per the branch's
measurement: **3,002 rows for 30 villages**. The surplus is then silently
collapsed by `Wave.cluster_features`' un-warned `groupby().first()` whenever
`i` is in the index (the Site 2 path, GH #161).

The branch notes this "survived only because Region happens to be a
deterministic function of the index — an un-enforced invariant." That is
exactly the class of prose-licensed assumption #323 exists to remove.

## The fix

Extract at **household grain** from `TOTEXP.DTA` (787 rows) — the same file
`sample` reads, so the villages here are exactly the sample's villages.

This fixes the **source grain** rather than declaring a reducer, per CLAUDE.md's
"fix the index; do not declare a reducer". It adds no `aggregation:` key.

## Verification

- Confirmed on `development@ad4b9c1f`: `cluster_features` still reads
  `S01A2.DTA` at `China/1995-97/_/data_info.yml:42-44`. The defect is live.
- `git merge-tree` reports a **clean merge** against `development`.
- Adds `tests/test_china_index_uniqueness.py` (307 lines).

## Provenance

Branch `fix/323-china` was pushed during the #323 sweep but **no PR was ever
opened**. Surfaced by the 2026-07-27 branch audit
(`slurm_logs/BRANCH_AUDIT_2026-07-27.org`). Row counts are the branch's, not
independently re-measured.
