### PR TITLE
feat(#682/#685): generalise query-time `labels=` beyond food's `j` index level

### DIFF
--- a/.coder/ledger/682-label-selection.md
+++ b/.coder/ledger/682-label-selection.md
@@ -1,0 +1,149 @@
+# Prior-Art Ledger — #682 / #685: query-time label selection beyond `j`
+
+> Per-task ledger. Inherits the repo §0 baseline in `STANDING.md` — this file
+> cites it, `CLAUDE.md` and `lsms_library/data_info.yml` rather than re-copying.
+
+**Search tier used:** ripgrep + git floor. **gitnexus was unavailable in this
+session** — the MCP `gitnexus_*` tools are not exposed to this agent (a
+`ToolSearch` for them returns only unrelated tools), so no
+`gitnexus_impact` / `gitnexus_detect_changes` could be run. The caller census in
+§2 is a `rg` sweep over `lsms_library/` + `tests/` and is complete for the four
+symbols touched.
+
+## §1 Task, restated
+
+The library already lets a caller pick a *label variant* for the `j` (item)
+index level of a food table: `Country('Uganda').food_expenditures(labels='Aggregate')`
+renames `j` from `harmonize_food`'s `Preferred Label` to its `Aggregate Label`.
+The mechanism is `Country._relabel_j` (`lsms_library/country.py:2315`), applied
+to the finished frame.
+
+This task gives the same *user-facing affordance* to non-food, non-`j` targets —
+the motivating one being the `Rural` **column** of `sample()` / `cluster_features()`,
+where a survey's finer settlement ladder (City / Large Town / … / Small Village)
+should be selectable while `Rural` keeps its canonical binary vocabulary
+(`data_info.yml` → `sample.Rural.spellings` / `cluster_features.Rural.spellings`:
+`{Urban, Rural}` plus `Informal`).
+
+It is **PR 1 of 2**: core only. No country config is wired here — GhanaLSS
+GLSS1/GLSS2 (#685) is a separate agent's change on top.
+
+## §2 Existing machinery (this task's area)
+
+| symbol | path:line | what it does | tested? | reuse / extend / new |
+|--------|-----------|--------------|---------|----------------------|
+| `Country._relabel_j` | `country.py:2315` | food's fine→coarse relabel of `j`, keyed on `Preferred Label`; owns the `LabelUnavailableError` vs `KeyError` taxonomy | `tests/test_food_labels.py` | **unchanged** (see §5) |
+| `Country._apply_categorical_mappings` | `country.py:2236` | auto-applies each `categorical_mapping` table whose name matches a column/index level, mapping **raw source value → `Preferred Label`**, keyed on `source_cols[0]` | indirectly, corpus-wide | **extend** — the implementation point |
+| `_build_replace_dict` (nested in the above) | `country.py:2261` | builds `{source_cols[0] value: Preferred Label}` | as above | extend (`target=` param) |
+| `_augment_numeric_code_keys` | `country.py:~95` | additively registers `'1'`/`'1.0'` variants of integer keys (GH #223 L2) | yes | reuse unchanged |
+| `_RESERVED_U_SENTINELS` / `protect_u_sentinels=` | `country.py:85`, `2236` | forbids a country `u` table remapping the `'kg'`/`'Value'` conversion tags (GH #361) | `tests/test_global_u_org.py` | reuse unchanged |
+| `Country._finalize_result` | `country.py:2375` | the single post-read pipeline; calls `_apply_categorical_mappings` at `country.py:2447` | integration surface | extend (`labels=` param) |
+| `Country.__getattr__`'s generated `method()` | `country.py:3735` | the public per-table method; owns the `labels=` kwarg today | many | extend (dict form) |
+| `LabelUnavailableError` | `errors.py:9` | `KeyError` subclass; `Feature` catches it to degrade | `tests/test_feature.py` | reuse unchanged |
+| `Feature.__call__` label degradation | `feature.py:514-580` | drops `LabelUnavailableError` countries, warns once, sets `attrs['labels_unavailable']` | yes | wording generalised only |
+| `build_transform` / `build_transforms_fingerprint` | `_build_registry.py:69`, `335` | folds the *source AST* of every tagged build entry point into `lsms_cache_hash` | `tests/test_build_transform_hash.py` | **constraint**, see §4 |
+
+## §3 Definitions & conventions in force
+
+- **Canonical `Rural` vocabulary** — `lsms_library/data_info.yml`,
+  `Index Info → sample.Rural.spellings` and `cluster_features.Rural.spellings`.
+  Not restated here.
+- **Categorical mapping auto-dispatch** — "If a column/index name in a returned
+  DataFrame matches a table name in the country's `categorical_mapping.org`
+  (case-insensitive) and that table has a `Preferred Label` column, the mapping
+  is applied automatically" (`CLAUDE.md` §"Canonical Schema").
+- **Cache exclusion class** — "*Excluded by design* (they re-run post-read,
+  never touching the parquet): `_finalize_result`, kinship, spellings,
+  categorical mappings" (`CLAUDE.md` §"Cache Behavior"). Verified, with a
+  caveat, in §4.
+- **`labels=` on the generated methods** — current contract in the generated
+  docstring, `country.py:3906`.
+- **Error taxonomy** — `errors.py:9` docstring: `LabelUnavailableError` =
+  missing *curation* (degradable by `Feature`); plain `KeyError` = malformed
+  table or a caller asking for a target that is not there (loud).
+- Repo-wide conventions (IO sanctions, pandas 3.0, `attrs['id_converted']`):
+  per `STANDING.md` §3/§4 and `CLAUDE.md`.
+
+## §4 Invariants & assumptions
+
+Repo-wide ones per `STANDING.md §4`. Task-specific:
+
+1. **`Preferred Label` → variant is one-to-many for `Rural`, so no output-side
+   relabel can work.** `_relabel_j` keys on `Preferred Label`; for a 7-way
+   settlement ladder that has 2 distinct `Preferred Label` values, `.to_dict()`
+   is last-row-wins and yields `{'Urban': 'Medium Town', 'Rural': 'Other'}`.
+   Measured; see `docs/design/label_selection.md`. This is *why* the
+   implementation point is the mapping site, where the raw code still exists.
+
+2. **`_aggregate_wave_data` is `@build_transform()`-tagged, so its source AST is
+   part of every `lsms_cache_hash`.** Measured counterfactual: adding one
+   defaulted keyword argument to its signature changes
+   `build_transforms_fingerprint(None)` `8bc39689… → ace7b84a…` and every
+   per-table fingerprint with it. `_finalize_result`,
+   `_apply_categorical_mappings`, `_relabel_j` and `Country.__getattr__` are all
+   **outside** the closure walk (`_finalize_result` is explicitly in
+   `_EXCLUDED_CALLABLES`, `_build_registry.py:127`). Therefore: label selection
+   must **not** be threaded through `_aggregate_wave_data`'s signature.
+
+3. **`_finalize_result` re-enters itself.** `_join_v_from_sample`
+   (`country.py:2412`) and `_location_lookup` fetch other tables, each of which
+   finalizes. Any out-of-band label channel must be **keyed on the requesting
+   `method_name`** or it leaks into those nested reads.
+
+4. **`source_cols[0]` ordering is load-bearing and unguarded.** The key column is
+   "the first column that is not `Preferred Label`". Reordering a table's columns
+   silently changes what it keys on.
+
+5. **A `Code`-keyed mapping table is only safe at country/wave scope.** Codes are
+   survey-specific (Iraq's `1` is not Ghana's `1`), and
+   `_augment_numeric_code_keys` widens the blast radius by also registering
+   `'1'`/`'1.0'`. Global tables under `lsms_library/categorical_mapping/` are
+   label-keyed today (`Alternate Spelling`, `Original Label`) with **one
+   exception**: `ehcvm_units.org` is `Code`-keyed — defensible because EHCVM is a
+   single multi-country instrument with one shared code list, but it means a
+   blanket assertion cannot be added without an allowlist. **Documented, not
+   enforced** — see §6.
+
+6. **`attrs['id_converted']` must survive** the mapping step
+   (`STANDING.md §4`; `CLAUDE.md` §"Panel ID Transitive Chains").
+
+## §5 Reuse decision
+
+| quantity | decision | reason |
+|----------|----------|--------|
+| food `j` fine→coarse relabel | **reuse, unchanged** | `_relabel_j` is correct for a function-shaped canonical→variant map; §4.1 says it is *structurally* wrong for coarse→fine |
+| raw-code → chosen label variant | **extend `_apply_categorical_mappings`** | the only point at which the raw code still exists (§4.1); reuses `_build_replace_dict`, `_augment_numeric_code_keys`, `protect_u_sentinels` |
+| error taxonomy | **reuse `LabelUnavailableError`** | `Feature`'s degradation contract (`feature.py:556`) depends on it; new code raises the same two classes for the same two reasons |
+| carrying the request from `method()` to the mapping site | **new (`contextvars.ContextVar`, method-name-scoped)** | §4.2: the only parameter route crosses a build-tagged orchestrator and would invalidate every cache in the corpus. §4.3 forces the method-name scoping. Explicit `labels=` params still exist on `_finalize_result` and `_apply_categorical_mappings`; the ContextVar covers exactly one hop |
+| cache invalidation | **reuse (none needed)** | selection is post-read; proven by an unchanged fingerprint |
+
+## §6 Open questions for the human
+
+- **Should a `Code`-keyed table at *global* scope be rejected?** (§4.5) It would
+  need an allowlist for `ehcvm_units.org`. Out of scope for a contained core
+  change; noted for follow-up.
+- **`Feature('sample')(labels={'Rural': …})` warns rather than degrading for
+  countries whose `sample` has no `Rural` column at all.** That follows from
+  making an absent target a plain `KeyError`, consistent with the existing
+  "result has no `'j'` index level" rule. If the graceful drop is wanted for
+  absent targets too, that is a one-line change of exception class — but it
+  would also change the `j` behaviour, so it is a deliberate decision, not a
+  default.
+
+---
+### Phase 3 — verification
+
+- `Country._apply_categorical_mappings` — **OK (anchored on §2/§4.1/§4.4)**:
+  extended with `labels=`; key selection now excludes the *target* column as
+  well as `Preferred Label`, a provable no-op when the target *is*
+  `Preferred Label` (pinned by `test_source_cols_ordering_is_the_key_column`).
+- `Country._finalize_result` — **OK (§4.2/§4.3)**: gains `labels=`, falls back to
+  the method-name-scoped ContextVar. Outside the build closure, so no hash change
+  (pinned by `test_label_selection_is_outside_the_build_fingerprint`).
+- `_label_selection` / `_LABEL_SELECTION` — **OK (§5, "new")**: justified by §4.2;
+  not a reinvention (nothing else in the repo carries read-path request state).
+- `_split_labels_arg` / `_label_targets_missing` — **OK (§2)**: new helpers, no
+  existing equivalent; `_split_labels_arg` preserves the scalar contract byte-for-byte.
+- `Country._relabel_j` — **OK (§5)**: unchanged.
+- `Feature._mark_labels_unavailable` — **OK (§2)**: warning wording generalised
+  from "food-label column" to "label column"; contract unchanged.

--- a/.coder/ledger/682-label-selection.md
+++ b/.coder/ledger/682-label-selection.md
@@ -29,10 +29,15 @@ GLSS1/GLSS2, but the GLSS2 7-way `rural` table was subsequently shown to decode
 `Y01C:NRCPL` — Household Questionnaire §1 Part C col. 13, *"Where does
 he/she live?"* for a **non-resident child** — i.e. a migration attribute, not a
 classification of the household's own settlement. GhanaLSS has no settlement
-ladder to preserve. The mechanism is still wanted for the audit's class-A cells,
-which are unaffected: **Iraq 2006-07** (measured here: 7 raw `xstrat` tiers →
-2 delivered values, 12,194 households in one bucket), Ethiopia ESS2/ESS3,
-Mali, Niger, Kazakhstan 1996.
+ladder to preserve. (#690/#691 have since merged: GLSS1/GLSS2 `Rural` is wired
+with `SU` folded to `Rural`, and no canonical `Semi-urban` was added.) The
+mechanism is still wanted for the audit's class-A cells, which are unaffected:
+**Iraq 2006-07** (measured here: 7 raw `xstrat` tiers → 2 delivered values,
+12,194 households in one bucket), Ethiopia ESS2/ESS3, Mali, Niger,
+Kazakhstan 1996. #704 additionally found that the obstacle to a *shared*
+settlement vocabulary is entity variation (locality vs. enumeration area vs.
+commune), not threshold variation — which argues for per-country label
+selection over any single harmonised ladder.
 
 It is **core only**. No country config is wired here, and none of the class-A
 cells is wired either — Iraq's `Rural` currently decodes through an inline
@@ -75,8 +80,10 @@ is a separate wiring change.
 - **`labels=` on the generated methods** — current contract in the generated
   docstring, `country.py:3906`.
 - **Error taxonomy** — `errors.py:9` docstring: `LabelUnavailableError` =
-  missing *curation* (degradable by `Feature`); plain `KeyError` = malformed
-  table or a caller asking for a target that is not there (loud).
+  missing *curation*, degradable by `Feature`; plain `KeyError` = a *defect*,
+  loud. As of the 2026-08-22 decision (§6) an absent target counts as missing
+  curation, so "defect" means specifically a malformed mapping table — and, for
+  the scalar form only, a food frame with no `j` level (§4.9).
 - Repo-wide conventions (IO sanctions, pandas 3.0, `attrs['id_converted']`):
   per `STANDING.md` §3/§4 and `CLAUDE.md`.
 
@@ -132,6 +139,16 @@ Repo-wide ones per `STANDING.md §4`. Task-specific:
    consults it. A wave-level table therefore cannot be selected with `labels=`.
    Verified, not assumed.
 
+9. **Absence and defect are the axis, not curation and structure.** An absent
+   target and an absent label column are one case (`LabelUnavailableError`,
+   degradable); a malformed table is the other (plain `KeyError`, loud). The
+   scalar form's "no `'j'` index level" stays loud because `j` is *required*
+   wherever it exists (`data_info.yml`), so its absence is a defect in the
+   frame — whereas `Rural` is explicitly not required on `sample`, so its
+   absence is a coverage fact. Pinned by
+   `test_relabel_j_no_j_level_stays_a_plain_keyerror` and
+   `test_absent_target_and_absent_label_column_raise_the_SAME_class`.
+
 8. **Two live defects sit in the same neighbourhood and are deliberately NOT
    touched here** (owned elsewhere): **#693** — `#+begin_example` blocks in a
    global `.org` are parsed as live tables by `all_dfs_from_orgfile`
@@ -156,13 +173,17 @@ Repo-wide ones per `STANDING.md §4`. Task-specific:
 - **Should a `Code`-keyed table at *global* scope be rejected?** (§4.5) It would
   need an allowlist for `ehcvm_units.org`. Out of scope for a contained core
   change; noted for follow-up.
-- **`Feature('sample')(labels={'Rural': …})` warns rather than degrading for
-  countries whose `sample` has no `Rural` column at all.** That follows from
-  making an absent target a plain `KeyError`, consistent with the existing
-  "result has no `'j'` index level" rule. If the graceful drop is wanted for
-  absent targets too, that is a one-line change of exception class — but it
-  would also change the `j` behaviour, so it is a deliberate decision, not a
-  default.
+- ~~**`Feature('sample')(labels={'Rural': …})` warns rather than degrading for
+  countries whose `sample` has no `Rural` column at all.**~~ **RESOLVED
+  2026-08-22, @ligon: degrade gracefully.** An absent target now raises
+  `LabelUnavailableError` like any other curation gap. Rationale: a country
+  simply not having the column is what `Feature` was built to degrade over, and
+  it is indistinguishable *to the caller* from a country that has the column but
+  not the requested variant. The malformed-table case stays a plain `KeyError`;
+  that is the distinction that matters and it is unchanged.
+  `_relabel_j`'s "no `'j'` index level" was re-examined and deliberately **not**
+  flipped — `j` is required wherever it exists, so its absence is a structural
+  defect rather than a coverage fact (§4.9).
 
 ---
 ### Phase 3 — verification
@@ -178,6 +199,9 @@ Repo-wide ones per `STANDING.md §4`. Task-specific:
   not a reinvention (nothing else in the repo carries read-path request state).
 - `_split_labels_arg` / `_label_targets_missing` — **OK (§2)**: new helpers, no
   existing equivalent; `_split_labels_arg` preserves the scalar contract byte-for-byte.
+- `_assert_label_targets_present` — **OK (§4.9)**: raises `LabelUnavailableError`,
+  per the 2026-08-22 decision in §6; the malformed-table plain `KeyError` and
+  `_relabel_j`'s no-`j` plain `KeyError` are untouched and separately pinned.
 - `Country._relabel_j` — **OK (§5)**: unchanged.
 - `Feature._mark_labels_unavailable` — **OK (§2)**: warning wording generalised
   from "food-label column" to "label column"; contract unchanged.

--- a/.coder/ledger/682-label-selection.md
+++ b/.coder/ledger/682-label-selection.md
@@ -20,13 +20,24 @@ to the finished frame.
 
 This task gives the same *user-facing affordance* to non-food, non-`j` targets —
 the motivating one being the `Rural` **column** of `sample()` / `cluster_features()`,
-where a survey's finer settlement ladder (City / Large Town / … / Small Village)
-should be selectable while `Rural` keeps its canonical binary vocabulary
-(`data_info.yml` → `sample.Rural.spellings` / `cluster_features.Rural.spellings`:
-`{Urban, Rural}` plus `Informal`).
+where a survey's finer settlement ladder should be selectable while `Rural` keeps
+its canonical binary vocabulary (`data_info.yml` → `sample.Rural.spellings` /
+`cluster_features.Rural.spellings`: `{Urban, Rural}` plus `Informal`).
 
-It is **PR 1 of 2**: core only. No country config is wired here — GhanaLSS
-GLSS1/GLSS2 (#685) is a separate agent's change on top.
+**Motivation re-pointed mid-task (2026-08-21).** The brief opened on GhanaLSS
+GLSS1/GLSS2, but the GLSS2 7-way `rural` table was subsequently shown to decode
+`Y01C:NRCPL` — Household Questionnaire §1 Part C col. 13, *"Where does
+he/she live?"* for a **non-resident child** — i.e. a migration attribute, not a
+classification of the household's own settlement. GhanaLSS has no settlement
+ladder to preserve. The mechanism is still wanted for the audit's class-A cells,
+which are unaffected: **Iraq 2006-07** (measured here: 7 raw `xstrat` tiers →
+2 delivered values, 12,194 households in one bucket), Ethiopia ESS2/ESS3,
+Mali, Niger, Kazakhstan 1996.
+
+It is **core only**. No country config is wired here, and none of the class-A
+cells is wired either — Iraq's `Rural` currently decodes through an inline
+`mapping:` dict in its wave YAML (route 4 below), so using this mechanism there
+is a separate wiring change.
 
 ## §2 Existing machinery (this task's area)
 
@@ -51,7 +62,12 @@ GLSS1/GLSS2 (#685) is a separate agent's change on top.
 - **Categorical mapping auto-dispatch** — "If a column/index name in a returned
   DataFrame matches a table name in the country's `categorical_mapping.org`
   (case-insensitive) and that table has a `Preferred Label` column, the mapping
-  is applied automatically" (`CLAUDE.md` §"Canonical Schema").
+  is applied automatically" (`CLAUDE.md` §"Canonical Schema"). This is **route 1**
+  of four decode routes; see `docs/guide/label-selection.md` §"Which decode path
+  this extends". The other three — an explicit `mappings:` key in wave YAML
+  (2 occurrences corpus-wide), `tools.code_label_map` consumed by a wave's own
+  formatter (`GhanaLSS/1991-92/_/mapping.py`), and an inline `mapping:` dict under
+  a `myvars` entry (Iraq's `Rural`, Malawi's housing) — are untouched.
 - **Cache exclusion class** — "*Excluded by design* (they re-run post-read,
   never touching the parquet): `_finalize_result`, kinship, spellings,
   categorical mappings" (`CLAUDE.md` §"Cache Behavior"). Verified, with a
@@ -72,7 +88,7 @@ Repo-wide ones per `STANDING.md §4`. Task-specific:
    relabel can work.** `_relabel_j` keys on `Preferred Label`; for a 7-way
    settlement ladder that has 2 distinct `Preferred Label` values, `.to_dict()`
    is last-row-wins and yields `{'Urban': 'Medium Town', 'Rural': 'Other'}`.
-   Measured; see `docs/design/label_selection.md`. This is *why* the
+   Measured; see `docs/guide/label-selection.md`. This is *why* the
    implementation point is the mapping site, where the raw code still exists.
 
 2. **`_aggregate_wave_data` is `@build_transform()`-tagged, so its source AST is
@@ -106,6 +122,24 @@ Repo-wide ones per `STANDING.md §4`. Task-specific:
 
 6. **`attrs['id_converted']` must survive** the mapping step
    (`STANDING.md §4`; `CLAUDE.md` §"Panel ID Transitive Chains").
+
+7. **Route 1 is country ∪ global scope, never wave.**
+   `_apply_categorical_mappings` reads `Country.categorical_mapping`
+   (`country.py:1637`), which merges `lsms_library/categorical_mapping/*.org`
+   with `{country}/_/categorical_mapping.org` and never opens a wave directory.
+   `Wave.categorical_mapping` (`country.py:862`) layers the wave's own tables on
+   top by plain `dict.update`, but nothing on the `Country(...)` read path
+   consults it. A wave-level table therefore cannot be selected with `labels=`.
+   Verified, not assumed.
+
+8. **Two live defects sit in the same neighbourhood and are deliberately NOT
+   touched here** (owned elsewhere): **#693** — `#+begin_example` blocks in a
+   global `.org` are parsed as live tables by `all_dfs_from_orgfile`
+   (`canonical_housing_labels.org`, 2 instances); **#694** — the unguarded
+   `df[col].str.strip()` inside `_apply_categorical_mappings` nulls non-string
+   values in an object column. The selection path reuses the *same* strip call,
+   so it neither worsens nor fixes #694, and #693's tables are label-keyed so
+   their key-column resolution is unchanged.
 
 ## §5 Reuse decision
 

--- a/docs/guide/label-selection.md
+++ b/docs/guide/label-selection.md
@@ -30,6 +30,15 @@ Mali (Bamako / autre urbain / rural), Niger (Communauté Urbaine / urbain /
 rural) and Kazakhstan 1996 — see the corpus-wide audit in
 [#682], class A.
 
+And a shared *vocabulary* would not fix it. A later corpus sweep ([#704]) found
+that what defeats cross-country settlement harmonisation is variation in the
+**entity being classified** — locality vs. enumeration area vs. commune — not
+variation in the population threshold. Two surveys can agree on the word "town"
+and still be classifying different objects. That is an argument for exactly
+this design: a per-country label column, selected by name at query time, with
+no pretence that one country's ladder means the same thing as another's. The
+canonical binary stays the only cross-country claim the library makes.
+
 `labels=` is the query-time escape hatch: the canonical value stays canonical,
 and a caller who wants the tier asks for it.
 
@@ -148,19 +157,43 @@ Two rules about that table:
 | situation | raises | `Feature` behaviour |
 |---|---|---|
 | country curates no such mapping table, or no such label column | `LabelUnavailableError` (a `KeyError` subclass) | drops the country, one aggregated warning, `df.attrs['labels_unavailable']` |
+| the result has no such column or index level | `LabelUnavailableError` | **same** — drops the country |
 | table exists but has no `Preferred Label`, or no key column left | plain `KeyError` | surfaces as a per-country "Failed to load" warning |
-| the result has no such column or index level | plain `KeyError` | as above |
 | `labels=` is neither a `str` nor a dict, or a dict value is not a `str` | `TypeError` | as above |
 
-The distinction is the point: *missing curation* is a normal state of the
-corpus and `Feature` degrades over it; a *malformed table* or a *target that
-isn't there* is a defect and stays loud.
+The distinction that matters is **absence vs. defect**. *Missing curation* — a
+country that curates no such label column, or has no such column at all — is a
+normal state of the corpus, and `Feature` degrades over it. A *malformed table*
+is a defect in curated config, and stays loud.
 
-One consequence worth stating plainly: `Rural` is not a required column of
-`sample`, so `Feature('sample')(labels={'Rural': …})` warns "Failed to load"
-for countries whose `sample` has no `Rural` column at all, rather than dropping
-them gracefully. That follows from making an absent target a plain `KeyError`,
-consistent with `_relabel_j`'s existing "result has no `'j'` index level".
+The first two rows are deliberately one case. A caller cannot tell them apart:
+`Rural` is not a required column of `sample` — "many countries' sample table
+carries only (v, weight, strata) and has no urban/rural indicator at all"
+(`lsms_library/data_info.yml`) — so a country lacking the column is a coverage
+fact about that country, exactly like a country lacking the label variant. A
+column that genuinely *is* declared required going missing is the business of
+the required-column guards (`Country._assert_built_required_columns`, the
+`grab_data` dropped-sub-df guard), which fire on the build path and say so
+loudly; it is not `labels=`'s job to re-report it.
+
+### Why the scalar form's "no `j`" case is *not* the same
+
+`_relabel_j` still raises a plain `KeyError` when the result has no `j` index
+level, and that asymmetry is intentional:
+
+- A **dict** names its target, and the target it names is typically an
+  *optional* column. Its absence is a coverage fact — missing curation.
+- A **scalar** names no target. `j` is implicit, and it is implicit because the
+  caller is asking for a *food* relabel. `j` is required on every table that has
+  one, so a food table without `j` is a structural defect of the frame, not a
+  country that never curated something. Degrading it would drop the country
+  from a `Feature` assembly under a warning naming the wrong cause.
+
+That branch is also near-unreachable: the registered-table path guards the call
+with `if 'j' in result.index.names`, and the derived-food path only reaches it
+for tables that have `j` by construction. It is a defensive guard, and
+weakening a defensive guard to match an unrelated case buys nothing. Pinned by
+`test_relabel_j_no_j_level_stays_a_plain_keyerror`.
 
 ---
 
@@ -274,3 +307,4 @@ Verification, both ways:
 [#682]: https://github.com/ligon/LSMS_Library/pull/682
 [#693]: https://github.com/ligon/LSMS_Library/issues/693
 [#694]: https://github.com/ligon/LSMS_Library/issues/694
+[#704]: https://github.com/ligon/LSMS_Library/pull/704

--- a/docs/guide/label-selection.md
+++ b/docs/guide/label-selection.md
@@ -1,0 +1,276 @@
+# Label selection (`labels=`)
+
+Surveys often classify the same thing at two resolutions: a canonical one the
+library harmonizes across countries, and a finer one the producer actually
+recorded. `labels=` lets a caller ask for the finer one at query time, without
+the canonical vocabulary ever changing.
+
+## The problem it exists for
+
+Iraq's IHSES 2006-07 stratifies every household into a settlement tier. The
+library delivers the canonical binary. Measured, cold, on the shipped data
+(17,822 households; `strata` is the raw `xstrat`, whose suffix is the tier):
+
+| raw tier | households | delivered `Rural` |
+|---|---:|---|
+| `urban center` | 5,413 | Urban |
+| `other urban` | 5,736 | Urban |
+| `al-karekh` (Baghdad) | 314 | Urban |
+| `al-rasafah` (Baghdad) | 318 | Urban |
+| `al-sader` (Baghdad) | 321 | Urban |
+| `extra` | 92 | Urban |
+| `rural` | 5,628 | Rural |
+
+Seven tiers become two values; 12,194 households land in one bucket. The
+canonical fold is right — `Rural ∈ {Urban, Rural}` is what makes the column
+comparable across 47 countries — but the detail should not be *unreachable*.
+
+The same shape recurs in Ethiopia ESS2/ESS3 (large town / small town),
+Mali (Bamako / autre urbain / rural), Niger (Communauté Urbaine / urbain /
+rural) and Kazakhstan 1996 — see the corpus-wide audit in
+[#682], class A.
+
+`labels=` is the query-time escape hatch: the canonical value stays canonical,
+and a caller who wants the tier asks for it.
+
+```python
+import lsms_library as ll
+
+c = ll.Country('Someland')
+c.sample()['Rural'].unique()
+# array(['Urban', 'Rural'], dtype=object)                      canonical
+
+c.sample(labels={'Rural': 'Settlement'})['Rural'].unique()
+# array(['City', 'Large Town', 'Medium Town', 'Small Town',
+#        'Large Village', 'Small Village', 'Other'], dtype=object)
+```
+
+**No country is wired for this yet.** This page documents the core mechanism
+and how to curate a table for it; the per-country wiring is separate work. Note
+in particular that Iraq's `Rural` currently comes from an inline `mapping:`
+dict in its wave `data_info.yml`, not from a `categorical_mapping.org` table —
+using this mechanism there means moving that decode into a table (see
+*Curating a table* below).
+
+## The two forms
+
+| form | targets | applied by |
+|---|---|---|
+| `labels='Aggregate'` (scalar) | the `j` index level, and **only** `j` | `Country._relabel_j`, on the finished frame |
+| `labels={'Rural': 'Settlement'}` (dict) | any column or index level, named explicitly | `Country._apply_categorical_mappings`, at the raw code |
+
+A scalar keeps its historical meaning byte for byte: it renames `j` from
+`Preferred Label` to `<variant> Label` and, for `food_expenditures` /
+`food_quantities`, re-aggregates. It never touches a column, even on a table
+that has a mapped one.
+
+A dict names its targets. Keys match columns and index levels
+case-insensitively. The variant resolves to the `'<variant> Label'` column of
+the same-named `categorical_mapping` table, falling back to a bare
+`'<variant>'` — the same rule the scalar form uses.
+
+The key `'j'` in a dict is routed to the scalar behaviour, so
+`labels={'j': 'Aggregate'}` and `labels='Aggregate'` are one request and there
+is exactly one mechanism per face. The two compose:
+`labels={'j': 'Aggregate', 'Rural': 'Settlement'}`.
+
+## Which decode path this extends — and which three it does not
+
+A raw survey code becomes a label by one of **four** routes. `labels=` extends
+only the first.
+
+1. **Auto-dispatch on a name match** — a `categorical_mapping` table whose name
+   matches a column or index level (case-insensitively) and which has a
+   `Preferred Label` column. Applied in `Country._apply_categorical_mappings`.
+   **This is the one `labels=` extends.**
+2. **An explicit `mappings:` key** in a wave's `data_info.yml`, for a table
+   whose name does *not* match the target (`harmonize_food` → `j`). Rare — two
+   occurrences in the corpus.
+3. **Direct Python consumption** — `tools.code_label_map('rural', …)` in a
+   wave's `mapping.py`, consumed by that wave's own formatter. This is where
+   GhanaLSS GLSS3/GLSS4 `Rural` actually comes from
+   (`GhanaLSS/1991-92/_/mapping.py`, `1998-99/_/mapping.py`).
+4. **An inline `mapping:` dict** under a `myvars` entry in a wave's
+   `data_info.yml` — Iraq's `Rural`, Malawi's housing columns.
+
+Routes 2–4 are untouched by this change and remain the right tool where they
+are used. A country that wants query-time selection has to move the decode to
+route 1.
+
+**Scope: route 1 is country ∪ global, never wave.**
+`_apply_categorical_mappings` reads `Country.categorical_mapping`, which merges
+`lsms_library/categorical_mapping/*.org` with the country's
+`_/categorical_mapping.org` — and never opens a wave directory. A table in
+`{country}/{wave}/_/categorical_mapping.org` is visible to
+`Wave.categorical_mapping` but is **not** auto-applied to a `Country(...)`
+read, with or without `labels=`.
+
+## Curating a table for it
+
+Add a label column to the country's `categorical_mapping.org` table. `Code`
+stays first, `Preferred Label` stays canonical:
+
+```org
+#+name: Rural
+| Code | Preferred Label | Settlement Label |
+|------+-----------------+------------------|
+|    1 | Urban           | City             |
+|    2 | Urban           | Large Town       |
+|    3 | Urban           | Medium Town      |
+|    4 | Rural           | Small Town       |
+|    5 | Rural           | Large Village    |
+|    6 | Rural           | Small Village    |
+|    7 | Rural           | Other            |
+```
+
+Nothing else is needed: the auto-dispatch already applies a table whose name
+matches a column or index level. Default reads are unaffected — they still
+resolve `Code → Preferred Label`.
+
+Two rules about that table:
+
+- **Keep the code column first.** The key column is "the first column that is
+  neither `Preferred Label` nor the requested variant". Reordering it so a
+  label column comes first makes the *default* mapping key on the wrong column
+  and silently decode nothing. This is pre-existing and unguarded; it is pinned
+  by `tests/test_label_selection.py::test_source_cols_ordering_is_the_key_column`.
+- **A `Code`-keyed table belongs at country or wave scope, never global.** Codes
+  are survey-specific — Iraq's `1` is not Ghana's `1` — and
+  `_augment_numeric_code_keys` additionally registers `'1'` / `'1.0'`, widening
+  the blast radius. The global tables under `lsms_library/categorical_mapping/`
+  are label-keyed (`Alternate Spelling`, `Original Label`) for this reason. The
+  one exception is `ehcvm_units.org`, defensible because EHCVM is a single
+  multi-country instrument with one shared code list. No assertion enforces
+  this yet.
+
+## Errors
+
+| situation | raises | `Feature` behaviour |
+|---|---|---|
+| country curates no such mapping table, or no such label column | `LabelUnavailableError` (a `KeyError` subclass) | drops the country, one aggregated warning, `df.attrs['labels_unavailable']` |
+| table exists but has no `Preferred Label`, or no key column left | plain `KeyError` | surfaces as a per-country "Failed to load" warning |
+| the result has no such column or index level | plain `KeyError` | as above |
+| `labels=` is neither a `str` nor a dict, or a dict value is not a `str` | `TypeError` | as above |
+
+The distinction is the point: *missing curation* is a normal state of the
+corpus and `Feature` degrades over it; a *malformed table* or a *target that
+isn't there* is a defect and stays loud.
+
+One consequence worth stating plainly: `Rural` is not a required column of
+`sample`, so `Feature('sample')(labels={'Rural': …})` warns "Failed to load"
+for countries whose `sample` has no `Rural` column at all, rather than dropping
+them gracefully. That follows from making an absent target a plain `KeyError`,
+consistent with `_relabel_j`'s existing "result has no `'j'` index level".
+
+---
+
+# Design note: why the mapping site, and not `_relabel_j`
+
+*This section exists so the implementation is not "simplified" back into a bug.
+Both proofs below are reproducible in about ten lines.*
+
+## 1. `Preferred Label` is the wrong key for a coarse→fine map
+
+`_relabel_j` builds its rename dict like this (`country.py`):
+
+```python
+rdict = (table[['Preferred Label', target]].dropna()
+         .set_index('Preferred Label')[target].to_dict())
+```
+
+That is sound for food, where the relation is **fine → coarse**: each item has
+exactly one `Preferred Label`, so canonical → variant is a *function* and can be
+applied to the finished frame.
+
+A settlement ladder runs the other way — **coarse → fine**. `Preferred Label`
+has two distinct values against a seven-rung ladder, so `.to_dict()` is
+last-row-wins:
+
+```python
+{'Urban': 'Medium Town', 'Rural': 'Other'}
+```
+
+Two entries for seven rungs, and both of them arbitrary. There is no way to
+repair this at the output, because by then the raw code has already been
+collapsed onto `Preferred Label` by `_apply_categorical_mappings` and the fine
+information is *gone from the frame*.
+
+So the selection has to happen where the raw code still exists — at the mapping
+site — by choosing **which label column that raw code resolves to**:
+
+```python
+{1: 'City', 2: 'Large Town', 3: 'Medium Town', 4: 'Small Town',
+ 5: 'Large Village', 6: 'Small Village', 7: 'Other'}
+```
+
+Seven entries, information-preserving, because the key (`Code`) is unique.
+
+`_relabel_j` is therefore left exactly as it was. It is not a legacy path to be
+migrated; it is the correct mechanism for the other direction.
+
+## 2. Why one hop of the plumbing is a ContextVar and not a parameter
+
+`_finalize_result` and `_apply_categorical_mappings` both take an explicit
+`labels=`. The remaining hop — from the generated `method()` down to the
+`_finalize_result` calls that happen *inside* `_aggregate_wave_data` — does not,
+and that is deliberate.
+
+`_aggregate_wave_data` carries `@build_transform()`. Its **source AST** is folded
+into `build_transforms_fingerprint`, which is folded into every
+`lsms_cache_hash`. Measured, on `development`, by adding a single defaulted
+keyword argument to its signature and changing nothing else:
+
+| `build_transforms_fingerprint(table)` | before | after one defaulted kwarg |
+|---|---|---|
+| `None` (all tables) | `8bc39689…` | `ace7b84a…` |
+| `sample` / `cluster_features` / `household_roster` | `1acba6d6…` | `a1aca3bd…` |
+
+Every cached parquet in the corpus would grade `stale` and rebuild — for a
+feature that runs *after* the cache read and cannot change a single cached byte.
+That is precisely the over-invalidation `_EXCLUDED_CALLABLES` exists to prevent;
+`_finalize_result` is already in it, "READ-path: re-applied on every read AFTER
+the cache".
+
+So the request travels in a `ContextVar` (`_LABEL_SELECTION`), and the value
+stored is `(method_name, {target: variant})`. **The method name is load-bearing,
+not decoration.** `_finalize_result` re-enters itself: `_join_v_from_sample`
+fetches `sample()` from inside the finalize of some other table, and
+`_location_lookup` does the same for `cluster_features`. Without the check, a
+selection requested for one table would be applied to another table fetched
+underneath it — and worse, an error raised inside that nested read is swallowed
+by `_join_v_from_sample`'s `except (…, KeyError, …)`, so the `v` join would
+silently vanish.
+
+Verification, both ways:
+
+- `tests/test_label_selection.py::test_label_selection_is_outside_the_build_fingerprint`
+  walks the real `@build_transform` closure and asserts
+  `_apply_categorical_mappings`, `_finalize_result`, `_relabel_j` and
+  `Country.__getattr__` are not in it. If a refactor drags them in, that test
+  fails — which is the warning.
+- Measured end to end on twelve real `(country, table)` cells across eight
+  countries (Uganda, Malawi, GhanaLSS, Guyana, Nigeria, Tanzania, Ethiopia):
+  every `Country._table_cache_hash` is byte-identical before and after this
+  change.
+
+## 3. What this change is not
+
+- It does **not** change any default read. `_apply_categorical_mappings` with
+  `labels=None` is the historical code path; the only structural edit is that
+  key-column selection now also excludes the requested target, which is a
+  provable no-op when the target *is* `Preferred Label`.
+- It does **not** wire any country.
+- It does **not** touch `_relabel_j`. Uganda's food numbers were re-measured
+  cold before and after: `food_expenditures`, `food_quantities`, `food_prices`
+  and `food_acquired`, each at `labels='Preferred'` and `labels='Aggregate'` —
+  identical row counts, distinct-`j` counts and column sums.
+- It does **not** fix two known defects in the same neighbourhood, deliberately:
+  [#693] (`#+begin_example` blocks in a global `.org` parse as live tables) and
+  [#694] (`_apply_categorical_mappings` nulls non-string values through an
+  unguarded `.str.strip()`). The selection path reuses the *same* strip call, so
+  it neither worsens nor fixes #694; #693 concerns label-keyed housing templates,
+  whose key-column resolution is unchanged here.
+
+[#682]: https://github.com/ligon/LSMS_Library/pull/682
+[#693]: https://github.com/ligon/LSMS_Library/issues/693
+[#694]: https://github.com/ligon/LSMS_Library/issues/694

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -76,6 +76,7 @@ from pyarrow.lib import ArrowInvalid
 from datetime import datetime
 from typing import Any, Callable, Iterable
 from contextlib import contextmanager, redirect_stdout
+from contextvars import ContextVar
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,127 @@ _RESERVED_U_SENTINELS = frozenset({'kg', 'Value'})
 
 # Derived food tables whose ``u`` level can carry the reserved sentinels.
 _U_SENTINEL_PROTECTED_METHODS = frozenset({'food_quantities', 'food_prices'})
+
+
+# ---------------------------------------------------------------------------
+# Query-time label selection (GH #682 / #685)
+#
+# Two DIFFERENT faces of the same user-facing ``labels=`` affordance:
+#
+#   * fine -> coarse (food).  ``labels='Aggregate'`` renames the ``j`` index
+#     from ``Preferred Label`` to ``Aggregate Label``.  Each item has exactly
+#     one Preferred Label, so canonical -> variant is a FUNCTION and can be
+#     applied to the finished frame.  That is :meth:`Country._relabel_j`.
+#
+#   * coarse -> fine (everything else, e.g. ``Rural``).  Here ``Preferred
+#     Label`` is the COARSE end: two canonical values against a seven-way
+#     settlement ladder.  Keying the rename on ``Preferred Label`` is
+#     last-row-wins garbage -- measured, ``{'Urban': 'Medium Town',
+#     'Rural': 'Other'}``.  The fine information only exists BEFORE
+#     :meth:`Country._apply_categorical_mappings` collapses the raw code onto
+#     ``Preferred Label``, so the selection has to happen THERE, keyed on the
+#     raw code.  See ``docs/design/label_selection.md``.
+#
+# The request therefore has to reach ``_apply_categorical_mappings``, which
+# sits inside ``_finalize_result``, which is called from inside
+# ``_aggregate_wave_data``.  ``_aggregate_wave_data`` carries
+# ``@build_transform()``: its source AST is folded into every
+# ``lsms_cache_hash`` (``_build_registry.build_transforms_fingerprint``).
+# Adding even one defaulted keyword argument to its signature was measured to
+# move the fingerprint for EVERY table -- a corpus-wide rebuild for a
+# read-path feature that cannot change a single cached byte.  So that one hop
+# is carried out of band by the ContextVar below rather than by a parameter.
+# ``_finalize_result`` and ``_apply_categorical_mappings`` do take an explicit
+# ``labels=``; both are outside the build closure (``_finalize_result`` is in
+# ``_build_registry._EXCLUDED_CALLABLES`` by name).
+#
+# The stored value is ``(method_name, {target: variant})``.  The method name is
+# load-bearing, not decoration: ``_finalize_result`` RE-ENTERS itself via
+# ``_join_v_from_sample`` / ``_location_lookup``, and without the check a
+# selection requested for ``household_roster`` would also be applied to the
+# ``sample`` frame fetched underneath it.
+# ---------------------------------------------------------------------------
+_LABEL_SELECTION: ContextVar = ContextVar("lsms_label_selection", default=None)
+
+
+@contextmanager
+def _label_selection(method_name: str | None, labels: dict | None):
+    """Scope a mapping-site label selection to one top-level table request."""
+    if not labels:
+        yield
+        return
+    token = _LABEL_SELECTION.set((method_name, dict(labels)))
+    try:
+        yield
+    finally:
+        _LABEL_SELECTION.reset(token)
+
+
+def _split_labels_arg(labels) -> tuple:
+    """Split the public ``labels=`` argument into its two faces.
+
+    Returns ``(j_labels, mapping_labels)``:
+
+    * ``j_labels`` -- the scalar handed to :meth:`Country._relabel_j`.
+      ``'Preferred'`` / ``None`` mean "no relabel".
+    * ``mapping_labels`` -- ``{target: variant}`` for the mapping-site
+      selection, or ``None``.
+
+    A **scalar** ``labels=`` keeps its historical meaning exactly: it targets
+    the ``j`` index level and nothing else, even on a table that also has a
+    mapped column.  A **dict** names its targets explicitly; the key ``'j'``
+    is routed to ``_relabel_j`` so that ``labels={'j': 'Aggregate'}`` is
+    identical to ``labels='Aggregate'`` and there is one mechanism per face.
+    """
+    if labels is None or isinstance(labels, str):
+        return labels, None
+    if isinstance(labels, dict):
+        d = {str(k): v for k, v in labels.items()}
+        j = d.pop('j', 'Preferred')
+        bad = [k for k, v in list(d.items()) + [('j', j)]
+               if not isinstance(v, str)]
+        if bad:
+            raise TypeError(
+                f"labels= dict values must be strings (the label variant); "
+                f"non-string value for {bad!r}")
+        return j, (d or None)
+    raise TypeError(
+        f"labels= must be a str (the 'j' label variant) or a "
+        f"{{target: variant}} dict; got {type(labels).__name__}")
+
+
+def _label_targets_missing(df, labels: dict | None) -> list:
+    """Keys of a ``labels=`` dict that name nothing in *df*.
+
+    Matching is case-insensitive, mirroring the categorical-mapping
+    auto-dispatch, and covers both columns and index levels.
+    """
+    if not labels or not isinstance(df, pd.DataFrame):
+        return []
+    present = {str(c).lower() for c in df.columns}
+    names = (list(df.index.names) if isinstance(df.index, pd.MultiIndex)
+             else [df.index.name])
+    present |= {str(n).lower() for n in names if n is not None}
+    return [k for k in labels if str(k).lower() not in present]
+
+
+def _assert_label_targets_present(df, labels: dict | None, *,
+                                  country: str, table: str) -> None:
+    """Raise a plain ``KeyError`` for a ``labels=`` target *df* does not have.
+
+    Deliberately a plain ``KeyError``, not :class:`LabelUnavailableError`:
+    consistent with :meth:`Country._relabel_j`'s "result has no ``'j'`` index
+    level", and distinct from the missing-CURATION case (the target IS there
+    but the country curates no such label column), which stays degradable by
+    :class:`~lsms_library.feature.Feature`.
+    """
+    missing = _label_targets_missing(df, labels)
+    if missing:
+        raise KeyError(
+            f"Cannot apply labels={ {k: labels[k] for k in missing} !r} to "
+            f"{country}/{table}: the result has no such column or index level "
+            f"(has: {sorted(map(str, df.columns))} + index "
+            f"{[n for n in (df.index.names or []) if n is not None]})")
 
 
 def _augment_numeric_code_keys(rdict: dict) -> dict:
@@ -2234,7 +2356,8 @@ class Country:
     
 
     def _apply_categorical_mappings(self, df: pd.DataFrame,
-                                    protect_u_sentinels: bool = False) -> pd.DataFrame:
+                                    protect_u_sentinels: bool = False,
+                                    labels: dict | None = None) -> pd.DataFrame:
         """Auto-apply categorical mappings where table names match columns or indices.
 
         For each column or index level in *df*, check whether
@@ -2254,22 +2377,67 @@ class Country:
         ``xs('kg', level='u')`` silently misses it.  food_acquired itself
         passes ``protect_u_sentinels=False`` so its raw unit-label
         canonicalization is unaffected.
+
+        ``labels`` (GH #682) selects a DIFFERENT label column of the matching
+        table for named targets: ``{'Rural': 'Settlement'}`` resolves each raw
+        ``Rural`` code to the table's ``'Settlement Label'`` column instead of
+        its ``'Preferred Label'``.  The key column is unchanged -- it is still
+        the raw code -- so this is information-preserving in a way no
+        output-side rename can be (see the module-level note above
+        ``_LABEL_SELECTION``).  ``None`` (the default) is the historical
+        behaviour, byte for byte.
         """
+        attrs = dict(getattr(df, "attrs", {}) or {})
+        # Case-insensitive, mirroring the table-name dispatch below.
+        wanted = {str(k).lower(): v for k, v in (labels or {}).items()}
         cat_maps = self.categorical_mapping
         if not cat_maps:
+            if wanted:
+                raise LabelUnavailableError(
+                    f"{self.name!r} curates no categorical_mapping tables at "
+                    f"all, so it cannot honour labels={labels!r}")
             return df
 
         # Build case-insensitive lookup
         lower_lookup = {name.lower(): name for name in cat_maps}
 
+        def _resolve_target(table: pd.DataFrame, variant: str,
+                            table_name: str) -> str:
+            """Column of *table* holding the requested label *variant*.
+
+            Same resolution rule as :meth:`_relabel_j`: ``'X Label'`` first,
+            then a bare ``'X'``.
+            """
+            candidate = f"{variant} Label"
+            if candidate in table.columns:
+                return candidate
+            if variant in table.columns:
+                return variant
+            available = [c for c in table.columns if c != "Preferred Label"]
+            # Country curates the table but not THIS label column -> missing
+            # curation, degradable by Feature (mirrors _relabel_j).
+            raise LabelUnavailableError(
+                f"Column {candidate!r} not in categorical_mapping table "
+                f"{table_name!r} on {self.name!r}; available: {available}")
+
         def _build_replace_dict(table: pd.DataFrame, *,
-                                drop_keys: set | None = None) -> dict | None:
+                                drop_keys: set | None = None,
+                                target: str = "Preferred Label") -> dict | None:
             if "Preferred Label" not in table.columns:
                 return None
-            source_cols = [c for c in table.columns if c != "Preferred Label"]
+            # The key column is "the first column that is neither the canonical
+            # label nor the requested variant".  Excluding *target* is a
+            # provable no-op when target IS 'Preferred Label' (the default
+            # path); it matters only for a multi-label table whose variant
+            # column precedes its code column, where keying on the target
+            # would map every value to itself.  NOTE: the ordering itself is
+            # load-bearing and unguarded -- see the test
+            # ``test_source_cols_ordering_is_the_key_column``.
+            source_cols = [c for c in table.columns
+                           if c not in ("Preferred Label", target)]
             if not source_cols:
                 return None
-            rdict = table.set_index(source_cols[0])["Preferred Label"].to_dict()
+            rdict = table.set_index(source_cols[0])[target].to_dict()
             # Numeric-code tables (e.g. a `Code` column 1, 2, 3) don't match
             # data that arrives as float-strings ('1.0') -- the documented
             # "format_id is applied to idxvars but not myvars" gotcha, which
@@ -2284,13 +2452,51 @@ class Country:
                 rdict = {k: v for k, v in rdict.items() if k not in drop_keys}
             return rdict
 
+        def _target_for(name: str, key: str | None) -> str | None:
+            """Label column to apply for frame element *name*, or None to skip.
+
+            Raises for the requested-but-uncurated cases, with the same
+            taxonomy as :meth:`_relabel_j`.
+            """
+            variant = wanted.get(name.lower())
+            if variant is None:
+                return "Preferred Label" if key is not None else None
+            if key is None:
+                # No mapping table of this name at all -> missing curation.
+                raise LabelUnavailableError(
+                    f"No categorical_mapping table named {name!r} on "
+                    f"{self.name!r}, so labels={{{name!r}: {variant!r}}} "
+                    f"cannot be honoured")
+            table = cat_maps[key]
+            if "Preferred Label" not in table.columns:
+                # Malformed: the table exists but has no canonical column, so
+                # nothing anchors the variant.  Loud, not degradable.
+                raise KeyError(
+                    f"categorical_mapping table {key!r} on {self.name!r} has "
+                    f"no 'Preferred Label' column; cannot select "
+                    f"labels={variant!r}")
+            return _resolve_target(table, variant, key)
+
+        def _dict_for(name: str, key: str, target: str) -> dict | None:
+            drop = (_RESERVED_U_SENTINELS
+                    if (protect_u_sentinels and name == 'u') else None)
+            rdict = _build_replace_dict(cat_maps[key], drop_keys=drop,
+                                        target=target)
+            if rdict is None and target != "Preferred Label":
+                raise KeyError(
+                    f"categorical_mapping table {key!r} on {self.name!r} has "
+                    f"no key column left once 'Preferred Label' and "
+                    f"{target!r} are excluded (columns: "
+                    f"{list(cat_maps[key].columns)})")
+            return rdict
+
         # Apply to columns
         for col in df.columns:
             key = lower_lookup.get(col.lower())
-            if key is None:
+            target = _target_for(col, key)
+            if target is None:
                 continue
-            drop = _RESERVED_U_SENTINELS if (protect_u_sentinels and col == 'u') else None
-            rdict = _build_replace_dict(cat_maps[key], drop_keys=drop)
+            rdict = _dict_for(col, key, target)
             if rdict:
                 if hasattr(df[col], 'str'):
                     df[col] = df[col].str.strip()
@@ -2302,14 +2508,17 @@ class Country:
                 if level_name is None:
                     continue
                 key = lower_lookup.get(level_name.lower())
-                if key is None:
+                target = _target_for(level_name, key)
+                if target is None:
                     continue
-                drop = (_RESERVED_U_SENTINELS
-                        if (protect_u_sentinels and level_name == 'u') else None)
-                rdict = _build_replace_dict(cat_maps[key], drop_keys=drop)
+                rdict = _dict_for(level_name, key, target)
                 if rdict:
                     df = df.rename(index=rdict, level=level_name)
 
+        # rename() builds a new object; keep attrs (notably id_converted, whose
+        # loss makes id_walk double-apply on transitive panel chains -- see
+        # CLAUDE.md "Panel ID Transitive Chains and the attrs Flag").
+        df.attrs = attrs
         return df
 
     def _relabel_j(self, df: pd.DataFrame, labels: str | None, *, reaggregate: bool) -> pd.DataFrame:
@@ -2373,7 +2582,8 @@ class Country:
         return result
 
     def _finalize_result(self, df: Any, scheme_entry: dict[str, Any], method_name: str,
-                         currency: str | None = None) -> pd.DataFrame | dict[str, Any]:
+                         currency: str | None = None,
+                         labels: dict | None = None) -> pd.DataFrame | dict[str, Any]:
         """
         Apply final harmonization steps (index augmentation, normalization, id walk)
         before returning a dataset to callers.
@@ -2383,7 +2593,22 @@ class Country:
         :func:`lsms_library.currency.attach_currency`.  Applied last so it sits
         on the fully-finalized frame and is preserved by the downstream
         ``_relabel_j`` / ``_add_market_index`` steps in the caller.
+
+        ``labels`` (GH #682) is the mapping-site label selection
+        ``{target: variant}``, forwarded to
+        :meth:`_apply_categorical_mappings`.  When not passed explicitly it is
+        read from the ``_LABEL_SELECTION`` ContextVar, and ONLY when the stored
+        request names this same ``method_name`` -- this method re-enters itself
+        via ``_join_v_from_sample`` / ``_location_lookup``, and a selection
+        asked of one table must not be applied to another table fetched
+        underneath it.  See the module-level note above ``_LABEL_SELECTION``
+        for why this one hop is out of band instead of a parameter.
         """
+        if labels is None:
+            requested = _LABEL_SELECTION.get()
+            if requested is not None and requested[0] == method_name:
+                labels = requested[1]
+
         if isinstance(df, dict):
             return df
 
@@ -2447,6 +2672,7 @@ class Country:
             df = self._apply_categorical_mappings(
                 df,
                 protect_u_sentinels=method_name in _U_SENTINEL_PROTECTED_METHODS,
+                labels=labels,
             )
 
             # Apply ``harmonize_<method_name>`` mapping to the ``j`` index
@@ -3735,6 +3961,11 @@ class Country:
             def method(waves=None, market=None, labels='Preferred', age_cuts=None,
                        units=None, volume_as_mass=True, currency=None, numeraire=None,
                        basis=None):
+                # `labels` has two faces; see _split_labels_arg.  `j_labels` is
+                # the historical scalar (food's fine->coarse rename of the `j`
+                # level); `map_labels` is the {target: variant} selection
+                # applied at the categorical-mapping site.
+                j_labels, map_labels = _split_labels_arg(labels)
                 if age_cuts is not None and name not in self._ROSTER_DERIVED:
                     raise TypeError(
                         f"{name}() got an unexpected keyword argument 'age_cuts'; "
@@ -3822,13 +4053,17 @@ class Country:
                             derived = transform_fn(fa, **transform_kwargs)
                             scheme_entry = self._materialization_entry(name)
                             derived = self._finalize_result(derived, scheme_entry, name,
-                                                            currency=currency)
+                                                            currency=currency,
+                                                            labels=map_labels)
                     except (FileNotFoundError, KeyError, ValueError, RuntimeError) as exc:
-                        if units is not None:
-                            # Caller explicitly asked for canonical units= behaviour;
-                            # the legacy fall-through path can't honour that, so
-                            # surface the failure rather than silently returning
-                            # un-units-aware data.
+                        if units is not None or map_labels:
+                            # Caller explicitly asked for canonical units= /
+                            # labels= behaviour; the legacy fall-through path
+                            # can't honour either, so surface the failure rather
+                            # than silently returning un-units-aware or
+                            # un-relabelled data.  (Without this, a bad labels=
+                            # dict raised by _apply_categorical_mappings would be
+                            # swallowed here and degrade to the legacy path.)
                             raise
                         logger.info(
                             "Deriving %s from food_acquired failed (%s); "
@@ -3838,8 +4073,10 @@ class Country:
                         # Relabel is outside the except so user-facing KeyErrors
                         # (bad labels=) propagate instead of silently falling
                         # through to the legacy aggregation path.
+                        _assert_label_targets_present(derived, map_labels,
+                                                      country=self.name, table=name)
                         reagg = name in {'food_expenditures', 'food_quantities'}
-                        derived = self._relabel_j(derived, labels, reaggregate=reagg)
+                        derived = self._relabel_j(derived, j_labels, reaggregate=reagg)
                         if market is not None:
                             derived = self._add_market_index(derived, column=market)
                         if numeraire is not None:
@@ -3870,6 +4107,16 @@ class Country:
                             "falling back to legacy aggregation", name, exc)
                         derived = None
                     if derived is not None:
+                        # This path never calls _finalize_result, so a mapping-site
+                        # `labels=` selection has nowhere to land.  Rather than
+                        # ignore it silently, assert the targets exist -- which for
+                        # a roster-DERIVED table they never do, because the roster
+                        # is aggregated away.  Post-hoc selection here would be
+                        # structurally broken anyway: the roster it derives from has
+                        # already been mapped onto Preferred Label, so the raw codes
+                        # are gone (the same argument as for _relabel_j).
+                        _assert_label_targets_present(derived, map_labels,
+                                                      country=self.name, table=name)
                         # _add_market_index lives OUTSIDE the except so a
                         # user-facing KeyError (a market= column this country
                         # lacks) propagates, instead of being misread as a
@@ -3883,12 +4130,19 @@ class Country:
                             derived = self._add_market_index(derived, column=market)
                         return derived
 
-                result = self._aggregate_wave_data(waves, name, currency=currency)
+                # The selection is carried to _finalize_result out of band (see
+                # _LABEL_SELECTION): _aggregate_wave_data is @build_transform()-
+                # tagged, so widening its signature would move every table's
+                # lsms_cache_hash for a change that cannot alter a cached byte.
+                with _label_selection(name, map_labels):
+                    result = self._aggregate_wave_data(waves, name, currency=currency)
+                _assert_label_targets_present(result, map_labels,
+                                              country=self.name, table=name)
                 # Apply relabeling to any table with a j index level
                 if (isinstance(result, pd.DataFrame) and not result.empty
                         and 'j' in (result.index.names or [])):
                     reagg = name in {'food_expenditures', 'food_quantities'}
-                    result = self._relabel_j(result, labels, reaggregate=reagg)
+                    result = self._relabel_j(result, j_labels, reaggregate=reagg)
                 if market is not None and isinstance(result, pd.DataFrame) and not result.empty:
                     result = self._add_market_index(result, column=market)
                 if numeraire is not None and isinstance(result, pd.DataFrame) and not result.empty:
@@ -3903,15 +4157,30 @@ class Country:
                 "market : str, optional\n",
                 "    Column from cluster_features (e.g. 'Region') to add as\n",
                 "    an ``m`` index level for demand estimation.\n",
-                "labels : str, optional\n",
-                "    Label column to use for the ``j`` index on derived food\n",
-                "    tables (food_expenditures, food_quantities, food_prices).\n",
-                "    Defaults to ``'Preferred'`` (current behaviour).  Other\n",
-                "    values (e.g. ``'Aggregate'``) select a same-named column\n",
-                "    from the country's ``food_items`` / ``harmonize_food``\n",
-                "    table; ``food_expenditures`` and ``food_quantities`` are\n",
-                "    re-aggregated after renaming.  Raises ``KeyError`` if the\n",
-                "    column is absent.\n",
+                "labels : str or dict, optional\n",
+                "    **Scalar form** -- label column to use for the ``j`` index\n",
+                "    on derived food tables (food_expenditures,\n",
+                "    food_quantities, food_prices).  Defaults to\n",
+                "    ``'Preferred'`` (current behaviour).  Other values (e.g.\n",
+                "    ``'Aggregate'``) select a same-named column from the\n",
+                "    country's ``food_items`` / ``harmonize_food`` table;\n",
+                "    ``food_expenditures`` and ``food_quantities`` are\n",
+                "    re-aggregated after renaming.  A scalar targets ``j`` and\n",
+                "    ONLY ``j``, even on a table that also has a mapped column.\n",
+                "    **Dict form** -- ``{target: variant}``, where *target*\n",
+                "    names a column or index level (case-insensitive) and\n",
+                "    *variant* selects the ``'<variant> Label'`` column (falling\n",
+                "    back to ``'<variant>'``) of the country's same-named\n",
+                "    ``categorical_mapping`` table.  E.g.\n",
+                "    ``labels={'Rural': 'Settlement'}`` decodes the raw\n",
+                "    settlement code to the finer ladder instead of the\n",
+                "    canonical ``Urban``/``Rural``.  The key ``'j'`` is routed to\n",
+                "    the scalar behaviour, so ``labels={'j': 'Aggregate'}`` and\n",
+                "    ``labels='Aggregate'`` are the same request.\n",
+                "    Raises ``LabelUnavailableError`` (a ``KeyError`` subclass)\n",
+                "    when the country curates no such label column, and a plain\n",
+                "    ``KeyError`` when the result has no such target at all or\n",
+                "    the mapping table is malformed.\n",
             ]
             if name in {'food_prices', 'food_quantities'}:
                 if name == 'food_prices':

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -197,17 +197,37 @@ def _label_targets_missing(df, labels: dict | None) -> list:
 
 def _assert_label_targets_present(df, labels: dict | None, *,
                                   country: str, table: str) -> None:
-    """Raise a plain ``KeyError`` for a ``labels=`` target *df* does not have.
+    """Raise :class:`LabelUnavailableError` for a ``labels=`` target *df* lacks.
 
-    Deliberately a plain ``KeyError``, not :class:`LabelUnavailableError`:
-    consistent with :meth:`Country._relabel_j`'s "result has no ``'j'`` index
-    level", and distinct from the missing-CURATION case (the target IS there
-    but the country curates no such label column), which stays degradable by
-    :class:`~lsms_library.feature.Feature`.
+    A country simply not having the column is **missing curation**, which is
+    exactly what :class:`~lsms_library.feature.Feature` was built to degrade
+    over — and it is indistinguishable, to the caller, from a country that has
+    the column but not the requested label variant, which already degrades.
+    So both take the same path: drop the country, one aggregated warning,
+    ``df.attrs['labels_unavailable']``.
+
+    This is not a defect being swallowed.  ``Rural`` is *deliberately* not
+    ``required`` on ``sample`` — "many countries' sample table carries only
+    (v, weight, strata) and has no urban/rural indicator at all"
+    (``lsms_library/data_info.yml``) — so its absence is a documented, normal
+    state of the corpus, not a broken build.  A column that genuinely IS
+    declared required going missing is the business of the required-column
+    guards (``Country._assert_built_required_columns``, the ``grab_data``
+    dropped-sub-df guard), which fire on the build path and say so loudly;
+    it is not ``labels=``'s job to re-report it.
+
+    What stays loud is the **malformed** table: it exists, but has no
+    ``Preferred Label`` or no key column left.  That is a defect in curated
+    config, not an absence, and it raises a plain ``KeyError`` from
+    :meth:`Country._apply_categorical_mappings`.  That is the distinction that
+    matters, and it is unchanged.
+
+    Deliberately NOT mirrored onto :meth:`Country._relabel_j`'s "result has no
+    ``'j'`` index level" — see the note there for why the two genuinely differ.
     """
     missing = _label_targets_missing(df, labels)
     if missing:
-        raise KeyError(
+        raise LabelUnavailableError(
             f"Cannot apply labels={ {k: labels[k] for k in missing} !r} to "
             f"{country}/{table}: the result has no such column or index level "
             f"(has: {sorted(map(str, df.columns))} + index "
@@ -2532,6 +2552,27 @@ class Country:
         if labels in (None, 'Preferred'):
             return df
         if not isinstance(df, pd.DataFrame) or 'j' not in (df.index.names or []):
+            # Stays a PLAIN KeyError while the dict form's absent-target case
+            # degrades (see _assert_label_targets_present).  The two look alike
+            # and are not:
+            #
+            #   * a DICT names its target, and the target it names is typically
+            #     an OPTIONAL column -- `Rural` is explicitly not `required` on
+            #     `sample` (data_info.yml).  Its absence is a coverage fact
+            #     about that country: missing curation, degradable.
+            #   * a SCALAR names no target; `j` is implicit, and it is implicit
+            #     because the caller is asking for a FOOD relabel.  `j` is
+            #     required on every table that has one, so a food table without
+            #     `j` is a structural defect of the frame, not a country that
+            #     never curated something.  Degrading would drop it from a
+            #     Feature assembly with a "no such label" warning that names
+            #     the wrong cause.
+            #
+            # This branch is also near-unreachable in practice: the registered
+            # -table path guards the call with `if 'j' in result.index.names`,
+            # and the derived-food path only reaches it for tables that have
+            # `j` by construction.  It is a defensive guard, and weakening a
+            # defensive guard to match an unrelated case buys nothing.
             raise KeyError(
                 f"Cannot apply labels={labels!r}: result has no 'j' index level"
             )
@@ -4178,9 +4219,11 @@ class Country:
                 "    the scalar behaviour, so ``labels={'j': 'Aggregate'}`` and\n",
                 "    ``labels='Aggregate'`` are the same request.\n",
                 "    Raises ``LabelUnavailableError`` (a ``KeyError`` subclass)\n",
-                "    when the country curates no such label column, and a plain\n",
-                "    ``KeyError`` when the result has no such target at all or\n",
-                "    the mapping table is malformed.\n",
+                "    when the country cannot honour the request -- it curates no\n",
+                "    such label column, or the result has no such target at all;\n",
+                "    ``Feature`` degrades over both.  A plain ``KeyError`` means\n",
+                "    the mapping table is MALFORMED (no ``Preferred Label``, or\n",
+                "    no key column left), which stays loud.\n",
             ]
             if name in {'food_prices', 'food_quantities'}:
                 if name == 'food_prices':

--- a/lsms_library/country.py
+++ b/lsms_library/country.py
@@ -110,7 +110,7 @@ _U_SENTINEL_PROTECTED_METHODS = frozenset({'food_quantities', 'food_prices'})
 #     'Rural': 'Other'}``.  The fine information only exists BEFORE
 #     :meth:`Country._apply_categorical_mappings` collapses the raw code onto
 #     ``Preferred Label``, so the selection has to happen THERE, keyed on the
-#     raw code.  See ``docs/design/label_selection.md``.
+#     raw code.  See ``docs/guide/label-selection.md``.
 #
 # The request therefore has to reach ``_apply_categorical_mappings``, which
 # sits inside ``_finalize_result``, which is called from inside

--- a/lsms_library/feature.py
+++ b/lsms_library/feature.py
@@ -573,9 +573,9 @@ class Feature:
             warnings.warn(
                 f"{self.table_name}: labels={kwargs.get('labels')!r} unavailable "
                 f"for {len(labels_unavailable)} country(ies) {labels_unavailable} "
-                f"-- they curate no such label column and were dropped from "
-                f"the assembly (kept {n_kept}). Add the column or pass a country "
-                f"subset to silence this."
+                f"-- they curate no such label column, or lack the target "
+                f"entirely, and were dropped from the assembly (kept {n_kept}). "
+                f"Add the column or pass a country subset to silence this."
             )
             result.attrs['labels_unavailable'] = list(labels_unavailable)
             return result

--- a/lsms_library/feature.py
+++ b/lsms_library/feature.py
@@ -573,7 +573,7 @@ class Feature:
             warnings.warn(
                 f"{self.table_name}: labels={kwargs.get('labels')!r} unavailable "
                 f"for {len(labels_unavailable)} country(ies) {labels_unavailable} "
-                f"-- they curate no such food-label column and were dropped from "
+                f"-- they curate no such label column and were dropped from "
                 f"the assembly (kept {n_kept}). Add the column or pass a country "
                 f"subset to silence this."
             )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
       - Caching: guide/caching.md
       - Panel Data: guide/panel-data.md
       - Coverage Matrix: guide/coverage.md
+      - Label Selection: guide/label-selection.md
   - API Reference:
       - Country: api/country.md
       - Wave: api/wave.md

--- a/tests/test_acquisition_source_validation.py
+++ b/tests/test_acquisition_source_validation.py
@@ -53,7 +53,8 @@ class _Stub:
     def _augment_index_from_related_tables(self, df, scheme_entry, _):
         return df
 
-    def _apply_categorical_mappings(self, df, protect_u_sentinels=False):
+    def _apply_categorical_mappings(self, df, protect_u_sentinels=False,
+                                    labels=None):
         return df
 
 

--- a/tests/test_label_selection.py
+++ b/tests/test_label_selection.py
@@ -510,6 +510,16 @@ def _make_country(countries_root: Path, name: str, cat_org: str | None,
     No ``#+begin_example`` blocks anywhere: ``all_dfs_from_orgfile`` parses the
     tables inside them as live mappings, so an illustrative block would become a
     real (and wrong) categorical table.
+
+    Source files are **parquet, not CSV**, on purpose.  ``get_dataframe`` is a
+    try-every-reader chain, not an extension dispatch: it attempts parquet, then
+    Stata, then pyreadstat, and only then ``read_csv``.  The Stata attempt
+    catches ``(ValueError, struct.error)`` only, and a CSV whose bytes happen to
+    parse as an old-format Stata header raises ``KeyError`` instead -- which
+    escapes and kills the read.  A CSV fixture therefore passes or fails by
+    luck about its own bytes.  Parquet is matched by the first reader.
+    (``pd.DataFrame.to_parquet`` here writes fixture SOURCE data, not a library
+    cache artifact, so the ``local_tools.to_parquet`` sanction does not apply.)
     """
     c = countries_root / name
     (c / "_").mkdir(parents=True)
@@ -536,7 +546,7 @@ def _make_country(countries_root: Path, name: str, cat_org: str | None,
         Wave: '2000'
 
         sample:
-            file: ../Data/hh.csv
+            file: ../Data/hh.parquet
             idxvars:
                 i: hhid
             myvars:
@@ -548,7 +558,71 @@ def _make_country(countries_root: Path, name: str, cat_org: str | None,
         "clust": ["c1", "c1", "c2", "c2", "c3", "c3", "c3"],
         "wt": [float(n) for n in range(1, 8)],
         "settlement": [1, 2, 3, 4, 5, 6, 7],
-    }).to_csv(c / "2000" / "Data" / "hh.csv", index=False)
+    }).to_parquet(c / "2000" / "Data" / "hh.parquet", index=False)
+
+
+_FOOD_ITEMS_ORG = """\
+#+name: food_items
+| Code | Preferred Label | Aggregate Label |
+|------+-----------------+-----------------|
+|  101 | Beans (fresh)   | Beans           |
+|  102 | Beans (dry)     | Beans           |
+|  103 | Matoke (bunch)  | Matoke          |
+|  104 | Matoke (heap)   | Matoke          |
+"""
+
+
+def _make_food_country(countries_root: Path, name: str = "Foodland") -> None:
+    """A country with ``food_acquired``, so ``food_expenditures`` DERIVES.
+
+    The derived-food branch of the generated ``method()`` is the one place a
+    ``labels=`` error can be swallowed (see the tests below), and no
+    ``sample``-only fixture reaches it.
+    """
+    c = countries_root / name
+    (c / "_").mkdir(parents=True)
+    (c / "2000" / "_").mkdir(parents=True)
+    (c / "2000" / "Data").mkdir(parents=True)
+    (c / "_" / "data_scheme.yml").write_text(textwrap.dedent(f"""\
+        Country: {name}
+
+        Waves:
+          - '2000'
+
+        Data Scheme:
+          food_acquired:
+            index: (i, t, j, u, s)
+            Quantity: float
+            Expenditure: float
+            Price: float
+        """))
+    (c / "_" / "categorical_mapping.org").write_text(_FOOD_ITEMS_ORG)
+    (c / "2000" / "_" / "data_info.yml").write_text(textwrap.dedent(f"""\
+        Country: {name}
+        Wave: '2000'
+
+        food_acquired:
+            file: ../Data/food.parquet
+            idxvars:
+                i: hhid
+                j: item
+                u: unit
+                s: source
+            myvars:
+                Quantity: qty
+                Expenditure: exp
+                Price: price
+        """))
+    pd.DataFrame({
+        "hhid": ["h1", "h1", "h1", "h2", "h2"],
+        "item": ["Beans (fresh)", "Beans (dry)", "Matoke (bunch)",
+                 "Matoke (heap)", "Beans (fresh)"],
+        "unit": ["Kg"] * 5,
+        "source": ["purchased"] * 5,
+        "qty": [1.0, 2.0, 3.0, 4.0, 5.0],
+        "exp": [10.0, 20.0, 30.0, 40.0, 50.0],
+        "price": [10.0, 10.0, 10.0, 10.0, 10.0],
+    }).to_parquet(c / "2000" / "Data" / "food.parquet", index=False)
 
 
 @pytest.fixture(scope="module")
@@ -556,6 +630,7 @@ def synthetic_tree(tmp_path_factory):
     root = tmp_path_factory.mktemp("label_selection")
     countries = root / "countries"
     countries.mkdir()
+    _make_food_country(countries)
     _make_country(countries, "Fixtureland", _SETTLEMENT_ORG)
     _make_country(countries, "Otherland", None)          # curates nothing
     _make_country(countries, "Malformedland",
@@ -748,6 +823,74 @@ def test_columnless_country_is_otherwise_healthy(synthetic_tree):
         print('COLUMNLESS_HEALTHY_OK')
         """, synthetic_tree)
     assert "COLUMNLESS_HEALTHY_OK" in out
+
+
+# ---------------------------------------------------------------------------
+# 4. The DERIVED-food branch
+#
+# Derived food tables take a different route through `method()` than
+# registered ones, so the `sample`-only fixtures never exercise the label
+# machinery there at all -- hence `Foodland`.
+#
+# Deliberately NOT keyed off a warm Uganda cache: the guard the other food
+# tests use (`Uganda/var/food_acquired.parquet` exists) is cleared by the test
+# suite itself, so such a test skips in exactly the runs that would exercise it.
+#
+# SCOPE NOTE, measured rather than assumed.  `method()`'s derived branch calls
+# `_finalize_result(..., labels=...)` inside a try whose
+# `except (..., KeyError, ...)` falls back to legacy aggregation, and
+# `LabelUnavailableError` IS a KeyError -- so there is a
+# `if units is not None or map_labels: raise` clause to stop the degrade being
+# swallowed.  These tests do NOT pin that clause: deleting `or map_labels` and
+# re-running leaves them green.  Two reasons, both real:
+#   * an ABSENT target is caught by `_assert_label_targets_present`, which sits
+#     OUTSIDE the try, so it never reaches the clause; and
+#   * when the fallthrough does happen here, the legacy path finds no
+#     registered `food_expenditures`, returns an empty frame, and the same
+#     outside-the-try guard raises the same class anyway.
+# The clause still earns its place -- a country with a REGISTERED legacy
+# `food_expenditures` could fall through to a frame that HAS the target, and
+# then the caller would silently receive Preferred labels instead of the
+# variant they asked for -- but that shape is not constructible from this
+# fixture, so it is stated here rather than claimed as covered.
+# ---------------------------------------------------------------------------
+
+def test_derived_food_path_propagates_the_degrade(synthetic_tree):
+    """A labels= error must reach the caller from the derived branch."""
+    out = _run("""
+        from lsms_library import Country
+        from lsms_library.errors import LabelUnavailableError
+        try:
+            Country('Foodland').food_expenditures(labels={'Rural': 'Settlement'})
+            raise AssertionError('derived path swallowed the degrade')
+        except LabelUnavailableError as e:
+            assert 'food_expenditures' in str(e), e
+            print('DERIVED_DEGRADE_PROPAGATED')
+        """, synthetic_tree)
+    assert "DERIVED_DEGRADE_PROPAGATED" in out
+
+
+def test_dict_j_equals_scalar_on_a_derived_table(synthetic_tree):
+    """The documented equivalence, on a real derived table.
+
+    Also pins `reaggregate`: four items collapse to two aggregates and the
+    expenditure total is preserved.
+    """
+    out = _run("""
+        import pandas as pd
+        from lsms_library import Country
+        f = Country('Foodland')
+        pref = f.food_expenditures()
+        scalar = f.food_expenditures(labels='Aggregate')
+        dict_j = f.food_expenditures(labels={'j': 'Aggregate'})
+        pd.testing.assert_frame_equal(scalar.sort_index(), dict_j.sort_index())
+        assert set(pref.index.get_level_values('j')) == {
+            'Beans (fresh)', 'Beans (dry)', 'Matoke (bunch)', 'Matoke (heap)'}
+        assert set(scalar.index.get_level_values('j')) == {'Beans', 'Matoke'}
+        assert pref['Expenditure'].sum() == scalar['Expenditure'].sum() == 150.0
+        print('DERIVED_DICT_J_OK')
+        """, synthetic_tree)
+    assert "DERIVED_DICT_J_OK" in out
 
 
 def test_feature_default_is_unaffected(synthetic_tree):

--- a/tests/test_label_selection.py
+++ b/tests/test_label_selection.py
@@ -300,21 +300,79 @@ def test_dict_j_key_is_the_scalar_request():
 
 
 # ---------------------------------------------------------------------------
-# Absent target -> plain KeyError (consistent with _relabel_j's no-'j' rule)
+# Absent target -> LabelUnavailableError (degrade), per @ligon on PR #697
 # ---------------------------------------------------------------------------
 
-def test_absent_target_is_a_plain_keyerror():
+def test_absent_target_degrades():
+    """A target the frame lacks is missing CURATION, not a defect.
+
+    ``Rural`` is deliberately not ``required`` on ``sample`` (data_info.yml:
+    "many countries' sample table carries only (v, weight, strata)"), so a
+    country lacking it is a normal state of the corpus and ``Feature`` should
+    degrade over it -- exactly as it already does for a country that has the
+    column but not the requested label variant.
+    """
     df = _sample_frame()
     assert _label_targets_missing(df, {"Rural": "Settlement"}) == []
     assert _label_targets_missing(df, {"Roof": "Detail"}) == ["Roof"]
-    with pytest.raises(KeyError) as ei:
+    with pytest.raises(LabelUnavailableError):
         _assert_label_targets_present(df, {"Roof": "Detail"},
                                       country="Fixtureland", table="sample")
-    assert not isinstance(ei.value, LabelUnavailableError)
     _assert_label_targets_present(df, {"Rural": "Settlement"},
                                   country="Fixtureland", table="sample")   # no raise
     _assert_label_targets_present(df, None,
                                   country="Fixtureland", table="sample")   # no raise
+
+
+def test_absent_target_and_absent_label_column_raise_the_SAME_class():
+    """The two curation gaps are one case to the caller, so one exception.
+
+    Left: the country has ``Rural`` but curates no ``Settlement Label``.
+    Right: the country curates the ladder but its frame has no ``Rural`` at all.
+    A caller cannot tell these apart and should not have to.
+    """
+    no_such_column = _fake_country({"Rural": _settlement_table()})
+    with pytest.raises(LabelUnavailableError):
+        no_such_column._apply_categorical_mappings(
+            _sample_frame(), labels={"Rural": "Nutrition"})
+
+    with pytest.raises(LabelUnavailableError):
+        _assert_label_targets_present(
+            _sample_frame().drop(columns=["Rural"]), {"Rural": "Settlement"},
+            country="Fixtureland", table="sample")
+
+
+def test_malformed_table_still_outranks_the_degrade():
+    """The distinction that DOES matter survives the flip.
+
+    A malformed table is a defect in curated config, not an absence, so it
+    stays a plain ``KeyError`` and is NOT degraded over.
+    """
+    tbl = _settlement_table().rename(columns={"Preferred Label": "Canonical Label"})
+    with pytest.raises(KeyError) as ei:
+        _fake_country({"Rural": tbl})._apply_categorical_mappings(
+            _sample_frame(), labels={"Rural": "Settlement"})
+    assert not isinstance(ei.value, LabelUnavailableError)
+
+
+def test_relabel_j_no_j_level_stays_a_plain_keyerror():
+    """Deliberately NOT flipped with the dict form -- the two differ.
+
+    A dict names an OPTIONAL column, so its absence is a coverage fact about
+    the country.  A scalar names no target: ``j`` is implicit because the
+    caller is asking for a food relabel, and ``j`` is required on every table
+    that has one -- so a food table without ``j`` is a structural defect of
+    the frame, not a country that never curated something.  Degrading it would
+    drop the country from a ``Feature`` assembly under a warning that names
+    the wrong cause.
+    """
+    fake = SimpleNamespace(name="Fixtureland",
+                           categorical_mapping={"food_items": _settlement_table()})
+    fake._relabel_j = _CountryCls._relabel_j.__get__(fake)
+    with pytest.raises(KeyError) as ei:
+        fake._relabel_j(_sample_frame(), "Aggregate", reaggregate=False)
+    assert not isinstance(ei.value, LabelUnavailableError)
+    assert "no 'j' index level" in str(ei.value)
 
 
 def test_index_levels_count_as_present_targets():
@@ -445,7 +503,8 @@ _SETTLEMENT_ORG = """\
 """
 
 
-def _make_country(countries_root: Path, name: str, cat_org: str | None) -> None:
+def _make_country(countries_root: Path, name: str, cat_org: str | None,
+                  *, with_rural: bool = True) -> None:
     """A minimal one-wave country whose ``sample`` reads a local CSV.
 
     No ``#+begin_example`` blocks anywhere: ``all_dfs_from_orgfile`` parses the
@@ -456,6 +515,7 @@ def _make_country(countries_root: Path, name: str, cat_org: str | None) -> None:
     (c / "_").mkdir(parents=True)
     (c / "2000" / "_").mkdir(parents=True)
     (c / "2000" / "Data").mkdir(parents=True)
+    rural_decl = "    Rural: str\n" if with_rural else ""
     (c / "_" / "data_scheme.yml").write_text(textwrap.dedent(f"""\
         Country: {name}
 
@@ -467,10 +527,10 @@ def _make_country(countries_root: Path, name: str, cat_org: str | None) -> None:
             index: (i, t)
             v: str
             weight: float
-            Rural: str
-        """))
+        """) + rural_decl)
     if cat_org is not None:
         (c / "_" / "categorical_mapping.org").write_text(cat_org)
+    rural_var = "        Rural: settlement\n" if with_rural else ""
     (c / "2000" / "_" / "data_info.yml").write_text(textwrap.dedent(f"""\
         Country: {name}
         Wave: '2000'
@@ -482,8 +542,7 @@ def _make_country(countries_root: Path, name: str, cat_org: str | None) -> None:
             myvars:
                 v: clust
                 weight: wt
-                Rural: settlement
-        """))
+        """) + rural_var)
     pd.DataFrame({
         "hhid": [f"h{n}" for n in range(1, 8)],
         "clust": ["c1", "c1", "c2", "c2", "c3", "c3", "c3"],
@@ -501,6 +560,9 @@ def synthetic_tree(tmp_path_factory):
     _make_country(countries, "Otherland", None)          # curates nothing
     _make_country(countries, "Malformedland",
                   _SETTLEMENT_ORG.replace("Preferred Label", "Canonical Label"))
+    # Curates the ladder, but its sample() has no Rural column at all -- the
+    # documented normal state for a country whose sample is (v, weight, strata).
+    _make_country(countries, "Columnlessland", _SETTLEMENT_ORG, with_rural=False)
     return {"LSMS_COUNTRIES_ROOT": str(countries),
             "LSMS_DATA_DIR": str(root / "data")}
 
@@ -588,13 +650,11 @@ def test_end_to_end_error_taxonomy(synthetic_tree):
         except KeyError:
             print('MALFORMED_PLAIN_KEYERROR')
 
-        # (c) target not in the frame -> plain KeyError
+        # (c) target not in the frame -> degrade, same as (a)
         try:
             Country('Fixtureland').sample(labels={'Roof': 'Detail'})
         except LabelUnavailableError:
-            raise AssertionError('absent target degraded instead of raising')
-        except KeyError:
-            print('ABSENT_TARGET_PLAIN_KEYERROR')
+            print('ABSENT_TARGET_LABEL_UNAVAILABLE')
 
         # (d) bad type
         try:
@@ -603,7 +663,7 @@ def test_end_to_end_error_taxonomy(synthetic_tree):
             print('BAD_TYPE_TYPEERROR')
         """, synthetic_tree)
     for marker in ("OTHERLAND_LABEL_UNAVAILABLE", "MALFORMED_PLAIN_KEYERROR",
-                   "ABSENT_TARGET_PLAIN_KEYERROR", "BAD_TYPE_TYPEERROR"):
+                   "ABSENT_TARGET_LABEL_UNAVAILABLE", "BAD_TYPE_TYPEERROR"):
         assert marker in out, out
 
 
@@ -643,6 +703,51 @@ def test_feature_degrades_for_an_uncurated_country(synthetic_tree):
         print('FEATURE_DEGRADE_OK')
         """, synthetic_tree)
     assert "FEATURE_DEGRADE_OK" in out
+
+
+def test_feature_degrades_for_a_country_with_no_such_column(synthetic_tree):
+    """@ligon, PR #697: a country whose frame lacks the target degrades too.
+
+    ``Otherland`` HAS ``Rural`` but curates no ``Settlement Label``;
+    ``Columnlessland`` curates the ladder but has no ``Rural`` column at all.
+    Both are missing curation from the caller's point of view, so both must be
+    dropped and reported the same way -- never as "Failed to load".
+    """
+    out = _run(f"""
+        import warnings
+        from lsms_library import Feature
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            df = Feature('sample')(['Fixtureland', 'Otherland', 'Columnlessland'],
+                                   labels={{'Rural': 'Settlement'}})
+        assert sorted(set(df.index.get_level_values('country'))) == ['Fixtureland'], df.index
+        assert list(df['Rural']) == {LADDER!r}, list(df['Rural'])
+        assert sorted(df.attrs['labels_unavailable']) == ['Columnlessland', 'Otherland'], \
+            df.attrs
+        msgs = [str(m.message) for m in w]
+        assert any('unavailable' in m and 'Columnlessland' in m for m in msgs), msgs
+        assert not any('Failed to load' in m for m in msgs), msgs
+        print('FEATURE_DEGRADE_BOTH_OK')
+        """, synthetic_tree)
+    assert "FEATURE_DEGRADE_BOTH_OK" in out
+
+
+def test_columnless_country_is_otherwise_healthy(synthetic_tree):
+    """Guard against the fixture proving the wrong thing.
+
+    ``Columnlessland`` must build fine WITHOUT a labels= request -- otherwise
+    the degradation above could be masking a broken country rather than
+    demonstrating the intended behaviour.
+    """
+    out = _run("""
+        from lsms_library import Country
+        df = Country('Columnlessland').sample()
+        assert len(df) == 7, len(df)
+        assert 'Rural' not in df.columns, df.columns
+        assert list(df['weight']) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+        print('COLUMNLESS_HEALTHY_OK')
+        """, synthetic_tree)
+    assert "COLUMNLESS_HEALTHY_OK" in out
 
 
 def test_feature_default_is_unaffected(synthetic_tree):

--- a/tests/test_label_selection.py
+++ b/tests/test_label_selection.py
@@ -1,0 +1,652 @@
+"""GH #682/#685 — query-time label selection beyond food's ``j`` index level.
+
+Three blocks:
+
+1. **Cache-independent unit tests** of ``Country._apply_categorical_mappings``
+   with an inline fake country, plus the ``_split_labels_arg`` /
+   ``_assert_label_targets_present`` contracts and the ``source_cols[0]``
+   ordering pin.
+2. **A structural cache test** — the label-selection machinery must stay
+   *outside* the ``@build_transform`` closure, or a read-path feature would
+   move every ``lsms_cache_hash`` in the corpus.
+3. **Subprocess integration tests** against a synthetic country tree
+   (``LSMS_COUNTRIES_ROOT`` + ``LSMS_DATA_DIR`` in a ``tmp_path``), covering the
+   real ``Country(...).sample(labels=...)`` path cold *and* warm, the error
+   taxonomy end to end, and ``Feature``'s graceful degradation.
+
+Why the mapping site and not ``_relabel_j``: see ``docs/design/label_selection.md``.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from lsms_library.country import (
+    Country as _CountryCls,
+    _RESERVED_U_SENTINELS,
+    _assert_label_targets_present,
+    _label_selection,
+    _label_targets_missing,
+    _split_labels_arg,
+    _LABEL_SELECTION,
+)
+from lsms_library.errors import LabelUnavailableError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures shared by the unit block
+# ---------------------------------------------------------------------------
+
+def _settlement_table() -> pd.DataFrame:
+    """A two-level ``Rural`` table: canonical binary + a 7-way ladder.
+
+    The column ORDER matters (``Code`` first) — see
+    ``test_source_cols_ordering_is_the_key_column``.
+    """
+    return pd.DataFrame({
+        "Code": [1, 2, 3, 4, 5, 6, 7],
+        "Preferred Label": ["Urban"] * 3 + ["Rural"] * 4,
+        "Settlement Label": ["City", "Large Town", "Medium Town", "Small Town",
+                             "Large Village", "Small Village", "Other"],
+    })
+
+
+def _fake_country(cat_maps, name="Fixtureland"):
+    """Minimal stand-in exposing what ``_apply_categorical_mappings`` reads."""
+    fake = SimpleNamespace(name=name, categorical_mapping=cat_maps)
+    fake._apply_categorical_mappings = (
+        _CountryCls._apply_categorical_mappings.__get__(fake))
+    return fake
+
+
+def _sample_frame(values=("1", "3", "6")):
+    idx = pd.MultiIndex.from_tuples(
+        [("2000", "v1", f"h{n}") for n in range(1, len(values) + 1)],
+        names=["t", "v", "i"])
+    df = pd.DataFrame({"Rural": list(values),
+                       "weight": [float(n) for n in range(1, len(values) + 1)]},
+                      index=idx)
+    df.attrs["id_converted"] = True
+    return df
+
+
+def _stub_finalize(fake):
+    """Bind the real ``_finalize_result`` onto a fake, stubbing only what the
+    label-selection branch does not exercise (index augmentation, id_walk,
+    the v-join)."""
+    fake._augment_index_from_related_tables = lambda df, scheme_entry, wave: df
+    fake.data_scheme = []            # no 'sample' -> no v-join re-entry
+    fake._updated_ids_cache = None   # no id_walk
+    fake._finalize_result = _CountryCls._finalize_result.__get__(fake)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# 1. The selection itself
+# ---------------------------------------------------------------------------
+
+def test_default_still_maps_to_preferred_label():
+    """No ``labels=`` -> historical behaviour, byte for byte."""
+    out = _fake_country({"Rural": _settlement_table()})._apply_categorical_mappings(
+        _sample_frame())
+    assert list(out["Rural"]) == ["Urban", "Urban", "Rural"]
+
+
+def test_selected_variant_resolves_the_raw_code():
+    """The whole point: the FINE label, recovered from the raw code."""
+    out = _fake_country({"Rural": _settlement_table()})._apply_categorical_mappings(
+        _sample_frame(), labels={"Rural": "Settlement"})
+    assert list(out["Rural"]) == ["City", "Medium Town", "Small Village"]
+
+
+def test_relabel_j_cannot_do_this():
+    """The proof that fixes the implementation point.
+
+    ``_relabel_j`` keys canonical -> variant on ``Preferred Label``.  That is a
+    function for food (one Preferred Label per item) and one-to-many here, so
+    ``to_dict()`` is last-row-wins.  If someone "simplifies" the selection back
+    onto the output side, this is what they get.
+    """
+    tbl = _settlement_table()
+    collapsed = (tbl[["Preferred Label", "Settlement Label"]]
+                 .dropna().set_index("Preferred Label")["Settlement Label"].to_dict())
+    assert collapsed == {"Urban": "Medium Town", "Rural": "Other"}
+    assert len(collapsed) == 2 < len(tbl)
+
+
+def test_target_key_is_case_insensitive():
+    out = _fake_country({"Rural": _settlement_table()})._apply_categorical_mappings(
+        _sample_frame(), labels={"rural": "Settlement"})
+    assert list(out["Rural"]) == ["City", "Medium Town", "Small Village"]
+
+
+def test_selection_applies_to_index_levels_too():
+    df = _sample_frame().reset_index().set_index(["t", "Rural", "i"])
+    out = _fake_country({"Rural": _settlement_table()})._apply_categorical_mappings(
+        df, labels={"Rural": "Settlement"})
+    assert list(out.index.get_level_values("Rural")) == [
+        "City", "Medium Town", "Small Village"]
+
+
+def test_bare_variant_column_name_is_accepted():
+    """``'X Label'`` first, then a bare ``'X'`` — the ``_relabel_j`` rule."""
+    tbl = _settlement_table().rename(columns={"Settlement Label": "Settlement"})
+    out = _fake_country({"Rural": tbl})._apply_categorical_mappings(
+        _sample_frame(), labels={"Rural": "Settlement"})
+    assert list(out["Rural"]) == ["City", "Medium Town", "Small Village"]
+
+
+def test_attrs_survive_the_selection():
+    """``id_converted`` must not be dropped — CLAUDE.md, panel-ID chains."""
+    df = _sample_frame().reset_index().set_index(["t", "Rural", "i"])
+    out = _fake_country({"Rural": _settlement_table()})._apply_categorical_mappings(
+        df, labels={"Rural": "Settlement"})
+    assert out.attrs.get("id_converted") is True
+
+
+def test_numeric_code_key_augmentation_survives_selection():
+    """``_augment_numeric_code_keys`` (GH #223 L2) still fires under selection."""
+    out = _fake_country({"Rural": _settlement_table()})._apply_categorical_mappings(
+        _sample_frame(values=("1.0", "3.0", "6.0")), labels={"Rural": "Settlement"})
+    assert list(out["Rural"]) == ["City", "Medium Town", "Small Village"]
+
+
+def test_u_sentinels_still_protected_under_selection():
+    """GH #361: a country ``u`` table must not remap 'kg'/'Value', selection or not."""
+    u_tbl = pd.DataFrame({
+        "Original Label": ["kg", "Value", "Tas"],
+        "Preferred Label": ["Kg", "value", "Basket"],
+        "Detail Label": ["Kilogramme", "Local currency", "Woven basket"],
+    })
+    idx = pd.MultiIndex.from_tuples(
+        [("2000", "h1", "Maize", "kg"), ("2000", "h1", "Salt", "Value"),
+         ("2000", "h1", "Yam", "Tas")], names=["t", "i", "j", "u"])
+    df = pd.DataFrame({"Quantity": [1.0, 2.0, 3.0]}, index=idx)
+    out = _fake_country({"u": u_tbl})._apply_categorical_mappings(
+        df, protect_u_sentinels=True, labels={"u": "Detail"})
+    got = list(out.index.get_level_values("u"))
+    assert set(_RESERVED_U_SENTINELS) <= set(got), got
+    assert got == ["kg", "Value", "Woven basket"]
+
+
+# ---------------------------------------------------------------------------
+# The source_cols[0] ordering hazard
+# ---------------------------------------------------------------------------
+
+def test_source_cols_ordering_is_the_key_column():
+    """PIN: the key column is "the first column that is not a label column".
+
+    Two halves, both deliberate:
+
+    * *default path* — reordering the table so a label column precedes ``Code``
+      makes the mapping key on the WRONG column and silently map nothing.  This
+      is a pre-existing, unguarded hazard; the test pins it so a future change
+      to the rule is a visible test failure rather than a quiet corpus-wide
+      re-decode.  **Keep the code column first.**
+    * *selection path* — the requested target is excluded from key selection,
+      so the same reordered table still keys on ``Code``.  Excluding the target
+      is a provable no-op when the target IS ``Preferred Label`` (the default),
+      which the first assertion of each pair holds fixed.
+    """
+    good = _settlement_table()                                    # Code first
+    bad = good[["Preferred Label", "Settlement Label", "Code"]]   # Code last
+
+    assert list(_fake_country({"Rural": good})._apply_categorical_mappings(
+        _sample_frame())["Rural"]) == ["Urban", "Urban", "Rural"]
+    # Reordered + default target: keys on 'Settlement Label', matches nothing,
+    # and the raw codes leak through untouched.  Silently wrong, by design of
+    # the historical rule.
+    assert list(_fake_country({"Rural": bad})._apply_categorical_mappings(
+        _sample_frame())["Rural"]) == ["1", "3", "6"]
+
+    # Selection excludes the target, so ordering cannot make it key on itself.
+    for tbl in (good, bad):
+        assert list(_fake_country({"Rural": tbl})._apply_categorical_mappings(
+            _sample_frame(), labels={"Rural": "Settlement"})["Rural"]) == [
+                "City", "Medium Town", "Small Village"]
+
+
+def test_no_key_column_left_is_a_loud_keyerror():
+    """A two-column ``| Preferred Label | X Label |`` table has nothing to key on."""
+    tbl = _settlement_table()[["Preferred Label", "Settlement Label"]]
+    with pytest.raises(KeyError) as ei:
+        _fake_country({"Rural": tbl})._apply_categorical_mappings(
+            _sample_frame(), labels={"Rural": "Settlement"})
+    assert not isinstance(ei.value, LabelUnavailableError)
+    assert "no key column left" in str(ei.value)
+
+
+# ---------------------------------------------------------------------------
+# Error taxonomy — Feature (feature.py:556) depends on this distinction
+# ---------------------------------------------------------------------------
+
+def test_no_mapping_table_is_label_unavailable():
+    """Missing curation -> degradable by Feature."""
+    with pytest.raises(LabelUnavailableError):
+        _fake_country({"Roof": _settlement_table()})._apply_categorical_mappings(
+            _sample_frame(), labels={"Rural": "Settlement"})
+
+
+def test_no_such_variant_column_is_label_unavailable():
+    with pytest.raises(LabelUnavailableError) as ei:
+        _fake_country({"Rural": _settlement_table()})._apply_categorical_mappings(
+            _sample_frame(), labels={"Rural": "Nutrition"})
+    assert "Settlement Label" in str(ei.value)      # names what IS available
+
+
+def test_country_with_no_mapping_tables_at_all_is_label_unavailable():
+    with pytest.raises(LabelUnavailableError):
+        _fake_country({})._apply_categorical_mappings(
+            _sample_frame(), labels={"Rural": "Settlement"})
+
+
+def test_table_without_preferred_label_is_a_plain_keyerror():
+    """Malformed table (has the table, no canonical column) -> loud, not degraded."""
+    tbl = _settlement_table().rename(columns={"Preferred Label": "Canonical Label"})
+    with pytest.raises(KeyError) as ei:
+        _fake_country({"Rural": tbl})._apply_categorical_mappings(
+            _sample_frame(), labels={"Rural": "Settlement"})
+    assert not isinstance(ei.value, LabelUnavailableError)
+    assert "Preferred Label" in str(ei.value)
+
+
+def test_malformed_table_is_still_silently_skipped_by_default():
+    """Unchanged: with no ``labels=``, a Preferred-Label-less table is skipped."""
+    tbl = _settlement_table().rename(columns={"Preferred Label": "Canonical Label"})
+    out = _fake_country({"Rural": tbl})._apply_categorical_mappings(_sample_frame())
+    assert list(out["Rural"]) == ["1", "3", "6"]
+
+
+# ---------------------------------------------------------------------------
+# _split_labels_arg: the scalar contract is non-negotiable
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("arg,expected", [
+    ("Preferred", ("Preferred", None)),
+    ("Aggregate", ("Aggregate", None)),
+    (None, (None, None)),
+    ({}, ("Preferred", None)),
+    ({"j": "Aggregate"}, ("Aggregate", None)),
+    ({"Rural": "Settlement"}, ("Preferred", {"Rural": "Settlement"})),
+    ({"j": "Aggregate", "Rural": "Settlement"},
+     ("Aggregate", {"Rural": "Settlement"})),
+])
+def test_split_labels_arg(arg, expected):
+    assert _split_labels_arg(arg) == expected
+
+
+def test_split_labels_arg_rejects_other_types():
+    with pytest.raises(TypeError):
+        _split_labels_arg(["Aggregate"])
+    with pytest.raises(TypeError):
+        _split_labels_arg({"Rural": 3})
+
+
+def test_dict_j_key_is_the_scalar_request():
+    """Documented equivalence: one mechanism per face."""
+    assert _split_labels_arg({"j": "Aggregate"}) == _split_labels_arg("Aggregate")
+
+
+# ---------------------------------------------------------------------------
+# Absent target -> plain KeyError (consistent with _relabel_j's no-'j' rule)
+# ---------------------------------------------------------------------------
+
+def test_absent_target_is_a_plain_keyerror():
+    df = _sample_frame()
+    assert _label_targets_missing(df, {"Rural": "Settlement"}) == []
+    assert _label_targets_missing(df, {"Roof": "Detail"}) == ["Roof"]
+    with pytest.raises(KeyError) as ei:
+        _assert_label_targets_present(df, {"Roof": "Detail"},
+                                      country="Fixtureland", table="sample")
+    assert not isinstance(ei.value, LabelUnavailableError)
+    _assert_label_targets_present(df, {"Rural": "Settlement"},
+                                  country="Fixtureland", table="sample")   # no raise
+    _assert_label_targets_present(df, None,
+                                  country="Fixtureland", table="sample")   # no raise
+
+
+def test_index_levels_count_as_present_targets():
+    df = _sample_frame().reset_index().set_index(["t", "Rural", "i"])
+    assert "Rural" in df.index.names and "Rural" not in df.columns
+    assert _label_targets_missing(df, {"Rural": "Settlement"}) == []   # index level
+    assert _label_targets_missing(df, {"weight": "X"}) == []           # column
+    assert _label_targets_missing(df, {"Roof": "X"}) == ["Roof"]
+
+
+# ---------------------------------------------------------------------------
+# ContextVar scoping — _finalize_result RE-ENTERS ITSELF
+# ---------------------------------------------------------------------------
+
+def test_label_selection_context_is_scoped_and_restored():
+    assert _LABEL_SELECTION.get() is None
+    with _label_selection("sample", {"Rural": "Settlement"}):
+        assert _LABEL_SELECTION.get() == ("sample", {"Rural": "Settlement"})
+    assert _LABEL_SELECTION.get() is None
+    # An empty/None selection must not set the var at all.
+    with _label_selection("sample", None):
+        assert _LABEL_SELECTION.get() is None
+    # ... and it is restored even when the body raises.
+    with pytest.raises(RuntimeError):
+        with _label_selection("sample", {"Rural": "Settlement"}):
+            raise RuntimeError("boom")
+    assert _LABEL_SELECTION.get() is None
+
+
+def test_context_selection_is_keyed_on_the_requesting_table():
+    """The load-bearing half of the scoping.
+
+    ``_finalize_result`` re-enters itself: ``_join_v_from_sample`` fetches
+    ``sample()`` from inside the finalize of some OTHER table.  If the stored
+    selection were applied regardless of table, that nested read would be
+    relabelled too — and worse, an error raised inside it is swallowed by
+    ``_join_v_from_sample``'s ``except (…, KeyError, …)``, so the ``v`` join
+    would silently vanish.
+    """
+    fake = _fake_country({"Rural": _settlement_table()})
+    captured = {}
+
+    def _spy(df, protect_u_sentinels=False, labels=None):
+        captured["labels"] = labels
+        return df
+
+    fake._apply_categorical_mappings = _spy
+    _stub_finalize(fake)
+
+    with _label_selection("household_roster", {"Rural": "Settlement"}):
+        fake._finalize_result(_sample_frame(), {}, "sample")
+    assert captured["labels"] is None, "selection leaked into a nested table read"
+
+    with _label_selection("household_roster", {"Rural": "Settlement"}):
+        fake._finalize_result(_sample_frame(), {}, "household_roster")
+    assert captured["labels"] == {"Rural": "Settlement"}
+
+
+def test_explicit_labels_argument_beats_the_context():
+    fake = _fake_country({"Rural": _settlement_table()})
+    captured = {}
+    def _spy(df, protect_u_sentinels=False, labels=None):
+        captured["labels"] = labels
+        return df
+
+    fake._apply_categorical_mappings = _spy
+    _stub_finalize(fake)
+    with _label_selection("sample", {"Rural": "Settlement"}):
+        fake._finalize_result(_sample_frame(), {}, "sample", labels={"Rural": "Other"})
+    assert captured["labels"] == {"Rural": "Other"}
+
+
+# ---------------------------------------------------------------------------
+# 2. Cache: the selection is post-read and must stay out of the build closure
+# ---------------------------------------------------------------------------
+
+def test_label_selection_is_outside_the_build_fingerprint():
+    """Structural proof that this feature cannot move any ``lsms_cache_hash``.
+
+    ``lsms_cache_hash`` folds in ``build_transforms_fingerprint``, which is the
+    *source AST* of every ``@build_transform``-tagged entry point and
+    everything its closure walk reaches.  ``_aggregate_wave_data`` IS tagged:
+    adding even one defaulted keyword argument to its signature was measured to
+    change the fingerprint for every table (a corpus-wide rebuild).  That is
+    precisely why the ``method() -> _finalize_result`` hop is carried by
+    ``_LABEL_SELECTION`` rather than by a parameter.
+
+    If a future refactor drags the label-selection machinery into the closure,
+    this test fails — which is the warning, not a nuisance.
+    """
+    from lsms_library._build_registry import _BUILD_TRANSFORMS, _closure_parts
+
+    seen: set = set()
+    parts: list = []
+    for _qn, (fn, _tables) in sorted(_BUILD_TRANSFORMS.items()):
+        parts += _closure_parts(fn, seen)
+
+    def _in_closure(qualname: str) -> bool:
+        return any(p.startswith(f"lsms_library.country.{qualname}=") for p in parts)
+
+    # sanity: the walk really does reach the tagged orchestrator
+    assert _in_closure("Country._aggregate_wave_data")
+    for qualname in ("Country._apply_categorical_mappings",
+                     "Country._finalize_result",
+                     "Country._relabel_j",
+                     "Country.__getattr__"):
+        assert not _in_closure(qualname), (
+            f"{qualname} entered the build-transform closure: editing it now "
+            f"invalidates every cached parquet in the corpus. Label selection "
+            f"is a READ-path feature and must stay outside it.")
+
+
+# ---------------------------------------------------------------------------
+# 3. Integration — a synthetic country tree, in a subprocess
+# ---------------------------------------------------------------------------
+
+_SETTLEMENT_ORG = """\
+#+name: Rural
+| Code | Preferred Label | Settlement Label |
+|------+-----------------+------------------|
+|    1 | Urban           | City             |
+|    2 | Urban           | Large Town       |
+|    3 | Urban           | Medium Town      |
+|    4 | Rural           | Small Town       |
+|    5 | Rural           | Large Village    |
+|    6 | Rural           | Small Village    |
+|    7 | Rural           | Other            |
+"""
+
+
+def _make_country(countries_root: Path, name: str, cat_org: str | None) -> None:
+    """A minimal one-wave country whose ``sample`` reads a local CSV.
+
+    No ``#+begin_example`` blocks anywhere: ``all_dfs_from_orgfile`` parses the
+    tables inside them as live mappings, so an illustrative block would become a
+    real (and wrong) categorical table.
+    """
+    c = countries_root / name
+    (c / "_").mkdir(parents=True)
+    (c / "2000" / "_").mkdir(parents=True)
+    (c / "2000" / "Data").mkdir(parents=True)
+    (c / "_" / "data_scheme.yml").write_text(textwrap.dedent(f"""\
+        Country: {name}
+
+        Waves:
+          - '2000'
+
+        Data Scheme:
+          sample:
+            index: (i, t)
+            v: str
+            weight: float
+            Rural: str
+        """))
+    if cat_org is not None:
+        (c / "_" / "categorical_mapping.org").write_text(cat_org)
+    (c / "2000" / "_" / "data_info.yml").write_text(textwrap.dedent(f"""\
+        Country: {name}
+        Wave: '2000'
+
+        sample:
+            file: ../Data/hh.csv
+            idxvars:
+                i: hhid
+            myvars:
+                v: clust
+                weight: wt
+                Rural: settlement
+        """))
+    pd.DataFrame({
+        "hhid": [f"h{n}" for n in range(1, 8)],
+        "clust": ["c1", "c1", "c2", "c2", "c3", "c3", "c3"],
+        "wt": [float(n) for n in range(1, 8)],
+        "settlement": [1, 2, 3, 4, 5, 6, 7],
+    }).to_csv(c / "2000" / "Data" / "hh.csv", index=False)
+
+
+@pytest.fixture(scope="module")
+def synthetic_tree(tmp_path_factory):
+    root = tmp_path_factory.mktemp("label_selection")
+    countries = root / "countries"
+    countries.mkdir()
+    _make_country(countries, "Fixtureland", _SETTLEMENT_ORG)
+    _make_country(countries, "Otherland", None)          # curates nothing
+    _make_country(countries, "Malformedland",
+                  _SETTLEMENT_ORG.replace("Preferred Label", "Canonical Label"))
+    return {"LSMS_COUNTRIES_ROOT": str(countries),
+            "LSMS_DATA_DIR": str(root / "data")}
+
+
+def _run(script: str, env_extra: dict) -> str:
+    env = dict(os.environ, **env_extra)
+    env.pop("LSMS_NO_CACHE", None)
+    r = subprocess.run([sys.executable, "-c",
+                        "import warnings; warnings.simplefilter('ignore')\n" +
+                        textwrap.dedent(script)],
+                       env=env, capture_output=True, text=True)
+    assert r.returncode == 0, f"stdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    return r.stdout
+
+
+LADDER = ["City", "Large Town", "Medium Town", "Small Town",
+          "Large Village", "Small Village", "Other"]
+BINARY = ["Urban"] * 3 + ["Rural"] * 4
+
+
+def test_end_to_end_cold_then_warm(synthetic_tree):
+    """Cold build, then a warm read off the L2-country parquet: same answer.
+
+    Also asserts what "post-read" MEANS: the cached parquet holds the RAW codes,
+    so both the canonical and the selected vocabulary are produced on read from
+    the same bytes.
+    """
+    out = _run(f"""
+        from pathlib import Path
+        import pandas as pd
+        from lsms_library import Country
+        from lsms_library.paths import data_root
+        LADDER = {LADDER!r}
+        BINARY = {BINARY!r}
+        assert list(Country('Fixtureland').sample()['Rural']) == BINARY
+        p = data_root('Fixtureland') / 'var' / 'sample.parquet'
+        assert p.exists(), p
+        raw = pd.read_parquet(p)
+        assert sorted(set(raw['Rural'].astype(str))) == list('1234567'), sorted(set(raw['Rural']))
+        # warm reads, both vocabularies, from the same cached bytes
+        assert list(Country('Fixtureland').sample()['Rural']) == BINARY
+        assert list(Country('Fixtureland').sample(labels={{'Rural': 'Settlement'}})['Rural']) == LADDER
+        print('COLD_WARM_OK')
+        """, synthetic_tree)
+    assert "COLD_WARM_OK" in out
+
+
+def test_end_to_end_cache_hash_is_unchanged_by_the_selection(synthetic_tree):
+    """The embedded ``lsms_cache_hash`` is identical before and after a
+    ``labels=`` read, and the parquet is not rewritten."""
+    out = _run("""
+        import pyarrow.parquet as pq
+        from lsms_library import Country
+        from lsms_library.paths import data_root
+        p = data_root('Fixtureland') / 'var' / 'sample.parquet'
+        Country('Fixtureland').sample()
+        before = (pq.read_schema(p).metadata or {}).get(b'lsms_cache_hash')
+        mtime_before = p.stat().st_mtime_ns
+        assert before is not None
+        Country('Fixtureland').sample(labels={'Rural': 'Settlement'})
+        after = (pq.read_schema(p).metadata or {}).get(b'lsms_cache_hash')
+        assert after == before, (before, after)
+        assert p.stat().st_mtime_ns == mtime_before, 'parquet was rewritten'
+        print('HASH_STABLE_OK')
+        """, synthetic_tree)
+    assert "HASH_STABLE_OK" in out
+
+
+def test_end_to_end_error_taxonomy(synthetic_tree):
+    out = _run("""
+        from lsms_library import Country
+        from lsms_library.errors import LabelUnavailableError
+
+        # (a) country curates no such table -> degradable
+        try:
+            Country('Otherland').sample(labels={'Rural': 'Settlement'})
+        except LabelUnavailableError:
+            print('OTHERLAND_LABEL_UNAVAILABLE')
+
+        # (b) malformed table -> plain KeyError, loud
+        try:
+            Country('Malformedland').sample(labels={'Rural': 'Settlement'})
+        except LabelUnavailableError:
+            raise AssertionError('malformed table degraded instead of raising')
+        except KeyError:
+            print('MALFORMED_PLAIN_KEYERROR')
+
+        # (c) target not in the frame -> plain KeyError
+        try:
+            Country('Fixtureland').sample(labels={'Roof': 'Detail'})
+        except LabelUnavailableError:
+            raise AssertionError('absent target degraded instead of raising')
+        except KeyError:
+            print('ABSENT_TARGET_PLAIN_KEYERROR')
+
+        # (d) bad type
+        try:
+            Country('Fixtureland').sample(labels=['Settlement'])
+        except TypeError:
+            print('BAD_TYPE_TYPEERROR')
+        """, synthetic_tree)
+    for marker in ("OTHERLAND_LABEL_UNAVAILABLE", "MALFORMED_PLAIN_KEYERROR",
+                   "ABSENT_TARGET_PLAIN_KEYERROR", "BAD_TYPE_TYPEERROR"):
+        assert marker in out, out
+
+
+def test_scalar_labels_never_touches_a_column(synthetic_tree):
+    """Back-compat: a scalar targets ``j`` and only ``j``.
+
+    ``sample`` has no ``j`` level and a mapped ``Rural`` column; a scalar must
+    leave ``Rural`` canonical.  (On a registered table with no ``j`` level the
+    scalar is a silent no-op — pre-existing behaviour, deliberately untouched;
+    the DICT form is the loud one.)
+    """
+    out = _run(f"""
+        from lsms_library import Country
+        assert list(Country('Fixtureland').sample(labels='Settlement')['Rural']) == {BINARY!r}
+        assert list(Country('Fixtureland').sample(labels='Preferred')['Rural']) == {BINARY!r}
+        assert list(Country('Fixtureland').sample()['Rural']) == {BINARY!r}
+        print('SCALAR_IS_J_ONLY_OK')
+        """, synthetic_tree)
+    assert "SCALAR_IS_J_ONLY_OK" in out
+
+
+def test_feature_degrades_for_an_uncurated_country(synthetic_tree):
+    """Contract B (feature.py:556): drop, warn once, mark ``attrs``."""
+    out = _run(f"""
+        import warnings
+        from lsms_library import Feature
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            df = Feature('sample')(['Fixtureland', 'Otherland'],
+                                   labels={{'Rural': 'Settlement'}})
+        assert sorted(set(df.index.get_level_values('country'))) == ['Fixtureland'], df.index
+        assert list(df['Rural']) == {LADDER!r}, list(df['Rural'])
+        assert df.attrs['labels_unavailable'] == ['Otherland'], df.attrs
+        msgs = [str(m.message) for m in w]
+        assert any('unavailable' in m and 'Otherland' in m for m in msgs), msgs
+        assert not any('Failed to load' in m for m in msgs), msgs
+        print('FEATURE_DEGRADE_OK')
+        """, synthetic_tree)
+    assert "FEATURE_DEGRADE_OK" in out
+
+
+def test_feature_default_is_unaffected(synthetic_tree):
+    out = _run(f"""
+        from lsms_library import Feature
+        df = Feature('sample')(['Fixtureland', 'Otherland'])
+        assert sorted(set(df.index.get_level_values('country'))) == ['Fixtureland', 'Otherland']
+        assert 'labels_unavailable' not in df.attrs
+        assert list(df.xs('Fixtureland', level='country')['Rural']) == {BINARY!r}
+        print('FEATURE_DEFAULT_OK')
+        """, synthetic_tree)
+    assert "FEATURE_DEFAULT_OK" in out

--- a/tests/test_label_selection.py
+++ b/tests/test_label_selection.py
@@ -14,7 +14,12 @@ Three blocks:
    real ``Country(...).sample(labels=...)`` path cold *and* warm, the error
    taxonomy end to end, and ``Feature``'s graceful degradation.
 
-Why the mapping site and not ``_relabel_j``: see ``docs/design/label_selection.md``.
+Why the mapping site and not ``_relabel_j``: see ``docs/guide/label-selection.md``.
+The real-world cells this exists for are the corpus audit's class A (GH #682):
+Iraq 2006-07 folds 7 raw ``xstrat`` settlement tiers onto 2 delivered values
+(12,194 households in one bucket), and Ethiopia ESS2/ESS3, Mali, Niger and
+Kazakhstan 1996 do the same at smaller scale.  None is wired; the fixture
+country below stands in for all of them so the test needs no microdata.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Core only. **No country config is wired** — this is the mechanism, not a use of it. Refs #682, #685.

## What it does

`labels='Aggregate'` already lets a caller pick a label variant for food's `j` index level. This extends the same *user-facing* affordance to any column or index level that has a matching `categorical_mapping` table.

```python
c.sample()['Rural'].unique()
# array(['Urban', 'Rural'])                                     canonical

c.sample(labels={'Rural': 'Settlement'})['Rural'].unique()
# array(['City', 'Large Town', 'Medium Town', 'Small Town',
#        'Large Village', 'Small Village', 'Other'])
```

## Motivation, re-pointed mid-task

The brief opened on GhanaLSS GLSS1/GLSS2. That motivation **evaporated**: the GLSS2 7-way `rural` table decodes `Y01C:NRCPL` — Household Questionnaire §1 Part C col. 13, *"Where does he/she live?"* about a **non-resident child** — so it is a migration attribute, not a settlement classification. (#690/#691 have since merged: GLSS1/GLSS2 `Rural` is wired with `SU` folded to `Rural`, and no canonical `Semi-urban` was added.)

The mechanism is still wanted, for #682's class-A cells. Measured read-only here on **Iraq 2006-07** (17,822 households; `strata` is the raw `xstrat`, whose suffix is the settlement tier):

| raw tier | households | delivered `Rural` |
|---|---:|---|
| `urban center` | 5,413 | Urban |
| `other urban` | 5,736 | Urban |
| `al-karekh` / `al-rasafah` / `al-sader` (Baghdad) | 314 / 318 / 321 | Urban |
| `extra` | 92 | Urban |
| `rural` | 5,628 | Rural |

Seven tiers → two values, 12,194 households in one bucket. Ethiopia ESS2/ESS3, Mali, Niger and Kazakhstan 1996 have the same shape. **None is wired here** — and note Iraq's `Rural` currently decodes through an inline `mapping:` dict in its wave YAML, a different route, so wiring it is separate work.

A shared *vocabulary* would not have fixed this either: #704 found that what defeats cross-country settlement harmonisation is variation in the **entity classified** (locality vs. enumeration area vs. commune), not the population threshold. That is an argument for exactly this design — a per-country label column selected by name, with no pretence that one country's ladder means another's.

## Why the mapping site, and not `_relabel_j`

`_relabel_j` keys canonical → variant on `Preferred Label`:

```python
rdict = (table[['Preferred Label', target]].dropna()
         .set_index('Preferred Label')[target].to_dict())
```

Sound for food, which is **fine → coarse**: one Preferred Label per item, so the map is a function. A settlement ladder is **coarse → fine** — two canonical values against seven rungs — so `.to_dict()` is last-row-wins. Measured:

```
{'Urban': 'Medium Town', 'Rural': 'Other'}
```

Two entries for seven rungs, both arbitrary. Unfixable at the output, because `_apply_categorical_mappings` has already collapsed the raw code onto `Preferred Label` and the fine information is gone from the frame. So the selection happens **at the mapping site**, choosing *which label column the raw code resolves to* — keyed on `Code`, which is unique, giving all seven entries.

`_relabel_j` is **unchanged**. It is not a legacy path; it is the correct mechanism for the other direction.

## API

| form | targets | applied by |
|---|---|---|
| `labels='Aggregate'` (scalar) | `j`, and **only** `j` | `_relabel_j`, on the finished frame |
| `labels={'Rural': 'Settlement'}` (dict) | any column or index level | `_apply_categorical_mappings`, at the raw code |

- Scalar behaviour is unchanged byte for byte, including on a table that has both a `j` level and a mapped column: a scalar never touches a column.
- Dict keys match columns and index levels case-insensitively; the variant resolves to `'<variant> Label'`, falling back to `'<variant>'` — `_relabel_j`'s existing rule.
- **`'j'` in a dict routes to `_relabel_j`**, so `labels={'j': 'Aggregate'}` ≡ `labels='Aggregate'`. One mechanism per face. They compose: `{'j': 'Aggregate', 'Rural': 'Settlement'}`.

### Error taxonomy — the axis is **absence vs. defect**

`Feature` (`feature.py:556`) depends on the distinction:

| situation | raises | `Feature` |
|---|---|---|
| no such mapping table, or no such label column | `LabelUnavailableError` | drops the country, one aggregated warning, `attrs['labels_unavailable']` |
| the result has no such column or index level | `LabelUnavailableError` | **same** |
| table has no `Preferred Label`, or no key column left (**malformed**) | plain `KeyError` | "Failed to load", loud |
| `labels=` is neither `str` nor dict, or a dict value is not a `str` | `TypeError` | as above |

**Resolved (@ligon, 2026-08-22)** — this was listed as an open decision in the first version of this PR and is now settled: an **absent target degrades**. A country simply not having the column is what `Feature` was built to degrade over, and it is indistinguishable *to the caller* from a country that has the column but not the requested variant. `Rural` is deliberately not `required` on `sample` — "many countries' sample table carries only (v, weight, strata) and has no urban/rural indicator at all" (`data_info.yml`) — so its absence is a documented, normal state of the corpus, not a broken build. A genuinely required column going missing is the business of the required-column guards (`_assert_built_required_columns`, the `grab_data` dropped-sub-df guard), not of `labels=`.

**`_relabel_j`'s "no `j` index level" is deliberately NOT flipped with it.** Re-examined as asked, and I agree they differ:

- a **dict** names its target, and the target it names is typically an *optional* column — absence is a coverage fact;
- a **scalar** names no target: `j` is implicit *because the caller is asking for a food relabel*, and `j` is required on every table that has one. A food table without `j` is a structural defect of the frame, and degrading it would drop the country under a warning naming the wrong cause.

That branch is also near-unreachable (the registered-table path guards the call with `if 'j' in result.index.names`; the derived-food path only reaches it for tables that have `j` by construction). It is a defensive guard, and weakening it to match an unrelated case buys nothing. Reasoning is written at the raise site, in `_assert_label_targets_present`'s docstring, and in the guide; pinned by `test_relabel_j_no_j_level_stays_a_plain_keyerror`.

One asymmetry surfaced and left alone: for a **registered** table the *scalar* form is a silent no-op when there is no `j` level, while the derived-food path raises. Pre-existing; back-compat was non-negotiable so it is untouched. The dict form is loud on both paths.

## Plumbing — and why one hop is out of band

`_finalize_result` and `_apply_categorical_mappings` both take an explicit `labels=`. The hop from `method()` down to the `_finalize_result` calls *inside* `_aggregate_wave_data` does not, deliberately.

`_aggregate_wave_data` carries `@build_transform()`; its **source AST** is folded into `build_transforms_fingerprint` → every `lsms_cache_hash`. Measured counterfactual on `development` — add one defaulted kwarg to its signature, change nothing else:

| `build_transforms_fingerprint(table)` | before | after |
|---|---|---|
| `None` (all tables) | `8bc39689…` | `ace7b84a…` |
| `sample` / `cluster_features` / `household_roster` | `1acba6d6…` | `a1aca3bd…` |

A corpus-wide rebuild, for a feature that runs *after* the cache read and cannot change a cached byte — exactly the over-invalidation `_EXCLUDED_CALLABLES` exists to prevent (`_finalize_result` is already listed there, "READ-path").

So that hop uses a `ContextVar` storing `(method_name, {target: variant})`. **The method name is load-bearing**: `_finalize_result` re-enters itself via `_join_v_from_sample` / `_location_lookup`, and an error raised inside such a nested read is swallowed by `_join_v_from_sample`'s `except (…, KeyError, …)` — so an unscoped selection could make the `v` join silently vanish.

## Cache evidence

- **12 real `Country._table_cache_hash` values, 8 countries × 4 tables** (Uganda, Malawi, GhanaLSS, Guyana, Nigeria, Tanzania, Ethiopia — `sample`, `cluster_features`, `food_acquired`, `household_roster`): **byte-identical** before and after.
- `build_transforms_fingerprint` for all tables: **byte-identical** (re-checked after the degrade change).
- Structural test `test_label_selection_is_outside_the_build_fingerprint` walks the real `@build_transform` closure and asserts `_apply_categorical_mappings`, `_finalize_result`, `_relabel_j` and `Country.__getattr__` are not in it — so a future refactor that drags them in fails a test rather than silently invalidating the corpus.
- End-to-end on a fixture country: the L2-country parquet holds the **raw codes**, both vocabularies are produced from the same cached bytes on a warm read, and the embedded `lsms_cache_hash` and the file mtime are unchanged by a `labels=` read.

## Food regression — real numbers

Uganda, cold, in a private `LSMS_DATA_DIR`, before (`development`) vs after. `diff` is empty.

| table | labels | rows | distinct `j` | column sum |
|---|---|---:|---:|---:|
| `food_expenditures` | Preferred | 247,049 | 130 | Expenditure 726,299,304.834043 |
| `food_expenditures` | Aggregate | 242,043 | 76 | Expenditure 726,299,304.834043 |
| `food_quantities` | Preferred | 349,057 | 129 | Quantity 1,457,881.374651 |
| `food_quantities` | Aggregate | 339,556 | 75 | Quantity 1,457,881.374651 |
| `food_prices` | Preferred | 349,081 | 129 | Price 1,023,109,994.968588 |
| `food_prices` | Aggregate | 349,081 | 75 | Price 1,023,109,994.968588 |
| `food_acquired` | Preferred | 355,571 | 130 | Expenditure 1,253,339,492.124043 |
| `food_acquired` | Aggregate | 355,571 | 76 | Expenditure 1,253,339,492.124043 |

`reaggregate` semantics intact: the derived tables collapse rows and preserve totals; `food_acquired` renames without summing (355,571 rows either way).

## Hazards handled

1. **`source_cols[0]` ordering.** Key selection now excludes the *requested target* as well as `Preferred Label` — a provable no-op when the target *is* `Preferred Label`. `test_source_cols_ordering_is_the_key_column` pins **both halves**, including the pre-existing hazard: reorder the table so a label column precedes `Code` and the *default* mapping keys on the wrong column and silently decodes nothing (raw `['1','3','6']` come straight through). Documented as "keep the code column first".
2. `_augment_numeric_code_keys` and `protect_u_sentinels` / `_RESERVED_U_SENTINELS` both tested under the new path.
3. Selection applies to **columns and index levels** alike; both tested.
4. `df.attrs` (`id_converted`) captured at entry and restored at exit of `_apply_categorical_mappings`; tested.
5. pandas 3.0: no `inplace=`, no chained indexing, no `fillna(method=)`.

## Also recorded

`docs/guide/label-selection.md` (added to the mkdocs nav) carries the user guide **and** the design note with both proofs. It also enumerates all **four** routes by which a raw code becomes a label, since only the first is extended: name-matched auto-dispatch; an explicit `mappings:` key in wave YAML (2 corpus-wide); `tools.code_label_map` consumed by a wave's own formatter (GhanaLSS GLSS3/GLSS4 `Rural`); and an inline `mapping:` dict under a `myvars` entry (Iraq, Malawi). And, verified: route 1 reads `Country.categorical_mapping`, which is country ∪ global and **never opens a wave directory** — a wave-level table cannot be selected with `labels=`.

Ledger at `.coder/ledger/682-label-selection.md`.

## Knowingly not done

- **#693** (`#+begin_example` tables in a global `.org` parse as live) and **#694** (unguarded `.str.strip()` nulls non-string values) are untouched. #694 is inside the function this branch modifies: the selection path reuses the *same* strip call, so it neither worsens nor fixes it. #693's tables are label-keyed, so their key-column resolution is unchanged here.
- **No `Code`-keyed-table-at-global-scope assertion.** The invariant is real (Iraq's `1` is not Ghana's `1`, and `_augment_numeric_code_keys` widens it) but `ehcvm_units.org` is a live global `Code`-keyed table, defensible as a single multi-country instrument. A guard needs an allowlist; documented instead. Noted in ledger §6.
- **gitnexus impact analysis could not be run** — the `gitnexus_*` MCP tools are not exposed in this session. The caller census was done at the ripgrep floor and is complete for the four symbols touched (`_apply_categorical_mappings`: 1 caller; `_finalize_result`: 3; `_relabel_j`: 2; plus 2 test stubs, one of which needed widening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019q5rAfxYg4uDUp1RcYAJTW
