### PR TITLE
feat(GhanaSPS): household_roster for all three waves — 54,251 people, and household_characteristics with it

### DIFF
--- a/lsms_library/categorical_mapping/kinship.yml
+++ b/lsms_library/categorical_mapping/kinship.yml
@@ -624,3 +624,22 @@ P:                                       [1, 0, consanguineal]   # low-confidenc
 "Grandfather / Mother":          [2, 0, consanguineal]
 "Brother/Sister In-Law":         [0, 1, affinal]
 "Father/Mother In-Law":          [1, 0, affinal]
+
+# --- GhanaSPS (Ghana Socio-Economic Panel Survey) variants ---
+# The relationship vocabulary DRIFTS across the three GSPS waves for the same
+# underlying category, so each spelling needs its own key.  Keys are given in
+# the title-cased form that _expand_kinship tries first ('X'.title()):
+#   adopted/foster/step  W1 'Adopted/Foster/Stepchild'
+#                        W2 'Adopted, foster, or stepchild'
+#                        W3 'Adopted, foster/stepchild'
+#   parent-in-law        W2 'Parent or parent-in-law'      (W1/W3 use 'Parent/Parent-in-Law')
+#   child-in-law         W2 'Son or daughter in-law'       (W1/W3 use 'Son/Daughter-in-law')
+# Tuples follow the existing composite precedents in this file:
+#   "Adopted / Foster/ Step Child" -> [-1, 0, step]
+#   "Parent/Parent-In-Law"         -> [1, 0, consanguineal]
+#   "Son/Daughter-in-law"          -> [-1, 0, affinal]
+"Adopted/Foster/Stepchild":      [-1, 0, step]
+"Adopted, Foster, Or Stepchild": [-1, 0, step]
+"Adopted, Foster/Stepchild":     [-1, 0, step]
+"Parent Or Parent-In-Law":       [1, 0, consanguineal]
+"Son Or Daughter In-Law":        [-1, 0, affinal]

--- a/lsms_library/countries/GhanaSPS/2009-10/_/data_info.yml
+++ b/lsms_library/countries/GhanaSPS/2009-10/_/data_info.yml
@@ -31,3 +31,93 @@ sample:
         panel_weight: hhweight3
         strata: loc7
         Rural: urbrur
+
+household_roster:
+    # S1D.dta is the wave-1 person roster: 18,889 rows, 5,009 households,
+    # (hhno, hhmid) unique -- exactly the 18,889 members the Baseline
+    # Descriptive Report documents.  Its households match key_hhld_info.dta
+    # exactly in BOTH directions (0 in S1D absent from the key file, 0 in the
+    # key file absent from S1D), so the sample v-join is total here -- unlike
+    # the food module, which has the 29/35 hhno discrepancy noted above.
+    #
+    # Variable labels read off the .dta, because the obvious guess is wrong:
+    #   s1d_1  "Q1 Sex"                        -> Sex   (Male/Female)
+    #   s1d_2  "Q2 Relationship to HH Head"    -> Relationship
+    #   s1d_4i "Q4i Age (years)"               -> Age
+    # NOTE s1d_2 is the RELATIONSHIP and s1d_4i is the AGE.  A prior task brief
+    # had these two swapped; the variable labels and the value distributions
+    # both settle it (s1d_2 takes 'Household Head'/'Child'/'Spouse'..., s1d_4i
+    # is numeric 0-120).
+    #
+    # `v` is NOT declared -- _join_v_from_sample() attaches it at API time.
+    #
+    # DOB triple deliberately NOT wired.  sid_3i (note the typo: `sid_`, not
+    # `s1d_`) / s1d_3ii / s1d_3iii are "Q3i Day of birth" / "Q3ii Month of
+    # birth" / "Q3 Year of birth", and age_handler() could turn them into
+    # fractional ages.  Left out because the reported age is already 18,884 of
+    # 18,889 non-null (5 missing), the day column is only 50% populated and
+    # object-dtype, and wave 1 has no interview-date table to anchor the
+    # arithmetic.  Cost exceeds the benefit; revisit if interview_date lands.
+    #
+    # ---------------------------------------------------------------------
+    # MonthsAway is DELIBERATELY NOT DECLARED FOR THIS WAVE.  Read this before
+    # "fixing" the omission.
+    #
+    # s1d_27 IS the right variable -- "Q27 For how many months has person been
+    # away from this household in last 12 months", the MonthsAway question in
+    # the CLAUDE.md taxonomy, and the same question waves 2 and 3 ask.  It is
+    # not wired because its MISSINGNESS is not the missingness the framework
+    # assumes.
+    #
+    # roster_to_characteristics() drops any member whose residence datum is
+    # NaN, on the premise (true for Uganda) that NaN means "question not asked
+    # because the person had left".  Here NaN means "this household's Q27-Q33
+    # block was never captured".  Measured on the shipped file:
+    #   - s1d_27 is non-null for 9,956 of 18,889 members (52.7%);
+    #   - the gap is HOUSEHOLD-level, not person-level: 2,188 of 5,009
+    #     households have NO member answered and 2,537 have EVERY member
+    #     answered, with only 284 partial.  48 whole EAs are at 0%;
+    #   - within the 2,188 all-missing households the non-null rate of s1d_27
+    #     is exactly 0.000000 and of s1d_28 exactly 0.000000, while every other
+    #     roster variable is populated at the SAME rate as in the answering
+    #     households (Sex 100%, Relationship 100%, Age 99.96%, religion 97.6%,
+    #     Q23 political office 98.5%).  So those households were fully
+    #     enumerated and only the Q27+ absence block is absent;
+    #   - answer rate is flat across age (51-57% in every band, infants
+    #     included), so it is not an eligibility skip.
+    #
+    # NaN is therefore NOT "never away", and filling 0 would fabricate data:
+    # the survey records 0 explicitly for 8,840 of the 9,956 answered members,
+    # so the 0-vs-NaN distinction is real and meaningful.
+    #
+    # Consequence of declaring it anyway, measured end-to-end: the derived
+    # household_characteristics would keep 9,942 of 18,889 persons and only
+    # 2,817 of 5,009 households -- 2,192 households (43.8%) would silently
+    # VANISH from a table whose household_roster is fully populated.
+    #
+    # Leaving it undeclared makes wave 1 hit the documented per-wave fallback
+    # in roster_to_characteristics ("a wave with no usable residence datum at
+    # all reverts to counting every roster member"), which emits a UserWarning
+    # naming the wave.  That is the honest outcome: every roster member
+    # counted, mean household size 3.771 = 18,889/5,009.  (The delivered
+    # household_characteristics shows 5,008 wave-1 households, not 5,009, for
+    # an unrelated reason: roster_to_characteristics then drops rows with a
+    # null Sex or Age, and hhno 107254027 is a ONE-PERSON household whose only
+    # member has no age.  See CONTENTS.org.)
+    #
+    # Also note s1d_27 has exactly ONE out-of-range value: hhno 105144071,
+    # hhmid 2 (female spouse, age 48) reports 15 months away in a 12-month
+    # reference period.  No negatives and no other value above 12.  Its meaning
+    # could not be determined from any document in the corpus.  It is moot
+    # while the column is undeclared; anyone wiring it later must decide
+    # explicitly (leaving it NA is the documented default) rather than clip
+    # silently.
+    # ---------------------------------------------------------------------
+    file: S1D.dta
+    idxvars:
+        i: hhno
+        pid: hhmid
+    myvars:
+        Sex: s1d_1
+        Age: s1d_4i
+        Relationship: s1d_2

