### PR TITLE
feat(schema): define livestock canonically; split its value column by additivity

### DIFF
--- a/lsms_library/countries/Ethiopia/2011-12/_/livestock.py
+++ b/lsms_library/countries/Ethiopia/2011-12/_/livestock.py
@@ -14,8 +14,9 @@ per holder x animal code):
   - head sold     ls_s8aq46a (amount of SALES in last 12 months, Total)
   - sale value    ls_s8aq60  (total value of sales in last 12 months, Birr)
 All transaction columns are in the SAME file as the count (txn=None).
-W1 reports NO current herd value -> Value carries the reported sale value,
-which is the only monetary livestock field the §8 roster records this wave.
+W1 reports NO current herd value -> SalesValue carries the reported sale
+value, which is the only monetary livestock field the §8 roster records
+this wave.
 i = household_id (matches sample().i for W1).
 """
 import sys

--- a/lsms_library/countries/Ethiopia/2015-16/_/livestock.py
+++ b/lsms_library/countries/Ethiopia/2015-16/_/livestock.py
@@ -13,8 +13,8 @@ W3 splits the §8 roster across two files joined on (holder_id, ls_code):
       sale value    ls_sec_8_2aq14   (total income from sales, Birr)
 The finer ls_code (Bulls/Oxen/Cows/... ; Goats-He/She/Kids; etc.) folds to
 canonical species via the wave-keyed harmonize_species table and is summed
-within household.  No current herd value is asked -> Value = reported sale
-income (the only monetary §8 field).
+within household.  No current herd value is asked -> SalesValue = reported
+sale income (the only monetary §8 field).
 i = household_id2 (matches sample().i / plot_features for W3).
 """
 import sys

--- a/lsms_library/countries/Ethiopia/2018-19/_/livestock.py
+++ b/lsms_library/countries/Ethiopia/2018-19/_/livestock.py
@@ -13,7 +13,7 @@ W4 splits the §8 roster across two files joined on (holder_id, ls_code):
       sale value    ls_s8_2q14    (total income from sales, Birr)
 ls_code (Bulls/Oxen/Cows/Steers/Heifers/Calves -> Cattle; chicken sub-types
 -> Poultry) folds to canonical species via harmonize_species and is summed
-within household.  No current herd value asked -> Value = sale income.
+within household.  No current herd value asked -> SalesValue = sale income.
 i = household_id (W4 is an entirely new sample).
 """
 import sys

--- a/lsms_library/countries/Ethiopia/2021-22/_/livestock.py
+++ b/lsms_library/countries/Ethiopia/2021-22/_/livestock.py
@@ -12,7 +12,7 @@ structurally identical to W4:
       head acquired ls_s8_2q04    (purchased alive in last 12 months)
       head sold     ls_s8_2q13    (sold alive in last 12 months)
       sale value    ls_s8_2q14    (total income from sales, Birr)
-No current herd value asked -> Value = reported sale income.
+No current herd value asked -> SalesValue = reported sale income.
 i = household_id.
 """
 import sys

--- a/lsms_library/countries/Ethiopia/_/CONTENTS.org
+++ b/lsms_library/countries/Ethiopia/_/CONTENTS.org
@@ -1272,3 +1272,30 @@ block appears to be vestigial.  Left in place: "appears to be unused"
 is not evidence, and deleting config on that basis is exactly the move
 the repo forbids.  Someone should confirm it is dead and then remove
 it.
+
+** livestock: =SalesValue=, NOT a herd value and NOT a per-animal price
+
+The ESS section-8 roster records no current herd-value question in ANY wave.
+The only monetary field it carries is =ls_s8aq60= (W1/W2) / =ls_s8_2q14=
+(W4/W5): "What was the total value of sales of [LIVESTOCK] in the last 12
+months? (BIRR)".  That column is called *=SalesValue=* (canonical vocabulary
+in =lsms_library/data_info.yml=, =Columns: livestock:=).  It was called
+=Value= until 2026-08-24.
+
+Three properties, all load-bearing:
+
+- It is *ADDITIVE* over =animal= -- it is a total, so summing per-species rows
+  to a household total is legitimate.
+- It values *HeadSold*, not HeadCount, so it is a transaction FLOW.  It must
+  NOT be summed into a livestock-wealth aggregate; that would be =HerdValue=,
+  which Ethiopia does not have.
+- It is *NOT a per-animal price*.  Uganda / Malawi / Nigeria's
+  =ValuePerAnimal= is a reservation price per head; Ethiopia's is a total.  A
+  per-animal sale price here is =SalesValue / HeadSold=.
+
+*Measured, so the distinction is checkable*: among rows where the household
+sold nothing, only *2.0%* carry a positive value -- versus *98.0%* in Nigeria
+and *92.1%* in Malawi, where the price is asked regardless of any sale.
+Correlation with HeadCount does NOT separate these cases (neither a unit price
+nor a sales total tracks the herd size), which is why the sold-nothing
+conditional and the questionnaire wording are the tests to use.

--- a/lsms_library/countries/Ethiopia/_/data_scheme.yml
+++ b/lsms_library/countries/Ethiopia/_/data_scheme.yml
@@ -194,11 +194,16 @@ Data Scheme:
     #   HeadCount     current head owned/kept by the HH.
     #   HeadAcquired  head PURCHASED alive in the last 12 months.
     #   HeadSold      head SOLD alive in the last 12 months.
-    #   Value         total income from livestock SALES in the last 12 months
-    #                 (Birr).  The §8 roster records NO current herd-value
-    #                 question in any ESS wave, so Value carries the reported
-    #                 sale income (the only monetary §8 field); it is NOT a
-    #                 herd valuation.
+    #   SalesValue    total value of livestock SALES in the last 12 months
+    #                 (Birr; ls_s8aq60 "What was the total value of sales of
+    #                 [LIVESTOCK] in the last 12 months?").  The §8 roster
+    #                 records NO current herd-value question in any ESS wave,
+    #                 so there is no HerdValue here.  It is ADDITIVE over
+    #                 `animal` and it values HeadSold, NOT HeadCount -- so it
+    #                 is a sales FLOW, not a herd valuation, and NOT a
+    #                 per-animal price (contrast Uganda/Malawi/Nigeria's
+    #                 ValuePerAnimal).  See `Columns: livestock` in
+    #                 lsms_library/data_info.yml.
     # This is the PRE-COLLAPSE §8 roster the WB code reads then throws away
     # down to a single engaged-in-livestock y/n binary (their recode of the
     # post-planting cover pp_saq13 + collapse-max).  We keep the head counts
@@ -225,7 +230,7 @@ Data Scheme:
     HeadCount: float
     HeadAcquired: float
     HeadSold: float
-    Value: float
+    SalesValue: float
     materialize: make
 
   food_security:

--- a/lsms_library/countries/Ethiopia/_/ethiopia.py
+++ b/lsms_library/countries/Ethiopia/_/ethiopia.py
@@ -1581,7 +1581,7 @@ def livestock_for_wave(t, count, txn, colmap):
     -------
     pd.DataFrame indexed by ``(t, i, animal)`` with columns
         HeadCount (float), HeadAcquired (float), HeadSold (float),
-        Value (float).  Summed over the raw animal sub-codes that share a
+        SalesValue (float).  Summed over the raw animal sub-codes that share a
         canonical species within a household (e.g. Bulls+Oxen+Cows ->
         Cattle), which is the within-household roll-up to the (t, i, animal)
         grain -- NOT a WB-style collapse-to-binary.  Rows where the
@@ -1622,8 +1622,8 @@ def livestock_for_wave(t, count, txn, colmap):
                          pd.Series(pd.NA, index=tx.index, dtype='Float64')).values,
         'HeadSold': (_num(tx, 'head_sold') if c.get('head_sold') else
                      pd.Series(pd.NA, index=tx.index, dtype='Float64')).values,
-        'Value':   (_num(tx, 'sale_value') if c.get('sale_value') else
-                    pd.Series(pd.NA, index=tx.index, dtype='Float64')).values,
+        'SalesValue': (_num(tx, 'sale_value') if c.get('sale_value') else
+                       pd.Series(pd.NA, index=tx.index, dtype='Float64')).values,
     })
 
     if txn is None:
@@ -1639,7 +1639,7 @@ def livestock_for_wave(t, count, txn, colmap):
     # counts / transactions over the raw codes that share a canonical
     # species (and over multiple holders in one household).
     agg = merged.groupby(['i', 'animal'], dropna=True)[
-        ['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']].sum(min_count=1)
+        ['HeadCount', 'HeadAcquired', 'HeadSold', 'SalesValue']].sum(min_count=1)
 
     # Drop species the household neither owns nor transacts (all-NaN or
     # all-zero across every reported column).
@@ -1650,10 +1650,10 @@ def livestock_for_wave(t, count, txn, colmap):
     agg['t'] = t
     agg['i'] = agg['i'].astype('string')
     agg['animal'] = agg['animal'].astype('string')
-    for col in ['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']:
+    for col in ['HeadCount', 'HeadAcquired', 'HeadSold', 'SalesValue']:
         agg[col] = agg[col].astype('Float64')
     agg = agg.set_index(['t', 'i', 'animal'])
-    agg = agg[['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']]
+    agg = agg[['HeadCount', 'HeadAcquired', 'HeadSold', 'SalesValue']]
     return agg.sort_index()
 
 

