### PR TITLE
fix(#681): GLSS1/GLSS2 cluster Region is now MEASURED, from BID Appendix I

### DIFF
--- a/lsms_library/countries/GhanaLSS/1987-88/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1987-88/_/data_info.yml
@@ -2,12 +2,25 @@ Country: GhanaLSS
 Wave: 1987-88
 
 cluster_features:
+    # Region and Ecological_zone come from BID Appendix I, NOT from this file.
+    # GLSS1/GLSS2 ship no cluster-location variable at all, so `Region` used to
+    # be INFERRED from Y01A.DAT:REGION -- the person's region of BIRTH -- as the
+    # modal value among a cluster's under-12s.  That was ~98% right and wrong
+    # for five clusters.  The Appendix is the survey's own cluster list and is
+    # authoritative (decision 2026-08-21); see `_/appendix_i_clusters.org`.
+    #
+    # `myvars` is intentionally EMPTY: this extraction exists only to enumerate
+    # the wave's cluster universe (176 clusters) from the microdata.  The
+    # attributes are attached by mapping.py::cluster_features.  Taking the
+    # universe from the data rather than the Appendix matters -- the Appendix
+    # lists 178 SAMPLING AREAS for 1987-88, which is not the same unit as a
+    # cluster.
+    #
+    # `Age: AGEY` was removed with the hook it fed (an `Age<12` filter).
     file: Y01A.DAT
     idxvars:
         v: CLUST
-    myvars:
-        Region: REGION
-        Age: AGEY
+    myvars: {}
 
 sample:
     file: Y00A.DAT

--- a/lsms_library/countries/GhanaLSS/1987-88/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1987-88/_/mapping.py
@@ -69,22 +69,39 @@ def Region(value):
 
 
 def cluster_features(df):
+    """Attach Appendix I's cluster attributes to this wave's cluster universe.
 
-    '''
-    Formatting dataframe for cluster features
-    
-    infers the region for each cluster via where most young kids have their birthplace as (less likely to move?)
-    '''
+    GLSS1/GLSS2 have NO cluster-location variable in the microdata.  This used
+    to infer the cluster's region as the modal birth region of its members
+    under 12 -- a documented approximation that agreed with the Appendix on
+    172/176 clusters and was wrong on the rest, always naming an
+    ADJACENT region (the border-migration failure the under-12 filter cannot
+    dodge).  Appendix I is authoritative; the inference is retired.
 
-    youngsters = df.query("Age<12")
-    foo = youngsters.reset_index().groupby(['t', 'v','Region']).count()
+    The cluster universe comes from the DATA (176 clusters), not from the
+    Appendix, which lists sampling areas.  A cluster absent from the Appendix
+    keeps `Region` NA rather than being dropped or guessed.
 
-    foo = foo.sort_values(by = "Age", ascending=False).reset_index().drop_duplicates(subset=['t', 'v'], keep='first', inplace = False)
-    foo = foo.sort_values(by = 'v')
-    foo = foo.set_index(['t', 'v'])
-    foo['Rural'] = pd.NA
+    `Rural` stays NA here: the Appendix is three-way (U/R/SU) against a
+    canonical vocabulary of {Urban, Rural} -- see GH #685.
+    """
+    # Load the country module BY PATH: `countries/GhanaLSS/_/` is not an
+    # importable package, and a path built from countries_root() honours
+    # LSMS_COUNTRIES_ROOT.
+    import importlib.util as _ilu
+    from lsms_library.paths import countries_root
+    _p = countries_root()/'GhanaLSS'/'_'/'ghanalss.py'
+    _spec = _ilu.spec_from_file_location('_ghanalss_country', _p)
+    _c = _ilu.module_from_spec(_spec); _spec.loader.exec_module(_c)
+    attrs = _c.appendix_i_cluster_attributes('yr1', 1000)
 
-    return foo[['Region', 'Rural']]
+    out = df.reset_index()[['t', 'v']].drop_duplicates()
+    out['v'] = out['v'].astype(str)
+    out = out.set_index(['t', 'v'])
+
+    joined = out.join(attrs, how='left')
+    joined['Rural'] = pd.NA
+    return joined[['Region', 'Rural', 'Ecological_zone']]
 
 def Int_t(value):
     '''

--- a/lsms_library/countries/GhanaLSS/1988-89/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1988-89/_/data_info.yml
@@ -2,15 +2,25 @@ Country: GhanaLSS
 Wave: 1988-89
 
 cluster_features:
+    # Region and Ecological_zone come from BID Appendix I, NOT from this file.
+    # GLSS1/GLSS2 ship no cluster-location variable at all, so `Region` used to
+    # be INFERRED from Y01A.DAT:REGION -- the person's region of BIRTH -- as the
+    # modal value among a cluster's under-12s.  That was ~98% right and wrong
+    # for five clusters.  The Appendix is the survey's own cluster list and is
+    # authoritative (decision 2026-08-21); see `_/appendix_i_clusters.org`.
+    #
+    # `myvars` is intentionally EMPTY: this extraction exists only to enumerate
+    # the wave's cluster universe (170 clusters) from the microdata.  The
+    # attributes are attached by mapping.py::cluster_features.  Taking the
+    # universe from the data rather than the Appendix matters -- the Appendix
+    # lists 178 SAMPLING AREAS for 1987-88, which is not the same unit as a
+    # cluster.
+    #
+    # `Age: AGEY` was removed with the hook it fed (an `Age<12` filter).
     file: Y01A.DAT
     idxvars:
         v: CLUST
-    myvars:
-        Region: REGION
-        # Age is pulled ONLY so mapping.py::cluster_features can restrict the
-        # modal-birth-region heuristic to members under 12; it is dropped
-        # before the frame is returned.  Mirrors 1987-88.
-        Age: AGEY
+    myvars: {}
 
 sample:
     file: Y00A.DAT

--- a/lsms_library/countries/GhanaLSS/1988-89/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1988-89/_/mapping.py
@@ -76,32 +76,39 @@ def Region(value):
     return region_dict.get(value_key, pd.NA)
 
 def cluster_features(df):
-    '''Collapse the person-grain roster frame to (t, v) cluster grain.
+    """Attach Appendix I's cluster attributes to this wave's cluster universe.
 
-    Mirrors 1987-88/_/mapping.py::cluster_features -- GLSS1 and GLSS2 have NO
-    cluster-location variable.  Both waves read `Region` for cluster_features
-    and `Birthplace` for household_roster from the SAME source column,
-    Y01A.DAT:REGION, which is the *person's region of birth*, not where the
-    cluster is.  So the cluster's region is INFERRED as the modal birth region
-    among household members under 12 (young children are least likely to have
-    migrated).  This is a documented approximation, not a measured value.
+    GLSS1/GLSS2 have NO cluster-location variable in the microdata.  This used
+    to infer the cluster's region as the modal birth region of its members
+    under 12 -- a documented approximation that agreed with the Appendix on
+    169/170 clusters and was wrong on the rest, always naming an
+    ADJACENT region (the border-migration failure the under-12 filter cannot
+    dodge).  Appendix I is authoritative; the inference is retired.
 
-    Without this, the framework collapses the person-grain frame with
-    groupby().first(), which takes an ARBITRARY person's birth region as the
-    whole cluster's region.  Measured on this wave that destroyed 14,559 of
-    14,924 rows across 167 conflicting clusters (GrainCollapseWarning), i.e.
-    the majority of clusters held members born in more than one region.
-    '''
+    The cluster universe comes from the DATA (170 clusters), not from the
+    Appendix, which lists sampling areas.  A cluster absent from the Appendix
+    keeps `Region` NA rather than being dropped or guessed.
 
-    youngsters = df.query("Age<12")
-    foo = youngsters.reset_index().groupby(['t', 'v', 'Region']).count()
+    `Rural` stays NA here: the Appendix is three-way (U/R/SU) against a
+    canonical vocabulary of {Urban, Rural} -- see GH #685.
+    """
+    # Load the country module BY PATH: `countries/GhanaLSS/_/` is not an
+    # importable package, and a path built from countries_root() honours
+    # LSMS_COUNTRIES_ROOT.
+    import importlib.util as _ilu
+    from lsms_library.paths import countries_root
+    _p = countries_root()/'GhanaLSS'/'_'/'ghanalss.py'
+    _spec = _ilu.spec_from_file_location('_ghanalss_country', _p)
+    _c = _ilu.module_from_spec(_spec); _spec.loader.exec_module(_c)
+    attrs = _c.appendix_i_cluster_attributes('yr2', 2000)
 
-    foo = foo.sort_values(by="Age", ascending=False).reset_index().drop_duplicates(subset=['t', 'v'], keep='first', inplace=False)
-    foo = foo.sort_values(by='v')
-    foo = foo.set_index(['t', 'v'])
-    foo['Rural'] = pd.NA
+    out = df.reset_index()[['t', 'v']].drop_duplicates()
+    out['v'] = out['v'].astype(str)
+    out = out.set_index(['t', 'v'])
 
-    return foo[['Region', 'Rural']]
+    joined = out.join(attrs, how='left')
+    joined['Rural'] = pd.NA
+    return joined[['Region', 'Rural', 'Ecological_zone']]
 
 def Int_t(value):
     '''

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -1002,30 +1002,67 @@ cannot fall through to the GLSS1 table.  (The same wave-first discipline is why
 1991-92 keeps its own =region= table: GLSS3 orders the two northern regions
 9=Upper West, 10=Upper East, the reverse of the country-level table.)
 
-** Trap 3: GLSS1/GLSS2 "cluster region" is INFERRED, not measured
+** Trap 3 (RESOLVED 2026-08-21): GLSS1/GLSS2 cluster region is now MEASURED
 
-GLSS1 and GLSS2 have *no cluster-location variable at all*.  Both waves read
-=cluster_features.Region= and =household_roster.Birthplace= from the *same*
-source column, =Y01A.DAT:REGION= -- which is the *person's region of birth*,
-not where the cluster is.
+*Kept as history.*  For the record of what the inference was and what it cost,
+because the shape of the mistake recurs.
 
-=mapping.py::cluster_features= in both waves therefore *infers* the cluster's
-region as the modal birth region among household members under 12 (young
-children being least likely to have migrated).  =Age= is pulled into
-=cluster_features= =myvars= purely so that filter can run; it is dropped before
-the frame is returned.
+*** What it was
 
-*This is an approximation, and any analysis keyed on GLSS1/GLSS2 cluster region
-inherits it.*  It loses no clusters (checked: 176 of 176 clusters in 1987-88
-have at least one under-12 with a valid birth region), but it is a guess about
-geography derived from a migration-sensitive question.
+GLSS1 and GLSS2 have *no cluster-location variable in the microdata* -- a sweep
+of all 170 dictionaries finds none; the only near-hit, =Y00A::LOC=, is 99.8%
+constant at 1 and is a fieldwork flag.
 
-1988-89 had no such function until 2026-08-19.  Once its decode was revived,
-the framework collapsed the person-grain frame with =groupby().first()=,
-taking an *arbitrary* person's birth region for the whole cluster --
-=GrainCollapseWarning= reported 14,559 of 14,924 rows destroyed across 167
-conflicting clusters, i.e. 167 of 170 clusters held members born in more than
-one region.
+So both waves read =cluster_features.Region= and =household_roster.Birthplace=
+from the *same* column, =Y01A.DAT:REGION= -- the person's *region of birth*.
+=mapping.py::cluster_features= then *inferred* the cluster's region as the modal
+birth region among members under 12 (young children being least likely to have
+migrated), with =Age: AGEY= pulled into =myvars= purely to feed that filter.
+
+The inference was strong on its own terms: 0 ties, the mode an outright
+majority in all 346 clusters, median modal share 91.5%, minimum 55%, off a
+median of 31 children per cluster.  It was *not* a coin flip.
+
+It was still a guess about geography derived from a migration-sensitive
+question, and it was *wrong for five clusters* -- every one naming an
+*adjacent* region, which is exactly the border-migration failure an under-12
+filter cannot dodge:
+
+| wave    |    v | name                | correct     | inferred |
+|---------+------+---------------------+-------------+----------|
+| 1987-88 | 1080 | Adwamasek/Wiwasi    | Ashanti     | Central  |
+| 1987-88 | 1107 | Ahantamwa(Tipokrom) | Brong Ahafo | Ashanti  |
+| 1987-88 | 1168 | Tato Bator          | Brong Ahafo | Volta    |
+| 1987-88 | 1188 | Damanko             | Volta       | Northern |
+| 1988-89 | 2334 | Huni Ofori          | Central     | Eastern  |
+
+*** What replaced it
+
+*Appendix I of =GHA_1988_GLSS_Basicinfo_EN.pdf=* -- "Complete List of GLSS
+Clusters" -- is the survey's own cluster list, and the BID carries a real text
+layer (no OCR).  It is *authoritative* for GLSS1/GLSS2 cluster attributes
+(decision, 2026-08-21).  Transcribed to =_/appendix_i_clusters.org=; the ten
+clusters the document itself marks "should be excluded" are in
+=_/appendix_i_extra_workloads.org= (none of which appear in the shipped data --
+checked).
+
+It matches *176 of 176* and *170 of 170* shipped clusters on
+=CLUST = 1000 + yr1= / =2000 + yr2=, and additionally supplies
+=Ecological_zone=, which these waves previously lacked.
+
+*** The lesson worth keeping
+
+The inference was reasonable, well-documented, measured, and *nobody looked for
+a better source for a year*.  The better source was a text-layer PDF sitting in
+=Documentation/= the whole time.  Before building an approximation, read the
+documentation the survey shipped with itself.
+
+Note also what the fix does NOT do: =Rural= stays =NA=.  The Appendix
+classifies clusters *three* ways -- =U= / =R= / =SU= (semi-urban, 52 clusters,
+20%) -- against a canonical vocabulary of ={Urban, Rural}=.  Folding =SU= would
+destroy a distinction the survey drew, so it waits on GH #685/#682 rather than
+being guessed away.  After this change =Y01A.DAT:REGION= feeds
+=household_roster.Birthplace= *only*, which is what it actually is.
 
 ** Trap 4: GLSS1 had no =region= table of its own, and the fallback is REVERSED
 

--- a/lsms_library/countries/GhanaLSS/_/appendix_i_clusters.org
+++ b/lsms_library/countries/GhanaLSS/_/appendix_i_clusters.org
@@ -1,0 +1,354 @@
+#+TITLE: GLSS1/GLSS2 cluster attributes, from BID Appendix I
+#+AUTHOR: Sue the Coder
+
+* Provenance
+
+Transcribed from *Appendix I, "Complete List of GLSS Clusters"* of
+=1988-89/Documentation/technical document/GHA_1988_GLSS_Basicinfo_EN.pdf=
+(the joint GLSS1/GLSS2 Basic Information Document, 56pp, which carries a real
+text layer -- no OCR involved).
+
+This is the survey's own cluster list.  It is *authoritative* for GLSS1/GLSS2
+cluster attributes: where it disagrees with the shipped microdata or with a
+value derived from it, the Appendix wins (decision, 2026-08-21).
+
+GLSS1 and GLSS2 ship *no cluster-location variable at all* -- a sweep of all
+170 dictionaries finds none; the only near-hit, =Y00A::LOC=, is 99.8% constant
+at 1 and is a fieldwork flag.  Before this table, =cluster_features.Region= was
+*inferred* as the modal birth region of a cluster's under-12s, and =Rural= was
+=NA= outright.
+
+** Join key
+
+The Appendix numbers clusters within each year; the microdata offsets them:
+
+: 1987-88 (GLSS1):  CLUST = 1000 + yr1
+: 1988-89 (GLSS2):  CLUST = 2000 + yr2
+
+Verified: *176 of 176* and *170 of 170* shipped clusters match.  The same
+=+2000= offset was independently derived from =HEALTH.DAT= value ranges during
+the GH #323 review, before this table was found.
+
+** Checks that this transcription is faithful
+
+- 273 data rows parsed from the PDF, *zero dropped* (every unmatched line is a
+  title, column header, page number, or the "Extra Workloads" marker).
+- The 85 rows carrying *both* year numbers match =1988-89/Data/CLYR1YR2.DAT='s
+  85 linked pairs exactly.
+- Dropping the 10 clusters the document itself lists under "Extra Workloads:
+  (should be excluded)" reproduces its urban/rural counts exactly:
+  95 =U= / 116 =R= / 52 =SU=.
+- 8 rows spot-checked character-by-character against the raw PDF text.
+
+** Counts
+
+- yr1: *178* rows.  The DDI's realised figure is 178 *sampling areas*; the
+  microdata has *176 clusters*.  A sampling area may hold more than one
+  cluster, so these are not the same unit -- do not "reconcile" them.
+- yr2: *170* rows, matching the microdata exactly.
+
+** Caveats
+
+- =Reg= and =EcoZone= are the Appendix's own abbreviations, kept *raw* so this
+  table can be audited against the PDF.  =region_abbrev= below decodes them.
+- =UrbRur= has *three* values -- =U=, =R= and =SU= (semi-urban).  It is NOT
+  wired yet: canonical =Rural= is ={Urban, Rural}= and folding =SU= would
+  destroy a distinction the survey drew (52 clusters, 20%).  See GH #685.
+- =EcoZone= is 3-way (C/F/S).  GLSS6 (2012-13) additionally uses =GAMA= for
+  Greater Accra; the Appendix has no such category, so Accra clusters here are
+  =C= (coastal).  That is a difference between the *sources*, not an error.
+- The 10 "Extra Workloads" clusters are in =appendix_i_extra_workloads.org=,
+  NOT here.
+
+* Cluster table
+
+#+name: appendix_i_clusters
+| yr1 | yr2 | Name | UrbRur | Reg | EcoZone |
+|-----+-----+------+--------+-----+---------|
+| 1 | 1 | Jewi Wharf | R | West | C |
+| 2 | . | Eikwe | R | West | C |
+| . | 6 | Nyamebekyere | R | West | C |
+| 3 | 9 | Bonzokrom | R | West | C |
+| 4 | . | Adiembra | R | West | C |
+| 5 | 5 | Mpehin | R | Cent | C |
+| . | 14 | New Kedadwin | R | West | C |
+| . | 22 | Etwia | R | Cent | C |
+| 6 | . | Ndansimon | R | Cent | C |
+| 7 | 25 | Oboom | R | Cent | C |
+| 8 | . | Nyamedome | R | Cent | C |
+| 9 | 33 | Nyakawadzi | R | Cent | C |
+| 10 | . | Nantsifa | R | Cent | C |
+| . | 38 | Kwanyaku/Obusamasi | R | Cent | C |
+| . | 46 | Lakpesedom | R | Gr.A | C |
+| 12 | . | Nkuntunse | R | Gr.A | C |
+| 13 | 49 | Bonikope | R | Gr.A | C |
+| 14 | . | Kortey/Queitsewe | R | East | C |
+| 15 | 57 | Tokpo (Dzokpo) | R | Gr.A | C |
+| 16 | . | Verkope | R | Volt | C |
+| . | 62 | Adusakope | R | Volt | C |
+| 17 | 65 | Sokpekope | R | Volt | C |
+| 19 | 73 | Ohawu | R | Volt | C |
+| . | 78 | Live Ga | R | Volt | C |
+| 20 | . | Tordzinu | R | Volt | C |
+| 21 | 81 | Elubo | SU | West | C |
+| 22 | . | Agona:BP Filling Station | SU | West | C |
+| . | 86 | Takoradi:Tanokrom | SU | West | C |
+| 23 | 89 | Inchaban | SU | West | C |
+| . | 94 | Cape Coast: Ahm Sch | U | Cent | C |
+| 25 | 97 | Narkwa | SU | Cent | C |
+| 26 | . | Sunkwaa | SU | Cent | C |
+| . | 102 | Owumaso | SU | Cent | C |
+| . | 110 | Bontrase | SU | Cent | C |
+| 28 | 113 | Agomeda | SU | Gr.A | C |
+| 29 | . | Mamfe | SU | East | C |
+| . | 118 | Adukrom | U | East | C |
+| 30 | 121 | Adidome | SU | Volt | C |
+| . | 126 | Tadzewu | SU | Volt | C |
+| 31 | 70 | Agbosome/Adina Mornu | SU | Volt | C |
+| 32 | 129 | Kwesimintsim | U | West | C |
+| 33 | . | Takoradi:Columbia Hot | U | West | C |
+| . | 134 | Takoradi:Windy Ridge | U | West | C |
+| 34 | 137 | Sekondi:Effiakuma | U | West | C |
+| 35 | . | Shama | U | West | C |
+| . | 142 | Elmina | U | Cent | C |
+| 36 | 145 | Cape Coast:Soc Welfare | U | Cent | C |
+| 37 | . | Moree | U | Cent | C |
+| 38 | . | Odoben | U | Cent | C |
+| 39 | 105 | Apam | U | Cent | C |
+| 40 | . | Senya Beraku | U | Cent | C |
+| . | 150 | Anomabo | U | Cent | C |
+| . | 158 | Bawjiase | U | Cent | C |
+| 41 | 161 | Agona Swedru | U | Cent | C |
+| 42 | 166 | Medina: Soc Welfare | U | Gr.A | C |
+| 43 | . | Accra: Chorkor Tea Garden | U | Gr.A | C |
+| 44 | . | Accra:Mamprobi | U | Gr.A | C |
+| . | 169 | Accra:Dansoman Est | U | Gr.A | C |
+| 45 | . | Accra:TownCouncil | U | Gr.A | C |
+| 46 | . | Accra:Abossey | U | Gr.A | C |
+| 48 | . | Accra:Darkuman | U | Gr.A | C |
+| 49 | 193 | Acc:No Kan Yoga Res | U | Gr.A | C |
+| 50 | . | Accra:Nii Boi Town | U | Gr.A | C |
+| 51 | 201 | Accra:Jamestown Police | U | Gr.A | C |
+| . | 206 | Acc:MAAB MedCenter | U | Gr.A | C |
+| 53 | . | Accra:GoBliss | U | Gr.A | C |
+| 54 | . | Accra:Osu Busi | U | Gr.A | C |
+| 55 | . | Acc:TeshieChrApoChurch | U | Gr.A | C |
+| 56 | . | Acc:Teshie Continen | U | Gr.A | C |
+| . | 214 | Labadi:SBC | U | Gr.A | C |
+| . | 217 | Accra: Teshie CAC | U | Gr.A | C |
+| . | 222 | Acc:Teshie Faith Cl | U | Gr.A | C |
+| 57 | 225 | Labadi: Lakpa House | U | Gr.A | C |
+| 58 | . | Acc:East Cantonments | U | Gr.A | C |
+| . | 230 | Burma Camp | U | Gr.A | C |
+| 59 | . | Accra:Nima market | U | Gr.A | C |
+| 60 | . | Accra:Nima Makolanta | U | Gr.A | C |
+| 62 | . | Accra:Alajo | U | Gr.A | C |
+| 63 | 249 | Tema:Comm2 trotro | U | Gr.A | C |
+| 64 | . | Tema:Comm4 market | U | Gr.A | C |
+| . | 254 | Tema:Gen Hosp | U | Gr.A | C |
+| 65 | 257 | Tema:New Town | U | Gr.A | C |
+| 66 | . | Tema:Ashiman | U | Gr.A | C |
+| . | 262 | Ashaiman | U | Gr.A | C |
+| 67 | 265 | Aburi | U | East | C |
+| 68 | . | Koforidua:Old Cemetery | U | East | C |
+| 69 | 273 | Koforidua:Zion | U | East | C |
+| 70 | . | Afiadenyigba | U | Volt | C |
+| . | 278 | Keta | U | Volt | C |
+| 71 | 281 | Dzodze | U | Volt | C |
+| . | 286 | Daaman | R | West | C |
+| 73 | 289 | Tarkwa-Aboso:Mantriam | R | West | F |
+| 74 | . | Moseaso | R | West | F |
+| . | 294 | Wassa Dunkwa | SU | West | F |
+| 75 | 297 | Techimantia | R | West | F |
+| 76 | . | Ahibenso | R | West | F |
+| . | 302 | Danielkrom | R | West | F |
+| 77 | 305 | Apronsie | R | West | F |
+| 78 | . | Fuakyekron | R | West | F |
+| . | 310 | Punikrom | R | West | F |
+| 79 | 313 | Dametsikrom | R | Cent | F |
+| 80 | 406 | Adwamasek/Wiwasi | R | Asha | F |
+| . | 318 | Odumase | R | Cent | C |
+| 81 | 321 | Agona Jema | R | Cent | F |
+| 82 | . | Praho | R | East | F |
+| . | 326 | Tabita | R | East | F |
+| 83 | 329 | Asuboa | R | East | F |
+| . | 334 | Huni Ofori | R | Cent | F |
+| 85 | 337 | Susumawu | R | East | F |
+| 86 | . | Shai Mameng | R | East | F |
+| . | 342 | Aponapon II | R | East | F |
+| 87 | 345 | Sageyimase | R | East | F |
+| . | 350 | Abepawtia | R | East | F |
+| 89 | 353 | Oframase | R | East | F |
+| 90 | . | Gbledi | R | Volt | F |
+| . | 358 | Alavanyo Deme | R | Volt | F |
+| 91 | 361 | Dzoko | R | Volt | F |
+| . | 366 | Botirampa | R | Asha | F |
+| 92 | . | Sereso | SU | Asha | F |
+| 93 | 369 | Konkromase | R | Asha | F |
+| . | 374 | Boankra | R | Asha | F |
+| 94 | . | Ofuase | R | Asha | F |
+| 95 | 377 | Kumasi:Oduom | U | Asha | F |
+| . | 382 | Nketia | R | Asha | F |
+| 96 | . | Kontomire | R | Asha | F |
+| 97 | 385 | Kyenkyenase | R | Asha | F |
+| . | 390 | Morontua | R | Asha | F |
+| 98 | . | Nsuaem | R | Asha | F |
+| 99 | 393 | Sefwi | R | Asha | F |
+| 100 | . | Nkoranza | R | Asha | F |
+| . | 398 | Akrofuom | R | Asha | F |
+| 101 | 401 | Old Ayasi/Omena | R | Asha | F |
+| 102 | . | Brahabebome | R | Asha | F |
+| 103 | 409 | Wioso | R | Asha | F |
+| 104 | . | Agyei Baah | R | Asha | F |
+| 105 | 417 | Kwakuben | R | Asha | F |
+| . | 422 | Ntabana | R | Asha | F |
+| 107 | 430 | Ahantamwa(Tipokrom) | R | Bron | F |
+| 108 | 429 | Yankye/Kukuom | R | Bron | F |
+| 109 | . | Bechem/New Bansakrom | R | Bron | F |
+| 111 | . | Asunsu No.1 | R | Bron | F |
+| . | 438 | Brofoyedru | R | Bron | F |
+| 112 | 445 | Heman | SU | West | F |
+| . | 446 | Abosso | U | West | F |
+| 113 | . | Boizan | SU | West | F |
+| 114 | 453 | Assin Manso | SU | Cent | F |
+| 115 | . | Nkontunse | SU | Cent | F |
+| . | 454 | Worakeso | R | Cent | F |
+| 117 | . | Bawduaa | SU | East | F |
+| . | 462 | Nkwateng | SU | East | F |
+| 118 | 469 | Anum Apapam | SU | East | F |
+| . | 470 | Kukurantumi | SU | East | F |
+| 119 | . | Bunso | SU | East | F |
+| 120 | 477 | Kwahu Praso | SU | East | F |
+| . | 478 | Asakraka | SU | East | F |
+| 121 | . | Kpandu Fesi | SU | Volt | F |
+| . | 486 | Nerebehi | SU | Asha | F |
+| 123 | . | Achiasi | SU | Asha | F |
+| 124 | 493 | Manso Abore | SU | Asha | F |
+| . | 494 | Fereso | SU | Asha | F |
+| 125 | . | Ampunyasi | SU | Asha | F |
+| 126 | 501 | Bompata | SU | Asha | F |
+| . | 502 | Nyaboe | SU | Asha | F |
+| 127 | . | Boanim | SU | Asha | F |
+| 128 | 509 | Bodomasi | SU | Asha | F |
+| . | 510 | Banko | SU | Asha | F |
+| 130 | 517 | Ahwiriwma | SU | Asha | F |
+| . | 518 | Gaoso(Gambia #2) | R | Bron | F |
+| 131 | . | Susuanso | SU | Bron | F |
+| 132 | 525 | Tanoso | SU | Bron | F |
+| . | 526 | Aworokowa | SU | Bron | F |
+| 133 | . | Tarkwa | U | West | F |
+| 134 | 533 | Bibiani | U | West | F |
+| . | 534 | Assin Foso | U | Cent | F |
+| 135 | . | Oda | U | East | F |
+| 136 | 541 | Akwatia | U | East | F |
+| . | 542 | Kade | U | East | F |
+| 137 | . | Asamankese | U | East | F |
+| 138 | 549 | Anyinam | U | East | F |
+| . | 550 | Begoro | U | East | F |
+| 139 | . | Mpraeso | U | East | F |
+| 140 | 557 | Kpandu: Adombo | U | Volt | F |
+| . | 558 | Kwamikrom | U | Volt | F |
+| 142 | 565 | Kumasi:City Hotel | U | Asha | F |
+| . | 566 | Kumasi: Bomso | U | Asha | F |
+| 143 | . | Kumasi:Military Sta | U | Asha | F |
+| 144 | 573 | Kumasi:Aboabo | U | Asha | F |
+| . | 574 | Kumasi: New Amakom | U | Asha | F |
+| 145 | . | Kumasi:Zongo | U | Asha | F |
+| 147 | . | Kumasi:Old tafo Moshi | U | Asha | F |
+| . | 582 | No Kumasi: Manhiya | U | Asha | F |
+| 148 | 589 | Kumasi:Old Tafo GOIL | U | Asha | F |
+| 149 | . | Obuasi | U | Asha | F |
+| 150 | 597 | Odumasi | U | Asha | F |
+| 151 | . | Effiduase | U | Asha | F |
+| . | 598 | Agogo | U | Asha | F |
+| . | 606 | Akumadan | U | Asha | F |
+| . | 614 | Sunyani:Park | U | Bron | F |
+| 153 | . | Kenyase No.2 | U | Bron | F |
+| 155 | . | Nsuare | U | Bron | F |
+| 156 | 621 | Dormaa Ahenkro | U | Bron | F |
+| . | 622 | Techiman | U | Bron | F |
+| 157 | . | Warapong | R | East | S |
+| 158 | 629 | Senchi | R | East | S |
+| . | 630 | Aboma Yaw | R | East | F |
+| 159 | . | Catterpillar | R | East | S |
+| 160 | 637 | Vudese | R | Volt | F |
+| 161 | . | Tokor | R | Volt | F |
+| . | 638 | Abutia-Agove | R | Volt | F |
+| 162 | 645 | Suhuem | R | Volt | S |
+| . | 646 | Amanfrom/Dodofie | R | Volt | F |
+| 163 | . | Duflumkpa | R | Volt | S |
+| 164 | 653 | Duodoso | R | Bron | S |
+| 165 | . | Boase | R | Bron | S |
+| . | 654 | Yaa Mansa I | R | Bron | F |
+| . | 662 | Buaben | R | Bron | F |
+| 167 | . | Jato Zongo | R | Bron | S |
+| 168 | 669 | Tato Bator | R | Bron | S |
+| 169 | . | Bobenyuron | R | Nort | S |
+| . | 670 | Kwakro Akura | R | Bron | S |
+| 170 | 677 | Kpandai/Kitare | R | Nort | S |
+| . | 678 | Dobum No.2 | R | Nort | S |
+| 171 | . | Tangmaya | R | Nort | S |
+| 172 | . | Zang | R | Nort | S |
+| . | 686 | Yeshie | R | Nort | S |
+| 173 | . | Zozali | R | Nort | S |
+| 174 | 693 | Tuni | R | Nort | S |
+| . | 694 | Gbenduri | R | Nort | S |
+| 175 | . | Chagu | R | UppW | S |
+| 176 | 701 | Jeyin Jamayiri | R | UppW | S |
+| 177 | . | Brutu | R | UppW | S |
+| 179 | . | Navrongo | R | UppE | S |
+| . | 710 | Anur Yeri | R | UppE | S |
+| 180 | 717 | Channia | R | UppE | S |
+| . | 718 | Shiega-Won/Tongo | R | UppE | S |
+| 181 | . | Kulbia-Nayire | R | UppE | S |
+| 182 | 725 | Dua II | R | UppE | S |
+| . | 726 | Zoko Kanga | R | UppE | S |
+| 183 | . | Yeliwoko | R | UppE | S |
+| 184 | 733 | Nafkoliga | R | UppE | S |
+| . | 734 | Zorsi-Natingo | R | UppE | S |
+| 186 | 741 | Amankwakrom | SU | East | S |
+| . | 742 | Tsito | SU | Volt | F |
+| 187 | . | Anfoega | SU | Volt | F |
+| 188 | 749 | Damanko | SU | Volt | S |
+| . | 750 | Dwenem | R | Bron | F |
+| 189 | . | Ewisa | SU | Bron | S |
+| 190 | 757 | Gyema | SU | Bron | S |
+| . | 758 | Okyeamekrom | SU | Bron | S |
+| 191 | . | Adibo | SU | Nort | S |
+| 192 | 765 | Charria | SU | UppW | S |
+| . | 766 | Tampala | SU | UppW | S |
+| 193 | . | Kpong | U | East | S |
+| 194 | 773 | Ho: Ahliha | U | Volt | F |
+| . | 774 | Ho: Estate House | U | Volt | F |
+| 195 | . | Wenchi | U | Bron | S |
+| 196 | 781 | Yeji | SU | Bron | S |
+| . | 782 | Bole | U | Nort | S |
+| 197 | . | Yendi | U | Nort | S |
+| 198 | . | Tamale: Zogbeli | U | Nort | S |
+| 199 | . | Kumbumgu | U | Nort | S |
+| 200 | 797 | Bolgatonga: Police | U | UppE | S |
+| . | 798 | Bolgatonga: Nawongo | U | UppE | S |
+
+* Decode tables
+
+#+name: region_abbrev
+| Reg  | Region        |
+|------+---------------|
+| West | Western       |
+| Cent | Central       |
+| Gr.A | Greater Accra |
+| East | Eastern       |
+| Volt | Volta         |
+| Asha | Ashanti       |
+| Bron | Brong Ahafo   |
+| Nort | Northern      |
+| UppE | Upper East    |
+| UppW | Upper West    |
+
+#+name: ecozone_abbrev
+| EcoZone | Ecological_zone |
+|---------+-----------------|
+| C       | Coastal         |
+| F       | Forest          |
+| S       | Savannah        |
+

--- a/lsms_library/countries/GhanaLSS/_/appendix_i_extra_workloads.org
+++ b/lsms_library/countries/GhanaLSS/_/appendix_i_extra_workloads.org
@@ -1,0 +1,31 @@
+#+TITLE: GLSS1/GLSS2 "Extra Workloads" -- clusters the BID says to EXCLUDE
+#+AUTHOR: Sue the Coder
+
+Appendix I of =GHA_1988_GLSS_Basicinfo_EN.pdf= ends with a section headed
+*"Extra Workloads:  (should be excluded)"*.  These ten clusters are listed
+there and are deliberately NOT part of =appendix_i_clusters.org=.
+
+Kept as a separate tracked file rather than dropped, so that (a) the exclusion
+is auditable against the PDF, and (b) anyone who finds one of these ids in the
+microdata knows the document's position on it.
+
+*Not yet checked*: whether any of these appear in the shipped data.  If they
+do, that is a finding to report, not something to silently filter.
+
+Dropping these ten from the parsed 273 rows reproduces the Appendix's own
+urban/rural counts exactly (95 =U= / 116 =R= / 52 =SU=), which is one of the
+checks that the transcription is faithful.
+
+#+name: appendix_i_extra_workloads
+| yr1 | yr2 | Name | UrbRur | Reg | EcoZone |
+|-----+-----+------+--------+-----+---------|
+| . | 174 | Accra:Dansoman | U | Gr.A | C |
+| . | 177 | Accra:Town Council | U | Gr.A | C |
+| . | 190 | Accra:Bubrashie | U | Gr.A | C |
+| . | 209 | Accra | U | Gr.A | C |
+| . | 233 | Accra:Nima market | U | Gr.A | C |
+| . | 238 | Accra:Nima Pleasant | U | Gr.A | C |
+| . | 246 | Accra:W.Af Sec School | U | Gr.A | C |
+| . | 685 | Zang | R | Nort | S |
+| . | 789 | Tamale: Zogbeli | U | Nort | S |
+| . | 790 | Tamale | U | Nort | S |

--- a/lsms_library/countries/GhanaLSS/_/ghanalss.py
+++ b/lsms_library/countries/GhanaLSS/_/ghanalss.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import numpy as np
 from collections import defaultdict
+from importlib.resources import files
 from lsms_library.local_tools import get_dataframe, DVCFS
 
 # Formatting  Functions for Ghana 2016-17
@@ -410,3 +411,71 @@ def concate_id(df, parta, partb, leading_zero = False, digit = None):
     na_id = df.loc[df[parta].isna(), 'newid'].iloc[0]
     df['newid'] = df['newid'].replace(na_id, pd.NA)
     return df['newid']
+
+
+# ---------------------------------------------------------------------------
+# BID Appendix I -- the authoritative GLSS1/GLSS2 cluster attribute table.
+# ---------------------------------------------------------------------------
+
+def appendix_i_cluster_attributes(year_column, offset):
+    """Cluster attributes for a GLSS1/GLSS2 wave, from BID Appendix I.
+
+    GLSS1 and GLSS2 ship NO cluster-location variable -- a sweep of all 170
+    dictionaries finds none.  `cluster_features.Region` used to be INFERRED as
+    the modal birth region of a cluster's under-12s, which was ~98% right and
+    wrong for five clusters.  Appendix I of the joint Basic Information
+    Document is the survey's own cluster list and is authoritative for these
+    waves (decision, 2026-08-21); see `_/appendix_i_clusters.org`.
+
+    Parameters
+    ----------
+    year_column : {'yr1', 'yr2'}
+        Appendix column holding this wave's cluster number.
+    offset : int
+        Added to that number to reach the microdata's ``CLUST``
+        (1000 for 1987-88, 2000 for 1988-89).  Verified: 176/176 and 170/170.
+
+    Returns
+    -------
+    DataFrame indexed by ``v`` (zero-free string ``CLUST``) with columns
+    ``Region`` and ``Ecological_zone``.
+
+    ``Rural`` is deliberately NOT returned.  The Appendix classifies clusters
+    THREE ways -- U / R / SU (semi-urban, 52 clusters) -- and canonical
+    ``Rural`` is {Urban, Rural}.  Folding ``SU`` would destroy a distinction
+    the survey drew, so it waits on the vocabulary decision in GH #685/#682.
+    """
+    # countries_root() honours LSMS_COUNTRIES_ROOT; a hardcoded
+    # files("lsms_library")/"countries" would silently read the installed
+    # package's config tree instead of a worktree under development (GH #436).
+    from lsms_library.paths import countries_root
+    path = countries_root()/'GhanaLSS'/'_'/'appendix_i_clusters.org'
+    tbl = tools.df_from_orgfile(path, name='appendix_i_clusters', to_numeric=False)
+    tbl.columns = [str(c).strip() for c in tbl.columns]
+    tbl = tbl.map(lambda x: str(x).strip() if pd.notna(x) else x)
+
+    regions = tools.df_from_orgfile(path, name='region_abbrev', to_numeric=False)
+    regions.columns = [str(c).strip() for c in regions.columns]
+    region_map = dict(zip(regions['Reg'].str.strip(), regions['Region'].str.strip()))
+
+    zones = tools.df_from_orgfile(path, name='ecozone_abbrev', to_numeric=False)
+    zones.columns = [str(c).strip() for c in zones.columns]
+    zone_map = dict(zip(zones['EcoZone'].str.strip(), zones['Ecological_zone'].str.strip()))
+
+    # A decode that silently yields {} is this country's most expensive
+    # recurring defect (GH #372/#377, #348, and the 2026-08-19 revival).
+    # Assert rather than discover it as a 100%-null column downstream.
+    assert region_map, 'region_abbrev decoded to an EMPTY dict'
+    assert zone_map, 'ecozone_abbrev decoded to an EMPTY dict'
+
+    tbl = tbl[tbl[year_column].astype(str).str.strip().ne('.')].copy()
+    tbl['v'] = (tbl[year_column].astype(int) + offset).astype(str)
+
+    out = pd.DataFrame({
+        'Region': tbl['Reg'].map(region_map).values,
+        'Ecological_zone': tbl['EcoZone'].map(zone_map).values,
+    }, index=pd.Index(tbl['v'].values, name='v'))
+
+    unmapped = tbl.loc[out['Region'].isna().values, 'Reg'].unique()
+    assert len(unmapped) == 0, f'unmapped region abbreviations: {list(unmapped)}'
+    return out


### PR DESCRIPTION
Implements the decision on #681: **Appendix I is authoritative** for GLSS1/GLSS2 cluster attributes.

## The problem

GLSS1 and GLSS2 ship **no cluster-location variable at all**. A sweep of all 170 dictionaries finds none; the only near-hit, `Y00A::LOC`, is 99.8% constant at 1 and is a fieldwork flag.

So `cluster_features.Region` was **inferred** — the modal birth region of a cluster's members under 12, read from `Y01A.DAT:REGION` (the person's region of *birth*), with `Age: AGEY` pulled into `myvars` purely to feed the `Age<12` filter.

The inference was strong on its own terms — 0 ties, the mode an outright majority in all 346 clusters, median share 91.5%, minimum 55%, off a median of 31 children. Not a coin flip. **But it was still a guess about geography from a migration-sensitive question, and it was wrong for five clusters.**

## The fix

**Appendix I of `GHA_1988_GLSS_Basicinfo_EN.pdf`** — "Complete List of GLSS Clusters" — is the survey's own cluster list. The BID carries a real text layer, so no OCR is involved.

Transcribed to `countries/GhanaLSS/_/appendix_i_clusters.org` (263 rows), with the ten clusters the document itself marks *"Extra Workloads: (should be excluded)"* kept separately in `appendix_i_extra_workloads.org`. **Checked: none of those ten appear in the shipped data** — the producer had already applied the exclusion.

Join is `CLUST = 1000 + yr1` / `2000 + yr2` — **176 of 176 and 170 of 170** shipped clusters match. That offset was independently derived from `HEALTH.DAT` value ranges during the #323 review *before* this table was found; the Appendix confirms it as documented fact.

### Five clusters change

Every one was assigned to an **adjacent** region — the border-migration failure an under-12 filter cannot dodge:

| wave | v | name | was | now |
|---|---|---|---|---|
| 1987-88 | 1080 | Adwamasek/Wiwasi | Central | **Ashanti** |
| 1987-88 | 1107 | Ahantamwa(Tipokrom) | Ashanti | **Brong Ahafo** |
| 1987-88 | 1168 | Tato Bator | Volta | **Brong Ahafo** |
| 1987-88 | 1188 | Damanko | Northern | **Volta** |
| 1988-89 | 2334 | Huni Ofori | Eastern | **Central** |

`Ecological_zone` (Coastal / Forest / Savannah) lands in the same change; these waves had no such column.

## `Rural` deliberately stays NA

The Appendix is **three-way** — `U` 95 / `R` 116 / **`SU` 52 (semi-urban)** — against a canonical vocabulary of `{Urban, Rural}`. Folding `SU` destroys a distinction the survey drew (20% of clusters) and makes the 9-stratum design unreconstructible. It waits on **#685 / #682** rather than being guessed away.

## Verification — cold, isolated `LSMS_DATA_DIR`

| check | result |
|---|---|
| `cluster_features` rows | **3,791 — unchanged**; index unique |
| 1987-88 / 1988-89 `Region` null | **0%** |
| `Ecological_zone` null | **0%** (new) |
| the five target clusters | all carry the Appendix value |
| all seven waves' cluster counts | unchanged (176/170/365/300/580/1200/1000) |
| `household_roster.Birthplace` | untouched — 1987-88 UE 743 / UW 768, 1988-89 UE 953 / UW 464 (the #676-corrected values) |
| `GrainCollapseWarning` | **0** |
| distinct region labels | 10, all canonical |

### That the transcription is faithful

- **273 data rows parsed, ZERO dropped** — every unmatched line is a title, column header, page number, or the "Extra Workloads" marker.
- The **85** both-year rows match `CLYR1YR2.DAT`'s 85 linked pairs **exactly**.
- Dropping the ten excluded clusters reproduces the Appendix's own **95 `U` / 116 `R` / 52 `SU`** counts **exactly**.
- **8 rows spot-checked character-by-character** against the raw PDF text.

This mattered: #676 established that reviving an unobservable mapping means *trusting* a table nobody has checked, and it had Upper East / Upper West reversed for 1,511 people.

## Two conventions followed deliberately

- Config paths resolve via **`countries_root()`**, not `files("lsms_library")/"countries"`, so a worktree under development is honoured (GH #436). The pre-existing code in these files uses the hardcoded form; new code does not.
- The decode **asserts non-empty** rather than discovering a 100%-null column downstream — this country's most expensive recurring defect (GH #372/#377, #348, and the 2026-08-19 revival).

## Consequence worth naming

After this, `Y01A.DAT:REGION` feeds **`household_roster.Birthplace` only** — which is what it actually is. The two stop sharing a source column.

`CONTENTS.org` "Trap 3" is rewritten as resolved history rather than deleted, with the lesson kept: *the inference was reasonable, documented and measured, and nobody looked for a better source for a year — the better source was a text-layer PDF sitting in `Documentation/` the whole time.*

Closes #681.