--- a/lsms_library/countries/GhanaSPS/2009-10/_/data_info.yml
+++ b/lsms_library/countries/GhanaSPS/2009-10/_/data_info.yml
@@ -60,58 +60,76 @@ household_roster:
     # arithmetic.  Cost exceeds the benefit; revisit if interview_date lands.
     #
     # ---------------------------------------------------------------------
-    # MonthsAway is DELIBERATELY NOT DECLARED FOR THIS WAVE.  Read this before
-    # "fixing" the omission.
+    # MonthsAway: s1d_27, with NaN read as 0.  Read this before changing it.
     #
-    # s1d_27 IS the right variable -- "Q27 For how many months has person been
-    # away from this household in last 12 months", the MonthsAway question in
-    # the CLAUDE.md taxonomy, and the same question waves 2 and 3 ask.  It is
-    # not wired because its MISSINGNESS is not the missingness the framework
-    # assumes.
+    # s1d_27 is "Q27 For how many months has person been away from this
+    # household in last 12 months" -- the MonthsAway question in the CLAUDE.md
+    # taxonomy, and the same question waves 2 and 3 ask.  It is non-null for
+    # only 9,956 of 18,889 members (52.7%), and an earlier version of this file
+    # left it UNDECLARED on the reasoning that NaN could not mean "never away",
+    # since the survey records 0 explicitly for 8,840 of the 9,956 answered.
     #
-    # roster_to_characteristics() drops any member whose residence datum is
-    # NaN, on the premise (true for Uganda) that NaN means "question not asked
-    # because the person had left".  Here NaN means "this household's Q27-Q33
-    # block was never captured".  Measured on the shipped file:
-    #   - s1d_27 is non-null for 9,956 of 18,889 members (52.7%);
-    #   - the gap is HOUSEHOLD-level, not person-level: 2,188 of 5,009
-    #     households have NO member answered and 2,537 have EVERY member
-    #     answered, with only 284 partial.  48 whole EAs are at 0%;
-    #   - within the 2,188 all-missing households the non-null rate of s1d_27
-    #     is exactly 0.000000 and of s1d_28 exactly 0.000000, while every other
-    #     roster variable is populated at the SAME rate as in the answering
-    #     households (Sex 100%, Relationship 100%, Age 99.96%, religion 97.6%,
-    #     Q23 political office 98.5%).  So those households were fully
-    #     enumerated and only the Q27+ absence block is absent;
-    #   - answer rate is flat across age (51-57% in every band, infants
-    #     included), so it is not an eligibility skip.
+    # That reasoning was WRONG, and the check that produced it was
+    # non-discriminating.  It observed that within the all-missing households
+    # s1d_27 and s1d_28 are both 0.000000 non-null -- but s1d_28 is only 0.1%
+    # non-null in the WHOLE FILE (18 rows), because Q28-Q33 are the follow-ups
+    # asked of people who ARE away.  They are ~absent everywhere, so their
+    # absence in those households discriminates nothing.
     #
-    # NaN is therefore NOT "never away", and filling 0 would fabricate data:
-    # the survey records 0 explicitly for 8,840 of the 9,956 answered members,
-    # so the 0-vs-NaN distinction is real and meaningful.
+    # Q27-Q33 is a skip block.  Confirmed on the shipped file:
+    #   - of the 8,933 members with s1d_27 missing, the number with any of
+    #     s1d_28..s1d_33 populated is NINE (0.101%), in 5 households;
+    #   - among members who DO answer, the Q28-33 block fires for 154 of the
+    #     1,116 away (s1d_27>0) and 14 of the 8,840 at home -- i.e. it is
+    #     conditional on being away, as the labels say.
     #