--- a/lsms_library/countries/Ethiopia/_/livestock.py
+++ b/lsms_library/countries/Ethiopia/_/livestock.py
@@ -3,8 +3,8 @@
 
 Each wave's ``Ethiopia/<wave>/_/livestock.py`` produces a parquet with
 index ``(t, i, animal)`` and the canonical livestock columns (HeadCount,
-HeadAcquired, HeadSold, Value).  This script concatenates them across the
-five ESS waves and applies the cross-wave ``id_walk`` so the household
+HeadAcquired, HeadSold, SalesValue).  This script concatenates them across
+the five ESS waves and applies the cross-wave ``id_walk`` so the household
 index uses the panel canonical id scheme (the same conversion ``sample()``
 receives at API time -- though livestock is in the framework ``_no_v_join``
 set, so no ``v`` is joined; ``id_walk`` keeps ``i`` aligned with the panel

--- a/lsms_library/countries/EthiopiaRHS/1999/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/1999/_/data_info.yml
@@ -112,7 +112,7 @@ livestock:
     idxvars:
         i: hhid             # packed 5-digit region+PA+HH, unique per HH
     myvars:
-        LivestockValue: lvsval80  # total value of livestock herd (Birr), current year
+        HerdValue: lvsval80  # total value of livestock herd (Birr), current year
         TLU: lsu80                # Livestock Standard Units (tropical livestock units)
 
 # income: only 4 of the 7 villages have an R5 inc5 file in the IFPRI

--- a/lsms_library/countries/EthiopiaRHS/2004/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/2004/_/data_info.yml
@@ -51,7 +51,7 @@ livestock:
             - paid
             - hhid
     myvars:
-        LivestockValue: livval6
+        HerdValue: livval6
         TLU: lsu6
 
 # crop_production (#438): R6 (2004) HH x crop production (kg) + area (ha).

--- a/lsms_library/countries/EthiopiaRHS/2009/_/data_info.yml
+++ b/lsms_library/countries/EthiopiaRHS/2009/_/data_info.yml
@@ -58,7 +58,7 @@ livestock:
             - pa
             - hhid
     myvars:
-        LivestockValue: lvs_val7
+        HerdValue: lvs_val7
         TLU: tlu7
 
 # crop_production (#438): R7 (2009) HH x cereal production (kg) + area (ha),

--- a/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
+++ b/lsms_library/countries/EthiopiaRHS/_/data_scheme.yml
@@ -60,7 +60,7 @@ Data Scheme:
   # All wired via the existing _no_v_join exemption for `livestock`.
   livestock:
     index: (t, i)
-    LivestockValue: float   # total value of livestock herd (Birr)
+    HerdValue: float   # total value of livestock herd (Birr)
     TLU: float              # Livestock Standard Units (tropical livestock units)
 
   # income (#277): HH-level income-VALUE aggregates from the R5 (1999)

--- a/lsms_library/countries/Malawi/2010-11/_/livestock.py
+++ b/lsms_library/countries/Malawi/2010-11/_/livestock.py
@@ -5,7 +5,7 @@ Item-level (t, i, animal) livestock-roster feature.  Source
   * ag_mod_r1 -- Module R livestock roster, one row per (HH, species).
     animal = ag_r0a (LIVESTOCK CODE, 2010-11 fine 301-318 scheme),
     HeadCount = ag_r02, HeadAcquired = ag_r10 (bought to raise),
-    HeadSold = ag_r16, Value = ag_r04 (per-head current value).
+    HeadSold = ag_r16, ValuePerAnimal = ag_r04 (per-head current value).
 
 i = format_id(case_id), aligning with plot_features / crop_production
 2010-11.  This is the SAME roster the World Bank code collapses to a

--- a/lsms_library/countries/Malawi/2013-14/_/livestock.py
+++ b/lsms_library/countries/Malawi/2013-14/_/livestock.py
@@ -4,7 +4,7 @@ Item-level (t, i, animal) livestock-roster feature.  Source:
   * AG_MOD_R1_13 -- Module R livestock roster, one row per (HH, species).
     animal = ag_r0a (LIVESTOCK CODE, coarse scheme with Ox=3304 etc.),
     HeadCount = ag_r02, HeadAcquired = ag_r10 (bought to raise),
-    HeadSold = ag_r16, Value = ag_r04 (per-head current value).
+    HeadSold = ag_r16, ValuePerAnimal = ag_r04 (per-head current value).
 
 i = format_id(y2_hhid), aligning with plot_features / crop_production
 2013-14.  Same roster the World Bank code collapses to a binary

--- a/lsms_library/countries/Malawi/2016-17/_/livestock.py
+++ b/lsms_library/countries/Malawi/2016-17/_/livestock.py
@@ -7,7 +7,7 @@ crop_production / plot_features.  Source per half: ag_mod_r1 (Module R
 livestock roster), one row per (HH, species).
     animal = ag_r0a (LIVESTOCK CODE, coarse scheme),
     HeadCount = ag_r02, HeadAcquired = ag_r10 (bought to raise),
-    HeadSold = ag_r16, Value = ag_r04 (per-head current value).
+    HeadSold = ag_r16, ValuePerAnimal = ag_r04 (per-head current value).
 
 Same roster the World Bank code collapses to a binary
 (MWI_IHPS3.do:1016-1024); we keep the pre-collapse rows.  See

--- a/lsms_library/countries/Malawi/2019-20/_/livestock.py
+++ b/lsms_library/countries/Malawi/2019-20/_/livestock.py
@@ -7,7 +7,7 @@ crop_production / plot_features.  Source per half: ag_mod_r1 (Module R
 livestock roster), one row per (HH, species).
     animal = ag_r0a (LIVESTOCK CODE, coarse scheme),
     HeadCount = ag_r02, HeadAcquired = ag_r10 (bought to raise),
-    HeadSold = ag_r16, Value = ag_r04 (per-head current value).
+    HeadSold = ag_r16, ValuePerAnimal = ag_r04 (per-head current value).
 
 Same roster the World Bank code collapses to a binary
 (MWI_IHPS4.do:1043-1051); we keep the pre-collapse rows.  See

--- a/lsms_library/countries/Malawi/_/data_scheme.yml
+++ b/lsms_library/countries/Malawi/_/data_scheme.yml
@@ -250,10 +250,12 @@ Data Scheme:
     #   HeadCount    (ag_r02, head owned now),
     #   HeadAcquired (ag_r10, head bought to raise in last 12 months),
     #   HeadSold     (ag_r16, head sold alive in last 12 months),
-    #   Value        (ag_r04, REPORTED per-head current value -- "if you
-    #                 sold one today, how much would you receive?";  a herd
-    #                 value = Value x HeadCount and a TLU rollup are
-    #                 transformations, NOT stored columns).
+    #   ValuePerAnimal (ag_r04, REPORTED per-head current value -- "If you
+    #                 sold one of the [LIVESTOCK] today, how much would you
+    #                 receive from the sale?").  NOT additive: a herd value
+    #                 (ValuePerAnimal x HeadCount) and a TLU rollup are
+    #                 transformations, NOT stored columns.  See
+    #                 `Columns: livestock` in lsms_library/data_info.yml.
     # `animal` is the harmonize_species Preferred Label (the wave scripts
     # reconcile 2010-11's fine 301-318 code scheme with the later coarse
     # scheme -- Ox=3304, Donkey/Horse=3305, Chicken=3310,
@@ -266,7 +268,7 @@ Data Scheme:
     HeadCount: float
     HeadAcquired: float
     HeadSold: float
-    Value: float
+    ValuePerAnimal: float
     materialize: make
   anthropometry:
     # Item-level (t, i, pid) body-measurement feature for the four IHS3+/

--- a/lsms_library/countries/Malawi/_/livestock.py
+++ b/lsms_library/countries/Malawi/_/livestock.py
@@ -2,8 +2,8 @@
 
 Each buildable wave's ``Malawi/<wave>/_/livestock.py`` produces a parquet
 indexed (t, i, animal) with the canonical item-level columns (HeadCount,
-HeadAcquired, HeadSold, Value).  This script concatenates them.  Cross-wave
-id_walk (panel-id chaining) is applied by the framework at API time in
+HeadAcquired, HeadSold, ValuePerAnimal).  This script concatenates them.
+Cross-wave id_walk (panel-id chaining) is applied by the framework at API time in
 _finalize_result.  ``v`` is NOT joined: 'livestock' is in the framework
 _no_v_join set (a household-level holding, not a cluster-keyed roster), so
 the grain stays (t, i, animal) with no cluster level.

--- a/lsms_library/countries/Malawi/_/malawi.py
+++ b/lsms_library/countries/Malawi/_/malawi.py
@@ -1656,10 +1656,11 @@ def assemble_plot_inputs(t, input_pieces, seed_purchase_pieces=None):
 #                      the closest single reported "acquired" figure -- a
 #                      born+gifts+bought total would be a transformation).
 #   * HeadSold      -- ag_r16: head sold alive in the last 12 months.
