### PR TITLE
chore(coverage): refresh the GhanaSPS matrix — it was blind to 3 of 7 features

### DIFF
--- a/.coder/coverage/latest.csv
+++ b/.coder/coverage/latest.csv
@@ -642,18 +642,27 @@ GhanaLSS,sample,2005-06,builds,declared,8687,fail: no_all_null_columns; warn: no
 GhanaLSS,sample,2012-13,sane,declared,16772,all checks pass
 GhanaLSS,sample,2016-17,sane,declared,14009,all checks pass
 GhanaLSS,updated_ids,,sane,declared,7,7 entries
-GhanaSPS,food_acquired,2009-10,sane,declared,119847,all checks pass
-GhanaSPS,food_acquired,2013-14,sane,declared,139339,all checks pass
-GhanaSPS,food_acquired,2017-18,sane,declared,148743,all checks pass
-GhanaSPS,food_expenditures,2009-10,sane,declared,119169,all checks pass
-GhanaSPS,food_expenditures,2013-14,sane,declared,133163,all checks pass
-GhanaSPS,food_expenditures,2017-18,sane,declared,145872,all checks pass
+GhanaSPS,food_acquired,2009-10,sane,declared,119847,warn: index_levels_match_scheme
+GhanaSPS,food_acquired,2013-14,sane,declared,139339,warn: index_levels_match_scheme
+GhanaSPS,food_acquired,2017-18,sane,declared,148743,warn: index_levels_match_scheme
+GhanaSPS,food_expenditures,2009-10,sane,declared,96513,all checks pass
+GhanaSPS,food_expenditures,2013-14,sane,declared,104543,all checks pass
+GhanaSPS,food_expenditures,2017-18,sane,declared,117347,all checks pass
 GhanaSPS,food_prices,2009-10,sane,declared,113722,all checks pass
 GhanaSPS,food_prices,2013-14,sane,declared,135620,all checks pass
 GhanaSPS,food_prices,2017-18,sane,declared,138098,all checks pass
 GhanaSPS,food_quantities,2009-10,sane,declared,114278,all checks pass
 GhanaSPS,food_quantities,2013-14,sane,declared,136872,all checks pass
 GhanaSPS,food_quantities,2017-18,sane,declared,138799,all checks pass
+GhanaSPS,household_characteristics,2009-10,sane,declared,5007,all checks pass
+GhanaSPS,household_characteristics,2013-14,sane,declared,4762,all checks pass
+GhanaSPS,household_characteristics,2017-18,sane,declared,5661,all checks pass
+GhanaSPS,household_roster,2009-10,sane,declared,18889,"warn: index_levels_match_scheme,no_constant_columns"
+GhanaSPS,household_roster,2013-14,sane,declared,16356,"warn: index_levels_match_scheme,no_constant_columns"
+GhanaSPS,household_roster,2017-18,sane,declared,19006,"warn: index_levels_match_scheme,no_constant_columns"
+GhanaSPS,sample,2009-10,sane,declared,5009,all checks pass
+GhanaSPS,sample,2013-14,sane,declared,4774,warn: no_constant_columns
+GhanaSPS,sample,2017-18,sane,declared,5669,warn: no_constant_columns
 Guatemala,assets,2000,sane,declared,37995,all checks pass
 Guatemala,cluster_features,2000,sane,declared,8,"warn: has_household_index,reasonable_size"
 Guatemala,food_acquired,2000,sane,declared,215982,warn: index_levels_match_scheme


### PR DESCRIPTION
`.coder/coverage/latest.csv` was last built **2026-08-20** and held **12** GhanaSPS cells, all food. `household_roster`, `sample` and `household_characteristics` landed **2026-08-21** (#677), so `ll.coverage()` has been under-reporting this country ever since.

**Now 21 cells, every one `sane`.**

Scoped run (`bench/matrix.py --countries GhanaSPS`), which upserts on `(country, feature, wave)`. Verified the other 34 countries are **byte-identical** before and after — 1850 → 1859 rows, +9 = 21−12.

## Two things the refresh surfaces — neither a defect

**1. Per-cell warnings the stale snapshot didn't carry.** `index_levels_match_scheme` on `food_acquired`/`household_roster`, and `no_constant_columns` on `household_roster` and on `sample` in 2013-14/2017-18. The `sample` one is the documented producer-side gap — waves 2 and 3 ship no weight, 2013-14 no geography — i.e. genuinely constant all-NaN columns, already evidenced in `_/data_scheme.yml`.

**2. `food_expenditures` row counts move a lot**, and I checked rather than assumed:

| wave | old | new |
|---|---|---|
| 2009-10 | 119,169 | 96,513 |
| 2013-14 | 133,163 | 104,543 |
| 2017-18 | 145,872 | 117,347 |

The table is **purchased-value-only by design** (#575/#585), and the split is exact:

| source | `food_acquired` sum | `food_expenditures` sum |
|---|---|---|
| `purchased` | 3,487,964.41 | **3,487,964.41** (rel diff `0.0e+00`) |
| `produced` | 1,070,503.21 | dropped by design |
| `inkind` | 290,734.55 | dropped by design |

So value is conserved **exactly** on the source that survives, and the remaining row drop within `purchased` (323,315 → 318,403) is the lossless `u` collapse — fewer rows, identical sum. The new totals also match an independent live `Country('GhanaSPS').food_expenditures()` call (318,403).

**Worth flagging for whoever looks next**: the old snapshot's 398,204 total is close to `food_acquired`'s full 407,929, which suggests the 2026-08-20 build was *not* purchased-only. Stated as an observation — confirming it would need a rebuild at that commit, which I did not do.

Refs #677.