-    # Consequence of declaring it anyway, measured end-to-end: the derived
-    # household_characteristics would keep 9,942 of 18,889 persons and only
-    # 2,817 of 5,009 households -- 2,192 households (43.8%) would silently
-    # VANISH from a table whose household_roster is fully populated.
+    # And the missingness is a RECORDING CONVENTION, not a person attribute.
+    # Per-EA answer rates are sharply bimodal -- 48 of 334 EAs at 0%, 128 at
+    # 100%, only 17 in the 25-75% middle -- and the share of RECORDED values
+    # that are non-zero falls monotonically as the EA answers more people:
     #
-    # Leaving it undeclared makes wave 1 hit the documented per-wave fallback
-    # in roster_to_characteristics ("a wave with no usable residence datum at
-    # all reverts to counting every roster member"), which emits a UserWarning
-    # naming the wave.  That is the honest outcome: every roster member
-    # counted, mean household size 3.771 = 18,889/5,009.  (The delivered
-    # household_characteristics shows 5,008 wave-1 households, not 5,009, for
-    # an unrelated reason: roster_to_characteristics then drops rows with a
-    # null Sex or Age, and hhno 107254027 is a ONE-PERSON household whose only
-    # member has no age.  See CONTENTS.org.)
+    #     EA answer rate |    n | % of recorded values that are NON-ZERO
+    #     ---------------+------+---------------------------------------
+    #     0-25%          |  468 | 95.9
+    #     25-50%         |  139 | 70.5
+    #     50-75%         |  227 | 12.8
+    #     75-99%         | 1745 |  4.2
+    #     100%           | 7377 |  6.3
     #
-    # Also note s1d_27 has exactly ONE out-of-range value: hhno 105144071,
-    # hhmid 2 (female spouse, age 48) reports 15 months away in a 12-month
-    # reference period.  No negatives and no other value above 12.  Its meaning
-    # could not be determined from any document in the corpus.  It is moot
-    # while the column is undeclared; anyone wiring it later must decide
-    # explicitly (leaving it NA is the documented default) rather than clip
-    # silently.
+    # Teams that recorded almost nobody recorded almost exclusively the AWAY
+    # cases; teams that recorded everybody wrote mostly zeros.  That is the
+    # signature of "blank = not away", so the 8,840 explicit zeros are not
+    # evidence against NaN->0 -- they are what the thorough teams wrote where
+    # the others left the cell empty.  The fill is applied by the
+    # `household_roster` df_edit hook in this wave's mapping.py.
+    #
+    # Cost of getting this wrong in the other direction: leaving it undeclared
+    # made wave 1 fall back to counting every roster member; declaring it
+    # WITHOUT the fill would have dropped 2,192 households (43.8%) from the
+    # derived household_characteristics, because roster_to_characteristics()
+    # drops members whose residence datum is NaN.
+    #
+    # Residuals, both documented rather than silently smoothed:
+    #   - the 9 members above have move data but no s1d_27.  Under NaN->0 they
+    #     are recorded as never away, which for them is probably wrong.  They
+    #     are 0.05% of the roster; the hook does not special-case them.
+    #   - exactly ONE out-of-range value: hhno 105144071, hhmid 2 (female
+    #     spouse, age 48) reports 15 months away in a 12-month reference
+    #     period.  No negatives, no other value above 12.  The hook clips it to
+    #     12 -- the largest value consistent with the reference period -- rather
+    #     than guessing at a keying error.  Note that leaving it at 15 would
+    #     make roster_to_characteristics compute clip(12-15, 0, None) = 0
+    #     months present and drop the person SILENTLY.
+    #   - declaring the column costs ONE household in the derived
+    #     household_characteristics: hhno 107268086, whose three members all
+    #     report 12 months away in the source (verified raw -- not the clip
+    #     above; it is the only household in the wave where every member
+    #     reports 12).  All three therefore have zero months present and are
+    #     filtered out, so the household disappears from a table its roster
+    #     populates.  That is the framework honouring the data, not a defect,
+    #     but it is the kind of silent vanishing worth naming.  (hhno
+    #     107254027 also has no household_characteristics row, for the
+    #     unrelated pre-existing reason that its single member has no Age.)
     # ---------------------------------------------------------------------
     file: S1D.dta
     idxvars:
@@ -121,3 +139,4 @@ household_roster:
         Sex: s1d_1
         Age: s1d_4i
         Relationship: s1d_2
+        MonthsAway: s1d_27

--- a/lsms_library/countries/GhanaSPS/2009-10/_/mapping.py
+++ b/lsms_library/countries/GhanaSPS/2009-10/_/mapping.py
@@ -43,3 +43,33 @@ def strata(value):
     '''loc7 -- the survey's 7-way locality stratification.  Kept as a code:
     no label table for it ships with the data.'''
     return tools.format_id(value)
+
+
+def household_roster(df):
+    '''Table-level ``df_edit`` hook: read a blank Q27 as "not away".
+
+    ``s1d_27`` ("months away in the last 12") is populated for only 52.7% of
+    members, and the blanks are a RECORDING CONVENTION rather than a person
+    attribute -- see the long note in this wave's ``data_info.yml``.  The
+    short version: Q27-Q33 is a skip block (of the 8,933 members missing
+    s1d_27, just 9 have any of Q28-Q33), and per-EA answer rates are bimodal,
+    with the share of recorded values that are NON-ZERO falling monotonically
+    from 95.9% in the EAs that recorded almost nobody to ~6% in the EAs that
+    recorded everybody.  Teams that wrote down few people wrote down the AWAY
+    ones; teams that wrote down everybody recorded the zeros too.
+
+    Without this fill, ``roster_to_characteristics()`` drops every NaN member
+    and 2,192 of 5,009 wave-1 households (43.8%) vanish from the derived
+    ``household_characteristics``.
+
+    The single out-of-range value (15 months in a 12-month window, hhno
+    105144071/hhmid 2) is clipped to 12 rather than guessed at.  Left alone it
+    would yield clip(12 - 15, 0, None) = 0 months present and drop the person
+    silently.
+    '''
+    if 'MonthsAway' not in df.columns:
+        return df
+    months = pd.to_numeric(df['MonthsAway'], errors='coerce')
+    df = df.copy()
+    df['MonthsAway'] = months.fillna(0).clip(upper=12)
+    return df

