### PR TITLE
fix(#704): decide .DAT layout from its .DCT instead of assuming one

### DIFF
--- a/lsms_library/countries/CotedIvoire/_/CONTENTS.org
+++ b/lsms_library/countries/CotedIvoire/_/CONTENTS.org
@@ -121,6 +121,116 @@ REL codes (F01A / SEC01A):
 - interview_date: date split across DAY1/MO1/YR1 — YAML path can't construct datetime
   (would need a Python script; not yet implemented)
 - shocks, assets, food_acquired: not attempted yet (complex multi-file modules)
+- community module: *available but NOT wired* — see the next section.
+
+** There IS a community module for all four CILSS waves (found 2026-08-22, GH #704)
+
+=COMM85.DAT= / =COMM86.DAT= / =COMM87.DAT= / =COMM88.DAT= (one per wave, each
+with a =.DCT=).  Nothing in this repository referenced them before 2026-08-22
+and no feature reads them; the =Implementation Status= table above lists only
+=sample=, =cluster_features= and =household_roster= for these waves.  They
+were reachable all along.
+
+*** Why they went unexamined: the same =.DAT=/=.DCT= trap as Ghana's
+
+The =.DCT= declares a fixed-width record (241 variables / 3132 columns for
+1985-86 and 1986-87; 213 / 2768 for 1987-88 and 1988-89).  *The shipped
+=.DAT= is comma-delimited with a header row* — actual line lengths are
+~530-560, not 3132.  A dictionary-driven =read_fwf= therefore returns a
+right-shaped frame of garbage without raising, which is exactly the failure
+=GhanaLSS/_/CONTENTS.org= records for GLSS1/GLSS2 =COMM.DAT=.  The #704
+settlement-threshold sweep filed all four as "Format unsupported" and
+predicted they were "the same shape as Ghana's =COMM.DAT=".  *Confirmed:
+they are.*  =get_dataframe= now detects the layout (GH #704); see the
+=.DAT=/=.DCT= block comment in =lsms_library/local_tools.py=.
+
+Note this does *not* contradict the =Implementation Status= claim that "the
+=.DAT/.DCT= files are readable by =get_dataframe()=".  They were readable —
+the fallback chain reached a bare =pd.read_csv=, which happens to be right
+about the delimiter.  What it got wrong was the =.= missing marker (so
+numeric columns shipped as strings) and, on large files, chunked dtype
+inference (the same code appearing as both =318= and ='318'=).
+
+*** What the four files contain
+
+| wave    | file        | vars | rows | clusters | schema                       |
+|---------+-------------+------+------+----------+------------------------------|
+| 1985-86 | =COMM85.DAT= |  241 |   54 |       54 | =CnnQnn=, 20 sections        |
+| 1986-87 | =COMM86.DAT= |  241 |   57 |       57 | =CnnQnn=, 20 sections        |
+| 1987-88 | =COMM87.DAT= |  213 |   47 |       47 | =SnnQnn=, 5 sections + dates |
+| 1988-89 | =COMM88.DAT= |  213 |   29 |       29 | =SnnQnn=, 5 sections + dates |
+
+One row per cluster, no duplicates.  *The instrument was redesigned between
+1986-87 and 1987-88*: the first two waves use =CLUSTER, C01Q01..C20Q03= with
+per-section repeat keys (=CL2=, =CL3=, ...), the last two use =CLUSTER,
+DAYINT, MOINT, YRINT, SUPID, INTMIN, S01Q01..S05Q24=.  Do not carry a
+variable mapping across that break.
+
+*** The key joins the existing cluster inventory exactly
+
+=CLUSTER= is the same =v= the library already uses.  Every community record
+matches a cluster in the wave's own =WEIGHT8x.DAT= — *54/54, 57/57, 47/47,
+29/29, zero orphans* — so these tables are join-ready against =sample= and
+=cluster_features= with no re-keying.
+
+*** IT IS A RURAL-ONLY INSTRUMENT.  This is the thing to know before using it.
+
+Cross-tabulating community-record coverage against the producer's own
+Urban/Rural definition (quoted verbatim in §1.1 point 3 below: /"Urban -
+Abidjan and Other Cities; Rural - East Forest, West Forest and Savanna"/)
+gives:
+
+| wave    | rural clusters covered | urban clusters covered |
+|---------+------------------------+------------------------|
+| 1985-86 | 53 / 57                | 1 / 43                 |
+| 1986-87 | 57 / 57                | 0 / 43                 |
+| 1987-88 | 46 / 50                | 1 / 50                 |
+| 1988-89 | 28 / 54                | 1 / 46                 |
+
+2 of 182 urban clusters across four waves.  *Any statistic computed from
+these files is a rural statistic*, whatever it is computed on.  In
+particular a settlement-population threshold applied to this module
+classifies only rural clusters and cannot produce a national urban share —
+the Q2 use case that surfaced the files in the first place.
+
+*** A population-shaped column, NOT confirmed to be population
+
+=C02Q01= (1985-86, 1986-87) and =S01Q01= (1987-88, 1988-89) are numeric,
+near-complete (50/54, 57/57, 46/47, 28/29) and distributed like community
+headcounts (medians 1125 / 1700 / 1000 / 750; ranges 85–16,000 / 120–19,000
+/ 100–13,000 / 150–9,000).  On the 25 clusters that appear in both the
+1986-87 and the 1987-88 files, the two *differently named* columns from the
+two *different* instrument designs correlate at r=0.79 (log r=0.77), with
+several exact agreements (4056↔4056, 500↔500).
+
+*That is evidence, and it is not proof.*  C4 — the questionnaire — is
+*unrunnable* here: all twelve CILSS questionnaire PDFs are image-only scans
+with no text layer and no OCR available (see /Where the statements live/
+below).  There is no =.DCT= label layer either: the dictionaries carry
+variable names and nothing else.  The #704 sweep's own hard-won lesson
+applies directly — /"a questionnaire question number is not evidence that
+the shipped variable is what you think it is.  Open the column."/ — and it
+cuts both ways: opening the column is also not evidence of what the
+question asked.  *Do not label these =Population= in any config until the
+instrument is read.*  Acquiring the 1996 CILSS Basic Information Document
+(catalog-hosted, listed in the acquisition queue below) is the cheap fix:
+its variable documentation would settle it.
+
+One methodological caveat on the above, recorded because it weakens the
+argument: the "control" column chosen to show that an arbitrary coded
+variable would *not* track across waves (=C02Q02=) turned out to track
+*more* tightly than the candidate (44/52 exact matches vs 5/49).  So the
+cross-wave correlation shows these two columns are the same quantity as
+each other; it does not by itself show that quantity is a headcount.  The
+magnitudes do the rest of the work, and magnitudes are suggestive, not
+dispositive.
+
+*** Status: reachable, not wired
+
+No feature is wired to these files and none is proposed here.  A
+=cluster_features= enrichment or a community-level table is the obvious
+candidate, gated on the rural-only caveat above and on identifying the
+variables from the instrument.
 
 ** Legacy food_expenditures
 

--- a/lsms_library/countries/GhanaLSS/1987-88/_/food_acquired.py
+++ b/lsms_library/countries/GhanaLSS/1987-88/_/food_acquired.py
@@ -26,7 +26,8 @@ from mapping import i as i_helper
 import numpy as np
 import pandas as pd
 sys.path.append('../../../_/')
-from lsms_library.local_tools import df_from_orgfile, to_parquet, get_dataframe
+from lsms_library.local_tools import (df_from_orgfile, format_id, get_dataframe,
+                                      to_parquet)
 
 t = '1987-88'
 VISIT = 1  # single "since my last visit" recall (D1: degenerate but kept)
@@ -53,7 +54,16 @@ def _value_only_side(fn, code_col, value_col, s):
     df['i'] = df['HID'].apply(i_helper)
 
     # food code -> harmonized Preferred Label (j)
-    df['j'] = df['FOODCD'].astype('string').replace(labelsd[code_col]['Preferred Label'])
+    #
+    # Normalize via format_id, NOT .astype('string').  The label table's keys
+    # are bare integer strings ('301'), and since GH #704 the .DAT reader
+    # honours Stata's '.' missing marker, so FOODCD arrives as float64 --
+    # .astype('string') would yield '301.0' and miss every code, shipping the
+    # raw number as the food label.  format_id strips the '.0' (its documented
+    # job) and returns None for NaN.  Same fix, same reason, as the GH #348
+    # unit decode in 1991-92.
+    df['j'] = (df['FOODCD'].apply(format_id).astype('string')
+                           .replace(labelsd[code_col]['Preferred Label']))
 
     # per-recall-period value (NOT the pre-annualized *_yearly column)
     df['value'] = pd.to_numeric(df[value_col].replace({'.': np.nan}), errors='coerce')

--- a/lsms_library/countries/GhanaLSS/1987-88/_/mapping.py
+++ b/lsms_library/countries/GhanaLSS/1987-88/_/mapping.py
@@ -33,9 +33,21 @@ def Sex(value):
 
 def Age(value):
     '''
-    Formatting age variable
+    Formatting age variable.
+
+    Dtype-agnostic on purpose.  This used to be
+    ``int(value) if value.isdigit() else pd.NA``, which requires a *string*
+    and raises ``AttributeError`` on any number -- it only ever worked
+    because AGEY happened to contain Stata's '.' missing marker and so
+    arrived as a str column.  Since GH #704 the .DAT reader honours that
+    marker, AGEY arrives as float64, and the whole wave's
+    ``household_roster`` build died.  (The sibling 1988-89 wave already
+    used the number-tolerant ``int(value)``.)
     '''
-    return int(value) if value.isdigit() else pd.NA
+    try:
+        return pd.NA if pd.isna(value) else int(float(value))
+    except (TypeError, ValueError):
+        return pd.NA
 
 def Birthplace(value):
     '''

--- a/lsms_library/countries/GhanaLSS/1988-89/_/food_acquired.py
+++ b/lsms_library/countries/GhanaLSS/1988-89/_/food_acquired.py
@@ -33,7 +33,8 @@ import pandas as pd
 sys.path.append('../../_')          # ghanalss.py (country-level helpers)
 sys.path.append('.')                # mapping.py  (this wave's i() helper)
 import mapping
-from lsms_library.local_tools import df_from_orgfile, to_parquet, get_dataframe
+from lsms_library.local_tools import (df_from_orgfile, format_id, get_dataframe,
+                                      to_parquet)
 
 t = '1988-89'
 # Single, degenerate recall window for this 1980s wave (design doc D3).
@@ -62,7 +63,14 @@ def _load_side(fn, code_col, value_col, source):
     df['i'] = df['HID'].apply(mapping.i)
 
     # Harmonized food item.
-    df['j'] = (df['FOODCD'].astype('string')
+    #
+    # Normalize via format_id, NOT .astype('string').  The label table's keys
+    # are bare integer strings ('301'), and since GH #704 the .DAT reader
+    # honours Stata's '.' missing marker, so FOODCD arrives as float64 --
+    # .astype('string') would yield '301.0' and miss every code, shipping the
+    # raw number as the food label.  format_id strips the '.0' (its documented
+    # job) and returns None for NaN.
+    df['j'] = (df['FOODCD'].apply(format_id).astype('string')
                            .replace(labelsd[code_col]['Preferred Label']))
 
     # Per-recall-period monetary value -> Expenditure (== Quantity, u='Value').

--- a/lsms_library/countries/GhanaLSS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaLSS/_/CONTENTS.org
@@ -1143,9 +1143,47 @@ The =.DCT= dictionaries look like Stata =infile= dictionaries and give
 =CID,CLUST,YRTITLND,HID,ACRFRM,...= and every row is comma-delimited.  Reading
 one with =pd.read_fwf(colspecs=...)= built from the =.DCT= "succeeds" and
 returns garbage -- shredded comma-strings spread across the wrong columns, with
-the numeric tail silently all-NaN and =nunique=0=.  Read them with
-=pd.read_csv(..., na_values=['.'])=; use the =.DCT= only as the authoritative
-*variable list*.
+the numeric tail silently all-NaN and =nunique=0=.  Use the =.DCT= only as the
+authoritative *variable list*.
+
+*** RESOLVED in the library reader (2026-08-22, GH #704)
+
+=get_dataframe= now reads a =.DAT= through its sibling =.DCT= and *detects*
+the layout rather than assuming one, so callers no longer need the
+=pd.read_csv(..., na_values=['.'])= workaround this section used to
+prescribe.  See the =.DAT=/=.DCT= block comment in =lsms_library/local_tools.py=
+for the detection rule.  Two things it fixes that were live here:
+
+1. *=.= is Stata's ASCII missing marker, and nothing was honouring it.*  A
+   single =.= in a numeric column silently demoted the whole column to
+   =str=.  Across the corpus's 531 =.DCT=-paired =.DAT= files, 449 gained
+   correctly-typed columns.
+2. *Worse than a =str= column: a MIXED =int=/=str= object column.*  Pandas
+   infers dtypes per chunk, so a bare =read_csv= on a large =.DAT= with a
+   =.= in it assigned =int64= to some chunks and =object= to others -- and
+   the same code then appeared *twice*, once as =318= and once as ='318'=.
+   Measured on =1987-88/Data/Y12A.DAT=: =FOODCD= has *61* real food codes
+   and one =.=, and the old reader reported *123* distinct values
+   (61 ints + 61 strings + the dot).  =FOODBLV= 2 -> 5, =MFOODBLY= 12 -> 25.
+   This is the =food_acquired= item code =j= for both GLSS1 and GLSS2.  A
+   groupby on such a column silently splits every key in two.  *This one
+   was not previously recorded anywhere.*
+
+*** Why this belongs with Traps 1-4
+
+Same signature as the categorical-decode traps above: *a thing that exists,
+looks authoritative, and silently does nothing (or does the wrong thing)
+while the build reports success.*  Trap 1 was a lookup dict that came back
+empty; Trap 4 was a fallback table nobody had ever exercised; the
+=#+name:= trap was an Org keyword attaching to the wrong element.  Here it
+is a *data dictionary that is wrong about its own file's layout* -- and,
+underneath it, a missing-value marker that no reader was reading.  In every
+case the failure is silent and looks exactly like success.
+
+The general rule these keep re-teaching: *when a declaration and the data
+disagree, the declaration is not automatically the loser -- but neither is
+it automatically the winner.  Test one against the other and fail loudly
+when they cannot be reconciled.*
 
 ** The =.DCT= label layer does not exist -- C1 cannot run on GLSS1/GLSS2
 

--- a/lsms_library/local_tools.py
+++ b/lsms_library/local_tools.py
@@ -71,6 +71,7 @@ import warnings
 import yaml
 import json
 import difflib
+import io
 import re
 import types
 from pyarrow.lib import ArrowInvalid
@@ -802,6 +803,288 @@ def _try_get_data_file(fn: str | Path) -> Path | None:
     return get_data_file(rel)
 
 
+# ---------------------------------------------------------------------------
+# ``.DAT`` / ``.DCT`` -- LSMS 1980s/90s ASCII extracts
+# ---------------------------------------------------------------------------
+#
+# The oldest surveys in the corpus (Côte d'Ivoire CILSS 1985-89, Ghana GLSS1/2,
+# Nicaragua EMNV 2001) ship each table as a pair: a ``.DAT`` payload and a
+# ``.DCT`` "data dictionary" in the Stata ``infile dictionary`` idiom --
+#
+#     dictionary
+#     parmfile=ascii
+#     variables
+#          1     12 R NO_CLST
+#         14     12 R CLUST
+#         ...
+#     endvars
+#
+# i.e. ``start-column  width  type  name``, describing a FIXED-WIDTH layout.
+#
+# *** The shipped .DAT files do not use that layout. ***  They are
+# comma-delimited with a header row.  A ``read_fwf(colspecs=...)`` built from
+# the dictionary "succeeds" and returns a frame of exactly the right shape
+# whose contents are shredded comma-strings and an all-NaN numeric tail --
+# silently, raising nothing.  That trap is recorded in
+# ``countries/GhanaLSS/_/CONTENTS.org`` ("GLSS1/GLSS2 .DAT files are
+# COMMA-SEPARATED WITH A HEADER ROW, not fixed-width") and was found by the
+# settlement-threshold sweep, PR #704.
+#
+# So the dictionary cannot be trusted about *layout*.  It is authoritative
+# about the *variable list*, and that is what makes the layout decidable:
+# ``_detect_dat_layout`` below tests the file against the dictionary rather
+# than guessing from the bytes alone.  The reason to route these files
+# through the dictionary at all, rather than leaving them to the bare
+# ``read_csv`` in the fallback chain, is that a bare ``read_csv`` has the
+# mirror-image failure: on a genuinely fixed-width file it returns a single
+# column of whole lines, equally silently.
+_DCT_VAR_RE = re.compile(r'^\s*(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s*$')
+
+#: Field value meaning "missing" in a Stata ASCII export.  Matched against
+#: the *whole* field, so ``2.5`` is untouched.
+_DAT_NA_VALUES = ['.']
+
+
+class DatLayoutError(ValueError):
+    """A ``.DAT``/``.DCT`` pair whose layout could not be established.
+
+    Raised rather than guessed at: both candidate parses (fixed-width and
+    comma-delimited) fail silently on the wrong file, returning a
+    plausibly-shaped frame full of garbage.
+    """
+
+
+def _parse_dct(text: str) -> "tuple[list[str], list[tuple[int, int]]] | None":
+    """Parse an LSMS ``.DCT`` ASCII data dictionary.
+
+    Returns ``(names, colspecs)`` where ``colspecs`` is the pandas
+    half-open 0-based ``[(start, end), ...]`` form, or ``None`` if *text*
+    is not a dictionary we recognise.
+
+    Only lines between ``variables`` and ``endvars`` are considered, and
+    every one of them must parse -- a dictionary we only half-understand
+    is not a dictionary we may act on.
+    """
+    names: list[str] = []
+    colspecs: list[tuple[int, int]] = []
+    in_vars = False
+    saw_block = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == 'variables':
+            in_vars = True
+            saw_block = True
+            continue
+        if stripped == 'endvars':
+            in_vars = False
+            continue
+        if not in_vars or not stripped:
+            continue
+        m = _DCT_VAR_RE.match(line)
+        if m is None:
+            return None          # unrecognised grammar -> not our dictionary
+        start, width = int(m.group(1)), int(m.group(2))
+        if start < 1 or width < 1:
+            return None
+        names.append(m.group(4))
+        colspecs.append((start - 1, start - 1 + width))
+    if not saw_block or not names:
+        return None
+    return names, colspecs
+
+
+def _dct_path_for(fn: str | Path) -> "tuple[Path, tuple[str, ...]] | None":
+    """``(path, suffixes-to-try)`` for the sibling ``.DCT`` of a ``.DAT``.
+
+    Purely lexical -- no I/O -- so every non-``.DAT`` read pays a single
+    string compare.  Case variants are tried in a deterministic order,
+    the payload's own suffix case first.
+    """
+    p = Path(fn)
+    if p.suffix.lower() != '.dat':
+        return None
+    order = ('.DCT', '.dct') if p.suffix.isupper() else ('.dct', '.DCT')
+    return p, order
+
+
+def _read_sidecar_bytes(fn: str | Path) -> "bytes | None":
+    """Raw bytes of a non-tabular sidecar, or ``None`` if unreachable.
+
+    Deliberately narrower than ``get_dataframe``'s chain: a local file,
+    else the DVC blob cache (sidecar md5 -> direct S3 on a miss).  It
+    stops there rather than falling through to ``DVCFS.open`` or the WB
+    NADA download, because this runs *speculatively* on every ``.DAT``
+    read, including ones with no dictionary at all.  ``DVCFS.open`` walks
+    the ``.dvc`` sidecar tree (~10-20s on Lustre per call, see
+    ``get_dataframe``) and the NADA path is a network round trip; paying
+    either to discover a file's absence would be a serious regression.
+    Unreachable simply means the caller keeps its old behaviour.
+    """
+    p = Path(fn)
+    for cand in ([p] if p.is_absolute() else [p, _COUNTRIES_DIR / p]):
+        try:
+            if cand.is_file() and not _is_polluted_workspace_copy(cand):
+                return cand.read_bytes()
+        except OSError:
+            continue
+    try:
+        _ensure_dvc_pulled(fn)
+        cache_path = _dvc_cache_path(fn)
+        if cache_path is not None:
+            return cache_path.read_bytes()
+    except OSError:
+        pass
+    return None
+
+
+def _load_dct_for(fn: str | Path) -> "tuple[list[str], list[tuple[int, int]]] | None":
+    """Locate and parse the ``.DCT`` dictionary belonging to ``.DAT`` *fn*.
+
+    Returns ``None`` -- leaving the caller on the untouched legacy reader
+    chain -- when *fn* is not a ``.DAT``, when no sibling dictionary can be
+    reached, or when the dictionary's grammar is unrecognised.  Only a
+    dictionary we fully parsed licenses the dictionary-driven read.
+    """
+    found = _dct_path_for(fn)
+    if found is None:
+        return None
+    p, suffixes = found
+    for suffix in suffixes:
+        raw = _read_sidecar_bytes(p.with_suffix(suffix))
+        if raw is None:
+            continue
+        for enc in ('utf-8', 'latin-1'):
+            try:
+                text = raw.decode(enc)
+            except UnicodeDecodeError:
+                continue
+            parsed = _parse_dct(text)
+            if parsed is not None:
+                return parsed
+            break
+    return None
+
+
+def _detect_dat_layout(lines: list[str], names: list[str],
+                       colspecs: list[tuple[int, int]]) -> str:
+    """Decide how a ``.DAT`` payload is laid out, given its dictionary.
+
+    *lines* is a sample of the file's non-empty lines (first line first).
+    Returns one of ``'csv-header'``, ``'fixed'``, ``'csv-noheader'``, or
+    ``'unknown'``.  Deterministic: no thresholds, no scoring, no
+    tie-breaking on row counts.
+
+    The three tests, in order, and why none of them can misfire:
+
+    ``csv-header``
+        Line 1 comma-splits into *exactly* the dictionary's variable names,
+        in order (case-insensitively).  A fixed-width file's line 1 is a
+        data record; for it to comma-split into its own dictionary's name
+        list it would have to literally contain that list -- at which point
+        it *is* a header row.
+
+    ``fixed``
+        Every sampled line fits inside the declared record, and every
+        column the dictionary leaves *between* fields is blank wherever the
+        line reaches it.  Comma-delimited numeric payloads carry no spaces,
+        so a comma-delimited line fails this on its first inter-field
+        column.  (Where the dictionary declares contiguous fields there are
+        no gap columns and this rests on the length test alone.)
+
+    ``csv-noheader``
+        Every sampled line comma-splits into exactly ``len(names)`` fields
+        and the fixed-width test already failed.
+
+    A fixed-width file that happens to carry commas *inside a text field*
+    is the case worth stating plainly: it fails ``csv-header`` (its first
+    record is not the name list), passes ``fixed`` (the commas sit inside
+    declared fields, so the gap columns are still blank), and never
+    reaches ``csv-noheader``.  It is read fixed-width, which is correct.
+    Had its comma count coincidentally equalled ``len(names) - 1``, the
+    earlier ``fixed`` verdict still wins.
+    """
+    if not lines:
+        return 'unknown'
+
+    header = [tok.strip().upper() for tok in lines[0].split(',')]
+    if header == [n.upper() for n in names]:
+        return 'csv-header'
+
+    reclen = max(end for _, end in colspecs)
+    last_start = max(start for start, _ in colspecs)
+    gap_cols = sorted(set(range(reclen)) -
+                      {c for start, end in colspecs for c in range(start, end)})
+    lengths = [len(line.rstrip('\r\n')) for line in lines]
+    fits = all(n <= reclen for n in lengths)
+    reaches = max(lengths) > last_start
+    gaps_blank = all(line[c] == ' '
+                     for line in lines
+                     for c in gap_cols if c < len(line))
+    if fits and reaches and gaps_blank:
+        return 'fixed'
+
+    if all(len(line.split(',')) == len(names) for line in lines):
+        return 'csv-noheader'
+
+    return 'unknown'
+
+
+def _read_dat_with_dct(raw: bytes, names: list[str],
+                       colspecs: list[tuple[int, int]],
+                       fn: str | Path,
+                       encoding: str | None = None,
+                       sample: int = 50) -> pd.DataFrame:
+    """Read a ``.DAT`` payload using its ``.DCT`` dictionary.
+
+    Detects the layout (see :func:`_detect_dat_layout`) and parses
+    accordingly, honouring the Stata ASCII missing-value marker ``.`` in
+    every mode -- without which a numeric column holding a single missing
+    value ships as a ``str`` column of digit-strings and dots.
+
+    Raises :class:`DatLayoutError` when the layout cannot be established.
+    """
+    for enc in ([encoding] if encoding else []) + ['utf-8', 'latin-1']:
+        try:
+            text = raw.decode(enc)
+            break
+        except (UnicodeDecodeError, LookupError):
+            continue
+    else:
+        raise DatLayoutError(f"{fn}: could not decode as text")
+
+    lines = [ln for ln in text.splitlines() if ln.strip()][:sample]
+    layout = _detect_dat_layout(lines, names, colspecs)
+
+    # ``low_memory=False`` is not an optimisation here, it is a correctness
+    # requirement.  Chunked type inference assigns dtypes per chunk, so a
+    # large ``.DAT`` could come back as an *object* column mixing ``int``
+    # and ``str`` for the same value -- measured on GhanaLSS 1987-88
+    # ``Y12A.DAT``, whose 61 real ``FOODCD`` food codes were reported as
+    # 123 distinct values (61 ints + 61 strings + the ``.``).  A groupby on
+    # such a column silently splits every key in two.
+    if layout == 'csv-header':
+        return pd.read_csv(io.StringIO(text), na_values=_DAT_NA_VALUES,
+                           low_memory=False)
+    if layout == 'csv-noheader':
+        return pd.read_csv(io.StringIO(text), header=None, names=names,
+                           na_values=_DAT_NA_VALUES, low_memory=False)
+    if layout == 'fixed':
+        return pd.read_fwf(io.StringIO(text), colspecs=colspecs, names=names,
+                           header=None, na_values=_DAT_NA_VALUES)
+
+    reclen = max(end for _, end in colspecs)
+    raise DatLayoutError(
+        f"{fn}: cannot establish the layout of this .DAT from its .DCT. "
+        f"The dictionary declares {len(names)} variables in a "
+        f"{reclen}-column fixed-width record, but the payload matches "
+        f"neither that record nor a {len(names)}-field comma-delimited "
+        f"one (first line has {len(lines[0].split(',')) if lines else 0} "
+        f"comma-separated fields and is {len(lines[0]) if lines else 0} "
+        f"characters long). Refusing to guess: both candidate parses "
+        f"return a plausibly-shaped frame of garbage without raising. "
+        f"See the .DAT/.DCT note in local_tools.py and GH #704.")
+
+
 def get_dataframe(fn: str | Path, convert_categoricals: bool = True, encoding: str | None = None, categories_only: bool = False) -> pd.DataFrame:
     """From a file named fn, try to return a dataframe.
 
@@ -879,6 +1162,22 @@ def get_dataframe(fn: str | Path, convert_categoricals: bool = True, encoding: s
             os.unlink(tmp_path)
 
     def read_file(f,convert_categoricals=convert_categoricals,encoding=encoding):
+        # ``.DAT`` with a sibling ``.DCT`` dictionary: read it through the
+        # dictionary (see the block comment above ``_parse_dct``).  The
+        # suffix test is a pure string compare, so every other file type
+        # pays nothing.  A ``.DAT`` whose dictionary is missing or written
+        # in a grammar we do not recognise falls through to the legacy
+        # chain below, unchanged.
+        dct = _load_dct_for(fn)
+        if dct is not None:
+            if isinstance(f, str):
+                raw = Path(f).read_bytes()
+            else:
+                f.seek(0)
+                raw = f.read()
+            return _read_dat_with_dct(raw, dct[0], dct[1], fn=fn,
+                                      encoding=encoding)
+
         if isinstance(f,str):
             try:
                 return pd.read_spss(f,convert_categoricals=convert_categoricals)

--- a/tests/test_dat_dct_reader.py
+++ b/tests/test_dat_dct_reader.py
@@ -1,0 +1,227 @@
+"""Regression coverage for the ``.DAT``/``.DCT`` parse path (GH #704).
+
+The oldest surveys in the corpus (Côte d'Ivoire CILSS 1985-89, Ghana
+GLSS1/GLSS2, Nicaragua EMNV 2001) ship 531 ``.DAT``/``.DCT`` pairs.  The
+``.DCT`` declares a fixed-width layout; the shipped ``.DAT`` is in fact
+comma-delimited with a header row.  *Both* readings fail silently on the
+wrong file:
+
+- a dictionary-driven ``read_fwf`` on the comma-delimited payload returns
+  a right-shaped frame of shredded strings with an all-NaN numeric tail
+  (the #704 finding), and
+- a bare ``read_csv`` on a genuinely fixed-width payload returns a single
+  column of whole lines.
+
+So the reader must *decide*, not assume.  These tests are all synthetic
+-- no DVC, no network, no fixtures from the corpus -- so they run in the
+cache-gated fast tier.
+
+Each of the first four tests fails on the pre-#704 reader:
+``test_missing_value_sentinel_becomes_na`` (it shipped ``str`` columns
+full of ``'.'``), ``test_true_fixed_width_is_not_read_as_csv`` (one
+column), ``test_fixed_width_with_commas_in_a_text_field``
+(comma-shredded), and ``test_undecidable_layout_raises`` (it silently
+returned garbage).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from lsms_library.local_tools import (DatLayoutError, _detect_dat_layout,
+                                      _load_dct_for, _parse_dct,
+                                      get_dataframe)
+
+# A three-variable dictionary in the corpus's own idiom: start column,
+# width, type code, name.  Fields are 12 wide on a stride of 13, so
+# columns 12 and 25 (0-based) are inter-field gaps.
+DCT = """dictionary
+parmfile=ascii
+variables
+     1     12 R CLUST
+    14     12 R POPUL
+    27     12 c NAME
+endvars
+"""
+
+NAMES = ['CLUST', 'POPUL', 'NAME']
+
+
+def _pair(tmp_path, dat_text, dct_text=DCT, stem='COMM'):
+    """Write a ``.DAT``/``.DCT`` pair and return the ``.DAT`` path."""
+    dat = tmp_path / f'{stem}.DAT'
+    dat.write_text(dat_text)
+    if dct_text is not None:
+        (tmp_path / f'{stem}.DCT').write_text(dct_text)
+    return str(dat)
+
+
+def _fw_row(clust, popul, name):
+    """One fixed-width record matching ``DCT``: 12/1/12/1/12 = 38 chars."""
+    return f'{clust:>12} {popul:>12} {name:<12}'
+
+
+# ---------------------------------------------------------------------------
+# The dictionary
+# ---------------------------------------------------------------------------
+
+def test_parse_dct_reads_names_and_colspecs():
+    names, colspecs = _parse_dct(DCT)
+    assert names == NAMES
+    assert colspecs == [(0, 12), (13, 25), (26, 38)]
+
+
+def test_parse_dct_accepts_the_separator_declaring_variant():
+    """``CotedIvoire/1988-89/Data/SEC10A.DCT`` is the corpus's one
+    dictionary that declares its own layout (``names=y``,
+    ``separator=,``) instead of ``parmfile=ascii``.  It must still
+    parse -- it carries the same ``variables``/``endvars`` block."""
+    text = DCT.replace('parmfile=ascii', 'names=y\nseparator=,')
+    names, _ = _parse_dct(text)
+    assert names == NAMES
+
+
+def test_parse_dct_rejects_an_unrecognised_grammar():
+    """A dictionary we only half-understand must not license a read.
+    Returning ``None`` leaves the caller on the legacy reader chain."""
+    text = DCT.replace('    14     12 R POPUL', '  _column(14) float POPUL %12f')
+    assert _parse_dct(text) is None
+
+
+def test_parse_dct_rejects_a_file_with_no_variables_block():
+    assert _parse_dct('dictionary\nparmfile=ascii\n') is None
+
+
+# ---------------------------------------------------------------------------
+# Layout detection
+# ---------------------------------------------------------------------------
+
+def test_detect_header_row():
+    names, colspecs = _parse_dct(DCT)
+    lines = ['CLUST,POPUL,NAME', '101,2000,Accra']
+    assert _detect_dat_layout(lines, names, colspecs) == 'csv-header'
+
+
+def test_detect_header_row_is_case_insensitive():
+    names, colspecs = _parse_dct(DCT)
+    lines = ['clust,popul,name', '101,2000,Accra']
+    assert _detect_dat_layout(lines, names, colspecs) == 'csv-header'
+
+
+def test_detect_fixed_width():
+    names, colspecs = _parse_dct(DCT)
+    lines = [_fw_row('101', '2000', 'Accra'), _fw_row('102', '750', 'Kumasi')]
+    assert _detect_dat_layout(lines, names, colspecs) == 'fixed'
+
+
+def test_detect_headerless_delimited():
+    names, colspecs = _parse_dct(DCT)
+    lines = ['101,2000,Accra', '102,750,Kumasi']
+    assert _detect_dat_layout(lines, names, colspecs) == 'csv-noheader'
+
+
+def test_a_comma_delimited_line_never_reads_as_fixed_width():
+    """The load-bearing asymmetry: comma-delimited numeric payloads carry
+    no spaces, so an inter-field gap column is never blank in one."""
+    names, colspecs = _parse_dct(DCT)
+    lines = ['101,2000,Accra']
+    assert _detect_dat_layout(lines, names, colspecs) != 'fixed'
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through ``get_dataframe``
+# ---------------------------------------------------------------------------
+
+def test_missing_value_sentinel_becomes_na(tmp_path):
+    """The live #704 defect: ``.`` is Stata's ASCII missing marker.  Left
+    unhandled, one missing value silently demotes a whole numeric column
+    to ``str`` -- which is what every one of the corpus's 531 pairs did."""
+    fn = _pair(tmp_path, 'CLUST,POPUL,NAME\n101,2000,Accra\n102,.,Kumasi\n')
+    df = get_dataframe(fn)
+
+    assert list(df.columns) == NAMES
+    assert len(df) == 2
+    assert pd.api.types.is_numeric_dtype(df['POPUL'])
+    assert df['POPUL'].iloc[0] == 2000
+    assert pd.isna(df['POPUL'].iloc[1])
+    # A decimal point *inside* a value is not a missing marker.
+    assert df['NAME'].tolist() == ['Accra', 'Kumasi']
+
+
+def test_decimal_values_are_not_mistaken_for_the_sentinel(tmp_path):
+    fn = _pair(tmp_path, 'CLUST,POPUL,NAME\n101,2.5,Accra\n')
+    df = get_dataframe(fn)
+    assert df['POPUL'].iloc[0] == pytest.approx(2.5)
+
+
+def test_true_fixed_width_is_not_read_as_csv(tmp_path):
+    """The mirror-image failure the detector also has to prevent: a bare
+    ``read_csv`` returns a single column of whole lines here."""
+    fn = _pair(tmp_path, '\n'.join([_fw_row('101', '2000', 'Accra'),
+                                    _fw_row('102', '750', 'Kumasi')]) + '\n')
+    df = get_dataframe(fn)
+
+    assert list(df.columns) == NAMES
+    assert df.shape == (2, 3)
+    assert df['CLUST'].tolist() == [101, 102]
+    assert df['POPUL'].tolist() == [2000, 750]
+    assert df['NAME'].tolist() == ['Accra', 'Kumasi']
+
+
+def test_fixed_width_sentinel_becomes_na(tmp_path):
+    fn = _pair(tmp_path, _fw_row('101', '.', 'Accra') + '\n'
+                         + _fw_row('102', '750', 'Kumasi') + '\n')
+    df = get_dataframe(fn)
+    assert pd.isna(df['POPUL'].iloc[0])
+    assert df['POPUL'].iloc[1] == 750
+
+
+def test_fixed_width_with_commas_in_a_text_field(tmp_path):
+    """The stated misfire case.  A fixed-width record whose text field
+    contains commas fails the header test (its first record is not the
+    dictionary's name list) and passes the fixed-width test (the commas
+    sit *inside* a declared field, so the gap columns are still blank).
+    It is read fixed-width, and the comma stays in the value."""
+    fn = _pair(tmp_path, _fw_row('101', '2000', 'Accra, GA') + '\n'
+                         + _fw_row('102', '750', 'Kumasi, AS') + '\n')
+    df = get_dataframe(fn)
+
+    assert df.shape == (2, 3)
+    assert df['NAME'].tolist() == ['Accra, GA', 'Kumasi, AS']
+    assert df['CLUST'].tolist() == [101, 102]
+
+
+def test_headerless_delimited_takes_names_from_the_dictionary(tmp_path):
+    fn = _pair(tmp_path, '101,2000,Accra\n102,.,Kumasi\n')
+    df = get_dataframe(fn)
+    assert list(df.columns) == NAMES
+    assert pd.isna(df['POPUL'].iloc[1])
+
+
+def test_undecidable_layout_raises(tmp_path):
+    """Neither hypothesis fits: five comma-separated fields against a
+    three-variable dictionary, too short to be the declared record.
+    Silently returning a plausible frame is what #704 was."""
+    fn = _pair(tmp_path, '1,2,3,4,5\n6,7,8,9,10\n')
+    with pytest.raises(DatLayoutError) as exc:
+        get_dataframe(fn)
+    assert 'cannot establish the layout' in str(exc.value)
+
+
+def test_dat_without_a_dictionary_is_left_on_the_legacy_path(tmp_path):
+    """Rwanda's ``PartA/B/C.dat`` and Pakistan's ``WEIGHTS.DAT`` ship with
+    no ``.DCT``.  With no dictionary there are no colspecs to build, so
+    behaviour must be exactly what it was."""
+    fn = _pair(tmp_path, 'CLUST,POPUL\n101,2000\n', dct_text=None)
+    df = get_dataframe(fn)
+    assert list(df.columns) == ['CLUST', 'POPUL']
+    assert _load_dct_for(fn) is None
+
+
+def test_unparseable_dictionary_is_left_on_the_legacy_path(tmp_path):
+    fn = _pair(tmp_path, 'CLUST,POPUL\n101,2000\n',
+               dct_text='infile dictionary {\n  _column(1) int CLUST %12f\n}\n')
+    assert _load_dct_for(fn) is None
+    df = get_dataframe(fn)
+    assert list(df.columns) == ['CLUST', 'POPUL']


### PR DESCRIPTION
Found by the settlement-threshold sweep, #704
(`slurm_logs/settlement_thresholds/FINDINGS_threshold_rules.org`). Opens the
CotedIvoire opportunity filed as #706.

## The premise, corrected — quoted on both sides

#704 says a fixed-width parse of these files "returns a DataFrame of the right
shape with all-NaN contents, and raises nothing." That is true, and it
describes a **`read_fwf(colspecs=...)` the sweep ran ad hoc** — `get_dataframe`
never had a `.DCT` path at all. Its fallback chain reaches a bare `read_csv`,
which happens to be right about the delimiter. `CotedIvoire/_/CONTENTS.org`
already says so:

> The `.DAT/.DCT` files are readable by `get_dataframe()` from `local_tools`.
> The prior agent incorrectly concluded they were not.

That stands. What the bare `read_csv` got **wrong**, on all 531 pairs:

1. **`.` is Stata's ASCII missing marker and nothing honoured it.** One missing
   value silently demoted a numeric column to `str`. 449 of 531 files gain
   correctly-typed columns.
2. **Worse — chunked type inference produced *mixed* `int`/`str` object
   columns.** GhanaLSS 1987-88 `Y12A.DAT` `FOODCD` — the `food_acquired` item
   code `j` — has **61** real codes and reported **123** distinct values (61
   ints + 61 strings + the dot). pandas even warns
   (`DtypeWarning: Columns (0: FOODCD, ...) have mixed types`); nothing read it.
   A groupby on such a column silently splits every key in two. *Not previously
   recorded anywhere.*
3. **Four Nicaragua files were hard-unreadable.** `ANTRO`, `CARATULA`,
   `EMNV01`, `PRECIOS`: latin-1 bytes killed `read_csv`, the chain fell to the
   filename retry, and `pd.read_spss` raised an uncaught `ReadstatError`.
4. **No detection at all**, so a genuinely fixed-width `.DAT` would come back as
   one column of whole lines — the mirror-image silent failure.

## The detection rule, and why it cannot misfire

`read_file` now reads a `.DAT` through its sibling `.DCT`. Three ordered tests
— no thresholds, no scoring, no tie-breaks:

| verdict | test |
|---|---|
| `csv-header` | line 1 comma-splits into **exactly** the dictionary's variable names, in order |
| `fixed` | every sampled line fits the declared record **and** every inter-field gap column the dictionary leaves is blank |
| `csv-noheader` | every line splits into exactly `len(names)` fields |
| — | otherwise **`DatLayoutError`**, naming both hypotheses and the evidence |

The asymmetry that makes this sound: **comma-delimited numeric payloads carry
no spaces**, so a declared gap column is never blank in one — a CSV line fails
`fixed` at its first gap column. And a fixed-width file's first record is not
its own dictionary's name list, so it cannot pass `csv-header` unless it
genuinely *is* a header.

**Stated plainly, as asked — a fixed-width file with commas inside a text
field:** it fails `csv-header` (first record is not the name list), **passes
`fixed`** (the commas sit *inside* declared fields, so the gap columns are
still blank), and never reaches `csv-noheader`. It is read fixed-width, which
is correct, and the comma stays in the value. Even if its incidental comma
count equalled `len(names) - 1`, the earlier `fixed` verdict wins. Pinned by
`test_fixed_width_with_commas_in_a_text_field`.

No dictionary, or a grammar we don't recognise → **untouched legacy chain**.
The sidecar lookup deliberately stops at the DVC blob cache rather than falling
through to `DVCFS.open` (~10-20 s Lustre tree walk) or a NADA download: it runs
speculatively on every `.DAT` read.

## Ghana: before / after

`get_dataframe('GhanaLSS/1987-88/Data/COMM.DAT')`, cold private `LSMS_DATA_DIR`:

| | before | after |
|---|---|---|
| shape | 137 x 311 | 137 x 311 |
| string-typed columns | many | **0 / 311** |
| columns holding a literal `"."` | yes | **0** |
| `POPUL` dtype | `str` | `float64` |
| `POPUL` head | `['1600','1500','750','470','280']` | `[1600.0, 1500.0, 750.0, 470.0, 280.0]` |

Cross-checked against the numbers #704 recorded **independently**:

| wave | `POPUL` non-null | min / med / max | matches FINDINGS |
|---|---|---|---|
| 1987-88 | 116 / 137 | 110 / 2,000 / 23,000 | yes |
| 1988-89 | 68 / 86 | 150 / 2,000 / 23,000 | yes |

Real values, not just "not NaN" — e.g. 1987-88 cluster 1: `POPUL` 1600,
`YRSEXIST` 150, `ELEC` 2, `PIPWAT` 2, `PRIMSCH` 1.

## Corpus sweep — all 535 `.DAT` files

| class | count |
|---|---|
| `csv-header` | **531** |
| no `.DCT` | 4 |
| `fixed` | 0 |
| `unknown` (raises) | **0** |

Every one of the 531 dictionary-paired files is comma-delimited with a header.
So `DatLayoutError` is **unreachable on the shipped corpus** — it guards future
acquisitions. The 4 dictionary-less files are Rwanda `PartA/B/C.dat` (genuinely
fixed-width) and Pakistan `WEIGHTS.DAT` (comma-delimited); none is referenced by
any config, all keep their old behaviour. All 531 `.DCT` files parse with one
grammar, 0 unparsed lines. One (`CotedIvoire/1988-89/Data/SEC10A.DCT`) declares
`names=y` / `separator=,` outright — the producer confirming the layout.

## Scope: three GhanaLSS consumers had to be repaired too

Turning `.`-bearing columns from `str` to `float64` is correct **and** changes
what downstream code receives. A cold GhanaLSS + CotedIvoire feature build
found exactly three sites that broke — all latent bugs the string dtype was
hiding. Shipping the reader fix without them would have been silent corruption:

1. `GhanaLSS/1987-88/_/mapping.py::Age` was
   `int(value) if value.isdigit() else NA`. `.isdigit()` needs a *string* and
   raises `AttributeError` on any number — it only ever worked because AGEY
   contained a `.`. **Left unrepaired, the reader change in commit 1 kills this
   wave's `household_roster` build outright — all 15,492 people.**

   *That is the intermediate state between this branch's two commits. Nothing
   was ever shipped that way, and no released version of the library is missing
   a 1987-88 roster.* Measured cold on both arms, private `LSMS_DATA_DIR` each:
   `development` delivers 15,492 rows for 1987-88 and 246,594 across all seven
   waves; this branch delivers 15,492 and 246,594; per-wave counts identical on
   all seven.
2. + 3. `1987-88` and `1988-89` `_/food_acquired.py` mapped the food code with
   `.astype('string')`, whose keys are bare integer strings. On a float column
   that yields `'301.0'` and misses everything: `j` *would become* 48 labels +
   **61 raw codes**. Same scope as (1) — the unrepaired intermediate state, not
   anything released. Repaired: **58 clean Preferred Labels, 0 numeric
   leakage**, both waves, which is also exactly what `development` delivers.

All three use `format_id`, the repo's canonical normalizer for exactly this
(`'123.0'` -> `'123'`) — the same fix, same reason, as the GH #348 unit decode.
Verified equivalent to the old reader row-by-row:

```
old      astype(string): 59 distinct j | mapped 77111/77112 | unmapped: ['.']
new_bad  astype(string): 61 distinct j | mapped     0/77112 | unmapped: ['301.0', ...]
new_fix  format_id     : 58 distinct j | mapped 77111/77112 | unmapped: []
old vs new_fix identical on 77111 / 77112 rows
```

The single differing row is the sentinel. **Corrected:** an earlier draft said
"the old build shipped a phantom food category literally named `.`". That is a
*wave-script-level* artifact and it does **not** reach delivered output. The
41-feature baseline below measures the delivered country-level
`food_acquired` on both arms: 5,259,344 rows, 304 distinct `j`, and **zero rows
with `j == '.'` on either arm** — 144,254 rows / 58 labels across the two 1980s
waves, identical. `development` delivered correct food labels, and the commit-2
repair is what *keeps* them correct after commit 1, not what introduces them.

These files are in `countries/{C}/_/` — no overlap with the concurrent
null-content-guard work in `get_dataframe`'s return path.

**CotedIvoire needed no change**: its waves map SEX/REL through YAML `mapping:`
dicts carrying both `'1'` and `1` keys, and Python dict lookup treats `1.0` and
`1` as the same key. Cold build: all 5 waves, 111,788 roster rows.

## Feature baseline — 41 features, value-level, cold, both arms

Every wired feature of every country with `.DAT` sources — **CotedIvoire (21),
GhanaLSS (14), Pakistan (6) = 41** — built cold on both arms and compared on
shape, index, **per-column values** and **dtype**. `development` (`5290f25c`)
vs this branch. A **separate private `LSMS_DATA_DIR` per arm**; the two arms are
plain tarball extracts of the two trees, so neither takes the DVC stage path and
they differ *only* in the code under test.

**82 / 82 builds succeeded. 40 / 41 features byte-identical; 0 value
differences; 0 dtype changes in any delivered column.** The 41st, `panel_ids`,
is a `dict` property rather than a frame — compared by `repr`, identical
(25,704 chars both arms).

| verdict | features |
|---|---|
| `IDENTICAL` (shape, index, every column value, every dtype) | 40 |
| `dict` property, identical by `repr` | 1 |

**Validity check — the arms genuinely differ at the reader**, so "identical" is
a real finding and not a vacuous comparison:

| same file, the two arms | old | new |
|---|---|---|
| `CotedIvoire/1985-86/Data/F01A.DAT` string-typed columns | 11 | **0** |
| ...columns holding a literal `"."` | 11 | **0** |
| `AGEY` dtype | `str` | `float64` |
| `AGEY` head | `['35', '18', '.', '41']` | `[35.0, 18.0, nan, 41.0]` |

So the reader change is live and material at the raw-read level, and **not one
delivered feature value moves**. `_finalize_result`'s canonical dtype
enforcement, plus the YAML `mapping:` dicts that carry both `'1'` and `1` keys,
absorb it completely. That is now measured evidence for "CotedIvoire needs no
change", which was previously asserted from the mapping-dict argument alone.

The reader change is therefore **user-visible in raw `get_dataframe` reads and
invisible in delivered features** — the two GhanaLSS consumer repairs in commit
2 are exactly what buys the second half of that sentence.

<details>
<summary><b>Per-feature baseline results — all 41, old vs new</b> (click to expand)</summary>

`development` `5290f25c` vs this branch, both cold, separate private
`LSMS_DATA_DIR` per arm. Compared on shape, index, per-column values and dtype.

| country | feature | result |
|---|---|---|
| CotedIvoire | `assets` | identical: shape 66857x4, index, every column value, every dtype |
| CotedIvoire | `cluster_features` | identical: shape 1484x4, index, every column value, every dtype |
| CotedIvoire | `crop_production` | identical: shape 22216x5, index, every column value, every dtype |
| CotedIvoire | `food_acquired` | identical: shape 296241x2, index, every column value, every dtype |
| CotedIvoire | `food_expenditures` | identical: shape 215620x1, index, every column value, every dtype |
| CotedIvoire | `food_prices` | identical: shape 213872x1, index, every column value, every dtype |
| CotedIvoire | `food_quantities` | identical: shape 294493x1, index, every column value, every dtype |
| CotedIvoire | `food_security` | identical: shape 12960x9, index, every column value, every dtype |
| CotedIvoire | `household_characteristics` | identical: shape 19367x15, index, every column value, every dtype |
| CotedIvoire | `household_roster` | identical: shape 111788x7, index, every column value, every dtype |
| CotedIvoire | `housing` | identical: shape 12992x2, index, every column value, every dtype |
| CotedIvoire | `individual_education` | identical: shape 79677x1, index, every column value, every dtype |
| CotedIvoire | `interview_date` | identical: shape 38973x2, index, every column value, every dtype |
| CotedIvoire | `livestock` | identical: shape 4711x3, index, every column value, every dtype |
| CotedIvoire | `people_last7days` | identical: shape 60617x8, index, every column value, every dtype |
| CotedIvoire | `plot_features` | identical: shape 14417x9, index, every column value, every dtype |
| CotedIvoire | `plot_inputs` | identical: shape 11250x3, index, every column value, every dtype |
| CotedIvoire | `plot_labor` | identical: shape 22264x2, index, every column value, every dtype |
| CotedIvoire | `sample` | identical: shape 19380x5, index, every column value, every dtype |
| CotedIvoire | `shocks` | identical: shape 13778x6, index, every column value, every dtype |
| CotedIvoire | `subjective_well_being` | identical: shape 12912x1, index, every column value, every dtype |
| GhanaLSS | `cluster_features` | identical: shape 3791x3, index, every column value, every dtype |
| GhanaLSS | `food_acquired` | identical: shape 5259344x3, index, every column value, every dtype |
| GhanaLSS | `food_expenditures` | identical: shape 1396544x1, index, every column value, every dtype |
| GhanaLSS | `food_prices` | identical: shape 1505751x1, index, every column value, every dtype |
| GhanaLSS | `food_quantities` | identical: shape 1611047x1, index, every column value, every dtype |
| GhanaLSS | `food_security` | identical: shape 13892x9, index, every column value, every dtype |
| GhanaLSS | `household_characteristics` | identical: shape 56313x15, index, every column value, every dtype |
| GhanaLSS | `household_roster` | identical: shape 246594x8, index, every column value, every dtype |
| GhanaLSS | `housing` | identical: shape 49994x8, index, every column value, every dtype |
| GhanaLSS | `individual_education` | identical: shape 159924x1, index, every column value, every dtype |
| GhanaLSS | `interview_date` | identical: shape 56340x1, index, every column value, every dtype |
| GhanaLSS | `panel_ids` | dict property; identical by repr (25,704 chars both arms) |
| GhanaLSS | `plot_features` | identical: shape 48349x3, index, every column value, every dtype |
| GhanaLSS | `sample` | identical: shape 56330x5, index, every column value, every dtype |
| Pakistan | `cluster_features` | identical: shape 300x2, index, every column value, every dtype |
| Pakistan | `household_characteristics` | identical: shape 4794x15, index, every column value, every dtype |
| Pakistan | `household_roster` | identical: shape 36079x8, index, every column value, every dtype |
| Pakistan | `housing` | identical: shape 4789x7, index, every column value, every dtype |
| Pakistan | `interview_date` | identical: shape 4956x1, index, every column value, every dtype |
| Pakistan | `sample` | identical: shape 4967x3, index, every column value, every dtype |

**41 features. 0 value differences. 0 dtype changes in any delivered column.**

</details>

*Not covered by this baseline:* the other 37 countries (no `.DAT` sources, so
structurally unaffected), and Nicaragua/Rwanda (`.DAT`/`.dat` present but no
`data_scheme.yml`, so no feature can move).

## Cache staleness

`local_tools.py` is **not** part of the v0.8.0 content hash, so this reader
change does not itself invalidate anything. GhanaLSS's affected waves *do*
self-invalidate (their `mapping.py` / wave scripts are hashed and I edited
them). CotedIvoire's warm caches don't invalidate, and don't need to — their
outputs are equivalent. **Deliberately not bumping `LSMS_CACHE_SCHEMA`**: it
would invalidate all 40 countries to fix 2. Anyone wanting cold certainty uses
`lsms-library cache clear --country {GhanaLSS,CotedIvoire}`.

## Tests

`tests/test_dat_dct_reader.py`, 18 synthetic cases — no DVC, no network, so they
run in the cache-gated fast tier. Four fail on the old parse, verified by
running them against the pre-change module:

| case | old behaviour |
|---|---|
| `.` sentinel -> numeric + NaN | `str` column containing `'.'` |
| true fixed-width | **1 column** named by the first data line |
| fixed-width w/ commas in a text field | **2 columns**, first row eaten as header |
| undecidable -> raises | silently returned a `(1, 5)` frame |

373 passed across `test_dat_dct_reader`, `test_format_id`, `test_data_access`,
`test_dvc_caching`, `test_countries_root_override`, `test_data_separation`,
`test_schema_consistency`.

## Not verified — stated plainly

- **The `DatLayoutError` branch is never exercised by shipped data** (0/535).
  It is covered only by a synthetic test.
- **C4 is unrunnable for the CotedIvoire population columns** — all twelve CILSS
  questionnaire PDFs are image-only scans, no OCR, and the `.DCT`s have no label
  layer. #706 does not assert what `C02Q01`/`S01Q01` are.
- ~~No full old-code *feature* baseline was built.~~ **One has now been built**
  (this bullet previously said otherwise). See *Feature baseline* below.
- **CotedIvoire 1988-89 `household_roster` is 10,560 rows against 10,563 raw** —
  3 rows whose REL/SEX was the `.` sentinel now drop out. Not measured against
  the old reader; three rows of sentinel garbage either way.
- `Rwanda/2000-01/_/food_expenditures.py` reads CotedIvoire's `F12A.DAT` (whose
  `FOODCD` changed dtype). **Dead code**: there is no `Rwanda/_/` directory at
  all, so nothing is registered and its `sys.path.append('../../_')` +
  `from cotedivoire import ...` cannot resolve. CotedIvoire's own twin scripts
  are likewise unregistered (`food_expenditures` appears 0 times in its
  `data_scheme.yml`; `food_acquired` is wired for 2018-19 only) — matching
  CONTENTS.org's "legacy scripts ... do not extend them".
- GhanaLSS 2005-06's community data ships as an unopened `community.zip`
  (out of scope).

## Documentation

- `GhanaLSS/_/CONTENTS.org` — the existing "COMMA-SEPARATED WITH A HEADER ROW"
  section now records the resolution, the mixed-dtype finding, and **why this
  belongs with Traps 1-4**: same signature — *a thing that exists, looks
  authoritative, and silently does nothing while the build reports success.*
  Trap 1 was a lookup dict that came back empty; Trap 4 a fallback nobody had
  exercised; here it is a data dictionary that is wrong about its own file's
  layout, over a missing-value marker no reader was reading.
- `CotedIvoire/_/CONTENTS.org` — new section on `COMM85-88.DAT`: contents, the
  two incompatible instrument designs, the exact cluster join, and the
  rural-only finding. The `REGION -> Rural` mapping is the **producer's own
  definition** (quoted verbatim in 1.1(3): *"Urban - Abidjan and Other Cities;
  Rural - East Forest, West Forest and Savanna"*) and is **used, not corrected**
  — it is what the rural-only cross-tab is measured against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019q5rAfxYg4uDUp1RcYAJTW