-#   * Value         -- ag_r04: REPORTED per-head current value ("if you sold
-#                      one [LIVESTOCK] today, how much would you receive?").
-#                      This is the per-head value the survey records; a herd
-#                      value (Value x HeadCount) and a TLU rollup are
+#   * ValuePerAnimal -- ag_r04: REPORTED per-head current value ("If you sold
+#                      one of the [LIVESTOCK] today, how much would you
+#                      receive from the sale?").  A per-head price, so NOT
+#                      additive; a herd value (ValuePerAnimal x HeadCount)
+#                      and a TLU rollup are
 #                      transformations, NOT stored columns.  Malawi reports
 #                      no herd-total value column, so we carry the honest
 #                      per-head figure rather than fabricating a total.
@@ -1690,8 +1691,9 @@ def _livestock_block(df, *, hhid, animalcode, owned_flag='ag_r01',
     All keyword args are RAW column names in ``df`` (or None when a wave
     lacks that field).  ``df`` must already carry an ``hhid`` string column.
     Returns a long DataFrame at grain (t, i, animal) with the reported item
-    columns (HeadCount, HeadAcquired, HeadSold, Value) and an internal
-    ``_animal_code`` used for the keep-filter / dedup.  NO aggregation.
+    columns (HeadCount, HeadAcquired, HeadSold, ValuePerAnimal) and an
+    internal ``_animal_code`` used for the keep-filter / dedup.  NO
+    aggregation.
     """
     species_map = _malawi_code_map('harmonize_species')
     code = pd.to_numeric(df[animalcode], errors='coerce').astype('Int64')
@@ -1723,7 +1725,7 @@ def _livestock_block(df, *, hhid, animalcode, owned_flag='ag_r01',
         'HeadCount':    head.values,
         'HeadAcquired': acq.values,
         'HeadSold':     sold_n.values,
-        'Value':        val.values,
+        'ValuePerAnimal': val.values,
         '_owns':        owns.values,
     })
     # Keep a roster row when the household genuinely holds the species:
@@ -1751,7 +1753,7 @@ def assemble_livestock(t, pieces):
     Returns
     -------
     pd.DataFrame indexed (t, i, animal) with columns HeadCount,
-    HeadAcquired, HeadSold, Value.  Item-level reported values only.
+    HeadAcquired, HeadSold, ValuePerAnimal.  Item-level reported values only.
     """
     cat = pd.concat(pieces, ignore_index=True)
 
@@ -1765,13 +1767,13 @@ def assemble_livestock(t, pieces):
     # is 1:1 per wave), so a duplicate here means the household reported the
     # same species on two roster lines: sum the head movements (HeadCount /
     # HeadAcquired / HeadSold are additive counts of the same herd) and take
-    # the first reported per-head Value (a per-head price is not additive).
+    # the first reported ValuePerAnimal (a per-head price is not additive).
     cat['t'] = t
     grp = cat.groupby(['t', 'i', 'animal'], as_index=False, dropna=False).agg({
         'HeadCount':    'sum',
         'HeadAcquired': 'sum',
         'HeadSold':     'sum',
-        'Value':        'first',
+        'ValuePerAnimal': 'first',
     })
     out = grp.set_index(['t', 'i', 'animal'])
     assert out.index.is_unique, f"Non-unique (t,i,animal) in livestock {t}"

--- a/lsms_library/countries/Mali/2014-15/_/livestock.py
+++ b/lsms_library/countries/Mali/2014-15/_/livestock.py
@@ -15,9 +15,9 @@ Variable map traced from MLI_EACI1.do + the s4a questionnaire labels:
   HeadCount      = s4aq04   "Nombre actuellement dans le troupeau"
   HeadAcquired   = s4aq15   "Nombre achete au cours des 12 derniers mois"
   HeadSold       = s4aq22   "Nombre vendu appartenant au menage"
-  Value (sales)  = s4aq24   "Valeur brute des ventes" (FCFA)
+  SalesValue     = s4aq24   "Valeur brute des ventes" (FCFA)
 
-The EACI roster carries NO current herd-value question, so Value is the
+The EACI roster carries NO current herd-value question, so SalesValue is the
 gross SALES value where reported (else NaN), matching the GAP-4 brief
 ("value where the source reports it; else NaN").  NO TLU, NO herd-value
 total, NO engaged-in-livestock binary — those are transformations over
@@ -55,7 +55,7 @@ df = pd.DataFrame({
     'HeadCount': owned['s4aq04'],
     'HeadAcquired': owned['s4aq15'],
     'HeadSold': owned['s4aq22'],
-    'Value': owned['s4aq24'],
+    'SalesValue': owned['s4aq24'],
 })
 
 df = livestock_finalize(df)

--- a/lsms_library/countries/Mali/2017-18/_/livestock.py
+++ b/lsms_library/countries/Mali/2017-18/_/livestock.py
@@ -14,7 +14,7 @@ Sources (passage 2 / post-harvest livestock module s8):
                        acquired / sold / sale-value the WB code never reads.
 
 i = (grappe, exploitation) — the 2017-18 household key (cf. crop_production
-/ plot_features).  HeadCount from s8a; HeadAcquired / HeadSold / Value
+/ plot_features).  HeadCount from s8a; HeadAcquired / HeadSold / SalesValue
 joined from s8b1 on (grappe, exploitation, species_code).
 
 Variable map traced from the s8a / s8b1 questionnaire labels:
@@ -23,9 +23,9 @@ Variable map traced from the s8a / s8b1 questionnaire labels:
   HeadCount      = s8aq06   "Nombre d'animaux ... actuellement dans le troupeau"
   HeadAcquired   = s8b1q10  "Nbre d'animaux ... achetes au cours des 12 ... mois"
   HeadSold       = s8b1q13  "Nbre ... appartenant au menage vendus ... 12 ... mois"
-  Value (sales)  = s8b1q14  "Valeur brute de la vente de ces animaux ... fcfa"
+  SalesValue     = s8b1q14  "Valeur brute de la vente de ces animaux ... fcfa"
 