--- a/lsms_library/countries/GhanaSPS/2013-14/_/data_info.yml
+++ b/lsms_library/countries/GhanaSPS/2013-14/_/data_info.yml
@@ -18,3 +18,70 @@ sample:
         i: FPrimary
     myvars:
         v: FPrimary
+
+household_roster:
+    # TWO-SOURCE table: the roster and its residence-duration variable live in
+    # different files, so this needs a `dfs:` merge.
+    #
+    #   01b2_roster.dta   16,356 rows, 4,774 households -- Sex/Age/Relationship
+    #   01d_background.dta 16,354 rows              -- MonthsAway (awaylast12)
+    #
+    # CARTESIAN CHECK (GH #323 site 4), measured on THIS wave, not in aggregate:
+    # (FPrimary, hhmid) is unique in BOTH frames -- 16,356 distinct keys in
+    # 16,356 roster rows and 16,354 in 16,354 background rows -- so the number
+    # of key values duplicated in both frames is 0 and the merge is exactly
+    # 1:1.  The background keys are a strict SUBSET of the roster keys
+    # (intersection 16,354; 0 background-only rows), and the 2 roster-only
+    # members simply take a NaN MonthsAway.
+    #
+    # `merge_how: left` with the roster as the primary sub-df: the roster is
+    # authoritative for which persons exist, background is a strict enrichment.
+    # (Here it is also output-identical to the `outer` default, since
+    # background contributes no rows of its own -- but that is a fact about
+    # this wave's extract, not a guarantee, and wave 3 is checked separately.)
+    #
+    # SOURCING NOTE -- 01b2_preroster.dta is NOT merged in, deliberately.  It is
+    # the wave-1 preload used to track attrition (22,613 rows carrying
+    # `currentmember`, `whynotmember`, `howlongnotmember`, `joinedwhy`), i.e. an
+    # EVENT table about joiners and leavers, not a roster.  Its
+    # `currentmember == 'Yes'` rows number exactly 16,356 -- the roster row
+    # count -- which is the check that 01b2_roster.dta is the complete set of
+    # current members and not a subset of it.  Its `currentmember == 'No'` rows
+    # (6,257) are people who LEFT and correctly do not belong in the roster.
+    # Note preroster.hhmid is float64 and mostly null; comparing it to the
+    # roster's int8 hhmid via astype(str) gives '1.0' vs '1' and a spurious
+    # zero overlap.
+    #
+    # `v` is NOT declared -- _join_v_from_sample() attaches it at API time.
+    # This wave ships no geography at all (see the `sample` note above), so
+    # every household's `v` comes from the FPrimary[-6:-3] EA slice.
+    dfs:
+        - df_roster
+        - df_background
+    df_roster:
+        file: 01b2_roster.dta
+        idxvars:
+            i: FPrimary
+            pid: hhmid
+        myvars:
+            Sex: gender
+            Age: ageyears
+            Relationship: relationship
+    df_background:
+        file: 01d_background.dta
+        idxvars:
+            i: FPrimary
+            pid: hhmid
+        myvars:
+            # "s01d_27 - Away in last 12" -- the same Q27 wave 1 asks, and
+            # here it is CLEAN: 16,353 of 16,354 non-null, values 0-12 with
+            # no out-of-range value and no sentinel.
+            MonthsAway: awaylast12
+    merge_on:
+        - i
+        - pid
+    merge_how: left
+    final_index:
+        - t
+        - i
+        - pid

--- a/lsms_library/countries/GhanaSPS/2017-18/_/data_info.yml
+++ b/lsms_library/countries/GhanaSPS/2017-18/_/data_info.yml
@@ -16,3 +16,74 @@ sample:
     myvars:
         v: FPrimary
         strata: region
