### PR TITLE
docs(#683): Ethiopia's `Rural` column is not comparable across waves

### DIFF
--- a/lsms_library/countries/Ethiopia/_/CONTENTS.org
+++ b/lsms_library/countries/Ethiopia/_/CONTENTS.org
@@ -437,6 +437,57 @@ Two facts to carry into any pooling of these five waves:
    ESS4/ESPS-5 catalog records do not say the frame was changed.  ESPS-5
    additionally drops Tigray from the represented population.
 
+** The =Rural= COLUMN changes meaning between waves (GH #683)
+
+The wave-by-wave universe statements below record what each round *covers*.
+This section records the operational consequence, which is a different fact and
+is the one that reaches users: *=sample().Rural= is not comparable across waves.*
+
+Measured cold on =development=:
+
+| wave    |    n | Urban | urban share | Rural |
+|---------+------+-------+-------------+-------|
+| 2011-12 | 3969 |   503 |       12.7% |  3466 |
+| 2013-14 | 5262 |  1939 |       36.8% |  3323 |
+| 2015-16 | 4954 |  1682 |       34.0% |  3272 |
+| 2018-19 | 6770 |  3655 |       54.0% |  3115 |
+| 2021-22 | 4959 |  2674 |       53.9% |  2285 |
+
+*This is not urbanisation, and it is not a reweighting.*  Note the *Rural*
+column: 3466 -> 3115 across a decade, essentially flat, while Urban grows
+seven-fold.  The sample is being *extended into urban strata*, not shifted.
+
+ESS1 was designed for "rural and small town areas" (see 2011-12 below).  So
+=Urban= in 2011-12 denotes *small towns only*, while from ESS2 it denotes *any
+urban area, including Addis Ababa*.  The same canonical value denotes two
+different populations, and until this note nothing in the config, the schema or
+this file said so.
+
+*** What breaks
+
+- A pooled regression with an urban dummy silently mixes two definitions.
+- Any wave-over-wave comparison of an urban/rural gap is confounded by the
+  definition shift.
+- The 12.7% -> 36.8% step between ESS1 and ESS2 is *mostly* that shift, not a
+  change in Ethiopia.
+
+*** Related, and not the same thing
+
+- =Rural= for 2013-14 and 2015-16 additionally *collapses* a small-town / large-
+  town distinction that exists in the source (3,621 households).  See the
+  corpus-wide audit in PR #682, which proposes a separate =SettlementType=
+  column for within-urban tiers rather than more =Rural= values.
+- ESS4 / ESPS-5 put *zero* of their urban households through the agriculture
+  questionnaire while urban is 54% of the sample, whereas ESS1--ESS3 did.  That
+  is a *module-conditionality* change, a second regime shift in the same
+  country, and it is likewise invisible at the API.
+
+*** Not claimed here
+
+The often-quoted "small town = under 10,000" threshold is *not* verified in
+this repo.  It should be confirmed against the survey report before anyone
+relies on it or repeats it in a tracked file.
+
 ** Wave by wave
 
 *** 2011-12 (ERSS / ESS1) -- rural and small towns only

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -7,6 +7,13 @@ Data Scheme:
     weight: float
     panel_weight: float
     strata: str
+    # GH #683: `Rural` is NOT comparable across waves.  ESS1 (2011-12) covered
+    # "rural and small town areas" only, so `Urban` there means SMALL TOWN;
+    # from ESS2 it means any urban area including Addis Ababa.  The urban share
+    # runs 12.7% -> 36.8% -> 34.0% -> 54.0% -> 53.9%, while the RURAL count is
+    # nearly flat (3,466 -> 3,115): the sample is being extended into urban
+    # strata, not shifted.  A pooled urban dummy mixes two definitions.
+    # Full note, with the measurements, in _/CONTENTS.org.
     Rural: str
 
   cluster_features:


### PR DESCRIPTION
Documentation only — **no config semantics change**. Verified Ethiopia's `data_scheme` still parses at 25 tables with `sample.Rural` unchanged.

## What this records

`CONTENTS.org` already documents what each ESS round *covers*. It did not document the **operational consequence**, which is the fact that actually reaches users: `sample().Rural` is not comparable across waves.

Measured cold on `development`:

| wave | n | Urban | urban share | Rural |
|---|---:|---:|---:|---:|
| 2011-12 | 3,969 | 503 | **12.7%** | 3,466 |
| 2013-14 | 5,262 | 1,939 | **36.8%** | 3,323 |
| 2015-16 | 4,954 | 1,682 | 34.0% | 3,272 |
| 2018-19 | 6,770 | 3,655 | **54.0%** | 3,115 |
| 2021-22 | 4,959 | 2,674 | 53.9% | 2,285 |

**This is not urbanisation, and not a reweighting.** Look at the *Rural* column: 3,466 → 3,115 across a decade, essentially flat, while Urban grows seven-fold. The sample is being **extended into urban strata**, not shifted.

ESS1 was designed for *"rural and small town areas"*. So `Urban` in 2011-12 denotes **small towns only**; from ESS2 it denotes **any urban area including Addis Ababa**. The same canonical value denotes two different populations, and nothing in the config, the schema, or `CONTENTS.org` said so.

## What breaks

- A pooled regression with an urban dummy silently mixes two definitions.
- Wave-over-wave urban/rural gaps are confounded by the definition shift.
- The 12.7% → 36.8% step between ESS1 and ESS2 is **mostly that shift**, not a change in Ethiopia.

## Recorded as distinct, not merged

- 2013-14 / 2015-16 additionally **collapse** a small-town / large-town distinction present in the source (3,621 households). PR #682 proposes a separate `SettlementType` column for within-urban tiers rather than more `Rural` values.
- **ESS4 / ESPS-5 put zero urban households through the agriculture questionnaire** while urban is 54% of the sample, whereas ESS1–ESS3 did. That is *module conditionality* — a second regime change in the same country, likewise invisible at the API.

Two different regime shifts, one country, both silent. Keeping them separate matters: conflating them would suggest one explanation covers both.

## Explicitly not claimed

The often-quoted **"small town = under 10,000"** threshold is *not* verified in this repo. I have left it out of the tracked text and flagged that it should be confirmed against the survey report before anyone relies on it — an unverified number in a tracked file is exactly the defect class this repo keeps paying for.

## Where it lives

- `Ethiopia/_/CONTENTS.org` — a new subsection under the universe section, ahead of the wave-by-wave detail
- `Ethiopia/_/data_scheme.yml` — a comment on `sample.Rural` pointing at it, so the next person editing the config sees it without opening `CONTENTS.org`

Closes #683.