### PR TITLE
feat(#685): GhanaLSS GLSS1/GLSS2 Rural nulls 6,341 -> 0; `SU` folds to `Rural`

### DIFF
--- a/lsms_library/countries/GhanaLSS/1987-88/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1987-88/_/data_info.yml
@@ -25,7 +25,10 @@ cluster_features:
 sample:
     # `Rural` is NOT read from a source column -- GLSS1/GLSS2 ship none.  The
     # `sample` df_edit hook in mapping.py broadcasts the cluster's BID
-    # Appendix I classification (U / R / SU) onto its households.  GH #685.
+    # Appendix I classification onto its households.  The Appendix is three-way
+    # (U / R / SU); `SU` is folded onto `Rural` by decision (@ligon,
+    # 2026-08-21), so the delivered vocabulary is the canonical binary.
+    # GH #685.
     file: Y00A.DAT
     idxvars:
         i: HID

--- a/lsms_library/countries/GhanaLSS/1987-88/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1987-88/_/data_info.yml
@@ -23,6 +23,9 @@ cluster_features:
     myvars: {}
 
 sample:
+    # `Rural` is NOT read from a source column -- GLSS1/GLSS2 ship none.  The
+    # `sample` df_edit hook in mapping.py broadcasts the cluster's BID
+    # Appendix I classification (U / R / SU) onto its households.  GH #685.
     file: Y00A.DAT
     idxvars:
         i: HID

--- a/lsms_library/countries/GhanaLSS/1987-88/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1987-88/_/mapping.py
@@ -82,9 +82,14 @@ def cluster_features(df):
     Appendix, which lists sampling areas.  A cluster absent from the Appendix
     keeps `Region` NA rather than being dropped or guessed.
 
-    `Rural` now comes from the Appendix too: canonical `Rural` gained a
-    `Semi-urban` value (GH #682), so the three-way U/R/SU no longer has to be
-    folded onto two.
+    `Rural` now comes from the Appendix too.  The Appendix is three-way --
+    U / R / SU -- and `SU` is folded onto `Rural` by decision (@ligon,
+    2026-08-21); canonical `Rural` stays the binary {Urban, Rural}.  That fold
+    is a judgement call and the survey offers no evidence either way (the GLSS2
+    7-way `rural` table once cited as precedent is editorial, is not on the
+    questionnaire, and decodes a non-resident child's place of residence -- see
+    GH #692; do not cite it).  The U/R/SU distinction IS lost here; the raw
+    three-way survives in `_/appendix_i_clusters.org`.
     """
     # Load the country module BY PATH: `countries/GhanaLSS/_/` is not an
     # importable package, and a path built from countries_root() honours
@@ -134,6 +139,12 @@ def sample(df):
     cluster (BID Appendix I, U / R / SU), and every household in an enumeration
     area shares its EA's settlement class by construction, so broadcasting is
     the meaning of the variable rather than an imputation.
+
+    The Appendix's `SU` (semi-urban) is folded onto `Rural` by decision
+    (@ligon, 2026-08-21) -- canonical `Rural` is the binary {Urban, Rural}.
+    The fold is a judgement call with no survey evidence either way; see
+    `_/appendix_i_clusters.org` and GH #692.  The distinction is lost in this
+    column and preserved raw in that org file.
 
     Households whose cluster is absent from the Appendix keep `Rural` NA rather
     than being guessed.  GH #685.

--- a/lsms_library/countries/GhanaLSS/1987-88/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1987-88/_/mapping.py
@@ -82,8 +82,9 @@ def cluster_features(df):
     Appendix, which lists sampling areas.  A cluster absent from the Appendix
     keeps `Region` NA rather than being dropped or guessed.
 
-    `Rural` stays NA here: the Appendix is three-way (U/R/SU) against a
-    canonical vocabulary of {Urban, Rural} -- see GH #685.
+    `Rural` now comes from the Appendix too: canonical `Rural` gained a
+    `Semi-urban` value (GH #682), so the three-way U/R/SU no longer has to be
+    folded onto two.
     """
     # Load the country module BY PATH: `countries/GhanaLSS/_/` is not an
     # importable package, and a path built from countries_root() honours
@@ -100,7 +101,6 @@ def cluster_features(df):
     out = out.set_index(['t', 'v'])
 
     joined = out.join(attrs, how='left')
-    joined['Rural'] = pd.NA
     return joined[['Region', 'Rural', 'Ecological_zone']]
 
 def Int_t(value):
@@ -124,3 +124,27 @@ def Int_t(value):
     return pd.to_datetime(f"{y}-{m}-{d}", format='%Y-%m-%d', errors='coerce')
 
 Visits = range(1,7)
+
+
+def sample(df):
+    """Broadcast the cluster's Appendix I `Rural` onto its households.
+
+    GLSS1/GLSS2 ship no household-level urban/rural variable -- a sweep of all
+    170 dictionaries finds none.  The classification that DOES exist is of the
+    cluster (BID Appendix I, U / R / SU), and every household in an enumeration
+    area shares its EA's settlement class by construction, so broadcasting is
+    the meaning of the variable rather than an imputation.
+
+    Households whose cluster is absent from the Appendix keep `Rural` NA rather
+    than being guessed.  GH #685.
+    """
+    import importlib.util as _ilu
+    from lsms_library.paths import countries_root
+    _p = countries_root()/'GhanaLSS'/'_'/'ghanalss.py'
+    _spec = _ilu.spec_from_file_location('_ghanalss_country', _p)
+    _c = _ilu.module_from_spec(_spec); _spec.loader.exec_module(_c)
+    attrs = _c.appendix_i_cluster_attributes('yr1', 1000)
+
+    out = df.copy()
+    out['Rural'] = out['v'].astype(str).map(attrs['Rural'])
+    return out

--- a/lsms_library/countries/GhanaLSS/1988-89/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1988-89/_/data_info.yml
@@ -25,7 +25,10 @@ cluster_features:
 sample:
     # `Rural` is NOT read from a source column -- GLSS1/GLSS2 ship none.  The
     # `sample` df_edit hook in mapping.py broadcasts the cluster's BID
-    # Appendix I classification (U / R / SU) onto its households.  GH #685.
+    # Appendix I classification onto its households.  The Appendix is three-way
+    # (U / R / SU); `SU` is folded onto `Rural` by decision (@ligon,
+    # 2026-08-21), so the delivered vocabulary is the canonical binary.
+    # GH #685.
     file: Y00A.DAT
     idxvars:
         i: HID

--- a/lsms_library/countries/GhanaLSS/1988-89/_/data_info.yml
+++ b/lsms_library/countries/GhanaLSS/1988-89/_/data_info.yml
@@ -23,6 +23,9 @@ cluster_features:
     myvars: {}
 
 sample:
+    # `Rural` is NOT read from a source column -- GLSS1/GLSS2 ship none.  The
+    # `sample` df_edit hook in mapping.py broadcasts the cluster's BID
+    # Appendix I classification (U / R / SU) onto its households.  GH #685.
     file: Y00A.DAT
     idxvars:
         i: HID

--- a/lsms_library/countries/GhanaLSS/1988-89/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1988-89/_/mapping.py
@@ -89,9 +89,14 @@ def cluster_features(df):
     Appendix, which lists sampling areas.  A cluster absent from the Appendix
     keeps `Region` NA rather than being dropped or guessed.
 
-    `Rural` now comes from the Appendix too: canonical `Rural` gained a
-    `Semi-urban` value (GH #682), so the three-way U/R/SU no longer has to be
-    folded onto two.
+    `Rural` now comes from the Appendix too.  The Appendix is three-way --
+    U / R / SU -- and `SU` is folded onto `Rural` by decision (@ligon,
+    2026-08-21); canonical `Rural` stays the binary {Urban, Rural}.  That fold
+    is a judgement call and the survey offers no evidence either way (the GLSS2
+    7-way `rural` table once cited as precedent is editorial, is not on the
+    questionnaire, and decodes a non-resident child's place of residence -- see
+    GH #692; do not cite it).  The U/R/SU distinction IS lost here; the raw
+    three-way survives in `_/appendix_i_clusters.org`.
     """
     # Load the country module BY PATH: `countries/GhanaLSS/_/` is not an
     # importable package, and a path built from countries_root() honours
@@ -141,6 +146,12 @@ def sample(df):
     cluster (BID Appendix I, U / R / SU), and every household in an enumeration
     area shares its EA's settlement class by construction, so broadcasting is
     the meaning of the variable rather than an imputation.
+
+    The Appendix's `SU` (semi-urban) is folded onto `Rural` by decision
+    (@ligon, 2026-08-21) -- canonical `Rural` is the binary {Urban, Rural}.
+    The fold is a judgement call with no survey evidence either way; see
+    `_/appendix_i_clusters.org` and GH #692.  The distinction is lost in this
+    column and preserved raw in that org file.
 
     Households whose cluster is absent from the Appendix keep `Rural` NA rather
     than being guessed.  GH #685.

--- a/lsms_library/countries/GhanaLSS/1988-89/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1988-89/_/mapping.py
@@ -89,8 +89,9 @@ def cluster_features(df):
     Appendix, which lists sampling areas.  A cluster absent from the Appendix
     keeps `Region` NA rather than being dropped or guessed.
 
-    `Rural` stays NA here: the Appendix is three-way (U/R/SU) against a
-    canonical vocabulary of {Urban, Rural} -- see GH #685.
+    `Rural` now comes from the Appendix too: canonical `Rural` gained a
+    `Semi-urban` value (GH #682), so the three-way U/R/SU no longer has to be
+    folded onto two.
     """
     # Load the country module BY PATH: `countries/GhanaLSS/_/` is not an
     # importable package, and a path built from countries_root() honours
@@ -107,7 +108,6 @@ def cluster_features(df):
     out = out.set_index(['t', 'v'])
 
     joined = out.join(attrs, how='left')
-    joined['Rural'] = pd.NA
     return joined[['Region', 'Rural', 'Ecological_zone']]
 
 def Int_t(value):
@@ -131,3 +131,27 @@ def Int_t(value):
     return pd.to_datetime(f"{y}-{m}-{d}", format='%Y-%m-%d', errors='coerce')
 
 Visits = range(1,7)
+
+
+def sample(df):
+    """Broadcast the cluster's Appendix I `Rural` onto its households.
+
+    GLSS1/GLSS2 ship no household-level urban/rural variable -- a sweep of all
+    170 dictionaries finds none.  The classification that DOES exist is of the
+    cluster (BID Appendix I, U / R / SU), and every household in an enumeration
+    area shares its EA's settlement class by construction, so broadcasting is
+    the meaning of the variable rather than an imputation.
+
+    Households whose cluster is absent from the Appendix keep `Rural` NA rather
+    than being guessed.  GH #685.
+    """
+    import importlib.util as _ilu
+    from lsms_library.paths import countries_root
+    _p = countries_root()/'GhanaLSS'/'_'/'ghanalss.py'
+    _spec = _ilu.spec_from_file_location('_ghanalss_country', _p)
+    _c = _ilu.module_from_spec(_spec); _spec.loader.exec_module(_c)
+    attrs = _c.appendix_i_cluster_attributes('yr2', 2000)
+
+    out = df.copy()
+    out['Rural'] = out['v'].astype(str).map(attrs['Rural'])
+    return out

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -1132,11 +1132,19 @@ error.
   =df[df.Region == 'Brong Ahafo']= silently dropped all 170 of that wave's
   clusters.  Corrected in the wave's own table.
 
-** The =SU= -> =Rural= fold: a decision with no survey evidence (2026-08-21)
+** The =SU= -> =Rural= fold: the decision, and what the survey does and does not say (2026-08-21; evidence verified and corrected 2026-08-22)
 
 Not a trap.  A *decision*, recorded here because the reasoning that was first
 published for it turned out to be false, and the next person to look at this
 will otherwise reconstruct the false version.
+
+The 2026-08-21 version of this section said the survey "offers no evidence
+either way" and carried the settlement-population definition below as an
+unverified second-hand quote.  Both statements were wrong: the definition is
+real and is verbatim in *four* files this repository ships, and it *is*
+evidence bearing on the fold -- see /What the survey says/.  Corrected
+2026-08-22 (GH #690).  The decision itself is unchanged and is not in
+question here.
 
 *What was decided.*  BID Appendix I classifies every GLSS1/GLSS2 cluster three
 ways -- =U=, =R=, =SU= (semi-urban).  =SU= is *52 of 263* Appendix clusters,
@@ -1156,30 +1164,140 @@ from GLSS2's own 7-way =rural= table in
   =Y01C:NRCPL= -- a *non-resident child's* place of residence, GLSS2 Household
   Questionnaire Section 1 Part C, column 13 (GH #692, PR #696).
 
-So GLSS does *not* "already answer the folding question for the middle of its
-ladder".  *The survey offers no evidence either way.*  The fold rests on
-judgement alone.  Do not cite the 7-way table for it.
+So the 7-way =rural= table does *not* "already answer the folding question for
+the middle of its ladder".  Do not cite it for the fold.  (The survey *does*
+have something to say -- just not there.  See the next heading.)
 
-*What the survey DOES say -- and why it still is not evidence.*  GLSS1's
-Sampling Procedure defines the three tiers by *settlement population*:
+*What the survey says.*  GLSS1's own sample design defines the three tiers by
+*settlement population*.  Verbatim, from the joint Basic Information Document
+covering both rounds, §3.1 "Sample Design",
+=1987-88/Documentation/technical document/GHA_1987_GLSS_Basicinfo_EN.pdf=,
+PDF page 13, printed page 11:
 
 #+begin_quote
 A final concern was that all three of the country's ecological zones (coastal, forest and savannah), and each of urban, semi-urban and rural areas (population greater than 5000, 1500 to 5000, and less than 1500, respectively) form the same proportion in the sample as they do in the national population.
 #+end_quote
 
-So =SU= is a real, *defined* tier -- settlements of 1,500 to 5,000 people --
-and not a residual or a coding artefact.  But the definition is a *size band*;
-it takes no position whatever on which side of a two-value collapse the band
-belongs to.  It sharpens what is being lost; it does not license the fold.
+The same sentence appears, word for word, in three further files this
+repository ships -- so the numbers are not resting on one transcription:
 
-/Provenance caveat, stated because this file's rules require it./  This quote
-is *second-hand*: it is transcribed from
-=slurm_logs/POPULATION_STATEMENTS_2026-07-21.org= (the GH #601 documentation
-sweep), which cites =1987-88/Documentation/GLSS 1987-88 Report.pdf=, "Sampling
-Procedure".  It was *not* re-verified against the PDF here -- that file's text
-layer is a CID-encoded subset font with no ToUnicode map and needs the glyph-map
-decode described in the transcription caveat above.  Re-verify before leaning on
-the exact numbers.
+| File                                                                      | Where                                        | Text layer     |
+|---------------------------------------------------------------------------+----------------------------------------------+----------------|
+| =1987-88/Documentation/technical document/GHA_1987_GLSS_Basicinfo_EN.pdf= | §3.1, PDF p. 13 / printed p. 11              | plain          |
+| =1988-89/Documentation/technical document/GHA_1988_GLSS_Basicinfo_EN.pdf= | §3.1, same text                              | plain          |
+| =1988-89/Documentation/ddi-documentation-english-4.pdf=                   | "Sampling" -> "Sampling Procedure", PDF p. 7 | plain          |
+| =1987-88/Documentation/GLSS 1987-88 Report.pdf=                           | "Sampling Procedure"                         | CID -- decoded |
+
+So =SU= is a real, *defined* tier -- and the fold is being made across a
+boundary the survey drew itself.
+
+*Band boundaries.*  The BID's "1500 to 5000" is inclusive-ambiguous at both
+ends.  The GLSS3 main report sharpens it, =1991-92/Documentation/pdf/G3report.pdf=,
+note to Table 7.3, PDF p. 75 / printed p. 57 (repeated under Table 7.9, printed
+p. 61):
+
+#+begin_quote
+Note:  Small rural localities are those with a 1984 population of less than 1500.  Semi-urban localities are those with a 1984 population of at least 1500 but less than 5000.
+#+end_quote
+
+Read together: rural < 1500 <= semi-urban < 5000 <= urban.  Note the one
+inconsistency, quoted rather than reconciled: the BID says urban is "greater
+than 5000", GLSS3's wording implies urban is *at least* 5000.  The population
+is the *1984 Census* population of the locality, not anything measured by the
+survey.
+
+*What this does and does not settle.*  It is a *size* band, and no
+GLSS1/GLSS2 document says in words "semi-urban is rural".  What it does
+establish is narrower and still useful: *the survey's own urban threshold is
+5,000, and the whole semi-urban band sits below it.*  So =SU= is not
+ambiguous relative to the survey's definition of urban -- it is, by that
+definition, not urban.  That is an argument about the fold's *direction*, and
+a far better one than the withdrawn =Classification= column.  It is not a
+statement that GSS intended =SU= to be reported as rural.
+
+Three further pieces of evidence point the same way.  None is a GLSS1/GLSS2
+sentence saying "semi-urban is rural"; take them for exactly what they are.
+
+- *GLSS1's own report never uses a semi-urban category, and its three
+  locality buckets exhaust the sample.*  =1987-88/Documentation/reports/GHA_1987_GLSS_Firstyear_Report_EN.pdf=
+  (GSS, August 1989) reports throughout by LOCALITY = ACCRA / OTHER URBAN /
+  RURAL / COUNTRY (Table 1, printed p. 6; Figure 3, printed p. 8), and its
+  Method section, printed p. ix, describes the very design quoted above as
+  "Stratification criteria were urban/rural and ecological zones."  Table 1's
+  sample sizes are Accra 1,393, Other Urban 3,956, Rural 10,143 -- summing to
+  *15,492*, which is exactly the BID's GLSS1 individual count.  The
+  semi-urban clusters are therefore inside one of those three, and the report
+  does not say which.
+- *The arithmetic says which.*  This is *inference from published totals*, not
+  a quote.  Urban = 65 clusters (BID Table 1a, below) against 5,349 urban
+  persons is 82 persons per cluster, and rural+SU = 111 clusters against
+  10,143 persons is 91 -- both near the overall 15,492/176 = 88.  Counting SU
+  as urban instead gives 100 clusters at 53 persons and 76 clusters at 133, a
+  2.5x spread that a design of 16/32/48-household workloads cannot produce.
+- *GSS itself performs this exact collapse one round later.*  In the GLSS3
+  main report, Tables 7.3 (printed p. 57) and 7.9 (printed p. 61) nest
+  "Semi-urban" and "Small rural" as the two sub-rows of a *Rural* total,
+  opposite Urban (Accra, Other urban); the prose reads "Within rural areas,
+  incomes were rather higher in semi-urban areas than in small rural areas"
+  (printed p. 61); and printed p. 85 lists "Accra/other urban/rural" and
+  "Accra/other urban/semi-urban/small rural" as alternative breakdowns of one
+  locality axis -- i.e. rural = semi-urban + small rural.  Same statistical
+  office, same 1984-Census thresholds, *different round*: GLSS3's sample is
+  not GLSS1/GLSS2's and its locality variable is not Appendix I's =UrbRur=.
+
+*What was searched, so the negative is falsifiable.*  Searched for any
+statement assigning =SU= to a side of a two-way split: the 1987 BID, the 1988
+BID, the GLSS1 DDI (decoded in full), the GLSS2 DDI, the GLSS3 main report,
+and the GLSS1 First Year Report (its text layer plus rendered pages ix, x, xi,
+6, 8).  In GLSS1/GLSS2 documentation every mention keeps *three* tiers: the
+definition sentence, BID Table 1a (printed p. 13), the =IMPRENT= regression
+dummies "rural, semi-urban, coastal, savannah" (printed p. 22), and the
+master-sample ordering "by region within each location (rural/semi-urban/urban)"
+quoted under /Oversamples and sub-samples/ above.  *Not* searched, and so
+establishing nothing: the bodies of the image-only GLSS1/GLSS2 documents
+beyond the pages named (the First Year Report's text layer is *front matter
+only* -- 9 of 115 pages carry any text; the Preliminary Report has 93
+characters, i.e. none), and the questionnaires, which are image-only.
+
+/Provenance of the quote./  The GH #601 sweep
+(=slurm_logs/POPULATION_STATEMENTS_2026-07-21.org=, GhanaLSS 1987-88,
+"Exclusions") was *first-hand*: its extractor decoded
+=1987-88/Documentation/GLSS 1987-88 Report.pdf= itself and recorded the
+method.  Its citation to that file's "Sampling Procedure" section is
+*accurate* -- confirmed here by an independent decode.  Only the copy into
+this file was second-hand, and it is now replaced by the text-layer sources
+above.
+
+/How the CID file was decoded, 2026-08-22, in case it is needed again./  The
+PDF embeds one subset font (=1E1ba2Arial=, 88 glyphs, =Identity-H=, no
+=cmap=, no =post=, no =ToUnicode=), so =pdfminer= emits =(cid:NN)= per glyph
+*but preserves real spaces and newlines*.  That makes it a plain
+monoalphabetic substitution with word boundaries intact.  Solve it by sliding
+long known cribs over the stream and keeping placements consistent with a
+partial bijection; a 60-character crib pins a placement uniquely.  The
+sentence under test was *excluded from the crib set* so that finding it is
+evidence and not assumption.  Two checks that the decode is not echoing its
+cribs: the digit =5= is pinned independently by "August 5, 2008" on the cover
+and by the table-of-contents page sequence 14/15/16; and the decoded GLSS1
+DDI reads "The methodology that was *used* reflects the purpose of the
+survey", where the BID and the GLSS2 DDI both read "that was *chosen*" -- a
+divergence a crib-echo could not produce.
+
+*Corroboration of the wiring (not of the direction).*  BID Table 1a, titled as
+printed "Survey Coverage / Number of Clusters in Household, Community, and
+Price Surveys by Region" -- the "by Region" is a sic; the rows are
+*localities* -- PDF p. 15 / printed p. 13.  Household-survey clusters:
+
+| Round             | Urban | Semi-Urban | Rural | Total |
+|-------------------+-------+------------+-------+-------|
+| Year 1 (1987-88)  |    65 |         35 |    76 |   176 |
+| Year 2 (1988-89)  |    56 |         31 |    83 |   170 |
+
+The delivered fold's cold counts (below: 111 Rural / 65 Urban and 114 Rural /
+56 Urban) reconcile with this *exactly* -- 76+35 = 111, 83+31 = 114, Urban
+unchanged in both rounds.  That is a check on the Appendix I classification
+and on the fold arithmetic.  It is *not* an argument about direction: Table
+1a itself keeps the three tiers.
 
 *What the fold costs, stated plainly.*  The U/R/SU distinction *is lost* in the
 delivered =Rural= column.  It is not recoverable from =sample()= or from

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -78,27 +78,40 @@ without an explicit mapping file.
 
 | Round  | Source file        | Variable | Values                           |
 |--------+--------------------+----------+----------------------------------|
-| GLSS1  | ---                | ---      | Not available                    |
-| GLSS2  | ---                | ---      | Not available                    |
+| GLSS1  | BID Appendix I     | =UrbRur= | U / R / SU (cluster-level)       |
+| GLSS2  | BID Appendix I     | =UrbRur= | U / R / SU (cluster-level)       |
 | GLSS3  | =POV_GH.DTA=      | =loc2=   | 1=Urban, 2=Rural (numeric)       |
 | GLSS4  | =SEC0A.DTA=        | =loc2=   | 1=Urban, 2=Rural (numeric)       |
-| GLSS5  | ---                | ---      | Not in cover page; in =pov_gh5=  |
+| GLSS5  | =parta/sec7.dta=   | =loc2=   | urban, rural (Stata value labels) |
 | GLSS6  | =g6loc_edt.dta=    | =loc2=   | Rural, Urban (string)            |
 | GLSS7  | =g7sec0.dta=       | =urbrur= | Rural, Urban (string)            |
 
-GLSS5 cover page (=sec0.dta=) has no urban/rural variable; =Rural= is
-NaN for that wave.  The cluster-level =loc2= is available in
-=pov_gh5.dta= and in =cluster_features= for GLSS5.
+GLSS5's cover page (=parta/sec0.dta=) has no urban/rural variable.  =Rural= was
+=NaN= for that wave until GH #659 (PR #687) wired it from =loc2= in
+*=parta/sec7.dta=*, which ships at exactly the =sample= grain with its own
+Stata value labels ={1: urban, 2: rural}=; measured cold 2026-08-22, 2005-06
+=sample().Rural= has *zero* nulls.  (This paragraph previously said "=Rural= is
+NaN for that wave"; that is stale.)
+
+*Do not reach for =aggregates/pov_gh5.dta= here.*  It is a documented decoy --
+same 8,687 rows and same distribution, but *no =hhid= column*, so there is
+nothing to join on.  =parta/sec2a.dta= carries a =loc2= that is 100% NULL.
+Both are recorded in =2005-06/_/data_info.yml=.
+
+GLSS1/GLSS2 have *no urban/rural variable in the microdata at all* -- see
+/Trap 3/ and /The =SU= -> =Rural= fold/ below.  Their =Rural= comes from BID
+Appendix I at the *cluster* level and is broadcast to the households of each
+cluster.  The Appendix's third value =SU= is folded onto =Rural=.
 
 ** =sample= feature source variables
 
 | Round | File             | i        | v     | weight   | strata | Rural  |
 |-------+------------------+----------+-------+----------+--------+--------|
-| GLSS1 | =Y00A.DAT=       | =HID=    | =CLUST= | ---    | ---    | ---    |
-| GLSS2 | =Y00A.DAT=       | =HID=    | =CLUST= | ---    | ---    | ---    |
+| GLSS1 | =Y00A.DAT=       | =HID=    | =CLUST= | ---    | ---    | Appendix I (broadcast) |
+| GLSS2 | =Y00A.DAT=       | =HID=    | =CLUST= | ---    | ---    | Appendix I (broadcast) |
 | GLSS3 | =POV_GH.DTA=     | =[clust,nh]= | =clust= | --- | =region= | =loc2= |
 | GLSS4 | =SEC0A.DTA=      | =[clust,nh]= | =clust= | --- | =region= | =loc2= |
-| GLSS5 | =parta/sec0.dta= | =hhid=   | =clust= | =weight= | =region= | --- |
+| GLSS5 | =parta/sec0.dta= | =hhid=   | =clust= | =weight= | =region= | =loc2= (=parta/sec7.dta=) |
 | GLSS6 | =PARTA/g6loc_edt.dta= | =HID= | =clust= | =weight= | =region= | =loc2= |
 | GLSS7 | =g7sec0.dta=     | =[clust,nh]= | =clust= | =WTA_S= | =region= | =urbrur= |
 
@@ -1057,12 +1070,15 @@ a better source for a year*.  The better source was a text-layer PDF sitting in
 =Documentation/= the whole time.  Before building an approximation, read the
 documentation the survey shipped with itself.
 
-Note also what the fix does NOT do: =Rural= stays =NA=.  The Appendix
-classifies clusters *three* ways -- =U= / =R= / =SU= (semi-urban, 52 clusters,
-20%) -- against a canonical vocabulary of ={Urban, Rural}=.  Folding =SU= would
-destroy a distinction the survey drew, so it waits on GH #685/#682 rather than
-being guessed away.  After this change =Y01A.DAT:REGION= feeds
-=household_roster.Birthplace= *only*, which is what it actually is.
+After this change =Y01A.DAT:REGION= feeds =household_roster.Birthplace=
+*only*, which is what it actually is.
+
+/Superseded note./  This section originally continued: "Note also what the fix
+does NOT do: =Rural= stays =NA= ... Folding =SU= would destroy a distinction the
+survey drew, so it waits on GH #685/#682 rather than being guessed away."  That
+was true when written and is *no longer the state of the code*: =Rural= is now
+wired from the Appendix, with =SU= folded onto =Rural=.  See /The =SU= ->
+=Rural= fold/ below for the decision and, more importantly, for what it costs.
 
 ** Trap 4: GLSS1 had no =region= table of its own, and the fallback is REVERSED
 
@@ -1115,6 +1131,86 @@ error.
   =Brong Ahafo=.  Harmless-looking, but it means
   =df[df.Region == 'Brong Ahafo']= silently dropped all 170 of that wave's
   clusters.  Corrected in the wave's own table.
+
+** The =SU= -> =Rural= fold: a decision with no survey evidence (2026-08-21)
+
+Not a trap.  A *decision*, recorded here because the reasoning that was first
+published for it turned out to be false, and the next person to look at this
+will otherwise reconstruct the false version.
+
+*What was decided.*  BID Appendix I classifies every GLSS1/GLSS2 cluster three
+ways -- =U=, =R=, =SU= (semi-urban).  =SU= is *52 of 263* Appendix clusters,
+20%.  Canonical =Rural= stays the binary ={Urban, Rural}=; =SU= is delivered as
+*=Rural=*.  @ligon's call, 2026-08-21, on GH #690.  An earlier iteration of
+that PR added a canonical =Semi-urban= value to =lsms_library/data_info.yml=;
+*it was withdrawn*, and the file is byte-identical to =development= again.
+
+*What is NOT true, and must not be re-cited.*  The fold was originally argued
+from GLSS2's own 7-way =rural= table in
+=1988-89/_/categorical_mapping.org=, whose =Classification= column puts
+=Small Town -> Rural=:
+
+- that =Classification= column is *editorial*.  It is *not on the
+  questionnaire*; someone added it (GH #692).
+- the table is not a settlement ladder for the household at all.  It decodes
+  =Y01C:NRCPL= -- a *non-resident child's* place of residence, GLSS2 Household
+  Questionnaire Section 1 Part C, column 13 (GH #692, PR #696).
+
+So GLSS does *not* "already answer the folding question for the middle of its
+ladder".  *The survey offers no evidence either way.*  The fold rests on
+judgement alone.  Do not cite the 7-way table for it.
+
+*What the survey DOES say -- and why it still is not evidence.*  GLSS1's
+Sampling Procedure defines the three tiers by *settlement population*:
+
+#+begin_quote
+A final concern was that all three of the country's ecological zones (coastal, forest and savannah), and each of urban, semi-urban and rural areas (population greater than 5000, 1500 to 5000, and less than 1500, respectively) form the same proportion in the sample as they do in the national population.
+#+end_quote
+
+So =SU= is a real, *defined* tier -- settlements of 1,500 to 5,000 people --
+and not a residual or a coding artefact.  But the definition is a *size band*;
+it takes no position whatever on which side of a two-value collapse the band
+belongs to.  It sharpens what is being lost; it does not license the fold.
+
+/Provenance caveat, stated because this file's rules require it./  This quote
+is *second-hand*: it is transcribed from
+=slurm_logs/POPULATION_STATEMENTS_2026-07-21.org= (the GH #601 documentation
+sweep), which cites =1987-88/Documentation/GLSS 1987-88 Report.pdf=, "Sampling
+Procedure".  It was *not* re-verified against the PDF here -- that file's text
+layer is a CID-encoded subset font with no ToUnicode map and needs the glyph-map
+decode described in the transcription caveat above.  Re-verify before leaning on
+the exact numbers.
+
+*What the fold costs, stated plainly.*  The U/R/SU distinction *is lost* in the
+delivered =Rural= column.  It is not recoverable from =sample()= or from
+=cluster_features()=.  This is a real loss, not a re-expression: the GLSS1/GLSS2
+design is 9 strata (3 ecological zones x 3 settlement classes), and the
+settlement axis now reaches the API as 2 values.  The raw three-way is
+*preserved* in the =UrbRur= column of =_/appendix_i_clusters.org=, which is
+where anyone reconstructing the design should read it.
+
+*What it buys.*  =Rural= was 100% NULL for both waves -- *6,341 households* and
+*346 clusters* -- because there is no urban/rural variable in the microdata at
+all.  Cold measurement, 2026-08-22: those nulls go to zero, 1987-88 delivers
+111 Rural / 65 Urban clusters and 1988-89 delivers 114 Rural / 56 Urban.
+Households whose cluster is absent from the Appendix would keep =NA=; in
+practice the Appendix matches 176/176 and 170/170, so none do.
+
+*Where the wiring lives, and why it is shaped that way.*  =urbrur_abbrev= in
+=_/appendix_i_clusters.org=, read explicitly by
+=ghanalss.py::appendix_i_cluster_attributes= with two asserts (non-empty dict;
+no unmapped abbreviation).  Deliberately *not* a =Code=-keyed
+=categorical_mapping.org= table: it is never auto-applied, cannot collide with
+the wave-level =rural= table, and *fails loudly* rather than shipping a null
+column -- which is this country's most expensive recurring defect (Traps 1 and
+4).  Two designs were proposed during GH #690 and *rejected*: a country-level
+=rural= categorical table (measured: it makes 1987-88 and 2005-06 inherit a
+table they do not have today -- the Trap 4 shape), and a
+=Preferred Label= / =Settlement Label= rename.  Do not revive either.
+
+*Superseded reading.*  =slurm_logs/rural_audit/FINDINGS_rural_values.org= s7.1
+recommends adding a canonical =Semi-urban=.  It is superseded by the above.  Do
+not re-file it.
 
 ** Cluster counts, and a vocabulary trap in the documentation
 

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -1247,13 +1247,26 @@ sentence saying "semi-urban is rural"; take them for exactly what they are.
 
 *What was searched, so the negative is falsifiable.*  Searched for any
 statement assigning =SU= to a side of a two-way split: the 1987 BID, the 1988
-BID, the GLSS1 DDI (decoded in full), the GLSS2 DDI, the GLSS3 main report,
-and the GLSS1 First Year Report (its text layer plus rendered pages ix, x, xi,
-6, 8).  In GLSS1/GLSS2 documentation every mention keeps *three* tiers: the
-definition sentence, BID Table 1a (printed p. 13), the =IMPRENT= regression
-dummies "rural, semi-urban, coastal, savannah" (printed p. 22), and the
-master-sample ordering "by region within each location (rural/semi-urban/urban)"
-quoted under /Oversamples and sub-samples/ above.  *Not* searched, and so
+BID, the GLSS1 DDI (decoded end to end -- the glyph map is partial, 48 of 84
+cids, but it resolves every letter and digit in the terms searched), the GLSS2
+DDI, the GLSS3 main report, and the GLSS1 First Year Report (its text layer
+plus rendered pages ix, x, xi, 6, 8).  In GLSS1/GLSS2 documentation every
+*classification* keeps three tiers: the definition sentence, BID Table 1a
+(printed p. 13), the =IMPRENT= regression dummies "rural, semi-urban, coastal,
+savannah" (printed p. 22), and the master-sample ordering "by region within
+each location (rural/semi-urban/urban)" quoted under /Oversamples and
+sub-samples/ above.
+
+One phrase in that corpus *is* two-way, and it is not a classification -- flagged
+so the next reader does not mistake it for one.  The GLSS1 DDI's Overview says a
+"price questionnaire was used in both urban and rural areas", and the BID says
+supervisors completed community questionnaires "for almost all rural, most
+semi-urban clusters and one urban cluster" (PDF p. 10 / printed p. 8).  Both describe *which
+clusters got which instrument*; the BID's version, which is the more specific of
+the two, names semi-urban separately.  Fieldwork coverage, not a settlement
+taxonomy.
+
+*Not* searched, and so
 establishing nothing: the bodies of the image-only GLSS1/GLSS2 documents
 beyond the pages named (the First Year Report's text layer is *front matter
 only* -- 9 of 115 pages carry any text; the Preliminary Report has 93
@@ -1285,8 +1298,10 @@ divergence a crib-echo could not produce.
 
 *Corroboration of the wiring (not of the direction).*  BID Table 1a, titled as
 printed "Survey Coverage / Number of Clusters in Household, Community, and
-Price Surveys by Region" -- the "by Region" is a sic; the rows are
-*localities* -- PDF p. 15 / printed p. 13.  Household-survey clusters:
+Price Surveys by Region" -- but its rows are *localities*, not regions, and
+the column totals are corroborated by the prose beneath it (102 and 71
+community questionnaires; 165 and 108 price) -- PDF p. 15 / printed p. 13.
+Household-survey clusters:
 
 | Round             | Urban | Semi-Urban | Rural | Total |
 |-------------------+-------+------------+-------+-------|

--- a/lsms_library/countries/GhanaLSS/_/appendix_i_clusters.org
+++ b/lsms_library/countries/GhanaLSS/_/appendix_i_clusters.org
@@ -51,9 +51,11 @@ the GH #323 review, before this table was found.
 
 - =Reg= and =EcoZone= are the Appendix's own abbreviations, kept *raw* so this
   table can be audited against the PDF.  =region_abbrev= below decodes them.
-- =UrbRur= has *three* values -- =U=, =R= and =SU= (semi-urban).  It is NOT
-  wired yet: canonical =Rural= is ={Urban, Rural}= and folding =SU= would
-  destroy a distinction the survey drew (52 clusters, 20%).  See GH #685.
+- =UrbRur= has *three* values -- =U=, =R= and =SU= (semi-urban) -- and all
+  three are wired.  Canonical =Rural= gained a =Semi-urban= value for exactly
+  this (GH #682); folding =SU= onto =Urban= or =Rural= would have destroyed a
+  distinction the survey drew (52 clusters, 20%) and made the 9-stratum design
+  (3 ecological zones x 3 settlement classes) unreconstructible.
 - =EcoZone= is 3-way (C/F/S).  GLSS6 (2012-13) additionally uses =GAMA= for
   Greater Accra; the Appendix has no such category, so Accra clusters here are
   =C= (coastal).  That is a difference between the *sources*, not an error.
@@ -344,6 +346,13 @@ the GH #323 review, before this table was found.
 | Nort | Northern      |
 | UppE | Upper East    |
 | UppW | Upper West    |
+
+#+name: urbrur_abbrev
+| UrbRur | Rural      |
+|--------+------------|
+| U      | Urban      |
+| R      | Rural      |
+| SU     | Semi-urban |
 
 #+name: ecozone_abbrev
 | EcoZone | Ecological_zone |

--- a/lsms_library/countries/GhanaLSS/_/appendix_i_clusters.org
+++ b/lsms_library/countries/GhanaLSS/_/appendix_i_clusters.org
@@ -51,11 +51,14 @@ the GH #323 review, before this table was found.
 
 - =Reg= and =EcoZone= are the Appendix's own abbreviations, kept *raw* so this
   table can be audited against the PDF.  =region_abbrev= below decodes them.
-- =UrbRur= has *three* values -- =U=, =R= and =SU= (semi-urban) -- and all
-  three are wired.  Canonical =Rural= gained a =Semi-urban= value for exactly
-  this (GH #682); folding =SU= onto =Urban= or =Rural= would have destroyed a
-  distinction the survey drew (52 clusters, 20%) and made the 9-stratum design
-  (3 ecological zones x 3 settlement classes) unreconstructible.
+- =UrbRur= has *three* values -- =U=, =R= and =SU= (semi-urban) -- and this
+  column keeps all three, *raw*.  The column the library *delivers* is the
+  canonical binary ={Urban, Rural}=, so =urbrur_abbrev= below folds =SU= onto
+  =Rural= (decision, @ligon, 2026-08-21).  *That fold is a judgement call; the
+  survey offers no evidence either way* -- see the note above that table.  The
+  three-way distinction (52 of 263 clusters, 20%) is therefore *lost* in the
+  delivered =Rural= column.  It is *not* lost here: anyone who needs it reads
+  =UrbRur= off the cluster table above.
 - =EcoZone= is 3-way (C/F/S).  GLSS6 (2012-13) additionally uses =GAMA= for
   Greater Accra; the Appendix has no such category, so Accra clusters here are
   =C= (coastal).  That is a difference between the *sources*, not an error.
@@ -347,12 +350,32 @@ the GH #323 review, before this table was found.
 | UppE | Upper East    |
 | UppW | Upper West    |
 
+The fold below is a *decision*, not a measurement.  =SU= (semi-urban) is
+delivered as =Rural= by @ligon's call, 2026-08-21.  Canonical =Rural= stays the
+binary ={Urban, Rural}=; no =Semi-urban= value was added to
+=lsms_library/data_info.yml=.
+
+*The survey offers no evidence either way.*  The GLSS2 7-way =rural= table's
+=Classification= column was previously cited on GH #690 as this country's own
+precedent for folding a middle tier to =Rural=.  It is not: that column is
+*editorial -- it is not on the questionnaire* (see GH #692), and the table
+decodes =Y01C:NRCPL=, a *non-resident child's* place of residence, not the
+household's settlement class.  *Do not cite it.*
+
+The raw three-way is preserved in the =UrbRur= column of the cluster table
+above, which this fold does not touch.
+
+(Keep commentary *above* the =#+name:= line.  An Org =#+name:= attaches to the
+NEXT element, so a block wedged between the keyword and the table steals the
+name and kills the decode with no error -- =CONTENTS.org= Trap 4 records that
+this already cost one silent no-op "fix" in this country.)
+
 #+name: urbrur_abbrev
-| UrbRur | Rural      |
-|--------+------------|
-| U      | Urban      |
-| R      | Rural      |
-| SU     | Semi-urban |
+| UrbRur | Rural |
+|--------+-------|
+| U      | Urban |
+| R      | Rural |
+| SU     | Rural |
 
 #+name: ecozone_abbrev
 | EcoZone | Ecological_zone |

--- a/lsms_library/countries/GhanaLSS/_/ghanalss.py
+++ b/lsms_library/countries/GhanaLSS/_/ghanalss.py
@@ -440,10 +440,11 @@ def appendix_i_cluster_attributes(year_column, offset):
     DataFrame indexed by ``v`` (zero-free string ``CLUST``) with columns
     ``Region`` and ``Ecological_zone``.
 
-    ``Rural`` is deliberately NOT returned.  The Appendix classifies clusters
-    THREE ways -- U / R / SU (semi-urban, 52 clusters) -- and canonical
-    ``Rural`` is {Urban, Rural}.  Folding ``SU`` would destroy a distinction
-    the survey drew, so it waits on the vocabulary decision in GH #685/#682.
+    ``Rural`` IS returned, as of GH #682: the canonical vocabulary gained a
+    ``Semi-urban`` value, so the Appendix's three-way U / R / SU no longer has
+    to be folded onto two.  ``SU`` is 52 of 263 clusters (20%); folding it
+    would have destroyed a distinction the survey drew and made the 9-stratum
+    design (3 ecological zones x 3 settlement classes) unreconstructible.
     """
     # countries_root() honours LSMS_COUNTRIES_ROOT; a hardcoded
     # files("lsms_library")/"countries" would silently read the installed
@@ -458,6 +459,10 @@ def appendix_i_cluster_attributes(year_column, offset):
     regions.columns = [str(c).strip() for c in regions.columns]
     region_map = dict(zip(regions['Reg'].str.strip(), regions['Region'].str.strip()))
 
+    urbrur = tools.df_from_orgfile(path, name='urbrur_abbrev', to_numeric=False)
+    urbrur.columns = [str(c).strip() for c in urbrur.columns]
+    urbrur_map = dict(zip(urbrur['UrbRur'].str.strip(), urbrur['Rural'].str.strip()))
+
     zones = tools.df_from_orgfile(path, name='ecozone_abbrev', to_numeric=False)
     zones.columns = [str(c).strip() for c in zones.columns]
     zone_map = dict(zip(zones['EcoZone'].str.strip(), zones['Ecological_zone'].str.strip()))
@@ -467,15 +472,19 @@ def appendix_i_cluster_attributes(year_column, offset):
     # Assert rather than discover it as a 100%-null column downstream.
     assert region_map, 'region_abbrev decoded to an EMPTY dict'
     assert zone_map, 'ecozone_abbrev decoded to an EMPTY dict'
+    assert urbrur_map, 'urbrur_abbrev decoded to an EMPTY dict'
 
     tbl = tbl[tbl[year_column].astype(str).str.strip().ne('.')].copy()
     tbl['v'] = (tbl[year_column].astype(int) + offset).astype(str)
 
     out = pd.DataFrame({
         'Region': tbl['Reg'].map(region_map).values,
+        'Rural': tbl['UrbRur'].map(urbrur_map).values,
         'Ecological_zone': tbl['EcoZone'].map(zone_map).values,
     }, index=pd.Index(tbl['v'].values, name='v'))
 
     unmapped = tbl.loc[out['Region'].isna().values, 'Reg'].unique()
     assert len(unmapped) == 0, f'unmapped region abbreviations: {list(unmapped)}'
+    bad_ur = tbl.loc[out['Rural'].isna().values, 'UrbRur'].unique()
+    assert len(bad_ur) == 0, f'unmapped urb/rur abbreviations: {list(bad_ur)}'
     return out

--- a/lsms_library/countries/GhanaLSS/_/ghanalss.py
+++ b/lsms_library/countries/GhanaLSS/_/ghanalss.py
@@ -438,13 +438,23 @@ def appendix_i_cluster_attributes(year_column, offset):
     Returns
     -------
     DataFrame indexed by ``v`` (zero-free string ``CLUST``) with columns
-    ``Region`` and ``Ecological_zone``.
+    ``Region``, ``Rural`` and ``Ecological_zone``.
 
-    ``Rural`` IS returned, as of GH #682: the canonical vocabulary gained a
-    ``Semi-urban`` value, so the Appendix's three-way U / R / SU no longer has
-    to be folded onto two.  ``SU`` is 52 of 263 clusters (20%); folding it
-    would have destroyed a distinction the survey drew and made the 9-stratum
-    design (3 ecological zones x 3 settlement classes) unreconstructible.
+    ``Rural`` IS returned, folded to the canonical binary {Urban, Rural} by
+    the ``urbrur_abbrev`` table in the same org file.  The Appendix classifies
+    clusters THREE ways -- U / R / SU (semi-urban, 52 of 263 clusters, 20%) --
+    and ``SU`` is delivered as ``Rural`` **by decision** (@ligon, 2026-08-21).
+
+    That is a judgement call and **the survey offers no evidence either way**.
+    The GLSS2 7-way ``rural`` table's ``Classification`` column was cited on
+    GH #690 as precedent for folding a middle tier to Rural; it is *editorial,
+    not on the questionnaire* (GH #692), and it decodes ``Y01C:NRCPL`` -- a
+    *non-resident child's* place of residence, not the household's settlement
+    class.  Do not cite it.
+
+    The U/R/SU distinction IS lost in the delivered column.  The raw three-way
+    survives in the ``UrbRur`` column of ``_/appendix_i_clusters.org`` for
+    anyone who needs it.
     """
     # countries_root() honours LSMS_COUNTRIES_ROOT; a hardcoded
     # files("lsms_library")/"countries" would silently read the installed

--- a/lsms_library/data_info.yml
+++ b/lsms_library/data_info.yml
@@ -152,20 +152,6 @@ Columns:
         # stratum is entirely metro=1), so there is no evidence they are urban.
         # Kept as a distinct, VISIBLE value rather than guessed away.  GH #602.
         Informal: []
-        # Third settlement stratum #2: a settlement-size tier BETWEEN village and
-        # town, named as such by the producer.  Used by GhanaLSS GLSS1/GLSS2
-        # (BID Appendix I stratifies every cluster U / R / SU -- 52 of 263
-        # clusters, 20%) and nowhere else at present.  GH #682/#685.
-        #
-        # NOT the same concept as `Informal` above: that is a formality/tenure
-        # class (squatter settlement), this is settlement SIZE.  Do not merge
-        # them, and do not reach for this for a WITHIN-URBAN tier -- Iraq's
-        # metropolitan, Ethiopia's large/small town, Mali's Bamako and Niger's
-        # Communaute Urbaine are all sub-divisions of Urban, not a middle
-        # category.  Those want a separate `SettlementType` column (#682 s7.3);
-        # folding them here would make one column carry four vocabularies and
-        # break the `== 'Urban'` filter that works today.
-        Semi-urban: [semi-urban, Semi-Urban, SEMI-URBAN, SU, semi urban]
   cluster_features:
     Region:
       type: str
@@ -190,20 +176,6 @@ Columns:
         # stratum is entirely metro=1), so there is no evidence they are urban.
         # Kept as a distinct, VISIBLE value rather than guessed away.  GH #602.
         Informal: []
-        # Third settlement stratum #2: a settlement-size tier BETWEEN village and
-        # town, named as such by the producer.  Used by GhanaLSS GLSS1/GLSS2
-        # (BID Appendix I stratifies every cluster U / R / SU -- 52 of 263
-        # clusters, 20%) and nowhere else at present.  GH #682/#685.
-        #
-        # NOT the same concept as `Informal` above: that is a formality/tenure
-        # class (squatter settlement), this is settlement SIZE.  Do not merge
-        # them, and do not reach for this for a WITHIN-URBAN tier -- Iraq's
-        # metropolitan, Ethiopia's large/small town, Mali's Bamako and Niger's
-        # Communaute Urbaine are all sub-divisions of Urban, not a middle
-        # category.  Those want a separate `SettlementType` column (#682 s7.3);
-        # folding them here would make one column carry four vocabularies and
-        # break the `== 'Urban'` filter that works today.
-        Semi-urban: [semi-urban, Semi-Urban, SEMI-URBAN, SU, semi urban]
     District:
       type: str
     Latitude:

--- a/lsms_library/data_info.yml
+++ b/lsms_library/data_info.yml
@@ -152,6 +152,20 @@ Columns:
         # stratum is entirely metro=1), so there is no evidence they are urban.
         # Kept as a distinct, VISIBLE value rather than guessed away.  GH #602.
         Informal: []
+        # Third settlement stratum #2: a settlement-size tier BETWEEN village and
+        # town, named as such by the producer.  Used by GhanaLSS GLSS1/GLSS2
+        # (BID Appendix I stratifies every cluster U / R / SU -- 52 of 263
+        # clusters, 20%) and nowhere else at present.  GH #682/#685.
+        #
+        # NOT the same concept as `Informal` above: that is a formality/tenure
+        # class (squatter settlement), this is settlement SIZE.  Do not merge
+        # them, and do not reach for this for a WITHIN-URBAN tier -- Iraq's
+        # metropolitan, Ethiopia's large/small town, Mali's Bamako and Niger's
+        # Communaute Urbaine are all sub-divisions of Urban, not a middle
+        # category.  Those want a separate `SettlementType` column (#682 s7.3);
+        # folding them here would make one column carry four vocabularies and
+        # break the `== 'Urban'` filter that works today.
+        Semi-urban: [semi-urban, Semi-Urban, SEMI-URBAN, SU, semi urban]
   cluster_features:
     Region:
       type: str
@@ -176,6 +190,20 @@ Columns:
         # stratum is entirely metro=1), so there is no evidence they are urban.
         # Kept as a distinct, VISIBLE value rather than guessed away.  GH #602.
         Informal: []
+        # Third settlement stratum #2: a settlement-size tier BETWEEN village and
+        # town, named as such by the producer.  Used by GhanaLSS GLSS1/GLSS2
+        # (BID Appendix I stratifies every cluster U / R / SU -- 52 of 263
+        # clusters, 20%) and nowhere else at present.  GH #682/#685.
+        #
+        # NOT the same concept as `Informal` above: that is a formality/tenure
+        # class (squatter settlement), this is settlement SIZE.  Do not merge
+        # them, and do not reach for this for a WITHIN-URBAN tier -- Iraq's
+        # metropolitan, Ethiopia's large/small town, Mali's Bamako and Niger's
+        # Communaute Urbaine are all sub-divisions of Urban, not a middle
+        # category.  Those want a separate `SettlementType` column (#682 s7.3);
+        # folding them here would make one column carry four vocabularies and
+        # break the `== 'Urban'` filter that works today.
+        Semi-urban: [semi-urban, Semi-Urban, SEMI-URBAN, SU, semi urban]
     District:
       type: str
     Latitude:


### PR DESCRIPTION
Wires GLSS1/GLSS2 `Rural`, which was **100% NULL** — 6,341 households and 346 clusters — because those waves ship no urban/rural variable at all. The classification comes from **BID Appendix I**, which stratifies every cluster three ways (`U` / `R` / `SU`).

**`SU` is delivered as `Rural`.** Canonical `Rural` stays the binary `{Urban, Rural}`.

> **Reworked 2026-08-22.** The original version of this PR added a canonical `Semi-urban` value. Per @ligon's decisions (#issuecomment-5377752999) and the correction at #issuecomment-5377957173, that is **withdrawn**: `lsms_library/data_info.yml` is now byte-identical to `development`.

## The fold is a judgement call, and the survey does not settle it

@ligon's call, 2026-08-21. **The survey offers no evidence either way**, and the evidence originally offered for it is void:

- The GLSS2 7-way `rural` table's `Classification` column — cited earlier on this PR as this country's own precedent for folding a middle tier to Rural (`Small Town → Rural`) — is **editorial**. It is not on the questionnaire.
- That table isn't about settlement class at all. It decodes `Y01C:NRCPL`, a **non-resident child's** place of residence (#692, PR #696).

**Do not cite it.** What the survey *does* say is a size band — GLSS1's Sampling Procedure defines urban as >5,000, semi-urban 1,500–5,000, rural <1,500. That sharpens what is being lost; it takes no position on a two-value collapse. (Recorded in `CONTENTS.org`, flagged second-hand: transcribed from the #601 sweep, not re-verified against that CID-encoded PDF here.)

## What is lost, stated plainly

**The U/R/SU distinction is gone from the delivered `Rural` column.** It is not recoverable from `sample()` or `cluster_features()`. GLSS1/GLSS2's design is 9 strata (3 ecological zones × 3 settlement classes) and the settlement axis now reaches the API as 2 values. This is a real loss, not a re-expression.

The raw three-way **is preserved** in the `UrbRur` column of `_/appendix_i_clusters.org`, which is where anyone reconstructing the design should read it.

## Scope

**Out:** both `Semi-urban` hunks from `lsms_library/data_info.yml`. That canonical file is the only mechanism by which this branch could affect another country, so reverting it is the structural proof that none can move.

**Kept as-is:** the `urbrur_abbrev` mechanism — an explicit org table read by `ghanalss.py` with asserts (non-empty dict; no unmapped abbreviation). No `Code` key, no auto-mapping, **fails loudly** rather than shipping a null column, which is this country's most expensive recurring defect (`CONTENTS.org` Traps 1 and 4).

**Rejected, do not revive** (both proposed and withdrawn during review): a country-level `rural` categorical table — measured, it makes 1987-88 and 2005-06 inherit a table they don't have today, the Trap 4 shape — and a `Preferred Label` / `Settlement Label` rename.

**Prose corrected.** The docstrings and caveats argued for `Semi-urban` ("folding it would have destroyed a distinction the survey drew and made the 9-stratum design unreconstructible"). All replaced. `CONTENTS.org` gains *"The `SU` → `Rural` fold: a decision with no survey evidence"*, and Trap 3's now-false tail is marked superseded rather than deleted.

Also fixed while in those tables: GLSS1/GLSS2 no longer read "Not available", and GLSS5's source is `parta/sec7.dta` (PR #687) — not `pov_gh5.dta`, which that wave's own YAML records as a **decoy** (same rows, no `hhid` to join on).

## Verified cold — private empty `LSMS_DATA_DIR`, `PYTHONPATH` asserted

| | before (`development`) | after |
|---|---|---|
| `sample().Rural` 1987-88 | 3,147 NA | 1,965 Rural / 1,182 Urban |
| `sample().Rural` 1988-89 | 3,194 NA | 2,124 Rural / 1,070 Urban |
| `sample().Rural` all 7 waves | **6,341 NA** | **0 NA**, 56,330 rows |
| `cluster_features().Rural` 1987-88 | 176 NA | **111 Rural / 65 Urban** |
| `cluster_features().Rural` 1988-89 | 170 NA | **114 Rural / 56 Urban** |
| `cluster_features().Rural` all 7 waves | 346 NA | **0 NA**, 3,791 rows |

- **Vocabulary is exactly `{Urban, Rural}`** in both tables, every wave — no `Semi-urban`, no raw `U`/`R`/`SU` leak. Asserted, not eyeballed.
- **All 52 `SU` clusters land in `Rural`.** They are 52 unique Appendix rows → **72 wave-cells** (36 in `yr1`, 36 in `yr2`, 20 bridging both years); every one delivers `Rural`. All 95 `U` cells → Urban, all 116 `R` cells → Rural. So `111 = 75 R + 36 SU` and `114 = 78 R + 36 SU`.
- **Appendix-absent clusters keep `Rural` NA** — proven by driving both hooks with a synthetic cluster id, since no real cluster exercises it (Appendix matches 176/176 and 170/170).
- **`LSMS_GRAIN_STRICT=1`: 0 grain reports, 0 `GrainCollapseWarning`s.**
- **Corpus:** 34 countries, 57 `(country, table)` cells with a delivered `Rural`, 491,690 rows — **0 cells differ** between the two library trees. South Africa's `Informal` intact (2 clusters / 83 households).
- `test_schema_consistency.py` + `test_declared_spellings.py`: **237 passed**.

Refs #682. **Closes #685.**