+
+household_roster:
+    # TWO-SOURCE table, same shape as 2013-14: roster + background for
+    # MonthsAway.
+    #
+    #   01b2_roster.dta    19,006 rows, 5,669 households
+    #   01d_background.dta 19,006 rows -- MonthsAway (awaylast12)
+    #
+    # CARTESIAN CHECK (GH #323 site 4), measured on THIS wave SEPARATELY -- a
+    # rule verified on 2013-14 does not transfer, which is the whole point of
+    # re-checking.  (FPrimary, hhmid) is unique in BOTH frames: 19,006 distinct
+    # keys in 19,006 rows on each side, 0 key values duplicated in both, and
+    # the intersection is all 19,006.  The merge is exactly 1:1 with no
+    # roster-only and no background-only rows.
+    #
+    # `merge_how: left`, roster authoritative -- see the 2013-14 note.
+    #
+    # SOURCING NOTE -- neither 01b2_newroster.dta nor 01b2_preroster.dta is
+    # merged in, and 01b2_roster.dta is NOT silently incomplete.  Checked:
+    #   - the roster carries its own `new_mem` flag: 14,168 'No' + 4,838 'Yes'
+    #     = 19,006, i.e. continuing members plus joiners, ALREADY UNIONED;
+    #   - 01b2_newroster.dta (4,839 rows, 2,449 households) is the JOINER
+    #     event table -- `joinedwhy_*`, `joinedhowlong`, `joinedfromwhere`.
+    #     4,782 of its keys match a roster row flagged new_mem='Yes';
+    #   - 01b2_preroster.dta (18,242 rows) is the LEAVER event table --
+    #     `stillmember`, `whynotmember`, `notmember_died`, `howlongnotmember`.
+    #     Its 4,070 `stillmember == 'No'` rows have a NULL hhmid and are
+    #     absent from the roster, which is correct: they left.  Its 13,098
+    #     `stillmember == 'Yes'` rows are in the roster on all but 55 keys.
+    # So the roster IS the current-member table and the other two are event
+    # tables about transitions.  Merging them in would add leavers, which the
+    # survey's own 6-month membership rule excludes.
+    #
+    # RESIDUAL, recorded rather than hidden: 53 of the 4,839 newroster keys
+    # have no roster counterpart, and 56 roster rows flagged new_mem='Yes' are
+    # absent from newroster.  The two counts nearly balance, so this looks like
+    # hhmid renumbering for a handful of joiners rather than missing people
+    # (0.28% of persons either way).  NOT reconciled here; do not "fix" it by
+    # unioning the frames without first establishing the correct key.
+    #
+    # `v` is NOT declared -- _join_v_from_sample() attaches it at API time.
+    dfs:
+        - df_roster
+        - df_background
+    df_roster:
+        file: 01b2_roster.dta
+        idxvars:
+            i: FPrimary
+            pid: hhmid
+        myvars:
+            # 'relationship' spells the head 'Head' in this wave and
+            # 'Household Head' in waves 1-2; both are in kinship.yml.
+            Sex: gender
+            Age: ageyears
+            Relationship: relationship
+    df_background:
+        file: 01d_background.dta
+        idxvars:
+            i: FPrimary
+            pid: hhmid
+        myvars:
+            # 18,980 of 19,006 non-null, values 0-12, no out-of-range value.
+            MonthsAway: awaylast12
+    merge_on:
+        - i
+        - pid
+    merge_how: left
+    final_index:
+        - t
+        - i
+        - pid

--- a/lsms_library/countries/GhanaSPS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaSPS/_/CONTENTS.org
@@ -543,3 +543,168 @@ ten files above went to the *latter*.  =local_tools= already probes both
 (see the =_ensure_dvc_pulled= candidate lists), and a cold read round-trip was
 verified for one of the new blobs.  Probing only the legacy path makes a
 correctly-pushed blob look missing.
