### PR TITLE
fix(GhanaLSS): GLSS1 Upper East/West reversed — 1,511 people, armed by #673's decode revival

### DIFF
--- a/lsms_library/countries/GhanaLSS/1987-88/_/categorical_mapping.org
+++ b/lsms_library/countries/GhanaLSS/1987-88/_/categorical_mapping.org
@@ -207,3 +207,49 @@ units.to_csv('unitlabels.csv')
 
 #+results:
 : None
+
+* Y01A
+
+# GLSS1 Y01A.DAT:REGION.  This wave had NO `region` table of its own until
+# 2026-08-20, so `code_label_map('region', _dirs)` fell through to the
+# country-level `_/categorical_mapping.org`, whose codes 9 and 10 are
+# Upper East / Upper West -- the REVERSE of every wave-level table in this
+# country (1988-89, 1991-92 and 1998-99 all read 9 = Upper West, 10 = Upper
+# East, and 1998-99's ordering was checked against the GLSS4 questionnaire).
+#
+# While this wave's decode was dead (`region_dict == {}`) the disagreement
+# was unobservable, because Region and Birthplace were 100% NA.  Reviving
+# the decode armed it, mislabelling 1,511 people and 11 clusters.
+#
+# The GLSS1 questionnaire is a scanned image with no text layer, so check C4
+# CANNOT be run for this wave.  The ordering below is therefore established
+# from four converging non-questionnaire lines of evidence, recorded in
+# `_/CONTENTS.org`:
+#   1. the 1988-89 cluster bridge (CLYR1YR2.DAT): of 85 linked clusters 75
+#      agree on region, but 0 of the 6 touching an Upper region agree -- and
+#      each differs in the direction a 9/10 swap predicts;
+#   2. the three sibling waves' own tables agree on 9 = Upper West;
+#   3. this wave's raw REGION codes run 1..11, i.e. the 11-code era list
+#      whose 11 is a single "Foreign Country", not GLSS2's 17-code list;
+#   4. Upper East is the more populous region, and every other wave shows
+#      more Upper East clusters than Upper West (ratios 1.78-3.00).  Under
+#      the fallback table 1987-88 alone inverted (4/7 = 0.57); corrected it
+#      reads 7/4 = 1.75, in line with its siblings.
+#
+# NOTE: the comments must stay ABOVE `#+name:`.  An Org `#+name:` keyword
+# attaches to the NEXT element, so a comment block between the keyword and
+# the table silently steals the name and the decode stays dead.
+#+name: region
+| Code | Label           |
+|------+-----------------|
+|    1 | Western         |
+|    2 | Central         |
+|    3 | Greater Accra   |
+|    4 | Eastern         |
+|    5 | Volta           |
+|    6 | Ashanti         |
+|    7 | Brong Ahafo     |
+|    8 | Northern        |
+|    9 | Upper West      |
+|   10 | Upper East      |
+|   11 | Foreign Country |

--- a/lsms_library/countries/GhanaLSS/1988-89/_/categorical_mapping.org
+++ b/lsms_library/countries/GhanaLSS/1988-89/_/categorical_mapping.org
@@ -138,7 +138,7 @@ The following tables are mapping of numerical codes to categorical labels for 19
 |    4 | Eastern       |
 |    5 | Volta         |
 |    6 | Ashanti       |
-|    7 | Brongahafo    |
+|    7 | Brong Ahafo   |
 |    8 | Northern      |
 |    9 | Upper West    |
 |   10 | Upper East    |

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -1014,6 +1014,58 @@ taking an *arbitrary* person's birth region for the whole cluster --
 conflicting clusters, i.e. 167 of 170 clusters held members born in more than
 one region.
 
+** Trap 4: GLSS1 had no =region= table of its own, and the fallback is REVERSED
+
+Found 2026-08-20, one day after Trap 1 was fixed, and *caused* by that fix.
+
+=1987-88/_/categorical_mapping.org= carried no =region= table, so
+=code_label_map('region', _dirs)= fell through =_dirs= to the *country-level*
+=_/categorical_mapping.org=.  That table reads =9 = Upper East, 10 = Upper
+West=.  *Every wave-level table in this country reads the reverse* -- 1988-89,
+1991-92 and 1998-99 all have =9 = Upper West, 10 = Upper East=, and 1998-99's
+ordering was checked against the GLSS4 questionnaire on 2026-08-19.
+
+While GLSS1's decode was dead the disagreement was *unobservable*: =region_dict=
+was ={}=, so =Region= and =Birthplace= were 100% NA and no value could be wrong.
+Reviving the decode (=18b6ca51=) armed it, and shipped *1,511 people* with
+=Birthplace= reversed and *11 of 176 clusters* with =Region= reversed.
+
+This is the same lesson as Trap 1, one level deeper, and it is worth stating
+plainly: *a fallback that has never been exercised has never been checked.*
+The country-level table was not wrong for anything that used it before --
+nothing used it.
+
+*** The evidence, since C4 cannot be run here
+
+The GLSS1 questionnaire is a scanned image with no text layer, so the
+questionnaire check is *unrunnable* for this wave.  Four converging lines of
+non-questionnaire evidence establish the ordering instead:
+
+| # | check | result |
+|---+-------+--------|
+| 1 | =1988-89/Data/CLYR1YR2.DAT= bridges 85 clusters across the two waves | 75/85 agree on region overall, but *0 of the 6* touching an Upper region agree -- each differing in the direction a 9/10 swap predicts |
+| 2 | the three sibling waves' own tables | all read =9 = Upper West= |
+| 3 | this wave's raw =REGION= codes | run =1..11=, the 11-code era list (11 = a single "Foreign Country"), not GLSS2's 17-code list |
+| 4 | Upper East is the more populous region | every other wave has more Upper East clusters than Upper West (ratios 1.78, 2.17, 3.00); 1987-88 alone inverted at 4/7 = 0.57 |
+
+After the fix the bridge agreement rises *88.2% -> 95.3%*, the Upper-region
+pairs go *0/6 -> 6/6*, and 1987-88's ratio becomes 7/4 = 1.75, in line with its
+siblings.  The 4 residual mismatches are single scattered pairs, consistent
+with the modal-birth-region approximation of Trap 3 rather than with a coding
+error.
+
+*** Two mechanical traps this sprang on the way
+
+- *An Org =#+name:= attaches to the NEXT element.*  A comment block placed
+  between =#+name: region= and the table silently steals the name; the table is
+  then unnamed, the lookup misses, and the decode stays dead *with no error*.
+  Keep commentary above the =#+name:= line.  The first attempt at this fix was
+  a silent no-op for exactly this reason, and it looked like a successful build.
+- =1988-89= spelled code 7 =Brongahafo= where all six other waves spell it
+  =Brong Ahafo=.  Harmless-looking, but it means
+  =df[df.Region == 'Brong Ahafo']= silently dropped all 170 of that wave's
+  clusters.  Corrected in the wave's own table.
+
 ** Cluster counts, and a vocabulary trap in the documentation
 
 Post-fix cluster counts are exactly the distinct =CLUST= values in the source:


