### PR TITLE
fix(#716): get_data_file accepts repo-relative paths, like get_dataframe already does

### DIFF
--- a/lsms_library/data_access.py
+++ b/lsms_library/data_access.py
@@ -1769,6 +1769,46 @@ def add_wave(country: str, catalog_id: str,
 # Main entry point
 # ---------------------------------------------------------------------------
 
+def _as_countries_relative(path: Path) -> Path:
+    """Normalise the path conventions callers actually use (GH #716).
+
+    ``get_data_file`` is documented as taking a path *relative to the
+    countries directory* (``GhanaLSS/1998-99/Documentation/x.pdf``).  But
+    :func:`local_tools.get_dataframe` -- the accessor ``CLAUDE.md`` points
+    everyone at first -- also accepts the **repo-relative** form
+    (``lsms_library/countries/GhanaLSS/.../x.pdf``), which is how paths are
+    written in scripts and in every ``CONTENTS.org`` example.  Passing that
+    form here used to build ``…/countries/lsms_library/countries/…``, derive
+    ``country='lsms_library'``/``wave='countries'``, and return ``None`` for a
+    file sitting on disk.
+
+    Accepted, in order:
+
+    * absolute under the countries root -> made relative to it;
+    * relative, carrying any trailing run of the countries-root parts as a
+      prefix (``lsms_library/countries/X``, ``countries/X``) -> prefix stripped;
+    * already countries-relative -> unchanged.
+
+    A path this cannot interpret is returned unchanged, so genuinely
+    unavailable files behave exactly as before.  The normalisation is
+    **structural**, not existence-based, because the whole point of this
+    function is to fetch files that are not on disk yet.
+    """
+    if path.is_absolute():
+        try:
+            return path.relative_to(_COUNTRIES_DIR)
+        except ValueError:
+            return path
+
+    root_parts = _COUNTRIES_DIR.parts
+    parts = path.parts
+    # Longest match first: strip 'lsms_library/countries' before 'countries'.
+    for n in range(min(len(root_parts), len(parts) - 1), 0, -1):
+        if parts[:n] == root_parts[-n:]:
+            return Path(*parts[n:])
+    return path
+
+
 def get_data_file(path: str | Path,
                   populate_cache: bool = False) -> Path | None:
     """Obtain a raw data file, trying local -> DVC remotes -> World Bank.
@@ -1788,7 +1828,7 @@ def get_data_file(path: str | Path,
         Absolute path to the file on local disk, or ``None`` if
         unavailable.
     """
-    path = Path(path)
+    path = _as_countries_relative(Path(path))
     abs_path = _COUNTRIES_DIR / path
     target_filename = path.name
 

--- a/tests/test_get_data_file_paths.py
+++ b/tests/test_get_data_file_paths.py
@@ -1,0 +1,63 @@
+"""``get_data_file`` must accept the path conventions callers actually use.
+
+GH #716.  ``get_data_file`` is documented as taking a *countries-relative*
+path, but ``local_tools.get_dataframe`` -- the accessor ``CLAUDE.md`` points
+everyone at first -- also accepts the *repo-relative* form, which is how paths
+are written in scripts and in every ``CONTENTS.org`` example.  Passing that
+form to ``get_data_file`` used to return ``None`` for a file on disk, and the
+``None`` then propagated as the string ``'None'`` into whatever consumed it.
+
+These tests pin the normalisation.  They are deliberately structural: the
+whole point of ``get_data_file`` is to fetch files that are *not* on disk yet,
+so the mapping must not depend on existence.
+"""
+from pathlib import Path
+
+import pytest
+
+from lsms_library.data_access import _as_countries_relative, _COUNTRIES_DIR
+
+REL = Path('GhanaLSS/1998-99/Documentation/GHA_1998_GLSS_Report_EN.pdf')
+
+
+@pytest.mark.parametrize('given', [
+    REL,                                              # documented form
+    Path('lsms_library/countries') / REL,             # repo-relative
+    Path('countries') / REL,                          # partial prefix
+    _COUNTRIES_DIR / REL,                             # absolute
+])
+def test_all_accepted_forms_normalise_to_countries_relative(given):
+    assert _as_countries_relative(Path(given)) == REL
+
+
+def test_normalisation_does_not_depend_on_the_file_existing():
+    """The fetch path exists to get files that are absent -- so must this."""
+    ghost = Path('Nowhere/2999-00/Data/absent.dta')
+    assert not (_COUNTRIES_DIR / ghost).exists()
+    assert _as_countries_relative(Path('lsms_library/countries') / ghost) == ghost
+
+
+def test_uninterpretable_paths_pass_through_unchanged():
+    """An absolute path outside the countries root is returned as-is, so a
+    genuinely unavailable file behaves exactly as it did before #716."""
+    outside = Path('/tmp/somewhere/else.dta')
+    assert _as_countries_relative(outside) == outside
+
+
+def test_longest_prefix_wins():
+    """'lsms_library/countries' must be stripped in full, not just 'countries'."""
+    got = _as_countries_relative(Path('lsms_library/countries') / REL)
+    assert got.parts[0] == 'GhanaLSS', got
+
+
+def test_a_country_directory_is_never_mistaken_for_the_prefix():
+    """Stripping is anchored at the START of the path, so a wave or file named
+    'countries' deeper in cannot trigger it."""
+    tricky = Path('GhanaLSS/1998-99/Data/countries/x.dta')
+    assert _as_countries_relative(tricky) == tricky
+
+
+def test_peru_ssp_case_from_the_original_report():
+    """The other path that silently returned None during the #713 work."""
+    rel = Path('Peru/1990/Data/N00A.SSP')
+    assert _as_countries_relative(Path('lsms_library/countries') / rel) == rel


### PR DESCRIPTION
Closes the path-convention asymmetry between the two sanctioned accessors.

## Before

```
get_data_file('lsms_library/countries/GhanaLSS/.../report.pdf')  -> None   ← silent
get_data_file('GhanaLSS/.../report.pdf')                         -> Path   ✓
get_dataframe('lsms_library/countries/GhanaLSS/.../POV_GH.DTA')  -> OK     ✓
get_dataframe('GhanaLSS/.../POV_GH.DTA')                         -> OK     ✓
```

`get_data_file` is *documented* as countries-relative, so strictly the caller was at fault — but `get_dataframe` accepts both, and repo-relative is what scripts and every `CONTENTS.org` example use. The convention people learn from the common case was silently wrong for the other.

## Why it was worse than a wrong argument

`_COUNTRIES_DIR / path` built `…/countries/lsms_library/countries/…`, so `country='lsms_library'`, `wave='countries'`. The only symptom was a stray `No SOURCE.org found for lsms_library/countries` on stderr — reading as an unrelated provenance warning. The `None` then propagated as the **string** `'None'`, so `extract_text(str(p))` raised `FileNotFoundError: 'None'` and pointed at the *tool*.

That mis-directed the #713 investigation **twice** — first into "pdftotext isn't installed", then into "the blob needs pulling". Neither was true; the file was on disk throughout.

## After

`_as_countries_relative` accepts absolute-under-root, any trailing run of the countries-root parts as a prefix (`lsms_library/countries/X`, `countries/X`), or an already-relative path. Anything uninterpretable passes through unchanged, so **genuinely unavailable files behave exactly as before** — verified: a nonexistent country and a too-short path still return `None` by the same routes.

The normalisation is **structural, not existence-based**, since the whole purpose of this function is fetching files that aren't on disk yet. A test pins that.

## Tests

9 new, all passing; 313 targeted tests pass. Notable cases:
- **longest prefix wins** — `lsms_library/countries` stripped in full, not just `countries`
- **anchored at the start** — a directory named `countries` deeper in the path must not trigger stripping
- **the two real paths** that silently returned `None` during #713: the GLSS4 report and Peru's `N00A.SSP`

## Left open on #716, deliberately

`get_data_file` still returns the same `None` for a mis-called path as for a genuinely unavailable file, so callers can't distinguish them. Validating the derived country against the real country list and warning is the other half — separable, and this PR is already the part that removes the trap.