### PR TITLE
build: require pandas >=3.0 — 2.2 silently corrupts pre-Stata-6 doubles (#709)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [ {name = "Ethan Ligon", email = "ligon@berkeley.edu"}
 license = {text = "CC-BY-4.0"}
 readme = "README.org"
 requires-python = ">=3.11, <4.0"
-dependencies = ["pandas >=2.2",
+dependencies = ["pandas >=3.0",
              "CFEDemands>=0.8.2",
              "PyYAML >=6.0,<7.0",
              "python-gnupg >=0.5,<1.0",


### PR DESCRIPTION
One line in `pyproject.toml`. Closes the only live exposure found by the #709 investigation.

## The exposure

`1.7498005798264095e+100` is **exactly 2^333** (bits `0x54C0000000000000`) — Stata's system-missing `.` for a `double` in .dta **format 104/105** (Stata 5 and earlier). Stata 6 (format 108) replaced it with 2^1023, which is why it matches neither of the two well-known sentinels: it is the *third, older* one.

pandas nulls it as of **3.0** ([pandas-dev/pandas#58149](https://github.com/pandas-dev/pandas/issues/58149), fixed by [#59325](https://github.com/pandas-dev/pandas/pull/59325)). **pandas 2.2 does not** — it returns a finite float.

Ten country-waves ship format 104/105 files (China 1995-97, GhanaLSS 1991-92 + 1998-99, India 1997-98, Kyrgyz 1993/96/97/98, Pakistan 1991, Panama 1997), ~28.5M reader-confirmed cells. **The boundary is the format stamp, not the year** — Guatemala 2000 is a year-2000 wave at format ≤105.

Measured on pandas 2.2 (simulated against the v2.2.3 source, corroborated with real `pyreadstat` output):

| cell | pandas 2.2 | correct |
|---|---|---|
| GhanaLSS 1991-92 `food_acquired.Price` | mean **1.71e99** | 342.6 |
| Panama 1997 `Expenditure` | mean **1.31e105** | 7.65e7 |

Panama's `notna()` row filter would additionally admit **74,657 empty records**.

## Why now

Delivered data is correct **today** only because every current environment happens to run pandas 3.x. Nothing enforces it — no lock file, no CI pin. A fresh install that resolves 2.2 silently poisons those tables.

This is a **data-correctness floor, not an API one**: the code itself runs fine on 2.2.

It also completes `dce47073` ("Loosen pandas version"), which removed the `<3.0` **ceiling** and left the 2.2 floor behind as an artifact. Nobody deliberately chose to support both, and `CLAUDE.md` has said *"This codebase targets pandas 3.0+"* throughout.

## Deliberately not doing

**No sentinel list in the reader.** That would duplicate, less precisely, a rule pandas already owns and maintains.

## Not covered by this

Kyrgyz 1998 `SECT_06.DTA:fprimary` = `-1.2255e294` — a **distinct** value that pandas does *not* filter and that **is delivered**. Tracked in #709.

## Cost

Excludes installs pinned below pandas 3.0. Given the corruption above, that is the intended trade — but it is a user-facing floor raise, so flagging it explicitly rather than burying it.