### PR DESCRIPTION
**Stacked on `audit/ghana-correctness` (PR #673).** Base it there so the diff stays to three files; merge after #673, or cherry-pick `e0f6e36b` into #673 before merging it.

## What is wrong

GLSS1 (`1987-88`) has no `region` table of its own, so `code_label_map('region', _dirs)` falls through to the **country-level** `_/categorical_mapping.org`, which reads `9 = Upper East, 10 = Upper West`.

**Every wave-level table in this country reads the reverse.** 1988-89, 1991-92 and 1998-99 all have `9 = Upper West, 10 = Upper East` — and 1998-99's ordering was verified against the GLSS4 questionnaire in `f5e6b66c`, yesterday.

## Why nobody saw it

While GLSS1's decode was dead, `region_dict` was `{}`, so `Region` and `Birthplace` were 100% NA — **no value could be wrong because there were no values.** Reviving the decode in `18b6ca51` armed it:

| table | affected |
|---|---|
| `household_roster.Birthplace` | **1,511 people** |
| `cluster_features.Region` | **11 of 176 clusters** |

This is the failure mode #673's own `CONTENTS.org` note warned about, recurring one wave over — *reviving a dead decode starts TRUSTING a mapping table nobody had reason to validate*. The generalisation worth keeping: **a fallback that has never been exercised has never been checked.** The country-level table was not wrong for anything that used it before, because nothing used it.

## Evidence — C4 is unrunnable here

The GLSS1 questionnaire is a scanned image with no text layer, so the questionnaire check **cannot be run** for this wave. I am not claiming it was. Four converging non-questionnaire lines establish the ordering:

| # | check | result |
|---|---|---|
| 1 | `1988-89/Data/CLYR1YR2.DAT` bridges 85 clusters across the waves | 75/85 agree on region overall, but **0 of the 6** touching an Upper region agree — each differing in the direction a 9/10 swap predicts |
| 2 | the three sibling waves' own tables | all read `9 = Upper West` |
| 3 | this wave's raw `REGION` codes | run `1..11` — the 11-code era list (11 = one "Foreign Country"), not GLSS2's 17-code list |
| 4 | Upper East is the more populous region | every other wave has more Upper East clusters than Upper West (1.78, 2.17, 3.00); 1987-88 alone inverted at 4/7 = **0.57** |

Under the 88.2% baseline agreement rate, 6 of 6 Upper pairs disagreeing by chance is ~3e-6.

## After the fix — verified cold, isolated `LSMS_DATA_DIR`, `dvc-cache` symlinked to shared L1

| metric | before | after |
|---|---|---|
| bridge agreement | 75/85 (88.2%) | **81/85 (95.3%)** |
| Upper-region pairs agreeing | **0 / 6** | **6 / 6** |
| 1987-88 UE/UW cluster ratio | 4/7 = 0.57 | **7/4 = 1.75** |
| `cluster_features` rows | 3,791 | 3,791 (unchanged) |
| 1987-88 kinship nulls | 0% | 0% (unchanged) |
| `GrainCollapseWarning`s | 0 | 0 |

The 4 residual bridge mismatches are scattered single pairs (Ashanti/Brong Ahafo, Central/Ashanti, Northern/Volta, Volta/Brong Ahafo), consistent with Trap 3's modal-birth-region approximation rather than a coding error.

## Also fixed

`1988-89` spelled code 7 **`Brongahafo`**; all six other waves use `Brong Ahafo`. So `df[df.Region == 'Brong Ahafo']` silently dropped that wave's 170 clusters. Corrected in the wave's own table — after this, the country has exactly 10 distinct region labels across all 7 waves.

## A mechanical trap worth reading

An Org `#+name:` attaches to the **next element**. A comment block placed between `#+name: region` and the table silently steals the name — the table ends up unnamed, the lookup misses, and the decode stays dead **with no error raised**. My first attempt at this fix was a silent no-op for exactly that reason and looked like a clean build. Commentary must sit *above* the `#+name:` line. Recorded as Trap 4 in `CONTENTS.org`.

Refs #673.