### PR TITLE
fix: scope pytest collection to tests/ — a stray *_test.py anywhere in the repo kills CI at collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,29 @@ style = "pep440"
 [build-system]
 requires = ["poetry-core>=2.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
 build-backend = "poetry_dynamic_versioning.backend"
+
+[tool.pytest.ini_options]
+# Collect ONLY from tests/.  Without this pytest scans the repo root, so ANY
+# file matching `test_*.py` or `*_test.py` anywhere in the tree is imported at
+# collection -- including analysis scripts under `slurm_logs/` and `SkunkWorks/`.
+#
+# That is not theoretical.  `slurm_logs/ghanasps/plot_identity_permutation_test.py`
+# (a re-checkable permutation test shipped alongside a findings doc, GH #729)
+# matched `*_test.py`, did its data loading at MODULE level, and hit
+# `NoCredentialsError` in CI:
+#
+#   ERROR collecting slurm_logs/ghanasps/plot_identity_permutation_test.py
+#   !!!!!! Interrupted: 1 error during collection !!!!!!
+#
+# An error at COLLECTION aborts the whole session -- zero tests ran, and the
+# message named neither a test nor the change under review.  Same failure shape
+# as GH #680 (the `fooddatacentral` top-level `tests` package).
+#
+# `SkunkWorks/` already holds four `test_*.py` files that are collected today
+# and are harmless only because their module-level code happens not to raise.
+# Naming discipline was the only thing standing between us and this, and naming
+# discipline is not enforcement.
+#
+# Measured before pinning: repo-root collection and `tests/`-only collection
+# both yield **4,851** items, so this scopes without losing coverage.
+testpaths = ["tests"]

--- a/tests/test_pytest_scoping.py
+++ b/tests/test_pytest_scoping.py
@@ -1,0 +1,57 @@
+"""Collection must be scoped to `tests/` (GH #729 fallout).
+
+pytest's default collection scans the rootdir, so any file matching
+`test_*.py` / `*_test.py` ANYWHERE in the repo is imported at collection
+time.  A module that does I/O at import then fails *during collection*,
+which aborts the entire session -- zero tests run, and the error names
+neither a test nor the change under review.
+
+That happened: `slurm_logs/ghanasps/plot_identity_permutation_test.py`
+shipped with a findings doc, matched `*_test.py`, loaded data at module
+level, and killed CI with `NoCredentialsError`.
+
+`SkunkWorks/` holds four `test_*.py` files collected today that are benign
+only because their module-level code does not raise.  This pins the setting
+so the protection is configuration rather than naming luck.
+"""
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _pytest_config() -> dict:
+    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
+        return tomllib.load(f).get("tool", {}).get("pytest", {}).get("ini_options", {})
+
+
+def test_testpaths_is_pinned_to_tests():
+    assert _pytest_config().get("testpaths") == ["tests"], (
+        "pyproject.toml must pin `testpaths = [\"tests\"]`.  Without it pytest "
+        "imports every test-named file in the repo at collection, and one that "
+        "does I/O at import aborts the whole session (GH #729)."
+    )
+
+
+def test_stray_collectible_scripts_outside_tests_are_not_a_landmine():
+    """Report them; do NOT fail on their existence.
+
+    We do not control what lands in `SkunkWorks/` or `slurm_logs/`, and an
+    analysis script is entitled to be named however its author likes now that
+    `testpaths` means it is never imported.  This test exists to keep the
+    inventory visible, so that if `testpaths` is ever removed the blast radius
+    is written down rather than rediscovered.
+    """
+    stray = [
+        p.relative_to(REPO_ROOT)
+        for pat in ("test_*.py", "*_test.py")
+        for p in REPO_ROOT.rglob(pat)
+        if "tests" not in p.relative_to(REPO_ROOT).parts
+        and ".venv" not in p.parts
+        and not any(part.startswith(".") for part in p.relative_to(REPO_ROOT).parts)
+    ]
+    print(f"collectible-named scripts outside tests/ ({len(stray)}): "
+          + ", ".join(sorted(str(s) for s in stray)))
+    assert True


### PR DESCRIPTION
This repo has **no `[tool.pytest.ini_options]` at all** — no `testpaths`, no `pytest.ini`, no `setup.cfg`. pytest therefore scans the **repo root** and imports every file matching `test_*.py` / `*_test.py` anywhere in the tree, at collection time.

## It just happened

#729 shipped `slurm_logs/ghanasps/plot_identity_permutation_test.py` — a re-checkable permutation test alongside a findings document. That is *good* practice and house practice: `slurm_logs/weight_normalisation/` ships `analyse.py`, `hash_probe.py`, `negative_control.py` for exactly the same reason.

But it matched `*_test.py`, did its data loading at **module level**, and CI died:

```
ERROR collecting slurm_logs/ghanasps/plot_identity_permutation_test.py
E   botocore.exceptions.NoCredentialsError: Unable to locate credentials
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
1 error in 48.44s
```

An error at **collection aborts the entire session** — zero tests ran, and the message named neither a test nor the change under review. Same failure shape as #680, and expensive for the same reason: the error points nowhere near its cause.

## Naming luck was the only protection

`SkunkWorks/` already holds **four** `test_*.py` files that are collected today:

```
SkunkWorks/test_list_based_tags.py   SkunkWorks/test_tag_as_name.py
SkunkWorks/test_tag_as_name_final.py SkunkWorks/test_yaml_tags.py
```

They are harmless **only because their module-level code happens not to raise**. Naming discipline is not enforcement.

## Measured before pinning — not a coverage trade

Repo-root collection and `tests/`-only collection returned the **same count** (4,851 items on the tree I measured). Nothing outside `tests/` contributes a single test item — those files define no test functions. They were only ever import-time liabilities.

## Negative-controlled

I planted a module-level `raise` in `slurm_logs/_landmine_test.py` and ran both ways on one tree:

| | result |
|---|---|
| **without** `testpaths` | `Interrupted: 1 error during collection` — 4,799 collected **+ 1 error** |
| **with** `testpaths` | clean — 4,799 collected |

*(Absolute counts differ between my two measurement runs — several suites parametrize over what is materialized in the data root. The valid comparison is within a single run, which is how both pairs above were taken.)*

## Tests

`tests/test_pytest_scoping.py` pins the setting. Its second test **prints, without failing on**, the inventory of collectible-named scripts outside `tests/` — so if `testpaths` is ever removed the blast radius is written down rather than rediscovered. It deliberately does not fail on their existence: now that they are never imported, an analysis script is entitled to any name.

The author of #729 is separately renaming and `__main__`-guarding that script, so the two fixes are independent and don't collide.

Refs #729, #680.