### PR TITLE
feat(GhanaSPS): wire individual_education for all three waves

### DIFF
--- a/lsms_library/countries/GhanaSPS/2009-10/_/data_info.yml
+++ b/lsms_library/countries/GhanaSPS/2009-10/_/data_info.yml
@@ -140,3 +140,60 @@ household_roster:
         Age: s1d_4i
         Relationship: s1d_2
         MonthsAway: s1d_27
+
+individual_education:
+    # S1FI.dta -- wave 1's Section 1F(i) "General Education" module.  18,894
+    # rows against a 18,889-person roster; the 5 extras all have a NULL
+    # `s1fi_hhmid` and are dropped by the df_edit hook (see below).  Every
+    # remaining (hhno, s1fi_hhmid) is unique and is in S1D.dta.
+    #
+    # Variable labels read off the .dta, since the names carry no meaning:
+    #   s1fi_2 "Q2 Has person ever attended school"                 -> _attended
+    #   s1fi_3 "Q3 What was the highest grade successfully completed"-> the ladder
+    #   s1fi_4 "Q4 What is the highest educational qualification"   -> _qual
+    #
+    # `_attended` and `_qual` are TEMPORARY: ghanasps.individual_education()
+    # consumes them and drops them, so the built table has only the declared
+    # `Educational Attainment` column.  The country's data_scheme.yml comment
+    # carries the measured argument for why all three are needed.
+    #
+    # Wave 1 is the only wave whose GRADE ladder reaches tertiary -- it has
+    # Level 100..400, Polytechnic, Diploma, HND 1..3, Masters, Teacher/Nursing
+    # Training and Koranic School as grades, none of which exist in the wave-2
+    # or wave-3 code list.  So the qualification fallback fires on only 203
+    # rows here ('Other'), against 501 and 775 later.
+    #
+    # Wave 1's screener is NOT clean, unlike waves 2 and 3, and the hook's
+    # ordering is written for that: `s1fi_2` is null for 1,577 rows of which
+    # 247 nonetheless carry a grade, answers 'No' for 4,878 of which 29 carry a
+    # grade and 51 a qualification, and answers 'Yes' for 12,439 of which 719
+    # carry no grade (636 of those do carry a qualification).  The grade wins
+    # wherever it exists; the qualification is consulted next; 'No' is applied
+    # last.  Nothing here is fabricated -- a row with none of the three stays
+    # NA and is dropped downstream.
+    #
+    # DELIVERED: 16,955 of the 18,889 roster people (89.8%), the LOWEST of the
+    # three waves.  Waves 2 and 3 lose essentially only under-3s (a clean
+    # module age floor); WAVE 1 DOES NOT.  Of its 1,934 unresolved people
+    # 1,266 are under 3 and 381 are aged 3-5, but 224 are aged 6-17 and 63 are
+    # 18+.  Those 287 school-age-and-older people have a row in S1FI.dta with
+    # `s1fi_2` null (or 'Yes') and no grade and no usable qualification -- the
+    # module reached them and recorded nothing.  Do NOT read that as "never
+    # attended": the survey records 'No' explicitly 4,878 times, so a blank is
+    # a different fact from a 'No' and is left NA rather than filled.  This is
+    # the same shape of wave-1 recording defect as the `s1d_27` blank block in
+    # `household_roster` above, and it is recorded, not repaired.
+    #
+    # `v` is NOT declared -- _join_v_from_sample() attaches it at API time.
+    file: S1FI.dta
+    idxvars:
+        i: hhno
+        pid: s1fi_hhmid
+    myvars:
+        Educational Attainment:
+            - s1fi_3
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+        _qual:
+            - s1fi_4
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+        _attended: s1fi_2

--- a/lsms_library/countries/GhanaSPS/2013-14/_/data_info.yml
+++ b/lsms_library/countries/GhanaSPS/2013-14/_/data_info.yml
@@ -85,3 +85,46 @@ household_roster:
         - t
         - i
         - pid
+
+individual_education:
+    # 01fi_generaleducation.dta -- Section 1F(i) "General Education".  IN THIS
+    # WAVE module `f` is education and `e` is employment; in 2017-18 both shift
+    # one letter (`f` becomes employment, `g` education) while keeping the same
+    # variable names.  See the country data_scheme.yml comment.
+    #
+    # 15,316 rows, 4,774 households, (FPrimary, hhmid) unique, every key in the
+    # roster.  The roster has 16,356 people: the 1,040 with no education record
+    # are children aged 0-2 (1,019 of the 1,022 with a recorded age; the module
+    # has an age floor of 3).  That is the whole of the shortfall -- a
+    # module-eligibility rule, not attrition.
+    #
+    # This wave's screener is EXACT: `attended == 'No'` <-> null grade, 3,779
+    # rows on both sides, 0 exceptions.  So the hook's step 2 recovers exactly
+    # the never-schooled and invents nothing.
+    #
+    # `highestgrade` here has NO tertiary rung -- its code list stops at S5 and
+    # sends every tertiary respondent to 95 'Other - Specify' (501 rows, all
+    # 501 with a non-null `highestqual`, overwhelmingly Bachelors / diploma /
+    # HND).  That is what the `_qual` fallback exists for.
+    #
+    # NOTE: this file triggers a UnicodeWarning (latin-1 fallback) on read --
+    # some strings in it are not valid UTF-8.  The decoded value labels were
+    # checked and are sane.  `pyreadstat` refuses the file outright
+    # (UnicodeDecodeError) where pandas falls back, so inspect it through
+    # `get_dataframe` / pandas, not pyreadstat.
+    #
+    # `_attended` / `_qual` are temporary and are dropped by
+    # ghanasps.individual_education().  `v` is NOT declared --
+    # _join_v_from_sample() attaches it at API time.
+    file: 01fi_generaleducation.dta
+    idxvars:
+        i: FPrimary
+        pid: hhmid
+    myvars:
+        Educational Attainment:
+            - highestgrade
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+        _qual:
+            - highestqual
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+        _attended: attended