-The EACI roster carries NO current herd-value question, so Value is the
+The EACI roster carries NO current herd-value question, so SalesValue is the
 gross SALES value where reported (else NaN).  NO TLU, NO herd-value total,
 NO engaged-in-livestock binary — those are transformations over these rows.
 """
@@ -61,7 +61,7 @@ flow = s8b1[['grappe', 'exploitation', 'animal_code',
              's8b1q10', 's8b1q13', 's8b1q14']].rename(columns={
     's8b1q10': 'HeadAcquired',
     's8b1q13': 'HeadSold',
-    's8b1q14': 'Value',
+    's8b1q14': 'SalesValue',
 })
 # Collapse the flow file to one row per (grappe, exploitation, species) in
 # case a species appears more than once; sum the reported flows.
@@ -69,7 +69,7 @@ flow = flow.groupby(['grappe', 'exploitation', 'animal_code'],
                     as_index=False).agg(
     HeadAcquired=('HeadAcquired', lambda s: pd.to_numeric(s, errors='coerce').sum(min_count=1)),
     HeadSold=('HeadSold', lambda s: pd.to_numeric(s, errors='coerce').sum(min_count=1)),
-    Value=('Value', lambda s: pd.to_numeric(s, errors='coerce').sum(min_count=1)),
+    SalesValue=('SalesValue', lambda s: pd.to_numeric(s, errors='coerce').sum(min_count=1)),
 )
 
 merged = s8a.merge(flow, on=['grappe', 'exploitation', 'animal_code'], how='left')
@@ -82,7 +82,7 @@ df = pd.DataFrame({
     'HeadCount': merged['s8aq06'],
     'HeadAcquired': merged['HeadAcquired'],
     'HeadSold': merged['HeadSold'],
-    'Value': merged['Value'],
+    'SalesValue': merged['SalesValue'],
 })
 
 df = livestock_finalize(df)

--- a/lsms_library/countries/Mali/_/CONTENTS.org
+++ b/lsms_library/countries/Mali/_/CONTENTS.org
@@ -603,3 +603,24 @@ a sampled household).
   tuples (9 dups).  The parquet stores the pre-walk (unique) index and
   lets the framework's idempotent id_walk in =_finalize_result= do the
   panel remap, consistent with every other Mali table.
+
+** livestock: =SalesValue=, NOT a herd value and NOT a per-animal price
+
+The EACI roster (s4a in 2014-15, s8a + s8b1 in 2017-18) has no current
+herd-value question.  Its only monetary livestock field is =s4aq24= /
+=s8b1q14=, "Valeur brute des ventes" -- the gross value of the animals SOLD
+in the last 12 months.  That column is called *=SalesValue=* (canonical
+vocabulary in =lsms_library/data_info.yml=, =Columns: livestock:=).  It was
+called =Value= until 2026-08-24.
+
+- *ADDITIVE* over =animal=; it is a total, not a unit price.
+- It values *HeadSold*, not HeadCount -- a transaction FLOW, so it must NOT be
+  summed into a livestock-wealth aggregate.  Mali has no =HerdValue=.
+- A per-animal sale price is =SalesValue / HeadSold=.
+
+*Measured*: among rows where the household sold nothing, *0.0%* carry a
+positive value (2014-15 and 2017-18 alike) -- versus 92-98% in Nigeria /
+Malawi, whose =ValuePerAnimal= is a reservation price asked whether or not
+anything was sold.  Note that correlation with HeadCount does NOT distinguish
+the two readings; both are near zero.  The sold-nothing conditional plus the
+questionnaire wording are what settle it.

--- a/lsms_library/countries/Mali/_/data_scheme.yml
+++ b/lsms_library/countries/Mali/_/data_scheme.yml
@@ -227,9 +227,13 @@ Data Scheme:
     # HeadCount    = number currently in the herd (s4aq04 / s8aq06).
     # HeadAcquired = number bought in the recall period (s4aq15 / s8b1q10).
     # HeadSold     = number owned by the HH sold (s4aq22 / s8b1q13).
-    # Value        = gross SALES value (FCFA) where reported (s4aq24 /
-    #                s8b1q14); NaN otherwise — the EACI roster carries NO
-    #                current herd-value question.
+    # SalesValue   = gross value of the animals SOLD (FCFA) where reported
+    #                (s4aq24 / s8b1q14 "Valeur brute des ventes"); NaN
+    #                otherwise — the EACI roster carries NO current
+    #                herd-value question, so there is no HerdValue.
+    #                ADDITIVE over `animal`; it values HeadSold, NOT
+    #                HeadCount, so it is a sales FLOW and NOT a per-animal
+    #                price.  See `Columns: livestock` in data_info.yml.
     #
     # NO TLU / herd-value total / engaged-in-livestock binary — those are
     # transformations.py rollups over these item rows.  Built by per-wave
@@ -238,7 +242,7 @@ Data Scheme:
     HeadCount: float
     HeadAcquired: float
     HeadSold: float
-    Value: float
+    SalesValue: float
     materialize: make
   plot_labor:
     # Item-level plot labor by source, GAP 3a (parity loop).  One row per

--- a/lsms_library/countries/Mali/_/livestock.py
+++ b/lsms_library/countries/Mali/_/livestock.py
@@ -2,8 +2,8 @@
 
 Each EACI wave's ``Mali/<wave>/_/livestock.py`` writes a parquet indexed by
 ``(t, i, animal)`` with the reported item-level columns (HeadCount,
-HeadAcquired, HeadSold, Value).  The livestock module lives in the EACI
-waves only (2014-15 EACIS4A_p2 / s4a, 2017-18 eaci17_s8ap2 + eaci17_s8b1p2 /
+HeadAcquired, HeadSold, SalesValue).  The livestock module lives in the
+EACI waves only (2014-15 EACIS4A_p2 / s4a, 2017-18 eaci17_s8ap2 + eaci17_s8b1p2 /
 s8a+s8b1).  The EHCVM waves (2018-19, 2021-22) carry no livestock roster, so
 they contribute nothing — the same wave split as crop_production /
 plot_inputs.

--- a/lsms_library/countries/Mali/_/mali.py
+++ b/lsms_library/countries/Mali/_/mali.py
@@ -515,7 +515,7 @@ def plot_inputs_finalize(df):
 #   HeadCount        — number currently in the herd (owned + raised),
 #   HeadAcquired     — number bought in the recall period,
 #   HeadSold         — number owned by the HH sold in the recall period,
-#   Value            — gross value of those sales (FCFA) where the source
+#   SalesValue       — gross value of those sales (FCFA) where the source
 #                      records it; NaN otherwise (the EACI roster carries NO
 #                      current herd-value question, only a sales value).
 #
@@ -547,7 +547,7 @@ def livestock_finalize(df):
 
     Expects raw columns already assembled:
         t, i, animal (numeric species code), HeadCount, HeadAcquired,
-        HeadSold, Value.
+        HeadSold, SalesValue.
     Maps the species code -> harmonize_species Preferred Label, coerces the
     reported count/value columns to numeric (clearing the EACI Manquant
     sentinels), drops content-free rows (a species the household does not
@@ -559,7 +559,7 @@ def livestock_finalize(df):
     df['animal'] = _species_labels(df['animal'])
     df = df.dropna(subset=['animal'])  # drop unmapped species codes
 
-    for c in ('HeadCount', 'HeadAcquired', 'HeadSold', 'Value'):
+    for c in ('HeadCount', 'HeadAcquired', 'HeadSold', 'SalesValue'):
         if c not in df.columns:
             df[c] = pd.NA
         df[c] = pd.to_numeric(df[c], errors='coerce')
@@ -573,7 +573,7 @@ def livestock_finalize(df):
     has_content = (df['HeadCount'].fillna(0).gt(0)
                    | df['HeadAcquired'].fillna(0).gt(0)
                    | df['HeadSold'].fillna(0).gt(0)
-                   | df['Value'].fillna(0).gt(0))
+                   | df['SalesValue'].fillna(0).gt(0))
     df = df[has_content]
 
     keys = ['t', 'i', 'animal']
@@ -582,9 +582,9 @@ def livestock_finalize(df):
         'HeadCount':    g['HeadCount'].sum(min_count=1),
         'HeadAcquired': g['HeadAcquired'].sum(min_count=1),
         'HeadSold':     g['HeadSold'].sum(min_count=1),
-        'Value':        g['Value'].sum(min_count=1),
+        'SalesValue':   g['SalesValue'].sum(min_count=1),
     })
-    out = out[['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']]
+    out = out[['HeadCount', 'HeadAcquired', 'HeadSold', 'SalesValue']]
     return out.sort_index()
 
 

--- a/lsms_library/countries/Nigeria/_/data_scheme.yml
+++ b/lsms_library/countries/Nigeria/_/data_scheme.yml
@@ -334,9 +334,11 @@ Data Scheme:
     #   HeadCount      head owned/kept now (s11iq2 W1-W3/W5; s11iq2a W4)
     #   HeadAcquired   head bought to raise (s11iq10 W1-W4; s11iq17 W5)
     #   HeadSold       head sold alive      (s11iq16 W1-W4; s11iq23 W5)
-    #   Value          reported reservation value of ONE head -- "if you
-    #                  sold one today, how much would you receive"
-    #                  (s11iq3 W1-W4; s11iq7 W5).  Per-head reported price,
+    #   ValuePerAnimal reported reservation value of ONE head -- "If you
+    #                  would sell one of the [ANIMAL] today, how much would
+    #                  you receive?" (s11iq3 W1-W4; s11iq7 W5).  A per-head
+    #                  price, so NOT additive; reported whether or not the
+    #                  household sold anything.  Reported price,
     #                  NOT a herd-value total and NOT the WB engaged
     #                  binary.
     # NO TLU, NO herd-value total, NO engaged-in-livestock binary -- those
@@ -345,7 +347,7 @@ Data Scheme:
     HeadCount: float
     HeadAcquired: float
     HeadSold: float
-    Value: float
+    ValuePerAnimal: float
     materialize: make
 
   anthropometry:

--- a/lsms_library/countries/Nigeria/_/livestock.py
+++ b/lsms_library/countries/Nigeria/_/livestock.py
@@ -10,8 +10,8 @@ roster richer: per-animal head counts, acquisitions, sales, and the
 reported per-head reservation value.
 
 Stores REPORTED item-level fields ONLY -- HeadCount (owned/kept now),
-HeadAcquired (bought to raise), HeadSold (sold alive), Value (reported
-reservation value of ONE head).  NO TLU, NO herd-value total, NO
+HeadAcquired (bought to raise), HeadSold (sold alive), ValuePerAnimal
+(reported reservation value of ONE head).  NO TLU, NO herd-value total, NO
 engaged-in-livestock binary (those are transformations over these rows;
 their binary = groupby.any()).
 
@@ -33,7 +33,7 @@ round; each wave maps to a single t = PP_QUARTER[wave]):
               questions (HeadCount s11iq2, acquire s11iq17, sold s11iq23,
               value s11iq7)
 
-Column-name map (HeadCount | HeadAcquired | HeadSold | Value):
+Column-name map (HeadCount | HeadAcquired | HeadSold | ValuePerAnimal):
   W1  s11iq2  | s11iq10 | s11iq16 | s11iq3
   W2  s11iq2  | s11iq10 | s11iq16 | s11iq3
   W3  s11iq2  | s11iq10 | s11iq16 | s11iq3
@@ -50,7 +50,7 @@ from nigeria import PP_QUARTER, _species_labels, livestock_for_wave
 
 species_labels = _species_labels()
 
-# (wave, file, animal_code, owned, HeadCount, HeadAcquired, HeadSold, Value)
+# (wave, file, animal_code, owned, HeadCount, HeadAcquired, HeadSold, ValuePerAnimal)
 SPECS = [
     ('2010-11',
      '../2010-11/Data/Post Planting Wave 1/Agriculture/sect11i_plantingw1.dta',

--- a/lsms_library/countries/Nigeria/_/nigeria.py
+++ b/lsms_library/countries/Nigeria/_/nigeria.py
@@ -821,11 +821,12 @@ def assemble_plot_inputs(t, parts):
 #   HeadAcquired   head bought to raise this period (s11iq10 W1-W4;
 #                  s11iq17 W5)
 #   HeadSold       head sold alive this period (s11iq16 W1-W4; s11iq23 W5)
-#   Value          reported reservation value of ONE head -- "if you sold
-#                  one today, how much would you receive" (s11iq3 W1-W4;
-#                  s11iq7 W5).  This is a per-head reported price, NOT a
-#                  herd-value total and NOT the WB engaged binary; a herd
-#                  value (HeadCount x Value) and TLU are transformations.
+#   ValuePerAnimal reported reservation value of ONE head -- "If you would
+#                  sell one of the [ANIMAL] today, how much would you
+#                  receive?" (s11iq3 W1-W4; s11iq7 W5).  A per-head reported
+#                  price, so NOT additive, and NOT a herd-value total nor the
+#                  WB engaged binary; a herd value (HeadCount x
+#                  ValuePerAnimal) and TLU are transformations.
 # NO TLU, NO herd-value total, NO engaged-in-livestock binary -- those
 # are transformations over these rows (their binary = groupby.any()).
 #
@@ -871,7 +872,7 @@ def livestock_for_wave(t, df, animal_code, owned, head_now, head_acquired,
         owned rows).
     head_now, head_acquired, head_sold, value : str or None
         Reported column names for HeadCount / HeadAcquired / HeadSold /
-        Value.  None -> that column is all-NA for the wave.
+        ValuePerAnimal.  None -> that column is all-NA for the wave.
     species_labels : dict
         {int animal_code: Preferred Label} from harmonize_species.
 
@@ -879,7 +880,7 @@ def livestock_for_wave(t, df, animal_code, owned, head_now, head_acquired,
     -------
     DataFrame indexed by (t, i, animal) with reported numeric columns.
     Keeps a row when the animal label resolves AND the household reports
-    something for it (any of HeadCount / HeadAcquired / HeadSold / Value
+    something for it (any of HeadCount / HeadAcquired / HeadSold / ValuePerAnimal
     non-missing-and-nonzero) so the roster grid's never-owned all-zero
     rows (W2-W4 enumerate every animal for every HH) do not bloat the
     feature.  A row with own==yes but all-zero quantities is still kept
@@ -901,7 +902,7 @@ def livestock_for_wave(t, df, animal_code, owned, head_now, head_acquired,
         'HeadCount': num(head_now).astype('Float64').values,
         'HeadAcquired': num(head_acquired).astype('Float64').values,
         'HeadSold': num(head_sold).astype('Float64').values,
-        'Value': num(value).astype('Float64').values,
+        'ValuePerAnimal': num(value).astype('Float64').values,
     }, index=df.index)
 
     if owned is not None and owned in df.columns:
@@ -916,7 +917,7 @@ def livestock_for_wave(t, df, animal_code, owned, head_now, head_acquired,
     # Keep rows the HH actually engaged with: either flagged owned, or any
     # reported quantity is non-null and nonzero.  Drop the roster-grid
     # not-owned all-zero filler rows (W2-W4) and unresolved animal labels.
-    qcols = ['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']
+    qcols = ['HeadCount', 'HeadAcquired', 'HeadSold', 'ValuePerAnimal']
     has_qty = pd.Series(False, index=piece.index)
     for c in qcols:
         v = piece[c]
@@ -931,7 +932,7 @@ def livestock_for_wave(t, df, animal_code, owned, head_now, head_acquired,
     out = out.drop_duplicates(subset=['t', 'i', 'animal'], keep='first')
 
     out = out.set_index(['t', 'i', 'animal']).sort_index()
-    return out[['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']]
+    return out[['HeadCount', 'HeadAcquired', 'HeadSold', 'ValuePerAnimal']]
 
 
 # ---------------------------------------------------------------------

--- a/lsms_library/countries/Uganda/_/data_scheme.yml
+++ b/lsms_library/countries/Uganda/_/data_scheme.yml
@@ -261,12 +261,19 @@ Data Scheme:
     #   HeadCount     — head owned now
     #   HeadAcquired  — head bought to raise (last reference period)
     #   HeadSold      — head sold alive
-    #   Value         — reported per-head animal value ('value if you sold
-    #                   one today' in 2009-10/2010-11; 'average value of
-    #                   each one sold' for 2011-12+, which dropped the
-    #                   sell-today question)
+    #   ValuePerAnimal — reported PER-HEAD animal value, so NOT additive.
+    #                   Two instrument variants, both per head: 'If you
+    #                   would sell one of the [...] today, how much would
+    #                   you receive?' (a6aq6) in 2009-10/2010-11, and 'What
+    #                   was, on average, the value of each sold?' (a6aq14b /
+    #                   s6aq14b) for 2011-12+, which dropped the sell-today
+    #                   question.  The switch is within-concept but changes
+    #                   COVERAGE: the later variant is defined only where the
+    #                   household sold, so the non-null rate falls from ~96%
+    #                   to ~21% at 2011-12.  See `Columns: livestock` in
+    #                   lsms_library/data_info.yml.
     # The WB engaged-livestock binary = groupby(['t','i']).any() over these
-    # rows; herd value = Value * HeadCount; TLU = sum(head * TLU-factor).
+    # rows; herd value = ValuePerAnimal * HeadCount; TLU = sum(head * TLU-factor).
     # All three are TRANSFORMATIONS -- never stored here.
     #
     # No v level: livestock is in the framework _no_v_join set
@@ -276,7 +283,7 @@ Data Scheme:
     HeadCount: float
     HeadAcquired: float
     HeadSold: float
-    Value: float
+    ValuePerAnimal: float
     materialize: make
   anthropometry:
     # Item-level anthropometry module (GAP 5 parity build).  One row per

--- a/lsms_library/countries/Uganda/_/livestock.py
+++ b/lsms_library/countries/Uganda/_/livestock.py
@@ -2,8 +2,8 @@
 
 Each wave's ``Uganda/<wave>/_/livestock.py`` produces a parquet indexed
 ``(t, i, animal)`` with the REPORTED livestock columns (HeadCount,
-HeadAcquired, HeadSold, Value).  This script concatenates them across waves
-and applies cross-wave id_walk so the household index uses the panel
+HeadAcquired, HeadSold, ValuePerAnimal).  This script concatenates them
+across waves and applies cross-wave id_walk so the household index uses the panel
 canonical id scheme.
 
 Source: the UNPS livestock roster (AGSEC6A/6B/6C) that the WB code reads

--- a/lsms_library/countries/Uganda/_/uganda.py
+++ b/lsms_library/countries/Uganda/_/uganda.py
@@ -2047,10 +2047,11 @@ INPUT_COLMAPS = {
 #   HeadCount      head owned now              (q5 / q5a / q3a / s..q03a)
 #   HeadAcquired   head bought to raise        (q12 / q13a / s..q13a)
 #   HeadSold       head sold alive             (q14 / q14a / s..q14a)
-#   Value          reported per-head value     (q6 'value if sold one today',
+#   ValuePerAnimal reported PER-HEAD value  (q6 'value if sold one today',
 #                  2009-10/2010-11; q14b 's..q14b' 'avg value of each sold' for
-#                  2011-12+ which dropped the sell-today question)
-# Herd value (= Value x HeadCount), TLU, and the WB engaged-livestock binary
+#                  2011-12+ which dropped the sell-today question).  Both
+#                  variants are per head, so the column is NOT additive.
+# Herd value (= ValuePerAnimal x HeadCount), TLU, and the WB engaged-livestock binary
 # (= groupby.any over these rows) are TRANSFORMATIONS, never stored here.
 #
 # Per-wave the animal type lives in different columns and two encodings:
@@ -2129,12 +2130,12 @@ def livestock_for_wave(t, df6a, df6b, df6c, colmap):
     Returns
     -------
     pd.DataFrame indexed ``(t, i, animal)`` with Float64 columns
-        ``HeadCount``, ``HeadAcquired``, ``HeadSold``, ``Value``.
+        ``HeadCount``, ``HeadAcquired``, ``HeadSold``, ``ValuePerAnimal``.
         One row per (household, species) -- duplicate species rows within
         a household (e.g. exotic + indigenous cattle, both mapping to
         'Cattle') are summed for the head columns and value-weighted-mean
-        for ``Value`` so the (t, i, animal) index is unique.  NO TLU, NO
-        herd-value total, NO engaged binary (all transformations).
+        for ``ValuePerAnimal`` so the (t, i, animal) index is unique.  NO
+        TLU, NO herd-value total, NO engaged binary (all transformations).
     """
     code_map = _species_code_map()
     str_map = _species_string_map()
