### PR TITLE
fix(#591): Nigeria food_prices drops ~99% of rows — q5a is PURCHASES, not own production

### DIFF
--- a/.coder/ledger/591-nigeria-prices.md
+++ b/.coder/ledger/591-nigeria-prices.md
@@ -118,6 +118,32 @@ per kg — a separate, pre-existing finding, logged in §6.)
   Nigeria tests instead of changing audit grading for every country.
 
 ---
+### Regression evidence (cross-country)
+
+Hashed every `(country, table)` cell for the 21 countries that build
+`food_acquired`, under **base `development` code** (a detached worktree at
+`2d3d5f71`, pre-fix cache) and under **this branch** (fixed cache), same
+`sha256` over index + values:
+
+```
+cells compared: 84   BYTE-IDENTICAL: 81   CHANGED: 3
+CHANGED:  Nigeria/food_acquired    1,005,656 -> 595,725
+          Nigeria/food_prices        125,507 -> 481,191
+          Nigeria/food_quantities    648,331 -> 594,463
+UNCHANGED: Nigeria/food_expenditures  + all 20 other countries, every table
+```
+
+The 20 untouched countries: Benin, Burkina_Faso, Cambodia, CotedIvoire,
+Ethiopia, EthiopiaRHS, GhanaLSS, GhanaSPS, Guatemala, Guinea-Bissau, Malawi,
+Mali, Nepal, Niger, Panama, Senegal, Serbia, Tanzania, Togo, Uganda.
+
+`bench/feature_audit/scan.py` on the fixed tree: one `fail`
+(`food_acquired | labels='Aggregate' | assembly_nonempty`), attributed to
+GhanaLSS by the scan's own adjacent record — *"labels='Aggregate' unavailable
+for 1 country(ies) ['GhanaLSS'] — they curate no such food-label column and were
+dropped from the assembly (kept 0)"*. No Nigeria file and no label code is
+touched by this branch; pre-existing.
+
 ### Phase 3 — verification
 
 - `nigeria.food_acquired_for_wave` — **OK (anchored on §2/§5)**: new Nigeria-local