--- a/lsms_library/countries/GhanaSPS/2017-18/_/data_info.yml
+++ b/lsms_library/countries/GhanaSPS/2017-18/_/data_info.yml
@@ -87,3 +87,58 @@ household_roster:
         - t
         - i
         - pid
+
+individual_education:
+    # 01gi_generaleducation.dta -- Section 1G(i) "General Education".  READ THE
+    # FILENAME TWICE.  In 2013-14 education is module `f`; in THIS wave every
+    # module letter shifted by one, so `f` is EMPLOYMENT
+    # (01fi_employmentmain.dta) and education is `g`.  The three variables are
+    # spelled IDENTICALLY in both waves -- `attended`, `highestgrade`,
+    # `highestqual` -- so wiring this wave to `01fi_employmentmain.dta` (the
+    # name that matches wave 2's education file) produces a plausible, silently
+    # wrong table rather than an error.
+    #
+    # Two tells, both measured:
+    #   - row count.  Education is 19,006 here (exactly the roster);
+    #     01fi_employmentmain.dta is 1,481 x 66 and carries `paidemployed` /
+    #     `maintasks` / `jobhoursperday`, no education variable at all.
+    #   - the variable LABELS DO NOT HELP -- they make it worse.  This file's
+    #     own labels still read `s01fi_02 - Ever Attended School`,
+    #     `s01fi_03 - Highest Grade`, `s01fi_04 - Highest Qualification`: the
+    #     instrument was renumbered but the labels were not, so a search for
+    #     `s01fi_` corroborates the WRONG file.  Trust the module content, not
+    #     the label prefix.
+    #
+    # 19,006 rows = the roster exactly, 5,669 households, (FPrimary, hhmid)
+    # unique, no roster-only and no file-only person.  Unlike wave 2, the
+    # under-3s ARE present here -- as rows with `attended`, `highestgrade` and
+    # `highestqual` all null (1,075 rows; 1,072 are aged 0-2).  Same age floor
+    # of 3, different shipping convention.  They resolve to NA and are dropped
+    # downstream, so both waves deliver the same population.
+    #
+    # This wave's code list is the one that DIVERGES from waves 1-2: it inserts
+    # SSS4 at 27 and shifts everything above it by one (27 = 'S1' in waves 1-2,
+    # 'SSS4' here), and adds L6 / U6 at 33 / 34.  Harmless because the mapping
+    # keys on the DECODED LABEL -- but fatal to any mapping written on codes.
+    # It also adds the explicit -999 "Don't know" / -888 "Refuse to answer"
+    # sentinels, both mapped to `Unknown`; neither occurs in the shipped data.
+    #
+    # `highestgrade` has no tertiary rung (it stops at U6), so all 775 tertiary
+    # respondents sit in -666 'Other (please specify)'; 774 of them have a
+    # non-null `highestqual` and the `_qual` fallback recovers them.
+    #
+    # `_attended` / `_qual` are temporary and are dropped by
+    # ghanasps.individual_education().  `v` is NOT declared --
+    # _join_v_from_sample() attaches it at API time.
+    file: 01gi_generaleducation.dta
+    idxvars:
+        i: FPrimary
+        pid: hhmid
+    myvars:
+        Educational Attainment:
+            - highestgrade
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+        _qual:
+            - highestqual
+            - mappings: ['harmonize_education', 'Original Label', 'Preferred Label']
+        _attended: attended

--- a/lsms_library/countries/GhanaSPS/_/CONTENTS.org
+++ b/lsms_library/countries/GhanaSPS/_/CONTENTS.org
@@ -708,3 +708,185 @@ exposes" above) -- =S1D.dta= and =key_hhld_info.dta= carry *identical*
 household sets in both directions.  The =v= join is therefore total for
 =household_roster=: 0 null =v= across all 54,251 rows in all three waves, 334
 distinct EAs.