@@ -2179,11 +2180,11 @@ def livestock_for_wave(t, df6a, df6b, df6c, colmap):
             'HeadCount':    _num('headcount').values,
             'HeadAcquired': _num('acquired').values,
             'HeadSold':     _num('sold').values,
-            'Value':        _num('value').values,
+            'ValuePerAnimal': _num('value').values,
         })
         pieces.append(piece)
 
-    cols = ['HeadCount', 'HeadAcquired', 'HeadSold', 'Value']
+    cols = ['HeadCount', 'HeadAcquired', 'HeadSold', 'ValuePerAnimal']
     if not pieces:
         return pd.DataFrame(columns=cols)
 
@@ -2198,17 +2199,17 @@ def livestock_for_wave(t, df6a, df6b, df6c, colmap):
         df[c] = pd.to_numeric(df[c], errors='coerce')
     measure = ['HeadCount', 'HeadAcquired', 'HeadSold']
     # Keep a row when ANY head measure is a positive number (owned now,
-    # bought, or sold).  Value alone (per-head price with no head count)
-    # is not evidence of ownership.
+    # bought, or sold).  ValuePerAnimal alone (a per-head price with no
+    # head count) is not evidence of ownership.
     has_head = (df[measure].fillna(0) > 0).any(axis=1)
     df = df[has_head]
 
     # Collapse to (t, i, animal): the roster splits a species across
     # exotic/indigenous and age/sex lines; those are the SAME species for
     # this axis, so sum the head columns and take a head-weighted mean of
-    # the reported per-head Value (NaN where no line reported a value).
+    # the reported ValuePerAnimal (NaN where no line reported a value).
     df['_w'] = df['HeadCount'].fillna(0)
