### PR TITLE
feat(GhanaSPS): wire `housing` for all three waves

### DIFF
--- a/lsms_library/countries/GhanaSPS/2009-10/_/data_info.yml
+++ b/lsms_library/countries/GhanaSPS/2009-10/_/data_info.yml
@@ -140,3 +140,63 @@ household_roster:
         Age: s1d_4i
         Relationship: s1d_2
         MonthsAway: s1d_27
+
+housing:
+    # S12AI.dta is the wave-1 housing module: 4,972 rows, one per household
+    # (`hhno` unique, 0 duplicates, 0 nulls), covering Q1-Q36 of Section 12A.
+    # Waves 2 and 3 split this same content across four files; wave 1 keeps
+    # it in one, so there is no `dfs:` merge here.
+    #
+    # Variable labels read off the .dta:
+    #   s12a_30 "Q30 What is the main construction material used for the
+    #            outer wall of the main b[uilding]"   -> NOT wired (Wall is
+    #                                                    not in the schema)
+    #   s12a_31 "Q31 What is the main construction material used for the
+    #            floor"                               -> Floor
+    #   s12a_32 "Q32 What is the main material used for the roof"  -> Roof
+    # Note 31 is the FLOOR and 32 is the ROOF, in that order -- the reverse
+    # of the (Roof, Floor) order the schema lists them in.
+    #
+    # A wave-1 naming trap worth knowing: the sibling file S12AII.dta spells
+    # its variables `s12b_*`, not `s12a_*`, despite being section 12A part
+    # II.  S12AII is the twin of waves 2/3's 12b_housingcharacteristics2.dta
+    # (dwelling type, rooms, occupancy, electricity) and carries NO material
+    # variable, so it cannot be used to fill wave 1's gap (see below).
+    #
+    # COVERAGE GAP, source-side: S12AI holds 4,972 of the wave's 5,009
+    # households.  The 37 absentees are absent from S12AI entirely; they are
+    # present in key_hhld_info.dta and S1D.dta (both 5,009).  S12AII covers
+    # 30 of the 37, but has no roof/floor variable.  Not recoverable from
+    # this extract.  The housing households are a strict SUBSET of the sample
+    # households (0 in housing but not in key_hhld_info), so the v-join is
+    # total -- 0 null `v`.
+    #
+    # DELIVERED ROWS: 4,899, not 4,972.  The 73 missing rows are the ones
+    # with BOTH Roof and Floor null; _finalize_result's dropna(how='all')
+    # (country.py, GH #645) removes them.  That is framework behaviour, not
+    # a filter written here, and it loses no material datum -- a row survives
+    # if EITHER column is populated.
+    #
+    # NULLS, left as NULL deliberately: in the source, Roof is non-null for
+    # 4,890/4,972 (82 missing) and Floor for 4,897/4,972 (75 missing); 73 of
+    # those overlap, so the delivered table carries 82-73 = 9 null Roof and
+    # 75-73 = 2 null Floor.  These are Stata missings, not sentinels -- wave
+    # 1 declares no Don't-know/Refuse codes on either variable (labels are
+    # just codes 1-9).  Nowhere near the null-read guard's 1/3-of-frame
+    # trigger and not an all-null column; do NOT reach for `optional: true`.
+    #
+    # `v` is NOT declared -- _join_v_from_sample() attaches it at API time.
+    #
+    # Label harmonisation is NOT done here.  It is done once, for all three
+    # waves, by the `Roof` / `Floor` tables in ../../_/categorical_mapping.org,
+    # which _apply_categorical_mappings auto-discovers by column name.  This
+    # wave contributes the two nastiest alternate spellings: `Cement/ concrete`
+    # (internal space after the slash, 3,921 rows) and `Corrugate iron sheets`
+    # (source typo: no 'd', 3,747 rows).  Its code-8 floor label `Terrazo`
+    # (one z, 0 observations) is mapped too, as insurance.
+    file: S12AI.dta
+    idxvars:
+        i: hhno
+    myvars:
+        Roof: s12a_32
+        Floor: s12a_31

--- a/lsms_library/countries/GhanaSPS/2013-14/_/data_info.yml
+++ b/lsms_library/countries/GhanaSPS/2013-14/_/data_info.yml
@@ -85,3 +85,47 @@ household_roster:
         - t
         - i
         - pid