+
+* individual_education: the module letter MOVES, and four other ways to get it wrong (2026-08-24)
+
+=individual_education= is now wired for all three waves, index =(t, i, pid)=
+with =v= joined from =sample()= at API time.  Delivered: 16,955 / 15,314 /
+17,910 people against rosters of 18,889 / 16,356 / 19,006 (89.8% / 93.6% /
+94.2% coverage; *zero* people appear in the education table who are not in the
+roster, in any wave).
+
+** 1. The module letter SHIFTS BY ONE between waves 2 and 3
+
+This is the trap that costs a silently-wrong table, because the *variable names
+do not shift with it*:
+
+| wave    | education module           | employment module          |
+|---------+----------------------------+----------------------------|
+| 2013-14 | =01fi_generaleducation.dta= | =01ei_employmentmain.dta=  |
+| 2017-18 | =01gi_generaleducation.dta= | =01fi_employmentmain.dta=  |
+
+So =01fi_*= is education in wave 2 and *employment* in wave 3.  In both waves
+the education variables are spelled identically -- =attended=, =highestgrade=,
+=highestqual= -- so a wave-3 config that reuses wave 2's *filename* points at
+the employment file and fails without an error.
+
+Two tells, and *one of them lies*:
+
+- *Row count works.*  Wave-3 education is 19,006 x 95 (exactly the roster);
+  =01fi_employmentmain.dta= is 1,481 x 66 and carries =paidemployed= /
+  =maintasks= / =jobhoursperday=, with no education variable at all.
+- *The variable LABELS DO NOT WORK -- they actively mislead.*
+  =01gi_generaleducation.dta='s own labels still read =s01fi_02 - Ever Attended
+  School=, =s01fi_03 - Highest Grade=, =s01fi_04 - Highest Qualification=.  The
+  instrument was renumbered =f= -> =g= but the *labels were never updated*, so
+  grepping the corpus for =s01fi_= corroborates the wrong file.  Trust module
+  content, never the label prefix.
+
+** 2. The grade CODES diverge between waves; the LABELS do not
+
+Wave 3 inserts =SSS4= at code 27 and shifts everything above it by one, then
+adds =L6= / =U6= at 33 / 34:
+
+| code | 2009-10 | 2013-14 | 2017-18 |
+|------+---------+---------+---------|
+|   26 | SSS3    | SSS3    | SSS3    |
+|   27 | S1      | S1      | *SSS4*  |
+|   28 | S2      | S2      | S1      |
+|   31 | S5      | S5      | S4      |
+
+=get_dataframe= decodes the Stata value labels, so mapping on the decoded label
+is safe and the divergence never bites.  A mapping written on the numeric codes
+would be silently wrong for one wave in three.  =_/categorical_mapping.org= is
+therefore keyed on labels, and says so.
+
+Wave 1 additionally has an entirely *different, longer* grade ladder: it is the
+only wave whose =s1fi_3= reaches tertiary (=Level 100= .. =Level 400=,
+=Polytechnic=, =Diploma=, =HND 1..3=, =Masters=, =Teacher/Nursing Training=,
+=Koranic School=, =O Level=, =A Level=, =Professional certificate=).  Waves 2
+and 3 have *no tertiary rung at all* -- their ladders stop at S5 / U6.
+
+** 3. The attainment answer is split across THREE variables, and needs all three
+
+=highestgrade= alone is not the table.  Measured cost of wiring it alone:
+
+- *12,827 never-schooled people would vanish.*  =attended == 'No'= implies a
+  null grade (exactly, in waves 2 and 3; 4,849 of 4,878 in wave 1), so those
+  rows would be deleted by =_finalize_result='s =dropna(how='all')=.  Wave 2
+  would then report =No education= for 9.6% of its rows where the survey says
+  24.7%.  The canonical vocabulary explicitly says to KEEP positively-recorded
+  never-schooled people as =No education=
+  (=canonical_education_labels.org=, "Never-schooled handling").
+- *501 (W2) + 775 (W3) graduates would come back =Unknown=.*  With no tertiary
+  rung in the grade ladder, every tertiary respondent lands in the survey's own
+  'Other' bucket -- and 501/501 and 774/775 of them have a non-null
+  =highestqual=, overwhelmingly Bachelors / diploma / HND.
+
+The two ladders are *complementary, not redundant*, which is why the fallback
+is narrow (grade absent or =Unknown= only) rather than a max() over both.
+Below the 'Other' bucket the qualification is essentially a function of the
+grade -- wave 2 has 7,470 people with qualification 'None' against 7,488 whose
+grade is at or below JSS2/M3 -- so substituting it there would add nothing and
+would override an explicit grade with an exam result.  In particular
+=highestqual == 'None'= means *holds no certificate*, NOT *never went to
+school*: a P6 leaver has qualification 'None'.
+
+This is what =ghanasps.individual_education()= (a =df_edit= hook, shared by all
+three waves) exists for; YAML =mapping:= is one-column-to-one-column.
+
+** 4. Wave 1's screener is NOT clean, and wave 1 loses school-age people
+
+Waves 2 and 3 are exact: =attended == 'No'= <-> null grade, no exceptions, and
+the only people missing an attainment datum are children under the module's age
+floor of 3 (1,019 of 1,042 in wave 2; 1,072 of 1,096 in wave 3).  Note the two
+waves ship those children *differently* -- wave 2 omits them from the file
+entirely, wave 3 includes the rows with every education variable null -- and
+the delivered population is the same either way.
+
+Wave 1 is messier and should not be described as having a clean age floor:
+
+- =s1fi_2= is *null* for 1,577 rows, 247 of which nonetheless carry a grade;
+- it answers *'No'* for 4,878, of which 29 carry a grade and 51 a qualification;
+- it answers *'Yes'* for 12,439, of which 719 carry no grade (636 of those do
+  carry a qualification).
+
+Of wave 1's 1,934 people with no delivered attainment, 1,266 are under 3 and
+381 are aged 3-5 -- but *224 are aged 6-17 and 63 are 18 or over*.  The module
+reached those 287 and recorded nothing.  A blank is *not* a 'No' here (the
+survey writes 'No' explicitly 4,878 times), so they are left NA rather than
+filled.  Same shape of wave-1 recording defect as the =s1d_27= blank block
+documented under =household_roster= above.
+
+** 5. Five wave-1 rows have a NULL person id, and one of them carries data
+
+=S1FI.dta= is 18,894 rows against an 18,889-person roster.  All five extras
+have a null =s1fi_hhmid=, which =format_id= turns into =None= -- a null =pid=
+index level, which would fail =no_null_index_levels=, and a non-unique index,
+since *three of the five share =hhno= 108294010*.  The hook drops them.
+
+Four carry no education data at all.  The fifth, =hhno= 105159025, records
+'Yes' / P6 / 'None' and is a *genuine loss*: =S1D.dta= has no member with that
+id, so there is no person to attach it to.  Recorded here rather than hidden.
+
+** Delivered distribution, for anyone checking a later change
+
+Per wave, as a share of that wave's delivered rows:
+
+| level                        | 2009-10 | 2013-14 | 2017-18 |
+|------------------------------+---------+---------+---------|
+| No education                 |   32.36 |   31.87 |   27.39 |
+| Informal                     |    0.04 |    0.00 |    0.00 |
+| Pre-primary                  |    5.44 |    6.23 |    5.93 |
+| Primary incomplete           |   22.25 |   21.97 |   20.75 |
+| Primary complete             |    5.44 |    5.23 |    5.71 |
+| Lower secondary              |    8.45 |    8.27 |    8.08 |
+| Lower secondary complete     |   15.66 |   15.11 |   17.14 |
+| Upper secondary              |    2.71 |    2.58 |    3.08 |
+| Upper secondary complete     |    4.52 |    5.94 |    8.26 |
+| Vocational/Technical         |    0.61 |    0.22 |    0.17 |
+| Tertiary certificate/diploma |    1.85 |    1.50 |    1.79 |
+| Bachelor                     |    0.54 |    0.76 |    1.13 |
+| Postgraduate                 |    0.06 |    0.12 |    0.18 |
+| Unknown                      |    0.05 |    0.21 |    0.41 |
+
+=Doctorate= never occurs: no wave's instrument offers it.  =Informal= occurs
+only in wave 1 (6 rows, =Koranic School=) because only wave 1's ladder has that
+rung -- it is *not* evidence that Koranic schooling stopped.  Likewise
+=Vocational/Technical= falls from 104 to 33/30 because wave 1 has
+=Vocational/Commercial= as a *grade* while waves 2 and 3 can only reach it
+through the qualification fallback.  Both are instrument artefacts, not trends,
+and a wave-over-wave comparison of those two rows is meaningless.
+
+The rise in =Upper secondary complete= (4.5 -> 5.9 -> 8.3) and =Bachelor=
+(0.54 -> 0.76 -> 1.13) across an eight-year panel of largely the same people is
+the expected direction and is *not* an instrument artefact -- those rungs exist
+in all three ladders.
+
+Cross-tabbed against roster =Age=, the mean canonical rank among adults falls
+monotonically with age -- 4.63 (25-34), 3.73 (35-49), 3.51 (50-64), 1.86 (65+)
+-- the standard cohort gradient; and 77.1% of under-5s are =No education= with
+a further 20.5% =Pre-primary=.  Note the direction: attainment *falls* with age
+here, it does not rise.  A check written expecting the opposite will report a
+false alarm.
+
+** A sibling-file defect noticed but NOT fixed here
+
+=GhanaLSS/_/categorical_mapping.org= contains =U6= *twice, with conflicting
+targets*: =Upper secondary complete= in its case-duplicated block (Upper Sixth
+Form) and =Postgraduate= in its GLSS1-3 letter-ladder block (=U= = University,
+year 6).  Both readings are correct for their own ladder; the table cannot hold
+both under one key, and =drop_duplicates(keep='first')= silently picks one.
+Per-country tables do not leak across countries, so GhanaSPS is unaffected --
+GhanaSPS declares its own =U6= -> =Upper secondary complete=.  Recorded so it
+is fixed in GhanaLSS deliberately rather than inherited by accident.
+
+** Reading these files
+
+=2013-14/Data/01fi_generaleducation.dta= is not valid UTF-8.  =get_dataframe= /
+pandas fall back to latin-1 with a =UnicodeWarning=; *=pyreadstat= refuses it
+outright* with =UnicodeDecodeError=, so the =metadataonly=True= triage recipe
+in the =add-feature= skill does not work on this file.  Use
+=pd.io.stata.StataReader= for its labels.  (Note: a task brief circulated in
+2026-08 placed this warning on the *2009-10* wave; measured, 2009-10's =S1FI= /
+=S1FII= / =S1FIII= read clean and it is wave 2 that warns.)