-    df['_vw'] = df['Value'] * df['_w']
+    df['_vw'] = df['ValuePerAnimal'] * df['_w']
     grouped = df.groupby(['t', 'i', 'animal'], dropna=False)
     out = grouped[measure].sum(min_count=1)
     vw_sum = grouped['_vw'].sum(min_count=1)
@@ -2216,8 +2217,8 @@ def livestock_for_wave(t, df6a, df6b, df6c, colmap):
     value = vw_sum / w_sum.where(w_sum > 0, pd.NA)
     # Fall back to a simple mean of reported values where head weights are
     # all zero/NaN but a value was nonetheless reported.
-    plain = grouped['Value'].mean()
-    out['Value'] = value.where(value.notna(), plain)
+    plain = grouped['ValuePerAnimal'].mean()
+    out['ValuePerAnimal'] = value.where(value.notna(), plain)
 
     for c in cols:
         out[c] = pd.to_numeric(out[c], errors='coerce').astype('Float64')
@@ -2226,7 +2227,7 @@ def livestock_for_wave(t, df6a, df6b, df6c, colmap):
 
 # Per-wave column maps for livestock_for_wave.  ``type`` is the animal-type
 # column; ``type_kind`` 'code' (harmonize_species) or 'string'
-# (_species_string_map).  Value is the reported per-head animal value: the
+# (_species_string_map).  ValuePerAnimal is the reported per-head value: the
 # 'sell one today' question (q6) where the wave asks it (2009-10, 2010-11),
 # else the 'average value of each sold' (q14b) for 2011-12+.
 LIVESTOCK_COLMAPS = {

--- a/lsms_library/currency.py
+++ b/lsms_library/currency.py
@@ -58,7 +58,14 @@ _DEFAULT_MONETARY: dict[str, frozenset[str]] = {
     "food_prices": frozenset({"Price"}),
     "community_prices": frozenset({"Price"}),
     "assets": frozenset({"Value", "Purchase Price"}),
-    "livestock": frozenset({"Value", "Purchase Price"}),
+    # livestock: the three canonical value columns, split by additivity
+    # (ValuePerAnimal / HerdValue / SalesValue -- see `Columns: livestock`
+    # in data_info.yml).  `Purchase Price` was here as a copy-paste from the
+    # `assets` line above and is dropped: NO country declares it in
+    # livestock (it is an assets-only column, in Senegal / Mali / Togo /
+    # Benin).  Kept in lockstep with the YAML by
+    # tests/test_currency_livestock_registry.py -- see the note below.
+    "livestock": frozenset({"ValuePerAnimal", "HerdValue", "SalesValue"}),
     "crop_production": frozenset({"Value_sold"}),
     "plot_labor": frozenset({"Wage"}),
     "earnings": frozenset({"Earnings"}),

--- a/lsms_library/data_info.yml
+++ b/lsms_library/data_info.yml
@@ -311,6 +311,133 @@ Columns:
   panel_ids:
     previous_i:
       type: str
+  livestock:
+    # Grain (t, i, animal) for the 13 roster countries; EthiopiaRHS is the
+    # documented (t, i) household-total variant (pre-aggregated herd scalars
+    # from the IFPRI ERHS deposit -- it has no per-species roster).
+    #
+    # NOTHING here is `required: true`, deliberately.  `required` in this file
+    # makes tests/test_schema_consistency.py::TestRequiredColumns demand the
+    # column of EVERY country declaring the table, and livestock's column set
+    # genuinely varies with the instrument: the 7 EHCVM countries record head
+    # counts and no value at all, EthiopiaRHS records value and no head
+    # counts.  Any `required` livestock column would be a false universal.
+    #
+    # ---- THE VALUE COLUMNS ARE SPLIT BY ADDITIVITY, NOT BY GRAIN ----
+    #
+    # Three distinct quantities were all spelled `Value`.  They share a dtype,
+    # a grain and a currency, so nothing in the library could tell them apart
+    # and all three graded `sane`.  Summing the wrong one is silent.  The
+    # split is by WHAT ARITHMETIC IS LEGAL:
+    #
+    #   ValuePerAnimal  price per head          -- NOT additive
+    #   HerdValue       stock total             -- additive over `animal`
+    #   SalesValue      transaction-flow total  -- additive over `animal`
+    #
+    # Which one a country has is settled on the QUESTIONNAIRE WORDING (quoted
+    # per column below), corroborated by a conditional test.  Correlation with
+    # HeadCount does NOT discriminate -- neither a unit price nor a sales
+    # total tracks herd size, so both look alike under it.  The test that
+    # separates them is: IS THE VALUE REPORTED WHEN NOTHING WAS SOLD?
+    #
+    #   % rows with value > 0 | given HeadSold == 0 | given HeadSold > 0
+    #   ----------------------+---------------------+--------------------
+    #   Nigeria               |         98.0        |        98.2
+    #   Malawi                |         92.1        |        91.4
+    #   Uganda 2009-10        |         99.2        |        89.6
+    #   Uganda 2011-12+       |          0.0        |        94.9
+    #   Ethiopia              |          2.0        |        95.6
+    #   Mali                  |          0.0        |        92.5
+    #
+    # A price reported regardless of any sale is a reservation price
+    # (Nigeria / Malawi / early Uganda).  A number that exists only when a
+    # sale happened is sale-linked -- but that alone does NOT prove it is a
+    # total: Uganda 2011-12+ is also 0.0 and is still PER HEAD ("the value of
+    # each sold").  Only the wording settles it, which is why it is quoted.
+    HeadCount:
+      type: float
+      note: |
+        Head of this animal owned / kept by the household at interview.
+        A stock.  Summing over `animal` adds cattle to chickens; the
+        meaningful aggregate is TLU (sum of head x species factor).  For the
+        roster countries TLU is a transformation over these rows and is
+        deliberately NOT stored -- see the TLU entry below for the one case
+        where the source ships it pre-aggregated.
+    HeadAcquired:
+      type: float
+      note: |
+        Head PURCHASED alive during the survey's recall window (12 months in
+        every country that records it).  A flow.  Births and gifts are
+        separate reported flows and are deliberately NOT folded in.
+    HeadSold:
+      type: float
+      note: |
+        Head SOLD alive during the recall window.  A flow, and the
+        denominator that turns SalesValue into a per-animal sale price.
+    ValuePerAnimal:
+      type: float
+      monetary: true
+      note: |
+        Price of ONE head, in local currency.  NOT ADDITIVE -- summing it
+        over `animal`, or over households, produces a number with no meaning.
+        A household's holding value is ValuePerAnimal * HeadCount, computed
+        by the analyst; the library does not store it.
+
+        Two instrument variants, both per-head:
+          - RESERVATION price -- "If you would sell one of the [ANIMAL]
+            today, how much would you receive?"  Reported whether or not
+            anything was sold.  Nigeria (s11iq3), Malawi (ag_r04), Uganda
+            2009-10 / 2010-11 (a6aq6).
+          - REALISED average -- "What was, on average, the value of each
+            sold?"  Defined only where the household sold.  Uganda 2011-12
+            onward (a6aq14b / s6aq14b), which dropped the sell-today question.
+
+        The switch is within-concept -- both are per head -- so it does not
+        change the column, but it DOES change coverage: Uganda's non-null
+        rate falls from ~96% to ~21% at 2011-12, and every non-null row from
+        then on is conditional on a sale.
+    HerdValue:
+      type: float
+      monetary: true
+      note: |
+        Total value of the animals described by this row, in local currency.
+        ADDITIVE: at (t, i, animal) it is the per-species herd total and sums
+        over `animal` to the household's livestock wealth; at the (t, i)
+        grain the row already IS the household total.
+
+        A stock -- it values HeadCount.  Contrast SalesValue, which values
+        HeadSold.  Declared by EthiopiaRHS (lvsval80 / livval6 / lvs_val7,
+        "total value of livestock herd", Birr, at the (t, i) grain).
+    SalesValue:
+      type: float
+      monetary: true
+      note: |
+        Gross value of the animals SOLD during the recall window, in local
+        currency.  ADDITIVE over `animal`, but a FLOW: it values HeadSold,
+        not HeadCount, so it is NOT a herd valuation and must never be summed
+        into a wealth aggregate.  A per-animal sale price is
+        SalesValue / HeadSold.
+
+        Declared by Ethiopia (ls_s8aq60, "What was the total value of sales
+        of [LIVESTOCK] in the last 12 months? (BIRR)") and Mali (s4aq24 /
+        s8b1q14, "Valeur brute des ventes").  Both rosters record NO current
+        herd value, which is why neither country has a HerdValue -- an
+        earlier reading that mapped these onto ValuePerAnimal would have
+        relabelled an additive total as a unit price.
+    TLU:
+      type: float
+      note: |
+        Tropical Livestock Units -- head weighted by a species conversion
+        factor, so herds of different composition are commensurable.  A
+        stock, additive over `animal`, and NOT monetary (it is an animal
+        count in cattle-equivalents, not a currency amount), which is why it
+        is absent from currency._DEFAULT_MONETARY['livestock'].
+
+        Stored ONLY where the source ships it pre-aggregated: EthiopiaRHS
+        (lsu80 / lsu6 / tlu7, at the (t, i) grain).  For the 13 roster
+        countries TLU is a transformation over HeadCount and is deliberately
+        not stored -- their configs say so individually, and computing it
+        needs a species factor table the library does not yet carry.
   crop_production:
     # NOTE: `condition` is an INDEX level, not a column -- deliberately
     # declared here anyway.  `_enforce_canonical_spellings` (country.py:3962)

--- a/tests/test_currency_livestock_registry.py
+++ b/tests/test_currency_livestock_registry.py
@@ -1,0 +1,204 @@
+"""Pin ``currency.py``'s livestock registry against the canonical YAML.
+
+WHY THIS FILE EXISTS
+--------------------
+``currency._DEFAULT_MONETARY`` is a hand-maintained *registry of which columns
+hold money*.  It is a second copy of a fact whose first copy is the
+``monetary:`` flag in ``lsms_library/data_info.yml``'s ``Columns`` section --
+and a second copy of a fact is a fact that can go stale.
+
+Renaming a monetary column and forgetting the registry is silent in the worst
+way this codebase knows: right shape, absent content.  Two mechanisms fail
+differently, and BOTH are load-bearing:
+
+1.  ``attach_currency`` gates on ``_monetary_columns(table, country)`` being
+    *non-empty* -- a TABLE-level test.  A stale registry entry (a column name
+    nothing declares any more) keeps that set non-empty, so the currency label
+    still attaches and the bug shows no symptom at all.
+2.  ``conversion.convert`` scales exactly ``_all_monetary_columns()`` -- a
+    COLUMN-level test.  A renamed column missing from the registry is
+    therefore **silently never converted**: the FX/PPP layer walks straight
+    past it and returns nominal local-currency numbers labelled as converted.
+
+Mechanism 1 is why the failure is invisible; mechanism 2 is why it matters.
+Neither is caught by the coverage matrix -- ``sane`` is a cold build and (per
+`docs/guide/coverage.md`) the grader does not check currency labels at all.
+
+WHAT THE PIN ASSERTS
+--------------------
+Set EQUALITY between the two declarations, so it fails if EITHER side changes
+alone -- adding a `monetary:` column to the YAML without the registry, or vice
+versa.  Plus a reachability check that every value column any country actually
+declares is covered, which is the direction a rename breaks.
+"""
+from importlib.resources import files
+
+import pytest
+import yaml
+
+from lsms_library.catalog import _country_dirs
+from lsms_library.currency import (
+    _DEFAULT_MONETARY,
+    _all_monetary_columns,
+    _load_country_scheme,
+    _monetary_columns,
+)
+
+TABLE = "livestock"
+
+# Structural keys of a `data_scheme.yml` table entry that are not columns.
+_NON_COLUMN_KEYS = {"index", "materialize", "backend", "aggregation", "optional"}
+
+
+def _canonical_columns() -> dict:
+    """The ``Columns: livestock:`` block of the canonical data_info.yml."""
+    path = files("lsms_library") / "data_info.yml"
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    cols = (data.get("Columns") or {}).get(TABLE)
+    assert isinstance(cols, dict), (
+        "data_info.yml has no `Columns: livestock:` block.  It is the "
+        "canonical declaration of the livestock schema; do not remove it."
+    )
+    return cols
+
+
+def _yaml_monetary() -> set:
+    return {c for c, meta in _canonical_columns().items()
+            if isinstance(meta, dict) and meta.get("monetary") is True}
+
+
+# ---------------------------------------------------------------------------
+# The pin itself
+# ---------------------------------------------------------------------------
+
+def test_registry_matches_canonical_yaml():
+    """``_DEFAULT_MONETARY['livestock']`` == the YAML's ``monetary: true`` set.
+
+    EQUALITY, deliberately -- not a subset either way.  A subset test would
+    pass while one side silently grew or shrank, which is exactly the drift
+    this file exists to stop.
+    """
+    seed = set(_DEFAULT_MONETARY[TABLE])
+    declared = _yaml_monetary()
+    assert seed == declared, (
+        "currency._DEFAULT_MONETARY['livestock'] has drifted from the "
+        "`monetary: true` columns in data_info.yml's `Columns: livestock:`.\n"
+        f"  only in currency.py : {sorted(seed - declared)}\n"
+        f"  only in data_info.yml: {sorted(declared - seed)}\n"
+        "Both must be updated together.  A column missing from the registry "
+        "is silently skipped by conversion.convert()."
+    )
+
+
+def test_canonical_value_columns_are_the_expected_three():
+    """The additivity split is a definition; pin the vocabulary itself.
+
+    ValuePerAnimal (a unit price, NOT additive), HerdValue (a stock total,
+    additive) and SalesValue (a transaction-flow total, additive) are three
+    genuinely different quantities that were all once spelled `Value`.
+    Adding a fourth is a definitional act and should be deliberate.
+    """
+    assert _yaml_monetary() == {"ValuePerAnimal", "HerdValue", "SalesValue"}
+
+
+def test_every_declared_livestock_value_column_is_monetary():
+    """No country may declare a livestock value column the registry misses.
+
+    This is the direction a rename breaks: the country YAML moves, the
+    registry does not, and `conversion.convert` stops scaling the column
+    without raising anything.
+    """
+    known = _all_monetary_columns()
+    non_monetary = {c for c, meta in _canonical_columns().items()
+                    if not (isinstance(meta, dict) and meta.get("monetary"))}
+
+    offenders = {}
+    for country in _country_dirs():
+        entry = _load_country_scheme(country).get(TABLE)
+        if not isinstance(entry, dict):
+            continue
+        for col in entry:
+            if not isinstance(col, str) or col in _NON_COLUMN_KEYS:
+                continue
+            if col in non_monetary or col in known:
+                continue
+            # A column name that reads like money but is in neither list.
+            if "value" in col.lower() or "price" in col.lower():
+                offenders.setdefault(country, []).append(col)
+
+    assert not offenders, (
+        "livestock value column(s) declared by a country but absent from the "
+        f"monetary registry: {offenders}.  Add them to "
+        "currency._DEFAULT_MONETARY['livestock'] AND to data_info.yml's "
+        "`Columns: livestock:` with `monetary: true`."
+    )
+
+
+def test_bare_Value_is_no_longer_a_livestock_column():
+    """`Value` was ambiguous across three meanings; it must not come back.
+
+    It stays legitimate in `assets`, which is why this check is scoped to
+    livestock rather than being a global Rejected Spelling.
+    """
+    offenders = [c for c in _country_dirs()
+                 if isinstance(_load_country_scheme(c).get(TABLE), dict)
+                 and "Value" in _load_country_scheme(c)[TABLE]]
+    assert not offenders, (
+        f"{offenders} still declare a bare `Value` in livestock.  Use "
+        "ValuePerAnimal (unit price), HerdValue (stock total) or SalesValue "
+        "(sales flow) -- see `Columns: livestock:` in data_info.yml."
+    )
+    assert "Value" not in _DEFAULT_MONETARY[TABLE]
+    # ... but assets must be untouched by that removal.
+    assert "Value" in _DEFAULT_MONETARY["assets"]
+
+
+def test_purchase_price_not_claimed_for_livestock():
+    """`Purchase Price` is an assets column; no livestock table declares it.
+
+    It sat in the livestock seed as a copy-paste from the `assets` line.
+    Harmless in isolation, but a registry that lists columns nothing declares
+    is precisely what keeps `attach_currency`'s non-empty gate open after a
+    real column has been renamed away -- i.e. it hides the failure above.
+    """
+    assert "Purchase Price" not in _DEFAULT_MONETARY[TABLE]
+    assert "Purchase Price" in _DEFAULT_MONETARY["assets"]
+
+    for country in _country_dirs():
+        entry = _load_country_scheme(country).get(TABLE)
+        if isinstance(entry, dict):
+            assert "Purchase Price" not in entry, (
+                f"{country} declares `Purchase Price` in livestock; the "
+                "registry no longer covers it."
+            )
+
+
+@pytest.mark.parametrize("column", ["ValuePerAnimal", "HerdValue", "SalesValue"])
+def test_conversion_layer_sees_each_value_column(column):
+    """`conversion.convert` scales exactly `_all_monetary_columns()`.
+
+    A canonical livestock value column missing from that union is silently
+    left in nominal local currency by every conversion call.
+    """
+    assert column in _all_monetary_columns()
+
+
+@pytest.mark.parametrize(
+    "country,column",
+    [("Uganda", "ValuePerAnimal"), ("Nigeria", "ValuePerAnimal"),
+     ("Malawi", "ValuePerAnimal"), ("Ethiopia", "SalesValue"),
+     ("Mali", "SalesValue"), ("EthiopiaRHS", "HerdValue")],
+)
+def test_country_value_column_resolves_as_monetary(country, column):
+    """End-to-end through the real resolver, per renamed country.
+
+    Belt-and-braces over the set equality above: this is the call
+    `Country._finalize_result` actually makes.
+    """
+    entry = _load_country_scheme(country).get(TABLE)
+    assert isinstance(entry, dict), f"{country} no longer declares livestock"
+    assert column in entry, (
+        f"{country}'s livestock declares {sorted(entry)}, not {column!r}"
+    )
+    assert column in _monetary_columns(TABLE, country)


### PR DESCRIPTION
## The headline: Ethiopia and Mali are `SalesValue`, not `ValuePerAnimal`

The brief for this change assigned all five `Value` countries to `ValuePerAnimal`, on the measurement that `Value` does not scale with `HeadCount` anywhere. **That measurement is correct but does not discriminate** — neither a unit price *nor a sales total* tracks herd size, so both look identical under it.

The test that separates them is whether the value is reported when the household **sold nothing**, and the questionnaire wording is what actually settles it:

| country / source var | value > 0 when sold **nothing** | when sold **something** | source wording |
|---|---:|---:|---|
| Nigeria `s11iq3` | **98.0%** | 98.2% | "If you would sell one of the [ANIMAL] today, how much would you receive?" |
| Malawi `ag_r04` | **92.1%** | 91.4% | "If you sold one of the [LIVESTOCK] today, how much would you receive from the sale?" |
| Uganda 2009-10 `a6aq6` | **99.2%** | 89.6% | "If you would sell one of the […] today, how much would you receive?" |
| Uganda 2011-12+ `a6aq14b` | 0.0% | 94.9% | "What was, **on average, the value of each** sold?" — still **per head** |
| Ethiopia `ls_s8aq60` | **2.0%** | 95.6% | "What was the **total value of sales** of [LIVESTOCK] in the last 12 months? (BIRR)" |
| Mali `s4aq24` / `s8b1q14` | **0.0%** | 92.5% | "**Valeur brute des ventes**" (gross value of sales) |

Ethiopia's and Mali's rosters record **no current herd value at all** — their own `data_scheme.yml` comments already said so. Those columns are the gross value of animals **sold**: additive, and a **flow** over `HeadSold` rather than a stock over `HeadCount`. Calling them `ValuePerAnimal` would have stamped "per head, not additive" on an additive total — precisely the misdeclaration this PR exists to prevent. They are not `HerdValue` either: summing them gives livestock **sales revenue**, not livestock **wealth**.

Uganda's 0.0% shows why the conditional alone is not sufficient: at 2011-12 the question changed from a reservation price to a realised average, but "the value of **each** one sold" is still per head. Same column, changed **coverage** (non-null falls ~96% → ~21%) — documented under `ValuePerAnimal`.

## What landed

A canonical `Columns: livestock:` block in `lsms_library/data_info.yml` — there was none, so nothing in the library said what a livestock column *means*. Three genuinely different quantities were all spelled `Value`; they share a dtype, a grain and a currency, so no guard could tell them apart and all three graded `sane`.

Split by **what arithmetic is legal**, not by grain:

| column | meaning | additive? |
|---|---|---|
| `ValuePerAnimal` | price per head | **no** |
| `HerdValue` | stock total (values `HeadCount`) | yes, over `animal` |
| `SalesValue` | transaction-flow total (values `HeadSold`) | yes, over `animal` |

| country | rename |
|---|---|
| Uganda, Nigeria, Malawi | `Value` → `ValuePerAnimal` |
| Ethiopia, Mali | `Value` → `SalesValue` |
| EthiopiaRHS | `LivestockValue` → `HerdValue` |

`TLU` is also declared. The block originally asserted TLU is "a transformation, not a stored column" — true for the 13 roster countries and **false** for EthiopiaRHS, whose source ships a pre-aggregated scalar (`lsu80` / `lsu6` / `tlu7`) and stores it. Leaving an undeclared stored column behind an assertion that it is never stored is the same imprecision this PR removes. Not monetary (an animal count in cattle-equivalents), so the registry pin is unaffected.

**Nothing is `required: true`** — `required` here makes `TestRequiredColumns` demand the column of *every* country declaring the table, and livestock's column set genuinely varies: the 7 EHCVM countries record head counts and no value, EthiopiaRHS records value and no head counts.

## The trap, and how it is pinned

`currency._DEFAULT_MONETARY["livestock"]` is a second copy of "which columns hold money". Renaming without it fails silently in **two different ways**:

- `attach_currency` gates on the set being **non-empty** (a *table*-level test) — a stale entry keeps the currency label attaching, so the bug shows **no symptom at all**;
- `conversion.convert` scales exactly `_all_monetary_columns()` (a *column*-level test) — so the renamed column is **silently never converted**: nominal local-currency numbers, labelled as converted.

The first is why it is invisible; the second is why it matters. Neither is caught by the coverage matrix (`sane` is a cold build, and the grader does not check currency labels).

`tests/test_currency_livestock_registry.py` pins the registry against the canonical YAML by **set equality**, so it fails if either side moves alone. **Proven by mutation, not asserted:**

| mutation | result |
|---|---|
| drop `SalesValue` from `currency.py` only | 1 failed |
| add a 4th `monetary:` column to the YAML only | 2 failed |
| revert one country to a bare `Value` | 2 failed |
| restore both | **14 passed** |

`Purchase Price` is **dropped** from the livestock set: no country declares it there (assets-only — Senegal / Mali / Togo / Benin). A registry listing columns nothing declares is exactly what holds the non-empty gate open after a real column has been renamed away.

## Verification — values unchanged, only the name moves

All **14** livestock countries rebuilt in a private `LSMS_DATA_DIR`; no bare `Value` / `LivestockValue` survives anywhere. For each renamed column, **rows / nulls / sum / full `describe()` are identical** to the pre-rename build:

| country | rename | rows | nulls | sum | verdict |
|---|---|---:|---:|---:|---|
| Uganda | `Value` → `ValuePerAnimal` | 27,073 | 14,884 | 1,395,710,540.6 | identical |
| Nigeria | `Value` → `ValuePerAnimal` | 23,196 | 382 | 608,948,785.0 | identical |
| Malawi | `Value` → `ValuePerAnimal` | 39,126 | 3,008 | 602,095,815.0 | identical |
| Mali | `Value` → `SalesValue` | 40,696 | 38,696 | 211,524,600.0 | identical |
| Ethiopia | `Value` → `SalesValue` | 37,179 | 15,665 | 48,516,593.0 | identical |
| EthiopiaRHS | `LivestockValue` → `HerdValue` | 3,473 | 0 | 17,249,893.4 | identical |

Currency unchanged: UGX / NGN / MWK / XOF / ETB / ETB.

## The concrete harm this fixes

`Feature('livestock')` still assembles **253,615 rows over 13 countries** — unchanged. But its single `Value` column is now `ValuePerAnimal` + `SalesValue`. That one column had been stacking **71,121 per-head prices** (Uganda / Nigeria / Malawi) on top of **23,514 sales totals** (Ethiopia / Mali) — **94,635 non-null numbers of two incompatible kinds**, with nothing in the library able to distinguish them. That pooling was live in the corpus.

## Test suite

`3328 passed, 2 failed` (worktree tests, worktree library, neutral cwd, private `LSMS_DATA_DIR`).

The 2 failures are `test_pakistan_cluster_features.py::{test_extraction_is_cluster_grain, test_geography_is_constant_within_cluster}`, and they are **pre-existing and environmental** — a DVC `PathMissingError` for Pakistan 1991's source, so the wave parquet is never materialized. Proven by A/B: the *same two* fail identically on unmodified `development` (`55097858`) in the same data dir. This branch touches neither Pakistan nor its test, and Pakistan declares no `livestock`.

Note the brief predicted 2 `CotedIvoire/cluster_features` failures (GH #592) — **those now pass**; the pre-existing-failure set on `development` has changed.

Separately, `393 passed` on the schema/currency/feature/conversion tests run explicitly against **this branch's** `data_info.yml` (those files resolve the canonical YAML via `Path(__file__)`, so they needed a worktree-rooted run to be exercised at all).

## Notes for the reviewer

- **`Country._assert_built_required_columns` caught a real miss.** Nigeria's producer is `nigeria.py:livestock_for_wave`, not the country script; the first pass renamed only the script. The guard raised a loud, actionable error instead of serving a wrong-named column — the guard did its job.
- **EthiopiaRHS has 3 livestock waves (1999, 2004, 2009), not 4** as the brief stated.
- **The 5 `Value` countries are all script-path** — none declares livestock in a wave `data_info.yml`, contrary to the brief. Only EthiopiaRHS is YAML-path.
- **The 7 EHCVM countries' "a `Value` (herd value) column is OMITTED" prose is deliberately left alone.** It is comment-only, and `data_scheme.yml` is a cache-hash input — rewording it would cold-rebuild seven countries' entire caches to buy nothing.
- **A pytest-invocation trap worth recording (relates to GH #734).** The suggested workaround — run pytest from the *main* checkout with `PYTHONPATH=<worktree>` — does **not** work. `python -m pytest` puts **cwd** at `sys.path[0]`, which beats `PYTHONPATH`, so the suite silently imports the *main checkout's* `lsms_library` **and** its `countries/` config. My first full run did exactly that and produced 12 phantom livestock failures: main's `data_scheme.yml` still said `Value` while the parquet cache (built by the worktree) said `ValuePerAnimal`. Running from a **neutral cwd** with `PYTHONPATH=<worktree>` and pointing pytest at the *worktree's* `tests/` resolves correctly and also sidesteps the #734 double-conftest error. Verified with the `assert 'worktrees' in lsms_library.__file__` check CLAUDE.md recommends.
- **`Feature('livestock')` excludes EthiopiaRHS** (its grain is `(t, i)`, not `(t, i, animal)`). Pre-existing, unchanged by this PR — `HerdValue`'s absence from `Feature` is not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFLYAj1WqLBPsJZFQGapvb