--- a/.coder/ledger/591-nigeria-prices.md
+++ b/.coder/ledger/591-nigeria-prices.md
@@ -1,0 +1,135 @@
+# Prior-Art Ledger — GH #591 (Nigeria food_prices drops ~99% of rows)
+
+**Search tier used:** ripgrep + git (floor). gitnexus not consulted.
+**Line anchors as of:** `d572d8a9` (drift expected — match on symbol name).
+
+## §1 Task, restated
+
+`Country('Nigeria').food_prices()` (default `units='kgvalue'`) returned 161–1,106
+rows for waves whose `food_acquired` holds 120k–160k rows — six of eight waves,
+all graded `sane`. `food_acquired` is a **script-path** (`materialize: make`)
+table: four wave-level `_/food_acquired.py` scripts write L2-wave parquets, the
+country-level `_/food_acquired.py` concatenates them, and `food_prices` /
+`food_quantities` / `food_expenditures` are **derived at runtime** from it via
+`_FOOD_DERIVED` (never registered in `data_scheme.yml` — per CLAUDE.md "Derived
+Tables"). The defect is therefore in the *build* path (a wave-script variable
+mapping), and its amplifier is in the *read* path
+(`food_prices_from_acquired`).
+
+## §2 Existing machinery (this task's area)
+
+| symbol | path:line | what it does | tested? | reuse / extend / new |
+|--------|-----------|--------------|---------|----------------------|
+| `food_acquired_to_canonical` | `build_transforms.py:26` | 2-way melt: `purchased = Quantity − Produced` (clipped ≥0), `produced = Produced` | yes | **NOT reused** — hardcodes a 2-source split with one shared `u`; Nigeria needs 3 sources each with its OWN unit. Editing it would bust `build_transforms_fingerprint` → rebuild `food_acquired` for ~20 countries (`country.py:687`). |
+| `_finalize_canonical_food_acquired` | `build_transforms.py:139` | shared filter (`Quantity>0 \| Expenditure>0`) + dedupe tail; sums `Quantity`/`Quantity_kg` with `min_count=1`, means `Price` | yes | **REUSED** — this is the blessed tail (GH #251) that Uganda/Tanzania/Malawi already call. |
+| `uganda.food_acquired_to_canonical` | `countries/Uganda/_/uganda.py:243` | prior art for a **3-source** melt (purchased/produced/inkind) that calls the shared tail | via Uganda build | **PATTERN REUSED** — `nigeria.food_acquired_for_wave` is the same shape, generalized over a `sources` dict because Nigeria's per-source *units* differ. |
+| `nigeria.harmonized_food_labels` | `countries/Nigeria/_/nigeria.py:88` | int-keyed `{code: Preferred Label}` from `harmonize_food` (GH #443) | via build | **REUSED** — the four wave scripts each had this inlined; now called once. |
+| `*_for_wave` helpers | `countries/Nigeria/_/nigeria.py` (`plot_features_for_wave`, `community_prices_for_wave`, …) | Nigeria's established "thin wave script + country-module helper" idiom | via build | **PATTERN REUSED** — `food_acquired_for_wave` joins them. |
+| `food_prices_from_acquired` | `transformations.py:~900` | derives `Price`; ends `v[['Price']].replace([0, inf, -inf], nan).dropna()` | `test_food_prices_units_kwarg.py` | **EXTENDED** — drop set unchanged, now accounted + warned. |
+| `_get_kg_factors` / `conversion_to_kgs` | `transformations.py:344` | infers unit→kg factors from `Expenditure/Quantity` ratios | partially | untouched — but it is a **victim**: it saw ~677 usable Nigeria rows/wave instead of ~57k. |
+| `community_prices` | `countries/Nigeria/_/community_prices.py` | surveyed cluster-level prices at `(t, v, j, u)` | via build | **REUSED as an INDEPENDENT YARDSTICK** — not as an input. See §5. |
+
+## §3 Definitions & conventions in force
+
+- **`s` (acquisition source)** — canonical values `purchased, produced, inkind,
+  other`; `transformations.S_VALUES:31`, enumerated in `data_info.yml:11` and
+  enforced by `validate_acquisition_source`. Gifts → `inkind`.
+- **`food_expenditures` basis** — `'purchased'` (default) = **cash outlay only**,
+  keep `s=='purchased'` (GH #575, `transformations.food_expenditures_from_acquired`).
+  Own-production/in-kind rows carry `Expenditure = NaN`.
+- **`food_prices(units='kgvalue')`** (the default) = `Expenditure / Quantity_kg`.
+  Per STANDING.md §3 and `DESIGN_food_prices_units_kwarg_2026-05-06.org`. This is
+  why the purchased row's `Quantity` and `Expenditure` **must describe the same
+  transaction** — otherwise the flagship path is a wrong number.
+- **Derived tables are not registered** in `data_scheme.yml` (CLAUDE.md).
+- **`u` is stored RAW** in Nigeria's parquets (the wave scripts' `.replace(unitcodes)`
+  is a no-op: the codes are `float64`, the map is string-keyed). Labels are applied
+  at API time by the automatic categorical mapping against `categorical_mapping.org`
+  `#+name:u`. Verified empirically — the cached parquet holds `u = '1.0'`, the API
+  returns `'Kg'`. **New code must keep storing the raw code** or the `u` vocabulary
+  shifts under every consumer.
+
+## §4 Invariants & assumptions
+
+- **Cache-hash coverage.** `Country._table_cache_hash` (`country.py:2230`) hashes
+  the country module `_/nigeria.py` (`cmod=`), the country concatenator, the
+  Makefile and `data_scheme.yml`; `Wave._input_hash` (`country.py:585`) hashes the
+  wave's `_/food_acquired.py` **text**. So a helper in `nigeria.py` IS versioned,
+  and script-path L2-wave parquets are evicted on the rebuild descent
+  (`_evict_hashless_wave_caches`, GH #479). Still cleared explicitly with
+  `lsms-library cache clear --country Nigeria` — Nigeria has round-name wave dirs
+  (`2012Q3/`, `2013Q1/`…) that `Country.waves` does not enumerate.
+- **`build_transforms_fingerprint(table)`** is folded into the cache hash for every
+  country that builds that table (`country.py:687`). Editing `build_transforms.py`
+  invalidates `food_acquired` for ~20 countries. → keep the fix in Nigeria-local files.
+- **All Nigeria unit columns (`q2b/q3b/q5b/q6b/q7b/q9b`) share ONE code space** —
+  verified: 3 uncoded values across ~500k rows in 8 files. So a per-source unit is
+  safe to store.
+- **`sum(Quantity over s) == total consumed`** held by construction pre-fix (because
+  `purchased` was a residual). It does NOT hold post-fix for W4 — see §6.
+
+## §5 Reuse decision
+
+| quantity | decision | reason |
+|----------|----------|--------|
+| 3-source melt | **new, Nigeria-local** (`nigeria.food_acquired_for_wave`) | the shared `food_acquired_to_canonical` cannot express per-source units, and editing it costs a 20-country rebuild (§4). Modelled on `uganda.food_acquired_to_canonical` (§2). |
+| filter + dedupe tail | **reuse** `_finalize_canonical_food_acquired` | the canonical rule (GH #251); reimplementing it is exactly the duplication that skill warns about. |
+| food-item labels | **reuse** `nigeria.harmonized_food_labels` | was copy-pasted into all four wave scripts. |
+| which quantity pairs with the expenditure | **decided by evidence, not fiat** | validated against `community_prices` — the independent surveyed price. See below. |
+| price-loss accounting | **new** (`_drop_unpriceable`) | nothing in the repo counted what the `.dropna()` ate. |
+
+**The denominator question, settled empirically.** W2/W3 offer two candidate
+purchased quantities (q3a = quantity purchased, which q4 paid for; q5a = quantity
+consumed out of purchases) and W4 likewise (q9a = most-recent purchase, which q10
+paid for; q5a). Compared median `Expenditure/Quantity` per `(t, j, u)` against the
+median `community_prices` for the same `(t, j, u)` — same native unit, so no kg
+conversion enters:
+
+| wave | variant | matched cells | median ratio survey/community | within ±25% |
+|------|---------|---------------|-------------------------------|-------------|
+| 2013Q1 | q5a | 30 | 1.021 | 47% |
+| 2013Q1 | **q3a** | 30 | 1.036 | **50%** |
+| 2019Q1 | q5a | 13 | 1.053 | 69% |
+| 2019Q1 | **q9a** | 14 | **0.948** | **93%** |
+
+The purchase-block quantity wins, decisively in W4. (Instrument validated: it
+reproduces wave 1 sanely and returns ratio **exactly 1.000** on `u='Kg'`/`'l'`
+cells. Its `u='g'` cells are junk — Nigeria's `community_prices` prices "g" rows
+per kg — a separate, pre-existing finding, logged in §6.)
+
+## §6 Open questions for the human
+
+- **W4 reference-period asymmetry (deliberate, documented, NOT silent).** In
+  2018-19 the purchase block (q9a/q10) is the household's *most recent purchase
+  within 30 days*, while produced/in-kind are *7-day* consumption. Pairing q10 with
+  q9a is the only way to get a real price, and every stored number stays
+  survey-reported — but `Quantity` summed across `s` is no longer a 7-day
+  consumption total for W4. The alternative (impute `Expenditure = q5a × price`,
+  which is what the WB's own W4 consumption aggregate does) would fix that at the
+  cost of **fabricating a number no respondent reported** and silently changing
+  `food_expenditures` for two waves. Rejected here; worth its own issue.
+- **`community_prices` `u='g'` rows look mis-scaled** (survey/community ratio
+  ≈ 1/400 on gram cells; exactly 1.000 on Kg/l cells). Not touched. Own issue.
+- **Cambodia** loses 7.9% of expenditure-bearing rows to the same `Price = inf`
+  signature (`Quantity == 0` with `Expenditure > 0`). The new warning will now say
+  so out loud. Own issue.
+- **`is_this_feature_sane` never checks row-count collapse relative to the source
+  table** — which is why all six broken cells graded `sane`. Guardrails added as
+  Nigeria tests instead of changing audit grading for every country.
+
+---
+### Phase 3 — verification
+
+- `nigeria.food_acquired_for_wave` — **OK (anchored on §2/§5)**: new Nigeria-local
+  melt; delegates the filter/dedupe to the shared `_finalize_canonical_food_acquired`
+  rather than re-deriving it; keeps `u` raw per §3.
+- Four wave `_/food_acquired.py` — **OK (§3)**: variable maps now follow the
+  questionnaire's own Stata labels; `Expenditure` on the purchased row only, per
+  the GH #575 cash-outlay convention.
+- `transformations._drop_unpriceable` — **OK (§2)**: drop *set* is provably
+  identical to the pre-#591 `.replace([0,inf,-inf],nan).dropna()`
+  (`tests/test_unpriceable_price_drop.py::test_same_rows_as_legacy_expression`), so
+  no other country's `food_prices` shifts by a row; only the accounting is new.
+- `food_expenditures_from_acquired` — **no code change**, comment only: its `0 →
+  drop` is a sparsity convention (0 contributes 0 to every sum), not the class of
+  loss #591 is about. Warning there would be noise that dilutes the real signal.

--- a/lsms_library/countries/Nigeria/2010-11/_/food_acquired.py
+++ b/lsms_library/countries/Nigeria/2010-11/_/food_acquired.py
@@ -1,120 +1,56 @@
 #!/usr/bin/env python
-"""Extract raw food acquisition data for Nigeria 2010-11.
+"""Extract raw food acquisition data for Nigeria 2010-11 (GHS-Panel W1).
 
-Produces item-level food consumption, purchase, and production data
-before any unit conversion.
+Item-level food consumption decomposed by acquisition source, before any
+unit conversion.
 
 Source files:
   - sect10b_harvestw1.csv  (post-harvest, 2011Q1)
   - sect7b_plantingw1.csv  (post-planting, 2010Q3)
+
+W1 questionnaire:
+  q2a/q2b  total quantity consumed (7 days) + unit
+  q3a/q3b  ... of which came from PURCHASES + unit   <- q4 pays for this
+  q4       amount spent on [ITEM] (Naira)
+  q5a/q5b  ... of which came from OWN PRODUCTION + unit
+  q6a/q6b  ... of which came from GIFTS + unit
+Identity q3a + q5a + q6a == q2a holds in 92% (PH) / 98% (PP) of rows.
+
+Before GH #591 this script built the purchased row as the residual
+(q2a - q5a), which silently folded GIFTS (q6a) into `purchased` and used
+the residual -- not the survey's own q3a -- as the price denominator.  We
+now take each source's REPORTED quantity and REPORTED unit.  See
+nigeria.food_acquired_for_wave for the wave-by-wave questionnaire
+renumbering that made W2-W4 catastrophically wrong.
 """
 import sys
-import numpy as np
+
 import pandas as pd
 
-sys.path.append('../../../_/')
-from lsms_library.local_tools import to_parquet, get_categorical_mapping, get_dataframe
-from lsms_library.transformations import food_acquired_to_canonical
-
-_food_labels_raw = get_categorical_mapping(tablename='harmonize_food',
-                                           idxvars='Code',
-                                           **{'Preferred Label': 'Preferred Label'})
-# Re-key harmonize_food on INT codes so the numeric item_cd (int64 in the
-# source CSV) resolves to its Preferred Label.  The Code column is
-# string-keyed, so a raw int j would otherwise never match and stay numeric
-# (GH #443).  Codes with a blank / '---' label legitimately stay raw.
-food_labels = {}
-for _k, _v in _food_labels_raw.items():
-    try:
-        _ik = int(_k)
-    except (TypeError, ValueError):
-        continue
-    if pd.isna(_v) or str(_v).strip() in ('', '---'):
-        continue
-    food_labels[_ik] = str(_v).strip()
-
-_unit_raw = get_categorical_mapping(tablename='u',
-                                     idxvars='Code',
-                                     **{'2010-11': '2010-11'})
-unitcodes = {k: v for k, v in _unit_raw.items() if isinstance(v, str)}
-
-zone_labels = {1: 'North central',
-               2: 'North east',
-               3: 'North west',
-               4: 'South east',
-               5: 'South south',
-               6: 'South west'}
-
-
-def extract_food(fn, varmap, t, food_labels):
-    """Read a food consumption file and produce a standardized DataFrame."""
-    df = get_dataframe(fn)
-
-    df = df.rename(columns=varmap)
-
-    # Apply food item labels
-    df['j'] = df['j'].replace(food_labels)
-
-    # Apply unit labels and zone labels
-    df['u'] = df['u'].replace(unitcodes).fillna('None')
-    df['m'] = df['m'].replace(zone_labels)
-
-    df['t'] = t
-
-    # Keep relevant columns
-    keep = ['t', 'i', 'j', 'u', 'm',
-            'Quantity', 'Expenditure', 'Produced']
-    keep = [c for c in keep if c in df.columns]
-    df = df[keep]
-
-    # Drop rows with no data
-    value_cols = [c for c in ['Quantity', 'Expenditure', 'Produced'] if c in df.columns]
-    df = df.replace('', pd.NA)
-    df = df.dropna(subset=value_cols, how='all')
-
-    return df
-
+sys.path.append('../../_/')
+from lsms_library.local_tools import to_parquet
+from nigeria import food_acquired_for_wave
 
 # --- Harvest (2011Q1) ---
-harvest_vars = {
-    'hhid': 'i',
-    'item_cd': 'j',
-    's10bq2a': 'Quantity',
-    's10bq2b': 'u',
-    's10bq4': 'Expenditure',
-    's10bq5a': 'Produced',
-    'zone': 'm',
-}
-harvest = extract_food('../Data/sect10b_harvestw1.csv',
-                        harvest_vars, '2011Q1', food_labels)
+harvest = food_acquired_for_wave(
+    '../Data/sect10b_harvestw1.csv', '2011Q1',
+    sources={
+        'purchased': {'quantity': 's10bq3a', 'unit': 's10bq3b'},
+        'produced':  {'quantity': 's10bq5a', 'unit': 's10bq5b'},
+        'inkind':    {'quantity': 's10bq6a', 'unit': 's10bq6b'},
+    },
+    expenditure='s10bq4')
 
 # --- Planting (2010Q3) ---
-planting_vars = {
-    'hhid': 'i',
-    'item_cd': 'j',
-    's7bq2a': 'Quantity',
-    's7bq2b': 'u',
-    's7bq4': 'Expenditure',
-    's7bq5a': 'Produced',
-    'zone': 'm',
-}
-planting = extract_food('../Data/sect7b_plantingw1.csv',
-                         planting_vars, '2010Q3', food_labels)
+planting = food_acquired_for_wave(
+    '../Data/sect7b_plantingw1.csv', '2010Q3',
+    sources={
+        'purchased': {'quantity': 's7bq3a', 'unit': 's7bq3b'},
+        'produced':  {'quantity': 's7bq5a', 'unit': 's7bq5b'},
+        'inkind':    {'quantity': 's7bq6a', 'unit': 's7bq6b'},
+    },
+    expenditure='s7bq4')
 
-# --- Combine and index ---
-df = pd.concat([harvest, planting], ignore_index=True)
-
-df['i'] = df['i'].astype(int).astype(str)
-
-df = df.set_index(['t', 'i', 'j', 'u'])
-df = df.sort_index()
-
-# Canonical reshape (GH #169): drop `m` (lives in cluster_features) and
-# melt (Quantity, Produced, Expenditure) onto the `s` (acquisition source)
-# axis.  `v` is added at API time by _join_v_from_sample.
-if 'm' in df.columns:
-    df = df.drop(columns=['m'])
-df = food_acquired_to_canonical(df, drop_columns=())
-df = df.sort_index()
+df = pd.concat([harvest, planting]).sort_index()
 
 to_parquet(df, 'food_acquired.parquet')

--- a/lsms_library/countries/Nigeria/2012-13/_/food_acquired.py
+++ b/lsms_library/countries/Nigeria/2012-13/_/food_acquired.py
@@ -1,112 +1,54 @@
 #!/usr/bin/env python
-"""Extract raw food acquisition data for Nigeria 2012-13.
+"""Extract raw food acquisition data for Nigeria 2012-13 (GHS-Panel W2).
 
 Source files:
   - sect10b_harvestw2.csv  (post-harvest, 2013Q1)
   - sect7b_plantingw2.csv  (post-planting, 2012Q3)
+
+W2 questionnaire (RENUMBERED vs W1 -- GH #591):
+  q2a/q2b  total quantity consumed (7 days) + unit
+  q3a/q3b  QUANTITY PURCHASED + unit                 <- q4 pays for this
+  q4       amount spent on [ITEM] (Naira)
+  q5a/q5b  consumption that came from PURCHASES + unit
+  q6a/q6b  consumption that came from OWN PRODUCTION + unit
+  q7a/q7b  consumption that came from GIFTS + unit
+Identity q5a + q6a + q7a == q2a holds in 99.9% (PH) / 99.2% (PP) of rows.
+
+Until GH #591 this script mapped q5a -> `Produced`, i.e. it labelled the
+PURCHASED quantity as own production, leaving the purchased row with
+(q2a - q5a) = q6a + q7a ~ 0 while the expenditure rode on it.  That made
+Price = Expenditure / 0 = inf for ~40% of rows, which
+food_prices_from_acquired silently dropped: 2013Q1 kept 161 price rows out
+of a 134k-row food_acquired.
 """
 import sys
-import numpy as np
+
 import pandas as pd
 
-sys.path.append('../../../_/')
-from lsms_library.local_tools import to_parquet, get_categorical_mapping, get_dataframe
-from lsms_library.transformations import food_acquired_to_canonical
-
-_food_labels_raw = get_categorical_mapping(tablename='harmonize_food',
-                                           idxvars='Code',
-                                           **{'Preferred Label': 'Preferred Label'})
-# Re-key harmonize_food on INT codes so the numeric item_cd (int64 in the
-# source CSV) resolves to its Preferred Label.  The Code column is
-# string-keyed, so a raw int j would otherwise never match and stay numeric
-# (GH #443).  Codes with a blank / '---' label legitimately stay raw.
-food_labels = {}
-for _k, _v in _food_labels_raw.items():
-    try:
-        _ik = int(_k)
-    except (TypeError, ValueError):
-        continue
-    if pd.isna(_v) or str(_v).strip() in ('', '---'):
-        continue
-    food_labels[_ik] = str(_v).strip()
-
-_unit_raw = get_categorical_mapping(tablename='u',
-                                     idxvars='Code',
-                                     **{'2012-13': '2012-13'})
-unitcodes = {k: v for k, v in _unit_raw.items() if isinstance(v, str)}
-
-zone_labels = {1: 'North central',
-               2: 'North east',
-               3: 'North west',
-               4: 'South east',
-               5: 'South south',
-               6: 'South west'}
-
-
-def extract_food(fn, varmap, t, food_labels):
-    """Read a food consumption file and produce a standardized DataFrame."""
-    df = get_dataframe(fn)
-
-    df = df.rename(columns=varmap)
-
-    df['j'] = df['j'].replace(food_labels)
-    df['u'] = df['u'].replace(unitcodes).fillna('None')
-    df['m'] = df['m'].replace(zone_labels)
-
-    df['t'] = t
-
-    keep = ['t', 'i', 'j', 'u', 'm',
-            'Quantity', 'Expenditure', 'Produced']
-    keep = [c for c in keep if c in df.columns]
-    df = df[keep]
-
-    value_cols = [c for c in ['Quantity', 'Expenditure', 'Produced'] if c in df.columns]
-    df = df.replace('', pd.NA)
-    df = df.dropna(subset=value_cols, how='all')
-
-    return df
-
+sys.path.append('../../_/')
+from lsms_library.local_tools import to_parquet
+from nigeria import food_acquired_for_wave
 
 # --- Harvest (2013Q1) ---
-harvest_vars = {
-    'hhid': 'i',
-    'item_cd': 'j',
-    's10bq2a': 'Quantity',
-    's10bq2b': 'u',
-    's10bq4': 'Expenditure',
-    's10bq5a': 'Produced',
-    'zone': 'm',
-}
-harvest = extract_food('../Data/sect10b_harvestw2.csv',
-                        harvest_vars, '2013Q1', food_labels)
+harvest = food_acquired_for_wave(
+    '../Data/sect10b_harvestw2.csv', '2013Q1',
+    sources={
+        'purchased': {'quantity': 's10bq3a', 'unit': 's10bq3b'},
+        'produced':  {'quantity': 's10bq6a', 'unit': 's10bq6b'},
+        'inkind':    {'quantity': 's10bq7a', 'unit': 's10bq7b'},
+    },
+    expenditure='s10bq4')
 
 # --- Planting (2012Q3) ---
-planting_vars = {
-    'hhid': 'i',
-    'item_cd': 'j',
-    's7bq2a': 'Quantity',
-    's7bq2b': 'u',
-    's7bq4': 'Expenditure',
-    's7bq5a': 'Produced',
-    'zone': 'm',
-}
-planting = extract_food('../Data/sect7b_plantingw2.csv',
-                         planting_vars, '2012Q3', food_labels)
+planting = food_acquired_for_wave(
+    '../Data/sect7b_plantingw2.csv', '2012Q3',
+    sources={
+        'purchased': {'quantity': 's7bq3a', 'unit': 's7bq3b'},
+        'produced':  {'quantity': 's7bq6a', 'unit': 's7bq6b'},
+        'inkind':    {'quantity': 's7bq7a', 'unit': 's7bq7b'},
+    },
+    expenditure='s7bq4')
 
-# --- Combine and index ---
-df = pd.concat([harvest, planting], ignore_index=True)
-
-df['i'] = df['i'].astype(int).astype(str)
-
-df = df.set_index(['t', 'i', 'j', 'u'])
-df = df.sort_index()
-
-# Canonical reshape (GH #169): drop `m` (lives in cluster_features) and
-# melt (Quantity, Produced, Expenditure) onto the `s` (acquisition source)
-# axis.  `v` is added at API time by _join_v_from_sample.
-if 'm' in df.columns:
-    df = df.drop(columns=['m'])
-df = food_acquired_to_canonical(df, drop_columns=())
-df = df.sort_index()
+df = pd.concat([harvest, planting]).sort_index()
 
 to_parquet(df, 'food_acquired.parquet')

--- a/lsms_library/countries/Nigeria/2015-16/_/food_acquired.py
+++ b/lsms_library/countries/Nigeria/2015-16/_/food_acquired.py
@@ -1,112 +1,50 @@
 #!/usr/bin/env python
-"""Extract raw food acquisition data for Nigeria 2015-16.
+"""Extract raw food acquisition data for Nigeria 2015-16 (GHS-Panel W3).
 
 Source files:
   - sect10b_harvestw3.csv  (post-harvest, 2016Q1)
   - sect7b_plantingw3.csv  (post-planting, 2015Q3)
+
+W3 questionnaire -- same numbering as W2 (GH #591):
+  q2a/q2b  total quantity consumed (7 days) + unit
+  q3a/q3b  QUANTITY PURCHASED + unit                 <- q4 pays for this
+  q4       amount spent on [ITEM] (Naira)
+  q5a/q5b  consumption that came from PURCHASES + unit
+  q6a/q6b  consumption that came from OWN PRODUCTION + unit
+  q7a/q7b  consumption that came from GIFTS + unit
+Identity q5a + q6a + q7a == q2a holds in ~100% of rows.
+
+Until GH #591 this script mapped q5a -> `Produced` (see 2012-13 for the
+mechanism); 2016Q1 kept 426 price rows out of a 138k-row food_acquired.
 """
 import sys
-import numpy as np
+
 import pandas as pd
 
-sys.path.append('../../../_/')
-from lsms_library.local_tools import to_parquet, get_categorical_mapping, get_dataframe
-from lsms_library.transformations import food_acquired_to_canonical
-
-_food_labels_raw = get_categorical_mapping(tablename='harmonize_food',
-                                           idxvars='Code',
-                                           **{'Preferred Label': 'Preferred Label'})
-# Re-key harmonize_food on INT codes so the numeric item_cd (int64 in the
-# source CSV) resolves to its Preferred Label.  The Code column is
-# string-keyed, so a raw int j would otherwise never match and stay numeric
-# (GH #443).  Codes with a blank / '---' label legitimately stay raw.
-food_labels = {}
-for _k, _v in _food_labels_raw.items():
-    try:
-        _ik = int(_k)
-    except (TypeError, ValueError):
-        continue
-    if pd.isna(_v) or str(_v).strip() in ('', '---'):
-        continue
-    food_labels[_ik] = str(_v).strip()
-
-_unit_raw = get_categorical_mapping(tablename='u',
-                                     idxvars='Code',
-                                     **{'2015-16': '2015-16'})
-unitcodes = {k: v for k, v in _unit_raw.items() if isinstance(v, str)}
-
-zone_labels = {1: 'North central',
-               2: 'North east',
-               3: 'North west',
-               4: 'South east',
-               5: 'South south',
-               6: 'South west'}
-
-
-def extract_food(fn, varmap, t, food_labels):
-    """Read a food consumption file and produce a standardized DataFrame."""
-    df = get_dataframe(fn)
-
-    df = df.rename(columns=varmap)
-
-    df['j'] = df['j'].replace(food_labels)
-    df['u'] = df['u'].replace(unitcodes).fillna('None')
-    df['m'] = df['m'].replace(zone_labels)
-
-    df['t'] = t
-
-    keep = ['t', 'i', 'j', 'u', 'm',
-            'Quantity', 'Expenditure', 'Produced']
-    keep = [c for c in keep if c in df.columns]
-    df = df[keep]
-
-    value_cols = [c for c in ['Quantity', 'Expenditure', 'Produced'] if c in df.columns]
-    df = df.replace('', pd.NA)
-    df = df.dropna(subset=value_cols, how='all')
-
-    return df
-
+sys.path.append('../../_/')
+from lsms_library.local_tools import to_parquet
+from nigeria import food_acquired_for_wave
 
 # --- Harvest (2016Q1) ---
-harvest_vars = {
-    'hhid': 'i',
-    'item_cd': 'j',
-    's10bq2a': 'Quantity',
-    's10bq2b': 'u',
-    's10bq4': 'Expenditure',
-    's10bq5a': 'Produced',
-    'zone': 'm',
-}
-harvest = extract_food('../Data/sect10b_harvestw3.csv',
-                        harvest_vars, '2016Q1', food_labels)
+harvest = food_acquired_for_wave(
+    '../Data/sect10b_harvestw3.csv', '2016Q1',
+    sources={
+        'purchased': {'quantity': 's10bq3a', 'unit': 's10bq3b'},
+        'produced':  {'quantity': 's10bq6a', 'unit': 's10bq6b'},
+        'inkind':    {'quantity': 's10bq7a', 'unit': 's10bq7b'},
+    },
+    expenditure='s10bq4')
 
 # --- Planting (2015Q3) ---
-planting_vars = {
-    'hhid': 'i',
-    'item_cd': 'j',
-    's7bq2a': 'Quantity',
-    's7bq2b': 'u',
-    's7bq4': 'Expenditure',
-    's7bq5a': 'Produced',
-    'zone': 'm',
-}
-planting = extract_food('../Data/sect7b_plantingw3.csv',
-                         planting_vars, '2015Q3', food_labels)
+planting = food_acquired_for_wave(
+    '../Data/sect7b_plantingw3.csv', '2015Q3',
+    sources={
+        'purchased': {'quantity': 's7bq3a', 'unit': 's7bq3b'},
+        'produced':  {'quantity': 's7bq6a', 'unit': 's7bq6b'},
+        'inkind':    {'quantity': 's7bq7a', 'unit': 's7bq7b'},
+    },
+    expenditure='s7bq4')
 
-# --- Combine and index ---
-df = pd.concat([harvest, planting], ignore_index=True)
-
-df['i'] = df['i'].astype(int).astype(str)
-
-df = df.set_index(['t', 'i', 'j', 'u'])
-df = df.sort_index()
-
-# Canonical reshape (GH #169): drop `m` (lives in cluster_features) and
-# melt (Quantity, Produced, Expenditure) onto the `s` (acquisition source)
-# axis.  `v` is added at API time by _join_v_from_sample.
-if 'm' in df.columns:
-    df = df.drop(columns=['m'])
-df = food_acquired_to_canonical(df, drop_columns=())
-df = df.sort_index()
+df = pd.concat([harvest, planting]).sort_index()
 
 to_parquet(df, 'food_acquired.parquet')

--- a/lsms_library/countries/Nigeria/2018-19/_/food_acquired.py
+++ b/lsms_library/countries/Nigeria/2018-19/_/food_acquired.py
@@ -1,127 +1,73 @@
 #!/usr/bin/env python
-"""Extract raw food acquisition data for Nigeria 2018-19.
-
-Produces item-level food consumption, purchase, and production data
-before any unit conversion.  Downstream scripts derive food_expenditures,
-food_prices, and food_quantities from this table.
+"""Extract raw food acquisition data for Nigeria 2018-19 (GHS-Panel W4).
 
 Source files:
   - sect10b_harvestw4.csv  (post-harvest, 2019Q1)
   - sect7b_plantingw4.csv  (post-planting, 2018Q3)
+
+W4 questionnaire -- renumbered AGAIN (GH #591).  The per-source unit
+columns are gone (q5a/q6a/q7a are "of [QTY] consumed, how much came
+from ...", so all three are in the CONSUMPTION unit q2b), and the purchase
+question moved into its own block with its own unit and kg factor:
+  q2a/q2b/q2_cvn  total consumed (7 days) + unit + Kg/L factor
+  q5a             ... of which came from PURCHASES   (unit q2b)
+  q6a             ... of which came from OWN PRODUCTION (unit q2b)
+  q7a             ... of which came from GIFTS/OTHER (unit q2b)
+  q8              did the HH purchase any [ITEM] in the past 30 days?
+  q9a/q9b/q9_cvn  quantity of the MOST RECENT PURCHASE + unit + Kg/L factor
+  q10             amount spent on that purchase       <- pays for q9a
+
+Two defects fixed here:
+  1. q5a was mapped to `Produced`.  It is the quantity consumed out of
+     PURCHASES; own production is q6a.  (Same inversion as W2/W3.)
+  2. q10 (the value of the most recent purchase) was paired with the
+     residual (q2a - q5a).  It pays for q9a, in unit q9b -- which differs
+     from the consumption unit q2b in 13% (PH) / 10% (PP) of rows.
+
+The purchased row therefore carries the PURCHASE TRANSACTION (q9a, q9b,
+q9_cvn, q10): every stored number is survey-reported and
+Expenditure/Quantity is a real price.  Validated against the independent
+community_prices survey (median survey/community unit-value ratio 0.95 on
+matched (t, j, u) cells; 93% within 25%).  Note the reference-period
+asymmetry this leaves: the purchased row is a 30-day most-recent purchase
+while produced / in-kind are 7-day consumption.  Imputing a 7-day
+purchased value (q5a x price) was rejected -- it would fabricate a number
+no respondent reported.  See nigeria.food_acquired_for_wave.
 """
 import sys
-import numpy as np
+
 import pandas as pd
 
-sys.path.append('../../../_/')
-from lsms_library.local_tools import to_parquet, get_categorical_mapping, get_dataframe
-from lsms_library.transformations import food_acquired_to_canonical
-
-_food_labels_raw = get_categorical_mapping(tablename='harmonize_food',
-                                           idxvars='Code',
-                                           **{'Preferred Label': 'Preferred Label'})
-# Re-key harmonize_food on INT codes so the numeric item_cd (int64 in the
-# source CSV) resolves to its Preferred Label.  The Code column is
-# string-keyed, so a raw int j would otherwise never match and stay numeric
-# (GH #443).  Codes with a blank / '---' label legitimately stay raw.
-food_labels = {}
-for _k, _v in _food_labels_raw.items():
-    try:
-        _ik = int(_k)
-    except (TypeError, ValueError):
-        continue
-    if pd.isna(_v) or str(_v).strip() in ('', '---'):
-        continue
-    food_labels[_ik] = str(_v).strip()
-
-_unit_raw = get_categorical_mapping(tablename='u',
-                                     idxvars='Code',
-                                     **{'2018-19': '2018-19'})
-unitcodes = {k: v for k, v in _unit_raw.items() if isinstance(v, str)}
-
-zone_labels = {1: 'North central',
-               2: 'North east',
-               3: 'North west',
-               4: 'South east',
-               5: 'South south',
-               6: 'South west'}
-
-
-def extract_food(fn, varmap, t, food_labels):
-    """Read a food consumption file and produce a standardized DataFrame."""
-    df = get_dataframe(fn)
-
-    df = df.rename(columns=varmap)
-
-    # Apply food item labels from categorical_mapping.org
-    df['j'] = df['j'].replace(food_labels)
-
-    # Apply unit labels and zone labels
-    df['u'] = df['u'].replace(unitcodes).fillna('None')
-    df['m'] = df['m'].replace(zone_labels)
-
-    df['t'] = t
-
-    # Keep relevant columns
-    keep = ['t', 'i', 'j', 'u', 'm',
-            'Quantity', 'Expenditure', 'Produced', 'kg_factor']
-    # Only keep columns that exist (some may be absent in some waves)
-    keep = [c for c in keep if c in df.columns]
-    df = df[keep]
-
-    # Drop rows with no data at all
-    value_cols = [c for c in ['Quantity', 'Expenditure', 'Produced'] if c in df.columns]
-    df = df.replace('', pd.NA)
-    df = df.dropna(subset=value_cols, how='all')
-
-    return df
-
+sys.path.append('../../_/')
+from lsms_library.local_tools import to_parquet
+from nigeria import food_acquired_for_wave
 
 # --- Harvest (2019Q1) ---
-harvest_vars = {
-    'hhid': 'i',
-    'item_cd': 'j',
-    's10bq2a': 'Quantity',         # total quantity consumed past 7 days
-    's10bq2b': 'u',                # unit of consumption
-    's10bq10': 'Expenditure',      # total value purchased
-    's10bq5a': 'Produced',         # home produced quantity
-    's10bq2_cvn': 'kg_factor',     # exact Kg/L conversion factor (GH #378)
-    'zone': 'm',
-}
-harvest = extract_food('../Data/sect10b_harvestw4.csv',
-                        harvest_vars, '2019Q1', food_labels)
+harvest = food_acquired_for_wave(
+    '../Data/sect10b_harvestw4.csv', '2019Q1',
+    sources={
+        'purchased': {'quantity': 's10bq9a', 'unit': 's10bq9b',
+                      'kg_factor': 's10bq9_cvn'},
+        'produced':  {'quantity': 's10bq6a', 'unit': 's10bq2b',
+                      'kg_factor': 's10bq2_cvn'},
+        'inkind':    {'quantity': 's10bq7a', 'unit': 's10bq2b',
+                      'kg_factor': 's10bq2_cvn'},
+    },
+    expenditure='s10bq10')
 
 # --- Planting (2018Q3) ---
-planting_vars = {
-    'hhid': 'i',
-    'item_cd': 'j',
-    's7bq2a': 'Quantity',
-    's7bq2b': 'u',
-    's7bq10': 'Expenditure',
-    's7bq5a': 'Produced',
-    's7bq2_cvn': 'kg_factor',      # exact Kg/L conversion factor (GH #378)
-    'zone': 'm',
-}
-planting = extract_food('../Data/sect7b_plantingw4.csv',
-                         planting_vars, '2018Q3', food_labels)
+planting = food_acquired_for_wave(
+    '../Data/sect7b_plantingw4.csv', '2018Q3',
+    sources={
+        'purchased': {'quantity': 's7bq9a', 'unit': 's7bq9b',
+                      'kg_factor': 's7bq9_cvn'},
+        'produced':  {'quantity': 's7bq6a', 'unit': 's7bq2b',
+                      'kg_factor': 's7bq2_cvn'},
+        'inkind':    {'quantity': 's7bq7a', 'unit': 's7bq2b',
+                      'kg_factor': 's7bq2_cvn'},
+    },
+    expenditure='s7bq10')
 
-# --- Combine and index ---
-df = pd.concat([harvest, planting], ignore_index=True)
-
-# Convert ID to string for consistency with household_roster
-df['i'] = df['i'].astype(int).astype(str)
-
-df = df.set_index(['t', 'i', 'j', 'u'])
-
-# Sort and save
-df = df.sort_index()
-
-# Canonical reshape (GH #169): drop `m` (lives in cluster_features) and
-# melt (Quantity, Produced, Expenditure) onto the `s` (acquisition source)
-# axis.  `v` is added at API time by _join_v_from_sample.
-if 'm' in df.columns:
-    df = df.drop(columns=['m'])
-df = food_acquired_to_canonical(df, drop_columns=())
-df = df.sort_index()
+df = pd.concat([harvest, planting]).sort_index()
 
 to_parquet(df, 'food_acquired.parquet')

--- a/lsms_library/countries/Nigeria/_/CONTENTS.org
+++ b/lsms_library/countries/Nigeria/_/CONTENTS.org
@@ -2,6 +2,75 @@
 * Food Conversion Table
 A food conversion table can be found at https://docs.google.com/spreadsheets/d/1whE_EW5x-jxrsKvYWfefdBppzp_TZhPP61bdEN-FEJ4/
 
+* food_acquired acquisition sources (GH #591)
+
+The GHS-Panel food module asks total 7-day consumption of each item and then
+decomposes it by *acquisition source*.  **The questionnaire was renumbered
+after wave 1** and the wave scripts did not follow.  The Stata variable
+labels (the =.dta= twins of the CSVs we build from) are unambiguous:
+
+| variable | W1 (2010-11)             | W2 / W3 (2012-13, 2015-16)      | W4 (2018-19)                        |
+|----------+--------------------------+---------------------------------+-------------------------------------|
+| q2a/q2b  | total consumed + unit    | total consumed + unit           | total consumed + unit (+q2_cvn kg)  |
+| q3a/q3b  | *from purchases* + unit  | *quantity purchased* + unit     | ---                                 |
+| q4       | amount spent             | amount spent                    | ---                                 |
+| q5a      | *own production*         | consumption from purchases      | consumption from purchases          |
+| q6a      | *gift*                   | *own production*                | *own production*                    |
+| q7a      | ---                      | *gift*                          | *gift / other*                      |
+| q8       | ---                      | ---                             | purchased in past 30 days? (y/n)    |
+| q9a/q9b  | ---                      | ---                             | *most recent purchase* + unit (+cvn)|
+| q10      | ---                      | ---                             | spent on that purchase              |
+
+Until #591 every wave mapped =q5a -> Produced=.  In W1 that is correct.  From
+W2 on, q5a is the quantity consumed *out of purchases*, so the build labelled
+purchases as own production and left the purchased row holding
+=(total - purchases) = q6a + q7a ~ 0= --- with the expenditure still riding on
+it.  =Price = Expenditure / 0 = inf=, and =food_prices_from_acquired= dropped
+those rows outright: **161--1,106 surviving price rows per wave against a
+120k--160k-row =food_acquired=**, and =food_quantities= reporting 87--94% of
+Nigerian food as own-produced (wave 1, never broken, says ~5%).
+
+Now each source row carries *its own reported quantity and its own reported
+unit* (all the =*b= unit columns share one code space), via
+=nigeria.food_acquired_for_wave=:
+
+- =s='purchased'= --- q3a/q3b (W1--W3) or q9a/q9b/q9_cvn (W4), with
+  =Expenditure= = q4 (W1--W3) or q10 (W4).  Quantity and Expenditure describe
+  the *same transaction*, which is what makes the unit value a price.
+- =s='produced'=  --- q5a (W1) or q6a (W2--W4).
+- =s='inkind'=    --- q6a (W1) or q7a (W2--W4).  Gifts were previously folded
+  into =purchased=.
+
+Validated against the *independent* =community_prices= survey (median
+survey/community unit-value ratio 0.95 on matched =(t, j, u)= cells in 2019Q1;
+93% within 25%).  =food_expenditures= is **unchanged, byte for byte** --- the
+expenditure always rode on the purchased row and still does.
+
+*** Reference-period caveat --- W4 (2018Q3 / 2019Q1) only
+
+W4 has no 7-day purchase-value question.  Its only monetary variable, q10, is
+the value of the household's *most recent purchase within the last 30 days*,
+and q9a is that purchase's quantity.  So for W4 the =purchased= row is a
+30-day purchase event while =produced= / =inkind= are 7-day consumption:
+**=Quantity= summed across =s= is not a 7-day consumption total for W4.**
+
+Pairing q10 with q9a is what makes the price right, and it keeps every stored
+number survey-reported.  The alternative --- imputing a 7-day purchased value
+as =q5a x price=, which is what the World Bank's own W4 consumption aggregate
+does --- was rejected here because it fabricates a number no respondent
+reported and would silently move =food_expenditures=.  Worth revisiting as its
+own issue.
+
+*** Stray unit codes in the per-source unit columns
+
+Carrying each source's own unit exposes three junk values the consumption unit
+=q2b= never had: codes *58* (W2 =q7b=), *65* (W3 =q3b=) and *103* (W3 =q5b=),
+one row each out of ~600k.  65 and 103 are *item* codes ("65. FRUITS: CANNED",
+"103. FISH-DRIED") that a keypunch put in a unit field; 58 has no label in any
+=.dta= label set.  They are left as raw codes rather than given an invented
+label --- the same treatment as the residual codes noted below.  (Sanity checks
+pass: =no_float_stringified_index= only inspects id levels.)
+
 * food_acquired unit codes (GH #223 Layer 2)
 
 The =s10bq2b= / =s7bq2b= unit variable is a numeric code.  The repo's

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -25,11 +25,28 @@ Data Scheme:
 
   food_acquired:
     # Canonical post-2026-05-05 (GH #169): s axis carries acquisition
-    # source (purchased / produced).  Wave-level food_acquired.py
-    # reshapes wide-form (Quantity-total, Produced-subset, Expenditure)
-    # into long-form on s via food_acquired_to_canonical.  `m` (zone)
-    # dropped — lives in cluster_features.  See
+    # source.  `m` (zone) dropped — lives in cluster_features.  See
     # slurm_logs/DESIGN_food_acquired_canonical_2026-05-05.org.
+    #
+    # GH #591: Nigeria emits THREE sources — purchased / produced / inkind
+    # (gifts) — built by nigeria.food_acquired_for_wave from each source's
+    # OWN reported quantity and OWN reported unit, not from a
+    # (total - produced) residual.  The GHS questionnaire was renumbered
+    # after wave 1 and the wave scripts had not followed: q5a was bound to
+    # `Produced` in every wave, but from W2 on q5a is the quantity consumed
+    # out of PURCHASES (own production moved to q6a, gifts to q7a).  The
+    # purchased row therefore held ~0 quantity while the expenditure rode
+    # on it → Price = E/0 = inf → silently dropped, leaving 161–1,106
+    # price rows per wave out of 120k–160k.
+    #
+    # Expenditure is carried on the s='purchased' row only, paired with the
+    # quantity the survey says it paid for: q3a (W1–W3) or q9a (W4).
+    # Reference-period caveat, W4 (2018Q3/2019Q1) ONLY: the purchase block
+    # (q9a/q9b/q9_cvn/q10) records the MOST RECENT purchase within 30 days,
+    # while produced/inkind are 7-day consumption.  Quantity summed across
+    # `s` is therefore not a 7-day consumption total for W4.  Imputing a
+    # 7-day purchased value (q5a × price) was rejected — it fabricates a
+    # number no respondent reported.  See Nigeria/_/CONTENTS.org.
     index: (t, i, j, u, s)
     Quantity: float
     Expenditure: float

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -1990,3 +1990,122 @@ def community_prices_for_wave(t, frames, mode, crop_labels=None):
     out['i'] = out['v']
     out = out.set_index(['t', 'v', 'i', 'j', 'u']).sort_index()
     return out[['Price']]
+
+
+# ---------------------------------------------------------------------
+# food_acquired (GH #591) -- acquisition-source split
+# ---------------------------------------------------------------------
+#
+# The GHS-Panel food module records 7-day consumption of each item and
+# decomposes it BY ACQUISITION SOURCE.  The questionnaire was RENUMBERED
+# after wave 1, and the wave scripts did not follow (GH #591) -- q5a was
+# bound to `Produced` in every wave, but from wave 2 on q5a is the
+# quantity consumed OUT OF PURCHASES, and own production moved to q6a.
+# The Stata variable labels are unambiguous:
+#
+#   W1 (2010-11)   q2a total consumed | q3a from purchases | q4 spend
+#                  | q5a own production | q6a gift
+#   W2 (2012-13)   q2a total consumed | q3a QUANTITY PURCHASED | q4 spend
+#   W3 (2015-16)   | q5a consumption from purchases | q6a own production
+#                  | q7a gift
+#   W4 (2018-19)   q2a total consumed (+q2_cvn kg factor)
+#                  | q5a from purchases | q6a own production | q7a gift
+#                  | q9a QUANTITY PURCHASED (+q9b unit, +q9_cvn kg factor)
+#                  | q10 spend on that purchase
+#
+# So: `Produced` is q5a in W1 but q6a in W2-W4, and the survey's own
+# purchase QUANTITY (the denominator the spend actually paid for) is q3a
+# in W1-W3 and q9a in W4 -- never the (total - produced) residual the old
+# scripts computed.  Gifts get their own canonical source (`inkind`).
+#
+# Every unit column (q2b/q3b/q5b/q6b/q7b/q9b) is coded in the SAME unit
+# code space (the `u` table in categorical_mapping.org), so each source
+# row carries the unit ITS quantity was reported in -- rather than
+# inheriting the consumption unit q2b, which differs from the W4 purchase
+# unit q9b in ~13% of rows.
+#
+# Reference-period caveat (W4 only): q9a/q10 describe the household's MOST
+# RECENT purchase within the last 30 days, while q6a/q7a are 7-day
+# consumption.  Pairing q10 with q9a is what makes the unit value a real
+# price (validated against the independent community_prices survey: median
+# ratio 0.95 on matched (t, j, u) cells, vs 1.05 and far noisier when q5a
+# is used as the denominator).  The alternative -- imputing a 7-day
+# purchased VALUE as q5a x price -- would fabricate a number no respondent
+# reported, so it is NOT done here.  Consumers aggregating quantity across
+# `s` for W4 should be aware the purchased row is a 30-day purchase, not a
+# 7-day consumption flow.
+
+def food_acquired_for_wave(fn, t, sources, expenditure,
+                           item='item_cd', hhid='hhid'):
+    """Canonical (t, i, j, u, s) food_acquired rows for one Nigeria round.
+
+    Parameters
+    ----------
+    fn : str
+        Path to the round's food module (``../Data/sect10b_harvestwN.csv``
+        or ``../Data/sect7b_plantingwN.csv``), read via ``get_dataframe``.
+    t : str
+        The round's period label (e.g. ``'2013Q1'``).
+    sources : dict
+        ``{s: {'quantity': var, 'unit': var, 'kg_factor': var|None}}`` for
+        each acquisition source ``s`` in ``purchased`` / ``produced`` /
+        ``inkind``.  ``kg_factor`` (optional) names a per-row survey-supplied
+        Kg/L conversion factor (W4's ``*_cvn``); when given, the row's exact
+        ``Quantity_kg`` is carried (GH #378).
+    expenditure : str
+        The variable holding the cash outlay.  Attached to the
+        ``s='purchased'`` row ONLY -- produced / in-kind rows carry no cash
+        expenditure (the framework's cross-country convention; see
+        ``food_expenditures_from_acquired`` basis='purchased', GH #575).
+
+    Returns
+    -------
+    pd.DataFrame
+        Indexed on ``(t, i, j, u, s)`` with columns ``Quantity``,
+        ``Expenditure`` (+ ``Quantity_kg`` where a kg factor was supplied).
+        ``v`` is intentionally absent -- joined from ``sample()`` at API
+        time.  Rows are kept where ``Quantity > 0`` OR ``Expenditure > 0``
+        and genuine duplicate keys are aggregated, via the shared
+        :func:`lsms_library.transformations._finalize_canonical_food_acquired`
+        tail (GH #251).
+    """
+    from lsms_library.local_tools import get_dataframe
+    from lsms_library.transformations import _finalize_canonical_food_acquired
+
+    df = get_dataframe(fn)
+
+    food_labels = harmonized_food_labels()
+
+    i = df[hhid].astype(int).astype(str)
+    j = df[item].replace(food_labels)
+    E = pd.to_numeric(df[expenditure], errors='coerce')
+
+    pieces = []
+    for s, spec in sources.items():
+        q = pd.to_numeric(df[spec['quantity']], errors='coerce')
+        # `u` is stored as the RAW unit code; the framework's automatic
+        # categorical mapping resolves it to the `u` table's Preferred
+        # Label at API time (do NOT pre-resolve here -- that is what every
+        # other Nigeria wave has always done and what the cached parquets
+        # hold).
+        u = df[spec['unit']]
+        piece = pd.DataFrame({
+            't': t,
+            'i': i.values,
+            'j': j.values,
+            'u': u.values,
+            's': s,
+            'Quantity': q.values,
+            'Expenditure': (E.values if s == 'purchased'
+                            else np.full(len(df), np.nan)),
+        })
+        kg_factor = spec.get('kg_factor')
+        if kg_factor is not None:
+            piece['Quantity_kg'] = (
+                q.values * pd.to_numeric(df[kg_factor], errors='coerce').values)
+        pieces.append(piece)
+
+    out = pd.concat(pieces, ignore_index=True)
+    out['u'] = out['u'].fillna('None')
+
+    return _finalize_canonical_food_acquired(out)

--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -4,6 +4,7 @@
 A collection of mappings to transform dataframes.
 """
 import re
+import warnings
 
 import pandas as pd
 import numpy as np
@@ -29,6 +30,112 @@ from .build_transforms import (  # noqa: F401  (re-export for back-compat)
 # value constraints on index levels, so the enumeration lives here and is
 # enforced in code by :func:`validate_acquisition_source`.
 S_VALUES = ('purchased', 'produced', 'inkind', 'other')
+
+# Warn when this share of the rows that *should* have produced a price
+# instead get dropped as 0 / inf / NaN by ``food_prices_from_acquired``
+# (GH #591).  A price that cannot be computed is data loss; dropping the
+# row makes the loss invisible (the row does not come back as NaN -- it
+# ceases to exist), which is how Nigeria shipped six waves of
+# food_prices built on 0.5% of the data, all graded `sane`.
+#
+# Calibration (all 20 cached food_acquired parquets, 2026-07): the share of
+# expenditure-bearing rows lost at this step is 74% for Nigeria (pre-#591),
+# 7.9% for Cambodia (same Quantity==0-with-Expenditure>0 signature, tracked
+# separately), 0.2-1.9% for the EHCVM family / Serbia / Uganda / Tanzania /
+# GhanaSPS, and 0 elsewhere.  5% therefore fires on a genuine defect and
+# stays quiet on the ordinary long tail of unpriceable rows.
+PRICE_LOSS_WARN_THRESHOLD = 0.05
+
+
+class UnpriceableRowsWarning(UserWarning):
+    """Emitted when ``food_prices`` drops a large share of priceable rows.
+
+    Subclasses ``UserWarning`` so it can be filtered / promoted to an error
+    (``warnings.simplefilter('error', UnpriceableRowsWarning)``) independently
+    of the library's other warnings.
+    """
+
+
+def _as_float(s):
+    """Series -> float64 ndarray with NaN for missing (pd.NA-safe)."""
+    return pd.to_numeric(s, errors='coerce').to_numpy(dtype='float64',
+                                                      na_value=np.nan)
+
+
+def _drop_unpriceable(v, units, expected, threshold=PRICE_LOSS_WARN_THRESHOLD):
+    """Drop rows with a 0 / +-inf / NaN Price -- loudly (GH #591).
+
+    Splits the dropped rows by cause before discarding them, records the
+    tally on ``result.attrs['price_rows_dropped']``, and emits ONE
+    aggregated :class:`UnpriceableRowsWarning` per call (never one per row)
+    when the loss exceeds *threshold* of the rows that ought to have
+    produced a price.
+
+    Causes
+    ------
+    ``inf``
+        ``Price = Expenditure / 0``: the survey recorded money spent but a
+        zero (or zero-after-kg-conversion) quantity.  ALWAYS a data defect
+        -- either a 0-as-missing sentinel or, as in Nigeria, a quantity
+        variable bound to the wrong survey question.
+    ``nan``
+        Quantity missing, or a unit with no kg factor (the ``kg*`` modes).
+    ``zero``
+        Zero Expenditure (``*value``) or a zero reported Price (``*price``).
+
+    Parameters
+    ----------
+    v : DataFrame
+        Frame carrying the computed ``Price`` column.
+    units : str
+        The ``food_prices`` mode, for the message.
+    expected : boolean ndarray
+        Rows that OUGHT to have produced a price -- the denominator of the
+        loss fraction.  Supplied by the caller from the *inputs* (Expenditure
+        > 0 for the ``*value`` modes; a non-null REPORTED Price for the
+        ``*price`` modes), never from the computed Price, so a conversion
+        failure counts as a loss rather than silently shrinking the base.
+    """
+    price = _as_float(v['Price'])
+
+    is_inf = np.isinf(price)
+    is_nan = np.isnan(price)
+    is_zero = (price == 0)
+    dropped = is_inf | is_nan | is_zero
+
+    expected = np.asarray(expected, dtype=bool)
+    lost = int((dropped & expected).sum())
+    n_expected = int(expected.sum())
+    tally = {
+        'units': units,
+        'rows_in': int(len(v)),
+        'expected': n_expected,
+        'dropped_total': int(dropped.sum()),
+        'dropped_expected': lost,
+        'inf': int((is_inf & expected).sum()),
+        'nan': int((is_nan & expected).sum()),
+        'zero': int((is_zero & expected).sum()),
+        'lost_fraction': (lost / n_expected) if n_expected else 0.0,
+    }
+
+    if n_expected and lost / n_expected > threshold:
+        warnings.warn(
+            f"food_prices(units={units!r}): dropped {lost:,} of {n_expected:,} "
+            f"priceable rows ({lost / n_expected:.1%}) because Price was "
+            f"inf ({tally['inf']:,}), NaN ({tally['nan']:,}) or zero "
+            f"({tally['zero']:,}).  An inf Price means the survey recorded an "
+            f"Expenditure against a ZERO Quantity -- typically a 0-as-missing "
+            f"sentinel or a quantity variable mapped to the wrong survey "
+            f"question.  These rows are DROPPED, not returned as NaN, so the "
+            f"gap is otherwise invisible.  See GH #591.",
+            UnpriceableRowsWarning,
+            stacklevel=3,
+        )
+
+    out = v[~dropped][['Price']]
+    out.attrs = dict(v.attrs)
+    out.attrs['price_rows_dropped'] = tally
+    return out
 
 
 def validate_acquisition_source(df: pd.DataFrame) -> None:
@@ -686,6 +793,13 @@ def food_expenditures_from_acquired(df, basis='purchased'):
 
     idx_names = list(df.index.names)
 
+    # Drop zero / missing Expenditure.  Unlike the same-shaped drop in
+    # food_prices_from_acquired (GH #591), this one is NOT silent data loss
+    # and deliberately gets no warning: a zero expenditure contributes zero
+    # to every downstream sum, so dropping the row is a sparsity convention,
+    # not the destruction of a number the user needed.  (The price drop is
+    # different in kind: there the row carried a POSITIVE expenditure and
+    # the price was uncomputable, so the row's information dies with it.)
     x = df[['Expenditure']].replace(0, np.nan).dropna()
     if basis == 'purchased' and 's' in idx_names:
         # Cash outlay only — drop non-purchased sources so the figure means
@@ -930,7 +1044,19 @@ def food_prices_from_acquired(df, units='kgvalue', *, volume_as_mass=True):
             # No u index → can't convert; emit NaN
             v = df.assign(Price=np.nan)
 
-    v = v[['Price']].replace([0, np.inf, -np.inf], np.nan).dropna()
+    # Zero / infinite / NaN prices are dropped -- but NOT silently (GH #591).
+    # The denominator of the loss is taken from the INPUTS: the rows that
+    # ought to have produced a price.  ``.replace(...).dropna()`` used to do
+    # this in one wordless expression, which is how ~99% of Nigeria's price
+    # rows vanished without a trace.  NaN-and-keep was considered and
+    # rejected: it would change the shape of food_prices for every country
+    # (Uganda +6,456 rows, Serbia +3,767, Tanzania +714, GhanaSPS +883) and
+    # downstream demand code assumes a dense frame.
+    if units in ('kgvalue', 'unitvalue'):
+        expected = _as_float(df['Expenditure']) > 0
+    else:                                   # 'kgprice' / 'unitprice'
+        expected = ~np.isnan(_as_float(df['Price']))
+    v = _drop_unpriceable(v, units, expected)
 
     # Aggregate over any non-canonical recall level (e.g. GhanaLSS's
     # ``visit`` — ~12 repeated recall visits per month) at the country
@@ -946,7 +1072,12 @@ def food_prices_from_acquired(df, units='kgvalue', *, volume_as_mass=True):
     # arbitrary visit's price via ``groupby().first()`` (GH #517).
     group_by = [n for n in ['t', 'i', 'j', 'u', 's'] if n in v.index.names]
     if group_by:
+        tally = v.attrs.get('price_rows_dropped')
         v = v.groupby(group_by).median()
+        # groupby drops attrs (pandas 2.x/3.x) -- keep the drop tally so a
+        # caller can audit the loss without parsing the warning text.
+        if tally is not None:
+            v.attrs['price_rows_dropped'] = tally
     return v
 
 

--- a/tests/test_nigeria_food_acquired_sources.py
+++ b/tests/test_nigeria_food_acquired_sources.py
@@ -1,0 +1,114 @@
+"""Nigeria food_acquired: the acquisition-source split must not be inverted.
+
+GH #591.  The GHS-Panel questionnaire was renumbered after wave 1 and the
+wave scripts did not follow: q5a stayed bound to ``Produced`` in every wave,
+but from W2 on q5a is the quantity consumed out of PURCHASES (own production
+moved to q6a).  Consequences, all silent, all graded `sane`:
+
+  * the purchased row held (total - purchases) ~= 0 while the expenditure
+    rode on it, so Price = Expenditure / 0 = inf and food_prices_from_acquired
+    DELETED the row -- 161 to 1,106 surviving price rows per wave against a
+    120k-160k-row food_acquired;
+  * food_quantities reported ~87-94% of Nigerian food as own-produced from
+    2012 on (the mirror image of the truth: wave 1 says ~6%).
+
+These are guardrails, not unit tests: they assert properties of the BUILT
+country table that would have caught the bug, and they are cheap once the
+cache is warm.  Skipped when the Nigeria microdata isn't available.
+"""
+import pytest
+
+pytestmark = pytest.mark.filterwarnings('ignore::UserWarning')
+
+COUNTRY = 'Nigeria'
+
+# Wave 1 (the only wave that was never broken) reports ~4-6% of food quantity
+# as own-produced.  The broken waves reported 87-94%.  25% is a wide,
+# deliberately un-tuned band: it passes on every wave post-fix (2.9-8.2%) and
+# fails on all six broken waves by a factor of 3.5 or more.
+MAX_PRODUCED_SHARE = 0.25
+
+
+@pytest.fixture(scope='module')
+def food_acquired():
+    ll = pytest.importorskip('lsms_library')
+    try:
+        df = ll.Country(COUNTRY).food_acquired()
+    except Exception as exc:                      # noqa: BLE001 - data absent
+        pytest.skip(f'Nigeria food_acquired unavailable: {exc}')
+    if df is None or df.empty:
+        pytest.skip('Nigeria food_acquired empty (no microdata)')
+    return df
+
+
+@pytest.fixture(scope='module')
+def food_prices():
+    ll = pytest.importorskip('lsms_library')
+    try:
+        df = ll.Country(COUNTRY).food_prices()
+    except Exception as exc:                      # noqa: BLE001
+        pytest.skip(f'Nigeria food_prices unavailable: {exc}')
+    if df is None or df.empty:
+        pytest.skip('Nigeria food_prices empty (no microdata)')
+    return df
+
+
+def test_all_waves_present(food_acquired):
+    ts = set(food_acquired.index.get_level_values('t'))
+    assert ts >= {'2010Q3', '2011Q1', '2012Q3', '2013Q1',
+                  '2015Q3', '2016Q1', '2018Q3', '2019Q1'}
+
+
+def test_source_split_is_not_inverted(food_acquired):
+    """Purchased quantity must exceed own-produced quantity in EVERY wave.
+
+    Pre-fix this fails for all six waves from 2012Q3 on (e.g. 2013Q1:
+    produced 8.97M vs purchased 1.03M -- the mirror image of the truth).
+    """
+    q = (food_acquired.groupby(['t', 's'])['Quantity'].sum()
+         .unstack(fill_value=0))
+    bad = {t: (row.get('purchased', 0), row.get('produced', 0))
+           for t, row in q.iterrows()
+           if not row.get('purchased', 0) > row.get('produced', 0)}
+    assert not bad, f'produced > purchased (inverted s-split) in: {bad}'
+
+
+def test_produced_share_is_plausible(food_acquired):
+    """Own production is a minority of Nigerian food acquisition in every wave.
+
+    Pre-fix: 87-94% for 2012Q3 onward.
+    """
+    q = (food_acquired.groupby(['t', 's'])['Quantity'].sum()
+         .unstack(fill_value=0))
+    share = q.get('produced', 0) / q.sum(axis=1)
+    bad = share[share > MAX_PRODUCED_SHARE]
+    assert bad.empty, (
+        f'implausible own-production share (> {MAX_PRODUCED_SHARE:.0%}) in:\n'
+        f'{bad.round(3).to_string()}')
+
+
+def test_gifts_are_their_own_acquisition_source(food_acquired):
+    """q6a/q7a (gifts) must land on s='inkind', not be folded into purchased."""
+    assert 'inkind' in set(food_acquired.index.get_level_values('s'))
+
+
+def test_food_prices_does_not_collapse(food_acquired, food_prices):
+    """Every wave must price the bulk of its purchased rows.
+
+    This is the #591 symptom stated as an invariant: food_prices row count per
+    wave must be within a factor of 2 of that wave's purchased-row count.
+    Pre-fix, six waves priced 0.2%-1.6% of their purchased rows.
+    """
+    purchased = (food_acquired.xs('purchased', level='s')
+                 .groupby('t').size())
+    priced = food_prices.groupby('t').size()
+    ratios = (priced / purchased).dropna()
+    bad = ratios[(ratios < 0.5) | (ratios > 2.0)]
+    assert bad.empty, (
+        'food_prices row count is not within 2x of the purchased-row count '
+        f'for:\n{ratios.round(4).to_string()}')
+
+
+def test_no_infinite_prices_survive(food_prices):
+    import numpy as np
+    assert np.isfinite(food_prices['Price'].astype('float64')).all()

--- a/tests/test_unpriceable_price_drop.py
+++ b/tests/test_unpriceable_price_drop.py
@@ -1,0 +1,127 @@
+"""The 0 / inf / NaN Price drop in food_prices_from_acquired must be LOUD.
+
+GH #591.  Before this landed, ``food_prices_from_acquired`` ended with
+
+    v = v[['Price']].replace([0, np.inf, -np.inf], np.nan).dropna()
+
+which is how six Nigeria waves shipped a food_prices table built on 0.5%
+of the data without anyone noticing: a row whose Expenditure was recorded
+against a ZERO Quantity produced ``Price = inf`` and was then *deleted*.
+It did not come back as NaN (which a user would see) -- it ceased to exist.
+
+These tests pin two things:
+  1. the drop still removes exactly the rows it always did (no behavior
+     change for the 15+ countries with a small, genuine unpriceable tail);
+  2. it is now accounted for -- a per-call aggregated warning above
+     PRICE_LOSS_WARN_THRESHOLD, plus a machine-readable tally on
+     ``.attrs['price_rows_dropped']``.
+"""
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lsms_library.transformations import (
+    PRICE_LOSS_WARN_THRESHOLD,
+    UnpriceableRowsWarning,
+    food_prices_from_acquired,
+)
+
+
+def _fa(rows):
+    """rows: (i, j, u, s, Quantity, Expenditure) -> canonical food_acquired."""
+    idx = pd.MultiIndex.from_tuples(
+        [('2020', r[0], r[1], r[2], r[3]) for r in rows],
+        names=['t', 'i', 'j', 'u', 's'])
+    return pd.DataFrame({'Quantity': [r[4] for r in rows],
+                         'Expenditure': [r[5] for r in rows]}, index=idx)
+
+
+def _sentinel_frame(n_bad=9, n_good=1):
+    """The Nigeria signature: Expenditure > 0 sitting on a ZERO Quantity.
+
+    n_bad rows are unpriceable (Price = inf); n_good are fine.  Defaults give
+    a 90% loss -- far above the 5% threshold.
+    """
+    rows = [(f'h{k}', 'rice', 'kg', 'purchased', 0.0, 500.0)
+            for k in range(n_bad)]
+    rows += [(f'g{k}', 'rice', 'kg', 'purchased', 10.0, 500.0)
+             for k in range(n_good)]
+    return _fa(rows)
+
+
+class TestLoudness:
+    def test_zero_quantity_with_expenditure_warns(self):
+        """The exact defect from #591 must produce a warning, not silence."""
+        with pytest.warns(UnpriceableRowsWarning, match=r'dropped 9 of 10'):
+            food_prices_from_acquired(_sentinel_frame())
+
+    def test_warning_names_inf_as_the_cause(self):
+        with pytest.warns(UnpriceableRowsWarning) as rec:
+            food_prices_from_acquired(_sentinel_frame())
+        msg = str(rec[0].message)
+        assert 'inf (9)' in msg
+        assert 'ZERO Quantity' in msg
+
+    def test_exactly_one_warning_per_call_not_one_per_row(self):
+        """1,000 bad rows -> ONE warning.  Per-row warnings would be unusable
+        noise and would be filtered away, which is how this stayed invisible."""
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter('always')
+            food_prices_from_acquired(_sentinel_frame(n_bad=1000, n_good=100))
+        assert sum(issubclass(w.category, UnpriceableRowsWarning)
+                   for w in rec) == 1
+
+    def test_tally_is_machine_readable(self):
+        with pytest.warns(UnpriceableRowsWarning):
+            out = food_prices_from_acquired(_sentinel_frame())
+        tally = out.attrs['price_rows_dropped']
+        assert tally['inf'] == 9
+        assert tally['expected'] == 10
+        assert tally['dropped_expected'] == 9
+        assert tally['lost_fraction'] == pytest.approx(0.9)
+
+    def test_small_genuine_tail_stays_quiet(self):
+        """A 1-in-100 unpriceable row is the ordinary long tail (EHCVM,
+        Uganda, Serbia ...) -- it must NOT warn, or the signal drowns."""
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter('always')
+            food_prices_from_acquired(_sentinel_frame(n_bad=1, n_good=99))
+        assert not any(issubclass(w.category, UnpriceableRowsWarning)
+                       for w in rec)
+
+    def test_threshold_is_five_percent(self):
+        assert PRICE_LOSS_WARN_THRESHOLD == 0.05
+
+
+class TestDropSemanticsUnchanged:
+    """The set of rows dropped must be IDENTICAL to the pre-#591 expression,
+    so no other country's food_prices shifts by a single row."""
+
+    def test_same_rows_as_legacy_expression(self):
+        fa = _fa([
+            ('h1', 'rice',  'kg', 'purchased', 10.0, 500.0),   # fine
+            ('h2', 'rice',  'kg', 'purchased',  0.0, 500.0),   # inf  -> drop
+            ('h3', 'rice',  'kg', 'purchased', 10.0,   0.0),   # zero -> drop
+            ('h4', 'rice',  'kg', 'purchased', np.nan, 500.0),  # NaN -> drop
+            ('h5', 'maize', 'kg', 'produced',  10.0, np.nan),  # NaN -> drop
+            ('h6', 'maize', 'kg', 'purchased',  4.0, 100.0),   # fine
+        ])
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UnpriceableRowsWarning)
+            out = food_prices_from_acquired(fa, units='unitvalue')
+
+        legacy = (fa.assign(Price=fa['Expenditure'] / fa['Quantity'])[['Price']]
+                  .replace([0, np.inf, -np.inf], np.nan).dropna()
+                  .groupby(['t', 'i', 'j', 'u', 's']).median())
+        pd.testing.assert_frame_equal(out.sort_index(), legacy.sort_index())
+
+    def test_negative_inf_also_dropped(self):
+        fa = _fa([('h1', 'rice', 'kg', 'purchased',  0.0, -500.0),  # -inf
+                  ('h2', 'rice', 'kg', 'purchased', 10.0,  500.0)])
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UnpriceableRowsWarning)
+            out = food_prices_from_acquired(fa, units='unitvalue')
+        assert len(out) == 1
+        assert np.isfinite(out['Price']).all()


### PR DESCRIPTION
Closes GH #591.

## The defect

`Country('Nigeria').food_prices()` returns **675–1,106 rows** for waves whose
`food_acquired` holds **120k–160k rows** — roughly **99% of Nigeria's price
data silently disappears in 6 of its 8 waves**, with no warning, no NaN and no
error. Per #591:

| wave | food_acquired | food_prices | survived |
|---|---|---|---|
| 2012Q3 | 121,750 | 675 | **0.6%** |
| 2013Q1 | 134,097 | 161 | **0.1%** |
| 2015Q3 | 147,516 | 509 | **0.3%** |
| 2018Q3 | 158,470 | 1,106 | **0.7%** |

The coverage matrix grades all of these cells `sane` — a direct illustration of
why `sane` is not `blessed`.

## Root cause — this refines the diagnosis in #591

#591 attributes the loss to "a `0`-as-missing sentinel that was never decoded to
`pd.NA`". The `Quantity == 0` with `Expenditure > 0` signature is real, but for
Nigeria it is a **symptom, not the cause**: the zeros are produced by *quantity
variables mapped to the wrong survey question*.

Verified live on `development@ad4b9c1f` —
`Nigeria/2018-19/_/food_acquired.py` maps:

```
:87   's10bq5a': 'Produced',   # home produced quantity
:101  's7bq5a':  'Produced',
```

`q5a` is **not** own production. Per the W4 instrument, `q5a`/`q6a`/`q7a` are
"of [QTY] consumed, how much came from …" — so:

- `q5a` = consumed out of **PURCHASES**; own production is **`q6a`**
  (the same inversion as W2/W3)
- `q10` (value of the most recent purchase) was paired with the residual
  `q2a - q5a`; it actually pays for **`q9a`**, in unit `q9b`, which differs
  from the consumption unit `q2b` in **10% (PP) / 13% (PH)** of rows

Dividing an expenditure by a quantity that does not correspond to it is what
manufactures the unpriceable rows.

## The fix — two parts

**1. Nigeria source mapping** (4 wave scripts, `nigeria.py`, `data_scheme.yml`).
The purchased row now carries the whole **purchase transaction**
(`q9a`, `q9b`, `q9_cvn`, `q10`), so every stored number is survey-reported and
`Expenditure / Quantity` is a real price. Note the scripts get *smaller*
(−415 lines against +915 total). The branch explicitly **rejects** deriving a
purchased value as `q5a × price` on the grounds that it "would fabricate a
number" — consistent with this repo's rule against inventing data.

**2. A framework guard so this can never be silent again**
(`transformations.py`, +133). Adds `UnpriceableRowsWarning` and
`PRICE_LOSS_WARN_THRESHOLD = 0.05`: if more than 5% of rows that *should* have
produced a price do not, it warns and names both candidate causes (a
`0`-as-missing sentinel, or a quantity mapped to the wrong question). It
subclasses `UserWarning` so it can be promoted to an error independently of the
library's other warnings.

This second part is **country-agnostic** and is the durable half of the PR.

## Country idiosyncrasy (per CLAUDE.md)

Nigeria is **post-planting / post-harvest**: each wave dir holds two rounds
needing distinct `t` values (`CONTENTS.org:37-39` — "post-planting (PP, ~Q3) and
post-harvest (PH, ~Q1 of the following year); the same households are visited in
both rounds"). `food_acquired` is a `materialize: make` script-path table, which
is exactly why the mapping lives in per-wave Python rather than YAML. The unit
discrepancy above is reported per-round for that reason.

## Tests

- `tests/test_nigeria_food_acquired_sources.py` — 6 tests, incl.
  `test_source_split_is_not_inverted`, `test_produced_share_is_plausible`,
  `test_food_prices_does_not_collapse`, `test_no_infinite_prices_survive`
- `tests/test_unpriceable_price_drop.py` — 5 tests on **synthetic** frames
  (`_sentinel_frame()`), so the framework guard is tested without data access

## Review items

1. **`test_nigeria_food_acquired_sources.py` is not gated on data access.** It
   carries only `pytest.mark.filterwarnings` plus `importorskip('lsms_library')`
   — which skips on a missing *package*, not on missing S3 credentials. It will
   fail wherever the Nigeria `.dta` files are unreachable. Compare
   `fix/323-niger-geo-regression-test` / `fix/605-ci-skip`, and the
   `_aws_creds_available()` gate used in #668. **Should gain a `requires_s3`
   marker before merge.** (`test_unpriceable_price_drop.py` needs no gate.)
2. `PRICE_LOSS_WARN_THRESHOLD = 0.05` is a new global default — worth a
   deliberate nod, since it will start warning for any country with genuinely
   sparse price data.
3. Row-count and percentage figures above are the branch's and #591's, **not**
   independently re-measured here.

Merges **clean** against `development`. Adds no `aggregation:` key.

## Provenance

Branch pushed during the #323 sweep; **no PR was ever opened**. Surfaced by the
2026-07-27 branch audit (`slurm_logs/BRANCH_AUDIT_2026-07-27.org`).
