### PR TITLE
fix(#719): collection is a dry run — no cache purge under --collect-only

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -33,6 +33,14 @@ Three-tier test strategy
 
 Use ``make test`` for the fast tier and ``make test-full`` (now passes
 ``--rebuild-caches``) for a fully cold rebuild.
+
+**Collection is a dry run** (GH #719).  Under ``--collect-only`` / ``--co`` no
+purge of any tier runs, because such an invocation executes no tests and must
+therefore have no side effects.  This matters beyond tidiness: the purge target
+resolves through ``data_root()``, which is a *shared* scratch path, so asking
+"what tests exist?" used to evict parquets belonging to other sessions -- and
+under ``--rebuild-caches`` it took every country, not just Uganda.  The purge
+itself is unchanged and still fires on every real run.
 """
 
 from __future__ import annotations
@@ -80,6 +88,29 @@ def pytest_configure(config):
         "markers",
         "slow: mark test as slow (requires network or full data loading).",
     )
+
+    if getattr(config.option, "collectonly", False):
+        # GH #719: collection is a DRY RUN.  ``--collect-only`` (and ``--co``)
+        # answers "what tests exist?" and executes none of them, so it must
+        # have no side effects -- yet every branch below deletes cached
+        # parquets out of ``data_root()``.
+        #
+        # That path is resolved from *config*, so on a shared checkout it is
+        # shared state: since the 2026-08-22 migration it points at the FCA
+        # scratch cache used by other sessions and other `fc_jevons` members,
+        # not at a private `~/.local/share`.  A `--collect-only` run would
+        # evict their warm parquets, and with `--rebuild-caches` it would take
+        # *every country*, not just Uganda.
+        #
+        # The purge itself is right and is deliberately left alone (stale
+        # parquets predating the v0.7.1 extraction fixes really do mask them --
+        # GH #196 / #197 / #161).  Only the TRIGGER is wrong.  `--no-purge` is
+        # not the answer here: it asks the operator to opt out of a correct
+        # default to dodge an incorrect side effect.
+        #
+        # Markers are registered above, before this return, because collection
+        # needs them.
+        return
 
     rebuild_caches = config.getoption("--rebuild-caches", default=False)
     if rebuild_caches:

--- a/tests/test_collectonly_no_purge.py
+++ b/tests/test_collectonly_no_purge.py
@@ -1,0 +1,92 @@
+"""``pytest --collect-only`` must not delete anybody's cache (GH #719).
+
+Collection is a dry run: it answers "what tests exist?" and executes no
+tests.  ``conftest.pytest_configure`` nonetheless ran a cache purge on
+*every* invocation, and the target resolves through ``data_root()`` -- which
+since the 2026-08-22 migration is a **shared** scratch path, not a private
+``~/.local/share``.  So `pytest --collect-only` evicted parquets belonging to
+other sessions, and under ``--rebuild-caches`` it took every country rather
+than just Uganda.
+
+These tests pin the *trigger*, not the purge.  The purge is correct and is
+deliberately still exercised on a real run -- which is what the negative
+controls below assert, so a regression that simply disabled purging
+altogether would fail here rather than pass.
+"""
+from __future__ import annotations
+
+import conftest
+
+
+class _Opt:
+    def __init__(self, collectonly, rebuild_caches=False, rebuild=False, no_purge=False):
+        self.collectonly = collectonly
+        self._map = {
+            "--rebuild-caches": rebuild_caches,
+            "--rebuild": rebuild,
+            "--no-purge": no_purge,
+        }
+
+
+class _Config:
+    """Minimal stand-in for pytest's Config: just what pytest_configure uses."""
+    def __init__(self, **kw):
+        self.option = _Opt(**kw)
+        self.ini_lines = []
+
+    def addinivalue_line(self, name, line):
+        self.ini_lines.append((name, line))
+
+    def getoption(self, name, default=None):
+        return self.option._map.get(name, default)
+
+
+def _run(monkeypatch, **kw):
+    """Call pytest_configure with the purges spied on; return what fired."""
+    calls = []
+    monkeypatch.setattr(conftest, "_purge_country_caches",
+                        lambda c: calls.append(("country", c)))
+    monkeypatch.setattr(conftest, "_purge_data_root_caches",
+                        lambda: calls.append(("all", None)))
+    monkeypatch.delenv("LSMS_NO_CACHE", raising=False)
+    cfg = _Config(**kw)
+    conftest.pytest_configure(cfg)
+    return cfg, calls
+
+
+# --- the fix -------------------------------------------------------------
+
+def test_collect_only_purges_nothing(monkeypatch):
+    cfg, calls = _run(monkeypatch, collectonly=True)
+    assert calls == [], f"--collect-only purged: {calls}"
+
+
+def test_collect_only_with_rebuild_caches_purges_nothing(monkeypatch):
+    """The worst case: --rebuild-caches purges EVERY country, not just Uganda."""
+    cfg, calls = _run(monkeypatch, collectonly=True, rebuild_caches=True)
+    assert calls == [], f"--collect-only --rebuild-caches purged: {calls}"
+
+
+def test_collect_only_still_registers_markers(monkeypatch):
+    """The early return must not skip marker registration -- collection needs it."""
+    cfg, _ = _run(monkeypatch, collectonly=True)
+    names = " ".join(line for _, line in cfg.ini_lines)
+    assert "rebuild:" in names and "slow:" in names
+
+
+# --- negative controls: a real run MUST still purge ----------------------
+# Without these, deleting the purge entirely would make the tests above pass.
+
+def test_real_run_still_purges_uganda(monkeypatch):
+    cfg, calls = _run(monkeypatch, collectonly=False)
+    assert calls == [("country", "Uganda")], f"expected the Uganda purge, got {calls}"
+
+
+def test_real_run_with_rebuild_caches_still_purges_everything(monkeypatch):
+    cfg, calls = _run(monkeypatch, collectonly=False, rebuild_caches=True)
+    assert ("all", None) in calls, f"expected the full purge, got {calls}"
+
+
+def test_no_purge_flag_still_honoured_on_a_real_run(monkeypatch):
+    cfg, calls = _run(monkeypatch, collectonly=False, no_purge=True)
+    assert calls == [], f"--no-purge should suppress the purge, got {calls}"

--- a/tests/test_collectonly_no_purge.py
+++ b/tests/test_collectonly_no_purge.py
@@ -15,7 +15,32 @@ altogether would fail here rather than pass.
 """
 from __future__ import annotations
 
-import conftest
+import importlib.util
+import sys
+from pathlib import Path
+
+# NOT ``import conftest``.  That spelling resolves to the broken top-level
+# ``tests``/``conftest`` shipped by a dependency and aborts pytest COLLECTION in
+# CI (GH #680), while passing locally because ``lsms_library.pth`` puts the repo
+# root ahead of site-packages -- invisible exactly where the mistake is made.
+# ``tests/test_tests_package_not_shadowed.py`` enforces this, and caught this
+# file.  Prefer the object pytest itself already loaded; fall back to loading
+# the root conftest by path, which is identical in every import mode.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_root_conftest():
+    mod = sys.modules.get("conftest")
+    if mod is not None and getattr(mod, "__file__", None) == str(_REPO_ROOT / "conftest.py"):
+        return mod
+    spec = importlib.util.spec_from_file_location(
+        "_lsms_root_conftest", _REPO_ROOT / "conftest.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+conftest = _load_root_conftest()
 
 
 class _Opt:


### PR DESCRIPTION
`conftest.pytest_configure` ran a cache purge on **every** pytest invocation, including `--collect-only` / `--co`, which executes no tests. Asking *"what tests exist?"* deleted cached parquets.

The blast radius is not local: the purge resolves its target through `data_root()` — i.e. from *config* — and since the 2026-08-22 migration that is the **shared FCA scratch cache** used by other sessions and other `fc_jevons` members, not a private `~/.local/share`.

## Worse than the issue describes

#719 reports the Uganda auto-purge. But the `--rebuild-caches` branch calls `_purge_data_root_caches()`, which deletes **every country's** cache — so `--rebuild-caches --collect-only` would have purged the entire corpus while running zero tests. **Both branches are now guarded.**

## The purge itself is left alone

Its rationale is sound — parquets predating the v0.7.1 extraction fixes really do mask them (#196 / #197 / #161) — and it still fires on every real run. **Only the trigger was wrong.**

`--no-purge` was not the answer: it asks the operator to opt out of a correct default in order to dodge an incorrect side effect.

Marker registration stays above the early return, because collection needs it.

## Verified four ways, not asserted

| # | check | result |
|---|---|---|
| 1 | **Unit**, purges spied on | `--collect-only` fires nothing, alone or with `--rebuild-caches`; markers still registered |
| 2 | **Negative controls** in the same file | a real run still purges Uganda; `--rebuild-caches` still purges everything; `--no-purge` still suppresses |
| 3 | **Mutation-tested, both directions** | restoring the bug (`if False:`) fails exactly the 2 fix tests; deleting the purge bodies fails exactly the 2 negative controls |
| 4 | **End-to-end**, real invocation, private `LSMS_DATA_DIR` seeded with 3 parquets | `--collect-only` → **3/3 survive**; real run → **0/3 survive** |

Check 2 exists because without it, deleting the purge outright would make the fix tests pass — the failure mode this repo keeps hitting. Check 3 is what proves the tests discriminate rather than merely pass.

Closes #719.