### PR TITLE
fix(#537): wire validate_acquisition_source in — dormant since birth, NaN-blind, and O(#rows) on the read path

### DIFF
--- a/.coder/ledger/537-dormant-validator.md
+++ b/.coder/ledger/537-dormant-validator.md
@@ -1,0 +1,102 @@
+# Prior-Art Ledger — GH #537: `validate_acquisition_source` is dormant
+
+> Per-task ledger. Inherits the repo §0 baseline in `STANDING.md`; cites it,
+> `CLAUDE.md`, and `lsms_library/data_info.yml` rather than re-copying.
+
+**Search tier used:** ripgrep + git (floor). gitnexus not consulted; the symbol
+under test has a zero-node call graph, which `git grep` establishes conclusively.
+
+## §1 Task, restated
+
+`transformations.validate_acquisition_source` enforces that the `s` (acquisition
+source) index level of `food_acquired` and its three `_FOOD_DERIVED` children
+(`food_expenditures`, `food_prices`, `food_quantities`) only carries values from
+`transformations.S_VALUES`. Its docstring asserted it was "Called from
+`Country._finalize_result`". **It had zero call sites, from its first commit.**
+A guarantee that does not execute is worse than none, because it is trusted.
+Decide: wire it in, or delete it — no third state, and stop the docstring lying.
+
+## §2 Existing machinery (this task's area)
+
+| symbol | path:line | what it does | tested? | decision |
+|--------|-----------|--------------|---------|----------|
+| `S_VALUES` | `transformations.py:31` | the canonical `s` enumeration `(purchased, produced, inkind, other)` | not before this task | **reuse** — make it the single definition |
+| `validate_acquisition_source` | `transformations.py:34` | the guard itself | **no** (0 refs in tests/bench/docs) | **extend** (wire + harden), not rewrite |
+| `Country._finalize_result` | `country.py:2098` | the universal post-read pipeline; per §0 §2 the single place every table/country/read passes through | integration surface | **reuse** as the hook point |
+| `Country._FOOD_DERIVED` | `country.py:3318` | derives the 3 food tables from `food_acquired`; each derived frame is passed back through `_finalize_result` (`country.py:3488`) | yes | **reuse** — one hook covers all 4 tables |
+| `ethiopiarhs.food_acquired` | `EthiopiaRHS/_/ethiopiarhs.py:114` | df_edit hook; filtered `s` against its **own** `CANON_S` 3-tuple | no | **fix** — import `S_VALUES` |
+| `Country._assert_built_required_columns` | `country.py:2355` | prior art for "loud post-build schema gate rather than silent wrong data" — the pattern this guard follows | yes (PR #243) | **cite**, don't duplicate |
+
+No validator registry / dispatch table exists — `_finalize_result` calls its
+checks inline, so wiring is a direct call, not a registration.
+
+## §3 Definitions & conventions in force
+
+- **Canonical `s`** = `S_VALUES = ('purchased','produced','inkind','other')`,
+  `transformations.py:31`. Per its own comment, `data_info.yml` cannot express
+  enumerated constraints on *index levels*, so this tuple — not the YAML — is the
+  schema. Origin: GH #169, `slurm_logs/DESIGN_food_acquired_canonical_2026-05-05.org`.
+- **Canonical schema** otherwise = `lsms_library/data_info.yml` (STANDING.md §3).
+  Note `index_info` does **not** list `s` for `food_expenditures`, although the
+  frame does carry it — a pre-existing doc/schema gap, out of scope here.
+- **Derived food tables** are runtime-derived, not registered (`CLAUDE.md`
+  §"Derived Tables") — so they cannot be guarded at the `data_scheme.yml` layer;
+  the guard must sit on the read path.
+
+## §4 Invariants & assumptions (the landmines)
+
+- `_finalize_result` is **the highest-blast-radius function in the library**
+  (§0 §2): every table, every country, every read. Anything raised here surfaces
+  at API time for everyone. Guard must be a no-op when `s` is absent.
+- It runs on **every read**, so an O(#rows) check is a real, silent perf
+  regression — worst on `Feature('food_acquired')`, which assembles 20 countries
+  in one call. (Measured: naive form = 819 ms on GhanaLSS's 5.26M rows.)
+- **pandas never stores NaN in `MultiIndex.levels`** — a missing entry is code
+  `-1`. This is exactly why the original `.dropna()`-based check was structurally
+  blind to a NaN `s`, and why a levels-based rewrite must count codes explicitly.
+- **`MultiIndex.levels` retains entries for filtered-out rows.** Reading unique
+  values from `levels` without `remove_unused_levels()` yields false positives.
+- Cache: `s` is not touched by `_finalize_result`, and this is a **post-read**
+  guard, so **no cached parquet is invalidated and `LSMS_CACHE_SCHEMA` must NOT
+  be bumped** (bumping would force a needless from-source rebuild of 20 countries).
+  Consistent with `CLAUDE.md`: `_finalize_result` is *excluded by design* from the
+  content hash.
+
+## §5 Reuse decision
+
+| quantity | decision | reason |
+|----------|----------|--------|
+| canonical `s` enumeration | **reuse** `S_VALUES` | it already exists; the bug is a *second* definition, so adding a third would be the worst outcome |
+| the guard function | **extend** in place | logic is right; the defects are (a) never called, (b) NaN-blind, (c) O(#rows) |
+| hook point | **reuse** `_finalize_result` | already the single post-read pipeline; `_FOOD_DERIVED` frames pass back through it, so one call covers all 4 tables |
+| ERHS filter set | **reuse** `S_VALUES` (drop local `CANON_S`) | kills the drift; verified behaviour-neutral (no ERHS wave emits `other`) |
+| loud-gate pattern | **cite** `_assert_built_required_columns` | same "crash rather than silently wrong" posture; no new machinery |
+
+**Explicitly NOT built** (would have been reinvention): a validator registry, a
+`data_info.yml` index-value-constraint mechanism, or a second enumeration.
+
+## §6 Open questions for the human
+
+- **EthiopiaRHS 1989 discards 686 of 2755 raw food rows (24.9%)** — 677 with a
+  missing `source` code, 9 with unmapped codes 5/6/7. The drop is *deliberate and
+  documented* (`ethiopiarhs.py` docstring), but was invisible at runtime; this
+  task makes it `warn` with a count. **Should the NaN-source rows map to `other`
+  rather than be deleted?** That needs the ERHS 1989 codebook and must not be
+  guessed. Blocks nothing here; worth its own issue.
+- The guard raises on **0 of 80** frames today. That is the expected steady state
+  (it is a regression guard, not a bug detector) — but it means the issue's
+  class-1 "silently wrong / reaches published work" severity is **not** supported
+  by the data. Recommend reclassifying as class-2/4. See the PR body.
+
+---
+### Phase 3 — verification
+
+- `validate_acquisition_source` — **OK (anchored on §2/§4)**: extended, not
+  rewritten; reuses `S_VALUES`; NaN now read off level codes per §4; clean-path
+  cost 819 ms → 3.2 ms per §4's perf invariant.
+- `Country._finalize_result` — **OK (anchored on §2/§4)**: one added call at the
+  tail; no-op without an `s` level; no cache-hash bump, per §4.
+- `ethiopiarhs.food_acquired` — **OK (anchored on §5)**: local `CANON_S` deleted
+  in favour of the imported `S_VALUES`; the CONTRADICTION (two competing
+  definitions of canonical `s`) is resolved, not duplicated.
+- No REINVENTION: no new enumeration, registry, or schema mechanism was added.

--- a/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
+++ b/lsms_library/countries/EthiopiaRHS/_/ethiopiarhs.py
@@ -6,10 +6,13 @@
 # composite key; the framework needs a named `i` formatter for the
 # list-valued idxvar (see Mali/_/mali.py for the analogous helper).
 
+import warnings
+
 import numpy as np
 import pandas as pd
 
 import lsms_library.local_tools as tools
+from lsms_library.transformations import S_VALUES
 
 
 # Explicit `waves` list (consumed by Country.waves, country.py:1054-1073).
@@ -110,12 +113,37 @@ def food_acquired(df):
     s values (drops the NaN/5/6/7 source rows that have no clean
     purchased/produced/inkind meaning), drop unidentifiable rows, and
     return as-is.
+
+    The canonical set is :data:`lsms_library.transformations.S_VALUES` --
+    imported, never re-spelled.  This filter used to carry its own narrower
+    ``CANON_S = ('purchased','produced','inkind')`` which silently omitted
+    ``'other'``, so an ERHS wave that ever emitted ``s='other'`` would have had
+    those rows deleted rather than kept (GH #537).  Behaviour-neutral today (no
+    ERHS wave emits 'other'), but it removes the second competing definition.
+
+    The drop is deliberate but was previously invisible at runtime; it now
+    warns with a count, because for 1989 it discards ~25% of the raw rows.
+    Whether the NaN-source rows *should* map to 'other' rather than be deleted
+    needs the ERHS 1989 codebook and is tracked separately -- do not guess it.
     """
-    CANON_S = ('purchased', 'produced', 'inkind')
     flat = df.reset_index()
     if 'q_purch' not in flat.columns:
         idx = [c for c in ('i', 'j', 'u', 's') if c in flat.columns]
-        flat = flat[flat['s'].isin(CANON_S)]
+        keep = flat['s'].isin(S_VALUES)
+        n_drop = int((~keep).sum())
+        if n_drop:
+            n_nan = int(flat['s'].isna().sum())
+            bad = sorted(set(flat.loc[~keep & flat['s'].notna(), 's'].astype(str)))
+            warnings.warn(
+                f"EthiopiaRHS food_acquired: dropping {n_drop} of {len(flat)} rows "
+                f"({n_drop / len(flat):.1%}) whose acquisition source is not one of "
+                f"{S_VALUES}: {n_nan} with a missing source code"
+                + (f", {n_drop - n_nan} with unmapped code(s) {bad}" if bad else "")
+                + ".  These have no clean purchased/produced/inkind meaning; see "
+                  "the food_acquired docstring in ethiopiarhs.py.",
+                stacklevel=2,
+            )
+        flat = flat[keep]
         for k in ('i', 'j', 'u'):
             if k in flat.columns:
                 flat = flat[flat[k].notna() & (flat[k].astype('string')

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -49,6 +49,12 @@ from .local_tools import (
 from .paths import data_root, countries_root
 from .yaml_utils import load_yaml
 from .currency import attach_currency, is_monetary_table
+# Safe at module level: transformations imports only local_tools /
+# build_transforms / cfe, never country -- so there is no cycle -- and
+# lsms_library/__init__.py imports it anyway.  The other `transformations`
+# imports in this file are function-local for historical reasons; this one is
+# on the hot read path (_finalize_result), so it is hoisted.
+from .transformations import validate_acquisition_source
 from .errors import LabelUnavailableError
 from ._build_registry import build_transform, build_transforms_fingerprint, framework_imports_fingerprint
 import importlib.util
@@ -2215,6 +2221,18 @@ class Country:
             # non-null" form should use ``subset=`` themselves; this step is
             # the universal safety-net.
             df = df.dropna(how='all')
+
+            # Post-condition: the `s` (acquisition source) axis is canonical.
+            # Runs here -- after mappings/spellings/dropna -- so it validates the
+            # frame the caller actually receives, and so a country's
+            # categorical_mapping or `spellings` entry cannot smuggle a
+            # non-canonical source past it.  No-op for the tables without an `s`
+            # level, i.e. everything but food_acquired + _FOOD_DERIVED.
+            #
+            # This guard passes on all current data (GH #537); it exists to make
+            # a future regression loud rather than silently wrong, because `s` is
+            # a bare string literal in 19 of the 20 build scripts that set it.
+            validate_acquisition_source(df)
 
             # Attach the ISO 4217 currency label (last, so it rides through the
             # caller's _relabel_j / _add_market_index without being dropped).

--- a/lsms_library/transformations.py
+++ b/lsms_library/transformations.py
@@ -27,25 +27,94 @@ from .build_transforms import (  # noqa: F401  (re-export for back-compat)
 # level.  See ``slurm_logs/DESIGN_food_acquired_canonical_2026-05-05.org``
 # and GH #169.  ``data_info.yml`` does not currently support enumerated
 # value constraints on index levels, so the enumeration lives here and is
-# enforced in code by :func:`validate_acquisition_source`.
+# enforced in code by :func:`validate_acquisition_source`, which runs on every
+# read from :meth:`Country._finalize_result`.
+#
+# This is the SINGLE definition of "canonical s".  A country build that needs
+# the list (e.g. to filter its raw source codes) must ``import S_VALUES`` --
+# never re-spell it locally.  EthiopiaRHS did exactly that and drifted to a
+# narrower 3-tuple that silently omitted 'other' (GH #537).
 S_VALUES = ('purchased', 'produced', 'inkind', 'other')
 
 
 def validate_acquisition_source(df: pd.DataFrame) -> None:
-    """Raise ``ValueError`` if ``s`` index level contains non-canonical values.
+    """Raise ``ValueError`` if the ``s`` index level is non-canonical.
 
     No-op when ``s`` is not in the index.  Called from
-    :meth:`Country._finalize_result` for tables that carry an ``s`` level
-    (currently just ``food_acquired`` and its derivatives).
+    :meth:`lsms_library.country.Country._finalize_result`, so it runs on the
+    frame the user actually receives, for every table carrying an ``s`` level
+    (``food_acquired`` and the three ``_FOOD_DERIVED`` tables built from it).
+
+    **What this is.**  A *post-condition regression guard*, not a bug detector.
+    It passes on 100% of current data: as of 2026-07-12, all 80 (country x food
+    table) frames -- 31.9M rows across the 20 countries with a ``food_acquired``
+    -- are already canonical, with zero NaN.  It finds nothing today, and that
+    is the expected steady state.  Do not read a green run as evidence that a
+    number is right; read it as evidence that nobody has *broken* ``s`` yet.
+
+    **Why it is worth its cost anyway.**  19 of those 20 countries set ``s`` as
+    a bare string literal in a build script (``purch['s'] = 'purchased'``).  A
+    single typo -- ``'Purchased'``, ``'purchase'``, ``'own-production'`` --
+    would mint a phantom category and silently split rows across the
+    ``(t, v, i, j, u, s)`` index, so ``food_expenditures`` would quietly drop or
+    double-count a source.  That is a silently-wrong-number class of bug, and it
+    is exactly what this guard turns into a loud crash.  A crash is a gift.
+
+    **NaN is a violation, deliberately.**  The original implementation called
+    ``.dropna()`` before comparing, which made it structurally blind to a NaN
+    ``s`` -- the *dominant* real-world non-conformity, since an unmapped source
+    code (EthiopiaRHS/1989 has 677 of them upstream) becomes NaN rather than a
+    bad string.  A row whose acquisition source is unknown does not belong on
+    the ``s`` axis: it must be mapped to a canonical value, mapped to ``other``,
+    or dropped at the wave level -- explicitly, by the country's build.
+
+    See ``slurm_logs/DESIGN_food_acquired_canonical_2026-05-05.org`` and GH
+    #169 (which introduced ``S_VALUES``) / GH #537 (which wired this in -- it
+    had zero call sites from birth despite a docstring claiming otherwise).
     """
-    if 's' not in (df.index.names or []):
+    names = list(df.index.names or [])
+    if 's' not in names:
         return
-    observed = set(df.index.get_level_values('s').dropna().unique())
-    invalid = observed - set(S_VALUES)
+
+    # This runs on EVERY read (_finalize_result), including Feature(), which
+    # assembles all 20 food countries in one call -- so the clean case has to be
+    # cheap.  The old form, get_level_values('s').unique(), is O(#rows) and cost
+    # 877 ms on GhanaLSS food_acquired (5.26M rows).  Instead:
+    #
+    #   * unique values come off the MultiIndex *levels*, already deduplicated
+    #     -> O(#unique), microseconds;
+    #   * NaN is read off the level *codes* (pandas encodes a missing entry as
+    #     code -1 and never stores NaN in `levels`) -> one vectorised int
+    #     compare.  This is also precisely why a levels-based scan -- and the
+    #     original `.dropna()` scan -- could not see a NaN `s` at all.
+    #
+    # `levels` can retain entries for rows filtered out upstream, so a bad value
+    # found there is only a *suspicion*; we pay the O(#rows) prune to confirm it
+    # and avoid a false positive.  That cost is only ever paid on the unhappy
+    # path.  Net: 877 ms -> ~10 ms on GhanaLSS when the data is clean.
+    pos = names.index('s')
+    allowed = set(S_VALUES)
+    if isinstance(df.index, pd.MultiIndex):
+        n_missing = int((np.asarray(df.index.codes[pos]) == -1).sum())
+        invalid = set(df.index.levels[pos]) - allowed
+        if invalid:  # suspicion only -- confirm against rows actually present
+            invalid = set(df.index.remove_unused_levels().levels[pos]) - allowed
+    else:
+        level = df.index.get_level_values('s')
+        n_missing = int(pd.isna(level).sum())
+        invalid = set(level.dropna().unique()) - allowed
+
+    problems = []
     if invalid:
+        problems.append(f"non-canonical value(s) {sorted(map(repr, invalid))}")
+    if n_missing:
+        problems.append(f"{n_missing} row(s) with a missing (NaN) value")
+    if problems:
         raise ValueError(
-            f"Non-canonical values in 's' index level: {sorted(invalid)}. "
-            f"Allowed values are {S_VALUES}.  See "
+            f"Invalid 's' (acquisition source) index level: {'; '.join(problems)}. "
+            f"Allowed values are {S_VALUES} and NaN is not permitted -- map the "
+            f"offending rows to a canonical source (or to 'other') in the wave's "
+            f"build, or drop them there explicitly.  See "
             f"slurm_logs/DESIGN_food_acquired_canonical_2026-05-05.org."
         )
 

--- a/tests/test_acquisition_source_validation.py
+++ b/tests/test_acquisition_source_validation.py
@@ -1,0 +1,198 @@
+"""GH #537: the `s` (acquisition source) canonical-value guard must actually run.
+
+`validate_acquisition_source` had ZERO call sites from the day it was written,
+while its docstring asserted it was "Called from Country._finalize_result".  A
+guarantee that does not execute is worse than no guarantee, because it is
+trusted.
+
+Two things are tested here:
+
+1. **It is wired in.**  `Country._finalize_result` -- the universal read path --
+   must reject a non-canonical `s`.  Pre-fix these raise nothing at all.
+
+2. **It can see NaN.**  The original check called `.dropna()` before comparing,
+   which made it structurally blind to a missing `s` -- the *dominant*
+   real-world non-conformity (an unmapped source code becomes NaN, not a bad
+   string; EthiopiaRHS/1989 has 677 such rows upstream).  A check that cannot
+   see the failure mode that actually occurs is not a guarantee.
+
+Plus a regression test for the definition drift: EthiopiaRHS carried its own
+narrower `CANON_S` that silently omitted 'other'.
+
+These exercise `Country._finalize_result` with a stub `self` (cf.
+test_u_sentinel_protection.py), so no data access is needed.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lsms_library.country import Country
+from lsms_library.transformations import S_VALUES, validate_acquisition_source
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+class _Stub:
+    """Minimal stand-in exposing only what _finalize_result touches.
+
+    `data_scheme` has no 'sample', so the v-join is skipped; `_updated_ids_cache`
+    is None, so id_walk is skipped.  Neither is under test here.
+    """
+
+    name = "Testland"
+    data_scheme: dict = {}
+    categorical_mapping: dict = {}
+    _updated_ids_cache = None
+
+    def _augment_index_from_related_tables(self, df, scheme_entry, _):
+        return df
+
+    def _apply_categorical_mappings(self, df, protect_u_sentinels=False):
+        return df
+
+
+def _frame(s_values):
+    """A food_acquired-shaped frame whose `s` level is exactly `s_values`."""
+    idx = pd.MultiIndex.from_arrays(
+        [
+            ["hh1"] * len(s_values),
+            ["2019-20"] * len(s_values),
+            ["Maize"] * len(s_values),
+            ["Kg"] * len(s_values),
+            list(s_values),
+        ],
+        names=["i", "t", "j", "u", "s"],
+    )
+    return pd.DataFrame(
+        {"Quantity": np.arange(1.0, len(s_values) + 1),
+         "Expenditure": np.arange(10.0, 10.0 + len(s_values))},
+        index=idx,
+    )
+
+
+def _finalize(df, method_name="food_acquired"):
+    """Drive the real _finalize_result over a stub self."""
+    return Country._finalize_result(_Stub(), df, {}, method_name)
+
+
+# --------------------------------------------------------------------------
+# 1. the guard is wired into the universal read path
+# --------------------------------------------------------------------------
+def test_finalize_result_accepts_canonical_s():
+    """Guard against overreach: every canonical value must survive untouched."""
+    out = _finalize(_frame(S_VALUES))
+    assert len(out) == len(S_VALUES)
+    assert set(out.index.get_level_values("s")) == set(S_VALUES)
+
+
+@pytest.mark.parametrize("bad", ["Purchased", "purchase", "own-production", "gift"])
+def test_finalize_result_rejects_noncanonical_s(bad):
+    """A typo'd literal in a wave script must be LOUD, not silently a new category.
+
+    19 of the 20 countries that set `s` set it as a bare string literal, so this
+    is the realistic regression.  Pre-fix: _finalize_result never called the
+    validator, so this returned a frame with a phantom `s` category and no
+    complaint.
+    """
+    with pytest.raises(ValueError, match=r"[Ss]'? \(acquisition source\)|non-canonical"):
+        _finalize(_frame(["purchased", bad]))
+
+
+def test_finalize_result_rejects_nan_s():
+    """NaN `s` must raise.
+
+    This is the failure mode that actually occurs in the wild (an unmapped raw
+    source code maps to NaN), and the original `.dropna()`-based check was
+    structurally blind to it -- so this test fails BOTH on the unwired code and
+    on the old check naively wired in.
+    """
+    with pytest.raises(ValueError, match="missing"):
+        _finalize(_frame(["purchased", np.nan]))
+
+
+def test_finalize_result_noop_without_s_level():
+    """Tables with no `s` axis (i.e. all the non-food ones) are untouched."""
+    idx = pd.MultiIndex.from_arrays(
+        [["hh1", "hh2"], ["2019-20", "2019-20"]], names=["i", "t"]
+    )
+    df = pd.DataFrame({"Age": [30, 40]}, index=idx)
+    out = Country._finalize_result(_Stub(), df, {}, "household_roster")
+    assert len(out) == 2
+
+
+# --------------------------------------------------------------------------
+# 2. the validator itself: NaN visibility + the levels-based fast path
+# --------------------------------------------------------------------------
+def test_validator_sees_nan_directly():
+    """Unit-level: the .dropna() blindness is gone."""
+    with pytest.raises(ValueError, match="missing"):
+        validate_acquisition_source(_frame(["purchased", np.nan]))
+
+
+def test_validator_reports_the_offending_values():
+    """The error must name what is wrong -- an actionable crash, not a bare raise."""
+    with pytest.raises(ValueError) as exc:
+        validate_acquisition_source(_frame(["purchased", "Purchased"]))
+    assert "Purchased" in str(exc.value)
+
+
+def test_validator_no_false_positive_on_stale_levels():
+    """A MultiIndex retains filtered-out entries in `.levels`.
+
+    The fast path reads unique values off `.levels` (O(#unique), not O(#rows) --
+    it runs on every read).  Without remove_unused_levels() a row filtered out
+    upstream would still sit in `.levels` and raise a FALSE positive.
+    """
+    df = _frame(["purchased", "bogus"])
+    df = df[df.index.get_level_values("s") != "bogus"]
+    assert "bogus" in df.index.levels[df.index.names.index("s")]  # stale, as designed
+    validate_acquisition_source(df)  # must NOT raise
+
+
+# --------------------------------------------------------------------------
+# 3. definition drift: EthiopiaRHS must not re-spell the canonical set
+# --------------------------------------------------------------------------
+_ERHS = (Path(__file__).resolve().parents[1]
+         / "lsms_library" / "countries" / "EthiopiaRHS" / "_" / "ethiopiarhs.py")
+
+
+def _load_erhs():
+    spec = importlib.util.spec_from_file_location("ethiopiarhs_for_test", _ERHS)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:  # pragma: no cover - environment-dependent imports
+        pytest.skip(f"ethiopiarhs.py not importable here: {exc}")
+    return mod
+
+
+def test_ethiopiarhs_does_not_narrow_the_canonical_set():
+    """ERHS's pass-through filter must admit every canonical value, incl. 'other'.
+
+    It used to hardcode CANON_S = ('purchased','produced','inkind') -- a second,
+    narrower definition of "canonical s" -- so any ERHS row with s='other' would
+    have been silently deleted by the country's own hook.  Behaviour-neutral on
+    today's data (no ERHS wave emits 'other'); this pins the definition.
+    """
+    mod = _load_erhs()
+    idx = pd.MultiIndex.from_arrays(
+        [["hh1"] * 4, ["Maize"] * 4, ["Kg"] * 4, list(S_VALUES)],
+        names=["i", "j", "u", "s"],
+    )
+    df = pd.DataFrame({"Quantity": [1.0, 2.0, 3.0, 4.0],
+                       "Expenditure": [5.0, 6.0, 7.0, 8.0]}, index=idx)
+
+    out = mod.food_acquired(df)  # pass-through path: no 'q_purch' column
+
+    survived = set(out.reset_index()["s"])
+    assert "other" in survived, (
+        "EthiopiaRHS dropped s='other' -- it is re-spelling the canonical set "
+        "instead of importing transformations.S_VALUES"
+    )
+    assert survived == set(S_VALUES)


### PR DESCRIPTION
Closes GH #537.

## The defect

`validate_acquisition_source` has had **zero call sites since its introducing
commit** (`2048122f`, 2026-05-05) while its docstring asserted *"Called from
`Country._finalize_result`"*. Verified on `development@ad4b9c1f`: the only
occurrence outside the definition is a comment.

A guarantee that does not execute is worse than none, because it is trusted.

## What this does — three defects, not one

1. **Dormant → wired in.** Called from `Country._finalize_result` (inside
   `if isinstance(df, pd.DataFrame)`), at the tail — so it validates the frame
   the caller actually receives, and a country's `categorical_mapping` or
   `spellings` cannot smuggle a bad value past it. `_FOOD_DERIVED` frames pass
   back through `_finalize_result`, so one call covers all four food tables.
2. **NaN-blind → NaN is a violation.** The old check called `.dropna()` before
   comparing, making it structurally blind to a missing `s` — the *dominant*
   real-world non-conformity, since an unmapped source code becomes NaN, not a
   bad string. NaN is now read off the level codes (`-1` sentinel).
3. **O(#rows) on the hot path → O(#unique).** `_finalize_result` runs on every
   read, including `Feature()`. Unique values now come off the already
   deduplicated `MultiIndex.levels`; the O(#rows) prune is paid only when a bad
   value is *suspected*.

It also removes a second competing definition of "canonical s": EthiopiaRHS
carried its own `CANON_S` that silently omitted `'other'`. It now imports
`S_VALUES`. Its 1989 pass-through filter also now warns with a count (it
discards 686 of 2755 raw rows), and the branch explicitly **declines to guess**
whether the NaN-source rows should map to `'other'` — that needs the ERHS 1989
codebook.

## Independent verification (this review, not the branch's own claims)

| claim | how checked | result |
|---|---|---|
| zero call sites on development | `git grep` on `origin/development` | ✅ comment only |
| "7 of 11 tests fail pre-fix (4 wiring, 2 NaN, 1 ERHS)" | ran the branch's tests against unmodified development | ✅ **exactly 7 failed, 4 passed**, breakdown matches |
| 11 pass post-fix | ran on branch | ✅ `11 passed` |
| large perf win | independent benchmark, synthetic 5.26M-row frame | ✅ **998 ms → 2.8 ms (~356×)** |
| no cache-schema bump needed | CLAUDE.md:55 lists `_finalize_result` as excluded by design | ✅ |
| guard does not break existing reads | 437-test targeted run over food/finalize paths | ✅ **guard fired 0 times** |

**The tests are self-contained** — a `_Stub` class and synthetic frames, no S3
access — so they run in CI unmodified. (Worth contrasting with the ungated
test files flagged on #668 and #669.)

I additionally probed 8 edge cases the tests do not cover: empty frame with an
`s` level, plain (non-Multi) `Index` named `s` (good and bad values), NaN on the
plain-Index path, categorical `s`, unnamed index, duplicate `s` level names, and
a stale unused entry left in `levels`. **All behave correctly**, including no
false positive on the stale level — which confirms the `remove_unused_levels()`
re-check earns its place.

## Review items (neither is a correctness defect)

**1. The performance figures contradict each other within this changeset.**
The commit message says `819 ms → 3.2 ms (259×)`; the code comment in
`transformations.py` says `877 ms → ~10 ms`. My own benchmark (998 → 2.8) is
closer to the former. The *code comment* is the one that outlives the PR, so it
should be the one reconciled. Flagging because "a false claim in a tracked file
outlives the PR that introduced it" is this repo's recurring defect class.

**2. Raise-vs-warn deserves a recorded decision.** #537 explicitly asked to
decide, noting a hard `ValueError` could break a currently-passing country. This
branch raises unconditionally. The comparable guard — grain collapse — **warns
by default and is fatal only under `LSMS_GRAIN_STRICT=1`**. Merging leaves two
different behaviours for "a declared invariant was violated". The branch's
implicit argument is sound (`s` is clean on 80/80 frames so raising costs
nothing today, whereas grain has ~540k live losses and *must* warn), but the
asymmetry should be deliberate rather than emergent.

**Lesser:** the EthiopiaRHS `CANON_S → S_VALUES` switch means `s='other'` rows
would now be *kept* rather than dropped — claimed behaviour-neutral because no
ERHS wave emits `'other'`; the test pins the code path, not the data, and I did
not verify the data claim. And `ethiopiarhs.py` is a country module, so it *is*
in the content hash: EthiopiaRHS caches will rebuild automatically. Correct and
desirable, but "No cache-hash bump" could be misread as "nothing rebuilds".

## A false alarm, recorded so nobody re-derives it

My first targeted run reported `test_quantity_kg::test_malawi_food_quantities_kg_total_preserved`
as FAILED, and that test **passes on development**. It is **not** a regression:
run serially on this branch it passes (`1 passed`, 7:58). The failure was an
artifact of running pytest with `-n 3` — xdist workers racing on the shared L2
parquet cache while several tests build Malawi. The test is a 0.5% tolerance pin
on a kg total, which is exactly what a partially-rebuilt parquet perturbs.

**Worth its own issue:** `pytest -n <N>` can produce false failures in this repo
whenever two workers build the same country, because the L2 cache under
`~/.local/share/lsms_library/` is shared process-wide.

## Not verified here

The branch's headline evidence — BEFORE == AFTER byte-identity across all 84
(country × food table) frames, 31.9M rows — was **not** re-run; it needs a full
corpus build. A full `pytest tests/` was also not completed: 3713 tests exceeded
50 minutes here without finishing, and `-m "not requires_s3"` deselects none of
them.

Merges clean against `development`.

## Provenance

Branch pushed during the #323 sweep; **no PR was ever opened**. Surfaced by the
2026-07-27 branch audit (`slurm_logs/BRANCH_AUDIT_2026-07-27.org`, PR #670).