--- a/lsms_library/countries/GhanaSPS/_/categorical_mapping.org
+++ b/lsms_library/countries/GhanaSPS/_/categorical_mapping.org
@@ -1,0 +1,130 @@
+#+title: Categorical mappings for GhanaSPS
+
+* Educational attainment (GH #171)
+
+Maps the GSPS grade and qualification labels onto the canonical ordinal
+vocabulary in =lsms_library/categorical_mapping/canonical_education_labels.org=.
+Row-additive over the global base in
+=lsms_library/categorical_mapping/harmonize_education.org= (=harmonize_education=
+is in =country._ADDITIVE_CATEGORICAL_TABLES=), so only GSPS-specific labels and
+GSPS spellings are listed here; country rows win on key collision.
+
+*ONE table serves TWO source variables.*  =individual_education= reads the
+grade ladder (=s1fi_3= / =highestgrade=) and, as a fallback, the qualification
+ladder (=s1fi_4= / =highestqual=) -- see the =data_scheme.yml= comment for why
+both are needed.  Every label below is unique to one ladder or means the same
+thing in both (=Masters= grade / =Master's= qual both -> =Postgraduate=;
+=Vocational/Commercial= grade / =Voc/Comm= qual both -> =Vocational/Technical=),
+so a single table is unambiguous.  Check that before adding a row.
+
+*Map on the DECODED LABEL, never on the numeric code.*  The codes diverge
+between waves while the labels do not: code 27 is ='S1'= in 2009-10 and
+2013-14 but ='SSS4'= in 2017-18, and every code above 26 is shifted by one in
+wave 3.  =get_dataframe= decodes the Stata value labels, so this table keys on
+the label and the divergence is harmless -- but a mapping written against the
+codes would be silently wrong for one wave in three.
+
+*Case and punctuation matter*: the lookup is an exact dict lookup
+(=df_data_grabber= does =df[col].map(lambda x: f.get(x, x))=), and an unmapped
+label PASSES THROUGH RAW rather than becoming NA.  The three waves spell the
+same category three ways (='Pre-School'= / ='Preschool'= / ='Pre-school'=;
+='GCE O Level'= / ="GCE 'O' level"=), so each spelling needs its own row.
+
+** Two rulings worth recording
+
+1. =Level 100= .. =Level 400= are Ghanaian *university* year designations.
+   The sibling survey has two precedents that point different ways --
+   =GhanaLSS/_/categorical_mapping.org= maps its GLSS7 =Year one..three= ->
+   =Tertiary certificate/diploma= and =Year four/five= -> =Bachelor= (a
+   commented, deliberate decision covering tertiary years generically), but
+   maps its GLSS1-3 letter-ladder =U1..U4= (University years 1-4) ->
+   =Bachelor=.  We follow the *commented* convention: 100/200/300 ->
+   =Tertiary certificate/diploma=, 400 -> =Bachelor=.  It keeps an in-progress
+   year below the completion rung, which is how the canonical vocabulary
+   already treats partially-completed primary and secondary cycles (=P1..P5=
+   -> =Primary incomplete=, =SSS1..SSS2= -> =Upper secondary=), and the
+   canonical ladder has no "tertiary incomplete" rung to use instead.
+   Affects 22 rows at Levels 100-300 and 54 at Level 400, all in 2009-10.
+
+2. =L6= / =U6= are Lower and Upper Sixth Form, which in the old Ghanaian
+   system follow =S1..S5= and lead to GCE A-Level; both -> =Upper secondary
+   complete= (37 rows, 2017-18 only).  NOTE: =GhanaLSS/_/categorical_mapping.org=
+   contains =U6= *twice with conflicting targets* -- =Upper secondary complete=
+   in its case-duplicated block and =Postgraduate= in its GLSS1-3 letter-ladder
+   block, where =U= means University rather than Upper Sixth.  Per-country
+   tables do not leak across countries, so that defect cannot reach GhanaSPS;
+   it is recorded here because it is a real ambiguity in a sibling file and
+   should be fixed there, not silently inherited.
+
+#+name: harmonize_education
+| Original Label                 | Preferred Label              |
+|--------------------------------+------------------------------|
+| Pre-School                     | Pre-primary                  |
+| Preschool                      | Pre-primary                  |
+| Pre-school                     | Pre-primary                  |
+| P1                             | Primary incomplete           |
+| P2                             | Primary incomplete           |
+| P3                             | Primary incomplete           |
+| P4                             | Primary incomplete           |
+| P5                             | Primary incomplete           |
+| P6                             | Primary complete             |
+| JSS1                           | Lower secondary              |
+| JSS2                           | Lower secondary              |
+| JSS3                           | Lower secondary complete     |
+| M1                             | Lower secondary              |
+| M2                             | Lower secondary              |
+| M3                             | Lower secondary              |
+| M4                             | Lower secondary complete     |
+| SSS1                           | Upper secondary              |
+| SSS2                           | Upper secondary              |
+| SSS3                           | Upper secondary complete     |
+| SSS4                           | Upper secondary complete     |
+| S1                             | Upper secondary              |
+| S2                             | Upper secondary              |
+| S3                             | Upper secondary              |
+| S4                             | Upper secondary              |
+| S5                             | Upper secondary complete     |
+| L6                             | Upper secondary complete     |
+| U6                             | Upper secondary complete     |
+| O Level                        | Upper secondary complete     |
+| A Level                        | Upper secondary complete     |
+| Koranic School                 | Informal                     |
+| Vocational/Commercial          | Vocational/Technical         |
+| Teacher/Nursing Training       | Tertiary certificate/diploma |
+| Polytechnic                    | Tertiary certificate/diploma |
+| Professional certificate       | Tertiary certificate/diploma |
+| HND 1                          | Tertiary certificate/diploma |
+| HND 2                          | Tertiary certificate/diploma |
+| HND 3                          | Tertiary certificate/diploma |
+| Level 100                      | Tertiary certificate/diploma |
+| Level 200                      | Tertiary certificate/diploma |
+| Level 300                      | Tertiary certificate/diploma |
+| Level 400                      | Bachelor                     |
+| Other                          | Unknown                      |
+| Other - Specify                | Unknown                      |
+| Other (please specify)         | Unknown                      |
+| Don't know                     | Unknown                      |
+| Refuse to answer               | Unknown                      |
+| MSLC                           | Lower secondary complete     |
+| BECE                           | Lower secondary complete     |
+| SSCE                           | Upper secondary complete     |
+| GCE O Level                    | Upper secondary complete     |
+| GCE 'O' level                  | Upper secondary complete     |
+| GCE A Level                    | Upper secondary complete     |
+| GCE 'A' level                  | Upper secondary complete     |
+| Voc/Comm                       | Vocational/Technical         |
+| Vocation/Comm                  | Vocational/Technical         |
+| Teacher Training               | Tertiary certificate/diploma |
+| Teacher training               | Tertiary certificate/diploma |
+| Teacher Post Secondary         | Tertiary certificate/diploma |
+| Teacher post-secondary         | Tertiary certificate/diploma |
+| Tech/Prof Cert                 | Tertiary certificate/diploma |
+| Tech/prof. certificate         | Tertiary certificate/diploma |
+| Tech/Prof. Dip.                | Tertiary certificate/diploma |
+| Technical/Professional Diploma | Tertiary certificate/diploma |
+| Tech/prof. diploma             | Tertiary certificate/diploma |
+| HND                            | Tertiary certificate/diploma |
+| Bachelor's                     | Bachelor                     |
+| Bachelors                      | Bachelor                     |
+| Master's                       | Postgraduate                 |
+| Masters                        | Postgraduate                 |

--- a/lsms_library/countries/GhanaSPS/_/data_scheme.yml
+++ b/lsms_library/countries/GhanaSPS/_/data_scheme.yml
@@ -67,6 +67,70 @@ Data Scheme:
         type: float
         optional: true
 
+  individual_education:
+    # Person-level educational attainment, all three waves.  Index is
+    # (t, i, pid) -- `v` is NOT declared and must NOT be: `sample` is wired for
+    # every wave, so _join_v_from_sample() attaches `v` at API time.
+    #
+    # Sources -- AND THE MODULE LETTER SHIFTS BETWEEN WAVES:
+    #   2009-10  S1FI.dta                    (s1fi_2 / s1fi_3 / s1fi_4)
+    #   2013-14  01fi_generaleducation.dta   (attended / highestgrade /
+    #                                         highestqual)
+    #   2017-18  01gi_generaleducation.dta   (SAME three variable names)
+    #
+    # In 2013-14 module `f` is education and `e` is employment; in 2017-18 both
+    # shifted one letter, so `f` is EMPLOYMENT and education is `g`.  The
+    # variable names are IDENTICAL in both waves, so pointing wave 3 at
+    # `01fi_employmentmain.dta` -- the name that matches wave 2's education
+    # file -- yields a plausible, silently wrong table.  Row count is the tell:
+    # wave-3 education is 19,006 (= the roster), employment is 1,481.  Worse,
+    # `01gi_generaleducation.dta`'s own VARIABLE LABELS still read `s01fi_02`,
+    # `s01fi_03`, `s01fi_04`, so the labels corroborate the wrong file.  See
+    # CONTENTS.org.
+    #
+    # WHY THE `df_edit` HOOK (ghanasps.individual_education).  A YAML `mapping:`
+    # maps one source column onto one target; the attainment answer here is
+    # split across three.  `_attended` and `_qual` are extracted as temporary
+    # columns and consumed -- and dropped -- by the hook.  Measured cost of
+    # NOT combining them, i.e. of wiring `highestgrade` alone:
+    #   - 12,827 people the survey POSITIVELY RECORDS as never having attended
+    #     school carry a null grade and would be deleted by `dropna(how='all')`.
+    #     Wave 2 would then report `No education` for 9.6% of its rows where
+    #     the survey says 24.7%.
+    #   - 501 (W2) + 775 (W3) people would come back `Unknown` although the
+    #     survey records a Bachelors / HND / diploma for them: waves 2 and 3
+    #     have NO tertiary rung in `highestgrade` at all and put every tertiary
+    #     respondent in the survey's own 'Other' bucket.
+    # The fallback is deliberately NARROW (only where the grade is absent or
+    # `Unknown`), not a max() over both ladders -- below the 'Other' bucket the
+    # qualification is essentially a function of the grade and substituting it
+    # would override an explicit grade with an exam result.  The hook's
+    # docstring carries the resolution order and its justification.
+    #
+    # Vocabulary: `lsms_library/categorical_mapping/canonical_education_labels.org`,
+    # via the row-additive `harmonize_education` table in this directory's
+    # `categorical_mapping.org` (which also records the two mapping rulings --
+    # university Levels 100-400, and Sixth Form L6/U6).  Map on the DECODED
+    # LABEL, never the numeric code: code 27 is 'S1' in waves 1-2 but 'SSS4' in
+    # wave 3.
+    #
+    # Age floor of 3: the module is not administered to children under 3.  Wave
+    # 2 omits them from the file entirely (1,040 roster people, ages 0-2); wave
+    # 3 keeps the rows with every education variable null (1,075, ages 0-2).
+    # Either way they have no attainment datum and are dropped.
+    #
+    # Delivered rows and roster coverage (measured on a cold build):
+    #   2009-10  16,955 of 18,889 roster people   89.8%
+    #   2013-14  15,314 of 16,356                 93.6%
+    #   2017-18  17,910 of 19,006                 94.2%
+    # 0 people appear here who are not in `household_roster`, in any wave.
+    # Waves 2 and 3 lose essentially only the under-3s; WAVE 1 ALSO LOSES 287
+    # people aged 6+ whose module row is simply blank -- a wave-1 recording
+    # defect, documented in 2009-10/_/data_info.yml, deliberately left NA
+    # rather than filled.
+    index: (t, i, pid)
+    Educational Attainment: str
+
   sample:
     # Cluster identity, wave by wave.  The EA is `id3` in 2009-10 and a
     # right-anchored slice of the household id in 2013-14 / 2017-18; each

--- a/lsms_library/countries/GhanaSPS/_/ghanasps.py
+++ b/lsms_library/countries/GhanaSPS/_/ghanasps.py
@@ -258,3 +258,117 @@ def change_id(x,fn=None,id0=None,id1=None,transform_id1=None):
     assert x.index.is_unique, "Non-unique index."
 
     return x
+
+
+# ---------------------------------------------------------------------------
+# individual_education (GH #171)
+# ---------------------------------------------------------------------------
+#
+# `df_edit` hook for the `individual_education` table, shared by ALL THREE
+# waves: `Wave.formatting_functions` starts from `Country.formatting_functions`
+# (which loads this module, `ghanasps.py`) and only then overlays the wave's own
+# `mapping.py`, so defining the hook once here binds it everywhere.  Each wave's
+# `data_info.yml` supplies the same three columns under the same names, which is
+# what makes one implementation legitimate rather than merely convenient.
+#
+# WHY A HOOK AT ALL.  The YAML `mapping:` machinery maps ONE source column onto
+# one target.  GSPS splits the attainment answer across three:
+#
+#   attended     ever attended school (Yes/No)
+#   highestgrade highest grade successfully completed  -- the primary ladder
+#   highestqual  highest educational qualification     -- the only ladder that
+#                reaches tertiary in waves 2 and 3
+#
+# Measured cost of wiring `highestgrade` alone (full numbers in CONTENTS.org):
+# 12,827 people whom the survey POSITIVELY RECORDS as never having attended
+# school would have a null grade and be deleted by `_finalize_result`'s
+# `dropna(how='all')` -- in wave 2 that would report `No education` for 9.6% of
+# the table when the survey says 24.7% -- and a further 501 (W2) + 775 (W3)
+# people would be reported `Unknown` when the survey knows they hold a degree,
+# diploma or HND.  Both are "an empty or wrong answer wearing the shape of a
+# right one".
+#
+# The two ladders are COMPLEMENTARY, not redundant, and that is why the
+# fallback is narrow rather than a max().  Waves 2 and 3 have NO tertiary rung
+# in `highestgrade` at all -- every tertiary person is dumped into the
+# 'Other - Specify' / 'Other (please specify)' bucket, whose qualification is
+# non-null for 501/501 (W2) and 774/775 (W3) and overwhelmingly tertiary.
+# Below that bucket the qualification is essentially a function of the grade
+# (W2: 7,470 people with qual 'None' against 7,488 whose grade is at or below
+# JSS2/M3), so substituting it there would add nothing and would risk
+# overriding an explicit grade with an exam result.
+
+# Harmonized qualification values that carry no information the grade ladder
+# did not already have.  'No education' is excluded because `highestqual`
+# 'None' means "holds no certificate", NOT "never went to school" -- a P6
+# leaver has qual 'None'.  Substituting it would silently demote them.
+_EDU_UNINFORMATIVE_QUAL = frozenset({'Unknown', 'No education'})
+
+
+def individual_education(df):
+    """Resolve `Educational Attainment` from grade + qualification + attended.
+
+    Receives the frame `Wave.grab_data` has already extracted and indexed as
+    `(t, i, pid)`, carrying:
+
+      Educational Attainment  -- harmonized `highestgrade`
+      _qual                   -- harmonized `highestqual`
+      _attended               -- raw Yes/No screener
+
+    Resolution order, and why:
+
+    1. Qualification fallback, applied where the grade is absent or resolved to
+       `Unknown` (i.e. it was the survey's own 'Other' bucket).  A qualification
+       that is itself `Unknown` or `No education` is not informative here (see
+       `_EDU_UNINFORMATIVE_QUAL`) and is skipped, leaving the row for step 2.
+    2. `attended == 'No'` -> `No education`, for rows still unresolved.  This is
+       the never-schooled case the canonical vocabulary explicitly says to KEEP
+       (canonical_education_labels.org, "Never-schooled handling"), and it is
+       ~exactly complementary to a null grade: in waves 2 and 3 every
+       `attended == 'No'` row has a null grade, and in wave 1 4,849 of 4,878 do.
+       Applied AFTER step 1 so that wave 1's rows which answer 'No' yet carry a
+       real qualification keep the qualification rather than being flattened.
+
+    Rows still unresolved keep NA and are dropped downstream by
+    `_finalize_result`'s `dropna(how='all')` -- the survey recorded nothing for
+    them.  In waves 2 and 3 those are overwhelmingly children under the
+    module's age floor of 3.
+
+    Finally drops the five wave-1 rows whose person id is null.  `format_id`
+    turns a NaN `s1fi_hhmid` into None, which would (a) fail the framework's
+    `no_null_index_levels` check and (b) make the index non-unique -- three of
+    the five share `hhno` 108294010.  Four carry no education data at all; the
+    fifth (hhno 105159025) records 'Yes'/P6/'None' and IS a real loss, recorded
+    in CONTENTS.org rather than hidden.  There is no way to attach it to a
+    person: S1D.dta has no member with that id.
+    """
+    if 'Educational Attainment' not in df.columns:
+        return df
+
+    df = df.copy()
+    ea = df['Educational Attainment'].astype(object)
+    ea = ea.where(ea.notna(), pd.NA)
+
+    # 1. qualification fallback
+    if '_qual' in df.columns:
+        qual = df['_qual'].astype(object)
+        qual = qual.where(qual.notna(), pd.NA)
+        usable = qual.notna() & ~qual.isin(_EDU_UNINFORMATIVE_QUAL)
+        unresolved = ea.isna() | ea.eq('Unknown')
+        ea = ea.mask(unresolved & usable, qual)
+
+    # 2. never-schooled
+    if '_attended' in df.columns:
+        att = df['_attended'].astype(str).str.strip().str.casefold()
+        ea = ea.mask(ea.isna() & att.eq('no'), 'No education')
+
+    df['Educational Attainment'] = ea
+    df = df.drop(columns=[c for c in ('_attended', '_qual') if c in df.columns])
+
+    # A null person id cannot be a row of a (t, i, pid) table.
+    if df.index.names is not None and 'pid' in list(df.index.names):
+        keep = pd.notna(df.index.get_level_values('pid'))
+        if not keep.all():
+            df = df[keep]
+
+    return df


### PR DESCRIPTION
Wires `individual_education` for **GhanaSPS**, all three waves. Config-only: three per-wave `data_info.yml` blocks (YAML path), one shared `df_edit` hook in the country module, a new `_/categorical_mapping.org`, the `data_scheme.yml` entry, and a `CONTENTS.org` section.

## What it delivers

| wave | rows | roster | coverage |
|---|---|---|---|
| 2009-10 | 16,955 | 18,889 | 89.8% |
| 2013-14 | 15,314 | 16,356 | 93.6% |
| 2017-18 | 17,910 | 19,006 | 94.2% |

Index `(t, i, pid)` (+ `v` joined at API time), unique, no null level. **Zero** people appear here who are not in `household_roster`, in any wave.

| level | 2009-10 | 2013-14 | 2017-18 |
|---|---|---|---|
| No education | 5,487 | 4,881 | 4,905 |
| Informal | 6 | 0 | 0 |
| Pre-primary | 923 | 954 | 1,062 |
| Primary incomplete | 3,772 | 3,365 | 3,716 |
| Primary complete | 923 | 801 | 1,022 |
| Lower secondary | 1,432 | 1,266 | 1,447 |
| Lower secondary complete | 2,656 | 2,314 | 3,070 |
| Upper secondary | 460 | 395 | 551 |
| Upper secondary complete | 767 | 909 | 1,479 |
| Vocational/Technical | 104 | 33 | 30 |
| Tertiary certificate/diploma | 313 | 229 | 320 |
| Bachelor | 92 | 117 | 202 |
| Postgraduate | 11 | 18 | 33 |
| Unknown | 9 | 32 | 73 |

All 14 values are canonical; `Doctorate` never occurs (no instrument offers it).

## The trap this PR is mostly about

**The education module letter shifts between waves and the variable names do not shift with it.** In 2013-14 `01fi_*` is education and `01ei_*` is employment; in 2017-18 every letter moved by one, so `01fi_*` is **employment** and education is `01gi_*`. Both waves spell the variables `attended` / `highestgrade` / `highestqual`, so reusing wave 2's filename in wave 3 reads the employment file and produces a plausible, silently wrong table.

And the variable **labels corroborate the wrong file**: `01gi_generaleducation.dta` still carries labels reading `s01fi_02` / `s01fi_03` / `s01fi_04` — the instrument was renumbered, the labels were not. Row count is the honest tell (education 19,006 = the roster; employment 1,481 × 66, with no education variable at all).

Separately, the numeric grade **codes** diverge: code 27 is `'S1'` in waves 1–2 and `'SSS4'` in wave 3, with everything above 26 shifted. The mapping is keyed on the **decoded label**, so this is harmless here — and fatal to any mapping written on codes.

## Why a `df_edit` hook rather than plain YAML

YAML `mapping:` is one source column onto one target; the attainment answer is split across three. Measured cost of wiring `highestgrade` alone:

- **12,827 never-schooled people would vanish.** `attended == 'No'` implies a null grade, so `dropna(how='all')` deletes them. Wave 2 would then report `No education` for 9.6% of its rows where the survey says 24.7%. The canonical vocabulary explicitly says to keep positively-recorded never-schooled people as `No education`.
- **501 (W2) + 775 (W3) graduates would come back `Unknown`.** Waves 2 and 3 have *no tertiary rung* in `highestgrade`; every tertiary respondent lands in the survey's own 'Other' bucket, where 501/501 and 774/775 have a non-null `highestqual`.

The fallback is deliberately **narrow** (grade absent or `Unknown` only), not a `max()` over both ladders: below the 'Other' bucket the qualification is essentially a function of the grade, and `highestqual == 'None'` means *holds no certificate*, not *never went to school* — a P6 leaver has 'None'.

One implementation serves all three waves because it lives in `GhanaSPS/_/ghanasps.py`, which `Wave.formatting_functions` loads before the wave's own `mapping.py`.

## Mapping rulings (both recorded in the org file with their basis)

- University **`Level 100..300` → `Tertiary certificate/diploma`, `Level 400` → `Bachelor`**, following the *commented* GhanaLSS convention for tertiary years (`Year one..three` / `Year four/five`) rather than its uncommented `U1..U4` ladder. 76 rows, wave 1 only. Either reading is defensible; both precedents are quoted in the file.
- Sixth Form **`L6` / `U6` → `Upper secondary complete`** (37 rows, wave 3).

## Other findings, now in `CONTENTS.org`

- **Age floor of 3, shipped two different ways.** Wave 2 omits under-3s from the file entirely (1,040 roster people); wave 3 keeps their rows with every education variable null (1,075). Same delivered population.
- **Wave 1 is *not* a clean age floor and its screener is *not* clean.** `s1fi_2` is null for 1,577 rows of which 247 still carry a grade; 287 of the people with no delivered attainment are aged 6 or over. A blank is not a 'No' (the survey writes 'No' 4,878 times), so they are left NA rather than filled.
- **Five wave-1 rows have a null `s1fi_hhmid`** — three share one `hhno`, so they are both a null index level and a duplicate index. Dropped by the hook. Four are empty; the fifth (`hhno` 105159025) records 'Yes'/P6/'None' and is a genuine unrecoverable loss: `S1D.dta` has no member with that id.
- **`Informal` and `Vocational/Technical` are instrument artefacts, not trends** — wave 1's grade ladder has `Koranic School` and `Vocational/Commercial` rungs that waves 2–3 lack. Do not read those two rows wave-over-wave.
- **`2013-14/Data/01fi_generaleducation.dta` is not valid UTF-8.** pandas falls back to latin-1 with a `UnicodeWarning`; `pyreadstat` refuses it outright, so the `metadataonly=True` triage recipe in the `add-feature` skill does not work on it. (A task brief placed this warning on the 2009-10 wave; measured, 2009-10 reads clean.)
- **Noted but not fixed:** `GhanaLSS/_/categorical_mapping.org` has `U6` twice with conflicting targets (Upper Sixth vs University year 6); `drop_duplicates(keep='first')` silently picks one. Country tables do not leak, so GhanaSPS is unaffected — flagged so it is fixed there deliberately.

## Verification

Cold build in a private `LSMS_DATA_DIR`, `LSMS_COUNTRIES_ROOT` pinned to the worktree, `LSMS_GRAIN_STRICT=1`:

- **0** `GrainCollapseWarning`, **0** `NullReadWarning` for this table (the 4 that remain are pre-existing `sample` weight/geography gaps).
- Vocabulary: 14 distinct values, **0 non-canonical, 0 nulls**.
- Warm re-read byte-identical to the cold build; wave parquets carry only `Educational Attainment` (i.e. the hook fired once and consumed its temporaries).
- Attainment × roster `Age`: 77.1% of under-5s `No education` + 20.5% `Pre-primary`; 68.7% of 10–14s `Primary incomplete`; mean canonical rank among adults falls monotonically with age (4.63 / 3.73 / 3.51 / 1.86 for 25–34 / 35–49 / 50–64 / 65+) — the expected cohort gradient.
- `is_this_feature_sane`: 16 pass, 1 warn, 0 fail. The warn is the API-joined `v` not being in the declared index — **pre-existing and identical for GhanaSPS `household_roster`**.
- `Feature('individual_education')(['GhanaSPS','Uganda'])` assembles cleanly.
- 440 tests pass: `test_schema_consistency`, `test_table_structure`, `test_declared_spellings`, `test_canonical_spellings`, `test_categorical_merge`, `test_capability`, `test_coverage_matrix`.

## Notes for the reviewer

- The new `_/categorical_mapping.org` is a build-time `.org` input, so it **invalidates GhanaSPS's existing L2 caches**. One-time rebuild cost, correct behaviour.
- **Not blessed** in `.coder/coverage/blessed.csv`: `blessed` means a human read the numbers, and none has. The distributions above are offered so one can.
- Two things I could **not** verify: whether the 287 wave-1 people aged 6+ with a blank module row were genuinely not asked or were asked and not recorded (no wave-1 education questionnaire distinguishes them in the corpus); and the `Level 100..400` ruling is a judgement between two live GhanaLSS precedents, not a fact the instrument states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFLYAj1WqLBPsJZFQGapvb