+
+housing:
+    # 12a_housingcharacteristics1iii_structure.dta is the wave-2 dwelling-
+    # structure file: 4,772 rows, `FPrimary` unique (0 duplicates, 0 nulls).
+    # Single file, single extraction -- no `dfs:` merge, so no cartesian risk.
+    #
+    # THE MODULE IS THE SAME ONE WAVE 1 USES, verified by content and not by
+    # the filename.  The source's own variable labels name the wave-1
+    # variables: `materialroof` is labelled "s12a_32 - Roof material" and
+    # `materialfloor` "s12a_31 - Floor material".  That matters here because
+    # GhanaSPS module letters do move between waves -- 01f is education in
+    # this wave and EMPLOYMENT in 2017-18 -- so filename continuity alone
+    # would not have been evidence.
+    #
+    # The other three 12* files were checked and are not candidates:
+    # …1i_rent (rent/construction cost), …1ii_utilities (water, lighting,
+    # cooking fuel), 12b_housingcharacteristics2 (dwelling type, rooms,
+    # occupancy, electricity).  None carries a roof or floor material.
+    # `materialouterwall` is here too and is deliberately not wired.
+    #
+    # COVERAGE: 4,772 of the wave's 4,774 households.  The two missing are
+    # 106199032 and 205163009, absent from this file but present in
+    # 01a_consent.dta.  Housing households are a strict SUBSET of the sample
+    # households, so the v-join is total.
+    #
+    # NULLS: none.  Roof and Floor are both 4,772/4,772 non-null.  This wave
+    # declares no Don't-know / Refuse sentinel on either variable (codes
+    # 1-8 plus 95 'Other - specify').
+    #
+    # `InstanceNumber` is a per-interview counter, not part of the key --
+    # FPrimary alone is unique, so it is not declared.
+    #
+    # `v` is NOT declared -- _join_v_from_sample() attaches it at API time.
+    #
+    # Label harmonisation is done once for all three waves by the `Roof` /
+    # `Floor` tables in ../../_/categorical_mapping.org.  This wave's
+    # distinctive spellings are `Corrugated iron sheets` (plural; wave 1 says
+    # `Corrugate`, wave 3 says `sheet`) and `Other - specify` (code 95).
+    file: 12a_housingcharacteristics1iii_structure.dta
+    idxvars:
+        i: FPrimary
+    myvars:
+        Roof: materialroof
+        Floor: materialfloor

--- a/lsms_library/countries/GhanaSPS/2017-18/_/data_info.yml
+++ b/lsms_library/countries/GhanaSPS/2017-18/_/data_info.yml
@@ -87,3 +87,64 @@ household_roster:
         - t
         - i
         - pid
+
+housing:
+    # 12a_housingcharacteristics1iii_structure.dta is the wave-3 dwelling-
+    # structure file: 5,669 rows, `FPrimary` unique (0 duplicates, 0 nulls) --
+    # complete coverage of the wave's 5,669 households, the only one of the
+    # three waves where housing is not short of the household count.
+    # Single file, single extraction -- no `dfs:` merge.
+    #
+    # SAME MODULE AS WAVES 1 AND 2, verified by content: `materialroof` is
+    # labelled "s12a_32 - Roof material" and `materialfloor` "s12a_31 - Floor
+    # material", i.e. the file carries wave 1's variable names in its own
+    # labels.  Checking the filename would NOT have been sufficient in this
+    # wave of all waves -- 01f is education in 2013-14 but EMPLOYMENT here
+    # (01fi_employmentmain / 01fii_employmentsecondary / 01fiii_unemployed),
+    # education having shifted to 01g.  Housing did not move; that is a fact
+    # established from the labels, not assumed from the name.
+    #
+    # `interviewedid` (wave 2 spells it `InstanceNumber`) is a per-interview
+    # counter, not part of the key.  Not declared.
+    #
+    # DELIVERED ROWS: 5,645, not 5,669.  The 24 missing rows are the ones
+    # with BOTH Roof and Floor null; _finalize_result's dropna(how='all')
+    # (country.py, GH #645) removes them.  Framework behaviour, not a filter
+    # written here; no material datum is lost, since a row survives if either
+    # column is populated.
+    #
+    # NULLS: in the source, Roof is 5,635/5,669 non-null (34 missing) and
+    # Floor 5,642/5,669 (27 missing); 24 of those overlap, so the delivered
+    # table carries 34-24 = 10 null Roof and 27-24 = 3 null Floor.
+    # These are Stata missings.  This wave DOES declare sentinels that the
+    # earlier waves do not -- -999 "Don't know", -888 "Refuse to answer",
+    # -777 "Not applicable", -666 "Other (please specify)" -- but only -666
+    # actually occurs (5 roof rows, 11 floor rows), and it is just this
+    # wave's spelling of "Other".  The three genuine non-response sentinels
+    # are absent from the shipped data, so no mapping row exists for them;
+    # if a future extract carries one it will survive unmapped and show up
+    # as a non-canonical value, which is the correct loud outcome.
+    #
+    # `v` is NOT declared -- _join_v_from_sample() attaches it at API time.
+    # Wave-3 `v` comes from the FPrimary[-6:-3] EA slice (see the `sample`
+    # note above and mapping.py); housing households are a strict subset of
+    # the sample households, so the join is total.
+    #
+    # MIXED-VINTAGE DIRECTORY NOTE (see CONTENTS.org): 2017-18/Data/ holds
+    # both our pre-anonymization copies and files acquired from Harvard
+    # Dataverse.  This file is one of the pre-existing ones; it carries
+    # `materialroof`/`materialfloor` either way, so nothing here depends on
+    # the extra variables our copy retains.
+    #
+    # Label harmonisation is done once for all three waves by the `Roof` /
+    # `Floor` tables in ../../_/categorical_mapping.org.  This wave's
+    # distinctive spellings are `Corrugated iron sheet` (SINGULAR -- wave 2
+    # says `sheets`, wave 1 `Corrugate iron sheets`), `Ceramic/marble tiles`
+    # (no slash before `tiles`, unlike waves 1-2) and `Other (please
+    # specify)`.
+    file: 12a_housingcharacteristics1iii_structure.dta
+    idxvars:
+        i: FPrimary
+    myvars:
+        Roof: materialroof
+        Floor: materialfloor