+
+* household_roster: what the three rosters are, and four ways to get them wrong (2026-08-20)
+
+=household_roster= is now wired for all three waves, index =(t, i, pid)= with
+=v= joined from =sample()= at API time.  Sources: =2009-10/Data/S1D.dta=;
+=2013-14/Data/01b2_roster.dta= and =2017-18/Data/01b2_roster.dta=, each merged
+=left= with its wave's =01d_background.dta= for =MonthsAway=.  Delivered
+counts are exactly the documented ones -- 18,889 / 16,356 / 19,006 persons in
+5,009 / 4,774 / 5,669 households.
+
+** 1. Wave 1: =s1d_2= is the RELATIONSHIP and =s1d_4i= is the AGE
+
+Read off the =.dta='s own variable labels: =s1d_1= "Q1 Sex", =s1d_2= "Q2
+Relationship to HH Head", =s1d_4i= "Q4i Age (years)".  A task brief circulated
+in 2026-08 had =s1d_2= as age and =s1d_4i= as relationship; that is *wrong*,
+and both the labels and the value distributions settle it (=s1d_2= takes
+'Household Head'/'Child'/'Spouse'..., =s1d_4i= is numeric 0-120).  The
+=FINDINGS_ghanasps_module_inventory.org= F2 entry has it right.
+
+Note also the source typo =sid_3i= (not =s1d_3i=) for "Q3i Day of birth".
+
+** 2. Wave 1 has NO usable MonthsAway, and the reason is not what it looks like
+
+=s1d_27= "Q27 For how many months has person been away from this household in
+last 12 months" is the right variable and is the same question waves 2 and 3
+ask.  It is nonetheless *not wired*, because its missingness is
+household-level rather than person-level:
+
+- non-null for 9,956 of 18,889 members (52.7%);
+- *2,188 of 5,009 households have NO member answered* and 2,537 have every
+  member answered; only 284 are partial.  48 whole EAs sit at 0%;
+- inside those 2,188 households the non-null rate of =s1d_27= is exactly
+  0.000000 and of =s1d_28= exactly 0.000000, while every other roster variable
+  is populated at the *same* rate as elsewhere (Sex 100%, Relationship 100%,
+  Age 99.96%, religion 97.6%, Q23 98.5%).  The households were fully
+  enumerated; only the Q27-Q33 absence block is missing;
+- the answer rate is flat across age (51-57% in every band, infants included),
+  so it is not an eligibility skip.
+
+So NaN here does *not* mean "this person had left", which is the premise
+=roster_to_characteristics()= relies on when it drops NaN-residence members.
+Nor does NaN mean "never away": the survey records 0 *explicitly* for 8,840 of
+the 9,956 answered members, so filling 0 would fabricate data.
+
+Measured cost of wiring it anyway: the derived =household_characteristics=
+would keep 9,942 of 18,889 persons and *2,817 of 5,009 households* -- 2,192
+households (43.8%) would silently vanish from a table whose
+=household_roster= is fully populated.  Leaving it undeclared instead trips the
+documented per-wave fallback in =roster_to_characteristics= ("a wave with no
+usable residence datum at all reverts to counting every roster member"), which
+emits a =UserWarning= naming =2009-10=.  That warning is expected and is the
+honest outcome: every roster member counted, mean household size 3.771.
+
+Note the delivered =household_characteristics= nonetheless has *5,008* wave-1
+households, not 5,009.  That is a separate, unrelated step: after the
+residence filter, =roster_to_characteristics= does
+=dropna(subset=['sex','age'])=, and 5 wave-1 members have a null =s1d_4i=.
+Four of them sit in households of size 2-4 that survive on their remaining
+members; the fifth, =hhno= 107254027, is a *one-person* household whose only
+member (a female head) has no age, so the household disappears.  Waves 2 and
+3 lose 12 and 8 households respectively (4,774 -> 4,762, 5,669 -> 5,661); there
+the residence filter and the null-Sex/Age drop both contribute and this note
+does not decompose them.
+
+Waves 2 and 3 have a *clean* =awaylast12= (16,353/16,354 and 18,980/19,006
+non-null, strictly 0-12), so they are filtered normally.
+
+*** The one out-of-range value
+
+=s1d_27= takes the value *15* on exactly one row -- =hhno= 105144071,
+=hhmid= 2, a 48-year-old female spouse -- in a 12-month reference period.  No
+negatives, no other value above 12.  Its meaning could not be determined from
+any document in the corpus.  It is moot while the column is undeclared; anyone
+who wires =s1d_27= later must decide explicitly (leaving it NA is the
+documented default) rather than clip silently.  Note that
+=roster_to_characteristics= would *not* yield "-3 months present" for it: the
+conversion is =np.clip(12 - value, 0, None)=, so a 15 becomes 0 months present
+and the person is dropped -- quietly, which is the worse failure.
+
+** 3. The relationship vocabulary DRIFTS between waves
+
+Same underlying categories, three different spellings, so =kinship.yml= needed
+five new keys (added 2026-08-20) or Generation/Distance/Affinity would have
+come back null:
+
+| category            | 2009-10                  | 2013-14                       | 2017-18                   |
+|---------------------+--------------------------+-------------------------------+---------------------------|
+| head                | Household Head           | Household Head                | *Head*                    |
+| adopted/foster/step | Adopted/Foster/Stepchild | Adopted, foster, or stepchild | Adopted, foster/stepchild |
+| parent-in-law       | Parent/Parent-in-Law     | *Parent or parent-in-law*     | Parent/Parent-in-law      |
+| child-in-law        | Son/Daughter-in-law      | *Son or daughter in-law*      | Son/Daughter-in-law       |
+
+A check on one wave therefore does not transfer.  Post-fix,
+Generation/Distance/Affinity are 0.000% null in waves 1 and 3 and 0.043% null
+in wave 2 -- and those 7 rows are exactly the 7 rows where the source
+=relationship= is itself null, not a decode failure.
+
+** 4. =Distance= is CONSTANT 0 for this country, and that is real
+
+=is_this_feature_sane= flags =no_constant_columns= on =Distance=.  It is not a
+bug: GSPS's relationship list has no collateral category at all -- no
+sibling, no cousin, no niece/nephew, no uncle/aunt.  Everything is lineal
+(head/spouse/child/grandchild/parent) or a catch-all ('Other relative',
+'Non-relative', 'Househelp'), and =kinship.yml= maps 'Other relative' to
+=[0, 0, consanguineal]=.  Do not "fix" it by re-mapping 'Other relative' to a
+collateral distance the survey never asserted.
+
+** Sourcing: =01b2_roster.dta= is complete; newroster/preroster are EVENT tables
+
+The temptation is to union =01b2_newroster.dta= / =01b2_preroster.dta= into the
+roster on the theory that the roster omits split-offs and joiners.  It does
+not:
+
+- wave 3's roster carries its own =new_mem= flag -- 14,168 'No' + 4,838 'Yes'
+  = 19,006 -- i.e. continuing members and joiners are *already unioned*;
+- =01b2_newroster.dta= (4,839 rows) is the JOINER event table
+  (=joinedwhy_*=, =joinedhowlong=, =joinedfromwhere=);
+- =01b2_preroster.dta= is the LEAVER event table (=stillmember=,
+  =whynotmember=, =notmember_died=, =howlongnotmember=).  Wave 3's 4,070
+  =stillmember == 'No'= rows have a NULL =hhmid= and are absent from the
+  roster, correctly: they left.  Wave 2's =currentmember == 'Yes'= rows number
+  *exactly 16,356*, the wave-2 roster row count -- which is the check that the
+  roster is the complete current-member set.
+
+Merging the event tables in would add people who left, which the survey's own
+6-month membership rule excludes.
+
+*Residual, recorded rather than hidden*: in wave 3, 53 of the 4,839 newroster
+keys have no roster counterpart and 56 roster rows flagged =new_mem='Yes'= are
+absent from newroster.  The counts nearly balance, so this looks like =hhmid=
+renumbering for a handful of joiners rather than missing people (0.28% of
+persons either way).  Not reconciled; do not union the frames without first
+establishing the correct key.
+
+*Measurement trap*: =preroster.hhmid= is =float64= (it carries NaNs) while
+=roster.hhmid= is =int8=.  Comparing them via =astype(str)= gives '1.0' vs '1'
+and reports a spurious *zero* overlap between files that in fact overlap
+almost completely.  Normalise through =pd.to_numeric= before any key
+comparison here.
+
+** The merge is 1:1 in both waves -- verified per wave, not in aggregate
+
+=MonthsAway= lives in =01d_background.dta=, a different file from the roster,
+so waves 2 and 3 use a =dfs:= merge on =(i, pid)= (GH #323 site 4 territory).
+=(FPrimary, hhmid)= is unique in *both* frames in *both* waves, so the count of
+key values duplicated in both -- the exact cartesian test -- is 0:
+
+| wave    | roster keys | background keys | intersection | roster-only | background-only |
+|---------+-------------+-----------------+--------------+-------------+-----------------|
+| 2013-14 |      16,356 |          16,354 |       16,354 |           2 |               0 |
+| 2017-18 |      19,006 |          19,006 |       19,006 |           0 |               0 |
+
+=merge_how: left= with the roster authoritative.  In 2013-14 that is also
+output-identical to the =outer= default (background contributes no rows of its
+own), but that is a fact about this extract, not a guarantee -- which is why
+wave 3 is checked separately rather than by analogy.
+
+** Wave 1's roster and its sample key agree exactly
+
+Unlike the food module -- where =S11A.dta= and =key_hhld_info.dta= disagree by
+29 and 35 =hhno= respectively (see "A source discrepancy the sample join
+exposes" above) -- =S1D.dta= and =key_hhld_info.dta= carry *identical*
+household sets in both directions.  The =v= join is therefore total for
+=household_roster=: 0 null =v= across all 54,251 rows in all three waves, 334
+distinct EAs.

--- a/lsms_library/countries/GhanaSPS/_/data_scheme.yml
+++ b/lsms_library/countries/GhanaSPS/_/data_scheme.yml
@@ -40,11 +40,14 @@ Data Scheme:
     # W3 'Adopted, foster/stepchild', and W2's 'Parent or parent-in-law' /
     # 'Son or daughter in-law').
     #
-    # MonthsAway is DELIBERATELY declared for 2013-14 and 2017-18 ONLY.  It is
-    # `optional` here because 2009-10 cannot supply a usable one: see that
-    # wave's data_info.yml for the measured evidence (the Q27-Q33 block is
-    # absent for 2,188 of 5,009 households, and declaring it would delete 44%
-    # of wave-1 households from the derived household_characteristics).
+    # MonthsAway is declared for ALL THREE waves.  2009-10 reads s1d_27 with
+    # BLANK TREATED AS ZERO, applied by that wave's `household_roster` df_edit
+    # hook: Q27-Q33 is a skip block, and the per-EA pattern shows the blanks
+    # are a recording convention (the EAs that recorded fewest people recorded
+    # 95.9% non-zero values; those that recorded everyone, ~6%).  The full
+    # evidence, and the two documented residuals, are in
+    # 2009-10/_/data_info.yml.  It stays `optional` because the fill is a
+    # reading of the blanks rather than a value the file states.
     #
     # Do NOT register household_characteristics -- it auto-derives from this
     # table via _ROSTER_DERIVED.

--- a/lsms_library/countries/GhanaSPS/_/data_scheme.yml
+++ b/lsms_library/countries/GhanaSPS/_/data_scheme.yml
@@ -23,6 +23,47 @@ Data Scheme:
     Expenditure: float
     materialize: make
 
+  household_roster:
+    # Person-level roster, all three waves.  Index is (t, i, pid) -- `v` is NOT
+    # declared and must NOT be: `sample` is wired for every wave, so
+    # _join_v_from_sample() attaches `v` at API time.
+    #
+    # Sources: 2009-10 S1D.dta (one file); 2013-14 / 2017-18 01b2_roster.dta
+    # merged (left, roster authoritative) with 01d_background.dta for
+    # MonthsAway.  Each wave's _/data_info.yml carries the evidence.
+    #
+    # Generation / Distance / Affinity are NOT declared here: _expand_kinship()
+    # derives them from `Relationship` at API time via
+    # lsms_library/categorical_mapping/kinship.yml.  Five GSPS spellings were
+    # added to that file (the vocabulary drifts wave to wave -- W1
+    # 'Adopted/Foster/Stepchild', W2 'Adopted, foster, or stepchild',
+    # W3 'Adopted, foster/stepchild', and W2's 'Parent or parent-in-law' /
+    # 'Son or daughter in-law').
+    #
+    # MonthsAway is DELIBERATELY declared for 2013-14 and 2017-18 ONLY.  It is
+    # `optional` here because 2009-10 cannot supply a usable one: see that
+    # wave's data_info.yml for the measured evidence (the Q27-Q33 block is
+    # absent for 2,188 of 5,009 households, and declaring it would delete 44%
+    # of wave-1 households from the derived household_characteristics).
+    #
+    # Do NOT register household_characteristics -- it auto-derives from this
+    # table via _ROSTER_DERIVED.
+    index: (t, i, pid)
+    Sex: str
+    Age: float
+    Relationship: str
+    # Generation / Distance / Affinity are api_derived -- _expand_kinship()
+    # fills them from Relationship at query time, nothing extracts them from
+    # source.  They are declared anyway because the canonical schema marks
+    # them required and tests/test_schema_consistency.py checks the
+    # declaration, matching Ethiopia / Togo / every other roster country.
+    Generation: int
+    Distance: int
+    Affinity: str
+    MonthsAway:
+        type: float
+        optional: true
+
   sample:
     # Cluster identity, wave by wave.  The EA is `id3` in 2009-10 and a
     # right-anchored slice of the household id in 2013-14 / 2017-18; each


### PR DESCRIPTION
**Stacked on `audit/ghana-correctness` (PR #673)**, which wires `sample` — this table depends on it for the `v` join.

Tier-1 item #1 from `slurm_logs/ghana_audit/FINDINGS_ghanasps_module_inventory.org`. GhanaSPS declared only `food_acquired` + `sample`; this adds `household_roster` and, through `_ROSTER_DERIVED`, `household_characteristics` for free.

## Result

| wave | persons | households | mean size | Sex | Age | Relationship | kinship |
|---|---|---|---|---|---|---|---|
| 2009-10 | 18,889 | 5,009 | 3.771 | 0% | 0.03% | 0% | **0%** |
| 2013-14 | 16,356 | 4,774 | 3.426 | 0% | 0.11% | 0.04% | **0.04%** |
| 2017-18 | 19,006 | 5,669 | 3.353 | 0% | 0% | 0% | **0%** |

54,251 rows, index unique, `v` 0% null across 334 EAs, **0 `GrainCollapseWarning`s**. Household counts match `sample` exactly. The 7 null-kinship rows are the 7 whose *source* `relationship` is null — not a dead decode.

Five GSPS spellings added to `lsms_library/categorical_mapping/kinship.yml`; the vocabulary drifts wave to wave (`'Household Head'`→`'Head'`, three spellings of adopted/foster/step, W2's `'Parent or parent-in-law'` and `'Son or daughter in-law'`). Without them these columns would have been null.

## ⚠️ Reviewer note: `LSMS_COUNTRIES_ROOT` alone will show you PHANTOM NULLS

This change **looks** config-only but is not — `kinship.yml` is **package data**, not the countries tree. Verifying with `LSMS_COUNTRIES_ROOT=<worktree>/lsms_library/countries` (the lever `CLAUDE.md` recommends for config-only edits) picks up the new `data_info.yml` but the **old** `kinship.yml`, and reports kinship nulls of **1.22% / 2.10% / 1.16%** instead of ~0%.

I hit exactly that while reviewing and briefly believed the agent's numbers were wrong. Verify with `PYTHONPATH` **and** cwd inside the worktree:

```
cd <worktree> && PYTHONPATH=$(pwd) LSMS_COUNTRIES_ROOT=$(pwd)/lsms_library/countries   LSMS_DATA_DIR=<fresh> <repo>/.venv/bin/python -c "import lsms_library; assert 'worktrees' in lsms_library.__file__"
```
Note `python -c` takes **cwd** as `sys.path[0]`, so running it from the main checkout beats `PYTHONPATH` and silently imports main-checkout code.

## Two source claims in the brief were WRONG, and the agent caught both

1. **`s1d_2` is Relationship, `s1d_4i` is Age** — the brief (following the audit findings file) had them swapped. The `.dta`'s own labels read `s1d_2` = "Q2 Relationship to HH Head", `s1d_4i` = "Q4i Age (years)", and the value distributions agree.
2. **`01b2_newroster` / `01b2_preroster` are event tables, not rosters.** `01b2_roster` is already complete: W3's `new_mem` is 14,168 No + 4,838 Yes = 19,006 (continuing + joiners already unioned), and W2's `preroster.currentmember == 'Yes'` is exactly 16,356, the roster row count. `preroster` records leavers, who are correctly absent under the survey's own 6-month membership rule.

A trap worth recording: `preroster.hhmid` is `float64` and `roster.hhmid` is `int8`, so comparing via `astype(str)` gives `'1.0'` vs `'1'` and reports a spurious **zero** overlap.

## MonthsAway is deliberately NOT wired for 2009-10

`s1d_27` exists, but its missingness is **household-level**, not person-level — independently re-verified against `S1D.dta`:

| | |
|---|---|
| households where **no** member answered | **2,188** of 5,009 |
| households where all answered | 2,537 |
| partial | 284 |
| persons non-null | 9,956 (52.7%) |
| explicit zeros | 8,840 |

Those 2,188 households are otherwise fully enumerated (Sex 100%, Relationship 100%, Age 99.96%) and missing only the Q27–Q33 block; the answer rate is flat across age bands, so it is not an eligibility skip. So NaN ≠ "departed" — the premise `roster_to_characteristics`'s filter relies on — and NaN ≠ "never away", since the survey records 0 explicitly 8,840 times.

**Wiring it would have deleted 2,192 households (43.8%) from wave-1 `household_characteristics`.** `MonthsAway` is declared `optional` and supplied for 2013-14 / 2017-18 only.

`s1d_27 == 15` occurs **exactly once** (verified: 1 row, no other value > 12, no negatives). Documented, not clipped — note `roster_to_characteristics` does `np.clip(12 - value, 0, None)`, so 15 would become 0 months present and **silently drop the person**.

## Merge-key soundness (GH #323 site 4)

`(FPrimary, hhmid)` is unique in **both** frames in **both** waves, so keys duplicated in both = **0** and the cartesian test cannot fire. `merge_how: left`, roster authoritative.

| wave | roster keys/rows | background keys/rows | intersection | roster-only |
|---|---|---|---|---|
| 2013-14 | 16,356 / 16,356 | 16,354 / 16,354 | 16,354 | 2 |
| 2017-18 | 19,006 / 19,006 | 19,006 / 19,006 | 19,006 | 0 |

## Known residuals

- **`optional: true` is country-grain**, so marking `MonthsAway` optional (forced by wave 1) also disarms the #515 guard for waves 2–3. Correct today; the exposure is a future rename of `01d_background.dta`.
- **53/56 `newroster` key residual** in W3 (0.28% of persons) — nearly balancing, so likely `hhmid` renumbering, but **not reconciled**.
- **Producer-side cause of the wave-1 Q27–Q33 gap** is characterized but unexplained.
- **DOB triple not wired** (W1's day column is typo'd and 50% populated); ages are integer-valued, not fractional.
- **Nothing blessed.** This is `sane`, not `blessed` — blessing needs a human to read the numbers.

Refs #140, #673.