--- a/lsms_library/countries/GhanaSPS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaSPS/_/CONTENTS.org
@@ -708,3 +708,145 @@ exposes" above) -- =S1D.dta= and =key_hhld_info.dta= carry *identical*
 household sets in both directions.  The =v= join is therefore total for
 =household_roster=: 0 null =v= across all 54,251 rows in all three waves, 334
 distinct EAs.
+
+* housing: one module, three spellings of everything (2026-08-24)
+
+=housing= is now wired for all three waves, index =(t, i)= with =v= joined
+from =sample()= at API time.  Pure YAML path -- one source file per wave, a
+two-column extraction, no =dfs:= merge and no script.  Delivered: 4,899 /
+4,772 / 5,645 households, =Roof= and =Floor= as canonical material strings.
+
+** The module does NOT move -- but the filename is not what proves it
+
+|    wave | file                                       | Roof           | Floor           |
+|---------+--------------------------------------------+----------------+-----------------|
+| 2009-10 | =S12AI.dta=                                | =s12a_32=      | =s12a_31=       |
+| 2013-14 | =12a_housingcharacteristics1iii_structure= | =materialroof= | =materialfloor= |
+| 2017-18 | =12a_housingcharacteristics1iii_structure= | =materialroof= | =materialfloor= |
+
+Housing looks stable at =12a= across waves, and it *is* -- but the check that
+establishes it is the waves-2/3 *variable labels*, which read literally
+"s12a_32 - Roof material" and "s12a_31 - Floor material".  The producers are
+asserting the continuity themselves.
+
+Filename continuity would not have been evidence, because in this survey it
+is demonstrably unreliable.  Verified on the shipped file lists: =01f= is
+EDUCATION in 2013-14 (=01fi_generaleducation=, =01fii_edcareer=,
+=01fiii_literacy=) and EMPLOYMENT in 2017-18 (=01fi_employmentmain=,
+=01fii_employmentsecondary=, =01fiii_unemployed=), education having moved to
+=01g=.  Note that =01fi_= exists in both waves and means different things.
+
+Also note *=s12a_31= is the FLOOR and =s12a_32= is the ROOF* -- the reverse
+of the order the schema lists the columns in.  (Same shape of trap as the
+=s1d_2= / =s1d_4i= swap recorded under =household_roster= above.)
+
+** Wave 1 splits the module differently, and its part II is misnamed
+
+Wave 1 keeps in ONE file (=S12AI=, Q1-Q36) what waves 2 and 3 split across
+four: rent, utilities, structure and =12b_housingcharacteristics2=.
+Roof/floor are Q30-Q32 of =S12AI=.
+
+The sibling =S12AII.dta= spells its variables *s12b_*, not *s12a_*, despite
+being section 12A part II.  It is the wave-1 twin of waves 2/3's
+=12b_housingcharacteristics2.dta= (dwelling type, rooms, occupancy status,
+electricity) and carries no material variable at all.
+
+** Three waves, three spellings of the modal roof
+
+The code frames are identical across waves -- same codes, same materials --
+but the Stata value labels are re-typed each wave.  The drift is punctuation
+and wording, *not case*, so case normalisation alone would not have caught
+it:
+
+| code | 2009-10                   | 2013-14                   | 2017-18                       |
+|------+---------------------------+---------------------------+-------------------------------|
+|    3 | Corrugate iron sheets     | Corrugated iron sheets    | Corrugated iron sheet         |
+|    1 | Palm leaves/Raffia/Thatch | Palm leaves/raffia/thatch | Palm leaves/raffia/thatch     |
+|    7 | Mud bricks /Earth         | Mud bricks/earth          | Mud bricks/earth              |
+|  oth | Other (9)                 | Other - specify (95)      | Other (please specify) (-666) |
+
+Wave 1's code 3 is "Corrugate", missing the *d* -- a source typo on the
+material 76% of households have.  Wave 3 drops the plural.  Floor is the
+same story: wave 1's code 4 is =Cement/ concrete= with an *internal space
+after the slash* (3,921 rows), its code 8 is =Terrazo= with one z, and wave
+3's code 7 is =Ceramic/marble tiles= where waves 1-2 write
+=Ceramic/Marble/Tiles= with a third slash.
+
+Harmonisation is done ONCE, for all three waves, by the =Roof= / =Floor=
+tables in =_/categorical_mapping.org= (this country's first such file),
+auto-discovered by column name and applied at API time.  Every Preferred
+Label comes from the shared vocabulary in
+=lsms_library/categorical_mapping/canonical_housing_labels.org=; the
+per-category reasoning is in that file's header.
+
+*** How this fails silently
+
+=_apply_categorical_mappings= applies =Series.replace()=, which leaves an
+unmatched value *unchanged* -- it does not null it and it does not raise.  A
+mistyped Alternate Spelling therefore shows up as a raw survey label quietly
+surviving into the delivered table.  The discriminating test is "is the
+delivered per-wave value set a SUBSET of the canonical vocabulary", never
+"do the distributions look plausible".
+
+** GSPS separates Bamboo from Wood; the canonical vocabulary does not
+
+The GSPS roof question offers *Wood* (code 2) and *Bamboo* (code 8) as
+separate options -- 20/10/11 and 29/7/8 observations across the three waves.
+=canonical_housing_labels.org= folds bamboo into =Wood= ("Includes bamboo
+planks/strips"), so the two collapse.  This is the only mapping in the
+country that merges a distinction the survey actually drew.
+
+It is done anyway rather than coining a country-local label, which would
+defeat the point of a shared vocabulary.  The loss is mitigated: the mapping
+runs at API time, so the cached parquet still carries =Bamboo=.  *Someone
+owning GH #170 should consider adding =Bamboo= (and =Terrazzo=) to the
+canonical lists* -- GhanaSPS appears to be the first country in the corpus
+whose roof question separates the two.
+
+=Terrazzo= is the other weak spot: no canonical label fits, and every
+available one merges it with some other GSPS floor category.  It goes to
+=Stone= ("Includes polished stone / marble"), which is what terrazzo is
+(marble chips in cement, ground and polished).  Recorded as a judgement,
+not a fact.
+
+** Coverage falls short of the household count in every wave, for two reasons
+
+|    wave | households | source rows | delivered | absent | all-null |
+|---------+------------+-------------+-----------+--------+----------|
+| 2009-10 |      5,009 |       4,972 |     4,899 |     37 |       73 |
+| 2013-14 |      4,774 |       4,772 |     4,772 |      2 |        0 |
+| 2017-18 |      5,669 |       5,669 |     5,645 |      0 |       24 |
+
+*Absent* households have no housing record in the shipped extract at all.
+Wave 1's 37 are missing from =S12AI= while present in =key_hhld_info.dta=
+and =S1D.dta= (both 5,009); =S12AII= covers 30 of them but has no material
+variable, so they cannot be recovered.  Wave 2's two are =106199032= and
+=205163009=.
+
+*All-null* rows are present in the source with BOTH Roof and Floor missing,
+and are removed by =_finalize_result='s =dropna(how='all')= (GH #645).  That
+is framework behaviour, not a filter in this config, and it costs no
+material datum -- a row survives if either column is populated, which is why
+9 null Roof / 2 null Floor remain in wave 1 and 10 / 3 in wave 3.
+
+Housing households are a strict SUBSET of the sample households in *all
+three* waves (0 housing-only ids anywhere), so unlike the food module -- with
+its 29/35 =hhno= discrepancy recorded above -- the =v= join is total: 0 null
+=v= across all 15,316 rows, 334 distinct EAs.
+
+** Wave 3 declares non-response sentinels the earlier waves do not
+
+=materialroof= / =materialfloor= in 2017-18 carry -999 "Don't know", -888
+"Refuse to answer", -777 "Not applicable" and -666 "Other (please specify)".
+Only *-666* actually occurs (5 roof rows, 11 floor rows), and it is merely
+this wave's spelling of "Other".  The three genuine non-response sentinels
+are absent from the data, so no mapping row is written for them -- if a
+future extract carries one it will survive unmapped and surface as a
+non-canonical value, which is the correct loud outcome.
+
+** Outer wall is available in every wave and is deliberately not wired
+
+=s12a_30= / =materialouterwall= is populated in all three waves (and waves
+2-3 add a code 11 "Mud bricks with cement plastering" that wave 1 lacks).
+The =housing= schema is Roof + Floor only; extending it is a schema change,
+not a GhanaSPS change.

--- a/lsms_library/countries/GhanaSPS/_/categorical_mapping.org
+++ b/lsms_library/countries/GhanaSPS/_/categorical_mapping.org
@@ -1,0 +1,171 @@
+#+title: GhanaSPS categorical mappings
+
+* Roof / Floor (housing)
+
+These two tables are auto-discovered by ~Country._apply_categorical_mappings~
+(the table name matches the column name, case-insensitively) and applied at
+API time to ~housing.Roof~ / ~housing.Floor~.  They are NOT baked into the
+cached parquet, so the raw survey labels remain recoverable from
+~{data_root}/GhanaSPS/*/_/housing.parquet~.
+
+The ~Preferred Label~ column is drawn ENTIRELY from the shared vocabulary in
+=lsms_library/categorical_mapping/canonical_housing_labels.org= (GH #170).
+No new canonical label is coined here: Uganda and Malawi both emit only
+canonical values, and a country that invents one defeats the point of the
+shared list.  Delivered value sets:
+
+  Roof  : Iron Sheets, Thatch, Asbestos, Concrete, Clay Tiles, Mud, Wood, Other
+  Floor : Earth, Concrete, Tiles, Vinyl/Linoleum, Bricks, Stone, Wood, Other
+
+** Two jobs, and the first one is the load-bearing one
+
+*** 1. Cross-wave drift WITHIN GhanaSPS
+
+The GSPS roof/floor code frames are identical across the three waves (same
+codes 1-8, same materials), but the Stata value LABELS are re-typed each
+wave.  The drift is punctuation and wording, not case -- so the case
+normalisation the ~housing~ sub-skill describes would not have caught it:
+
+| code | 2009-10                   | 2013-14                   | 2017-18                   |
+|------+---------------------------+---------------------------+---------------------------|
+|    3 | Corrugate iron sheets     | Corrugated iron sheets    | Corrugated iron sheet     |
+|    1 | Palm leaves/Raffia/Thatch | Palm leaves/raffia/thatch | Palm leaves/raffia/thatch |
+|    7 | Mud bricks /Earth         | Mud bricks/earth          | Mud bricks/earth          |
+|    9 | Other                     | Other - specify (95)      | Other (please specify) (-666) |
+
+Note code 3 in wave 1 is "Corrugate", not "Corrugated" -- a source typo --
+and wave 3 drops the plural.  Three spellings of the modal roof material.
+Floor is the same story: wave 1's code 4 is =Cement/ concrete= with an
+INTERNAL space after the slash, and its code 8 is =Terrazo= with one z.
+Internal whitespace survives ~.str.strip()~, so both must appear verbatim.
+
+*** 2. Mapping GSPS's categories onto the canonical vocabulary
+
+Every judgement made, and its basis:
+
+- =Corrugate(d) iron sheet(s)= -> *Iron Sheets*.  Canonical roof label,
+  "Most common across LSMS-ISA"; Uganda maps =Iron sheets=/=Tin= to it.
+- =Palm leaves/raffia/thatch= -> *Thatch*.  Canonical "dried plant
+  material"; Malawi maps =Grass= to it, Uganda =Thatch, Straw=.
+- =Cement/concrete= (roof AND floor) -> *Concrete*.  The canon deliberately
+  keeps =Cement= and =Concrete= distinct, but GSPS offers ONE combined
+  option, so the distinction is not recoverable for Ghana.  Uganda's tables
+  resolve the identical compound (=Concrete/cement=, =Concrete/ Cement=) to
+  =Concrete= in both its Roof and Floor tables; that precedent breaks the
+  tie.  For a roof this is also unambiguous on the merits (a cement-screed
+  roof is not a thing); for a floor a Ghanaian "cement/concrete" floor is
+  more often a screed, so this call is precedent-driven, not physical.
+- =Asbestos/slate= -> *Asbestos*.  The canon carries BOTH =Asbestos= and
+  =Slate= (the latter added for Tajikistan), and GSPS lumps them into one
+  option.  Asbestos (fibre-cement) sheet is the common Ghanaian roofing of
+  the two; slate roofing is essentially absent.  NOT verified against the
+  questionnaire -- the instrument prints the same compound option.
+- =Roofing tiles= -> *Clay Tiles*.  GSPS does not say "clay", but the canon
+  has no generic roof-tile label and Uganda maps its own unqualified
+  =Tiles=/=tiles= to =Clay Tiles=.  Exact precedent.
+- =Mud bricks/earth= -> *Mud*.  Canonical =Mud= is documented as
+  "Includes Adobe (sun-dried mud brick)", which is this category.
+- =Bamboo= -> *Wood*.  Canonical =Wood= is documented as "Includes bamboo
+  planks/strips".  BUT SEE THE CAVEAT BELOW -- this is the one mapping that
+  merges two distinct GSPS categories.
+- =Earth/mud/mud bricks= -> *Earth*.  Canonical, matching Uganda
+  (=Rammed earth=) and Malawi (=Smoothed mud=).
+- =Ceramic/marble(/) tiles= -> *Tiles*; =Vinyl tiles= -> *Vinyl/Linoleum*.
+  The canon's separate =Vinyl/Linoleum= label ("resilient sheet/tile
+  flooring (linoleum, vinyl, vinyl tiles)") is what keeps these two GSPS
+  categories from colliding on =Tiles=.  Without it this would have been a
+  merge.
+- =Burnt bricks= -> *Bricks*.  Canonical floor label.  Note GSPS's
+  =Earth/mud/mud bricks= is the UNFIRED brick category and goes to =Earth=,
+  so the two brick categories stay apart.
+- =Terrazo=/=Terrazzo= -> *Stone*.  THE WEAKEST CALL IN THIS FILE.  The
+  canon has no terrazzo label, and every available canonical label merges
+  terrazzo with some other GSPS floor category: =Concrete= merges it with
+  the 4,673-row =Cement/concrete=, =Tiles= with =Ceramic/marble tiles=,
+  =Other= with GSPS's own =Other=.  =Stone= is documented as "Includes
+  polished stone / marble", which is literally what terrazzo is (marble
+  chips in cement, ground and polished), and it keeps terrazzo among the
+  premium floors for welfare work.  It merges with GSPS's =Stone= (17-18
+  rows/wave).  Recorded as a judgement, not a fact.
+- =Other= / =Other - specify= / =Other (please specify)= -> *Other*.
+
+*** CAVEAT: Bamboo -> Wood is a real merge, and GSPS is why the canon should change
+
+GSPS's roof question offers *Wood* (code 2) and *Bamboo* (code 8) as
+SEPARATE options -- 20/10/11 and 29/7/8 observations respectively across
+the three waves.  The canonical vocabulary folds bamboo into =Wood=, so
+the two collapse.  That is a genuine loss of a distinction the survey drew,
+and it is the only such loss in this file.
+
+It is done anyway because unilaterally coining a canonical label in a
+country-wiring change would break the invariant that makes
+=canonical_housing_labels.org= worth having.  The loss is mitigated: the
+mapping is applied at API time only, so ~pd.read_parquet~ on the cached
+housing parquet still shows =Bamboo=, and ~s12a_32~ / ~materialroof~ in
+the source are untouched.
+
+RECOMMENDATION for whoever owns GH #170: add *Bamboo* (and possibly
+*Terrazzo*) to the canonical roof/floor lists and re-point the two rows
+below.  GhanaSPS appears to be the first country in the corpus whose roof
+question separates bamboo from wood.
+
+*** What is deliberately NOT mapped
+
+- Wave 3 declares the sentinels -999 "Don't know", -888 "Refuse to answer"
+  and -777 "Not applicable" on both variables.  NONE of them occurs in the
+  data (checked on the shipped file), so no row is written for them.  If a
+  future extract carries one it will pass through unmapped and show up as a
+  non-canonical value -- which is the correct, loud outcome.  (-666 DOES
+  occur and is just wave 3's spelling of "Other".)
+- Outer wall (=s12a_30= / =materialouterwall=) is present in every wave and
+  is deliberately not wired: the `housing` schema is Roof + Floor only.
+
+*** How this fails silently, and why the test is a subset assertion
+
+~_apply_categorical_mappings~ applies ~Series.replace(rdict)~, which leaves
+an unmatched value UNCHANGED rather than nulling it.  So a missing or
+mistyped Alternate Spelling does not raise and does not show up as a null --
+the raw label simply survives into the delivered table.  The discriminating
+check is therefore "is the delivered per-wave value set a SUBSET of the
+canonical set above", never "do the distributions look plausible".
+
+#+name: Roof
+| Alternate Spelling     | Preferred Label |
+|------------------------+-----------------|
+| Corrugate iron sheets  | Iron Sheets     |
+| Corrugated iron sheets | Iron Sheets     |
+| Corrugated iron sheet  | Iron Sheets     |
+| Palm leaves/Raffia/Thatch | Thatch       |
+| Palm leaves/raffia/thatch | Thatch       |
+| Asbestos/Slate         | Asbestos        |
+| Asbestos/slate         | Asbestos        |
+| Cement/Concrete        | Concrete        |
+| Cement/concrete        | Concrete        |
+| Roofing tiles          | Clay Tiles      |
+| Mud bricks /Earth      | Mud             |
+| Mud bricks/earth       | Mud             |
+| Bamboo                 | Wood            |
+| Wood                   | Wood            |
+| Other                  | Other           |
+| Other - specify        | Other           |
+| Other (please specify) | Other           |
+
+#+name: Floor
+| Alternate Spelling     | Preferred Label |
+|------------------------+-----------------|
+| Earth/Mud/Mud bricks   | Earth           |
+| Earth/mud/mud bricks   | Earth           |
+| Cement/ concrete       | Concrete        |
+| Cement/concrete        | Concrete        |
+| Ceramic/Marble/Tiles   | Tiles           |
+| Ceramic/marble/tiles   | Tiles           |
+| Ceramic/marble tiles   | Tiles           |
+| Vinyl tiles            | Vinyl/Linoleum  |
+| Burnt bricks           | Bricks          |
+| Terrazo                | Stone           |
+| Terrazzo               | Stone           |
+| Stone                  | Stone           |
+| Wood                   | Wood            |
+| Other                  | Other           |
+| Other - specify        | Other           |
+| Other (please specify) | Other           |

--- a/lsms_library/countries/GhanaSPS/_/data_scheme.yml
+++ b/lsms_library/countries/GhanaSPS/_/data_scheme.yml
@@ -90,3 +90,70 @@ Data Scheme:
     panel_weight: float
     strata: str
     Rural: str
+
+  housing:
+    # Dwelling roof / floor material, all three waves, YAML path (no script:
+    # one source file per wave, a straight column extraction, and the label
+    # harmonisation lives in _/categorical_mapping.org rather than in code).
+    #
+    # Sources -- the module is stable at 12/12a across waves, CONFIRMED BY
+    # CONTENT rather than by filename (GhanaSPS module letters are not
+    # reliable -- verified on the shipped file lists, 01f is EDUCATION in
+    # 2013-14 (01fi_generaleducation, 01fii_edcareer, 01fiii_literacy) and
+    # EMPLOYMENT in 2017-18 (01fi_employmentmain, 01fii_employmentsecondary,
+    # 01fiii_unemployed), education having moved to 01g).  The wave-2/3
+    # variables carry the WAVE-1 variable name in their own Stata labels:
+    # `materialroof` is labelled
+    # "s12a_32 - Roof material" and `materialfloor` "s12a_31 - Floor
+    # material" -- which is the producers themselves asserting the
+    # continuity:
+    #
+    #   2009-10  S12AI.dta                                  s12a_32 / s12a_31
+    #   2013-14  12a_housingcharacteristics1iii_structure.dta  materialroof /
+    #   2017-18  12a_housingcharacteristics1iii_structure.dta  materialfloor
+    #
+    # Wave 1 keeps in ONE file (S12AI, Q1-Q36) what waves 2 and 3 split into
+    # four (…1i_rent, …1ii_utilities, …1iii_structure, 12b_…2).  Roof/floor
+    # are Q30-Q32 of S12AI; S12AII is the wave-1 twin of 12b and carries no
+    # material variable, so there is nothing to merge and no `dfs:` block.
+    #
+    # `v` is NOT declared and must NOT be: `sample` is wired for every wave,
+    # so _join_v_from_sample() attaches it at API time.  The join is total --
+    # the housing households are a strict SUBSET of the sample households in
+    # all three waves (0 housing-only ids anywhere), so `v` is 0% null.
+    #
+    # ROW COUNTS ARE BELOW THE HOUSEHOLD COUNTS IN EVERY WAVE, from two
+    # independent causes.  Both are benign; neither is a config defect.
+    #
+    #   wave     households  source rows  delivered  absent  all-null
+    #   2009-10       5,009        4,972      4,899      37        73
+    #   2013-14       4,774        4,772      4,772       2         0
+    #   2017-18       5,669        5,669      5,645       0        24
+    #
+    # (a) ABSENT -- households with no housing record at all in the shipped
+    #     extract.  Wave 1's 37 are absent from S12AI entirely (they ARE in
+    #     key_hhld_info.dta and S1D.dta, both 5,009); S12AII covers 30 of
+    #     them but has no material variable, so they are not recoverable.
+    #     Wave 2's 2 are 106199032 and 205163009.
+    # (b) ALL-NULL -- rows present in the source with BOTH Roof and Floor
+    #     missing, removed by _finalize_result's dropna(how='all')
+    #     (country.py, GH #645).  This is framework behaviour, not a filter
+    #     written here, and it costs no material data: a row survives if
+    #     EITHER column is populated, which is why 9 Roof-nulls and 2
+    #     Floor-nulls remain in wave 1 and 10 / 3 in wave 3.
+    #
+    # Checked arithmetic, wave 1: 82 Roof-null and 75 Floor-null source rows,
+    # of which 73 are null in both -> 4,972 - 73 = 4,899 delivered, with
+    # 82 - 73 = 9 and 75 - 73 = 2 nulls left.  Wave 3: 34 / 27 / 24 -> 5,645
+    # delivered with 10 and 3 nulls.  Wave 2 has no nulls at all.
+    #
+    # Roof / Floor are harmonised at API time by the `Roof` and `Floor`
+    # tables in _/categorical_mapping.org, auto-discovered by column name.
+    # Every Preferred Label is drawn from the shared vocabulary in
+    # lsms_library/categorical_mapping/canonical_housing_labels.org; the
+    # per-judgement reasoning, including the one genuine merge
+    # (GSPS separates Bamboo from Wood; the canon does not), is in that file.
+    # Wall material exists in every wave and is deliberately not wired.
+    index: (t, i)
+    Roof: str
+    Floor: str


### PR DESCRIPTION
Wires `housing` (index `(t, i)`; `Roof`, `Floor`) for all three GhanaSPS waves. Config only — YAML path, no script.

## Source, and why the filename is not the evidence

| wave | file | Roof | Floor |
|---|---|---|---|
| 2009-10 | `S12AI.dta` | `s12a_32` | `s12a_31` |
| 2013-14 | `12a_housingcharacteristics1iii_structure.dta` | `materialroof` | `materialfloor` |
| 2017-18 | `12a_housingcharacteristics1iii_structure.dta` | `materialroof` | `materialfloor` |

Housing really is stable at module 12/12a — but what establishes that is the waves-2/3 **variable labels**, which read literally `"s12a_32 - Roof material"` and `"s12a_31 - Floor material"`: the producers naming wave 1's variables. Filename continuity would not have been evidence. Verified on the shipped file lists, `01f` is **education** in 2013-14 (`01fi_generaleducation`, `01fii_edcareer`, `01fiii_literacy`) and **employment** in 2017-18 (`01fi_employmentmain`, `01fii_employmentsecondary`, `01fiii_unemployed`), education having moved to `01g`. The same `01fi_` stem exists in both waves and means different things.

Two more traps, now in `CONTENTS.org`: `s12a_31` is the **floor** and `s12a_32` the **roof** (reverse of the schema's column order); and wave 1's `S12AII.dta` spells its variables `s12b_*`, not `s12a_*`, despite being section 12A part II — it carries no material variable, so there is nothing to merge and no `dfs:` block anywhere here.

## Label harmonisation

Adds GhanaSPS's first `_/categorical_mapping.org`, with `Roof` / `Floor` tables auto-discovered by column name — the mechanism Uganda and Malawi already use.

**The drift is punctuation and wording, not case**, so the case normalisation the `housing` sub-skill describes would not have caught it. Code frames are identical across waves; the Stata labels are re-typed each time:

| | 2009-10 | 2013-14 | 2017-18 |
|---|---|---|---|
| roof 3 | `Corrugate iron sheets` | `Corrugated iron sheets` | `Corrugated iron sheet` |
| floor 4 | `Cement/ concrete` | `Cement/concrete` | `Cement/concrete` |
| floor 7 | `Ceramic/Marble/Tiles` | `Ceramic/marble/tiles` | `Ceramic/marble tiles` |
| floor 8 | `Terrazo` | `Terrazzo` | `Terrazzo` |
| other | `Other` | `Other - specify` | `Other (please specify)` |

Wave 1's roof label is missing the **d** — a source typo on the material 76% of households have — and its floor label carries an **internal space after the slash**, which `.str.strip()` does not touch.

Every Preferred Label comes from `lsms_library/categorical_mapping/canonical_housing_labels.org` (#170). No country-local label is coined: Uganda and Malawi both emit only canonical values, and a country that invents one defeats the shared list.

## Judgement calls (each with its basis in `categorical_mapping.org`)

- **`Cement/concrete` → `Concrete`** (roof and floor). The canon deliberately keeps `Cement` and `Concrete` distinct, but GSPS offers **one combined option**, so the distinction is not recoverable for Ghana. Uganda resolves the identical compound (`Concrete/cement`) to `Concrete` in both its tables — that breaks the tie. **Consequence: a cross-country "cement floor" query gets Malawi and not Ghana.** Precedent-driven, not physical.
- **`Asbestos/slate` → `Asbestos`.** Canon carries both labels; GSPS lumps them. Not verified against the questionnaire — the instrument prints the same compound option.
- **`Roofing tiles` → `Clay Tiles`.** GSPS never says "clay", but the canon has no generic roof-tile label and Uganda maps its own unqualified `Tiles` there.
- **`Vinyl tiles` → `Vinyl/Linoleum`, `Ceramic/marble tiles` → `Tiles`.** The canon's separate `Vinyl/Linoleum` label is exactly what keeps these two GSPS categories from colliding on `Tiles`.
- **`Terrazzo` → `Stone`.** The weakest call in the PR. No canonical label fits, and every option merges terrazzo with some other GSPS floor category; `Stone` is documented as "includes polished stone / marble", which is what terrazzo is. Recorded as judgement, not fact.
- **`Bamboo` → `Wood` — the one genuine merge.** GSPS's roof question offers `Wood` (code 2) and `Bamboo` (code 8) *separately* (20/10/11 and 29/7/8 obs). The canon folds bamboo into `Wood`. Done per canon rather than coining a country-local label; mitigated because the mapping runs at **API time**, so the cached parquet still carries `Bamboo`. **Recommend #170 add `Bamboo` (and `Terrazzo`)** — GhanaSPS appears to be the first country in the corpus whose roof question separates the two.

## Verification (cold `LSMS_DATA_DIR`, values not shapes)

| wave | households | source rows | delivered | absent | all-null |
|---|---|---|---|---|---|
| 2009-10 | 5,009 | 4,972 | 4,899 | 37 | 73 |
| 2013-14 | 4,774 | 4,772 | 4,772 | 2 | 0 |
| 2017-18 | 5,669 | 5,669 | 5,645 | 0 | 24 |

Delivered counts sit below the household counts from two benign causes, both documented: households with **no housing record in the shipped extract** (wave 1's 37 are in `key_hhld_info.dta` and `S1D.dta` but not `S12AI`; `S12AII` covers 30 of them but has no material variable), and source rows with **both** columns null, removed by `_finalize_result`'s `dropna(how='all')` (#645). No material datum is lost — a row survives if either column is populated, which is why 9/2 nulls remain in wave 1 and 10/3 in wave 3.

Full delivered distributions:

| Roof | 2009-10 | 2013-14 | 2017-18 | | Floor | 2009-10 | 2013-14 | 2017-18 |
|---|---|---|---|---|---|---|---|---|
| Iron Sheets | 3747 | 3768 | 4670 | | Concrete | 3921 | 3960 | 4673 |
| Thatch | 610 | 374 | 320 | | Earth | 873 | 496 | 714 |
| Asbestos | 297 | 336 | 352 | | Tiles | 14 | 141 | 111 |
| Concrete | 141 | 182 | 117 | | Wood | 36 | 86 | 26 |
| Clay Tiles | 10 | 24 | 141 | | Vinyl/Linoleum | 18 | 38 | 71 |
| Wood | 49 | 17 | 19 | | Stone | 18 | 33 | 36 |
| Other | 12 | 58 | 5 | | Other | 4 | 16 | 11 |
| Mud | 24 | 13 | 11 | | Bricks | 13 | 2 | 0 |
| *(null)* | 9 | 0 | 10 | | *(null)* | 2 | 0 | 3 |

- `(t, i)` unique, **0 duplicates**; 0 null index levels; `v` **0% null** across all 15,316 rows, 334 EAs (housing households are a strict subset of the sample households in every wave).
- **The discriminating check is a subset assertion**, not "the distributions look right": `_apply_categorical_mappings` uses `Series.replace()`, which leaves an unmatched value **unchanged** rather than nulling it, so a mistyped Alternate Spelling fails silently. Delivered value sets are asserted ⊆ the canonical vocabulary, and the per-wave sets are identical across all three waves.
- **0 `GrainCollapse` reports**, re-verified on a cold parquet dir under `LSMS_GRAIN_STRICT=1`.
- **0 `NullRead` reports for `housing`.** The four that fire are pre-existing on `sample` (the documented producer-side weight/geography gaps).
- `is_this_feature_sane`: 16 pass / 1 warn / 0 fail — the warn is the expected extra `v` level.
- `pytest tests/test_schema_consistency.py tests/test_table_structure.py` — **345 passed**.
- `Feature('housing')(['GhanaSPS','Malawi'])` assembles on one shared vocabulary.

## Not done

Outer wall (`s12a_30` / `materialouterwall`) is populated in every wave and deliberately not wired — the `housing` schema is Roof + Floor, and extending it is a schema change rather than a GhanaSPS one.

Branched from `a61e563d` (origin/development).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFLYAj1WqLBPsJZFQGapvb
